### PR TITLE
Keep flame chart bar titles from scrolling out of scope until they have to using 'position: sticky'

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -158,12 +158,12 @@ class FrameFlameChart extends CoreElement {
   // TODO(kenzie): re-assess this drawing logic.
   void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
     final item = Element.div()..className = 'flame-chart-item';
-    final wrapper = Element.div()..className = 'flame-chart-item-label-wrapper';
-    wrapper.append(Element.span()
+    final labelWrapper = Element.div()
+      ..className = 'flame-chart-item-label-wrapper';
+    labelWrapper.append(Element.span()
       ..text = event.name
-      ..className = 'flame-chart-item-label'
-    );
-    item.append(wrapper);
+      ..className = 'flame-chart-item-label');
+    item.append(labelWrapper);
     final style = item.style;
     style.background = event.isCpuEvent
         ? colorToCss(nextCpuColor())
@@ -171,7 +171,10 @@ class FrameFlameChart extends CoreElement {
     style.left = '${left}px';
     if (width != null) {
       style.width = '${width}px';
-      wrapper.style.maxWidth = '${width}px';
+      // This is critical to avoid having labels overflow the items boundaries.
+      // For some reason, overflow:hidden does not play well with
+      // position: sticky; so we have to implement this way.
+      labelWrapper.style.maxWidth = '${width}px';
     }
     style.top = '${top}px';
     element.append(item);

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:html';
+
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
@@ -155,15 +157,23 @@ class FrameFlameChart extends CoreElement {
 
   // TODO(kenzie): re-assess this drawing logic.
   void _drawFlameChartItem(TimelineEvent event, int left, int width, int top) {
-    final CoreElement item = div(text: event.name, c: 'flame-chart-item');
-    item.element.style.background = event.isCpuEvent
+    final item = Element.div()..className = 'flame-chart-item';
+    final wrapper = Element.div()..className = 'flame-chart-item-label-wrapper';
+    wrapper.append(Element.span()
+      ..text = event.name
+      ..className = 'flame-chart-item-label'
+    );
+    item.append(wrapper);
+    final style = item.style;
+    style.background = event.isCpuEvent
         ? colorToCss(nextCpuColor())
         : colorToCss(nextGpuColor());
-    item.element.style.left = '${left}px';
+    style.left = '${left}px';
     if (width != null) {
-      item.element.style.width = '${width}px';
+      style.width = '${width}px';
+      wrapper.style.maxWidth = '${width}px';
     }
-    item.element.style.top = '${top}px';
-    add(item);
+    style.top = '${top}px';
+    element.append(item);
   }
 }

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -57,3 +57,16 @@
     white-space: nowrap;
     cursor: default;
 }
+
+.flame-chart-item-label-wrapper {
+    position: sticky;
+    left: 0;
+    position: -webkit-sticky;
+    overflow: hidden;
+    display: inline-block;
+}
+
+.flame-chart-item-label {
+    display: inline-block;
+    color: black;
+}


### PR DESCRIPTION
`position: sticky` is a recently added browser feature perfect for this use case.
@DanTup we should also use `position:sticky to add sticky headers to the table views.

It is a bit fiddly so I had to make the DOM a bit more complicated to get it to the work. At the core, you need to make sure no parents have overflow:hidden as that appears to just disable the feature and it appears you need to have separate containers for the stick container and then content inside it. However, it is possible I have missed something and the label and the sticky wrapper can be merged into a single div. I stopped iterating once it worked.
Setting the max width on the wrapper around the label is very important as otherwise you will have text overflowing out of the line chart bars which looks pretty bad.

![keep_flame_bar_titles_in_view](https://user-images.githubusercontent.com/1226812/52576448-f0561200-2dd4-11e9-9fe0-2248371771bc.gif)
