### PR TITLE
remove older assumption of a default port

### DIFF
--- a/lib/framework/framework_core.dart
+++ b/lib/framework/framework_core.dart
@@ -20,9 +20,11 @@ class FrameworkCore {
   }
 
   static void initVmService(
-      void errorReporter(String title, dynamic error)) async {
-    // Identify port so that we can connect the VmService.
+    void errorReporter(String title, dynamic error),
+  ) async {
     int port;
+
+    // Identify the port so that we can connect to the VM service.
     if (window.location.search.isNotEmpty) {
       final Uri uri = Uri.parse(window.location.toString());
       final String portStr = uri.queryParameters['port'];
@@ -30,18 +32,22 @@ class FrameworkCore {
         port = int.tryParse(portStr);
       }
     }
-    port ??= 8100;
 
-    final Completer<Null> finishedCompleter = Completer<Null>();
+    if (port != null) {
+      final Completer<Null> finishedCompleter = Completer<Null>();
 
-    try {
-      final VmServiceWrapper service =
-          await connect('localhost', port, finishedCompleter);
-      if (serviceManager != null) {
-        await serviceManager.vmServiceOpened(service, finishedCompleter.future);
+      try {
+        final VmServiceWrapper service =
+            await connect('localhost', port, finishedCompleter);
+        if (serviceManager != null) {
+          await serviceManager.vmServiceOpened(
+            service,
+            onClosed: finishedCompleter.future,
+          );
+        }
+      } catch (e) {
+        errorReporter('Unable to connect to service on port $port', e);
       }
-    } catch (e) {
-      errorReporter('Unable to connect to service on port $port', e);
     }
   }
 }

--- a/lib/service_manager.dart
+++ b/lib/service_manager.dart
@@ -119,7 +119,9 @@ class ServiceConnectionManager {
   }
 
   Future<void> vmServiceOpened(
-      VmServiceWrapper service, Future<void> onClosed) async {
+    VmServiceWrapper service, {
+    @required Future<void> onClosed,
+  }) async {
     final vm = await service.getVM();
     this.vm = vm;
     sdkVersion = vm.version;

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -6,15 +6,14 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:test/test.dart';
-import 'package:vm_service_lib/vm_service_lib.dart';
-
 import 'package:devtools/eval_on_dart_library.dart';
 import 'package:devtools/globals.dart';
 import 'package:devtools/service_extensions.dart' as extensions;
 import 'package:devtools/service_manager.dart';
 import 'package:devtools/service_registrations.dart' as registrations;
 import 'package:devtools/vm_service_wrapper.dart';
+import 'package:test/test.dart';
+import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'support/flutter_test_driver.dart';
 import 'support/flutter_test_environment.dart';
@@ -320,9 +319,9 @@ void main() {
       // Enable a numeric extension on the test device.
       const numericExtensionDescription = extensions.slowAnimations;
       final numericArgs = {
-        numericExtensionDescription.extension
-            .substring(numericExtensionDescription.extension.lastIndexOf('.') + 1):
-        numericExtensionDescription.enabledValue
+        numericExtensionDescription.extension.substring(
+                numericExtensionDescription.extension.lastIndexOf('.') + 1):
+            numericExtensionDescription.enabledValue
       };
       const numericEvalExpression = 'timeDilation';
       final numericLibrary = EvalOnDartLibrary(
@@ -339,7 +338,8 @@ void main() {
 
       // Open the VmService and verify that the enabled extension states are
       // reflected in [ServiceExtensionManager].
-      await serviceManager.vmServiceOpened(service, Completer().future);
+      await serviceManager.vmServiceOpened(service,
+          onClosed: Completer().future);
       await serviceManager
           .serviceExtensionManager.extensionStatesUpdated.future;
 

--- a/test/service_manager_test.dart
+++ b/test/service_manager_test.dart
@@ -338,8 +338,10 @@ void main() {
 
       // Open the VmService and verify that the enabled extension states are
       // reflected in [ServiceExtensionManager].
-      await serviceManager.vmServiceOpened(service,
-          onClosed: Completer().future);
+      await serviceManager.vmServiceOpened(
+        service,
+        onClosed: Completer().future,
+      );
       await serviceManager
           .serviceExtensionManager.extensionStatesUpdated.future;
 

--- a/test/support/flutter_test_environment.dart
+++ b/test/support/flutter_test_environment.dart
@@ -70,7 +70,7 @@ class FlutterTestEnvironment {
 
       _service = _flutter.vmService;
       setGlobal(ServiceConnectionManager, ServiceConnectionManager());
-      await serviceManager.vmServiceOpened(_service, Completer().future);
+      await serviceManager.vmServiceOpened(_service, onClosed: Completer().future);
 
       if (_afterNewSetup != null) await _afterNewSetup();
     }


### PR DESCRIPTION
- remove older assumption of a default port

Flutter no longer starts the service protocol on port 8100; remove this assumption in the code.