### PR TITLE
Convert broadcast stream to single-subscriber for buffering

### DIFF
--- a/lib/service.dart
+++ b/lib/service.dart
@@ -16,7 +16,7 @@ Future<VmService> connect(
 
   ws.onOpen.listen((_) {
     final Stream<dynamic> inStream =
-        ws.onMessage.asyncMap<dynamic>((MessageEvent e) {
+        wrapStream(ws.onMessage).asyncMap<dynamic>((MessageEvent e) {
       if (e.data is String) {
         return e.data;
       } else {
@@ -195,4 +195,17 @@ class IsolateManager {
 
     return isolates.isEmpty ? null : isolates.first;
   }
+}
+
+/// Wraps a broadcast stream as a single-subscription stream to workaround
+/// events being dropped for DOM/WebSocker broadcast streams when paused
+/// (such as in an asyncMap).
+/// https://github.com/dart-lang/sdk/issues/34656
+Stream<T> wrapStream<T>(Stream<T> stream) {
+  final StreamController<T> controller = new StreamController<T>();
+  StreamSubscription<T> subscription;
+  controller.onListen =
+      () => subscription = stream.listen((T e) => controller.add(e));
+  controller.onCancel = () => subscription.cancel();
+  return controller.stream;
 }

--- a/lib/service.dart
+++ b/lib/service.dart
@@ -16,7 +16,8 @@ Future<VmService> connect(
 
   ws.onOpen.listen((_) {
     final Stream<dynamic> inStream =
-        wrapStream(ws.onMessage).asyncMap<dynamic>((MessageEvent e) {
+        convertBroadcastToSingleSubscriber(ws.onMessage)
+            .asyncMap<dynamic>((MessageEvent e) {
       if (e.data is String) {
         return e.data;
       } else {
@@ -198,10 +199,10 @@ class IsolateManager {
 }
 
 /// Wraps a broadcast stream as a single-subscription stream to workaround
-/// events being dropped for DOM/WebSocker broadcast streams when paused
+/// events being dropped for DOM/WebSocket broadcast streams when paused
 /// (such as in an asyncMap).
 /// https://github.com/dart-lang/sdk/issues/34656
-Stream<T> wrapStream<T>(Stream<T> stream) {
+Stream<T> convertBroadcastToSingleSubscriber<T>(Stream<T> stream) {
   final StreamController<T> controller = new StreamController<T>();
   StreamSubscription<T> subscription;
   controller.onListen =


### PR DESCRIPTION
When pausing/unpausing the websocket stream, messages are dropped. This creates a new stream that listens to the websocket stream and just relays messages (but messages will be buffered in the StreamController).

Fixes #34.