### PR TITLE
Prevent leaked flutter_tester processes when frame_rendering tests fail

### DIFF
--- a/packages/devtools/test/frame_rendering_test.dart
+++ b/packages/devtools/test/frame_rendering_test.dart
@@ -39,43 +39,49 @@ void main() {
     test('FramesTracker tracks frames', () async {
       await env.setupEnvironment();
 
-      await _forceDrawFrame();
-      expect(framesTracker.samples, isNotEmpty);
-      expect(framesTracker.samples.length, equals(1));
-
-      await env.tearDownEnvironment();
+      try {
+        await _forceDrawFrame();
+        expect(framesTracker.samples, isNotEmpty);
+        expect(framesTracker.samples.length, equals(1));
+      } finally {
+        await env.tearDownEnvironment();
+      }
     });
 
     test('FramesTracker pauses and resumes', () async {
       await env.setupEnvironment();
 
-      framesTracker.pause();
-      expect(framesTracker.eventStreamSubscription.isPaused, isTrue);
+      try {
+        framesTracker.pause();
+        expect(framesTracker.eventStreamSubscription.isPaused, isTrue);
 
-      await _forceDrawFrame();
-      expect(framesTracker.samples.length, equals(1));
+        await _forceDrawFrame();
+        expect(framesTracker.samples.length, equals(1));
 
-      framesTracker.resume();
-      expect(framesTracker.eventStreamSubscription.isPaused, isFalse);
+        framesTracker.resume();
+        expect(framesTracker.eventStreamSubscription.isPaused, isFalse);
 
-      await _forceDrawFrame();
-      expect(framesTracker.samples.length, equals(2));
-
-      await env.tearDownEnvironment();
+        await _forceDrawFrame();
+        expect(framesTracker.samples.length, equals(2));
+      } finally {
+        await env.tearDownEnvironment();
+      }
     });
 
     test('FramesTracker calcRecentFPS', () async {
       await env.setupEnvironment();
 
-      framesTracker.samples = _fakeSamplesForLowFPS;
-      expect(framesTracker.calcRecentFPS(), equals(29.999999999999996));
-      expect(framesTracker.calcRecentFPS().round(), equals(30));
+      try {
+        framesTracker.samples = _fakeSamplesForLowFPS;
+        expect(framesTracker.calcRecentFPS(), equals(29.999999999999996));
+        expect(framesTracker.calcRecentFPS().round(), equals(30));
 
-      framesTracker.samples = _fakeSamplesFor60FPS;
-      expect(framesTracker.calcRecentFPS(), equals(59.99999999999999));
-      expect(framesTracker.calcRecentFPS().round(), equals(60));
-
-      await env.tearDownEnvironment(force: true);
+        framesTracker.samples = _fakeSamplesFor60FPS;
+        expect(framesTracker.calcRecentFPS(), equals(59.99999999999999));
+        expect(framesTracker.calcRecentFPS().round(), equals(60));
+      } finally {
+        await env.tearDownEnvironment(force: true);
+      }
     });
   }, tags: 'useFlutterSdk');
 }

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -42,7 +42,6 @@ class FlutterTestEnvironment {
   set beforeTearDown(VoidAsyncFunction f) => _beforeTearDown = f;
 
   bool _needsSetup = true;
-  bool get _needsTeardown => !_needsSetup;
 
   // Switch this flag to false to debug issues with non-atomic test behavior.
   bool reuseTestEnvironment = true;
@@ -80,7 +79,11 @@ class FlutterTestEnvironment {
   }
 
   Future<void> tearDownEnvironment({bool force = false}) async {
-    if (!_needsTeardown || (!force && reuseTestEnvironment)) {
+    if (_needsSetup) {
+      // _needsSetup=true means we've never run setup code or already cleaned up
+      return;
+    }
+    if (!force && reuseTestEnvironment) {
       // Skip actually tearing down for better test performance.
       return;
     }

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -42,6 +42,7 @@ class FlutterTestEnvironment {
   set beforeTearDown(VoidAsyncFunction f) => _beforeTearDown = f;
 
   bool _needsSetup = true;
+  bool get _needsTeardown => !_needsSetup;
 
   // Switch this flag to false to debug issues with non-atomic test behavior.
   bool reuseTestEnvironment = true;
@@ -79,7 +80,7 @@ class FlutterTestEnvironment {
   }
 
   Future<void> tearDownEnvironment({bool force = false}) async {
-    if (!force && reuseTestEnvironment) {
+    if (!_needsTeardown || (!force && reuseTestEnvironment)) {
       // Skip actually tearing down for better test performance.
       return;
     }


### PR DESCRIPTION
When running `frame_rendering` tests on Windows there are some failures. Currently this results in the `teardown` calls being skipped, which means `flutter_tester` is left around and subsequent tests fail with more cryptic errors (for example failing to delete `build\assets` because another process is using the folder).

I don't know `try/finally` is the best way to fix this, it may be nicer to use setup/teardown:

```dart
setUp(env.setupEnvironment);
tearDown(env.tearDownEnvironment);
```

However this is complicated by the `force` in the last test (which I presume is to ensure the reuse of the Flutter stuff isn't reused across other tests) and I didn't want to mess too much in here. If you'd rather do this another way, feel free to bin this or suggest changes - I was just opening it because I'd already changed it to help debug the tests locally.