### PR TITLE
Fix tests.

### DIFF
--- a/lib/inspector/inspector_controller.dart
+++ b/lib/inspector/inspector_controller.dart
@@ -486,6 +486,7 @@ class InspectorController implements InspectorServiceClient {
   }
 
   Future<void> updateSelectionFromService() async {
+    final bool firstFrame = !treeLoadStarted;
     treeLoadStarted = true;
     _selectionGroups.cancelNext();
 
@@ -507,7 +508,8 @@ class InspectorController implements InspectorServiceClient {
         if (group.disposed) return;
       }
 
-      if (detailsSelection?.valueRef == details.selectedDiagnostic?.valueRef &&
+      if (!firstFrame &&
+          detailsSelection?.valueRef == details.selectedDiagnostic?.valueRef &&
           newSelection?.valueRef == selectedDiagnostic?.valueRef) {
         // No need to change the selection as it didn't actually change.
         _selectionGroups.cancelNext();

--- a/test/goldens/inspector_controller_initial_tree_with_styles.txt
+++ b/test/goldens/inspector_controller_initial_tree_with_styles.txt
@@ -1,4 +1,4 @@
-▼[[]<grayed> </grayed>root <grayed>]</grayed>
+▼[R]<grayed> </grayed>root <grayed>]</grayed>
   ▼[M]<grayed> </grayed>MyApp
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold

--- a/test/goldens/inspector_controller_selection_with_styles.txt
+++ b/test/goldens/inspector_controller_selection_with_styles.txt
@@ -1,4 +1,4 @@
-▼[[]<grayed> </grayed>root <grayed>]</grayed>
+▼[R]<grayed> </grayed>root <grayed>]</grayed>
   ▼[M]<grayed> </grayed>MyApp
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold

--- a/test/inspector_controller_test.dart
+++ b/test/inspector_controller_test.dart
@@ -339,7 +339,7 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[[] root ]\n'
+            '▼[R] root ]\n'
                 '  ▼[M] MyApp\n'
                 '    ▼[M] MaterialApp\n'
                 '      ▼[S] Scaffold\n'
@@ -365,7 +365,7 @@ void main() async {
       // select row index 5.
       tree.onTap(const Offset(0, rowHeight * 5.5));
       const textSelected = // Comment to make dartfmt behave.
-          '▼[[] root ]\n'
+          '▼[R] root ]\n'
           '  ▼[M] MyApp\n'
           '    ▼[M] MaterialApp\n'
           '      ▼[S] Scaffold\n'
@@ -436,7 +436,7 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[[] root ]\n'
+            '▼[R] root ]\n'
                 '  ▼[M] MyApp\n'
                 '    ▼[M] MaterialApp\n'
                 '      ▼[S] Scaffold <-- selected\n'
@@ -463,7 +463,7 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[[] root ]\n'
+            '▼[R] root ]\n'
                 '  ▼[M] MyApp\n'
                 '    ▼[M] MaterialApp\n'
                 '      ▼[S] Scaffold\n'
@@ -486,7 +486,7 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[[] root ]\n'
+            '▼[R] root ]\n'
                 '  ▼[M] MyApp\n'
                 '    ▼[M] MaterialApp\n'
                 '      ▼[S] Scaffold <-- selected\n'
@@ -524,7 +524,7 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[[] root ]\n'
+            '▼[R] root ]\n'
                 '  ▼[M] MyApp\n'
                 '    ▼[M] MaterialApp\n'
                 '      ▼[S] Scaffold\n'


### PR DESCRIPTION
Update goldens to match that the root widget is now correctly
identified as a Root widget 'R' instead
of a '[' widget.
This is due to using the widget class name instead of parsing the description.