### PR TITLE
use a non-animating icon for 'track widget rebuilds'

### DIFF
--- a/lib/service_extensions.dart
+++ b/lib/service_extensions.dart
@@ -74,7 +74,7 @@ const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.profileWidgetBuilds',
   description: 'Track widget rebuilds',
   tooltip: 'Visualize widget rebuilds',
-  icon: FlutterIcons.greyProgress,
+  icon: FlutterIcons.greyProgr,
   enabledValue: true,
   disabledValue: false,
 );

--- a/lib/ui/icons.dart
+++ b/lib/ui/icons.dart
@@ -114,6 +114,8 @@ class FlutterIcons {
   static const Icon extractMethod =
       UrlIcon('/icons/preview/extract_method.png');
 
+
+  static const Icon greyProgr = UrlIcon('/icons/perf/GreyProgr@2x.png');
   static const Icon greyProgress = UrlIcon('/icons/perf/grey_progress.gif');
   static const Icon redProgress = UrlIcon('/icons/perf/red_progress.gif');
   static const Icon yellowProgress = UrlIcon('/icons/perf/yellow_progress.gif');

--- a/lib/ui/icons.dart
+++ b/lib/ui/icons.dart
@@ -115,7 +115,7 @@ class FlutterIcons {
       UrlIcon('/icons/preview/extract_method.png');
 
 
-  static const Icon greyProgr = UrlIcon('/icons/perf/GreyProgr@2x.png');
+  static const Icon greyProgr = UrlIcon('/icons/perf/GreyProgr.png');
   static const Icon greyProgress = UrlIcon('/icons/perf/grey_progress.gif');
   static const Icon redProgress = UrlIcon('/icons/perf/red_progress.gif');
   static const Icon yellowProgress = UrlIcon('/icons/perf/yellow_progress.gif');


### PR DESCRIPTION
- use a non-animating icon for 'track widget rebuilds'
- fix https://github.com/flutter/devtools/issues/102

<img width="206" alt="screen shot 2019-01-12 at 12 21 12 pm" src="https://user-images.githubusercontent.com/1269969/51078070-94c52700-1664-11e9-8b1c-364da7bd109c.png">
