### PR TITLE
add a connect dialog

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -416,6 +416,7 @@ class ConnectDialog {
     });
 
     textfield.element.onKeyDown.listen((KeyboardEvent event) {
+      // Check for an enter key press ('\n').
       if (event.keyCode == 13) {
         event.preventDefault();
 
@@ -448,27 +449,31 @@ class ConnectDialog {
   void _tryConnect() {
     final InputElement inputElement = textfield.element;
     final String value = inputElement.value.trim();
-
     final int port = int.tryParse(value);
+
+    void handleConnectError() {
+      // TODO(devoncarew): We should provide the user some instructions about
+      // how to resolve an issue connecting.
+      framework.toast("Unable to connect to '$value'.");
+    }
 
     if (port != null) {
       _connect(port).catchError((dynamic error) {
-        framework.toast("Unable to connect to '$value'.");
+        handleConnectError();
       });
     } else {
       try {
         final Uri uri = Uri.parse(value);
         if (uri.hasPort) {
           _connect(uri.port).catchError((dynamic error) {
-            framework.toast("Unable to connect to '$value'.");
+            handleConnectError();
           });
         } else {
-          framework.toast("Unable to connect to '$value'.");
+          handleConnectError();
         }
       } catch (_) {
         // ignore
-
-        framework.toast("Unable to connect to '$value'.");
+        handleConnectError();
       }
     }
   }

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -12,6 +12,7 @@ import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../utils.dart';
+import 'framework_core.dart';
 
 class Framework {
   Framework() {
@@ -25,6 +26,8 @@ class Framework {
 
     globalActions =
         ActionsContainer(CoreElement.from(querySelector('#global-actions')));
+
+    connectDialog = new ConnectDialog(this);
   }
 
   final List<Screen> screens = <Screen>[];
@@ -35,6 +38,7 @@ class Framework {
   StatusLine pageStatus;
   StatusLine auxiliaryStatus;
   ActionsContainer globalActions;
+  ConnectDialog connectDialog;
 
   final Map<Screen, CoreElement> _screenContents = {};
 
@@ -51,6 +55,10 @@ class Framework {
     window.history.pushState(null, screen.name, ref);
 
     load(screen);
+  }
+
+  void showConnectionDialog() {
+    connectDialog.show();
   }
 
   void loadScreenFromLocation() {
@@ -367,4 +375,123 @@ class Toast extends CoreElement {
 
   @override
   String toString() => '$title $message';
+}
+
+class ConnectDialog {
+  ConnectDialog(this.framework) {
+    parent = CoreElement.from(querySelector('#connect-dialog'));
+    parent.layoutVertical();
+
+    parent.add([
+      h2(text: 'Connect'),
+      CoreElement('dl', classes: 'form-group')
+        ..add([
+          CoreElement('dt')
+            ..add([
+              label(text: 'Connect to a running app')
+                ..setAttribute('for', 'port-field'),
+            ]),
+          CoreElement('dd')
+            ..add([
+              p(
+                  text: 'Enter a port or URL to a running Dart or Flutter '
+                      'application.',
+                  c: 'note'),
+            ]),
+          CoreElement('dd')
+            ..add([
+              textfield = CoreElement('input', classes: 'form-control input-sm')
+                ..setAttribute('type', 'text')
+                ..setAttribute('placeholder', 'Port')
+                ..id = 'port-field',
+              connectButton = PButton('Connect')
+                ..small()
+                ..clazz('margin-left'),
+            ]),
+        ]),
+    ]);
+
+    connectButton.click(() {
+      _tryConnect();
+    });
+
+    textfield.element.onKeyDown.listen((KeyboardEvent event) {
+      if (event.keyCode == 13) {
+        event.preventDefault();
+
+        _tryConnect();
+      }
+    });
+  }
+
+  final Framework framework;
+
+  CoreElement parent;
+  CoreElement textfield;
+  CoreElement connectButton;
+
+  void show() {
+    parent.display = 'initial';
+  }
+
+  void hide() {
+    parent.display = 'none';
+  }
+
+  bool isVisible() => parent.display != 'none';
+
+  @visibleForTesting
+  void connectTo(int port) async {
+    await _connect(port);
+  }
+
+  void _tryConnect() {
+    final InputElement inputElement = textfield.element;
+    final String value = inputElement.value.trim();
+
+    final int port = int.tryParse(value);
+
+    if (port != null) {
+      _connect(port).catchError((dynamic error) {
+        framework.toast("Unable to connect to '$value'.");
+      });
+    } else {
+      try {
+        final Uri uri = Uri.parse(value);
+        if (uri.hasPort) {
+          _connect(uri.port).catchError((dynamic error) {
+            framework.toast("Unable to connect to '$value'.");
+          });
+        } else {
+          framework.toast("Unable to connect to '$value'.");
+        }
+      } catch (_) {
+        // ignore
+
+        framework.toast("Unable to connect to '$value'.");
+      }
+    }
+  }
+
+  Future _connect(int port) async {
+    final bool connected = await FrameworkCore.initVmService(
+      explicitPort: port,
+      errorReporter: (String title, dynamic error) {
+        // ignore - we report this in _tryConnect
+      },
+    );
+
+    if (connected) {
+      // Re-write the url to include the new port
+      final Location location = window.location;
+      Uri uri = Uri.parse(location.href);
+      uri = uri.replace(queryParameters: {'port': port.toString()});
+      window.history.pushState(null, null, uri.toString());
+
+      // Hide the dialog
+      hide();
+    } else {
+      throw 'not connected';
+    }
+  }
 }

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -19,13 +19,15 @@ import '../framework/framework.dart';
 import '../logging/logging.dart';
 import '../main.dart';
 
-// TODO(devoncarew): Only enable logging after enabled by the client.
-
 class App {
   App(this.framework) {
     _register<void>('echo', echo);
     _register<void>('switchPage', switchPage);
     _register<String>('currentPageId', currentPageId);
+
+    // ConnectDialog
+    _register<void>('connectDialog.isVisible', connectDialogIsVisible);
+    _register<void>('connectDialog.connectTo', connectDialogConnectTo);
 
     // LoggingScreen
     _register<void>('logs.clearLogs', logsClearLogs);
@@ -73,8 +75,6 @@ class App {
     };
 
     js.context['devtools'] = binding;
-
-    _sendNotification('app.inited');
   }
 
   Future<void> echo(dynamic message) async {
@@ -87,12 +87,19 @@ class App {
       throw 'page $pageId not found';
     }
     framework.load(screen);
-
-    // TODO(devoncarew): Listen for and log framework page change events?
   }
 
   Future<String> currentPageId([dynamic _]) async {
     return framework.current?.id;
+  }
+
+  Future<bool> connectDialogIsVisible([dynamic _]) async {
+    return framework.connectDialog.isVisible();
+  }
+
+  Future<void> connectDialogConnectTo([dynamic port]) async {
+    // ignore: invalid_use_of_visible_for_testing_member
+    return framework.connectDialog.connectTo(port);
   }
 
   Future<void> logsClearLogs([dynamic _]) async {

--- a/packages/devtools/test/integration_tests/app.dart
+++ b/packages/devtools/test/integration_tests/app.dart
@@ -30,4 +30,39 @@ void appTests() {
     final String currentPageId = await tools.currentPageId();
     expect(currentPageId, 'logs');
   });
+
+  test('connect dialog displays', () async {
+    // start with no port
+    final Uri baseAppUri = webdevFixture.baseUri.resolve('index.html');
+    final DevtoolsManager tools =
+        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+    await tools.start(appFixture, overrideUri: baseAppUri);
+
+    final ConnectDialogManager connectDialog = ConnectDialogManager(tools);
+
+    // make sure the connect dialog displays
+    await waitFor(() async => await connectDialog.isVisible());
+
+    // have it connect to a port
+    await connectDialog.connectTo(appFixture.servicePort);
+
+    // make sure the connect dialog becomes hidden
+    await waitFor(() async => !(await connectDialog.isVisible()));
+  });
+}
+
+class ConnectDialogManager {
+  ConnectDialogManager(this.tools);
+
+  final DevtoolsManager tools;
+
+  Future<bool> isVisible() async {
+    final AppResponse response =
+        await tools.tabInstance.send('connectDialog.isVisible');
+    return response.result;
+  }
+
+  Future connectTo(int port) async {
+    await tools.tabInstance.send('connectDialog.connectTo', port);
+  }
 }

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -51,10 +51,11 @@ class DevtoolsManager {
   final BrowserTabInstance tabInstance;
   final Uri baseUri;
 
-  Future<void> start(AppFixture appFixture) async {
+  Future<void> start(AppFixture appFixture, {Uri overrideUri}) async {
     final Uri baseAppUri =
         baseUri.resolve('index.html?port=${appFixture.servicePort}');
-    await tabInstance.tab.navigate(baseAppUri.toString());
+    await tabInstance.tab
+        .navigate(overrideUri?.toString() ?? baseAppUri.toString());
 
     // wait for app initialization
     await tabInstance.getBrowserChannel();

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -54,8 +54,7 @@ class DevtoolsManager {
   Future<void> start(AppFixture appFixture, {Uri overrideUri}) async {
     final Uri baseAppUri =
         baseUri.resolve('index.html?port=${appFixture.servicePort}');
-    await tabInstance.tab
-        .navigate(overrideUri?.toString() ?? baseAppUri.toString());
+    await tabInstance.tab.navigate('${overrideUri ?? baseAppUri}');
 
     // wait for app initialization
     await tabInstance.getBrowserChannel();

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -53,6 +53,8 @@
 
 <div id="messages-container" class="container"></div>
 
+<form id="connect-dialog" class="container"></form>
+
 <div id="content" class="container" flex layout vertical style="overflow: auto;">
     <div class="blankslate">
         <p>Loading…</p>

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -12,8 +12,12 @@ void main() {
   // Load the web app framework.
   final PerfToolFramework framework = PerfToolFramework();
 
-  FrameworkCore.initVmService((String title, dynamic error) {
+  FrameworkCore.initVmService(errorReporter: (String title, dynamic error) {
     framework.showError(title, error);
+  }).then((bool connected) {
+    if (!connected) {
+      framework.showConnectionDialog();
+    }
   });
 
   framework.loadScreenFromLocation();

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -802,3 +802,10 @@ html [full] {
 .action-button+.action-button {
     margin-left: 8px;
 }
+
+#connect-dialog {
+    display: none;
+    padding-bottom: 10px;
+    border-bottom: 1px solid #eee;
+    margin-bottom: 20px;
+}


### PR DESCRIPTION
- add a connect dialog
- fix https://github.com/flutter/devtools/issues/105

This shows when the app initially starts up, if no port is specified to connect to. In future iterations, we'll need to show the dialog when we lose a connection, improve how we listen for browser history changes, and make sure that the app in general responds well to connecting to an app, losing that connection, and re-gaining another connection.

<img width="733" alt="screen shot 2019-02-05 at 3 06 42 pm" src="https://user-images.githubusercontent.com/1269969/52313880-173fbe80-2965-11e9-8fa8-f7b3e19f5e07.png">

---

<img width="229" alt="screen shot 2019-02-05 at 3 06 49 pm" src="https://user-images.githubusercontent.com/1269969/52313883-1b6bdc00-2965-11e9-88ad-42b90c4f8697.png">
