### PR TITLE
Support Windows newlines in Debugger tests

### DIFF
--- a/packages/devtools/test/support/cli_test_driver.dart
+++ b/packages/devtools/test/support/cli_test_driver.dart
@@ -130,7 +130,7 @@ class CliAppFixture extends AppFixture {
   }
 
   static List<int> _parseLines(String source, String keyword) {
-    final List<String> lines = source.split('\n');
+    final List<String> lines = source.replaceAll('\r', '').split('\n');
     final List<int> matches = [];
 
     for (int i = 0; i < lines.length; i++) {


### PR DESCRIPTION
Fixes some tests on Windows where we weren't parsing markers out of the source because the line didn't end with the expected text.