### PR TITLE
Use overflow-anchor as a better fix for scrolling behaviour

### DIFF
--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -205,13 +205,6 @@ class Table<T> extends Object with SetStateMixin {
   }
 
   void _rebuildVirtualTable() {
-    // When we modify the height of the spacer above the viewport, Chrome automatically
-    // adjusts the scrollTop to compensate because it's trying to keep the same content
-    // visible to the user. However, since we're overwriting the rows contents (shifting
-    // the data in the rows) we want to retain the original scroll position so must stash
-    // it and reset it later.
-    final int originalScrollTop = element.scrollTop;
-
     int firstRenderedRowInclusive = 0;
     int lastRenderedRowExclusive = rows?.length ?? 0;
 
@@ -273,10 +266,6 @@ class Table<T> extends Object with SetStateMixin {
         (rows.length - lastRenderedRowExclusive) * rowHeight;
     _spacerAfterVisibleRows.height = '${spacerAfterHeight}px';
     _tbody.element.children.add(_spacerAfterVisibleRows.element);
-
-    // Restore the scroll position the user had scrolled to since Chrome may
-    // have modified it after we changed the height of the "before" spacer.
-    element.scrollTop = originalScrollTop;
   }
 
   void _rebuildStaticTable() => _buildTableRows(

--- a/web/styles.css
+++ b/web/styles.css
@@ -112,6 +112,10 @@ span.label.gc {
     background-color: #424242;
 }
 
+.table-virtual {
+    overflow-anchor: none;
+}
+
 .table-virtual td {
     max-width: 500px; /* required for text-overflow to work? */
     overflow: hidden;


### PR DESCRIPTION
Some browsers (Chrome definitely) try to stop the visible portion of the page moving when there are DOM changes above/below. This messed with our virtual table because while we were resizing the padding row at the top, it would scroll down by the same amount. I couldn't find a way to disable it so I put a hack in (keep track of the scrollTop and re-set it afterwards). This worked, but it actually messed with the programatic smooth scrolling because we'd end up re-setting it during the animation and the browser would then leave it as-is (so a long smooth scroll would stop after only a few pixels).

Turns out, there is a proper way to disable it, so this removes our hack and uses that.