### PR TITLE
change the icon used for paint baselines

### DIFF
--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -50,7 +50,7 @@ const debugPaint = ToggleableServiceExtensionDescription<bool>._(
 const debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaintBaselinesEnabled',
   description: 'Paint Baselines',
-  icon: FlutterIcons.painting,
+  icon: FlutterIcons.text,
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Paint Baselines',


### PR DESCRIPTION
- change the icon used for paint baselines

<img width="240" alt="screen shot 2019-02-10 at 6 04 54 pm" src="https://user-images.githubusercontent.com/1269969/52543562-83546500-2d5f-11e9-9256-9cd4c17c208d.png">
