### PR TITLE
Ensure links work when inside subfolders

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,3 +1,8 @@
 theme: jekyll-theme-primer
+# This should match the path where the live deployment is, so `jekyll serve`
+# puts the local version at the same relative path.
+baseurl: /devtools
+# Set the repository so that site.github.xxx works when serving locally.
+repository: flutter/devtools
 kramdown:
   parse_block_html: true

--- a/docs/_includes/toc.html
+++ b/docs/_includes/toc.html
@@ -1,31 +1,31 @@
 <nav class="menu docs-menu">
-  <a class="menu-item {% if page.name == 'index.md' %} selected {% endif %}" href="index.html">
+  <a class="menu-item {% if page.name == 'index.md' %} selected {% endif %}" href="{{ "/" | relative_url }}">
     Getting Started
   </a>
 
-  <a class="menu-item indent {% if page.name == 'android_studio.md' %} selected {% endif %}" href="android_studio">
+  <a class="menu-item indent {% if page.name == 'android_studio.md' %} selected {% endif %}" href="{{ "/android_studio" | relative_url }}">
     Android Studio / IntelliJ
   </a>
-  <a class="menu-item indent {% if page.name == 'vscode.md' %} selected {% endif %}" href="vscode">
+  <a class="menu-item indent {% if page.name == 'vscode.md' %} selected {% endif %}" href="{{ "/vscode" | relative_url }}">
     VS Code
   </a>
-  <a class="menu-item indent {% if page.name == 'cli.md' %} selected {% endif %}" href="cli">
+  <a class="menu-item indent {% if page.name == 'cli.md' %} selected {% endif %}" href="{{ "/cli" | relative_url }}">
     Command Line
   </a>
 
   <div class="menu-item no-nav">
     Using DevTools
   </div>
-  <a class="menu-item indent {% if page.name == 'inspector.md' %} selected {% endif %}" href="inspector">
+  <a class="menu-item indent {% if page.name == 'inspector.md' %} selected {% endif %}" href="{{ "/inspector" | relative_url }}">
     Flutter Inspector
   </a>
-  <a class="menu-item indent {% if page.name == 'timeline.md' %} selected {% endif %}" href="timeline">
+  <a class="menu-item indent {% if page.name == 'timeline.md' %} selected {% endif %}" href="{{ "/timeline" | relative_url }}">
     Timeline View
   </a>
-  <a class="menu-item indent {% if page.name == 'debugger.md' %} selected {% endif %}" href="debugger">
+  <a class="menu-item indent {% if page.name == 'debugger.md' %} selected {% endif %}" href="{{ "/debugger" | relative_url }}">
     Debugger
   </a>
-  <a class="menu-item indent {% if page.name == 'logging.md' %} selected {% endif %}" href="logging">
+  <a class="menu-item indent {% if page.name == 'logging.md' %} selected {% endif %}" href="{{ "/logging" | relative_url }}">
     Logging View
   </a>
 </nav>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -14,8 +14,8 @@
         <span class="masthead-logo">Dart DevTools</span>
 
         <nav class="masthead-nav">
-          <a href="https://flutter.github.io/devtools/" class="active">Docs</a>
-          <a href="https://github.com/flutter/devtools">Github</a>
+          <a href="{{ "/" | relative_url }}" class="active">Docs</a>
+          <a href="{{ site.github.repository_url }}">Github</a>
         </nav>
       </div>
     </header>


### PR DESCRIPTION
I noticed locally that if you end up in what the browser thinks is a folder, eg. `/vscode/` instead of `/vscode` then the relative paths would be wrong (so the nav links would then go to `/vscode/cli` etc.).

So, I fixed it (along with some other minor niggles, such as making `jekyll serve` use `/devtools` locally to reduce the chance of links that work locally but not live like #262). However I just discovered that `/vscode/` doesn't work when hosted remotely:

https://flutter.github.io/devtools/vscode/

So, some of this may be unnecessary and I'm not sure if we should land it (I think it's better this way, since if we add anything in sub-folders it'll keep things working - but it does come at the expense of being more verbose).

@devoncarew