### PR TITLE
Support reversed tables for improved performance

### DIFF
--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -65,7 +65,7 @@ class LoggingScreen extends Screen {
   }
 
   CoreElement _createTableView() {
-    loggingTable = new Table<LogData>.virtual();
+    loggingTable = new Table<LogData>.virtual(isReversed: true);
 
     loggingTable.addColumn(new LogWhenColumn());
     loggingTable.addColumn(new LogKindColumn());
@@ -170,20 +170,14 @@ class LoggingScreen extends Screen {
 
   List<LogData> data = <LogData>[];
   void _log(LogData log) {
-    // Build a new list that has 1 item more (clamped at kMaxLogItemsLength)
-    // and insert this new item at the start, followed by the required number
-    // of items from the old data. This is faster than insert(0, log).
-    //
-    // If this turns out to be too slow, we can make it faster (saving around
-    // 30-40% of the time) by just .add()ing to the list and having a flag on
-    // the table to reverse data for rendering ([length-index] when reading data).
-    final int totalItems = (data.length + 1).clamp(0, kMaxLogItemsLength);
-    data = List<LogData>(totalItems)
-      ..[0] = log
-      ..setRange(1, totalItems, data);
+    // Insert the new item and clamped the list to kMaxLogItemsLength. The table
+    // is rendered reversed so new items are at the top but we can use .add() here
+    // which is must faster than inserting at the start of the list.
+    data.add(log);
+    data.length = data.length.clamp(0, kMaxLogItemsLength);
 
     if (visible && loggingTable != null) {
-      loggingTable.setRows(data, anchorAlternatingRowsToBottom: true);
+      loggingTable.setRows(data);
       _updateStatus();
     }
   }


### PR DESCRIPTION
The log table adds to the top (visually) but adding to the start of a list is expensive. This allows appending to the end (which is really fast when the list doesn't need to grow) and then just reverses when rendering.

However, it has a bug... We now truncate the new event off the end when the list hits the max number:

```dart
data.length = data.length.clamp(0, kMaxLogItemsLength);
```

@devoncarew It just occurred to me that our performance savings by not having to insert at the start of the list go out the window when we now need to remove an item from the start on every insertion!

So, as-is, this PR is a bit pointless. The only thing I can come up with is wrapping the list and allowing the start offset to float (eg. once we hit the max items, we just overwrite items and increase the "starting index" and wrap around). It's probably not too complicated to code (and could likely be wrapped up in a list class so the table can just index directly), but it does mean this code gets a little more complex to understand. Do you think it's worth the trade-off? (or do you have any other ideas?)