### PR TITLE
Don't run tests that run flutter concurrently

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -65,7 +65,7 @@ elif [ "$BOT" = "flutter_sdk_tests" ]; then
     cd devtools
 
     # Run tests that require the Flutter SDK.
-    pub run test --reporter expanded --tags useFlutterSdk
+    pub run test -j1 --reporter expanded --tags useFlutterSdk
 
 else
 


### PR DESCRIPTION
This took me longer to figure out than it should have! I was seeing file locking issues on Windows at the starts of tests, even teardowns all looked good. It turned out teardowns hadn't run because we had multiple suites running 🙄

I've only added it for the flutter_sdk tests since I don't think it'll be required for the others. 