### PR TITLE
Fix race in cli_test_driver

### DIFF
--- a/packages/devtools/test/support/cli_test_driver.dart
+++ b/packages/devtools/test/support/cli_test_driver.dart
@@ -74,7 +74,7 @@ class CliAppFixture extends AppFixture {
   static Future<CliAppFixture> create(String appScriptPath) async {
     final Process process = await Process.start(
       Platform.resolvedExecutable,
-      <String>['--observe=0', appScriptPath],
+      <String>['--observe=0', '--pause-isolates-on-start', appScriptPath],
     );
 
     final Stream<String> lines =
@@ -102,6 +102,9 @@ class CliAppFixture extends AppFixture {
         VmServiceWrapper(await vmServiceConnect('localhost', port));
 
     final VM vm = await serviceConnection.getVM();
+
+    await Future.wait(
+        vm.isolates.map((isolate) => serviceConnection.resume(isolate.id)));
 
     return CliAppFixture._(
       appScriptPath,


### PR DESCRIPTION
On Travis Windows we were hitting this race in `cli_test_driver`. We start a Dart process with `--observe=0` but we don't start it paused so the first print statements sometimes came before the Observatory banner and the coed always assumed the first line output was the banner.

```
Running C:\Users\travis\build\DanTup\devtools\dart-sdk\bin\dart.exe --observe=0 test/fixtures/logging_app.dart
PID = 5036
5036: Got line: starting logging app
5036: Got line: Observatory listening on http://127.0.0.1:49855/
```

The result is that when the first line came through, we crashed:

```
01:15 +3 -1: test\integration_tests\integration_test.dart: integration app can switch pages [E]
  FormatException: Invalid radix-10 number (at character 1)
  starting logging ap
  ^
  
  dart:core                                 int.parse
  test\support\cli_test_driver.dart 103:26  CliAppFixture.create
  ===== asynchronous gap ===========================
  dart:async                                _AsyncAwaitCompleter.completeError
  test\support\cli_test_driver.dart         CliAppFixture.create
  ===== asynchronous gap ===========================
  dart:async                                _asyncThenWrapperHelper
  test\support\cli_test_driver.dart         CliAppFixture.create
  test\integration_tests\app.dart 15:38     appTests.<fn>
```

We could've just waited for the one that looked like the banner, but it seems more sensible to connect and unpause so that if in future we need tests to be able to collect the first actual line, we can do it by giving a hook before the unpause.