### PR TITLE
Use FlutterTestEnvironment for tests.

### DIFF
--- a/test/frame_rendering_test.dart
+++ b/test/frame_rendering_test.dart
@@ -18,10 +18,10 @@ void main() {
     FramesTracker framesTracker;
 
     final FlutterTestEnvironment env = FlutterTestEnvironment(
-      FlutterRunConfiguration(withDebugger: true),
+      const FlutterRunConfiguration(withDebugger: true),
     );
 
-    env.afterSetup = () {
+    env.afterNewSetup = () {
       framesTracker = FramesTracker(env.service);
       framesTracker.start();
       expect(framesTracker.eventStreamSubscription, isNotNull);

--- a/test/inspector_controller_test.dart
+++ b/test/inspector_controller_test.dart
@@ -6,6 +6,9 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:meta/meta.dart';
+import 'package:test/test.dart';
+
 import 'package:devtools/globals.dart';
 import 'package:devtools/inspector/flutter_widget.dart';
 import 'package:devtools/inspector/inspector_controller.dart';
@@ -16,8 +19,6 @@ import 'package:devtools/ui/fake_flutter/fake_flutter.dart';
 import 'package:devtools/ui/flutter_html_shim.dart' as shim;
 import 'package:devtools/ui/icons.dart';
 import 'package:devtools/ui/material_icons.dart';
-import 'package:meta/meta.dart';
-import 'package:test/test.dart';
 
 import 'matchers/fake_flutter_matchers.dart';
 import 'matchers/matchers.dart';
@@ -324,6 +325,10 @@ void main() async {
   };
 
   group('inspector controller tests', () {
+    tearDownAll(() async {
+      await env.tearDownEnvironment(force: true);
+    });
+
     test('initial state', () async {
       await env.setupEnvironment();
 
@@ -528,7 +533,7 @@ void main() async {
       // TODO(jacobr): would be nice to have some tests that trigger a hot
       // reload that actually changes app state in a meaningful way.
 
-      await env.tearDownEnvironment(force: true);
+      await env.tearDownEnvironment();
     });
   }, tags: 'useFlutterSdk');
 }

--- a/test/inspector_service_test.dart
+++ b/test/inspector_service_test.dart
@@ -3,100 +3,71 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:async';
 import 'dart:io';
 
-import 'package:test/test.dart';
-
-import 'package:devtools/globals.dart';
 import 'package:devtools/inspector/diagnostics_node.dart';
 import 'package:devtools/inspector/flutter_widget.dart';
 import 'package:devtools/inspector/inspector_service.dart';
-import 'package:devtools/service_manager.dart';
-import 'package:devtools/vm_service_wrapper.dart';
+import 'package:test/test.dart';
 
 import 'matchers/fake_flutter_matchers.dart';
 import 'matchers/matchers.dart';
-import 'support/flutter_test_driver.dart';
+import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
+import 'support/flutter_test_environment.dart';
 
 /// Switch this flag to false to debug issues with non-atomic test behavior.
 bool reuseTestEnvironment = true;
 
-void main() {
-  bool widgetCreationTracked;
-  FlutterRunTestDriver _flutter;
-  VmServiceWrapper service;
+void main() async {
+  Catalog.setCatalog(
+      Catalog.decode(await File('web/widgets.json').readAsString()));
   InspectorService inspectorService;
 
-  Future<void> setupEnvironment(bool trackWidgetCreation) async {
-    if (trackWidgetCreation == widgetCreationTracked && reuseTestEnvironment) {
-      // Setting up the environment is slow so we reuse the existing environment
-      // when possible.
-      return;
-    }
-    widgetCreationTracked = trackWidgetCreation;
+  final FlutterTestEnvironment env = FlutterTestEnvironment(
+    const FlutterRunConfiguration(withDebugger: true),
+  );
 
-    Catalog.setCatalog(
-        Catalog.decode(await File('web/widgets.json').readAsString()));
-
-    _flutter = FlutterRunTestDriver(Directory('test/fixtures/flutter_app'));
-
-    await _flutter.run(
-      withDebugger: true,
-      trackWidgetCreation: trackWidgetCreation,
-    );
-    service = _flutter.vmService;
-
-    setGlobal(ServiceConnectionManager, ServiceConnectionManager());
-
-    await serviceManager.vmServiceOpened(service, Completer().future);
+  env.afterNewSetup = () async {
     await ensureInspectorServiceDependencies();
-    inspectorService = await InspectorService.create(service);
-    if (trackWidgetCreation) {
+    inspectorService = await InspectorService.create(env.service);
+    if (env.runConfig.trackWidgetCreation) {
       await inspectorService.inferPubRootDirectoryIfNeeded();
     }
-  }
+  };
 
-  Future<void> tearDownEnvironment({bool force = false}) async {
-    if (!force && reuseTestEnvironment) {
-      // Skip actually tearing down for better test performance.
-      return;
-    }
+  env.beforeTearDown = () {
     inspectorService.dispose();
     inspectorService = null;
-
-    await service.allFuturesCompleted.future;
-    await _flutter.stop();
-  }
+  };
 
   try {
     group('inspector service tests', () {
       test('track widget creation on', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('useDaemonApi', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
         expect(inspectorService.useDaemonApi, isTrue);
         // TODO(jacobr): add test where we trigger a breakpoint and verify that
         // the daemon api is now false.
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('hasServiceMethod', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
         expect(inspectorService.hasServiceMethod('someDummyName'), isFalse);
         expect(inspectorService.hasServiceMethod('getRootWidgetSummaryTree'),
             isTrue);
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('createObjectGroup', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
 
         final g1 = inspectorService.createObjectGroup('g1');
         final g2 = inspectorService.createObjectGroup('g2');
@@ -111,11 +82,11 @@ void main() {
         await g1Disposed;
         await g2Disposed;
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('infer pub root directories', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
         final group = inspectorService.createObjectGroup('test-group');
         // These tests are moot if widget creation is not tracked.
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
@@ -125,11 +96,11 @@ void main() {
         expect(rootDirectory, endsWith('/test/fixtures/flutter_app/lib'));
         await group.dispose();
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('widget tree', () async {
-        await setupEnvironment(true);
+        await env.setupEnvironment();
         final group = inspectorService.createObjectGroup('test-group');
         final RemoteDiagnosticsNode root =
             await group.getRoot(FlutterTreeType.widget);
@@ -228,11 +199,16 @@ void main() {
 
         await group.dispose();
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       test('render tree', () async {
-        await setupEnvironment(false);
+        await env.setupEnvironment(
+          config: const FlutterRunConfiguration(
+            withDebugger: true,
+            trackWidgetCreation: false,
+          ),
+        );
 
         final group = inspectorService.createObjectGroup('test-group');
         final RemoteDiagnosticsNode root =
@@ -283,17 +259,20 @@ void main() {
           ),
         );
 
-        await tearDownEnvironment();
+        await env.tearDownEnvironment();
       });
 
       // Run this test last as it will take a long time due to setting up the test
       // environment from scratch.
       test('track widget creation off', () async {
-        await setupEnvironment(false);
+        // trackwidgetCreation should still be set to false from the previous
+        // test case, so we do not need to specify trackWidgetCreation: false
+        // here.
+        await env.setupEnvironment();
 
         expect(await inspectorService.isWidgetCreationTracked(), isFalse);
 
-        await tearDownEnvironment(force: true);
+        await env.tearDownEnvironment(force: true);
       });
 
       // TODO(jacobr): add tests verifying that we can stop the running device

--- a/test/inspector_service_test.dart
+++ b/test/inspector_service_test.dart
@@ -5,10 +5,11 @@
 @TestOn('vm')
 import 'dart:io';
 
+import 'package:test/test.dart';
+
 import 'package:devtools/inspector/diagnostics_node.dart';
 import 'package:devtools/inspector/flutter_widget.dart';
 import 'package:devtools/inspector/inspector_service.dart';
-import 'package:test/test.dart';
 
 import 'matchers/fake_flutter_matchers.dart';
 import 'matchers/matchers.dart';
@@ -42,6 +43,10 @@ void main() async {
 
   try {
     group('inspector service tests', () {
+      tearDownAll(() async {
+        await env.tearDownEnvironment(force: true);
+      });
+
       test('track widget creation on', () async {
         await env.setupEnvironment();
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
@@ -265,14 +270,16 @@ void main() async {
       // Run this test last as it will take a long time due to setting up the test
       // environment from scratch.
       test('track widget creation off', () async {
-        // trackwidgetCreation should still be set to false from the previous
-        // test case, so we do not need to specify trackWidgetCreation: false
-        // here.
-        await env.setupEnvironment();
+        await env.setupEnvironment(
+          config: const FlutterRunConfiguration(
+            withDebugger: true,
+            trackWidgetCreation: false,
+          ),
+        );
 
         expect(await inspectorService.isWidgetCreationTracked(), isFalse);
 
-        await env.tearDownEnvironment(force: true);
+        await env.tearDownEnvironment();
       });
 
       // TODO(jacobr): add tests verifying that we can stop the running device

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -222,7 +222,7 @@ void main() {
     });
   }, tags: 'useFlutterSdk');
 
-  group('serviceManagerTests - restoring device-enabled extension for', () {
+  group('serviceManagerTests - restoring device-enabled extension:', () {
     FlutterRunTestDriver _flutter;
     String _flutterIsolateId;
     VmServiceWrapper service;

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -6,14 +6,15 @@
 import 'dart:async';
 import 'dart:io';
 
+import 'package:test/test.dart';
+import 'package:vm_service_lib/vm_service_lib.dart';
+
 import 'package:devtools/eval_on_dart_library.dart';
 import 'package:devtools/globals.dart';
 import 'package:devtools/service_extensions.dart' as extensions;
 import 'package:devtools/service_manager.dart';
 import 'package:devtools/service_registrations.dart' as registrations;
 import 'package:devtools/vm_service_wrapper.dart';
-import 'package:test/test.dart';
-import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'support/flutter_test_driver.dart';
 import 'support/flutter_test_environment.dart';
@@ -23,6 +24,10 @@ void main() {
     final FlutterTestEnvironment env = FlutterTestEnvironment(
       const FlutterRunConfiguration(withDebugger: true),
     );
+
+    tearDownAll(() async {
+      await env.tearDownEnvironment(force: true);
+    });
 
     test('vmServiceOpened', () async {
       await env.setupEnvironment();
@@ -218,7 +223,7 @@ void main() {
       expect(finalResult.runtimeType, equals(InstanceRef));
       expect(finalResult.valueAsString, equals('false'));
 
-      await env.tearDownEnvironment(force: true);
+      await env.tearDownEnvironment();
     });
   }, tags: 'useFlutterSdk');
 

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -16,30 +16,18 @@ import 'package:test/test.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'support/flutter_test_driver.dart';
+import 'support/flutter_test_environment.dart';
 
 void main() {
   group('serviceManagerTests', () {
-    FlutterRunTestDriver _flutter;
-    VmServiceWrapper service;
-
-    setUp(() async {
-      _flutter = FlutterRunTestDriver(Directory('test/fixtures/flutter_app'));
-
-      await _flutter.run(withDebugger: true);
-      service = _flutter.vmService;
-
-      setGlobal(ServiceConnectionManager, ServiceConnectionManager());
-
-      await serviceManager.vmServiceOpened(service, Completer().future);
-    });
-
-    tearDown(() async {
-      await service.allFuturesCompleted.future;
-      await _flutter.stop();
-    });
+    final FlutterTestEnvironment env = FlutterTestEnvironment(
+      const FlutterRunConfiguration(withDebugger: true),
+    );
 
     test('vmServiceOpened', () async {
-      expect(serviceManager.service, equals(service));
+      await env.setupEnvironment();
+
+      expect(serviceManager.service, equals(env.service));
       expect(serviceManager.isolateManager, isNotNull);
       expect(serviceManager.serviceExtensionManager, isNotNull);
       expect(serviceManager.isolateManager.isolates, isNotEmpty);
@@ -48,14 +36,18 @@ void main() {
         await serviceManager.isolateManager.onSelectedIsolateChanged
             .firstWhere((ref) => ref != null);
       }
+
+      await env.tearDownEnvironment();
     });
 
     test('toggle boolean service extension', () async {
+      await env.setupEnvironment();
+
       final extensionName = extensions.debugPaint.extension;
       const evalExpression = 'debugPaintSizeEnabled';
       final library = EvalOnDartLibrary(
         'package:flutter/src/rendering/debug.dart',
-        service,
+        env.service,
       );
 
       await _verifyExtensionStateOnTestDevice(evalExpression, 'false', library);
@@ -70,14 +62,18 @@ void main() {
 
       await _verifyExtensionStateOnTestDevice(evalExpression, 'true', library);
       await _verifyExtensionStateInServiceManager(extensionName, true, true);
+
+      await env.tearDownEnvironment();
     });
 
     test('toggle String service extension', () async {
+      await env.setupEnvironment();
+
       final extensionName = extensions.togglePlatformMode.extension;
       const evalExpression = 'defaultTargetPlatform.toString()';
       final library = EvalOnDartLibrary(
         'package:flutter/src/foundation/platform.dart',
-        service,
+        env.service,
       );
 
       await _verifyExtensionStateOnTestDevice(
@@ -100,14 +96,18 @@ void main() {
         library,
       );
       await _verifyExtensionStateInServiceManager(extensionName, true, 'iOS');
+
+      await env.tearDownEnvironment();
     });
 
     test('toggle numeric service extension', () async {
+      await env.setupEnvironment();
+
       final extensionName = extensions.slowAnimations.extension;
       const evalExpression = 'timeDilation';
       final library = EvalOnDartLibrary(
         'package:flutter/src/scheduler/binding.dart',
-        service,
+        env.service,
       );
 
       await _verifyExtensionStateOnTestDevice(evalExpression, '1.0', library);
@@ -122,9 +122,13 @@ void main() {
 
       await _verifyExtensionStateOnTestDevice(evalExpression, '5.0', library);
       await _verifyExtensionStateInServiceManager(extensionName, true, 5.0);
+
+      await env.tearDownEnvironment();
     });
 
     test('callService', () async {
+      await env.setupEnvironment();
+
       final registeredService = serviceManager
               .registeredMethodsForService[registrations.hotReload.service] ??
           const [];
@@ -134,9 +138,13 @@ void main() {
         registrations.hotReload.service,
         isolateId: serviceManager.isolateManager.selectedIsolate.id,
       );
+
+      await env.tearDownEnvironment();
     });
 
     test('callService throws exception', () async {
+      await env.setupEnvironment();
+
       // Service with less than 1 registration.
       expect(serviceManager.callService('fakeMethod'), throwsException);
 
@@ -144,9 +152,13 @@ void main() {
       serviceManager.registeredMethodsForService.putIfAbsent('fakeMethod',
           () => ['registration1.fakeMethod', 'registration2.fakeMethod']);
       expect(serviceManager.callService('fakeMethod'), throwsException);
+
+      await env.tearDownEnvironment();
     });
 
     test('callMulticastService', () async {
+      await env.setupEnvironment();
+
       final registeredService = serviceManager
               .registeredMethodsForService[registrations.hotReload.service] ??
           const [];
@@ -156,21 +168,33 @@ void main() {
         registrations.hotReload.service,
         isolateId: serviceManager.isolateManager.selectedIsolate.id,
       );
+
+      await env.tearDownEnvironment();
     });
 
     test('callMulticastService throws exception', () async {
+      await env.setupEnvironment();
+
       expect(serviceManager.callService('fakeMethod'), throwsException);
+
+      await env.tearDownEnvironment();
     });
 
     test('hotReload', () async {
+      await env.setupEnvironment();
+
       await serviceManager.performHotReload();
+
+      await env.tearDownEnvironment();
     });
 
     test('hotRestart', () async {
+      await env.setupEnvironment();
+
       const evalExpression = 'topLevelFieldForTest';
       final library = EvalOnDartLibrary(
         'package:flutter_app/main.dart',
-        service,
+        env.service,
       );
 
       // Verify topLevelFieldForTest is false initially.
@@ -193,22 +217,24 @@ void main() {
       final finalResult = await library.eval(evalExpression, isAlive: null);
       expect(finalResult.runtimeType, equals(InstanceRef));
       expect(finalResult.valueAsString, equals('false'));
+
+      await env.tearDownEnvironment(force: true);
     });
   }, tags: 'useFlutterSdk');
 
-  group('serviceManagerTests - restoring device-enabled extension:', () {
+  group('serviceManagerTests - restoring device-enabled extension for', () {
     FlutterRunTestDriver _flutter;
     String _flutterIsolateId;
     VmServiceWrapper service;
 
     setUp(() async {
-      setGlobal(ServiceConnectionManager, ServiceConnectionManager());
-
       _flutter = FlutterRunTestDriver(Directory('test/fixtures/flutter_app'));
-      await _flutter.run(withDebugger: true);
+      await _flutter.run(
+          runConfig: const FlutterRunConfiguration(withDebugger: true));
       _flutterIsolateId = await _flutter.getFlutterIsolateId();
 
       service = _flutter.vmService;
+      setGlobal(ServiceConnectionManager, ServiceConnectionManager());
     });
 
     tearDown(() async {
@@ -251,95 +277,81 @@ void main() {
       );
     }
 
-    /// Helper method to enable an extension on the test device, open the
-    /// vmService, and verify the enabled extension state is reflected by
-    /// [ServiceExtensionManager].
-    Future<void> _enableExtensionAndOpenVmService(
-      extensions.ToggleableServiceExtensionDescription extensionDescription,
-      Map<String, dynamic> args,
-      String evalExpression,
-      EvalOnDartLibrary library, {
-      String enabledValue,
-      String disabledValue,
-    }) async {
-      await _enableExtensionOnTestDevice(
-        extensionDescription,
-        args,
-        evalExpression,
-        library,
-        enabledValue: enabledValue,
-        disabledValue: disabledValue,
-      );
-
-      await serviceManager.vmServiceOpened(service, Completer().future);
-
-      await serviceManager
-          .serviceExtensionManager.extensionStatesUpdated.future;
-
-      await _verifyExtensionStateInServiceManager(
-        extensionDescription.extension,
-        true,
-        extensionDescription.enabledValue,
-      );
-    }
-
-    test('bool extension', () async {
-      const extensionDescription = extensions.debugPaint;
-      final args = {'enabled': true};
-      const evalExpression = 'debugPaintSizeEnabled';
-      final library = EvalOnDartLibrary(
+    test('all extension types', () async {
+      // Enable a boolean extension on the test device.
+      const boolExtensionDescription = extensions.debugPaint;
+      final boolArgs = {'enabled': true};
+      const boolEvalExpression = 'debugPaintSizeEnabled';
+      final boolLibrary = EvalOnDartLibrary(
         'package:flutter/src/rendering/debug.dart',
         service,
         isolateId: _flutterIsolateId,
       );
-
-      await _enableExtensionAndOpenVmService(
-        extensionDescription,
-        args,
-        evalExpression,
-        library,
+      await _enableExtensionOnTestDevice(
+        boolExtensionDescription,
+        boolArgs,
+        boolEvalExpression,
+        boolLibrary,
       );
-    });
 
-    test('String extension', () async {
-      const extensionDescription = extensions.togglePlatformMode;
-      final args = {'value': 'iOS'};
-      const evalExpression = 'defaultTargetPlatform.toString()';
-      final library = EvalOnDartLibrary(
+      // Enable a String extension on the test device.
+      const stringExtensionDescription = extensions.togglePlatformMode;
+      final stringArgs = {'value': 'iOS'};
+      const stringEvalExpression = 'defaultTargetPlatform.toString()';
+      final stringLibrary = EvalOnDartLibrary(
         'package:flutter/src/foundation/platform.dart',
         service,
         isolateId: _flutterIsolateId,
       );
-
-      await _enableExtensionAndOpenVmService(
-        extensionDescription,
-        args,
-        evalExpression,
-        library,
+      await _enableExtensionOnTestDevice(
+        stringExtensionDescription,
+        stringArgs,
+        stringEvalExpression,
+        stringLibrary,
         enabledValue: 'TargetPlatform.iOS',
         disabledValue: 'TargetPlatform.android',
       );
-    });
 
-    test('numeric extension', () async {
-      const extensionDescription = extensions.slowAnimations;
-      final args = {
-        extensionDescription.extension
-                .substring(extensionDescription.extension.lastIndexOf('.') + 1):
-            extensionDescription.enabledValue
+      // Enable a numeric extension on the test device.
+      const numericExtensionDescription = extensions.slowAnimations;
+      final numericArgs = {
+        numericExtensionDescription.extension
+            .substring(numericExtensionDescription.extension.lastIndexOf('.') + 1):
+        numericExtensionDescription.enabledValue
       };
-      const evalExpression = 'timeDilation';
-      final library = EvalOnDartLibrary(
+      const numericEvalExpression = 'timeDilation';
+      final numericLibrary = EvalOnDartLibrary(
         'package:flutter/src/scheduler/binding.dart',
         service,
         isolateId: _flutterIsolateId,
       );
+      await _enableExtensionOnTestDevice(
+        numericExtensionDescription,
+        numericArgs,
+        numericEvalExpression,
+        numericLibrary,
+      );
 
-      await _enableExtensionAndOpenVmService(
-        extensionDescription,
-        args,
-        evalExpression,
-        library,
+      // Open the VmService and verify that the enabled extension states are
+      // reflected in [ServiceExtensionManager].
+      await serviceManager.vmServiceOpened(service, Completer().future);
+      await serviceManager
+          .serviceExtensionManager.extensionStatesUpdated.future;
+
+      await _verifyExtensionStateInServiceManager(
+        boolExtensionDescription.extension,
+        true,
+        boolExtensionDescription.enabledValue,
+      );
+      await _verifyExtensionStateInServiceManager(
+        stringExtensionDescription.extension,
+        true,
+        stringExtensionDescription.enabledValue,
+      );
+      await _verifyExtensionStateInServiceManager(
+        numericExtensionDescription.extension,
+        true,
+        numericExtensionDescription.enabledValue,
       );
     });
   }, tags: 'useFlutterSdk');

--- a/test/support/flutter_test_driver.dart
+++ b/test/support/flutter_test_driver.dart
@@ -63,11 +63,10 @@ abstract class FlutterTestDriver {
 
   Future<void> _setupProcess(
     List<String> args, {
-    bool withDebugger = false,
-    bool pauseOnExceptions = false,
+    FlutterRunConfiguration runConfig = const FlutterRunConfiguration(),
     File pidFile,
   }) async {
-    if (withDebugger) {
+    if (runConfig.withDebugger) {
       args.add('--start-paused');
     }
     if (pidFile != null) {
@@ -256,57 +255,52 @@ class FlutterRunTestDriver extends FlutterTestDriver {
   String _currentRunningAppId;
 
   Future<void> run({
-    bool withDebugger = false,
-    bool pauseOnExceptions = false,
-    bool trackWidgetCreation = true,
+    FlutterRunConfiguration runConfig = const FlutterRunConfiguration(),
     File pidFile,
   }) async {
     final args = <String>[
       'run',
       '--machine',
     ];
-    if (trackWidgetCreation) {
+    if (runConfig.trackWidgetCreation) {
       args.add('--track-widget-creation');
     }
     args.addAll(['-d', 'flutter-tester']);
     await _setupProcess(
       args,
-      withDebugger: withDebugger,
-      pauseOnExceptions: pauseOnExceptions,
+      runConfig: runConfig,
       pidFile: pidFile,
     );
   }
 
   Future<void> attach(
     int port, {
-    bool withDebugger = false,
-    bool pauseOnExceptions = false,
+    FlutterRunConfiguration runConfig = const FlutterRunConfiguration(),
     File pidFile,
   }) async {
-    await _setupProcess(<String>[
-      'attach',
-      '--machine',
-      '-d',
-      'flutter-tester',
-      '--debug-port',
-      '$port',
-    ],
-        withDebugger: withDebugger,
-        pauseOnExceptions: pauseOnExceptions,
-        pidFile: pidFile);
+    await _setupProcess(
+      <String>[
+        'attach',
+        '--machine',
+        '-d',
+        'flutter-tester',
+        '--debug-port',
+        '$port',
+      ],
+      runConfig: runConfig,
+      pidFile: pidFile,
+    );
   }
 
   @override
   Future<void> _setupProcess(
     List<String> args, {
-    bool withDebugger = false,
-    bool pauseOnExceptions = false,
+    FlutterRunConfiguration runConfig = const FlutterRunConfiguration(),
     File pidFile,
   }) async {
     await super._setupProcess(
       args,
-      withDebugger: withDebugger,
-      pauseOnExceptions: pauseOnExceptions,
+      runConfig: runConfig,
       pidFile: pidFile,
     );
 
@@ -322,7 +316,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     final Future<Map<String, dynamic>> started =
         _waitFor(event: 'app.started', timeout: appStartTimeout);
 
-    if (withDebugger) {
+    if (runConfig.withDebugger) {
       final Map<String, dynamic> debugPort =
           await _waitFor(event: 'app.debugPort', timeout: appStartTimeout);
       final String wsUriString = debugPort['params']['wsUri'];
@@ -349,7 +343,7 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       // expected by tests. Tests will reload/restart as required if they need
       // to hit breakpoints, etc.
       await waitForPause();
-      if (pauseOnExceptions) {
+      if (runConfig.pauseOnExceptions) {
         await vmService.setExceptionPauseMode(
             await getFlutterIsolateId(), ExceptionPauseMode.kUnhandled);
       }
@@ -476,9 +470,8 @@ Stream<String> _transformToLines(Stream<List<int>> byteStream) {
       .transform<String>(const LineSplitter());
 }
 
-// TODO(kenzie): use FlutterRunConfiguration for run, attach, and _setupProcess.
 class FlutterRunConfiguration {
-  FlutterRunConfiguration({
+  const FlutterRunConfiguration({
     this.withDebugger = false,
     this.pauseOnExceptions = false,
     this.trackWidgetCreation = true,

--- a/test/support/flutter_test_environment.dart
+++ b/test/support/flutter_test_environment.dart
@@ -56,9 +56,14 @@ class FlutterTestEnvironment {
         _needsSetup ||
         !reuseTestEnvironment ||
         _isNewRunConfig(config)) {
-      _needsSetup = false;
+      // If we already have a running test device, stop it before setting up a
+      // new one.
+      if (_flutter != null) await tearDownEnvironment(force: true);
+
       // Update the run configuration if we have a new one.
       if (_isNewRunConfig(config)) _runConfig = config;
+
+      _needsSetup = false;
 
       _flutter = FlutterRunTestDriver(Directory(testAppDirectory));
       await _flutter.run(runConfig: _runConfig);

--- a/test/support/flutter_test_environment.dart
+++ b/test/support/flutter_test_environment.dart
@@ -12,30 +12,29 @@ import 'package:devtools/vm_service_wrapper.dart';
 
 import 'flutter_test_driver.dart';
 
-/// Switch this flag to false to debug issues with non-atomic test behavior.
-bool reuseTestEnvironment = true;
-
 class FlutterTestEnvironment {
   FlutterTestEnvironment(
     this._runConfig, {
     this.testAppDirectory = 'test/fixtures/flutter_app',
   });
 
-  final FlutterRunConfiguration _runConfig;
+  FlutterRunConfiguration _runConfig;
+  FlutterRunConfiguration get runConfig => _runConfig;
   final String testAppDirectory;
   FlutterRunTestDriver _flutter;
   FlutterRunTestDriver get flutter => _flutter;
   VmServiceWrapper _service;
   VmServiceWrapper get service => _service;
 
-  // This function will be called before creating and running the Flutter app.
-  VoidAsyncFunction _beforeSetup;
-  set beforeSetup(VoidAsyncFunction f) => _beforeSetup = f;
-
   // This function will be called after we have ran the Flutter app and the
   // vmService is opened.
-  VoidAsyncFunction _afterSetup;
-  set afterSetup(VoidAsyncFunction f) => _afterSetup = f;
+  VoidAsyncFunction _afterNewSetup;
+  set afterNewSetup(VoidAsyncFunction f) => _afterNewSetup = f;
+
+  // This function will be called for every call to [setupEnvironment], even
+  // when the setup is not forced or triggered by a new FlutterRunConfiguration.
+  VoidAsyncFunction _afterEverySetup;
+  set afterEverySetup(VoidAsyncFunction f) => _afterEverySetup = f;
 
   // The function will be called before tearing down the test and stopping the
   // Flutter app.
@@ -44,28 +43,33 @@ class FlutterTestEnvironment {
 
   bool _needsSetup = true;
 
-  Future<void> setupEnvironment({bool force = false}) async {
-    if (!force && !_needsSetup && reuseTestEnvironment) {
-      // Setting up the environment is slow so we reuse the existing environment
-      // when possible.
-      return;
+  // Switch this flag to false to debug issues with non-atomic test behavior.
+  bool reuseTestEnvironment = true;
+
+  Future<void> setupEnvironment({
+    bool force = false,
+    FlutterRunConfiguration config,
+  }) async {
+    // Setting up the environment is slow so we reuse the existing environment
+    // when possible.
+    if (force ||
+        _needsSetup ||
+        !reuseTestEnvironment ||
+        _isNewRunConfig(config)) {
+      _needsSetup = false;
+      // Update the run configuration if we have a new one.
+      if (_isNewRunConfig(config)) _runConfig = config;
+
+      _flutter = FlutterRunTestDriver(Directory(testAppDirectory));
+      await _flutter.run(runConfig: _runConfig);
+
+      _service = _flutter.vmService;
+      setGlobal(ServiceConnectionManager, ServiceConnectionManager());
+      await serviceManager.vmServiceOpened(_service, Completer().future);
+
+      if (_afterNewSetup != null) await _afterNewSetup();
     }
-    if (_beforeSetup != null) await _beforeSetup();
-
-    _flutter = FlutterRunTestDriver(Directory(testAppDirectory));
-    await _flutter.run(
-      withDebugger: _runConfig.withDebugger,
-      pauseOnExceptions: _runConfig.pauseOnExceptions,
-      trackWidgetCreation: _runConfig.trackWidgetCreation,
-    );
-
-    _service = _flutter.vmService;
-    setGlobal(ServiceConnectionManager, ServiceConnectionManager());
-    await serviceManager.vmServiceOpened(_service, Completer().future);
-
-    if (_afterSetup != null) await _afterSetup();
-
-    _needsSetup = false;
+    if (_afterEverySetup != null) await _afterEverySetup();
   }
 
   Future<void> tearDownEnvironment({bool force = false}) async {
@@ -73,11 +77,15 @@ class FlutterTestEnvironment {
       // Skip actually tearing down for better test performance.
       return;
     }
-    if (_beforeSetup != null) await _beforeTearDown();
+    if (_beforeTearDown != null) await _beforeTearDown();
 
     await _service.allFuturesCompleted.future;
     await _flutter.stop();
 
     _needsSetup = true;
+  }
+
+  bool _isNewRunConfig(FlutterRunConfiguration config) {
+    return config != null && config != _runConfig;
   }
 }


### PR DESCRIPTION
- Use FlutterTestEnvironment to setUp/tearDown tests only when necessary. Significantly shortens test time.
- Consolidate "serviceManagerTests - restoring device-enabled extensions" group into a single test to avoid unnecessary setUp/tearDown.
- Use FlutterRunConfiguration throughout flutter_test_driver.dart.