### PR TITLE
Reset _flutter when tearing down

### DIFF
--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -87,6 +87,7 @@ class FlutterTestEnvironment {
 
     await _service.allFuturesCompleted.future;
     await _flutter.stop();
+    _flutter = null;
 
     _needsSetup = true;
   }


### PR DESCRIPTION
I'm trying to track down test failures on Windows and set `reuseTestEnvironment = false` but found that the second `frame_rendering` test fails because at the start of the test it calls `setupEnvironment`, which has this:

```dart
if (_flutter != null) await tearDownEnvironment(force: true);
```

So even though it was already torn down by the end of the previous test it tries to do it again, which means `FrameTracker.shop()` gets called again, which fails this assert:

```dart
assert(eventStreamSubscription != null);
```

