### PR TITLE
always record timeline frames when on the timeline page

### DIFF
--- a/lib/device/device.dart
+++ b/lib/device/device.dart
@@ -94,6 +94,7 @@ class DeviceScreen extends Screen {
     _createBoolToggle('ext.flutter.repaintRainbow');
     _createBoolToggle('ext.flutter.showPerformanceOverlay');
     _createBoolToggle('ext.flutter.debugAllowBanner');
+    _createBoolToggle('ext.flutter.debugProfileBuilds');
   }
 
   void _createBoolToggle(String rpc) {

--- a/lib/framework/framework.dart
+++ b/lib/framework/framework.dart
@@ -109,9 +109,12 @@ class Framework {
 
   void load(Screen screen) {
     if (current != null) {
-      current.exiting();
+      final Screen oldScreen = current;
+      current = null;
+      oldScreen.exiting();
+
       pageStatus.removeAll();
-      _contents[current] = mainElement.element.children.toList();
+      _contents[oldScreen] = mainElement.element.children.toList();
       mainElement.element.children.clear();
     } else {
       mainElement.element.children.clear();
@@ -122,6 +125,7 @@ class Framework {
     if (_contents.containsKey(current)) {
       mainElement.element.children.addAll(_contents[current]);
     } else {
+      current.framework = this;
       current.createContent(this, mainElement);
     }
 
@@ -231,6 +235,8 @@ abstract class Screen {
   final String id;
   final String iconClass;
 
+  Framework framework;
+
   final Property<bool> _visible = new Property<bool>(true);
 
   final List<StatusItem> statusItems = <StatusItem>[];
@@ -254,6 +260,8 @@ abstract class Screen {
   void createContent(Framework framework, CoreElement mainDiv) {}
 
   void entering() {}
+
+  bool get isCurrentScreen => framework != null && framework.current == this;
 
   void exiting() {}
 

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -24,7 +24,6 @@ import '../utils.dart';
 const int kMaxLogItemsLength = 40;
 
 class LoggingScreen extends Screen {
-  Framework framework;
   Table<LogData> loggingTable;
   StatusItem logCountStatus;
   SetStateMixin loggingStateMixin = new SetStateMixin();
@@ -44,8 +43,6 @@ class LoggingScreen extends Screen {
 
   @override
   void createContent(Framework framework, CoreElement mainDiv) {
-    this.framework = framework;
-
     mainDiv.add(<CoreElement>[
       _createTableView()..clazz('section'),
     ]);

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -26,7 +26,6 @@ class MemoryScreen extends Screen {
 
   PButton loadSnapshotButton;
   Table<ClassHeapStats> memoryTable;
-  Framework framework;
 
   MemoryChart memoryChart;
   SetStateMixin memoryChartStateMixin = new SetStateMixin();
@@ -44,8 +43,6 @@ class MemoryScreen extends Screen {
 
   @override
   void createContent(Framework framework, CoreElement mainDiv) {
-    this.framework = framework;
-
     mainDiv.add(<CoreElement>[
       createLiveChartArea(),
       div(c: 'section'),

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -23,7 +23,6 @@ class PerformanceScreen extends Screen {
   PButton resetButton;
   CoreElement progressElement;
   Table<PerfData> perfTable;
-  Framework framework;
 
   CpuChart cpuChart;
   SetStateMixin cpuChartStateMixin = new SetStateMixin();
@@ -43,8 +42,6 @@ class PerformanceScreen extends Screen {
 
   @override
   void createContent(Framework framework, CoreElement mainDiv) {
-    this.framework = framework;
-
     mainDiv.add(<CoreElement>[
       createLiveChartArea(),
       div(c: 'section'),

--- a/lib/timeline/timeline.dart
+++ b/lib/timeline/timeline.dart
@@ -87,49 +87,23 @@ class TimelineScreen extends Screen {
         ..add(frameDetailsUI = new FrameDetailsUI()..attribute('hidden')),
     ]);
 
-    trackWidgetBuildsButton.click(() {
-      final bool wasSelected =
-          trackWidgetBuildsButton.element.classes.contains('selected');
-      trackWidgetBuildsButton.toggleClass('selected');
-      serviceInfo.service.callServiceExtension(
-        'ext.flutter.debugProfileBuilds',
-        isolateId: serviceInfo.isolateManager.selectedIsolate.id,
-        args: <String, bool>{'enabled': !wasSelected},
-      );
-    });
+    void handleToggleButton(PButton button, String serviceCallName) {
+      button.click(() {
+        final bool wasSelected = button.element.classes.contains('selected');
+        button.toggleClass('selected');
+        serviceInfo.service.callServiceExtension(
+          serviceCallName,
+          isolateId: serviceInfo.isolateManager.selectedIsolate.id,
+          args: <String, bool>{'enabled': !wasSelected},
+        );
+      });
+    }
 
-    perfOverlayButton.click(() {
-      final bool wasSelected =
-          perfOverlayButton.element.classes.contains('selected');
-      perfOverlayButton.toggleClass('selected');
-      serviceInfo.service.callServiceExtension(
-        'ext.flutter.showPerformanceOverlay',
-        isolateId: serviceInfo.isolateManager.selectedIsolate.id,
-        args: <String, bool>{'enabled': !wasSelected},
-      );
-    });
-
-    repaintRainbowButton.click(() {
-      final bool wasSelected =
-          repaintRainbowButton.element.classes.contains('selected');
-      repaintRainbowButton.toggleClass('selected');
-      serviceInfo.service.callServiceExtension(
-        'ext.flutter.repaintRainbow',
-        isolateId: serviceInfo.isolateManager.selectedIsolate.id,
-        args: <String, bool>{'enabled': !wasSelected},
-      );
-    });
-
-    debugDrawButton.click(() {
-      final bool wasSelected =
-          debugDrawButton.element.classes.contains('selected');
-      debugDrawButton.toggleClass('selected');
-      serviceInfo.service.callServiceExtension(
-        'ext.flutter.debugPaint',
-        isolateId: serviceInfo.isolateManager.selectedIsolate.id,
-        args: <String, bool>{'enabled': !wasSelected},
-      );
-    });
+    handleToggleButton(
+        trackWidgetBuildsButton, 'ext.flutter.debugProfileBuilds');
+    handleToggleButton(perfOverlayButton, 'ext.flutter.showPerformanceOverlay');
+    handleToggleButton(repaintRainbowButton, 'ext.flutter.repaintRainbow');
+    handleToggleButton(debugDrawButton, 'ext.flutter.debugPaint');
 
     serviceInfo.onConnectionAvailable.listen(_handleConnectionStart);
     if (serviceInfo.hasConnection) {


### PR DESCRIPTION
- update which framework toggles we expose in the timeline page (now, `Track widget builds`, `performance overlay`, `repaint rainbow`, and `debug draw`)
- when the user is on the timeline page, always record frames
- add a `pause` and `resume` button so users can pause the UI when lots of frames are being created

@DanTup 

<img width="293" alt="screen shot 2018-09-06 at 2 59 08 pm" src="https://user-images.githubusercontent.com/1269969/45187779-c0cc2980-b1e6-11e8-93ca-19ce649b1c1c.png">

<img width="572" alt="screen shot 2018-09-06 at 2 59 01 pm" src="https://user-images.githubusercontent.com/1269969/45187790-ca559180-b1e6-11e8-8dc0-29295bddb0a6.png">
