### PR TITLE
Always use \n when checking out goldens files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,6 @@
 *.jar    binary
 *.png    binary
 *.zip    binary
+
+# Preserve \n line endings in Golden files.
+**/test/goldens/* eol=lf


### PR DESCRIPTION
@devoncarew @jacob314 On Windows some tests (eg. Inspector "widget tree") fail because the goldens files end up with CrLf on Windows but we compare them to strings built by the widget inspector code that always has `\n`.

I'm not sure whether we should make the inspector generate text with `\r\n` on Windows, or whether our Golden files should be checked out consistently (eg. always `\n`).

This fixes the tests doing the second option (ensuring goldens always have `\n` on disk) but if you think we should do the opposite, let me know.