### PR TITLE
TimelineFrame timing logic rewrite

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -109,7 +109,7 @@ class FrameFlameChart extends CoreElement {
     drawCpuEvents();
 
     // TODO(kenzie): improve this by adding a spacer div instead of just
-    //  increasing the row. Do this once each section is in its own container.
+    // increasing the row. Do this once each section is in its own container.
     // Add an additional row for spacing between CPU and GPU events.
     row++;
 

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -28,9 +28,9 @@ class FrameFlameChart extends CoreElement {
     if (_debugEventTrace && frame != null) {
       final StringBuffer buf = new StringBuffer();
       buf.writeln('CPU for frame ${frame.id}:');
-      frame.pipelineProduceFlow.format(buf, '  ');
+      frame.cpuEventFlow.format(buf, '  ');
       buf.writeln('GPU for frame ${frame.id}:');
-      frame.pipelineConsumeFlow.format(buf, '  ');
+      frame.gpuEventFlow.format(buf, '  ');
       print(buf.toString());
     }
 
@@ -83,7 +83,7 @@ class FrameFlameChart extends CoreElement {
 
       maxRow = row;
 
-      drawRecursively(frame.pipelineProduceFlow, row);
+      drawRecursively(frame.cpuEventFlow, row);
 
       row = maxRow;
 
@@ -99,7 +99,7 @@ class FrameFlameChart extends CoreElement {
 
       maxRow = row;
 
-      drawRecursively(frame.pipelineConsumeFlow, row);
+      drawRecursively(frame.gpuEventFlow, row);
 
       row = maxRow;
 
@@ -108,6 +108,8 @@ class FrameFlameChart extends CoreElement {
 
     drawCpuEvents();
 
+    // TODO(kenzie): improve this by adding a spacer div instead of just
+    //  increasing the row. Do this once each section is in its own container.
     // Add an additional row for spacing between CPU and GPU events.
     row++;
 

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -87,7 +87,7 @@ class FrameFlameChart extends CoreElement {
 
       row = maxRow;
 
-      row += 2;
+      row++;
     }
 
     void drawGpuEvents() {
@@ -103,10 +103,14 @@ class FrameFlameChart extends CoreElement {
 
       row = maxRow;
 
-      row += 2;
+      row++;
     }
 
     drawCpuEvents();
+
+    // Add an additional row for spacing between CPU and GPU events.
+    row++;
+
     drawGpuEvents();
   }
 

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -17,24 +17,20 @@ class FrameFlameChart extends CoreElement {
   }
 
   TimelineFrame frame;
+  CoreElement sectionTitles;
+  CoreElement flameChart;
 
   void updateFrameData(TimelineFrame frame) {
     this.frame = frame;
 
     clear();
 
-    // TODO(kenzie): Sometimes we see a dump of the event trace that does not
-    //  match what we draw in the flame chart. Fix this.
     if (_debugEventTrace && frame != null) {
       final StringBuffer buf = new StringBuffer();
       buf.writeln('CPU for frame ${frame.id}:');
-      for (TimelineEvent event in frame.cpuEvents) {
-        event.format(buf, '  ');
-      }
+      frame.pipelineProduceFlow.format(buf, '  ');
       buf.writeln('GPU for frame ${frame.id}:');
-      for (TimelineEvent event in frame.gpuEvents) {
-        event.format(buf, '  ');
-      }
+      frame.pipelineConsumeFlow.format(buf, '  ');
       print(buf.toString());
     }
 
@@ -44,7 +40,7 @@ class FrameFlameChart extends CoreElement {
   }
 
   void _render(TimelineFrame frame) {
-    const int leftIndent = 60;
+    const int leftIndent = 80;
     const int rowHeight = 25;
 
     // TODO(kenzie): re-write this scale logic.
@@ -79,20 +75,19 @@ class FrameFlameChart extends CoreElement {
     }
 
     void drawCpuEvents() {
+      final int sectionTop = row * rowHeight;
       final CoreElement sectionTitle = div(text: 'CPU', c: 'timeline-title');
       sectionTitle.element.style.left = '0';
-      sectionTitle.element.style.top = '0';
+      sectionTitle.element.style.top = '${sectionTop}px';
       add(sectionTitle);
 
       maxRow = row;
 
-      for (TimelineEvent event in frame.cpuEvents) {
-        drawRecursively(event, row);
-      }
+      drawRecursively(frame.pipelineProduceFlow, row);
 
       row = maxRow;
 
-      row++;
+      row += 2;
     }
 
     void drawGpuEvents() {
@@ -104,13 +99,11 @@ class FrameFlameChart extends CoreElement {
 
       maxRow = row;
 
-      for (TimelineEvent event in frame.gpuEvents) {
-        drawRecursively(event, row);
-      }
+      drawRecursively(frame.pipelineConsumeFlow, row);
 
       row = maxRow;
 
-      row++;
+      row += 2;
     }
 
     drawCpuEvents();

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -24,10 +24,6 @@ class TimelineController {
       StreamController<Null>.broadcast();
   Stream<Null> get onFramesCleared => _framesClearedController.stream;
 
-  // Timeline data.
-  final List<TimelineEvent> dartEvents = <TimelineEvent>[];
-  final List<TimelineEvent> gpuEvents = <TimelineEvent>[];
-
   TimelineData _timelineData;
   TimelineData get timelineData => _timelineData;
 
@@ -38,9 +34,6 @@ class TimelineController {
 
   void pause() {
     _paused = true;
-
-    dartEvents.clear();
-    gpuEvents.clear();
   }
 
   void resume() {

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -438,7 +438,7 @@ class TimelineEvent {
 
     return findChild(this, childName);
   }
-  
+
   void addChild(TimelineEvent child, {bool knownChildLocation = true}) {
     // Places the child in it's correct position amongst the other children.
     void _putChildInSubtree(TimelineEvent root) {

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -520,7 +520,7 @@ div.tabnav {
 .frame-timeline {
     position: relative;
     margin-top: 4px;
-    whitespace: pre;
+    white-space: pre;
     overflow: scroll;
 }
 
@@ -530,6 +530,7 @@ div.tabnav {
     padding: 0 2px;
     position: absolute;
     overflow-x: hidden;
+    white-space: pre;
     cursor: default;
 }
 

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -520,7 +520,6 @@ div.tabnav {
 .frame-timeline {
     position: relative;
     margin-top: 4px;
-    white-space: pre;
     overflow: scroll;
 }
 
@@ -530,7 +529,7 @@ div.tabnav {
     padding: 0 2px;
     position: absolute;
     overflow-x: hidden;
-    white-space: pre;
+    white-space: nowrap;
     cursor: default;
 }
 


### PR DESCRIPTION
This PR rewrites and corrects timeline frame timing. 
Assumptions:
1) Each frame will have one "chunk" of CPU work (pipelineProduceFlow).
2) Each frame will have one "chunk" of GPU work (pipelineConsumeFlow).
3) Frame id, startTime, and endTime will be derived from Flow events (see https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/edit#heading=h.4qqub5rv9ybk). We get a start flow event and an end flow event for each frame.

Basic logic description can be described as such:
- Listen for all events and store relevant "chunks"
- Assign a single CPU "chunk" and a single GPU "chunk" to each frame based on whether the chunk fits in the frame's time boundary

Logic assumptions discussed with @chinmaygarde. Added him to this PR for one last check. Opened an [issue](https://github.com/flutter/flutter/issues/27609) in flutter/flutter to preserve the event names we are depending on.

Verified that frame timing for CPU and GPU work matches Observatory:
![screen shot 2019-02-06 at 10 17 50 am](https://user-images.githubusercontent.com/43759233/52366997-dd6fc600-29ff-11e9-9bd7-a3634f8a9d45.png)
![observatorycomparison](https://user-images.githubusercontent.com/43759233/52367006-e19be380-29ff-11e9-8bee-d0d286ff14d9.png)
![screen shot 2019-02-06 at 11 26 27 am](https://user-images.githubusercontent.com/43759233/52367978-2c1e5f80-2a02-11e9-9424-e8d620247da8.png)
Flame chart still has UI work to do.

Additional small fixes in this PR:
- Fixes small CSS bug in flame chart
- Removes dead code from timeline_controller.dart