### PR TITLE
Cap "x events" label at the min bound and add a + to the end

### DIFF
--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -81,7 +81,10 @@ class LoggingScreen extends Screen {
 
   void _updateStatus() {
     final int count = loggingTable.rows.length;
-    logCountStatus.element.text = '${nf.format(count)} events';
+    final String label = count >= kMaxLogItemsLowerBound
+        ? '${nf.format(kMaxLogItemsLowerBound)}+'
+        : nf.format(count);
+    logCountStatus.element.text = '$label events';
   }
 
   @override


### PR DESCRIPTION
Will show "5000+" once it hits 5001 and then stay that way (while the number of actual events in the table will fluctuate between 5000 and 5500 as we batch-truncate the list).