### PR TITLE
Schedule rebuild immediately on scroll to avoid flicker.

### DIFF
--- a/lib/framework/framework.dart
+++ b/lib/framework/framework.dart
@@ -36,27 +36,22 @@ class Framework {
     assert(screen != null);
 
     final String search = window.location.search;
-    final String ref = search == null ? screen.ref : '${screen.ref}$search';
+    final String ref = search == null ? screen.ref : '$search${screen.ref}';
     window.history.pushState(null, screen.name, ref);
 
     load(screen);
   }
 
   void loadScreenFromLocation() {
-    // Look for an explicit path, otherwise re-direct to '/'
-    String path = window.location.pathname;
-
-    // Special case the development path.
-    if (path == '/devtools/web/index.html' || path == '/index.html') {
-      path = '/';
+    // Screens are identified by the hash as that works better with the webdev
+    // server.
+    String id = window.location.hash;
+    if (id.isNotEmpty) {
+      assert(id[0] == '#');
+      id = id.substring(1);
     }
-
-    final String first =
-        (path.startsWith('/') ? path.substring(1) : path).split('/').first;
-    Screen screen = getScreen(first.isEmpty ? path : first);
-    if (screen == null && path == '/') {
-      screen = screens.first;
-    }
+    Screen screen = getScreen(id);
+    screen ??= screens.first;
     if (screen != null) {
       load(screen);
     } else {
@@ -218,7 +213,7 @@ abstract class Screen {
 
   final List<StatusItem> statusItems = <StatusItem>[];
 
-  String get ref => id == '/' ? id : '/$id';
+  String get ref => id.isEmpty ? id : '#$id';
 
   bool get visible => _visible.value;
 

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 import 'dart:html';
+import 'dart:js';
 
 import 'package:devtools/framework/framework.dart';
 import 'package:meta/meta.dart';
@@ -28,7 +29,8 @@ class Table<T> extends Object with SetStateMixin {
     _spacerBeforeVisibleRows = new CoreElement('tr');
     _spacerAfterVisibleRows = new CoreElement('tr');
 
-    _visibilityObserver = new IntersectionObserver(_visibilityChange);
+    // TODO(jacobr): remove call to allowInterop once bug in dart:html is fixed.
+    _visibilityObserver = new IntersectionObserver(allowInterop(_visibilityChange));
     _visibilityObserver.observe(_spacerBeforeVisibleRows.element);
     _visibilityObserver.observe(_spacerAfterVisibleRows.element);
     element.onScroll.listen((_) => _rebuildTable());

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -29,7 +29,8 @@ class Table<T> extends Object with SetStateMixin {
     _spacerBeforeVisibleRows = new CoreElement('tr');
     _spacerAfterVisibleRows = new CoreElement('tr');
 
-    // TODO(jacobr): remove call to allowInterop once bug in dart:html is fixed.
+    // TODO(jacobr): remove call to allowInterop once
+    // https://github.com/dart-lang/sdk/issues/35484 is fixed.
     _visibilityObserver = new IntersectionObserver(allowInterop(_visibilityChange));
     _visibilityObserver.observe(_spacerBeforeVisibleRows.element);
     _visibilityObserver.observe(_spacerAfterVisibleRows.element);

--- a/lib/ui/elements.dart
+++ b/lib/ui/elements.dart
@@ -310,39 +310,3 @@ class TrustedHtmlTreeSanitizer implements NodeTreeSanitizer {
   @override
   void sanitizeTree(Node node) {}
 }
-
-abstract class CoreElementOwner {
-  CoreElement get element;
-}
-
-// TODO(dantup): Remove this (plus HasCoreElement above) when we methods on
-// CoreElement to handle add/remove from DOM.
-abstract class OnAddedToDomMixin implements CoreElementOwner {
-  bool isInDom = false;
-  MutationObserver observer;
-  final StreamController<void> _addedToDomController =
-      new StreamController<void>.broadcast();
-
-  Stream<void> get onAddedToDom {
-    // Set up an observer that can detect when this element is added to the DOM.
-    // TODO(dantup): Can mixins have anything like constructors?
-    if (observer == null) {
-      observer = new MutationObserver(
-          (List<dynamic> mutations, MutationObserver observer) {
-        if (document.body.contains(element.element) && !isInDom) {
-          isInDom = true;
-          _addedToDomController.add(null);
-        } else if (!document.body.contains(element.element) && isInDom) {
-          isInDom = false;
-        }
-      });
-
-      // Enable/disable the observer based on whether anyone is listening.
-      _addedToDomController.onListen =
-          () => observer.observe(document.body, childList: true, subtree: true);
-      _addedToDomController.onCancel = () => observer.disconnect();
-    }
-
-    return _addedToDomController.stream;
-  }
-}


### PR DESCRIPTION
Use visibility observers instead of guessing at when visibility changes.
Visibility observers are an almost magic bullet for infinite scrolling on the web so I was able to strip out the mutation observer and window sizing code.
Fixes bug when initially only 4 rows were drawn for the memory view on first load.

Fixes
https://github.com/flutter/devtools/issues/64

Fixes flicker part of
https://github.com/flutter/devtools/issues/25