### PR TITLE
Add virtual table

### DIFF
--- a/lib/framework/framework.dart
+++ b/lib/framework/framework.dart
@@ -275,12 +275,8 @@ abstract class Screen {
 }
 
 class SetStateMixin {
-  Timer timer;
-
   void setState(Function rebuild) {
-    timer?.cancel();
-    // TODO(devoncarew): listen for rAFs instead
-    timer = new Timer(Duration.zero, rebuild);
+    window.requestAnimationFrame((_) => rebuild());
   }
 }
 

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -336,7 +336,7 @@ class LogDetailsUI extends CoreElement {
         ..text = _data.kind
         ..clazz('label', removeOthers: true)
         ..clazz(getCssClassForEventKind(data));
-      // TODO: Can we format the JSON better?
+      // TODO(dantup): Can we format the JSON better?
       message.text = _data.message;
     }
     attribute('hidden', _data == null);

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -172,6 +172,7 @@ class LoggingScreen extends Screen {
     // TODO(dantup): Maybe add to a small buffer and then after xms insert
     // that full buffer into the list here to avoid a list rebuild on every single
     // insert.
+    // Or maybe append to the end of the list and reverse index-based operations?
     final List<LogData> data = <LogData>[log];
     data.addAll(loggingTable.rows);
 

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -154,18 +154,19 @@ class LoggingScreen extends Screen {
   void _handleConnectionStop(dynamic event) {}
 
   void _log(LogData log) {
-    loggingStateMixin.setState(() {
-      // TODO(devoncarew): make this much more efficient
-      final List<LogData> data = <LogData>[log];
-      data.addAll(loggingTable.rows);
+    // TODO(devoncarew): make this much more efficient
+    // TODO(dantup): Maybe add to a small buffer and then after xms insert
+    // that full buffer into the list here to avoid a list rebuild on every single
+    // insert.
+    final List<LogData> data = List<LogData>.from(loggingTable.rows)
+      ..insert(0, log);
 
-      if (data.length > kMaxLogItemsLength) {
-        data.removeRange(kMaxLogItemsLength, data.length);
-      }
+    if (data.length > kMaxLogItemsLength) {
+      data.removeRange(kMaxLogItemsLength, data.length);
+    }
 
-      loggingTable.setRows(data, anchorAlternatingRowsToBottom: true);
-      _updateStatus();
-    });
+    loggingTable.setRows(data, anchorAlternatingRowsToBottom: true);
+    _updateStatus();
   }
 
   String createFrameDivHtml(FrameInfo frame) {

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -163,7 +163,7 @@ class LoggingScreen extends Screen {
     }
 
     loggingStateMixin.setState(() {
-      loggingTable.setRows(data);
+      loggingTable.setRows(data, anchorAlternatingRowsToBottom: true);
       _updateStatus();
     });
   }

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -52,7 +52,7 @@ class LoggingScreen extends Screen {
   }
 
   CoreElement _createTableView() {
-    loggingTable = new Table<LogData>();
+    loggingTable = new Table<LogData>.virtual();
 
     loggingTable.addColumn(new LogWhenColumn());
     loggingTable.addColumn(new LogKindColumn());

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:intl/intl.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -154,15 +156,15 @@ class LoggingScreen extends Screen {
   void _handleConnectionStop(dynamic event) {}
 
   void _log(LogData log) {
-    // TODO(devoncarew): make this much more efficient
-    final List<LogData> data = <LogData>[log];
-    data.addAll(loggingTable.rows);
-
-    if (data.length > kMaxLogItemsLength) {
-      data.removeRange(kMaxLogItemsLength, data.length);
-    }
-
     loggingStateMixin.setState(() {
+      // TODO(devoncarew): make this much more efficient
+      final List<LogData> data = <LogData>[log];
+      data.addAll(loggingTable.rows);
+
+      if (data.length > kMaxLogItemsLength) {
+        data.removeRange(kMaxLogItemsLength, data.length);
+      }
+
       loggingTable.setRows(data, anchorAlternatingRowsToBottom: true);
       _updateStatus();
     });

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -172,8 +172,8 @@ class LoggingScreen extends Screen {
     // TODO(dantup): Maybe add to a small buffer and then after xms insert
     // that full buffer into the list here to avoid a list rebuild on every single
     // insert.
-    final List<LogData> data = List<LogData>.from(loggingTable.rows)
-      ..insert(0, log);
+    final List<LogData> data = <LogData>[log];
+    data.addAll(loggingTable.rows);
 
     if (data.length > kMaxLogItemsLength) {
       data.removeRange(kMaxLogItemsLength, data.length);

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -21,7 +21,7 @@ import '../utils.dart';
 
 // TODO(devoncarew): don't update DOM when we're not active; update once we return
 
-const int kMaxLogItemsLength = 40;
+const int kMaxLogItemsLength = 5000;
 
 class LoggingScreen extends Screen {
   Framework framework;

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -59,7 +59,7 @@ class LoggingScreen extends Screen {
     ]);
 
     // TODO(dantup): Can we (should we?) detect when the content is overflowed
-    // in the table, and only show the defailts
+    // in the table, and only show the defaults?
     loggingTable.onSelect
         .listen((LogData selection) => logDetailsUI.data = selection);
 

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -210,7 +210,9 @@ class Table<T> extends Object with SetStateMixin {
                 tableRow.element.children[currentColumnIndex++])
             : td();
 
-        // TODO: Remove/replace old classes
+        // TODO(dantup): Should we make CoreElement expose ClassList instead
+        // of having flat strings?
+        tableCell.element.classes.clear();
         column.cssClass.split(' ').forEach(tableCell.clazz);
 
         if (column.numeric) {

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -236,11 +236,10 @@ class Table<T> extends Object with SetStateMixin {
     // Remove any additional rows that we had left that we didn't reuse above.
     if (currentRowIndex > 0 &&
         currentRowIndex < _tbody.element.children.length) {
-      // TODO: Why does removeAt(i) work, but not removeRange (UnimplementedError)?
-      // _tbody.element.children
-      //     .removeRange(currentRowIndex, _tbody.element.children.length);
-      for (int i = currentRowIndex; i < _tbody.element.children.length; i++)
-        _tbody.element.children.removeAt(i);
+      // removeRange doesn't work in dart:html (UnimplementedError) so we have
+      // to remove them one at a time.
+      while (_tbody.element.children.length >= currentRowIndex)
+        _tbody.element.children.removeLast();
     }
     // Set the "after" spacer to the correct height to keep the scroll size
     // correct for the number or rows to come after.

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -17,10 +17,10 @@ import 'utils.dart';
 class Table<T> extends Object with SetStateMixin {
   final CoreElement element;
   bool isVirtual = false;
-  bool offsetRowColor = false;
+  bool _offsetRowColor = false;
   double rowHeight;
-  bool hasPendingRebuild = false;
-  Map<Element, T> dataForRow = <Element, T>{};
+  bool _hasPendingRebuild = false;
+  final Map<Element, T> _dataForRow = <Element, T>{};
 
   List<Column<T>> columns = <Column<T>>[];
   List<T> rows;
@@ -78,7 +78,7 @@ class Table<T> extends Object with SetStateMixin {
     final int differenceInRowCount =
         (rows?.length ?? 0) - (this.rows?.length ?? 0);
     if (anchorAlternatingRowsToBottom && differenceInRowCount % 2 == 1) {
-      offsetRowColor = !offsetRowColor;
+      _offsetRowColor = !_offsetRowColor;
     }
     this.rows = rows.toList();
 
@@ -126,12 +126,12 @@ class Table<T> extends Object with SetStateMixin {
     // TODO(dantup): It'd be good to push this logic up into setState, but we may need to be
     // able to distinguish functions that must be called on the next RAF versus those
     // where calls are allowed to be skipped (for ex in this case).
-    if (!hasPendingRebuild) {
+    if (!_hasPendingRebuild) {
       // Set a flag to ensure we don't schedule rebuilds if there's already one
       // in the queue.
-      hasPendingRebuild = true;
+      _hasPendingRebuild = true;
       setState(() {
-        hasPendingRebuild = false;
+        _hasPendingRebuild = false;
         _rebuildTable();
       });
     }
@@ -223,7 +223,7 @@ class Table<T> extends Object with SetStateMixin {
     }
 
     _tbody.element.children.remove(rowColorCompensator.element);
-    bool shouldOffsetRowColor = offsetRowColor;
+    bool shouldOffsetRowColor = _offsetRowColor;
     // If we're skipping an odd number or rows, we need to invert whether to include
     // the row color compensator.
     if (firstRenderedRowInc % 2 == 1) {
@@ -246,9 +246,9 @@ class Table<T> extends Object with SetStateMixin {
       // user clicks the row to select it. This lets us reuse a single
       // click handler attached when we created the row instead of rebinding
       // it when rows are reused as we scroll.
-      dataForRow[tableRow.element] = row;
+      _dataForRow[tableRow.element] = row;
       void selectRow(Element row) {
-        _select(row, dataForRow[row]);
+        _select(row, _dataForRow[row]);
       }
 
       if (!isReusableRow) {
@@ -337,15 +337,15 @@ class Table<T> extends Object with SetStateMixin {
       }
     }
 
-    _selectedObject = object;
-
     if (row != null) {
       row.classes.add('selected');
     }
 
-    if (object != null && _selectedObject != object) {
+    if (_selectedObject != object) {
       _selectController.add(object);
     }
+
+    _selectedObject = object;
   }
 
   void _clearSelection() => _select(null, null);

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -18,6 +18,7 @@ class Table<T> extends Object with SetStateMixin {
   bool isVirtual = false;
   bool offsetRowColor = false;
   double rowHeight;
+  bool hasPendingRebuild = false;
 
   List<Column<T>> columns = <Column<T>>[];
   List<T> rows;
@@ -111,7 +112,15 @@ class Table<T> extends Object with SetStateMixin {
       _doSort();
     }
 
-    _rebuildTable();
+    if (!hasPendingRebuild) {
+      // Set a flag to ensure we don't schedule rebuilds if there's already one
+      // in the queue.
+      hasPendingRebuild = true;
+      setState(() {
+        hasPendingRebuild = false;
+        _rebuildTable();
+      });
+    }
   }
 
   void _doSort() {

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
+import 'package:devtools/framework/framework.dart';
+
 import 'ui/elements.dart';
 import 'utils.dart';
 
@@ -12,7 +14,7 @@ import 'utils.dart';
 
 // TODO(devoncarew): virtualize
 
-class Table<T> {
+class Table<T> extends Object with SetStateMixin {
   final CoreElement element;
   bool isVirtual = false;
   double rowHeight;
@@ -28,7 +30,6 @@ class Table<T> {
   CoreElement _tbody;
   CoreElement _beforeRowsSpacer;
   CoreElement _afterRowsSpacer;
-  Timer _scrollRebuildTimer;
 
   Map<Column<T>, CoreElement> spanForColumn = <Column<T>, CoreElement>{};
 
@@ -48,14 +49,7 @@ class Table<T> {
     _beforeRowsSpacer = new CoreElement('tr');
     _afterRowsSpacer = new CoreElement('tr');
 
-    element.onScroll.listen((_) {
-      // When scrolling, wait for a break of 100ms before we start rebuilding
-      if (_scrollRebuildTimer != null && _scrollRebuildTimer.isActive) {
-        _scrollRebuildTimer.cancel();
-      }
-      _scrollRebuildTimer =
-          new Timer(Duration(milliseconds: 100), _rebuildTable);
-    });
+    element.onScroll.listen((_) => setState(_rebuildTable));
   }
 
   Stream<T> get onSelect => _selectController.stream;

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -282,8 +282,10 @@ class Table<T> extends Object with SetStateMixin {
           currentRowIndex < _tbody.element.children.length;
       // Reuse a row if one already exists in the table.
       final CoreElement tableRow = isReusableRow
-          ? new CoreElement.from(_tbody.element.children[currentRowIndex++])
+          ? new CoreElement.from(_tbody.element.children[currentRowIndex])
           : tr();
+
+      currentRowIndex++;
 
       // Keep the data for each row in a map so we can look it up when the
       // user clicks the row to select it. This lets us reuse a single

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -237,7 +237,9 @@ class Table<T> extends Object with SetStateMixin {
         // TODO(dantup): Should we make CoreElement expose ClassList instead
         // of having flat strings?
         tableCell.element.classes.clear();
-        column.cssClass.split(' ').forEach(tableCell.clazz);
+        if (column.cssClass != null) {
+          column.cssClass.split(' ').forEach(tableCell.clazz);
+        }
 
         if (column.numeric) {
           tableCell.clazz('right');

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -127,9 +127,6 @@ class Table<T> extends Object with SetStateMixin {
   }
 
   void _scheduleRebuild() {
-    // TODO(dantup): It'd be good to push this logic up into setState, but we may need to be
-    // able to distinguish functions that must be called on the next RAF versus those
-    // where calls are allowed to be skipped (for ex in this case).
     if (!_hasPendingRebuild) {
       // Set a flag to ensure we don't schedule rebuilds if there's already one
       // in the queue.

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -309,11 +309,13 @@ class Table<T> extends Object with SetStateMixin {
       for (Column<T> column in columns) {
         final bool isReusableColumn =
             currentColumnIndex < tableRow.element.children.length;
-        // Reuse or create a row.
+        // Reuse or create a cell.
         final CoreElement tableCell = isReusableColumn
             ? new CoreElement.from(
-                tableRow.element.children[currentColumnIndex++])
+                tableRow.element.children[currentColumnIndex])
             : td();
+
+        currentColumnIndex++;
 
         // TODO(dantup): Should we make CoreElement expose ClassList instead
         // of having flat strings?

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -200,8 +200,11 @@ class Table<T> extends Object with SetStateMixin {
     // Calculate the subset of rows to render based on scroll position.
     final int firstVisibleRow =
         ((element.scrollTop - _thead.offsetHeight) / rowHeight).floor();
-    final int numVisibleRows = (element.offsetHeight / rowHeight).ceil();
-    firstRenderedRowInclusive = firstVisibleRow.clamp(0, rows?.length ?? 0);
+    final int numVisibleRows = (element.offsetHeight / rowHeight).ceil() + 1;
+    final int highestPossibleFirstRenderedRow =
+        rows == null ? 0 : rows.length - (numVisibleRows + 1);
+    firstRenderedRowInclusive =
+        firstVisibleRow.clamp(0, highestPossibleFirstRenderedRow);
     // Calculate the last rendered row. +2 is for:
     //   1) because it's exclusive so needs to be one higher
     //   2) because we need to render the extra partially-visible row

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -123,6 +123,9 @@ class Table<T> extends Object with SetStateMixin {
   }
 
   void _scheduleRebuild() {
+    // TODO(dantup): It'd be good to push this logic up into setState, but we may need to be
+    // able to distinguish functions that must be called on the next RAF versus those
+    // where calls are allowed to be skipped (for ex in this case).
     if (!hasPendingRebuild) {
       // Set a flag to ensure we don't schedule rebuilds if there's already one
       // in the queue.

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -209,7 +209,18 @@ class CoreElement {
     element.style.display = value;
   }
 
+  int get scrollTop => element.scrollTop;
+
+  int get offsetHeight => element.offsetHeight;
+
+  String get height => element.style.height;
+
+  set height(String value) {
+    element.style.height = value;
+  }
+
   Stream<MouseEvent> get onClick => element.onClick.where((_) => !disabled);
+  Stream<Event> get onScroll => element.onScroll;
 
   /// Subscribe to the [onClick] event stream with a no-arg handler.
   StreamSubscription<Event> click(void handle(), [void shiftHandle()]) {

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -111,9 +111,12 @@ class CoreElement {
   void icon(String iconName) =>
       element.classes.addAll(<String>['icon', 'icon-$iconName']);
 
-  void clazz(String _class) {
+  void clazz(String _class, {bool removeOthers = false}) {
     if (_class.contains(' ')) {
       throw new ArgumentError('spaces not allowed in class names');
+    }
+    if (removeOthers) {
+      element.classes.clear();
     }
     element.classes.add(_class);
   }

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -211,6 +211,8 @@ class CoreElement {
 
   int get scrollTop => element.scrollTop;
 
+  set scrollTop(int value) => element.scrollTop = value;
+
   int get offsetHeight => element.offsetHeight;
 
   String get height => element.style.height;

--- a/test/tables_test.dart
+++ b/test/tables_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 @TestOn('browser')
 import 'dart:html';
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -83,20 +83,33 @@ th.right {
     text-align: right;
 }
 
-td.pre {
+.pre {
     white-space: pre;
 }
 
-td.pre-wrap {
+.pre-wrap {
     white-space: pre-wrap;
 }
 
-td.monospace {
+.monospace {
     font-family: monospace;
 }
 
 span.label {
     background-color: #616161;
+}
+
+span.label.stderr {
+    background-color: #F44336;
+}
+span.label.stdout {
+    background-color: #78909C;
+}
+span.label.flutter {
+    background-color: #0091ea;
+}
+span.label.gc {
+    background-color: #424242;
 }
 
 .table-virtual td {
@@ -452,6 +465,10 @@ div.tabnav {
     position: absolute;
     overflow-x: hidden;
     cursor: default;
+}
+
+.log-details .label {
+    margin-right: 5px;
 }
 
 .frame-panel {

--- a/web/styles.css
+++ b/web/styles.css
@@ -99,6 +99,13 @@ span.label {
     background-color: #616161;
 }
 
+.table-virtual td {
+    max-width: 500px; /* required for text-overflow to work? */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 table thead {
     background-color: #f3f3f3;
     border-bottom: 1px solid #dfe2e5;


### PR DESCRIPTION
I started on some basic support for a virtual table. It renders a single "spacer" row at the top/bottom of the table to cover all rows that are offscreen. During scrolling it will triggers rebuild (by calling requestAnimationFrame).

There are still a bunch of things that need improving (see below), but I thought it worth getting some feedback in case I'm going in the wrong direction.

- [x] Figure out if reusing the TR/TD nodes is much faster than re-creating on each rebuild (we're only throwing away/re-creating the number of rows on the screen `* 3` but it still seems wasteful)
- [x] Figure out if we need to throttle our onScroll -> rAF -> rebuild
- [x] Selection should be preserved across rebuilds (both for scrolling, but also when new rows are added - currently it just gets cleared)
- [x] Rows that are larger than the specified height can upset calculations and make it appear to "jump" once they are scrolled up off screen and then removed from the DOM
- [x] Alternating colours sometimes "jump" and look weird - this is made worse by us adding new rows to the top - I think we should find a fix for this (eg. when a single row is added to the top, the background colours should "move down a row" too, so a single events background doesn't change)