### PR TITLE
don't use the custom scrollbar for the debugger UI

### DIFF
--- a/lib/inspector/inspector.dart
+++ b/lib/inspector/inspector.dart
@@ -49,7 +49,7 @@ class InspectorScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    final CoreElement screenDiv = div()..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     final CoreElement buttonSection = div(c: 'section')
       ..layoutHorizontal()

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -47,7 +47,7 @@ class LoggingScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    final CoreElement screenDiv = div()..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     this.framework = framework;
 

--- a/lib/memory/memory.dart
+++ b/lib/memory/memory.dart
@@ -47,7 +47,7 @@ class MemoryScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    final CoreElement screenDiv = div()..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     screenDiv.add(<CoreElement>[
       createLiveChartArea(),

--- a/lib/performance/performance.dart
+++ b/lib/performance/performance.dart
@@ -43,7 +43,7 @@ class PerformanceScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    final CoreElement screenDiv = div()..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     screenDiv.add(<CoreElement>[
       createLiveChartArea(),

--- a/web/index.html
+++ b/web/index.html
@@ -44,10 +44,6 @@
     </div>
 </header>
 
-<div id="toolbar" layout horizontal>
-    <button class="btn btn-sm" type="button" disabled=""><span></span><span>Connect…</span></button>
-</div>
-
 <div id="error-container" class="container"></div>
 
 <div id="content" class="container" flex layout vertical style="overflow: auto;">

--- a/web/index.html
+++ b/web/index.html
@@ -42,6 +42,10 @@
     </div>
 </header>
 
+<div id="toolbar" layout horizontal>
+    <button class="btn btn-sm" type="button" disabled=""><span></span><span>Connect…</span></button>
+</div>
+
 <div id="error-container" class="container"></div>
 
 <div id="content" class="container" flex layout vertical style="overflow: auto;">
@@ -52,7 +56,7 @@
 
 <footer flex layout horizontal none class="footer align-items-center">
     <div class="footer-status" id="global-status" flex>
-        &nbsp;
+        <select class="form-select select-sm" disabled></select>
     </div>
 
     <div class="footer-status text-center" id="page-status" flex horiz-padding>

--- a/web/styles.css
+++ b/web/styles.css
@@ -663,8 +663,6 @@ manipulation in our table and ViewportCanvas code.
 Currently we overwrite the default to keep the scrollbars always visible
 but a more subtle solution would be better. */
 
-/* todo: set up most pages with this */
-
 .custom-scrollbar ::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 9px;

--- a/web/styles.css
+++ b/web/styles.css
@@ -22,6 +22,7 @@ body {
 
 .masthead {
     padding: 16px 20px;
+    margin-bottom: 20px;
     text-align: center;
     background-color: #4078c0;
 }
@@ -62,13 +63,6 @@ body {
 
 .masthead-nav .active {
     color: #fff;
-}
-
-#toolbar {
-    padding: 10px 30px;
-    margin-bottom: 10px;
-    color: #7a7a7a;
-    border-bottom: 1px solid #eee;
 }
 
 h2 {

--- a/web/styles.css
+++ b/web/styles.css
@@ -22,7 +22,6 @@ body {
 
 .masthead {
     padding: 16px 20px;
-    margin-bottom: 20px;
     text-align: center;
     background-color: #4078c0;
 }
@@ -63,6 +62,13 @@ body {
 
 .masthead-nav .active {
     color: #fff;
+}
+
+#toolbar {
+    padding: 10px 30px;
+    margin-bottom: 10px;
+    color: #7a7a7a;
+    border-bottom: 1px solid #eee;
 }
 
 h2 {
@@ -651,21 +657,21 @@ nav.menu li {
     color: #ccc;
 }
 
-/*
-We have to do something with the scrollbars as they flicker due to DOM
+/* We have to do something with the scrollbars as they flicker due to DOM
 manipulation in our table and ViewportCanvas code.
 
 Currently we overwrite the default to keep the scrollbars always visible
-but a more subtle solution would be better.
-*/
+but a more subtle solution would be better. */
 
-::-webkit-scrollbar {
+/* todo: set up most pages with this */
+
+.custom-scrollbar ::-webkit-scrollbar {
     -webkit-appearance: none;
     width: 9px;
     height: 9px;
 }
 
-::-webkit-scrollbar-thumb {
+.custom-scrollbar ::-webkit-scrollbar-thumb {
     border-radius: 4px;
     background-color: rgba(0,0,0,.5);
     box-shadow: 0 0 1px rgba(255,255,255,.5);


### PR DESCRIPTION
- don't use the custom scrollbar for the debugger UI (some of the nav areas on the left are small, and showing both horizontal and vertical scrollbars reduces available space)
