### PR TITLE
Update event listener to reflect latest changes in package/flutter.

### DIFF
--- a/lib/service_manager.dart
+++ b/lib/service_manager.dart
@@ -343,9 +343,8 @@ class ServiceExtensionManager {
       case 'Flutter.Frame':
         await _onFrameEventReceived();
         break;
-      case 'Flutter.ServiceExtensionChanged':
-        final String name =
-            'ext.flutter.${event.json['extensionData']['extension']}';
+      case 'Flutter.ServiceExtensionStateChanged':
+        final String name = event.json['extensionData']['extension'];
         final String valueFromJson = event.json['extensionData']['value'];
 
         final dynamic value = _getExtensionValueFromJson(name, valueFromJson);


### PR DESCRIPTION
Event sent in package flutter is now ServiceExtensionStateChanged instead of ServiceExtensionChanged. Also, the full extension name is being sent now so we do not need to add the prefix ourselves.