### PR TITLE
Add additional tables to Memory view for drilling down

### DIFF
--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:typed_data';
 
 import 'package:vm_service_lib/vm_service_lib.dart';
 
@@ -208,10 +207,10 @@ class MemoryScreen extends Screen {
 
       // Set the rows blank so old data is removed while this request is in-flight.
       // TODO(dantup): Should table support showing a spinner?
-      // instancesTable.setRows(<InstanceSummary>[]);
+      instancesTable.setRows(<InstanceSummary>[]);
 
-      // final Class c =
-      //     await serviceInfo.service.getObject(_isolateId, row.classRef.id);
+      final Class c =
+          await serviceInfo.service.getObject(_isolateId, row.classRef.id);
 
       // // TODO(dantup): Find out what we should actually be displaying here.
       // if (c.library.type == '@Library') {

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -281,7 +281,7 @@ class MemoryScreen extends Screen {
     });
 
     // Kick off population of data for the table.
-    // TODO: If it turns out not to be async work, remove the spinner.
+    // TODO(dantup): If it turns out not to be async work, remove the spinner.
     row.getData().then((List<InstanceData> data) {
       table.setRows(data);
       spinner.element.remove();

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -22,6 +22,15 @@ import '../utils.dart';
 // TODO(devoncarew): have a 'show vm objects' checkbox
 
 class MemoryScreen extends Screen {
+  MemoryScreen()
+      : super(name: 'Memory', id: 'memory', iconClass: 'octicon-package') {
+    classCountStatus = new StatusItem();
+    addStatusItem(classCountStatus);
+
+    objectCountStatus = new StatusItem();
+    addStatusItem(objectCountStatus);
+  }
+
   StatusItem classCountStatus;
   StatusItem objectCountStatus;
 
@@ -35,15 +44,6 @@ class MemoryScreen extends Screen {
   SetStateMixin memoryChartStateMixin = new SetStateMixin();
   MemoryTracker memoryTracker;
   ProgressElement progressElement;
-
-  MemoryScreen()
-      : super(name: 'Memory', id: 'memory', iconClass: 'octicon-package') {
-    classCountStatus = new StatusItem();
-    addStatusItem(classCountStatus);
-
-    objectCountStatus = new StatusItem();
-    addStatusItem(objectCountStatus);
-  }
 
   @override
   void createContent(Framework framework, CoreElement mainDiv) {
@@ -331,11 +331,11 @@ class MemoryScreen extends Screen {
 }
 
 class MemoryRow {
+  MemoryRow(this.name, this.bytes, this.percentage);
+
   final String name;
   final int bytes;
   final double percentage;
-
-  MemoryRow(this.name, this.bytes, this.percentage);
 
   @override
   String toString() => name;
@@ -383,18 +383,16 @@ class MemoryColumnInstanceCount extends Column<ClassHeapStats> {
 }
 
 class MemoryColumnSimple<T> extends Column<T> {
-  String Function(T) getter;
   MemoryColumnSimple(String name, this.getter, {bool wide = false})
       : super(name, wide: wide);
+
+  String Function(T) getter;
 
   @override
   String getValue(T item) => getter(item);
 }
 
 class MemoryChart extends LineChart<MemoryTracker> {
-  CoreElement processLabel;
-  CoreElement heapLabel;
-
   MemoryChart(CoreElement parent) : super(parent) {
     processLabel = parent.add(div(c: 'perf-label'));
     processLabel.element.style.left = '0';
@@ -402,6 +400,9 @@ class MemoryChart extends LineChart<MemoryTracker> {
     heapLabel = parent.add(div(c: 'perf-label'));
     heapLabel.element.style.right = '0';
   }
+
+  CoreElement processLabel;
+  CoreElement heapLabel;
 
   @override
   void update(MemoryTracker data) {
@@ -452,6 +453,8 @@ class MemoryChart extends LineChart<MemoryTracker> {
 }
 
 class MemoryTracker {
+  MemoryTracker(this.service);
+
   static const Duration kMaxGraphTime = Duration(minutes: 1);
   static const Duration kUpdateDelay = Duration(seconds: 1);
 
@@ -464,8 +467,6 @@ class MemoryTracker {
   final Map<String, List<HeapSpace>> isolateHeaps = <String, List<HeapSpace>>{};
   int heapMax;
   int processRss;
-
-  MemoryTracker(this.service);
 
   bool get hasConnection => service != null;
 
@@ -580,11 +581,11 @@ class MemoryTracker {
 }
 
 class HeapSample {
+  HeapSample(this.bytes, this.time, this.isGC);
+
   final int bytes;
   final int time;
   final bool isGC;
-
-  HeapSample(this.bytes, this.time, this.isGC);
 }
 
 String _printMb(num bytes, int fractionDigits) =>
@@ -599,6 +600,12 @@ String _printMb(num bytes, int fractionDigits) =>
 //   promotedBytes: 0
 // }
 class ClassHeapStats {
+  ClassHeapStats(this.json) {
+    classRef = ClassRef.parse(json['class']);
+    _update(json['new']);
+    _update(json['old']);
+  }
+
   static const int ALLOCATED_BEFORE_GC = 0;
   static const int ALLOCATED_BEFORE_GC_SIZE = 1;
   static const int LIVE_AFTER_GC = 2;
@@ -617,12 +624,6 @@ class ClassHeapStats {
 
   ClassRef classRef;
 
-  ClassHeapStats(this.json) {
-    classRef = ClassRef.parse(json['class']);
-    _update(json['new']);
-    _update(json['old']);
-  }
-
   String get type => json['type'];
 
   void _update(List<dynamic> stats) {
@@ -638,10 +639,11 @@ class ClassHeapStats {
 }
 
 class InstanceSummary {
+  InstanceSummary(this.clazz, this.id);
+
   Class clazz;
   String id;
 
-  InstanceSummary(this.clazz, this.id);
   @override
   String toString() => '[InstanceSummary id: $id, class: ${clazz.name}]';
 
@@ -666,11 +668,11 @@ class InstanceSummary {
 }
 
 class InstanceData {
+  InstanceData(this.instance, this.name, this.value);
+
   InstanceSummary instance;
   String name;
   dynamic value;
-
-  InstanceData(this.instance, this.name, this.value);
 
   @override
   String toString() => '[InstanceData name: $name, value: $value]';

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -113,6 +113,7 @@ class MemoryScreen extends Screen {
 
   Future<Null> _loadAllocationProfile() async {
     loadSnapshotButton.disabled = true;
+    tableStack.first.element.display = null;
     final Spinner spinner =
         tableStack.first.element.add(new Spinner()..clazz('padded'));
 
@@ -130,7 +131,7 @@ class MemoryScreen extends Screen {
         return stats.instancesCurrent > 0; //|| stats.instancesAccumulated > 0;
       }).toList();
 
-      tableStack.first.setRows(heapStats);
+      tableStack.first..setRows(heapStats);
       _updateStatus(heapStats);
       spinner.element.remove();
     } finally {
@@ -205,6 +206,7 @@ class MemoryScreen extends Screen {
 
   Table<ClassHeapStats> _createHeapStatsTableView() {
     final Table<ClassHeapStats> table = new Table<ClassHeapStats>.virtual()
+      ..element.display = 'none'
       ..element.clazz('memory-table');
 
     table.addColumn(new MemoryColumnSize());

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -99,7 +99,7 @@ class MemoryScreen extends Screen {
       tableContainer.element.scrollTo(<String, dynamic>{
         'left': tableContainer.element.scrollWidth,
         'top': 0,
-        'behavior': 'smooth'
+        'behavior': 'smooth',
       });
     }
   }

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -107,6 +107,8 @@ class MemoryScreen extends Screen {
 
   Future<Null> _loadAllocationProfile() async {
     loadSnapshotButton.disabled = true;
+    final Spinner spinner =
+        tableStack.first.element.add(new Spinner()..clazz('padded'));
 
     // TODO(devoncarew): error handling
 
@@ -124,6 +126,7 @@ class MemoryScreen extends Screen {
 
       tableStack.first.setRows(heapStats);
       _updateStatus(heapStats);
+      spinner.element.remove();
     } finally {
       loadSnapshotButton.disabled = false;
     }
@@ -244,6 +247,7 @@ class MemoryScreen extends Screen {
 
   Table<InstanceData> _createInstanceDetailsTableView(InstanceSummary row) {
     final Table<InstanceData> table = new Table<InstanceData>.virtual();
+    final Spinner spinner = table.element.add(new Spinner()..clazz('padded'));
     table.addColumn(new MemoryColumnSimple<InstanceData>(
         'Name', (InstanceData row) => row.name));
     table.addColumn(new MemoryColumnSimple<InstanceData>(
@@ -259,7 +263,11 @@ class MemoryScreen extends Screen {
     });
 
     // Kick off population of data for the table.
-    row.getData().then(table.setRows);
+    // TODO: If it turns out not to be async work, remove the spinner.
+    row.getData().then((List<InstanceData> data) {
+      table.setRows(data);
+      spinner.element.remove();
+    });
 
     return table;
   }

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -130,7 +130,7 @@ class MemoryScreen extends Screen {
         return stats.instancesCurrent > 0; //|| stats.instancesAccumulated > 0;
       }).toList();
 
-      tableStack.first..setRows(heapStats);
+      tableStack.first.setRows(heapStats);
       _updateStatus(heapStats);
       spinner.element.remove();
     } finally {

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -257,9 +257,15 @@ class MemoryScreen extends Screen {
       // TODO(dantup): Push the relevant table.
       // For literlals, do nothing?
       // For other objects, push an InstanceDetails table?
-      // final Table<InstanceData> newTable =
-      //     row == null ? null : _createInstanceDetailsTableView(row);
-      // _pushNextTable(table, newTable);
+
+      // For testing purposes, the first row (id) will just push
+      // another table with another instance in (this is how references out may
+      // work?).
+      if (row.name == 'id') {
+        final Table<InstanceData> newTable =
+            row == null ? null : _createInstanceDetailsTableView(row.instance);
+        _pushNextTable(table, newTable);
+      }
     });
 
     // Kick off population of data for the table.
@@ -637,21 +643,22 @@ class InstanceSummary {
     // TODO(dantup): Replace with real implementation.
     await Future<void>.delayed(const Duration(milliseconds: 500));
     return <InstanceData>[
-      new InstanceData('id', id),
-      new InstanceData('name', 'Joe Bloggs'),
-      new InstanceData('email', 'something@example.org'),
-      new InstanceData('company', 'Bloggs Corp'),
-      new InstanceData('telephone', '01234 567 890'),
-      new InstanceData('shoeSize', 11),
+      new InstanceData(this, 'id', id),
+      new InstanceData(this, 'name', 'Joe Bloggs'),
+      new InstanceData(this, 'email', 'something@example.org'),
+      new InstanceData(this, 'company', 'Bloggs Corp'),
+      new InstanceData(this, 'telephone', '01234 567 890'),
+      new InstanceData(this, 'shoeSize', 11),
     ];
   }
 }
 
 class InstanceData {
+  InstanceSummary instance;
   String name;
   dynamic value;
 
-  InstanceData(this.name, this.value);
+  InstanceData(this.instance, this.name, this.value);
 
   @override
   String toString() => '[InstanceData name: $name, value: $value]';

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:html';
 import 'dart:math' as math;
 
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -67,7 +68,7 @@ class MemoryScreen extends Screen {
               div()..flex(),
             ])
         ]),
-      tableContainer = div(c: 'section')..layoutHorizontal()
+      tableContainer = div(c: 'section overflow-auto')..layoutHorizontal()
     ]);
 
     _pushNextTable(null, _createHeapStatsTableView());
@@ -96,6 +97,11 @@ class MemoryScreen extends Screen {
     if (next != null) {
       tableStack.addLast(next);
       tableContainer.add(next.element..clazz('margin-left'));
+      tableContainer.element.scrollTo(<String, dynamic>{
+        'left': tableContainer.element.scrollWidth,
+        'top': 0,
+        'behavior': 'smooth'
+      });
     }
   }
 
@@ -198,7 +204,8 @@ class MemoryScreen extends Screen {
   }
 
   Table<ClassHeapStats> _createHeapStatsTableView() {
-    final Table<ClassHeapStats> table = new Table<ClassHeapStats>.virtual();
+    final Table<ClassHeapStats> table = new Table<ClassHeapStats>.virtual()
+      ..element.clazz('memory-table');
 
     table.addColumn(new MemoryColumnSize());
     table.addColumn(new MemoryColumnInstanceCount());
@@ -216,7 +223,8 @@ class MemoryScreen extends Screen {
   }
 
   Table<InstanceSummary> _createInstanceListTableView(ClassHeapStats row) {
-    final Table<InstanceSummary> table = new Table<InstanceSummary>.virtual();
+    final Table<InstanceSummary> table = new Table<InstanceSummary>.virtual()
+      ..element.clazz('memory-table');
     table.addColumn(new MemoryColumnSimple<InstanceSummary>(
         'Instance ID', (InstanceSummary row) => row.id));
 
@@ -246,7 +254,8 @@ class MemoryScreen extends Screen {
   }
 
   Table<InstanceData> _createInstanceDetailsTableView(InstanceSummary row) {
-    final Table<InstanceData> table = new Table<InstanceData>.virtual();
+    final Table<InstanceData> table = new Table<InstanceData>.virtual()
+      ..element.clazz('memory-table');
     final Spinner spinner = table.element.add(new Spinner()..clazz('padded'));
     table.addColumn(new MemoryColumnSimple<InstanceData>(
         'Name', (InstanceData row) => row.name));
@@ -265,6 +274,8 @@ class MemoryScreen extends Screen {
         final Table<InstanceData> newTable =
             row == null ? null : _createInstanceDetailsTableView(row.instance);
         _pushNextTable(table, newTable);
+      } else {
+        _pushNextTable(table, null);
       }
     });
 

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:html';
 import 'dart:math' as math;
 
 import 'package:vm_service_lib/vm_service_lib.dart';

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -36,8 +36,7 @@ class MemoryScreen extends Screen {
 
   PButton loadSnapshotButton;
 
-  // TODO(dantup): Is it reasonable to put dynamic here?
-  ListQueue<Table<dynamic>> tableStack = ListQueue<Table<dynamic>>();
+  ListQueue<Table<Object>> tableStack = ListQueue<Table<Object>>();
   CoreElement tableContainer;
 
   MemoryChart memoryChart;

--- a/lib/ui/custom.dart
+++ b/lib/ui/custom.dart
@@ -35,3 +35,9 @@ class ProgressElement extends CoreElement {
     completeElement.element.style.width = '${(200 * _value / _max).round()}px';
   }
 }
+
+class Spinner extends CoreElement {
+  Spinner() : super('div') {
+    clazz('spinner');
+  }
+}

--- a/web/styles.css
+++ b/web/styles.css
@@ -381,6 +381,12 @@ div.tabnav {
     margin-bottom: 0;
 }
 
+.memory-table {
+    /* Just width doesn't work? */
+    max-width: 500px;
+    min-width: 500px;
+}
+
 .timeline-frames {
     overflow-x: scroll;
     white-space: nowrap;

--- a/web/styles.css
+++ b/web/styles.css
@@ -508,3 +508,33 @@ div.tabnav-tab {
     border-top-left-radius: 0;
     border-bottom-left-radius: 0;
 }
+
+.spinner.padded {
+    margin: 5px;
+}
+
+.spinner {
+    display: inline-block;
+    width: 32px;
+    height: 32px;
+}
+.spinner:after {
+    content: " ";
+    display: block;
+    width: 23px;
+    height: 23px;
+    margin: 1px;
+    border-radius: 50%;
+    border: 3px solid #4078c0;
+    border-color: #4078c0 transparent #4078c0 transparent;
+    animation: spin 1.2s linear infinite;
+}
+@keyframes spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}
+  


### PR DESCRIPTION
@devoncarew This adds multiple tables to the Memory page that appear/disappear based on selection (hopefully this is what you were describing - see below).

Currently it has hard-coded data because I'm not sure how to get the data. I did wire it up to `_getInstances` in the VM then realised that it was supposed to be a snapshot (most things returned `Sentinel` fetching them live!).

I can see there's a `_loadHeapSnapshot` function but it's commented out, and it only seems to result in a byte array. Is there any info on how this works I can look at? And do we need to be concerned about it being fetched separately to `_getAllocationProfile` (su the results might not match perfectly)?

![screen shot 2018-09-19 at 3 02 04 pm](https://user-images.githubusercontent.com/1078012/45758269-2542ac00-bc1d-11e8-976a-0df37b6275c3.png)
![screen shot 2018-09-19 at 3 02 10 pm](https://user-images.githubusercontent.com/1078012/45758270-2542ac00-bc1d-11e8-80e2-befa783aee1a.png)
![screen shot 2018-09-19 at 3 02 15 pm](https://user-images.githubusercontent.com/1078012/45758274-2542ac00-bc1d-11e8-8966-5697517c7663.png)
