### PR TITLE
Make table headers sticky

### DIFF
--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -11,8 +11,6 @@ import 'framework/framework.dart';
 import 'ui/elements.dart';
 import 'utils.dart';
 
-// TODO(devoncarew): fixed position header
-
 class Table<T> extends Object with SetStateMixin {
   Table()
       : element = div(a: 'flex', c: 'overflow-y table-border'),
@@ -125,8 +123,9 @@ class Table<T> extends Object with SetStateMixin {
                 c: 'interactable${column.supportsSorting ? ' sortable' : ''}');
             s.click(() => _columnClicked(column));
             _spanForColumn[column] = s;
-            final CoreElement header = th(c: column.numeric ? 'right' : 'left')
-              ..add(s);
+            final CoreElement header =
+                th(c: 'sticky-top ${column.numeric ? 'right' : 'left'}')
+                  ..add(s);
             if (column.wide) {
               header.clazz('wide');
             }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -113,6 +113,11 @@ span.label.gc {
     background-color: #424242;
 }
 
+.sticky-top {
+    position: sticky;
+    top: 0;
+}
+
 .table-virtual {
     overflow-anchor: none;
 }


### PR DESCRIPTION
This only seems to work on the `th`'s, not on `thead` or `tr`. Seems to work fine on all the tables I could find (logging, performance, memory) though a minor niggle is that it doesn't seem to span behind the scrollbar, so there's a thin white strip on the right edge once you scroll down (if anyone has ideas for removing this, lmk!).

![screenshot 2019-02-12 at 10 20 05 am](https://user-images.githubusercontent.com/1078012/52628531-ca517000-2eaf-11e9-9e26-5b7e2c6b9fe5.png)
