### PR TITLE
refactor how we switch between pages

### DIFF
--- a/lib/debugger/debugger.dart
+++ b/lib/debugger/debugger.dart
@@ -59,7 +59,9 @@ class DebuggerScreen extends Screen {
   ConsoleArea consoleArea;
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
+  CoreElement createContent(Framework framework) {
+    final CoreElement screenDiv = div()..layoutVertical();
+
     CoreElement sourceArea;
     CoreElement consoleDiv;
 
@@ -109,7 +111,7 @@ class DebuggerScreen extends Screen {
     consoleArea = ConsoleArea();
     List<CoreElement> navEditorPanels;
 
-    mainDiv.add(<CoreElement>[
+    screenDiv.add(<CoreElement>[
       div(c: 'section')
         ..flex()
         ..layoutHorizontal()
@@ -292,6 +294,8 @@ class DebuggerScreen extends Screen {
     });
 
     consoleArea.refresh();
+
+    return screenDiv;
   }
 
   @override
@@ -302,17 +306,6 @@ class DebuggerScreen extends Screen {
 
     // TODO(devoncarew): On restoring the page, the execution point marker can
     // get out of position
-
-    sourceEditor.restoreScrollPosition();
-    consoleArea.restoreScrollPosition();
-  }
-
-  @override
-  void exiting() {
-    // Codemirror can loose the scroll position when being hidden and shown.
-    // We record and restore it here manually.
-    sourceEditor.saveScrollPosition();
-    consoleArea.saveScrollPosition();
   }
 
   void _initialize() {
@@ -835,7 +828,6 @@ class SourceEditor {
   Map<int, List<Breakpoint>> linesToBreakpoints = <int, List<Breakpoint>>{};
   int _currentLineClass;
   CoreElement _executionPointElement;
-  ScrollInfo _savedScrollInfo;
 
   void setBreakpoints(List<Breakpoint> breakpoints) {
     this.breakpoints = breakpoints;
@@ -985,17 +977,6 @@ class SourceEditor {
 
     _refreshMarkers();
   }
-
-  void saveScrollPosition() {
-    _savedScrollInfo = codeMirror.getScrollInfo();
-  }
-
-  void restoreScrollPosition() {
-    if (_savedScrollInfo != null) {
-      codeMirror.scrollTo(_savedScrollInfo.left, _savedScrollInfo.top);
-      _savedScrollInfo = null;
-    }
-  }
 }
 
 typedef URIDescriber = String Function(String uri);
@@ -1075,6 +1056,7 @@ class ScriptsView implements CoreElementView {
   SelectableList<ScriptRef> _items;
 
   String rootLib;
+
   List<ScriptRef> get items => _items.items;
 
   @override
@@ -1414,7 +1396,6 @@ class ConsoleArea implements CoreElementView {
 
   CoreElement _container;
   CodeMirror _editor;
-  ScrollInfo _savedScrollInfo;
 
   @override
   CoreElement get element => _container;
@@ -1447,16 +1428,5 @@ class ConsoleArea implements CoreElementView {
   @visibleForTesting
   String getContents() {
     return _editor.getDoc().getValue();
-  }
-
-  void saveScrollPosition() {
-    _savedScrollInfo = _editor.getScrollInfo();
-  }
-
-  void restoreScrollPosition() {
-    if (_savedScrollInfo != null) {
-      _editor.scrollTo(_savedScrollInfo.left, _savedScrollInfo.top);
-      _savedScrollInfo = null;
-    }
   }
 }

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -46,7 +46,9 @@ class LoggingScreen extends Screen {
   bool hasPendingDomUpdates = false;
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
+  CoreElement createContent(Framework framework) {
+    final CoreElement screenDiv = div()..layoutVertical();
+
     this.framework = framework;
 
     // TODO(devoncarew): Add checkbox toggles to enable specific logging channels.
@@ -54,7 +56,7 @@ class LoggingScreen extends Screen {
     LogDetailsUI logDetailsUI;
     CoreElement detailsDiv;
 
-    mainDiv.add(<CoreElement>[
+    screenDiv.add(<CoreElement>[
       div(c: 'section')
         ..add(<CoreElement>[
           form()
@@ -92,6 +94,8 @@ class LoggingScreen extends Screen {
     loggingTable.onRowsChanged.listen((_) {
       _updateStatus();
     });
+
+    return screenDiv;
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -122,7 +122,7 @@ class NotFoundScreen extends Screen {
   NotFoundScreen() : super(name: 'Not Found', id: 'notfound');
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
-    mainDiv.add(p(text: 'Page not found: ${window.location.pathname}'));
+  CoreElement createContent(Framework framework) {
+    return p(text: 'Page not found: ${window.location.pathname}');
   }
 }

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -46,8 +46,10 @@ class MemoryScreen extends Screen {
   ProgressElement progressElement;
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
-    mainDiv.add(<CoreElement>[
+  CoreElement createContent(Framework framework) {
+    final CoreElement screenDiv = div()..layoutVertical();
+
+    screenDiv.add(<CoreElement>[
       createLiveChartArea(),
       div(c: 'section'),
       div(c: 'section')
@@ -84,6 +86,8 @@ class MemoryScreen extends Screen {
       _handleConnectionStart(serviceManager.service);
     }
     serviceManager.onConnectionClosed.listen(_handleConnectionStop);
+
+    return screenDiv;
   }
 
   void _pushNextTable(Table<dynamic> current, Table<dynamic> next) {

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -42,8 +42,10 @@ class PerformanceScreen extends Screen {
   CpuTracker cpuTracker;
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
-    mainDiv.add(<CoreElement>[
+  CoreElement createContent(Framework framework) {
+    final CoreElement screenDiv = div()..layoutVertical();
+
+    screenDiv.add(<CoreElement>[
       createLiveChartArea(),
       div(c: 'section'),
       div(c: 'section')
@@ -76,6 +78,8 @@ class PerformanceScreen extends Screen {
       _handleConnectionStart(serviceManager.service);
     }
     serviceManager.onConnectionClosed.listen(_handleConnectionStop);
+
+    return screenDiv;
   }
 
   void _handleIsolateChanged() {

--- a/lib/timeline/timeline.dart
+++ b/lib/timeline/timeline.dart
@@ -53,7 +53,9 @@ class TimelineScreen extends Screen {
   PButton resumeButton;
 
   @override
-  void createContent(Framework framework, CoreElement mainDiv) {
+  CoreElement createContent(Framework framework) {
+    final CoreElement screenDiv = div()..layoutVertical();
+
     FrameDetailsUI frameDetailsUI;
 
     final CoreElement upperButtonSection = div(c: 'section')
@@ -79,7 +81,7 @@ class TimelineScreen extends Screen {
       ..disabled = true
       ..click(_resumeRecording);
 
-    mainDiv.add(<CoreElement>[
+    screenDiv.add(<CoreElement>[
       upperButtonSection,
       div(c: 'section'),
       createLiveChartArea(),
@@ -116,6 +118,8 @@ class TimelineScreen extends Screen {
         frameDetailsUI.updateData(data);
       }
     });
+
+    return screenDiv;
   }
 
   CoreElement createLiveChartArea() {

--- a/web/index.html
+++ b/web/index.html
@@ -22,10 +22,12 @@
     <link rel="stylesheet" href="packages/devtools/debugger/debugger.css">
     <link rel="stylesheet" href="packages/devtools/inspector/inspector.css">
     <link rel="stylesheet" href="packages/devtools/logging/logging.css">
+
     <link href="packages/codemirror/codemirror.css" rel="stylesheet">
     <script src="packages/codemirror/codemirror.js"></script>
 
     <script type="text/javascript" src="third_party/split/split.min.js"></script>
+
     <script defer src="main.dart.js"></script>
 </head>
 

--- a/web/styles.css
+++ b/web/styles.css
@@ -740,3 +740,8 @@ but a more subtle solution would be better.
     /* Support for IE. */
     font-feature-settings: 'liga';
 }
+
+html [full] {
+    height: 100%;
+    overflow: hidden;
+}


### PR DESCRIPTION
- refactor how we switch between pages
- fix https://github.com/flutter/devtools/issues/135

Instead of removing page contents from the DOM and adding them back when switching app screens, we set the page container to `display: none` and back again. This addresses problems with retaining some screen state, like scroll positions. We'll need to watch to see if we get hit in the future by having more DOM elements in the page.

Additionally, address a problem where we would get an exception thrown into the event loop if we connected to a CLI app and opened the inspector page.
