### PR TITLE
Add VS Code launch configs

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+	"recommendations": [
+		"msjsdiag.debugger-for-chrome"
+	],
+	"unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,13 @@
+{
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch web app",
+			"url": "http://localhost:8080",
+			"webRoot": "${workspaceFolder}/web",
+			"preLaunchTask": "webdev serve"
+		}
+	]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,29 @@
+{
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "webdev serve",
+			"type": "shell",
+			"args": [
+				"run",
+				"webdev",
+				"serve",
+				"web"
+			],
+			"command": "pub",
+			"group": "build",
+			"isBackground": true,
+			"problemMatcher": {
+				"owner": "custom",
+				"pattern": {
+					"regexp": "__________"
+				},
+				"background": {
+					"activeOnStart": true,
+					"beginsPattern": "^\\[INFO\\] Starting Build",
+					"endsPattern": "^\\[INFO\\] Succeeded after"
+				}
+			}
+		}
+	]
+}


### PR DESCRIPTION
These are for convenience when working on devtools. They make it possible to press F5 and have webdev server run as a tsak in the BG, and once compilation is finished the browser will launch. Requires the Chrome Debugger extension.

Debugging is not reliable right now.