### PR TITLE
Fix frame timing formatting

### DIFF
--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -155,13 +155,15 @@ class LoggingScreen extends Screen {
       if (e.extensionKind == 'Flutter.Frame') {
         final FrameInfo frame = FrameInfo.from(e.extensionData.data);
 
+        final String frameInfo =
+            '<span class="pre">frame ${frame.number} ${frame.elapsedMs.toStringAsFixed(1).padLeft(4)}ms </span>';
         final String div = createFrameDivHtml(frame);
 
         _log(new LogData(
           '${e.extensionKind.toLowerCase()}',
-          'frame ${frame.number} ${frame.elapsedMs.toStringAsFixed(1).padLeft(4)}ms',
+          '',
           e.timestamp,
-          extraHtml: div,
+          extraHtml: '$frameInfo$div',
         ));
       } else {
         _log(new LogData('${e.extensionKind.toLowerCase()}', e.json.toString(),


### PR DESCRIPTION
As part of the virtual table we had to set `whitespace: nowrap` on the cells (else any messages with newlines would wrap, like GC events) but that removes the `pre` formatting used here to pad the numbers:

![screen shot 2018-09-18 at 12 10 39 pm](https://user-images.githubusercontent.com/1078012/45684308-c9552600-bb3d-11e8-9f67-3aa7eaa4370b.png)

This puts a span in so that the timing can be set back to `pre` for this spacing.