### PR TITLE
Add colors to flame chart.

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -10,6 +10,14 @@ import 'timeline_protocol.dart';
 // Switch this flag to true to dump the frame event trace to console.
 bool _debugEventTrace = false;
 
+// Amber 50 color palette from
+// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+const cpuColorPalette = ['#FFECB3', '#FFE082', '#FFD54F', '#FFCA28'];
+
+// Light Green 50 color palette from
+// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+const gpuColorPalette = ['#DCEDC8', '#C5E1A5', '#AED581', '#9CCC65'];
+
 class FrameFlameChart extends CoreElement {
   FrameFlameChart() : super('div') {
     flex();
@@ -19,6 +27,20 @@ class FrameFlameChart extends CoreElement {
   TimelineFrame frame;
   CoreElement sectionTitles;
   CoreElement flameChart;
+
+  int cpuColorOffset = 0;
+  String get cpuColor {
+    final color = cpuColorPalette[cpuColorOffset % cpuColorPalette.length];
+    cpuColorOffset++;
+    return color;
+  }
+
+  int gpuColorOffset = 0;
+  String get gpuColor {
+    final color = gpuColorPalette[gpuColorOffset % gpuColorPalette.length];
+    gpuColorOffset++;
+    return color;
+  }
 
   void updateFrameData(TimelineFrame frame) {
     this.frame = frame;
@@ -76,7 +98,8 @@ class FrameFlameChart extends CoreElement {
 
     void drawCpuEvents() {
       final int sectionTop = row * rowHeight;
-      final CoreElement sectionTitle = div(text: 'CPU', c: 'timeline-title');
+      final CoreElement sectionTitle = div(text: 'CPU', c: 'flame-chart-item');
+      sectionTitle.element.style.background = cpuColorPalette.last;
       sectionTitle.element.style.left = '0';
       sectionTitle.element.style.top = '${sectionTop}px';
       add(sectionTitle);
@@ -92,7 +115,8 @@ class FrameFlameChart extends CoreElement {
 
     void drawGpuEvents() {
       final int sectionTop = row * rowHeight;
-      final CoreElement sectionTitle = div(text: 'GPU', c: 'timeline-title');
+      final CoreElement sectionTitle = div(text: 'GPU', c: 'flame-chart-item');
+      sectionTitle.element.style.background = gpuColorPalette.last;
       sectionTitle.element.style.left = '0';
       sectionTitle.element.style.top = '${sectionTop}px';
       add(sectionTitle);
@@ -118,7 +142,8 @@ class FrameFlameChart extends CoreElement {
 
   // TODO(kenzie): re-assess this drawing logic.
   void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
-    final CoreElement item = div(text: event.name, c: 'timeline-title');
+    final CoreElement item = div(text: event.name, c: 'flame-chart-item');
+    item.element.style.background = event.isCpuEvent ? cpuColor : gpuColor;
     item.element.style.left = '${left}px';
     if (width != null) {
       item.element.style.width = '${width}px';

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import '../ui/elements.dart';
+import '../ui/fake_flutter/dart_ui/dart_ui.dart';
+import '../ui/flutter_html_shim.dart';
 import 'timeline_protocol.dart';
 
 // TODO(kenzie): implement zoom functionality.
@@ -12,11 +14,21 @@ bool _debugEventTrace = false;
 
 // Amber 50 color palette from
 // https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-const cpuColorPalette = ['#FFECB3', '#FFE082', '#FFD54F', '#FFCA28'];
+const cpuColorPalette = [
+  Color(0xFFFFECB3),
+  Color(0xFFFFE082),
+  Color(0xFFFFD54F),
+  Color(0xFFFFCA28),
+];
 
 // Light Green 50 color palette from
 // https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-const gpuColorPalette = ['#DCEDC8', '#C5E1A5', '#AED581', '#9CCC65'];
+const gpuColorPalette = [
+  Color(0xFFDCEDC8),
+  Color(0xFFC5E1A5),
+  Color(0xFFAED581),
+  Color(0xFF9CCC65),
+];
 
 class FrameFlameChart extends CoreElement {
   FrameFlameChart() : super('div') {
@@ -28,17 +40,17 @@ class FrameFlameChart extends CoreElement {
   CoreElement sectionTitles;
   CoreElement flameChart;
 
-  int cpuColorOffset = 0;
-  String get cpuColor {
-    final color = cpuColorPalette[cpuColorOffset % cpuColorPalette.length];
-    cpuColorOffset++;
+  int _cpuColorOffset = 0;
+  Color get cpuColor {
+    final color = cpuColorPalette[_cpuColorOffset % cpuColorPalette.length];
+    _cpuColorOffset++;
     return color;
   }
 
-  int gpuColorOffset = 0;
-  String get gpuColor {
-    final color = gpuColorPalette[gpuColorOffset % gpuColorPalette.length];
-    gpuColorOffset++;
+  int _gpuColorOffset = 0;
+  Color get gpuColor {
+    final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
+    _gpuColorOffset++;
     return color;
   }
 
@@ -99,7 +111,7 @@ class FrameFlameChart extends CoreElement {
     void drawCpuEvents() {
       final int sectionTop = row * rowHeight;
       final CoreElement sectionTitle = div(text: 'CPU', c: 'flame-chart-item');
-      sectionTitle.element.style.background = cpuColorPalette.last;
+      sectionTitle.element.style.background = colorToCss(cpuColorPalette.last);
       sectionTitle.element.style.left = '0';
       sectionTitle.element.style.top = '${sectionTop}px';
       add(sectionTitle);
@@ -116,7 +128,7 @@ class FrameFlameChart extends CoreElement {
     void drawGpuEvents() {
       final int sectionTop = row * rowHeight;
       final CoreElement sectionTitle = div(text: 'GPU', c: 'flame-chart-item');
-      sectionTitle.element.style.background = gpuColorPalette.last;
+      sectionTitle.element.style.background = colorToCss(gpuColorPalette.last);
       sectionTitle.element.style.left = '0';
       sectionTitle.element.style.top = '${sectionTop}px';
       add(sectionTitle);
@@ -143,7 +155,8 @@ class FrameFlameChart extends CoreElement {
   // TODO(kenzie): re-assess this drawing logic.
   void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
     final CoreElement item = div(text: event.name, c: 'flame-chart-item');
-    item.element.style.background = event.isCpuEvent ? cpuColor : gpuColor;
+    item.element.style.background =
+        event.isCpuEvent ? colorToCss(cpuColor) : colorToCss(gpuColor);
     item.element.style.left = '${left}px';
     if (width != null) {
       item.element.style.width = '${width}px';

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -39,16 +39,16 @@ class FrameFlameChart extends CoreElement {
   TimelineFrame frame;
   CoreElement sectionTitles;
   CoreElement flameChart;
-
   int _cpuColorOffset = 0;
-  Color get cpuColor {
+  int _gpuColorOffset = 0;
+
+  Color nextCpuColor() {
     final color = cpuColorPalette[_cpuColorOffset % cpuColorPalette.length];
     _cpuColorOffset++;
     return color;
   }
 
-  int _gpuColorOffset = 0;
-  Color get gpuColor {
+  Color nextGpuColor() {
     final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
     _gpuColorOffset++;
     return color;
@@ -155,8 +155,9 @@ class FrameFlameChart extends CoreElement {
   // TODO(kenzie): re-assess this drawing logic.
   void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
     final CoreElement item = div(text: event.name, c: 'flame-chart-item');
-    item.element.style.background =
-        event.isCpuEvent ? colorToCss(cpuColor) : colorToCss(gpuColor);
+    item.element.style.background = event.isCpuEvent
+        ? colorToCss(nextCpuColor())
+        : colorToCss(nextGpuColor());
     item.element.style.left = '${left}px';
     if (width != null) {
       item.element.style.width = '${width}px';

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -303,10 +303,10 @@ class TimelineData {
   }
 
   void _maybeAddCompletedFrame(TimelineFrame frame) {
-    if (frame.isReadyForTimeline && !frame.addedToTimeline.isCompleted) {
+    if (frame.isReadyForTimeline && frame.addedToTimeline == null) {
       _frameCompleteController.add(frame);
       _pendingFrames.remove(frame);
-      frame.addedToTimeline.complete();
+      frame.addedToTimeline = true;
     }
   }
 }
@@ -322,7 +322,14 @@ class TimelineFrame {
   final String id;
 
   /// Marks whether this frame has been added to the timeline.
-  final Completer<Null> addedToTimeline = Completer();
+  ///
+  /// This should only be set once.
+  bool get addedToTimeline => _addedToTimeline;
+  bool _addedToTimeline;
+  set addedToTimeline(v) {
+    assert(_addedToTimeline == null);
+    _addedToTimeline = v;
+  }
 
   /// Flow of events showing the CPU work for the frame.
   TimelineEvent get cpuEventFlow => _cpuEventFlow;

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -540,5 +540,5 @@ void main() async {
 
       await env.tearDownEnvironment();
     });
-  }, tags: 'useFlutterSdk');
+  }, tags: 'useFlutterSdk', timeout: const Timeout.factor(2));
 }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -523,9 +523,8 @@ div.tabnav {
     overflow: scroll;
 }
 
-.frame-timeline .timeline-title {
+.frame-timeline .flame-chart-item {
     border-radius: 2px;
-    background: #ddd;
     padding: 0 2px;
     position: absolute;
     overflow-x: hidden;


### PR DESCRIPTION
Grabbed [Material color palettes](https://material.io/design/color/the-color-system.html#tools-for-picking-colors) Light Green 50 and Amber 50.

Colors can easily be changed - open to suggestions @InMatrix.

<img width="1591" alt="screen shot 2019-02-07 at 11 31 53 am" src="https://user-images.githubusercontent.com/43759233/52438108-5db02d00-2acd-11e9-837f-6288b1c52489.png">
