### PR TITLE
use package:pedantic

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,26 +1,16 @@
-# Specify analysis options.
-#
-# Until there are meta linter rules, each desired lint must be explicitly enabled.
-# See: https://github.com/dart-lang/linter/issues/288
-#
-# For a list of lints, see: http://dart-lang.github.io/linter/lints/
-# See the configuration guide for more
-# https://github.com/dart-lang/sdk/tree/master/pkg/analyzer#configuring-the-analyzer
-#
-# This file contains the analysis options used by Flutter tools, such as IntelliJ,
-# Android Studio, and the `flutter analyze` command.
+# Start with a base-line of the package:pedantic lints.
+include: package:pedantic/analysis_options.yaml
 
+# Override with more lints to closely match the flutter/flutter repo style.
 analyzer:
-  # strong-mode:
-  #   implicit-dynamic: false
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
     # treat missing returns as a warning (not a hint)
     missing_return: warning
   exclude:
-  - build/**
-  - test/fixtures/flutter_app
+    - build/**
+    - test/fixtures/flutter_app
 
 linter:
   rules:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,5 +1,5 @@
 # Start with a base-line of the package:pedantic lints.
-#include: package:pedantic/analysis_options.yaml
+include: package:pedantic/analysis_options.yaml
 
 analyzer:
   errors:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,6 @@
 # Start with a base-line of the package:pedantic lints.
-include: package:pedantic/analysis_options.yaml
+#include: package:pedantic/analysis_options.yaml
 
-# Override with more lints to closely match the flutter/flutter repo style.
 analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
@@ -14,6 +13,10 @@ analyzer:
 
 linter:
   rules:
+    # Added on top of the flutter/flutter lints:
+    - prefer_generic_function_type_aliases
+
+    # From flutter/flutter:
     # these rules are documented on and in the same order as
     # the Dart Lint rules page to make maintenance easier
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dev_dependencies:
   build_runner: 1.0.0
   build_test: any
   build_web_compilers: any
+  pedantic: ^1.0.0
   test: ^1.0.0
   webdev: 1.0.1
   webkit_inspection_protocol: ^0.3.6


### PR DESCRIPTION
- use `package:pedantic` as our base for analysis options; layer the flutter/flutter repo options on top

@pq 
