### PR TITLE
rev the service protocol lib version to capture a bug fix

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   meta: ^1.1.0
   path: ^1.6.0
   rxdart: ^0.20.0
-  vm_service_lib: ^0.3.10+1
+  vm_service_lib: ^0.3.10+2
 
 dev_dependencies:
   build_runner: 1.0.0


### PR DESCRIPTION
- rev the service protocol lib version to capture a bug fix

The VM can return invalid types for `Instance.closureContext`; this new version of the service protocol library does not try and deserialize that field.