### PR TITLE
fix an issue with the svg heights

### DIFF
--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -368,7 +368,7 @@ class MemoryChart extends LineChart<MemoryTracker> {
     // TODO(devoncarew): draw dots for GC events?
 
     chartElement.setInnerHtml('''
-            <svg viewBox="0 0 ${dim.x} ${dim.y}">
+            <svg viewBox="0 0 ${dim.x} ${LineChart.fixedHeight}">
             <polyline
                 fill="none"
                 stroke="#0074d9"

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -226,7 +226,7 @@ class CpuChart extends LineChart<CpuTracker> {
     const int vRange = 100;
 
     chartElement.setInnerHtml('''
-<svg viewBox="0 0 0 0 ${dim.x} ${dim.y}">
+<svg viewBox="0 0 0 0 ${dim.x} ${LineChart.fixedHeight}">
 <polyline
     fill="none"
     stroke="#0074d9"

--- a/lib/timeline/fps.dart
+++ b/lib/timeline/fps.dart
@@ -77,7 +77,7 @@ class FramesChart extends LineChart<FramesTracker> {
     }
 
     chartElement.setInnerHtml('''
-     <svg viewBox="0 0 ${dim.x} ${dim.y}">
+     <svg viewBox="0 0 ${dim.x} ${LineChart.fixedHeight}">
      ${svgElements.join('\n')}
      </svg>
      ''');


### PR DESCRIPTION
- fix an issue with the svg heights

The SVG containers are constrained to 100px high; the svg elements itself needs to be that high, less 2 pixels for the top and bottom borders. Here we use the hard-coded `LineChart.fixedHeight` 98px value; we could also use the calculated height (`dim.y`) and subtract 2 for the borders.

@jacob314 @kenzieschmoll 