### PR TITLE
Add a build.yaml to disable dart2js optimisation

### DIFF
--- a/packages/devtools/build.yaml
+++ b/packages/devtools/build.yaml
@@ -3,6 +3,5 @@ targets:
     builders:
       build_web_compilers|entrypoint:
         options:
-          compiler: dart2js
           dart2js_args:
           - -O0

--- a/packages/devtools/build.yaml
+++ b/packages/devtools/build.yaml
@@ -1,0 +1,8 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        options:
+          compiler: dart2js
+          dart2js_args:
+          - -O0


### PR DESCRIPTION
This is the file I had to create to change this when testing locally. I think it's worth committing to have  better stack traces in the pre-built version while it's in development/preview?