### PR TITLE
Hide bad errors + fix null references

### DIFF
--- a/lib/framework/framework.dart
+++ b/lib/framework/framework.dart
@@ -140,7 +140,8 @@ class Framework {
     if (error != null) {
       message = '$error';
       // Only display the error object if it has a custom Dart toString.
-      if (message.startsWith('[object ')) {
+      if (message.startsWith('[object ') ||
+          message.startsWith('Instance of ')) {
         message = null;
       }
     }
@@ -165,8 +166,10 @@ class Framework {
     if (title != null) {
       flash.add(label(text: title));
     }
-    for (String text in message.split('\n\n')) {
-      flash.add(div(text: text));
+    if (message != null) {
+      for (String text in message.split('\n\n')) {
+        flash.add(div(text: text));
+      }
     }
 
     final CoreElement errorContainer =


### PR DESCRIPTION
I think this is a reasonable fix for #179?

We had code that was hiding `[object ` errors but this was coming through as `Instance of blah`.

In addition, I added a null check to `messages` since it's set to null but this code tries to split and enumerate it.