### PR TITLE
have reload action clear the debugger console

### DIFF
--- a/lib/core/message_bus.dart
+++ b/lib/core/message_bus.dart
@@ -1,0 +1,49 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+/// An event type for use with [MessageBus].
+class BusEvent {
+  BusEvent(this.type, {this.data});
+
+  final String type;
+  final Object data;
+
+  @override
+  String toString() => type;
+}
+
+/// A message bus class. Clients can listen for classes of events, optionally
+/// filtered by a string type. This can be used to decouple events sources and
+/// event listeners.
+class MessageBus {
+  MessageBus() {
+    _controller = new StreamController.broadcast();
+  }
+
+  StreamController<BusEvent> _controller;
+
+  /// Listen for events on the event bus. Clients can pass in an optional [type],
+  /// which filters the events to only those specific ones.
+  Stream<BusEvent> onEvent({String type}) {
+    if (type == null) {
+      return _controller.stream;
+    } else {
+      return _controller.stream.where((BusEvent event) => event.type == type);
+    }
+  }
+
+  /// Add an event to the event bus.
+  void addEvent(BusEvent event) {
+    _controller.add(event);
+  }
+
+  /// Close (destroy) this [MessageBus]. This is generally not used outside of a
+  /// testing context. All stream listeners will be closed and the bus will not
+  /// fire any more events.
+  void close() {
+    _controller.close();
+  }
+}

--- a/lib/debugger/debugger.dart
+++ b/lib/debugger/debugger.dart
@@ -10,6 +10,7 @@ import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
+import '../core/message_bus.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../ui/custom.dart';
@@ -294,6 +295,19 @@ class DebuggerScreen extends Screen {
     });
 
     consoleArea.refresh();
+
+    messageBus.onEvent(type: 'reload.start').listen((_) {
+      consoleArea.clear();
+    });
+    messageBus.onEvent(type: 'reload.end').listen((BusEvent event) {
+      consoleArea.appendText('${event.data}\n\n');
+    });
+    messageBus.onEvent(type: 'restart.start').listen((_) {
+      consoleArea.clear();
+    });
+    messageBus.onEvent(type: 'restart.end').listen((BusEvent event) {
+      consoleArea.appendText('${event.data}\n\n');
+    });
 
     return screenDiv;
   }
@@ -1405,6 +1419,10 @@ class ConsoleArea implements CoreElementView {
   CoreElement get element => _container;
 
   void refresh() => _editor.refresh();
+
+  void clear() {
+    _editor.getDoc().setValue('');
+  }
 
   void appendText(String text) {
     // We delay writes here to batch up calls to editor.replaceRange().

--- a/lib/framework/framework_core.dart
+++ b/lib/framework/framework_core.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:html' hide Screen;
 
+import '../core/message_bus.dart';
 import '../globals.dart';
 import '../service.dart';
 import '../service_manager.dart';
@@ -17,6 +18,7 @@ class FrameworkCore {
 
   static void _setServiceConnectionManager() {
     setGlobal(ServiceConnectionManager, ServiceConnectionManager());
+    setGlobal(MessageBus, MessageBus());
   }
 
   static void initVmService(

--- a/lib/globals.dart
+++ b/lib/globals.dart
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'core/message_bus.dart';
 import 'service_manager.dart';
 
 final Map<Type, dynamic> globals = <Type, dynamic>{};
 
 ServiceConnectionManager get serviceManager =>
     globals[ServiceConnectionManager];
+
+MessageBus get messageBus => globals[MessageBus];
 
 void setGlobal(Type clazz, dynamic instance) {
   globals[clazz] = instance;

--- a/lib/logging/logging.dart
+++ b/lib/logging/logging.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:intl/intl.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
+import '../core/message_bus.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../inspector/diagnostics_node.dart';
@@ -74,7 +75,8 @@ class LoggingScreen extends Screen {
               span()..flex(),
             ])
         ]),
-      div(c: 'section log-area')..flex()
+      div(c: 'section log-area')
+        ..flex()
         ..add(<CoreElement>[
           _createTableView()
             ..layoutHorizontal()
@@ -104,6 +106,21 @@ class LoggingScreen extends Screen {
     _updateStatus();
     loggingTable.onRowsChanged.listen((_) {
       _updateStatus();
+    });
+
+    messageBus.onEvent(type: 'reload.end').listen((BusEvent event) {
+      _log(LogData(
+        'hot.reload',
+        event.data,
+        DateTime.now().millisecondsSinceEpoch,
+      ));
+    });
+    messageBus.onEvent(type: 'restart.end').listen((BusEvent event) {
+      _log(LogData(
+        'hot.restart',
+        event.data,
+        DateTime.now().millisecondsSinceEpoch,
+      ));
     });
 
     return screenDiv;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -131,6 +131,12 @@ class PerfToolFramework extends Framework {
   }
 
   void _buildReloadRestartButtons() async {
+    // TODO(devoncarew): We currently create hot reload events when hot reload
+    // is initialed, and react to those events in the UI. Going forward, we'll
+    // want to instead have flutter_tools fire hot reload events, and react to
+    // them in the UI. That will mean that our UI will update appropriately
+    // even when other clients (the CLI, and IDE) initial the hot reload.
+
     final ActionButton reloadAction =
         ActionButton('icons/hot-reload-white@2x.png', 'Hot Reload');
     reloadAction.click(() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -134,7 +134,7 @@ class PerfToolFramework extends Framework {
     final ActionButton reloadAction =
         ActionButton('icons/hot-reload-white@2x.png', 'Hot Reload');
     reloadAction.click(() async {
-      // Hide any previous status related to reload.
+      // Hide any previous status related to / restart.
       reloadStatus?.dispose();
 
       final Status status = Status(auxiliaryStatus, 'reloading...');
@@ -164,7 +164,7 @@ class PerfToolFramework extends Framework {
     final ActionButton restartAction =
         ActionButton('icons/hot-restart-white@2x.png', 'Hot Restart');
     restartAction.click(() async {
-      // Hide any previous status related to reload.
+      // Hide any previous status related to / restart.
       reloadStatus?.dispose();
 
       final Status status = Status(auxiliaryStatus, 'restarting...');
@@ -182,7 +182,7 @@ class PerfToolFramework extends Framework {
         messageBus.addEvent(BusEvent('restart.end', data: message));
         status.setText(message);
       } catch (_) {
-        const String message = 'error performing reload';
+        const String message = 'error performing restart';
         messageBus.addEvent(BusEvent('restart.end', data: message));
         status.setText(message);
       } finally {

--- a/test/core/message_bus_test.dart
+++ b/test/core/message_bus_test.dart
@@ -1,0 +1,53 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:devtools/core/message_bus.dart';
+import 'package:test/test.dart';
+
+void main() {
+  defineTests();
+}
+
+void defineTests() {
+  group('message_bus', () {
+    test('fire one event', () async {
+      final MessageBus bus = new MessageBus();
+      final Future<List<BusEvent>> future =
+          bus.onEvent(type: 'app.restart').toList();
+      _fireEvents(bus);
+      bus.close();
+      final List<BusEvent> list = await future;
+      expect(list, hasLength(1));
+    });
+
+    test('fire two events', () async {
+      final MessageBus bus = new MessageBus();
+      final Future<List<BusEvent>> future =
+          bus.onEvent(type: 'file.saved').toList();
+      _fireEvents(bus);
+      bus.close();
+      final List<BusEvent> list = await future;
+      expect(list, hasLength(2));
+      expect(list[0].data, 'foo.dart');
+      expect(list[1].data, 'bar.dart');
+    });
+
+    test('receive all events', () async {
+      final MessageBus bus = new MessageBus();
+      final Future<List<BusEvent>> future = bus.onEvent().toList();
+      _fireEvents(bus);
+      bus.close();
+      final List<BusEvent> list = await future;
+      expect(list, hasLength(3));
+    });
+  });
+}
+
+void _fireEvents(MessageBus bus) {
+  bus.addEvent(new BusEvent('app.restart'));
+  bus.addEvent(new BusEvent('file.saved', data: 'foo.dart'));
+  bus.addEvent(new BusEvent('file.saved', data: 'bar.dart'));
+}


### PR DESCRIPTION
- have a hot reload action clear the debugger console
- write some status about the reload into both the console and the logging view
- add in a message bus to the app, in order to decouple a bit messages sources from people that want to consume those messages

Having reload clear the console is a bit of usability feedback from other tools - likely good to carry forward here.

The message bus uses almost entirely untyped events - clients know how to unpack them based on the event name (`'reload.start'`). I was on the fence about having a strongly typed API vs. unpacking things from a `dynamic` data field.

<img width="384" alt="screen shot 2019-01-28 at 12 58 50 pm" src="https://user-images.githubusercontent.com/1269969/51866967-3607da80-22ff-11e9-9589-4183fc07d5dc.png">

<img width="293" alt="screen shot 2019-01-28 at 12 58 41 pm" src="https://user-images.githubusercontent.com/1269969/51866974-3b652500-22ff-11e9-98a5-6bc3a70c81c4.png">
