### PR TITLE
Add a delay to fix some races running tests on Windows

### DIFF
--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -56,10 +56,17 @@ class DevtoolsManager {
         baseUri.resolve('index.html?port=${appFixture.servicePort}');
     await tabInstance.tab.navigate(baseAppUri.toString());
 
-    await delay();
-
     // wait for app initialization
     await tabInstance.getBrowserChannel();
+
+    // TODO(dantup): Find a better way to wait for something here. This delay
+    // fixes the following tests on Windows (list scripts has also been seen to
+    // fail elsewhere).
+    //     integration logging displays log data [E]
+    //     integration logging log screen postpones write when offscreen [E]
+    //     integration debugging lists scripts [E]
+    // integration debugging pause [E]
+    await delay();
   }
 
   Future<void> switchPage(String page) async {


### PR DESCRIPTION
Adding a delay here fixes at least 4 tests on my Windows machine (and at least some of these were failures on Travis). I'm not exactly sure why, but I suspect maybe we're not waiting for the app to be fully initialized and connected to the VM, but I'm not certain.

I think we should be able to come up with something better, but in as quest to have tests running on CI on Windows it may be worth having this temporarily (I did have a go but couldn't find an easy way to wait on something in the DOM to signal everything was definitely ready).