### PR TITLE
Update split2js callback signatures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@ addons:
 env:
   - BOT=main
   - BOT=test_ddc
-# TODO(devoncarew): Uncomment this once the app runs in release mode.
-#  - BOT=test_dart2js
+  - BOT=test_dart2js
   - BOT=flutter_sdk_tests
 script: ./tool/travis.sh
 

--- a/packages/devtools/lib/src/ui/split.dart
+++ b/packages/devtools/lib/src/ui/split.dart
@@ -15,8 +15,9 @@ import 'package:js/js_util.dart' as js_util;
 import 'elements.dart';
 
 typedef _ElementStyleCallback = Function(
-    Object dimension, Object size, num gutterSize);
-typedef _GutterStyleCallback = Function(Object dimension, num gutterSize);
+    Object dimension, Object size, num gutterSize, int index);
+typedef _GutterStyleCallback = Function(
+    Object dimension, num gutterSize, int index);
 
 @JS()
 @anonymous
@@ -75,12 +76,12 @@ Splitter flexSplit(
   return _split(
     parts.map((o) => o is CoreElement ? o.element : o).toList(),
     _SplitOptions(
-      elementStyle: allowInterop((dimension, size, gutterSize) {
+      elementStyle: allowInterop((dimension, size, gutterSize, index) {
         return js_util.jsify({
           'flex-basis': 'calc($size% - ${gutterSize}px)',
         });
       }),
-      gutterStyle: allowInterop((dimension, gutterSize) {
+      gutterStyle: allowInterop((dimension, gutterSize, index) {
         return js_util.jsify({
           'flex-basis': '${gutterSize}px',
         });


### PR DESCRIPTION
Fixes #193.

It happens when you call a function with the wrong number of args. I replaced splitjs with an unminified version and this is in the call stack:

![screenshot 2019-01-31 at 10 49 23 am](https://user-images.githubusercontent.com/1078012/52049496-e49d5c80-2545-11e9-9dab-4d8490dec4b4.png)

Our `_ElementStyleCallback` only has three args (which is what the docs for splitjs shows), but the code is passing a fourth. I'm not sure why this doesn't fail under DDC though (the issue linked above suggests they should be consistent).

Adding an extra arg to our callbacks (`int index`) seems to solve the issue (and still works under DDC). I guess we need to be careful with external code (eg. when updating) that they don't make changes that are non-breaking for JS, but breaking for us.

**Note:** I have some test failures locally when using dart2js that seem to be another issue (debugger tab), so I'm gonna let this run on the bots to see if the results match but may revert the enable-dart2js tests after so we can land this fix at least (and I'll open an issue for the other one).