### PR TITLE
Enable builds on Travis Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 
 language: dart
 dart:
@@ -28,5 +29,6 @@ script: ./tool/travis.sh
 
 cache:
   directories:
-  - $HOME/.pub-cache
+  - $HOME/.pub-cache # macOS / Linux
+  - $APPDATA/Roaming/Pub/Cache # Windows
   - packages/devtools/.dart_tool/build

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:html' as html;
 
 import 'package:codemirror/codemirror.dart';
-import 'package:devtools/src/ui/theme.dart';
 import 'package:meta/meta.dart';
 import 'package:split/split.dart' as split;
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -25,6 +24,7 @@ import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
+import '../ui/theme.dart';
 import '../ui/ui_utils.dart';
 
 // TODO(devoncarew): improve selection behavior in the left nav area

--- a/packages/devtools/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools/lib/src/eval_on_dart_library.dart
@@ -83,8 +83,8 @@ class EvalOnDartLibrary {
       }
       assert(!_libraryRef.isCompleted);
       _libraryRef.completeError(new LibraryNotFound(_candidateLibraryNames));
-    } catch (e) {
-      _handleError(e);
+    } catch (e, stack) {
+      _handleError(e, stack);
     }
   }
 
@@ -126,13 +126,13 @@ class EvalOnDartLibrary {
         throw result;
       }
       return result;
-    } catch (e) {
-      _handleError(e);
+    } catch (e, stack) {
+      _handleError(e, stack);
     }
     return null;
   }
 
-  void _handleError(dynamic e) {
+  void _handleError(dynamic e, StackTrace stack) {
     if (_disposed) return;
 
     switch (e.runtimeType) {
@@ -144,6 +144,9 @@ class EvalOnDartLibrary {
         break;
       default:
         print('Unrecognized error: $e');
+    }
+    if (stack != null) {
+      print(stack);
     }
   }
 

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -13,11 +13,11 @@
 /// of code that uses icons can run on the Dart VM.
 library icons;
 
-import 'package:devtools/src/ui/material_icons.dart';
-import 'package:devtools/src/ui/theme.dart';
 import 'package:meta/meta.dart';
 
 import 'fake_flutter/fake_flutter.dart';
+import 'material_icons.dart';
+import 'theme.dart';
 
 abstract class Icon {
   const Icon();

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -322,10 +322,10 @@ void main() async {
     await tree.nextUiFrame;
   };
 
-  env.beforeTearDown = () async {
-    inspectorController.dispose();
+  env.beforeEveryTearDown = () async {
+    inspectorController?.dispose();
     inspectorController = null;
-    inspectorService.dispose();
+    inspectorService?.dispose();
     inspectorService = null;
   };
 

--- a/packages/devtools/test/inspector_service_test.dart
+++ b/packages/devtools/test/inspector_service_test.dart
@@ -29,14 +29,17 @@ void main() async {
 
   env.afterNewSetup = () async {
     await ensureInspectorServiceDependencies();
+  };
+
+  env.afterEverySetup = () async {
     inspectorService = await InspectorService.create(env.service);
     if (env.runConfig.trackWidgetCreation) {
       await inspectorService.inferPubRootDirectoryIfNeeded();
     }
   };
 
-  env.beforeTearDown = () async {
-    inspectorService.dispose();
+  env.beforeEveryTearDown = () async {
+    inspectorService?.dispose();
     inspectorService = null;
   };
 

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -307,6 +307,18 @@ class WebdevFixture {
         process.stdout.transform(utf8.decoder).transform(const LineSplitter());
     final Completer<String> hasUrl = Completer<String>();
 
+    process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((String line) {
+      final err = 'error starting webdev: $line';
+      if (!hasUrl.isCompleted) {
+        hasUrl.completeError(err);
+      } else {
+        print(err);
+      }
+    });
+
     lines.listen((String line) {
       if (verbose) {
         print('webdev • ${line.trim()}');

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -283,7 +283,7 @@ class WebdevFixture {
   }) async {
     // 'pub run webdev serve web'
 
-    final List<String> cliArgs = ['serve', 'web'];
+    final List<String> cliArgs = ['global', 'run', 'webdev', 'serve', 'web'];
     if (release) {
       cliArgs.add('--release');
     }
@@ -298,7 +298,7 @@ class WebdevFixture {
     }
 
     final Process process = await Process.start(
-      'webdev',
+      Platform.isWindows ? 'pub.bat' : 'pub',
       cliArgs,
       environment: environment,
     );

--- a/packages/devtools/test/integration_tests/integration_test.dart
+++ b/packages/devtools/test/integration_tests/integration_test.dart
@@ -31,5 +31,5 @@ void main() {
     group('app', appTests);
     group('logging', loggingTests);
     group('debugging', debuggingTests);
-  }, timeout: const Timeout.factor(2));
+  }, timeout: const Timeout.factor(4));
 }

--- a/packages/devtools/test/memory_service_test.dart
+++ b/packages/devtools/test/memory_service_test.dart
@@ -71,6 +71,10 @@ void main() async {
   };
 
   group('MemoryController', () {
+    tearDownAll(() {
+      env.tearDownEnvironment(force: true);
+    });
+
     test('heap info', () async {
       await env.setupEnvironment();
 

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -40,6 +40,14 @@ class Chrome {
       if (FileSystemEntity.isFileSync(defaultPath)) {
         return Chrome.from(defaultPath);
       }
+    } else if (Platform.isWindows) {
+      final String progFiles = Platform.environment['PROGRAMFILES(X86)'];
+      final String chromeInstall = '$progFiles\\Google\\Chrome';
+      final String defaultPath = '$chromeInstall\\Application\\chrome.exe';
+
+      if (FileSystemEntity.isFileSync(defaultPath)) {
+        return Chrome.from(defaultPath);
+      }
     }
 
     // TODO(devoncarew): check default install locations for linux

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -78,7 +78,9 @@ class Chrome {
       '--user-data-dir=${getCreateChromeDataDir()}',
       '--remote-debugging-port=$debugPort'
     ];
-    if (_useChromeHeadless) {
+    // TODO(dantup): Chrome headless currently hangs on Windows (both Travis and
+    // locally), so use non-headless there until we have a fix.
+    if (_useChromeHeadless && !Platform.isWindows) {
       args.addAll(<String>[
         '--headless',
         '--disable-gpu',

--- a/packages/devtools/test/support/flutter_test_driver.dart
+++ b/packages/devtools/test/support/flutter_test_driver.dart
@@ -75,7 +75,8 @@ abstract class FlutterTestDriver {
     }
     _debugPrint('Spawning flutter $args in ${_projectFolder.path}');
 
-    _proc = await Process.start('flutter', args.toList(),
+    _proc = await Process.start(
+        Platform.isWindows ? 'flutter.bat' : 'flutter', args,
         workingDirectory: _projectFolder.path,
         environment: <String, String>{
           'FLUTTER_TEST': 'true',


### PR DESCRIPTION
Travis doesn't support `language:dart` on Windows. @mit-mit has had a go at making it work (see https://travis-ci.community/t/dart-support-on-windows/450) but it seems like it might be blocked. Since we're not really using it for anything other than the SDK download, I figured we could just do the download in the shell script. I don't know whether any of this may be translatable to the Travis Ruby script (@kevmoo - FYI - Devon said you may be interested in improving Dart-on-Travis-on-Windows).

**This doesn't totally work yet** but it's now getting into tests (and failing) at least. I thought it was worth opening for discussion. If we think doing it this way is reasonable, I think I should be able to finish it off fairly easily next week (I'll investigate the Linux issues more too).

@devoncarew 