### PR TITLE
Add background colors to flame chart.

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -105,8 +105,8 @@ class FrameFlameChart extends CoreElement {
     final int frameStartOffset = frame.startTime;
 
     final cpuSectionHeight =
-        frame.cpuEventFlow.getDepth() * rowHeight + sectionSpacing;
-    final gpuSectionHeight = frame.gpuEventFlow.getDepth() * rowHeight;
+        frame.cpuEventFlow.depth * rowHeight + sectionSpacing;
+    final gpuSectionHeight = frame.gpuEventFlow.depth * rowHeight;
     final flameChartWidth = max(
         element.clientWidth,
         leftIndent +

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -35,12 +35,18 @@ const gpuColorPalette = [
   mainGpuColor,
 ];
 
+const cpuSectionBackground = Color(0xFFF9F9F9);
+const gpuSectionBackground = Color(0xFFF3F3F3);
+
 class FrameFlameChart extends CoreElement {
   FrameFlameChart() : super('div') {
     flex();
     layoutVertical();
-    clazz('flame-chart');
-    element.style.backgroundColor = colorToCss(const Color(0xFFF3F3F3));
+    element.style
+      ..backgroundColor = colorToCss(gpuSectionBackground)
+      ..position = 'relative'
+      ..marginTop = '4px'
+      ..overflow = 'hidden';
 
     enableDragScrolling(this);
   }
@@ -85,19 +91,21 @@ class FrameFlameChart extends CoreElement {
   void _render(TimelineFrame frame) {
     const int leftIndent = 70;
     const int rowHeight = 25;
+    const int sectionSpacing = 15;
 
     // 16,666 microseconds / frame will achieve a frame rate of 60 FPS.
     const double targetMicrosPerFrame = 1000 * 1000 / 60.0;
 
-    // Pixels per microsecond in order to fit a single frame in 1500px. In order
-    // for the whole frame to fit in 1500px at this drawing ratio, the frame
-    // duration must be [targetMicrosPerFrame] or less. 1500px is arbitrary.
+    /// Pixels per microsecond in order to fit a single frame in 1500px.
+    ///
+    /// For the whole frame to fit in 1500px at this drawing ratio, the frame
+    /// duration must be [targetMicrosPerFrame] or less. 1500px is arbitrary.
     const double pixelsPerMicro = 1500 / targetMicrosPerFrame;
 
     final int frameStartOffset = frame.startTime;
 
-    // Add 15 to account for vertical spacing between the CPU and GPU sections.
-    final cpuSectionHeight = frame.cpuEventFlow.getDepth() * rowHeight + 15;
+    final cpuSectionHeight =
+        frame.cpuEventFlow.getDepth() * rowHeight + sectionSpacing;
     final gpuSectionHeight = frame.gpuEventFlow.getDepth() * rowHeight;
     final flameChartWidth = max(
         element.clientWidth,
@@ -112,6 +120,9 @@ class FrameFlameChart extends CoreElement {
 
       _drawFlameChartItem(
         event,
+        // TODO(kenzie): technically we will want to round to fraction of a px
+        // for high dpi devices where 1 logical pixel may equal 2 physical
+        // pixels, etc.
         leftIndent + startPx.round(),
         (endPx - startPx).round(),
         row * rowHeight,
@@ -127,17 +138,17 @@ class FrameFlameChart extends CoreElement {
       final section = div(c: 'flame-chart-section');
       add(section);
 
-      final style = section.element.style;
-      style.height = '${cpuSectionHeight}px';
-      style.width = '${flameChartWidth}px';
-      style.backgroundColor = colorToCss(const Color(0xFFF9F9F9));
+      section.element.style
+        ..height = '${cpuSectionHeight}px'
+        ..width = '${flameChartWidth}px'
+        ..backgroundColor = colorToCss(cpuSectionBackground);
 
       final sectionTitle = div(text: 'CPU', c: 'flame-chart-item');
-      final titleStyle = sectionTitle.element.style;
-      titleStyle.background = colorToCss(mainCpuColor);
-      titleStyle.fontWeight = 'bold';
-      titleStyle.left = '0';
-      titleStyle.top = '0';
+      sectionTitle.element.style
+        ..background = colorToCss(mainCpuColor)
+        ..fontWeight = 'bold'
+        ..left = '0'
+        ..top = '0';
       section.add(sectionTitle);
 
       drawRecursively(frame.cpuEventFlow, 0, section);
@@ -147,16 +158,16 @@ class FrameFlameChart extends CoreElement {
       final section = div(c: 'flame-chart-section');
       add(section);
 
-      final style = section.element.style;
-      style.height = '${gpuSectionHeight}px';
-      style.width = '${flameChartWidth}px';
+      section.element.style
+        ..height = '${gpuSectionHeight}px'
+        ..width = '${flameChartWidth}px';
 
       final sectionTitle = div(text: 'GPU', c: 'flame-chart-item');
-      final titleStyle = sectionTitle.element.style;
-      titleStyle.background = colorToCss(mainGpuColor);
-      titleStyle.fontWeight = 'bold';
-      titleStyle.left = '0';
-      titleStyle.top = '0';
+      sectionTitle.element.style
+        ..background = colorToCss(mainGpuColor)
+        ..fontWeight = 'bold'
+        ..left = '0'
+        ..top = '0';
       section.add(sectionTitle);
 
       drawRecursively(frame.gpuEventFlow, 0, section);

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -160,7 +160,8 @@ class FrameFlameChart extends CoreElement {
 
       section.element.style
         ..height = '${gpuSectionHeight}px'
-        ..width = '${flameChartWidth}px';
+        ..width = '${flameChartWidth}px'
+        ..top = '${cpuSectionHeight}px';
 
       final sectionTitle = div(text: 'GPU', c: 'flame-chart-item');
       sectionTitle.element.style

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -48,7 +48,13 @@
     overflow: hidden;
 }
 
-.flame-chart .flame-chart-item {
+.flame-chart-section {
+    min-width: 100%;
+    position: relative;
+    box-shadow: inset 4px 4px 9px -7px #bbbbbb;
+}
+
+.flame-chart-section .flame-chart-item {
     border-radius: 2px;
     padding: 0 2px;
     position: absolute;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -42,12 +42,6 @@
     border: 2px solid #A2A2A2;
 }
 
-.flame-chart {
-    position: relative;
-    margin-top: 4px;
-    overflow: hidden;
-}
-
 .flame-chart-section {
     min-width: 100%;
     position: relative;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -44,7 +44,7 @@
 
 .flame-chart-section {
     min-width: 100%;
-    position: relative;
+    position: absolute;
     box-shadow: inset 4px 4px 9px -7px #bbbbbb;
 }
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -545,6 +545,7 @@ class TimelineEvent {
       }
       return maximum + 1;
     }
+
     return maxDepth(this);
   }
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -453,6 +453,21 @@ class TimelineEvent {
   bool get isCpuEventFlow => _hasChild('Engine::BeginFrame');
   bool get isGpuEventFlow => _hasChild('PipelineConsume');
 
+  /// Returns the depth of this TimelineEvent tree, including [this].
+  int get depth => _depth ?? _getDepth(this);
+  int _depth;
+
+  int _getDepth(TimelineEvent root) {
+    if (root == null) {
+      return 0;
+    }
+    _depth = 0;
+    for (TimelineEvent child in root.children) {
+      _depth = max(_depth, _getDepth(child));
+    }
+    return _depth + 1;
+  }
+
   /// Whether there is a child with the given name [childName] is contained
   /// somewhere in the subtree [children].
   bool _hasChild(String childName) {
@@ -531,20 +546,6 @@ class TimelineEvent {
     } else {
       return startTime < e.startTime;
     }
-  }
-
-  /// Returns the depth of this TimelineEvent tree, including [this].
-  int getDepth() => _getDepth(this);
-
-  int _getDepth(TimelineEvent root) {
-    if (root == null) {
-      return 0;
-    }
-    int depth = 0;
-    for (TimelineEvent child in root.children) {
-      depth = max(depth, _getDepth(child));
-    }
-    return depth + 1;
   }
 
   void format(StringBuffer buf, String indent) {

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -534,19 +534,17 @@ class TimelineEvent {
   }
 
   /// Returns the depth of this TimelineEvent tree, including [this].
-  int getDepth() {
-    int maxDepth(TimelineEvent root) {
-      if (root == null) {
-        return 0;
-      }
-      int maximum = 0;
-      for (TimelineEvent child in root.children) {
-        maximum = max(maximum, maxDepth(child));
-      }
-      return maximum + 1;
-    }
+  int getDepth() => _getDepth(this);
 
-    return maxDepth(this);
+  int _getDepth(TimelineEvent root) {
+    if (root == null) {
+      return 0;
+    }
+    int depth = 0;
+    for (TimelineEvent child in root.children) {
+      depth = max(depth, _getDepth(child));
+    }
+    return depth + 1;
   }
 
   void format(StringBuffer buf, String indent) {

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -453,20 +453,22 @@ class TimelineEvent {
   bool get isCpuEventFlow => _hasChild('Engine::BeginFrame');
   bool get isGpuEventFlow => _hasChild('PipelineConsume');
 
-  /// Returns the depth of this TimelineEvent tree, including [this].
-  int get depth => _depth ?? _getDepth(this);
-  int _depth;
-
-  int _getDepth(TimelineEvent root) {
-    if (root == null) {
-      return 0;
+  /// Depth of this TimelineEvent tree, including [this].
+  ///
+  /// We assume that TimelineEvent nodes are not modified after the first time
+  /// [depth] is accessed. We would need to clear the cache if this was
+  /// supported.
+  int get depth {
+    if (_depth != 0) {
+      return _depth;
     }
-    _depth = 0;
-    for (TimelineEvent child in root.children) {
-      _depth = max(_depth, _getDepth(child));
+    for (TimelineEvent child in children) {
+      _depth = max(_depth, child.depth);
     }
-    return _depth + 1;
+    return _depth = _depth + 1;
   }
+
+  int _depth = 0;
 
   /// Whether there is a child with the given name [childName] is contained
   /// somewhere in the subtree [children].

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 
 // For documentation, see the Chrome "Trace Event Format" document:
 // https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU/preview
@@ -530,6 +531,21 @@ class TimelineEvent {
     } else {
       return startTime < e.startTime;
     }
+  }
+
+  /// Returns the depth of this TimelineEvent tree, including [this].
+  int getDepth() {
+    int maxDepth(TimelineEvent root) {
+      if (root == null) {
+        return 0;
+      }
+      int maximum = 0;
+      for (TimelineEvent child in root.children) {
+        maximum = max(maximum, maxDepth(child));
+      }
+      return maximum + 1;
+    }
+    return maxDepth(this);
   }
 
   void format(StringBuffer buf, String indent) {


### PR DESCRIPTION
Pulls CPU and GPU sections out into their own divs, adds background color to each section, and tweaks drawing logic.
<img width="1169" alt="screen shot 2019-02-12 at 8 11 31 am" src="https://user-images.githubusercontent.com/43759233/52649793-d6343680-2e9d-11e9-8dc4-fade7400e4f0.png">

