### PR TITLE
Switch to headless Chrome on bots

### DIFF
--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -206,7 +206,13 @@ class BrowserTabInstance {
   }
 
   Future<void> close() async {
-    await tab.wipConnection.target.closeTarget(tab.wipTab.id);
+    // In Headless Chrome, we get Inspector.detached when we close the last
+    // target rather than a response.
+    await Future.any(<Future<Object>>[
+      tab.wipConnection.onNotification
+          .firstWhere((n) => n.method == 'Inspector.detached'),
+      tab.wipConnection.target.closeTarget(tab.wipTab.id),
+    ]);
   }
 
   void _handleBrowserMessage(Map<dynamic, dynamic> message) {

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -13,6 +13,8 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     as wip show ChromeTab;
 
+final _useChromeHeadless = Platform.environment['TEST_HEADLESS_CHROME'] != null;
+
 class Chrome {
   factory Chrome.from(String executable) {
     return FileSystemEntity.isFileSync(executable)
@@ -66,6 +68,13 @@ class Chrome {
       '--user-data-dir=${getCreateChromeDataDir()}',
       '--remote-debugging-port=$debugPort'
     ];
+    if (_useChromeHeadless) {
+      args.addAll(<String>[
+        '--headless',
+        '--disable-gpu',
+        '--no-sandbox',
+      ]);
+    }
     if (url != null) {
       args.add(url);
     }
@@ -207,7 +216,7 @@ class ChromeTab {
   }
 
   Future<String> createNewTarget() {
-    return _wip.target.createTarget('');
+    return _wip.target.createTarget('about:blank');
   }
 
   bool get isConnected => _wip != null;

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -13,7 +13,9 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     as wip show ChromeTab;
 
-final _useChromeHeadless = Platform.environment['TEST_HEADLESS_CHROME'] != null;
+// Change this if you want to be able to see Chrome opening while tests run
+// to aid debugging.
+const _useChromeHeadless = true;
 
 class Chrome {
   factory Chrome.from(String executable) {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -22,6 +22,9 @@ echo "which dart: " `which dart`
 # Provision our packages.
 pub get
 
+# Use Headless Chrome on the bots (this is required for Linux).
+export TEST_HEADLESS_CHROME=true
+
 if [ "$BOT" = "main" ]; then
 
     # Verify that dartfmt has been run.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -22,9 +22,6 @@ echo "which dart: " `which dart`
 # Provision our packages.
 pub get
 
-# Use Headless Chrome on the bots (this is required for Linux).
-export TEST_HEADLESS_CHROME=true
-
 if [ "$BOT" = "main" ]; then
 
     # Verify that dartfmt has been run.


### PR DESCRIPTION
This seems to be required for things to work properly on Linux (which isn't enabled yet, but I think is mostly working now) but there's probably no harm having it here too.

Unfortunately headless Chrome seems kinda eager to quit, so when you close the last target it seems to detach the inspector. I've added a workaround for this, though I don't know if this is a good solution.

(I also had some issues spawning a target with new url so added `about:blank`; I couldn't find anything to verify whether the empty URL should've been valid).