### PR TITLE
Keep the selected row centered when scrolling with keyboard

### DIFF
--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -419,7 +419,22 @@ class Table<T> extends Object with SetStateMixin {
     _select(row?.element, dataObject, newIndex);
 
     if (keepVisible) {
-      final double rowOffsetPixels = newIndex * rowHeight;
+      final double rowOffsetPixels =
+          (newIndex * rowHeight) + _thead.offsetHeight;
+      final int visibleStartOffsetPixels = element.scrollTop;
+      final int visibleEndOffsetPixels =
+          element.scrollTop + element.offsetHeight;
+      // If the row Offset is at least 1 row within the visible area, we don't need
+      // to scroll. We subtract an extra rowHeight from the end to allow for the height
+      // of the row itself.
+      final double allowedViewportStart = visibleStartOffsetPixels + rowHeight;
+      final double allowedViewportEnd = visibleEndOffsetPixels - rowHeight * 2;
+
+      if (rowOffsetPixels >= allowedViewportStart &&
+          rowOffsetPixels <= allowedViewportEnd) {
+        return;
+      }
+
       final double halfTableHeight = element.offsetHeight / 2;
       final int newScrollTop = (rowOffsetPixels - halfTableHeight)
           .round()

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -409,10 +409,25 @@ class Table<T> extends Object with SetStateMixin {
   /// and not necessarily for rows[] since it may be being rendered in reverse.
   /// This way, +1 will always move down the visible table.
   @visibleForTesting
-  void selectByIndex(int newIndex) {
+  void selectByIndex(int newIndex,
+      {bool keepVisible = true, String scrollBehavior = 'smooth'}) {
     final CoreElement row = _rowForIndex[newIndex];
     final T dataObject = data[_translateRowIndex(newIndex)];
     _select(row?.element, dataObject, newIndex);
+
+    if (keepVisible) {
+      final double rowOffsetPixels = newIndex * rowHeight;
+      final double halfTableHeight = element.offsetHeight / 2;
+      final int newScrollTop = (rowOffsetPixels - halfTableHeight)
+          .round()
+          .clamp(0, element.scrollHeight);
+
+      element.element.scrollTo(<String, dynamic>{
+        'left': 0,
+        'top': newScrollTop,
+        'behavior': scrollBehavior,
+      });
+    }
   }
 
   void _clearSelection() => _select(null, null, null);

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -408,6 +408,9 @@ class Table<T> extends Object with SetStateMixin {
   /// Selects by index. Note: This is index of the row as it's rendered
   /// and not necessarily for rows[] since it may be being rendered in reverse.
   /// This way, +1 will always move down the visible table.
+  /// scrollBehaviour is a string as defined for the HTML scrollTo() method
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo (eg.
+  /// `smooth`, `instance`, `auto`).
   @visibleForTesting
   void selectByIndex(int newIndex,
       {bool keepVisible = true, String scrollBehavior = 'smooth'}) {

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -212,6 +212,8 @@ class CoreElement {
     element.style.display = value;
   }
 
+  int get scrollHeight => element.scrollHeight;
+
   int get scrollTop => element.scrollTop;
 
   set scrollTop(int value) => element.scrollTop = value;

--- a/test/tables_test.dart
+++ b/test/tables_test.dart
@@ -76,7 +76,7 @@ void main() {
       final Element tbody = table.element.element.querySelector('tbody');
 
       // Select a row that will be offscreen.
-      table.selectByIndex(500);
+      table.selectByIndex(500, keepVisible: false);
       // Ensure there are no selected rows.
       expect(tbody.querySelectorAll('tr.selected'), isEmpty);
 
@@ -90,6 +90,24 @@ void main() {
 
       // Ensure there is now a single visible row marked as selected.
       expect(tbody.querySelectorAll('tr.selected'), hasLength(1));
+    });
+
+    test('scrolls to the selection automatically', () async {
+      final Element tbody = table.element.element.querySelector('tbody');
+
+      // Select a row that is offscreen.
+      table.selectByIndex(500, scrollBehavior: 'instant');
+
+      // Wait for two frames, to ensure that the onScroll fired and then we
+      // definitely rebuilt the table.
+      await window.animationFrame;
+      await window.animationFrame;
+
+      // Ensure there is now a single visible row marked as selected.
+      expect(tbody.querySelectorAll('tr.selected'), hasLength(1));
+      final int rowNumber = getApproximatelyFirstRenderedDataIndex(table);
+      expect(rowNumber, greaterThan(450));
+      expect(rowNumber, lessThan(550));
     });
 
     test('render rows starting around 500 when scrolled down the page',


### PR DESCRIPTION
+ tests.

Fixes #38.