### PR TITLE
Table key events

### DIFF
--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -255,6 +255,9 @@ class Table<T> extends Object with SetStateMixin {
       firstRenderedRowInclusive: 0,
       lastRenderedRowExclusive: rows?.length ?? 0);
 
+  int _translateRowIndex(int index) =>
+      !isReversed ? index : (rows?.length ?? 0) - 1 - index;
+
   int _buildTableRows({
     @required int firstRenderedRowInclusive,
     @required int lastRenderedRowExclusive,
@@ -262,13 +265,10 @@ class Table<T> extends Object with SetStateMixin {
   }) {
     _tbody.element.children.remove(_dummyRowToForceAlternatingColor.element);
 
-    int translateRowIndex(int index) =>
-        !isReversed ? index : (rows?.length ?? 0) - 1 - index;
-
     // Enable the dummy row to fix alternating backgrounds when the first rendered
     // row (taking into account if we're reversing) index is an odd.
     final bool shouldOffsetRowColor =
-        translateRowIndex(firstRenderedRowInclusive) % 2 == 1;
+        _translateRowIndex(firstRenderedRowInclusive) % 2 == 1;
     if (shouldOffsetRowColor) {
       _tbody.element.children
           .insert(0, _dummyRowToForceAlternatingColor.element);
@@ -278,7 +278,7 @@ class Table<T> extends Object with SetStateMixin {
     for (int index = firstRenderedRowInclusive;
         index < lastRenderedRowExclusive;
         index++) {
-      final T row = rows[translateRowIndex(index)];
+      final T row = rows[_translateRowIndex(index)];
       final bool isReusableRow =
           currentRowIndex < _tbody.element.children.length;
       // Reuse a row if one already exists in the table.

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -29,7 +29,8 @@ class Table<T> extends Object with SetStateMixin {
   Column<T> _sortColumn;
   SortOrder _sortDirection;
 
-  CoreElement _table;
+  final CoreElement _table = new CoreElement('table')
+    ..clazz('full-width')
   CoreElement _thead;
   CoreElement _tbody;
 
@@ -48,19 +49,21 @@ class Table<T> extends Object with SetStateMixin {
       : element = div(a: 'flex', c: 'overflow-y table-border'),
         _isVirtual = false,
         isReversed = false {
-    _table = new CoreElement('table')..clazz('full-width');
-    element.add(_table);
+    _init();
   }
 
   Table.virtual({this.rowHeight = 29.0, this.isReversed = false})
       : element = div(a: 'flex', c: 'overflow-y table-border table-virtual'),
         _isVirtual = true {
-    _table = new CoreElement('table')..clazz('full-width');
-    element.add(_table);
+    _init();
     _spacerBeforeVisibleRows = new CoreElement('tr');
     _spacerAfterVisibleRows = new CoreElement('tr');
 
     element.onScroll.listen((_) => _scheduleRebuild());
+  }
+
+  void _init() {
+    element.add(_table);
   }
 
   Stream<T> get onSelect => _selectController.stream;

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -226,6 +226,7 @@ class CoreElement {
 
   Stream<MouseEvent> get onClick => element.onClick.where((_) => !disabled);
   Stream<Event> get onScroll => element.onScroll;
+  Stream<KeyboardEvent> get onKeyDown => element.onKeyDown;
 
   /// Subscribe to the [onClick] event stream with a no-arg handler.
   StreamSubscription<Event> click(void handle(), [void shiftHandle()]) {

--- a/test/tables_test.dart
+++ b/test/tables_test.dart
@@ -64,6 +64,34 @@ void main() {
       expect(rowNumber, lessThan(5));
     });
 
+    test('can selected by index', () async {
+      final Element tbody = table.element.element.querySelector('tbody');
+
+      table.selectByIndex(0);
+      // Ensure a single visible row is marked as selected.
+      expect(tbody.querySelectorAll('tr.selected'), hasLength(1));
+    });
+
+    test('can select an offscreen row then scroll it into view', () async {
+      final Element tbody = table.element.element.querySelector('tbody');
+
+      // Select a row that will be offscreen.
+      table.selectByIndex(500);
+      // Ensure there are no selected rows.
+      expect(tbody.querySelectorAll('tr.selected'), isEmpty);
+
+      // Scroll to approx row 500.
+      table.element.scrollTop = 29 * 500;
+
+      // Wait for two frames, to ensure that the onScroll fired and then we
+      // definitely rebuilt the table.
+      await window.animationFrame;
+      await window.animationFrame;
+
+      // Ensure there is now a single visible row marked as selected.
+      expect(tbody.querySelectorAll('tr.selected'), hasLength(1));
+    });
+
     test('render rows starting around 500 when scrolled down the page',
         () async {
       // Scroll to approx row 500.


### PR DESCRIPTION
This lets you use up/down cursor keys to move selections in the table. It tracks the selected index/object even if there's no HTML row representing it, so the selection will update even if the new row isn't rendered.

It doesn't do:

- Handle page up/page down/home/end (I've opened #37 to track)
- Automatically scroll the table when the new selection is offscreen (opened #38)