### PR TITLE
tweak the logging page's layout

### DIFF
--- a/lib/logging/logging.css
+++ b/lib/logging/logging.css
@@ -7,30 +7,13 @@ td.log-label-column {
     max-width: 148px;
 }
 
+.log-container {
+    overflow-y: hidden;
+}
+
 .log-details {
     overflow-y: scroll;
     overflow-wrap: break-word;
     padding-left: 5px;
     padding-right: 5px;
-}
-
-.logging-container {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    overflow: hidden;
-    margin-top: 10px;
-    align-items: center;
-    flex: 1 1 auto;
-    box-sizing: border-box;
-    flex-direction: row;
-}
-
-.logging-panel {
-    border: 1px solid #dfe2e5;
-    border-radius: 3px;
-    overflow-y: scroll;
-    scroll-behavior: smooth;
-    width: 100%;
-    height: 100%;
 }

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -76,7 +76,8 @@ class LoggingScreen extends Screen {
               span()..flex(),
             ])
         ]),
-      div(c: 'section')
+      div(c: 'section log-container')
+        ..flex()
         ..add(<CoreElement>[
           _createTableView()
             ..layoutHorizontal()
@@ -622,6 +623,12 @@ class LogDetailsUI extends CoreElement {
     this.data = data;
 
     tree = null;
+
+    if (data == null) {
+      message.text = '';
+      return;
+    }
+
     if (data.node != null) {
       message.clear();
       tree = InspectorTreeHtml(
@@ -649,11 +656,6 @@ class LogDetailsUI extends CoreElement {
       tree.root = root;
       message.add(tree.element);
 
-      return;
-    }
-
-    if (data == null) {
-      message.text = '';
       return;
     }
 


### PR DESCRIPTION
- tweak the logging page's layout; use the full area even w/o much content, and improve sizing when there is lots of content
- address an NPE (`data` can be null after calling 'clear logs')

@pq 