### PR TITLE
Polish logging

### DIFF
--- a/lib/inspector/diagnostics_node.dart
+++ b/lib/inspector/diagnostics_node.dart
@@ -260,6 +260,8 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   /// Description if the property [value] is null.
   String get ifNull => getStringMember('ifNull');
 
+  bool get allowWrap => getBooleanMember('allowWrap', true);
+
   /// Optional tooltip typically describing the property.
   ///
   /// Example tooltip: 'physical pixels per logical pixel'

--- a/lib/inspector/inspector.css
+++ b/lib/inspector/inspector.css
@@ -2,9 +2,12 @@
 /* Use of this source code is governed by a BSD-style license that can be */
 /* found in the LICENSE file. */
 
-.inspector-tree {
+.inspector-tree-container {
     border: 1px solid #dfe2e5;
     border-radius: 3px;
+}
+
+.inspector-tree {
     overflow: scroll;
     scroll-behavior: smooth;
     width: 100%;
@@ -29,6 +32,11 @@
     .inspector-container {
         flex-direction: row;
     }
+}
+
+.inspector-no-wrap {
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .inspector-tree-row-content {

--- a/lib/inspector/inspector_tree_canvas.dart
+++ b/lib/inspector/inspector_tree_canvas.dart
@@ -218,7 +218,7 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
       onTap: onTap,
       onMouseMove: onMouseMove,
       onMouseLeave: onMouseLeave,
-      classes: 'inspector-tree',
+      classes: 'inspector-tree inspector-tree-container',
     );
   }
 

--- a/lib/inspector/inspector_tree_html.dart
+++ b/lib/inspector/inspector_tree_html.dart
@@ -84,11 +84,13 @@ class InspectorTreeNodeRenderHtmlBuilder
   InspectorTreeNodeRenderHtmlBuilder({
     @required DiagnosticLevel level,
     @required DiagnosticsTreeStyle treeStyle,
+    @required this.allowWrap,
   }) : super(level: level, treeStyle: treeStyle);
 
   TextStyle lastStyle;
   String font;
   String color;
+  final bool allowWrap;
   final List<HtmlPaintEntry> _entries = [];
 
   @override
@@ -114,10 +116,14 @@ class InspectorTreeNodeRenderHtmlBuilder
   @override
   InspectorTreeNodeHtmlRender build() {
     // The html renderer does not know what its size is.
-    return InspectorTreeNodeHtmlRender(_entries, const Size(0, 0), [
+    final classes = [
       'inspector-level-${diagnosticLevelToName[level]}',
       'inspector-style-${treeStyleToName[treeStyle]}',
-    ]);
+    ];
+    if (!allowWrap) {
+      classes.add('inspector-no-wrap');
+    }
+    return InspectorTreeNodeHtmlRender(_entries, const Size(0, 0), classes);
   }
 }
 
@@ -152,6 +158,7 @@ class InspectorTreeNodeHtml extends InspectorTreeNode {
     return InspectorTreeNodeRenderHtmlBuilder(
       level: diagnostic.level,
       treeStyle: diagnostic.style,
+      allowWrap: diagnostic.allowWrap
     );
   }
 }
@@ -164,7 +171,7 @@ class InspectorTreeHtml extends InspectorTree implements InspectorTreeWeb {
     VoidCallback onSelectionChange,
     TreeEventCallback onExpand,
     TreeEventCallback onHover,
-  })  : _container = div(c: 'inspector-tree'),
+  })  : _container = div(c: 'inspector-tree-html'),
         super(
           summaryTree: summaryTree,
           treeType: treeType,

--- a/lib/inspector/inspector_tree_html.dart
+++ b/lib/inspector/inspector_tree_html.dart
@@ -158,7 +158,7 @@ class InspectorTreeNodeHtml extends InspectorTreeNode {
     return InspectorTreeNodeRenderHtmlBuilder(
       level: diagnostic.level,
       treeStyle: diagnostic.style,
-      allowWrap: diagnostic.allowWrap
+      allowWrap: diagnostic.allowWrap,
     );
   }
 }

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -46,6 +46,7 @@ class LoggingScreen extends Screen {
   }
 
   Table<LogData> loggingTable;
+  LogDetailsUI logDetailsUI;
   StatusItem logCountStatus;
   SetStateMixin loggingStateMixin = SetStateMixin();
 
@@ -61,9 +62,6 @@ class LoggingScreen extends Screen {
 
     // TODO(devoncarew): Add checkbox toggles to enable specific logging channels.
 
-    LogDetailsUI logDetailsUI;
-    CoreElement detailsDiv;
-
     screenDiv.add(<CoreElement>[
       div(c: 'section')
         ..add(<CoreElement>[
@@ -76,22 +74,23 @@ class LoggingScreen extends Screen {
               span()..flex(),
             ])
         ]),
-      div(c: 'section')
+      div(c: 'section')..flex()
         ..add(<CoreElement>[
           _createTableView()
             ..layoutHorizontal()
             ..clazz('section')
             ..flex(),
-          detailsDiv = div(c: 'section table-border')
-            ..layoutHorizontal()
-            ..add(logDetailsUI = LogDetailsUI()),
+          logDetailsUI = LogDetailsUI(),
         ])
         ..layoutHorizontal(),
     ]);
 
+    // Needed otherwise the splitter is broken if the details view wants a
+    // larger width than expected. TODO(jacobr): find a cleaner solution.
+    logDetailsUI.element.style.width = '0';
     // configure the table / details splitter
     split.flexSplit(
-      [loggingTable.element, detailsDiv],
+      [loggingTable.element, logDetailsUI],
       gutterSize: defaultSplitterWidth,
       sizes: [60, 40],
       horizontal: true,
@@ -141,6 +140,7 @@ class LoggingScreen extends Screen {
 
   void _clear() {
     data.clear();
+    logDetailsUI?.setData(null);
     loggingTable.setRows(data);
   }
 
@@ -600,7 +600,7 @@ class LogDetailsUI extends CoreElement {
     flex();
 
     add(<CoreElement>[
-      content = div(c: 'log-details')
+      content = div(c: 'log-details table-border')
         ..flex()
         ..add(message = div(c: 'pre-wrap monospace')),
     ]);
@@ -622,6 +622,12 @@ class LogDetailsUI extends CoreElement {
     this.data = data;
 
     tree = null;
+
+    if (data == null) {
+      message.text = '';
+      return;
+    }
+
     if (data.node != null) {
       message.clear();
       tree = InspectorTreeHtml(
@@ -649,11 +655,6 @@ class LogDetailsUI extends CoreElement {
       tree.root = root;
       message.add(tree.element);
 
-      return;
-    }
-
-    if (data == null) {
-      message.text = '';
       return;
     }
 


### PR DESCRIPTION
Polish CSS for logging.
When rendering really wide html the existing view was busting the splitter due to CSS being CSS.
Don't really care so worked around it.

Added support for fixed width entries so the footer on overflow looks good.
Before:
<img width="1093" alt="screen shot 2019-01-22 at 7 51 52 pm" src="https://user-images.githubusercontent.com/1226812/51582282-3aa43d00-1e80-11e9-8a17-7a3f6c16ed38.png">
After:
<img width="1107" alt="screen shot 2019-01-22 at 7 57 09 pm" src="https://user-images.githubusercontent.com/1226812/51582290-409a1e00-1e80-11e9-9fb6-9ac59697c81c.png">

