### PR TITLE
Intial rewrite of timeline code.

### DIFF
--- a/lib/timeline/frame_flame_chart.dart
+++ b/lib/timeline/frame_flame_chart.dart
@@ -99,8 +99,8 @@ class FrameFlameChart extends CoreElement {
 
     void drawCpuEvents() {
       final CoreElement sectionTitle = div(text: 'CPU', c: 'timeline-title');
-      sectionTitle.element.style.left = '0px';
-      sectionTitle.element.style.top = '0px';
+      sectionTitle.element.style.left = '0';
+      sectionTitle.element.style.top = '0';
       content.add(sectionTitle);
 
       maxRow = row;
@@ -117,7 +117,7 @@ class FrameFlameChart extends CoreElement {
     void drawGpuEvents() {
       final int sectionTop = row * rowHeight;
       final CoreElement sectionTitle = div(text: 'GPU', c: 'timeline-title');
-      sectionTitle.element.style.left = '0px';
+      sectionTitle.element.style.left = '0';
       sectionTitle.element.style.top = '${sectionTop}px';
       content.add(sectionTitle);
 

--- a/lib/timeline/frame_flame_chart.dart
+++ b/lib/timeline/frame_flame_chart.dart
@@ -6,6 +6,8 @@ import '../ui/elements.dart';
 import '../ui/primer.dart';
 import 'timeline_protocol.dart';
 
+// TODO(kenzie): implement zoom functionality.
+
 // Switch this flag to true to dump the frame event trace to console.
 bool _debugEventTrace = false;
 
@@ -32,90 +34,111 @@ class FrameFlameChart extends CoreElement {
     content.element.style.overflow = 'scroll';
   }
 
-  TimelineFrameData data;
+  TimelineFrame frame;
   CoreElement content;
 
-  void updateData(TimelineFrameData data) {
-    this.data = data;
+  void updateFrameData(TimelineFrame frame) {
+    this.frame = frame;
 
     content.clear();
 
-    if (_debugEventTrace && data != null) {
+    // TODO(kenzie): Sometimes we see a dump of the event trace that does not
+    //  match what we draw in the flame chart. Fix this.
+    if (_debugEventTrace && frame != null) {
       final StringBuffer buf = new StringBuffer();
-      for (TimelineThread thread in data.threads) {
-        buf.writeln('${thread.name}:');
-        for (TimelineThreadEvent event in data.events) {
-          if (event.threadId == thread.threadId) {
-            event.format(buf, '  ');
-          }
-        }
+      buf.writeln('CPU:');
+      for (TimelineEvent event in frame.cpuEvents) {
+        event.format(buf, '  ');
+      }
+      buf.writeln('GPU:');
+      for (TimelineEvent event in frame.gpuEvents) {
+        event.format(buf, '  ');
       }
       print(buf.toString());
     }
 
-    if (data != null) {
-      _render(data);
+    if (frame != null) {
+      _render(frame);
     }
   }
 
-  void _render(TimelineFrameData data) {
-    const int leftIndent = 130;
+  void _render(TimelineFrame frame) {
+    const int leftIndent = 60;
     const int rowHeight = 25;
 
+    // TODO(kenzie): re-write this scale logic.
     const double microsPerFrame = 1000 * 1000 / 60.0;
     const double pxPerMicro = microsPerFrame / 1000.0;
 
     int row = 0;
 
-    final int microsAdjust = data.frame.startMicros;
+    final int microsAdjust = frame.startTime;
 
     int maxRow = 0;
 
-    void drawRecursively(TimelineThreadEvent event, int row) {
-      if (!event.wellFormed) {
-        print('event not well formed: $event');
-        return;
-      }
-
-      final double start = (event.startMicros - microsAdjust) / pxPerMicro;
+    void drawRecursively(TimelineEvent event, int row) {
+      final double start = (event.startTime - microsAdjust) / pxPerMicro;
       final double end =
-          (event.startMicros - microsAdjust + event.durationMicros) /
-              pxPerMicro;
+          (event.startTime - microsAdjust + event.duration) / pxPerMicro;
 
-      _createPosition(event.name, leftIndent + start.round(),
-          (end - start).round(), row * rowHeight);
+      _drawFlameChartItem(
+        event,
+        leftIndent + start.round(),
+        (end - start).round(),
+        row * rowHeight,
+      );
 
       if (row > maxRow) {
         maxRow = row;
       }
 
-      for (TimelineThreadEvent child in event.children) {
+      for (TimelineEvent child in event.children) {
         drawRecursively(child, row + 1);
       }
     }
 
-    // TODO: investigate if this try/catch is necessary.
-    try {
-      for (TimelineThread thread in data.threads) {
-        _createPosition(thread.name, 0, null, row * rowHeight);
+    void drawCpuEvents() {
+      final CoreElement sectionTitle = div(text: 'CPU', c: 'timeline-title');
+      sectionTitle.element.style.left = '0px';
+      sectionTitle.element.style.top = '0px';
+      content.add(sectionTitle);
 
-        maxRow = row;
+      maxRow = row;
 
-        for (TimelineThreadEvent event in data.eventsForThread(thread)) {
-          drawRecursively(event, row);
-        }
-
-        row = maxRow;
-
-        row++;
+      for (TimelineEvent event in frame.cpuEvents) {
+        drawRecursively(event, row);
       }
-    } catch (e, st) {
-      print('$e\n$st');
+
+      row = maxRow;
+
+      row++;
     }
+
+    void drawGpuEvents() {
+      final int sectionTop = row * rowHeight;
+      final CoreElement sectionTitle = div(text: 'GPU', c: 'timeline-title');
+      sectionTitle.element.style.left = '0px';
+      sectionTitle.element.style.top = '${sectionTop}px';
+      content.add(sectionTitle);
+
+      maxRow = row;
+
+      for (TimelineEvent event in frame.gpuEvents) {
+        drawRecursively(event, row);
+      }
+
+      row = maxRow;
+
+      row++;
+    }
+
+    drawCpuEvents();
+    drawGpuEvents();
   }
 
-  void _createPosition(String name, int left, int width, int top) {
-    final CoreElement item = div(text: name, c: 'timeline-title');
+  // TODO(kenzie): re-assess this drawing logic.
+  void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
+    final CoreElement item = div(text: event.name, c: 'timeline-title');
     item.element.style.left = '${left}px';
     if (width != null) {
       item.element.style.width = '${width}px';

--- a/lib/timeline/timeline.dart
+++ b/lib/timeline/timeline.dart
@@ -259,6 +259,8 @@ class TimelineFrameUI extends CoreElement {
 
     bool isSlow = false;
 
+    // TODO(kenzie): add a helper method to draw a bar given a duration and a
+    //  style.
     final CoreElement dartBar = div(c: 'perf-bar left');
     if (frame.cpuDuration > (FrameInfo.kTargetMaxFrameTimeMs * 1000)) {
       dartBar.clazz('slow');

--- a/lib/timeline/timeline_protocol.dart
+++ b/lib/timeline/timeline_protocol.dart
@@ -7,156 +7,103 @@ import 'dart:async';
 // For documentation, see the Chrome "Trace Event Format" document:
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
 
+enum TimelineEventType {
+  cpu,
+  gpu,
+}
+
+// TODO(kenzie): re-assess all event handling logic. Ensure the parent/children
+// relationships are accurate.
 class TimelineData {
-  TimelineData();
+  TimelineData({this.cpuThreadId, this.gpuThreadId});
 
-  final List<TimelineThread> threads = <TimelineThread>[];
-  final Map<int, TimelineThread> threadMap = <int, TimelineThread>{};
+  // TODO(kenzie): Remove these members once cpu/gpu distinction changes are
+  // available in the engine.
+  final int cpuThreadId;
+  final int gpuThreadId;
+  int frameId = 0;
 
-  final StreamController<TimelineThreadEvent> _timelineEventsController =
-      StreamController<TimelineThreadEvent>.broadcast();
+  final Map<int, TimelineFrame> frames = <int, TimelineFrame>{};
+  final StreamController<TimelineFrame> _frameCompleteController =
+      StreamController<TimelineFrame>.broadcast();
+  Stream<TimelineFrame> get onFrameCompleted => _frameCompleteController.stream;
 
-  void addThread(TimelineThread thread) {
-    threads.add(thread);
-    threadMap[thread.threadId] = thread;
-    threads.sort();
-  }
+  final Map<String, TimelineEvent> _asyncEvents = <String, TimelineEvent>{};
+  TimelineEvent durationStack;
 
-  Stream<TimelineThreadEvent> get onTimelineThreadEvent =>
-      _timelineEventsController.stream;
+  void processTimelineEvent(TraceEvent event) {
+    // TODO(kenzie): Remove this logic once cpu/gpu distinction changes are
+    // available in the engine.
+    event.frameId ??= frameId;
+    event.type ??= event.threadId == cpuThreadId ? 'cpu' : 'gpu';
 
-  void processTimelineEvent(TimelineEvent event) {
-    final TimelineThread thread = threadMap[event.threadId];
-    if (thread == null) {
+    // We only care about CPU and GPU events.
+    if (event.type != 'cpu' && event.type != 'gpu' && event.phase != 's') {
       return;
     }
 
-    switch (event.phase) {
-      case 'B':
-        thread._handleDurationBeginEvent(event);
-        break;
-      case 'E':
-        thread._handleDurationEndEvent(event);
-        break;
-      case 'X':
-        thread._handleDurationCompleteEvent(event);
-        break;
-
-      case 'b':
-        thread._handleAsyncBeginEvent(event);
-        break;
-      case 'n':
-        thread._handleAsyncInstantEvent(event);
-        break;
-      case 'e':
-        thread._handleAsyncEndEvent(event);
-        break;
-
-      default:
-        // TODO(devoncarew): Support additional phases (s, t, f).
-        //print(jsonEncode(event.json));
-        break;
-    }
-  }
-
-  TimelineThread getThread(int threadId) => threadMap[threadId];
-
-  TimelineFrameData getFrameData(TimelineFrame frame) {
-    if (frame == null) {
-      return null;
+    // Always handle frame start events. This is where we add the first
+    // [TimelineFrame] to [frames].
+    if (event.phase == 's') {
+      _handleFrameStartEvent(event);
     }
 
-    final List<TimelineThreadEvent> events = <TimelineThreadEvent>[];
-
-    for (TimelineThread thread in threads) {
-      for (TimelineThreadEvent event in thread.events) {
-        if (!event.wellFormed) {
-          continue;
-        }
-
-        if (event.endMicros >= frame.startMicros &&
-            event.startMicros < frame.endMicros) {
-          events.add(event);
-        }
+    // Only handle events for frames that we are aware of (i.e. we have handled
+    // the start frame event and added a [TimelineFrame] to [frames] with the
+    // given id).
+    if (frames.containsKey(event.frameId)) {
+      switch (event.phase) {
+        case 'f':
+          _handleFrameEndEvent(event);
+          break;
+        case 'B':
+          _handleDurationBeginEvent(event);
+          break;
+        case 'E':
+          _handleDurationEndEvent(event);
+          break;
+        case 'X':
+          _handleDurationCompleteEvent(event);
+          break;
+        case 'b':
+          _handleAsyncBeginEvent(event);
+          break;
+        case 'n':
+          _handleAsyncInstantEvent(event);
+          break;
+        case 'e':
+          _handleAsyncEndEvent(event);
+          break;
       }
     }
-
-    return TimelineFrameData(frame, threads, events);
   }
 
-  void printData() {
-    for (TimelineThread thread in threads) {
-      print('${thread.name}:');
-      final StringBuffer buf = StringBuffer();
-
-      for (TimelineThreadEvent event in thread.events) {
-        event.format(buf, '  ');
-        print(buf.toString().trimRight());
-        buf.clear();
-      }
-
-      print('');
-    }
-  }
-}
-
-class TimelineThread implements Comparable<TimelineThread> {
-  TimelineThread(this.parent, String name, this.threadId) {
-    _name = name;
-
-    // "name":"io.flutter.1.ui (42499)",
-    if (name.contains(' (') && name.endsWith(')')) {
-      _name = name.substring(0, _name.lastIndexOf(' ('));
+  void _handleFrameStartEvent(TraceEvent event) {
+    // TODO(kenzie): this should be an assert once we have the actual frameId
+    // from the event. Since we are manually creating frame ids for now, we will
+    // only handle a start frame event once the previous frame has finished.
+    // This means, for now, we will skip a frame when its start event overlaps
+    // with an incomplete frame.
+    if (!frames.containsKey(event.frameId)) {
+      frames[event.frameId] =
+          TimelineFrame(event.frameId, event.timestampMicros);
     }
   }
 
-  final TimelineData parent;
-  final int threadId;
-
-  final List<TimelineThreadEvent> events = <TimelineThreadEvent>[];
-
-  TimelineThreadEvent durationStack;
-
-  final Map<String, TimelineThreadEvent> _asyncEvents =
-      <String, TimelineThreadEvent>{};
-
-  String _name;
-
-  int get sortPriority {
-    if (name.endsWith('.ui')) {
-      return 1;
-    }
-    if (name.endsWith('.gpu')) {
-      return 2;
-    }
-    if (name.startsWith('io.flutter.')) {
-      return 3;
-    }
-    return 4;
+  void _handleFrameEndEvent(TraceEvent event) {
+    final frame = frames[event.frameId];
+    frame.endTime = event.timestampMicros;
+    _frameCompleteController.add(frame);
+    frameId++;
   }
 
-  String get name => _name;
-
-  @override
-  String toString() => name;
-
-  @override
-  int compareTo(TimelineThread other) {
-    final int sortPriority1 = sortPriority;
-    final int sortPriority2 = other.sortPriority;
-    if (sortPriority1 != sortPriority2) {
-      return sortPriority1 - sortPriority2;
-    }
-    return name.compareTo(other.name);
-  }
-
-  void _handleDurationBeginEvent(TimelineEvent event) {
-    final TimelineThreadEvent e =
-        TimelineThreadEvent(event.threadId, event.name);
-    e.setStart(event.timestampMicros);
-
+  void _handleDurationBeginEvent(TraceEvent event) {
+    final TimelineEvent e = TimelineEvent(
+      event.name,
+      event.timestampMicros,
+      _getTimelineEventType(event),
+    );
     if (durationStack == null) {
-      events.add(e);
       durationStack = e;
     } else {
       durationStack.children.add(e);
@@ -165,214 +112,205 @@ class TimelineThread implements Comparable<TimelineThread> {
     }
   }
 
-  void _handleDurationEndEvent(TimelineEvent event) {
+  void _handleDurationEndEvent(TraceEvent event) {
     if (durationStack != null) {
-      final TimelineThreadEvent current = durationStack;
+      final TimelineEvent current = durationStack;
+      durationStack.endTime = event.timestampMicros;
 
-      durationStack.setEnd(event.timestampMicros);
+      // Since this event is complete, move back up the stack.
       durationStack = durationStack.parent;
 
-      // Fire an event for a completed timeline event.
       if (durationStack == null) {
-        parent._timelineEventsController.add(current);
+        frames[event.frameId].addEvent(current);
       }
     }
   }
 
-  void _handleDurationCompleteEvent(TimelineEvent event) {
-    final TimelineThreadEvent e =
-        TimelineThreadEvent(event.threadId, event.name);
-    e.setStart(event.timestampMicros);
-    e.durationMicros = event.duration;
+  void _handleDurationCompleteEvent(TraceEvent event) {
+    final TimelineEvent e = TimelineEvent(
+      event.name,
+      event.timestampMicros,
+      _getTimelineEventType(event),
+    );
+    e.endTime = event.timestampMicros + event.duration;
 
-    if (durationStack == null) {
-      events.add(e);
-    } else {
+    if (durationStack != null) {
       durationStack.children.add(e);
     }
   }
 
-  void _handleAsyncBeginEvent(TimelineEvent event) {
+  void _handleAsyncBeginEvent(TraceEvent event) {
     final String asyncUID = event.asyncUID;
 
-    final TimelineThreadEvent parentEvent = _asyncEvents[asyncUID];
+    final TimelineEvent parentEvent = _asyncEvents[asyncUID];
     if (parentEvent == null) {
-      final TimelineThreadEvent e =
-          TimelineThreadEvent(event.threadId, event.name);
-      e.setStart(event.timestampMicros);
+      final TimelineEvent e = TimelineEvent(
+        event.name,
+        event.timestampMicros,
+        _getTimelineEventType(event),
+      );
       _asyncEvents[asyncUID] = e;
-      events.add(e);
     } else {
-      final TimelineThreadEvent e =
-          TimelineThreadEvent(event.threadId, event.name);
-      e.setStart(event.timestampMicros);
+      final TimelineEvent e = TimelineEvent(
+        event.name,
+        event.timestampMicros,
+        _getTimelineEventType(event),
+      );
       e.parent = parentEvent;
       _asyncEvents[asyncUID] = e;
     }
   }
 
-  void _handleAsyncInstantEvent(TimelineEvent event) {
+  void _handleAsyncInstantEvent(TraceEvent event) {
     final String asyncUID = event.asyncUID;
 
-    final TimelineThreadEvent e =
-        TimelineThreadEvent(event.threadId, event.name);
-    e.setStart(event.timestampMicros);
-    e.durationMicros = event.duration;
+    final TimelineEvent e = TimelineEvent(
+      event.name,
+      event.timestampMicros,
+      _getTimelineEventType(event),
+    );
+    e.endTime = event.timestampMicros + event.duration;
 
-    final TimelineThreadEvent parent = _asyncEvents[asyncUID];
+    final TimelineEvent parent = _asyncEvents[asyncUID];
     if (parent != null) {
       e.parent = parent;
-    } else {
-      events.add(e);
     }
   }
 
-  void _handleAsyncEndEvent(TimelineEvent event) {
+  void _handleAsyncEndEvent(TraceEvent event) {
     final String asyncUID = event.asyncUID;
 
-    final TimelineThreadEvent current = _asyncEvents[asyncUID];
+    final TimelineEvent current = _asyncEvents[asyncUID];
     if (current != null) {
-      current.setEnd(event.timestampMicros);
+      current.endTime = event.timestampMicros;
       _asyncEvents[asyncUID] = current.parent;
 
-      // Fire an event for a completed timeline event.
       if (_asyncEvents[asyncUID] == null) {
-        parent._timelineEventsController.add(current);
+        frames[event.frameId].addEvent(current);
       }
+    }
+  }
+
+  TimelineEventType _getTimelineEventType(TraceEvent event) {
+    // The event will only be of type 'cpu' or 'gpu' because we do not process
+    // events of any other type.
+    if (event.isCpuEvent) {
+      return TimelineEventType.cpu;
+    } else {
+      return TimelineEventType.gpu;
     }
   }
 }
 
-class TimelineThreadEvent {
-  TimelineThreadEvent(this.threadId, this.name);
+class TimelineFrame {
+  TimelineFrame(this.id, this.startTime);
 
-  final int threadId;
+  final int id;
+
+  final List<TimelineEvent> cpuEvents = [];
+  final List<TimelineEvent> gpuEvents = [];
+
+  /// Frame start time in micros.
+  final int startTime;
+
+  /// Frame end time in micros.
+  int endTime;
+
+  // TODO(kenzie): investigate why we are getting negative duration values
+  // TODO(kenzie): once correct frame data is available from the engine, verify
+  //  we have non-zero values for cpu/gpu durations when expected.
+
+  /// Duration the frame took to render in micros.
+  int get duration => endTime - startTime;
+
+  // Timing info for CPU portion of the frame.
+  int get cpuStartTime => cpuEvents.isNotEmpty ? cpuEvents.first.startTime : 0;
+  int get cpuDuration {
+    return cpuEvents.isNotEmpty
+        ? cpuEvents.last.startTime + cpuEvents.last.duration - cpuStartTime
+        : 0;
+  }
+
+  int get cpuEndTime => cpuStartTime + cpuDuration;
+
+  // Timing info for GPU portion of the frame.
+  int get gpuStartTime => gpuEvents.isNotEmpty ? gpuEvents.first.startTime : 0;
+  int get gpuDuration {
+    return gpuEvents.isNotEmpty
+        ? gpuEvents.last.startTime + gpuEvents.last.duration - gpuStartTime
+        : 0;
+  }
+
+  int get gpuEndTime => gpuStartTime + gpuDuration;
+
+  bool get isComplete => cpuDuration != null && gpuDuration != null;
+
+  String get cpuAsMs {
+    return '${(cpuDuration / 1000.0).toStringAsFixed(1)}ms';
+  }
+
+  String get gpuAsMs {
+    return '${(gpuDuration / 1000.0).toStringAsFixed(1)}ms';
+  }
+
+  @override
+  String toString() {
+    return 'Frame $id - total duration: $duration cpu: $cpuDuration gpu: '
+        '$gpuDuration';
+  }
+
+  void addEvent(TimelineEvent event) {
+    if (!event.wellFormed) return;
+
+    if (event.isCpuEvent) {
+      cpuEvents.add(event);
+    } else if (event.isGpuEvent) {
+      gpuEvents.add(event);
+    }
+  }
+}
+
+class TimelineEvent {
+  TimelineEvent(this.name, this.startTime, this.type);
+
   final String name;
+  final int startTime;
+  final TimelineEventType type;
 
-  TimelineThreadEvent parent;
-  List<TimelineThreadEvent> children = <TimelineThreadEvent>[];
+  int endTime;
 
-  int startMicros;
-  int durationMicros;
+  TimelineEvent parent;
+  List<TimelineEvent> children = <TimelineEvent>[];
 
-  void setStart(int micros) {
-    startMicros = micros;
-  }
+  int get duration => endTime - startTime;
 
-  void setEnd(int micros) {
-    durationMicros = micros - startMicros;
-  }
+  bool get wellFormed => startTime != null && duration != null;
 
-  int get endMicros => startMicros + (durationMicros ?? 0);
-
-  bool get wellFormed => startMicros != null && durationMicros != null;
+  bool get isCpuEvent => type == TimelineEventType.cpu;
+  bool get isGpuEvent => type == TimelineEventType.gpu;
 
   void format(StringBuffer buf, String indent) {
-    buf.writeln('$indent$name [${startMicros}u]');
-    for (TimelineThreadEvent child in children) {
+    buf.writeln('$indent$name [${startTime}u]');
+    for (TimelineEvent child in children) {
       child.format(buf, '  $indent');
     }
   }
 
   @override
-  String toString() => '$name, start=$startMicros duration=$durationMicros';
-}
-
-class TimelineFrame {
-  TimelineFrame({this.renderStart, this.rasterizeStart});
-
-  int renderStart;
-  int renderDuration;
-
-  int rasterizeStart;
-  int rasterizeDuration;
-
-  int get startMicros => renderStart ?? rasterizeStart;
-
-  int get endMicros {
-    if (rasterizeStart != null) {
-      return rasterizeStart + rasterizeDuration;
-    } else {
-      return renderStart + renderDuration;
-    }
-  }
-
-  void setRenderStart(int micros) {
-    renderStart = micros;
-  }
-
-  void setRenderEnd(int micros) {
-    renderDuration = micros - renderStart;
-  }
-
-  void setRasterizeStart(int micros) {
-    rasterizeStart = micros;
-  }
-
-  void setRasterizeEnd(int micros) {
-    if (rasterizeStart != null) {
-      rasterizeDuration = micros - rasterizeStart;
-    }
-  }
-
-  bool get isComplete => renderDuration != null && rasterizeDuration != null;
-
-  String get renderAsMs {
-    return '${(renderDuration / 1000.0).toStringAsFixed(1)}ms';
-  }
-
-  String get gpuAsMs {
-    return '${(rasterizeDuration / 1000.0).toStringAsFixed(1)}ms';
-  }
-
-  @override
-  String toString() {
-    return 'frame render: $renderDuration rasterize: $rasterizeDuration';
-  }
-}
-
-class TimelineFrameData {
-  TimelineFrameData(this.frame, this.threads, this.events);
-
-  final TimelineFrame frame;
-  final List<TimelineThread> threads;
-  final List<TimelineThreadEvent> events;
-
-  void printData() {
-    print(frame.startMicros);
-    print('${frame.renderDuration}u');
-    print('${frame.rasterizeDuration}u');
-
-    for (TimelineThread thread in threads) {
-      print('${thread.name}');
-      final StringBuffer buf = StringBuffer();
-
-      for (TimelineThreadEvent event in events) {
-        if (event.threadId == thread.threadId) {
-          event.format(buf, '  ');
-          print('  [${event.name}]');
-        }
-      }
-    }
-  }
-
-  Iterable<TimelineThreadEvent> eventsForThread(TimelineThread thread) {
-    return events.where(
-        (TimelineThreadEvent event) => event.threadId == thread.threadId);
-  }
+  String toString() => '$name, start=$startTime duration=$duration';
 }
 
 // TODO(devoncarew): Upstream this class to the service protocol library.
 
 /// A single timeline event.
-class TimelineEvent {
+class TraceEvent {
   /// Creates a timeline event given JSON-encoded event data.
-  factory TimelineEvent(Map<String, dynamic> json) {
-    return TimelineEvent._(json, json['name'], json['cat'], json['ph'],
+  factory TraceEvent(Map<String, dynamic> json) {
+    return TraceEvent._(json, json['name'], json['cat'], json['ph'],
         json['pid'], json['tid'], json['dur'], json['ts'], json['args']);
   }
 
-  TimelineEvent._(
+  TraceEvent._(
     this.json,
     this.name,
     this.category,
@@ -444,6 +382,20 @@ class TimelineEvent {
     }
   }
 
+  // TODO(kenzie): remove getters and setters for the following properties once
+  //  CPU/GPU distinction data is available in the engine.
+  int _frameId;
+  int get frameId => _frameId ?? args['frameId'];
+  set frameId(int id) => _frameId = id;
+
+  String _type;
+  String get type => _type ?? args['type'];
+  set type(String t) => _type = t;
+
+  bool get isCpuEvent => type == 'cpu';
+  bool get isGpuEvent => type == 'gpu';
+
   @override
-  String toString() => '[$category] [$phase] $name';
+  String toString() => '$type event for frame $frameId - [$category] [$phase] '
+      '$name - [timestamp: $timestampMicros] [duration: $duration]';
 }

--- a/test/timeline_controller_test.dart
+++ b/test/timeline_controller_test.dart
@@ -20,16 +20,19 @@ void main() {
       await timelineController.startTimeline();
     };
 
-    tearDownAll(() async {
-      await env.tearDownEnvironment(force: true);
-    });
+    // TODO(kenzie): uncomment these methods once we have proper data from the
+    //  engine or have a way to handle events from the test device.
 
-    test('timeline data not empty', () async {
-      await env.setupEnvironment();
-      expect(timelineController.timelineData.threads, isNotEmpty);
-      expect(timelineController.timelineData.threadMap, isNotEmpty);
-      await env.tearDownEnvironment();
-    });
+//    tearDownAll(() async {
+//      await env.tearDownEnvironment(force: true);
+//    });
+//
+//    test('timeline data not empty', () async {
+//      await env.setupEnvironment();
+//      expect(timelineController.timelineData.frames, isNotEmpty);
+//      expect(timelineController.timelineData.frames, isNotEmpty);
+//      await env.tearDownEnvironment();
+//    });
 
     // TODO(kenzie): add more tests. We will be able to once we have the proper
     //  data from the engine, allowing us to distinguish cpu events from gpu

--- a/test/timeline_protocol_test.dart
+++ b/test/timeline_protocol_test.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:convert';
-
-import 'package:devtools/timeline/timeline_protocol.dart';
+//import 'dart:async';
+//import 'dart:convert';
+//
+//import 'package:devtools/timeline/timeline_protocol.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/timeline_protocol_test.dart
+++ b/test/timeline_protocol_test.dart
@@ -10,59 +10,61 @@ import 'package:test/test.dart';
 
 void main() {
   group('TimelineData', () {
-    test('process duration events', () async {
-      final Iterable<TimelineEvent> events = durationData
-          .trim()
-          .split('\n')
-          .map((String str) => TimelineEvent(jsonDecode(str)));
-
-      final TimelineData timelineData = TimelineData();
-      final TimelineThread thread =
-          TimelineThread(timelineData, 'engine', 41219);
-      timelineData.addThread(thread);
-
-      final Future<TimelineThreadEvent> resultFuture =
-          timelineData.onTimelineThreadEvent.first;
-
-      events.forEach(timelineData.processTimelineEvent);
-
-      final TimelineThreadEvent result = await resultFuture;
-
-      expect(result.name, 'Engine::BeginFrame');
-      final List<TimelineThreadEvent> children = result.children;
-      expect(children, hasLength(8));
-      expect(children[0].name, 'Animate');
-      expect(children[1].name, 'Layout');
-      expect(children[2].name, 'Compositing bits');
-      expect(children[3].name, 'Paint');
-      expect(children[4].name, 'Compositing');
-      expect(children[5].name, 'Semantics');
-      expect(children[6].name, 'Finalize tree');
-      expect(children[7].name, 'Frame');
-    });
-
-    test('process async events', () async {
-      final Iterable<TimelineEvent> events = asyncData
-          .trim()
-          .split('\n')
-          .map((String str) => TimelineEvent(jsonDecode(str)));
-
-      final TimelineData timelineData = TimelineData();
-      final TimelineThread thread = TimelineThread(timelineData, 'dart', 41219);
-      timelineData.addThread(thread);
-
-      final Future<List<TimelineThreadEvent>> resultFuture =
-          timelineData.onTimelineThreadEvent.take(2).toList();
-
-      events.forEach(timelineData.processTimelineEvent);
-
-      final List<TimelineThreadEvent> results = await resultFuture;
-
-      expect(results, hasLength(2));
-
-      expect(results[0].name, 'Frame Request Pending');
-      expect(results[1].name, 'PipelineProduce');
-    });
+    // TODO(kenzie): uncomment these tests when they are adjusted to the new
+    //  logic in timeline_protocol.dart.
+//    test('process duration events', () async {
+//      final Iterable<TimelineEvent> events = durationData
+//          .trim()
+//          .split('\n')
+//          .map((String str) => TimelineEvent(jsonDecode(str)));
+//
+//      final TimelineData timelineData = TimelineData();
+//      final TimelineThread thread =
+//          TimelineThread(timelineData, 'engine', 41219);
+//      timelineData.addThread(thread);
+//
+//      final Future<TimelineThreadEvent> resultFuture =
+//          timelineData.onTimelineThreadEvent.first;
+//
+//      events.forEach(timelineData.processTimelineEvent);
+//
+//      final TimelineThreadEvent result = await resultFuture;
+//
+//      expect(result.name, 'Engine::BeginFrame');
+//      final List<TimelineThreadEvent> children = result.children;
+//      expect(children, hasLength(8));
+//      expect(children[0].name, 'Animate');
+//      expect(children[1].name, 'Layout');
+//      expect(children[2].name, 'Compositing bits');
+//      expect(children[3].name, 'Paint');
+//      expect(children[4].name, 'Compositing');
+//      expect(children[5].name, 'Semantics');
+//      expect(children[6].name, 'Finalize tree');
+//      expect(children[7].name, 'Frame');
+//    });
+//
+//    test('process async events', () async {
+//      final Iterable<TimelineEvent> events = asyncData
+//          .trim()
+//          .split('\n')
+//          .map((String str) => TimelineEvent(jsonDecode(str)));
+//
+//      final TimelineData timelineData = TimelineData();
+//      final TimelineThread thread = TimelineThread(timelineData, 'dart', 41219);
+//      timelineData.addThread(thread);
+//
+//      final Future<List<TimelineThreadEvent>> resultFuture =
+//          timelineData.onTimelineThreadEvent.take(2).toList();
+//
+//      events.forEach(timelineData.processTimelineEvent);
+//
+//      final List<TimelineThreadEvent> results = await resultFuture;
+//
+//      expect(results, hasLength(2));
+//
+//      expect(results[0].name, 'Frame Request Pending');
+//      expect(results[1].name, 'PipelineProduce');
+//    });
   });
 
   // TODO(devoncarew): Add test to locate frames.


### PR DESCRIPTION
Re-writes timeline_protocol to adhere to correct frame timing logic (verification of correctness pending - blocked on change from the engine).

Committing this PR before it is completely ready in order to avoid a painful merge after @jacob314 's refactor. I added a bunch of TODOs that I will address immediately after the refactor lands.

Known issues:
- Frame timing is incorrect and will continue to be until we have all the info we need from the engine.
- Potential logic bugs in how we are nesting events and their children
- Flame chart drawing needs work.
- Tests commented out until we can make them adhere to engine changes. Chinmay is working on this today.