### PR TITLE
add a link to a code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,4 @@
 # Code of conduct
 
 When contributing code to the `devtools` project, please observe
-Flutter's [code of conduct](https://github.com/flutter/flutter/edit/master/CODE_OF_CONDUCT.md).
+Flutter's [code of conduct](https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+# Code of conduct
+
+When contributing code to the `devtools` project, please observe
+Flutter's [code of conduct](https://github.com/flutter/flutter/edit/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
- add a link to a code of conduct (similar to how flutter/flutter-intellij does it)
