### PR TITLE
 Refactor timeline code to use TimelineController

### DIFF
--- a/lib/timeline/frame_flame_chart.dart
+++ b/lib/timeline/frame_flame_chart.dart
@@ -71,7 +71,7 @@ class FrameFlameChart extends CoreElement {
 
     int maxRow = 0;
 
-    void _drawRecursively(TimelineThreadEvent event, int row) {
+    void drawRecursively(TimelineThreadEvent event, int row) {
       if (!event.wellFormed) {
         print('event not well formed: $event');
         return;
@@ -90,7 +90,7 @@ class FrameFlameChart extends CoreElement {
       }
 
       for (TimelineThreadEvent child in event.children) {
-        _drawRecursively(child, row + 1);
+        drawRecursively(child, row + 1);
       }
     }
 
@@ -102,7 +102,7 @@ class FrameFlameChart extends CoreElement {
         maxRow = row;
 
         for (TimelineThreadEvent event in data.eventsForThread(thread)) {
-          _drawRecursively(event, row);
+          drawRecursively(event, row);
         }
 
         row = maxRow;

--- a/lib/timeline/frame_flame_chart.dart
+++ b/lib/timeline/frame_flame_chart.dart
@@ -1,0 +1,127 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../ui/elements.dart';
+import '../ui/primer.dart';
+import 'timeline_protocol.dart';
+
+class FrameFlameChart extends CoreElement {
+  FrameFlameChart() : super('div') {
+    layoutVertical();
+    flex();
+
+    // TODO(devoncarew): listen to tab changes
+    content = div(c: 'frame-timeline')..flex();
+
+    final PTabNav tabNav = PTabNav(<PTabNavTab>[
+      PTabNavTab('Frame timeline'),
+      PTabNavTab('Widget build info'),
+      PTabNavTab('Skia picture'),
+    ]);
+
+    add(<CoreElement>[
+      tabNav,
+      content,
+    ]);
+
+    content.element.style.whiteSpace = 'pre';
+    content.element.style.overflow = 'scroll';
+  }
+
+  TimelineFrameData data;
+  CoreElement content;
+
+  void updateData(TimelineFrameData data) {
+    this.data = data;
+
+    content.clear();
+
+//    if (data != null) {
+//      StringBuffer buf = new StringBuffer();
+//
+//      for (TimelineThread thread in data.threads) {
+//        buf.writeln('${thread.name}:');
+//
+//        for (TEvent event in data.events) {
+//          if (event.threadId == thread.threadId) {
+//            event.format(buf, '  ');
+//          }
+//        }
+//      }
+//
+//      content.text = buf.toString();
+//    }
+
+    if (data != null) {
+      _render(data);
+    }
+  }
+
+  void _render(TimelineFrameData data) {
+    const int leftIndent = 130;
+    const int rowHeight = 25;
+
+    const double microsPerFrame = 1000 * 1000 / 60.0;
+    const double pxPerMicro = microsPerFrame / 1000.0;
+
+    int row = 0;
+
+    final int microsAdjust = data.frame.startMicros;
+
+    int maxRow = 0;
+
+    Function drawRecursively;
+
+    drawRecursively = (TimelineThreadEvent event, int row) {
+      if (!event.wellFormed) {
+        print('event not well formed: $event');
+        return;
+      }
+
+      final double start = (event.startMicros - microsAdjust) / pxPerMicro;
+      final double end =
+          (event.startMicros - microsAdjust + event.durationMicros) /
+              pxPerMicro;
+
+      _createPosition(event.name, leftIndent + start.round(),
+          (end - start).round(), row * rowHeight);
+
+      if (row > maxRow) {
+        maxRow = row;
+      }
+
+      for (TimelineThreadEvent child in event.children) {
+        drawRecursively(child, row + 1);
+      }
+    };
+
+    try {
+      for (TimelineThread thread in data.threads) {
+        _createPosition(thread.name, 0, null, row * rowHeight);
+
+        maxRow = row;
+
+        for (TimelineThreadEvent event in data.eventsForThread(thread)) {
+          drawRecursively(event, row);
+        }
+
+        row = maxRow;
+
+        row++;
+      }
+    } catch (e, st) {
+      print('$e\n$st');
+    }
+  }
+
+  void _createPosition(String name, int left, int width, int top) {
+    final CoreElement item = div(text: name, c: 'timeline-title');
+    item.element.style.left = '${left}px';
+    if (width != null) {
+      item.element.style.width = '${width}px';
+    }
+    item.element.style.top = '${top}px';
+    content.add(item);
+  }
+}

--- a/lib/timeline/timeline_controller.dart
+++ b/lib/timeline/timeline_controller.dart
@@ -1,0 +1,154 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'dart:async';
+
+import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
+
+import '../globals.dart';
+import 'timeline_protocol.dart';
+
+/// This class must not have direct dependencies on dart:html.
+///
+/// This allows tests of the complicated logic in this class to run on the VM
+/// and will help simplify porting this code to work with Hummingbird.
+class TimelineController {
+  // Frame data.
+  static const int maxFrames = 120;
+  List<TimelineFrame> frames = <TimelineFrame>[];
+  final StreamController<TimelineFrame> _frameAddedController =
+      StreamController<TimelineFrame>.broadcast();
+  Stream<TimelineFrame> get onFrameAdded => _frameAddedController.stream;
+  final StreamController<Null> _framesClearedController =
+      StreamController<Null>.broadcast();
+  Stream<Null> get onFramesCleared => _framesClearedController.stream;
+
+  // Timeline data.
+  List<TimelineThreadEvent> dartEvents = <TimelineThreadEvent>[];
+  List<TimelineThreadEvent> gpuEvents = <TimelineThreadEvent>[];
+
+  TimelineData _timelineData;
+  TimelineData get timelineData => _timelineData;
+
+  bool get hasStarted => timelineData != null;
+
+  bool _paused = false;
+  bool get paused => _paused;
+
+  void pause() {
+    _paused = true;
+
+    dartEvents.clear();
+    gpuEvents.clear();
+  }
+
+  void resume() {
+    _paused = false;
+  }
+
+  Future<void> startTimeline() async {
+    await serviceManager.service
+        .setVMTimelineFlags(<String>['GC', 'Dart', 'Embedder']);
+    await serviceManager.service.clearVMTimeline();
+
+    final Response response = await serviceManager.service.getVMTimeline();
+    final List<dynamic> list = response.json['traceEvents'];
+    final List<Map<String, dynamic>> traceEvents =
+        list.cast<Map<String, dynamic>>();
+
+    final List<TimelineEvent> events = traceEvents
+        .map((Map<String, dynamic> event) => TimelineEvent(event))
+        .where((TimelineEvent event) {
+      return event.name == 'thread_name';
+    }).toList();
+
+    final TimelineData timelineData = TimelineData();
+
+    for (TimelineEvent event in events) {
+      final TimelineThread thread =
+          TimelineThread(timelineData, event.args['name'], event.threadId);
+      // TODO(kenzie): once we have gpu/cpu distinction data from engine, only
+      // add the threads that contain those events.
+      timelineData.addThread(thread);
+    }
+
+    timelineData.onTimelineThreadEvent.listen((TimelineThreadEvent event) {
+      processTimelineEvent(timelineData.getThread(event.threadId), event);
+    });
+
+    _timelineData = timelineData;
+  }
+
+  void processTimelineEvent(TimelineThread thread, TimelineThreadEvent event) {
+    if (thread == null) {
+      return;
+    }
+
+    // io.flutter.1.ui, io.flutter.1.gpu
+    if (thread.name.endsWith('.ui')) {
+      // PipelineProduce
+      if (event.name == 'PipelineProduce' && event.wellFormed) {
+        dartEvents.add(event);
+
+        _processSamplesData();
+      }
+    } else if (thread.name.endsWith('.gpu')) {
+      // MessageLoop::RunExpiredTasks
+      if (event.name == 'MessageLoop::RunExpiredTasks' && event.wellFormed) {
+        gpuEvents.add(event);
+
+        _processSamplesData();
+      }
+    }
+  }
+
+  void _processSamplesData() {
+    while (dartEvents.isNotEmpty && gpuEvents.isNotEmpty) {
+      int dartStart = dartEvents.first.startMicros;
+
+      // Throw away any gpu samples that start before dart ones.
+      while (gpuEvents.isNotEmpty && gpuEvents.first.startMicros < dartStart) {
+        gpuEvents.removeAt(0);
+      }
+
+      if (gpuEvents.isEmpty) {
+        break;
+      }
+
+      // Find the newest dart sample that starts before a gpu one.
+      final int gpuStart = gpuEvents.first.startMicros;
+      while (dartEvents.length > 1 &&
+          (dartEvents[0].startMicros < gpuStart &&
+              dartEvents[1].startMicros < gpuStart)) {
+        dartEvents.removeAt(0);
+      }
+
+      if (dartEvents.isEmpty) {
+        break;
+      }
+
+      // Return the pair.
+      dartStart = dartEvents.first.startMicros;
+      if (dartStart > gpuStart) {
+        break;
+      }
+
+      final TimelineThreadEvent dartEvent = dartEvents.removeAt(0);
+      final TimelineThreadEvent gpuEvent = gpuEvents.removeAt(0);
+
+      final TimelineFrame frame = TimelineFrame(
+          renderStart: dartEvent.startMicros,
+          rasterizeStart: gpuEvent.startMicros);
+      frame.renderDuration = dartEvent.durationMicros;
+      frame.rasterizeDuration = gpuEvent.durationMicros;
+
+      frames.add(frame);
+
+      if (frames.length > maxFrames) {
+        frames.removeAt(0);
+      }
+
+      _frameAddedController.add(frame);
+    }
+  }
+}

--- a/lib/timeline/timeline_protocol.dart
+++ b/lib/timeline/timeline_protocol.dart
@@ -117,9 +117,6 @@ class TimelineThread implements Comparable<TimelineThread> {
 
   TimelineThreadEvent durationStack;
 
-  bool get isDartThread => _name == 'io.flutter.1.ui';
-  bool get isGpuThread => _name == 'io.flutter.1.gpu';
-
   final Map<String, TimelineThreadEvent> _asyncEvents =
       <String, TimelineThreadEvent>{};
 

--- a/lib/timeline/timeline_protocol.dart
+++ b/lib/timeline/timeline_protocol.dart
@@ -117,6 +117,9 @@ class TimelineThread implements Comparable<TimelineThread> {
 
   TimelineThreadEvent durationStack;
 
+  bool get isDartThread => _name == 'io.flutter.1.ui';
+  bool get isGpuThread => _name == 'io.flutter.1.gpu';
+
   final Map<String, TimelineThreadEvent> _asyncEvents =
       <String, TimelineThreadEvent>{};
 

--- a/test/timeline_controller_test.dart
+++ b/test/timeline_controller_test.dart
@@ -35,5 +35,5 @@ void main() {
     //  data from the engine, allowing us to distinguish cpu events from gpu
     //  events as well as to know accurate frame start times, end times, and
     //  events.
-  });
+  }, tags: 'useFlutterSdk');
 }

--- a/test/timeline_controller_test.dart
+++ b/test/timeline_controller_test.dart
@@ -1,0 +1,34 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools/timeline/timeline_controller.dart';
+import 'package:test/test.dart';
+
+import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
+import 'support/flutter_test_environment.dart';
+
+void main() {
+  group('TimelineController', () {
+    final timelineController = TimelineController();
+
+    final env = FlutterTestEnvironment(
+      const FlutterRunConfiguration(withDebugger: true),
+    );
+
+    env.afterNewSetup = () async {
+      await timelineController.startTimeline();
+    };
+
+    tearDownAll(() async {
+      await env.tearDownEnvironment(force: true);
+    });
+
+    test('timeline data not empty', () async {
+      await env.setupEnvironment();
+      expect(timelineController.timelineData.threads, isNotEmpty);
+      expect(timelineController.timelineData.threadMap, isNotEmpty);
+      await env.tearDownEnvironment();
+    });
+  });
+}

--- a/test/timeline_controller_test.dart
+++ b/test/timeline_controller_test.dart
@@ -30,5 +30,10 @@ void main() {
       expect(timelineController.timelineData.threadMap, isNotEmpty);
       await env.tearDownEnvironment();
     });
+
+    // TODO(kenzie): add more tests. We will be able to once we have the proper
+    //  data from the engine, allowing us to distinguish cpu events from gpu
+    //  events as well as to know accurate frame start times, end times, and
+    //  events.
   });
 }


### PR DESCRIPTION
- Use timeline controller to manage business logic. Moved code from TimelineFramesBuilder over to TimelineController (straight port, no new code).
- Rename FrameDetailsUI to FrameFlameChart and extract to its own file (straight port, no new code).
- Add simple timeline test to setup timeline test environment. Test runs on VM.