### PR TITLE
updates to the logging view

### DIFF
--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -341,9 +341,9 @@ class _StdoutEventHandler {
       if (message == '\n') {
         loggingScreen._log(new LogData(
           buffer.kind,
-          buffer.details + message.replaceAll('\n', r'\n'),
+          buffer.details + message,
           buffer.timestamp,
-          summary: buffer.summary + message.replaceAll('\n', r'\n'),
+          summary: buffer.summary + message,
           isError: buffer.isError,
         ));
         buffer = null;
@@ -358,9 +358,6 @@ class _StdoutEventHandler {
     if (message.length > 200) {
       summary = message.substring(0, 200) + '…';
     }
-    summary = summary.replaceAll('\t', r'\t');
-    summary = summary.replaceAll('\r', r'\r');
-    summary = summary.replaceAll('\n', r'\n');
 
     final LogData data = new LogData(
       name,

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -219,14 +219,14 @@ class LoggingScreen extends Screen {
         });
       }
 
-      final bool logLevelError =
-          (level != null && level >= Level.SEVERE.value) ? true : false;
+      final bool isError =
+          level != null && level >= Level.SEVERE.value ? true : false;
 
       _log(new LogData(
         loggerName,
         details,
         e.timestamp,
-        isError: logLevelError,
+        isError: isError,
         summary: summary,
         detailsComputer: detailsComputer,
       ));

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -237,7 +237,7 @@ class Table<T> extends Object with SetStateMixin {
         _tbody.element.children.removeLast();
     }
     // Set the "after" spacer to the correct height to keep the scroll size
-    // correct for the number or rows to come after.
+    // correct for the number of rows to come after.
     final double spacerAfterHeight =
         (rows.length - lastRenderedRowExclusive) * rowHeight;
     _spacerAfterVisibleRows.height = '${spacerAfterHeight}px';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,10 +11,10 @@ dependencies:
   logging: ^0.11.0
   meta: ^1.1.0
   path: ^1.6.0
-  vm_service_lib: ^0.3.9
+  vm_service_lib: ^0.3.9+1
 
 dev_dependencies:
-  build_runner: any
+  build_runner: '>=0.8.10 <0.11.0'
   build_web_compilers: any
   test: ^1.0.0
   webdev: 0.2.4+1

--- a/web/styles.css
+++ b/web/styles.css
@@ -478,6 +478,11 @@ div.tabnav {
 }
 
 
+td.log-label-column {
+    text-align: right;
+    max-width: 148px;
+}
+
 .log-details {
     height: 126px;
     overflow-y: scroll;
@@ -528,6 +533,7 @@ div.tabnav-tab {
     width: 32px;
     height: 32px;
 }
+
 .spinner:after {
     content: " ";
     display: block;
@@ -539,6 +545,7 @@ div.tabnav-tab {
     border-color: #4078c0 transparent #4078c0 transparent;
     animation: spin 1.2s linear infinite;
 }
+
 @keyframes spin {
     0% {
         transform: rotate(0deg);
@@ -547,4 +554,3 @@ div.tabnav-tab {
         transform: rotate(360deg);
     }
 }
-  


### PR DESCRIPTION
- misc general improvements to the logging view
- allow for asynchronously calculated log entry details (for when we need to query the VM for more details)
- add a `clear all ` button to the log view
- when logging stdout text, delay 1ms to see if we get the newline associated with the current stdout message
- make sure the log kind column doesn't become too wide

@DanTup 