### PR TITLE
make the dartfmt check more verbose

### DIFF
--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -432,6 +432,8 @@ class ServiceExtensionManager {
             'WidgetsBinding.instance.debugDidSendFirstFrameEvent',
             isAlive: null,
           );
+
+
           didSendFirstFrameEvent =
               value != null && value.valueAsString == 'true';
         }

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -433,7 +433,6 @@ class ServiceExtensionManager {
             isAlive: null,
           );
 
-
           didSendFirstFrameEvent =
               value != null && value.valueAsString == 'true';
         }

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -32,8 +32,10 @@ if [ "$BOT" = "main" ]; then
 
     # Verify that dartfmt has been run.
     echo "Checking dartfmt..."
-    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
+
+    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/ > /dev/null) ]]; then
         echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
+        dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
         exit 1
     fi
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -24,20 +24,20 @@ pub get
 
 if [ "$BOT" = "main" ]; then
 
+    # Verify that dartfmt has been run.
+    echo "Checking dartfmt..."
+
+    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
+        echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
+        dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
+        exit 1
+    fi
+
     # Analyze the source.
     pub global activate tuneup && tuneup check
 
     # Ensure we can build the app.
     pub run webdev build
-
-    # Verify that dartfmt has been run.
-    echo "Checking dartfmt..."
-
-    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/ > /dev/null) ]]; then
-        echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
-        dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
-        exit 1
-    fi
 
 elif [ "$BOT" = "test_ddc" ]; then
 


### PR DESCRIPTION
- make the dartfmt check more verbose

I don't believe that we were previously emitting the files that needed formatting; this does that in a step after we recognize that there are unformatted files.