### PR TITLE
ensure that longer logs layout well

### DIFF
--- a/lib/logging/logging.css
+++ b/lib/logging/logging.css
@@ -7,30 +7,13 @@ td.log-label-column {
     max-width: 148px;
 }
 
+.log-area {
+    overflow-y: hidden;
+}
+
 .log-details {
     overflow-y: scroll;
     overflow-wrap: break-word;
     padding-left: 5px;
     padding-right: 5px;
-}
-
-.logging-container {
-    height: 100%;
-    width: 100%;
-    display: flex;
-    overflow: hidden;
-    margin-top: 10px;
-    align-items: center;
-    flex: 1 1 auto;
-    box-sizing: border-box;
-    flex-direction: row;
-}
-
-.logging-panel {
-    border: 1px solid #dfe2e5;
-    border-radius: 3px;
-    overflow-y: scroll;
-    scroll-behavior: smooth;
-    width: 100%;
-    height: 100%;
 }

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -74,7 +74,7 @@ class LoggingScreen extends Screen {
               span()..flex(),
             ])
         ]),
-      div(c: 'section')..flex()
+      div(c: 'section log-area')..flex()
         ..add(<CoreElement>[
           _createTableView()
             ..layoutHorizontal()


### PR DESCRIPTION
- ensure that longer logs layout well (w/o this, when we have many log items, the logging table won't scroll, but instead grow longer than the screen)