### PR TITLE
ctor ordering; fixed height for charts

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -27,9 +27,6 @@ import 'utils.dart';
 //       the UI on re-activate
 
 class PerfToolFramework extends Framework {
-  StatusItem isolateSelectStatus;
-  PSelect isolateSelect;
-
   PerfToolFramework() {
     setGlobal(ServiceConnectionManager, new ServiceConnectionManager());
 
@@ -43,6 +40,9 @@ class PerfToolFramework extends Framework {
 
     initTestingModel();
   }
+
+  StatusItem isolateSelectStatus;
+  PSelect isolateSelect;
 
   void initGlobalUI() {
     final CoreElement mainNav =

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -203,12 +203,12 @@ class PerformanceScreen extends Screen {
 }
 
 class CpuChart extends LineChart<CpuTracker> {
-  CoreElement usageLabel;
-
   CpuChart(CoreElement parent) : super(parent) {
     usageLabel = parent.add(div(c: 'perf-label'));
     usageLabel.element.style.right = '0';
   }
+
+  CoreElement usageLabel;
 
   @override
   void update(CpuTracker data) {

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -33,6 +33,7 @@ class Table<T> extends Object with SetStateMixin {
 
   final CoreElement element;
   final bool _isVirtual;
+
   // Whether to reverse the display of data. This is to allow appending data
   // to this.rows quickly (using .add()) while still supporting new data being
   // inserted at the top.
@@ -42,6 +43,7 @@ class Table<T> extends Object with SetStateMixin {
 
   List<Column<T>> columns = <Column<T>>[];
   List<T> data;
+
   int get rowCount => data?.length ?? 0;
 
   Column<T> _sortColumn;
@@ -451,10 +453,10 @@ class Table<T> extends Object with SetStateMixin {
 }
 
 abstract class Column<T> {
+  Column(this.title, {this.wide = false});
+
   final String title;
   final bool wide;
-
-  Column(this.title, {this.wide = false});
 
   String get cssClass => null;
 

--- a/lib/timeline/fps.dart
+++ b/lib/timeline/fps.dart
@@ -11,9 +11,6 @@ import '../charts/charts.dart';
 import '../ui/elements.dart';
 
 class FramesChart extends LineChart<FramesTracker> {
-  CoreElement fpsLabel;
-  CoreElement lastFrameLabel;
-
   FramesChart(CoreElement parent) : super(parent) {
     fpsLabel = parent.add(div(c: 'perf-label'));
     fpsLabel.element.style.left = '0';
@@ -26,6 +23,9 @@ class FramesChart extends LineChart<FramesTracker> {
     lastFrameLabel.element.style.bottom = null;
     lastFrameLabel.element.style.textAlign = '-webkit-right';
   }
+
+  CoreElement fpsLabel;
+  CoreElement lastFrameLabel;
 
   @override
   void update(FramesTracker data) {
@@ -84,13 +84,6 @@ class FramesChart extends LineChart<FramesTracker> {
 }
 
 class FramesTracker {
-  static const int kMaxFrames = 60;
-
-  VmService service;
-  final StreamController<Null> _changeController =
-      new StreamController<Null>.broadcast();
-  List<FrameInfo> samples = <FrameInfo>[];
-
   FramesTracker(this.service) {
     service.onExtensionEvent.listen((Event e) {
       if (e.extensionKind == 'Flutter.Frame') {
@@ -99,6 +92,13 @@ class FramesTracker {
       }
     });
   }
+
+  static const int kMaxFrames = 60;
+
+  VmService service;
+  final StreamController<Null> _changeController =
+      new StreamController<Null>.broadcast();
+  List<FrameInfo> samples = <FrameInfo>[];
 
   bool get hasConnection => service != null;
 
@@ -151,9 +151,9 @@ class FramesTracker {
 }
 
 class FrameInfo {
-  static const double kTargetMaxFrameTimeMs = 1000.0 / 60;
-
   FrameInfo(this.number, this.elapsedMs, this.startTimeMs);
+
+  static const double kTargetMaxFrameTimeMs = 1000.0 / 60;
 
   static FrameInfo from(Map<dynamic, dynamic> data) {
     return new FrameInfo(

--- a/test/tables_test.dart
+++ b/test/tables_test.dart
@@ -122,8 +122,9 @@ int getApproximatelyFirstRenderedDataIndex(Table<TestData> table) {
 }
 
 class TestData {
-  String message;
   TestData(this.message);
+
+  final String message;
 }
 
 class TestColumn extends Column<TestData> {


### PR DESCRIPTION
A few different changes in here:

- fix the chart heights to 98px; we'd previously relied on calculating it on first layout, but that could occasionally yield inconsistent heights (fix https://github.com/flutter/devtools/issues/31)
- re-order some ctor declarations to address a lint
- add a dispose method to the Chart abstract class to better call out that it registers a global listener

@DanTup 