### PR TITLE
rename html title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Flutter DevTools
+# DevTools
 [![Build Status](https://travis-ci.org/flutter/devtools.svg?branch=master)](https://travis-ci.org/flutter/devtools)
 
 Performance tools for Flutter.

--- a/web/index.html
+++ b/web/index.html
@@ -12,7 +12,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-    <title>Flutter DevTools</title>
+    <title>DevTools</title>
     <link rel="shortcut icon" href="favicon.ico">
 
     <link rel="stylesheet" href="packages/devtools/ui/primer_6.0.0.css">
@@ -33,7 +33,7 @@
 
 <header flex none class="masthead">
     <div>
-        <a class="masthead-logo" id="title">Flutter DevTools</a>
+        <a class="masthead-logo" id="title">DevTools</a>
 
         <nav class="masthead-nav" id="main-nav">
             <!-- add the known pages -->


### PR DESCRIPTION
- rename `Flutter Devtools` ==> `Devtools`

We'll likely continue to iterate here, but this is a good, slightly less restrictive name for now.

<img width="362" alt="screen shot 2019-01-22 at 8 45 37 am" src="https://user-images.githubusercontent.com/1269969/51551041-7f998680-1e22-11e9-8275-90afe924afdd.png">
