### PR TITLE
Virtual table improvements/fixes

### DIFF
--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -62,12 +62,6 @@ class LoggingScreen extends Screen {
     // in the table, and only show the defaults?
     loggingTable.onSelect
         .listen((LogData selection) => logDetailsUI.data = selection);
-
-    serviceInfo.onConnectionAvailable.listen(_handleConnectionStart);
-    if (serviceInfo.hasConnection) {
-      _handleConnectionStart(serviceInfo.service);
-    }
-    serviceInfo.onConnectionClosed.listen(_handleConnectionStop);
   }
 
   CoreElement _createTableView() {

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -174,15 +174,13 @@ class LoggingScreen extends Screen {
 
   List<LogData> data = <LogData>[];
   void _log(LogData log) {
-    // TODO(devoncarew): make this much more efficient
-    // TODO(dantup): Maybe add to a small buffer and then after xms insert
-    // that full buffer into the list here to avoid a list rebuild on every single
-    // insert.
-    // Or maybe append to the end of the list and reverse index-based operations?
-
     // Build a new list that has 1 item more (clamped at kMaxLogItemsLength)
     // and insert this new item at the start, followed by the required number
-    // of items from the old data.
+    // of items from the old data. This is faster than insert(0, log).
+    //
+    // If this turns out to be too slow, we can make it faster (saving around
+    // 30-40% of the time) by just .add()ing to the list and having a flag on
+    // the table to reverse data for rendering ([length-index] when reading data).
     final int totalItems = (data.length + 1).clamp(0, kMaxLogItemsLength);
     data = List<LogData>(totalItems)
       ..[0] = log

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -198,18 +198,19 @@ class Table<T> extends Object with SetStateMixin {
     int currentRowIndex = 0;
 
     // Calculate the subset of rows to render based on scroll position.
+    final int totalRows = rows?.length ?? 0;
     final int firstVisibleRow =
         ((element.scrollTop - _thead.offsetHeight) / rowHeight).floor();
     final int numVisibleRows = (element.offsetHeight / rowHeight).ceil() + 1;
     final int highestPossibleFirstRenderedRow =
-        rows == null ? 0 : rows.length - (numVisibleRows + 1);
+        (totalRows - (numVisibleRows + 1)).clamp(0, totalRows);
     firstRenderedRowInclusive =
         firstVisibleRow.clamp(0, highestPossibleFirstRenderedRow);
     // Calculate the last rendered row. +2 is for:
     //   1) because it's exclusive so needs to be one higher
     //   2) because we need to render the extra partially-visible row
-    lastRenderedRowExclusive = (firstRenderedRowInclusive + numVisibleRows + 2)
-        .clamp(0, rows?.length ?? 0);
+    lastRenderedRowExclusive =
+        (firstRenderedRowInclusive + numVisibleRows + 2).clamp(0, totalRows);
 
     // Add a spacer row to fill up the content off-screen.
     final double spacerBeforeHeight = firstRenderedRowInclusive * rowHeight;

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -84,7 +84,7 @@ class Table<T> extends Object with SetStateMixin {
     if (anchorAlternatingRowsToBottom && differenceInRowCount % 2 == 1) {
       _offsetRowColor = !_offsetRowColor;
     }
-    this.rows = rows.toList();
+    this.rows = rows;
 
     if (_thead == null) {
       _thead = new CoreElement('thead')


### PR DESCRIPTION
- Fixes a bug when showing the table when rows = null
- Stops cloning the list passed to `setRows` in tables (this isn't ideal, but for big tables just copying the list can take a long time - I think the risk is low and if a consumer of the table wants, it can provide a cloned list to setRows)
- Removes duplicated code that resulted in double-logging (I think I messed this up in a merge/rebase with conflicts - the code was supposed to be moved)
- Update comments above perf of `_log` and remove TODOs

The last one - I had previously mentioned adding a small buffer, but it turned out to be slightly complicated and I came up with a better idea - just reusing the same list and appending using `.add()` - this gets fast because the table capacity doubles so once the table gets big (or near its max size). The downside is that logs are added to the bottom - but we can easily fix that with a flag on the table that just reverses the index as it reads data.

That said, it's performing well enough locally that I didn't think it was worth that complexity. If you feel that we do need to make it faster, I think this should be the first thing to try - just lmk.