### PR TITLE
Set default serve port to 9100

### DIFF
--- a/packages/devtools/bin/devtools.dart
+++ b/packages/devtools/bin/devtools.dart
@@ -23,12 +23,14 @@ final argParser = new ArgParser()
     argMachine,
     negatable: false,
     abbr: 'm',
-    help: 'Sets output format to JSON for consumption in tools',
+    help: 'Sets output format to JSON for consumption in tools.',
   )
   ..addOption(
     argPort,
     abbr: 'p',
-    help: 'Port to serve DevTools on',
+    help: 'Port to serve DevTools on. '
+        'Pass 0 to automatically assign an available port.',
+    defaultsTo: '9100',
   );
 
 bool machineMode = false;


### PR DESCRIPTION
It slightly bugs me that it puts quotes around it though as it's a string?

```
 -p, --port       Port to serve DevTools on. Pass 0 to automatically assign an available port.
                  (defaults to "9100")
```
