### PR TITLE
change package imports; add copyrights

### DIFF
--- a/lib/device/device.dart
+++ b/lib/device/device.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools/service_extensions.dart' as extensions;
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../service_extensions.dart' as extensions;
 import '../ui/elements.dart';
 import '../ui/ui_utils.dart';
 

--- a/lib/eval_on_dart_library.dart
+++ b/lib/eval_on_dart_library.dart
@@ -3,11 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:devtools/inspector/inspector_service.dart';
+
 import 'package:meta/meta.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'globals.dart';
+import 'inspector/inspector_service.dart';
 import 'vm_service_wrapper.dart';
 
 class EvalOnDartLibrary {

--- a/lib/framework/framework_core.dart
+++ b/lib/framework/framework_core.dart
@@ -1,9 +1,14 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:html' hide Screen;
-import 'package:devtools/globals.dart';
-import 'package:devtools/service.dart';
-import 'package:devtools/service_manager.dart';
-import 'package:devtools/vm_service_wrapper.dart';
+
+import '../globals.dart';
+import '../service.dart';
+import '../service_manager.dart';
+import '../vm_service_wrapper.dart';
 
 class FrameworkCore {
   static void init() {

--- a/lib/inspector/diagnostics_node.dart
+++ b/lib/inspector/diagnostics_node.dart
@@ -1,10 +1,15 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 
-import 'package:devtools/inspector/flutter_widget.dart';
-import 'package:devtools/inspector/inspector_service.dart';
-import 'package:devtools/ui/icons.dart';
-import 'package:devtools/utils.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
+
+import '../ui/icons.dart';
+import '../utils.dart';
+import 'flutter_widget.dart';
+import 'inspector_service.dart';
 
 /// The various priority levels used to filter which diagnostics are shown and
 /// omitted.
@@ -374,6 +379,7 @@ class DiagnosticsNode {
   }
 
   InspectorSourceLocation _creationLocation;
+
   InspectorSourceLocation get creationLocation {
     if (_creationLocation != null) {
       return _creationLocation;

--- a/lib/inspector/flutter_widget.dart
+++ b/lib/inspector/flutter_widget.dart
@@ -1,10 +1,15 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 library flutter_widget;
 
 import 'dart:convert';
 
-import 'package:devtools/ui/icons.dart';
-import 'package:devtools/utils.dart';
 import 'package:http/http.dart';
+
+import '../ui/icons.dart';
+import '../utils.dart';
 
 class Category {
   const Category(this.label, this.icon);

--- a/lib/inspector/inspector_service.dart
+++ b/lib/inspector/inspector_service.dart
@@ -1,13 +1,17 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:devtools/inspector/diagnostics_node.dart';
-import 'package:devtools/inspector/flutter_widget.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../eval_on_dart_library.dart';
 import '../globals.dart';
+import 'diagnostics_node.dart';
+import 'flutter_widget.dart';
 
 /// Manages communication between inspector code running in the Flutter app and
 /// the inspector.
@@ -239,6 +243,7 @@ class ObjectGroup {
   bool disposed;
 
   EvalOnDartLibrary get inspectorLibrary => inspectorService.inspectorLibrary;
+
   bool get useDaemonApi => inspectorService.useDaemonApi;
 
   /// Once an ObjectGroup has been disposed, all methods returning

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:devtools/vm_service_wrapper.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
@@ -16,6 +15,7 @@ import '../timeline/fps.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../utils.dart';
+import '../vm_service_wrapper.dart';
 
 // TODO(devoncarew): filtering, and enabling additional logging
 

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:math' as math;
 
-import 'package:devtools/vm_service_wrapper.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../charts/charts.dart';
@@ -17,6 +16,7 @@ import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../utils.dart';
+import '../vm_service_wrapper.dart';
 
 // TODO(devoncarew): expose _getAllocationProfile
 

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -12,12 +12,12 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js' as js;
 
-import 'package:devtools/main.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../debugger/debugger.dart';
 import '../framework/framework.dart';
 import '../logging/logging.dart';
+import '../main.dart';
 
 // TODO(devoncarew): Only enable logging after enabled by the client.
 
@@ -45,7 +45,8 @@ class App {
     _register<List<String>>(
         'debugger.getCallStackFrames', debuggerGetCallStackFrames);
     _register<List<String>>('debugger.getVariables', debuggerGetVariables);
-    _register<String>('debugger.getConsoleContents', debuggerGetConsoleContents);
+    _register<String>(
+        'debugger.getConsoleContents', debuggerGetConsoleContents);
   }
 
   static void register(PerfToolFramework framework) {

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:devtools/vm_service_wrapper.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../charts/charts.dart';
@@ -15,6 +14,7 @@ import '../tables.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../utils.dart';
+import '../vm_service_wrapper.dart';
 
 class PerformanceScreen extends Screen {
   PerformanceScreen()

--- a/lib/tables.dart
+++ b/lib/tables.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:js';
 
-import 'package:devtools/framework/framework.dart';
 import 'package:meta/meta.dart';
 
+import 'framework/framework.dart';
 import 'ui/elements.dart';
 import 'utils.dart';
 
@@ -31,7 +31,8 @@ class Table<T> extends Object with SetStateMixin {
 
     // TODO(jacobr): remove call to allowInterop once
     // https://github.com/dart-lang/sdk/issues/35484 is fixed.
-    _visibilityObserver = new IntersectionObserver(allowInterop(_visibilityChange));
+    _visibilityObserver =
+        new IntersectionObserver(allowInterop(_visibilityChange));
     _visibilityObserver.observe(_spacerBeforeVisibleRows.element);
     _visibilityObserver.observe(_spacerAfterVisibleRows.element);
     element.onScroll.listen((_) => _rebuildTable());

--- a/lib/timeline/fps.dart
+++ b/lib/timeline/fps.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:devtools/vm_service_wrapper.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../charts/charts.dart';
 import '../ui/elements.dart';
+import '../vm_service_wrapper.dart';
 
 class FramesChart extends LineChart<FramesTracker> {
   FramesChart(CoreElement parent) : super(parent) {

--- a/lib/timeline/timeline.dart
+++ b/lib/timeline/timeline.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:devtools/service_extensions.dart' as extensions;
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../service_extensions.dart' as extensions;
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';

--- a/lib/vm_service_wrapper.dart
+++ b/lib/vm_service_wrapper.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 class VmServiceWrapper implements VmService {

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -1,3 +1,7 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 @TestOn('vm')
 import 'dart:async';
 import 'dart:io';

--- a/test/support/cli_test_driver.dart
+++ b/test/support/cli_test_driver.dart
@@ -1,3 +1,7 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';


### PR DESCRIPTION
- use relative self-reference imports in lib/
- sort imports in some files
- add copyright headers

We were using both relative self-references in this project and package: self-references. We'll want to stick with one style or the other, in order to avoid issues with the same library being loaded twice, and appearing as two different libraries.