### PR TITLE
fix an issue with the height of the performance charts

### DIFF
--- a/lib/charts/charts.dart
+++ b/lib/charts/charts.dart
@@ -10,14 +10,14 @@ import '../framework/framework.dart';
 import '../ui/elements.dart';
 
 abstract class LineChart<T> {
-  LineChart(this.parent) {
+  LineChart(this.parent, {String classes}) {
     parent.element.style.position = 'relative';
 
     _windowResizeSubscription =
         window.onResize.listen((Event e) => _updateSize());
     Timer.run(_updateSize);
 
-    chartElement = parent.add(div()
+    chartElement = parent.add(div(c: classes)
       ..layoutVertical()
       ..flex());
 

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -329,7 +329,7 @@ class MemoryColumnSimple<T> extends Column<T> {
 }
 
 class MemoryChart extends LineChart<MemoryTracker> {
-  MemoryChart(CoreElement parent) : super(parent) {
+  MemoryChart(CoreElement parent) : super(parent, classes: 'perf-chart') {
     processLabel = parent.add(div(c: 'perf-label'));
     processLabel.element.style.left = '0';
 

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -204,7 +204,7 @@ class PerformanceScreen extends Screen {
 }
 
 class CpuChart extends LineChart<CpuTracker> {
-  CpuChart(CoreElement parent) : super(parent) {
+  CpuChart(CoreElement parent) : super(parent, classes: 'perf-chart') {
     usageLabel = parent.add(div(c: 'perf-label'));
     usageLabel.element.style.right = '0';
   }

--- a/lib/timeline/fps.dart
+++ b/lib/timeline/fps.dart
@@ -12,7 +12,7 @@ import '../charts/charts.dart';
 import '../ui/elements.dart';
 
 class FramesChart extends LineChart<FramesTracker> {
-  FramesChart(CoreElement parent) : super(parent) {
+  FramesChart(CoreElement parent) : super(parent, classes: 'perf-chart') {
     fpsLabel = parent.add(div(c: 'perf-label'));
     fpsLabel.element.style.left = '0';
     fpsLabel.element.style.top = '0';


### PR DESCRIPTION
The performance charts (memory, timeline view, ...) would sometimes not size themselves properly; this PR associated a css style with them which sets the height to the same as the parent container (currently `100px`).