### PR TITLE
Switch to using shelf and map /packages/ to "pack" folder

### DIFF
--- a/packages/devtools/bin/devtools.dart
+++ b/packages/devtools/bin/devtools.dart
@@ -69,7 +69,6 @@ void main(List<String> arguments) async {
 
   // Make a handler that delegates to the correct handler based on path.
   final handler = (shelf.Request request) {
-    print(request.url.path);
     return request.url.path.startsWith('packages/')
         // request.change here will strip the `packages` prefix from the path
         // so it's relative to packHandler's root.

--- a/packages/devtools/bin/devtools.dart
+++ b/packages/devtools/bin/devtools.dart
@@ -7,9 +7,11 @@ import 'dart:io';
 import 'dart:isolate';
 
 import 'package:args/args.dart';
-import 'package:http_server/http_server.dart' show VirtualDirectory;
 import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
+import 'package:shelf/shelf.dart' as shelf;
+import 'package:shelf/shelf_io.dart' as shelf;
+import 'package:shelf_static/shelf_static.dart';
 
 const argHelp = 'help';
 const argMachine = 'machine';
@@ -48,23 +50,35 @@ void main(List<String> arguments) async {
   }
 
   final bool machineMode = args[argMachine];
+  final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
+
   final Uri resourceUri = await Isolate.resolvePackageUri(
       Uri(scheme: 'package', path: 'devtools/devtools.dart'));
   final packageDir = path.dirname(path.dirname(resourceUri.toFilePath()));
-  final String buildDir = path.join(packageDir, 'build');
-  final virDir = new VirtualDirectory(buildDir);
 
-  // Set up a directory handler to serve index.html files.
-  virDir.allowDirectoryListing = true;
-  virDir.directoryHandler = (dir, request) {
-    final indexUri = new Uri.file(dir.path).resolve('index.html');
-    virDir.serveFile(new File(indexUri.toFilePath()), request);
+  // Default static handler for all non-package requests.
+  final String buildDir = path.join(packageDir, 'build');
+  final buildHandler =
+      createStaticHandler(buildDir, defaultDocument: 'index.html');
+
+  // The packages folder is renamed in the pub package so this handler serves
+  // out of the `pack` folder.
+  final String packagesDir = path.join(packageDir, 'build', 'pack');
+  final packHandler =
+      createStaticHandler(packagesDir, defaultDocument: 'index.html');
+
+  // Make a handler that delegates to the correct handler based on path.
+  final handler = (shelf.Request request) {
+    print(request.url.path);
+    return request.url.path.startsWith('packages/')
+        // request.change here will strip the `packages` prefix from the path
+        // so it's relative to packHandler's root.
+        ? packHandler(request.change(path: 'packages'))
+        : buildHandler(request);
   };
 
-  final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
-  final server = await HttpServer.bind('127.0.0.1', port);
+  final server = await shelf.serve(handler, '127.0.0.1', port);
 
-  virDir.serve(server);
   printOutput(
     'Serving DevTools at http://${server.address.host}:${server.port}',
     {

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -16,7 +16,8 @@ dependencies:
   meta: ^1.1.0
   path: ^1.6.0
   pedantic: ^1.4.0
-  http_server: ^0.9.8+1
+  shelf: ^0.7.4
+  shelf_static: ^0.2.8
   rxdart: ^0.20.0
   vm_service_lib: ^0.3.10+2
 


### PR DESCRIPTION
This switches to using Shelf to allow us to map /packages/ to a /pack/ folder on disk, since `pub` seems to automatically exclude folders named `packages` from the published package.

Note: In its current form, this means if you publish (`pub run build_runner build`) and then serve (`dart bin/devtools.dart`) you'll get 404s because the `packages` folder has not been renamed to `pack`. We could add handling for this (if `packages` exists but `pack` does not, don't do the conditional routing) however that makes it easier to not notice you haven't renamed the folder when testing locally preparing to release, so I'm not sure if it's better like this (though it does currently mean the VS Code build+serve command won't work - but we can resolve that depending on our preference for this).