### PR TITLE
Add keyboard navigation to SelectableTree

### DIFF
--- a/packages/devtools/analysis_options.yaml
+++ b/packages/devtools/analysis_options.yaml
@@ -2,9 +2,6 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
-  #strong-mode:
-  #  implicit-casts: false
-  #  implicit-dynamic: false
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/packages/devtools/analysis_options.yaml
+++ b/packages/devtools/analysis_options.yaml
@@ -2,6 +2,9 @@
 include: package:pedantic/analysis_options.yaml
 
 analyzer:
+  #strong-mode:
+  #  implicit-casts: false
+  #  implicit-dynamic: false
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:html';
 
 import 'elements.dart';
 import 'trees.dart';
+import 'trees_html.dart';
 
 class ProgressElement extends CoreElement {
   ProgressElement() : super('div') {
@@ -140,27 +140,12 @@ class SelectableTreeNodeItem<T> {
 class SelectableTree<T> extends CoreElement
     with
         Tree<SelectableTreeNodeItem<T>>,
-        TreeNavigator<SelectableTreeNodeItem<T>> {
+        TreeNavigator<SelectableTreeNodeItem<T>>,
+        HtmlTreeNavigator<SelectableTreeNodeItem<T>> {
   SelectableTree() : super('ul') {
     // Ensure the tree can be tabbed into.
     element.tabIndex = 0;
-    element.onKeyDown.listen(_handleKeyPress);
-  }
-
-  void _handleKeyPress(KeyboardEvent e) {
-    if (e.keyCode == KeyCode.DOWN) {
-      moveDown();
-    } else if (e.keyCode == KeyCode.UP) {
-      moveUp();
-    } else if (e.keyCode == KeyCode.RIGHT) {
-      moveRight();
-    } else if (e.keyCode == KeyCode.LEFT) {
-      moveLeft();
-    } else {
-      return; // don't preventDefault if we were anything else.
-    }
-
-    e.preventDefault();
+    element.onKeyDown.listen(handleKeyPress);
   }
 
   List<T> items = <T>[];
@@ -272,7 +257,7 @@ class SelectableTree<T> extends CoreElement
 
   @override
   void select(TreeNode<SelectableTreeNodeItem<T>> node, {bool clear = false}) {
-    selectedItem?.data?.element?.toggleClass('selected', false);
+    _selectedItem?.data?.element?.toggleClass('selected', false);
 
     if (clear) {
       node = null;

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -140,7 +140,7 @@ class SelectableTreeNodeItem<T> {
 class SelectableTree<T> extends CoreElement
     with
         Tree<SelectableTreeNodeItem<T>>,
-        TreeKeyboardNavigation<SelectableTreeNodeItem<T>> {
+        TreeNavigator<SelectableTreeNodeItem<T>> {
   SelectableTree() : super('ul') {
     // Ensure the tree can be tabbed into.
     element.tabIndex = 0;
@@ -149,13 +149,13 @@ class SelectableTree<T> extends CoreElement
 
   void _handleKeyPress(KeyboardEvent e) {
     if (e.keyCode == KeyCode.DOWN) {
-      handleDownKey();
+      moveDown();
     } else if (e.keyCode == KeyCode.UP) {
-      handleUpKey();
+      moveUp();
     } else if (e.keyCode == KeyCode.RIGHT) {
-      handleRightKey();
+      moveRight();
     } else if (e.keyCode == KeyCode.LEFT) {
-      handleLeftKey();
+      moveLeft();
     } else {
       return; // don't preventDefault if we were anything else.
     }

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -121,7 +121,6 @@ class SelectableList<T> extends CoreElement {
 
     _selectedElement = element;
     element?.toggleClass('selected', true);
-    // TODO(dantup): Figure out why this doesn't work.
     element?.scrollIntoView();
     _selectionController.add(item);
   }
@@ -326,6 +325,7 @@ class SelectableTree<T> extends CoreElement {
 
     _selectedItem = element;
     element?.toggleClass('selected', true);
+    element?.scrollIntoView();
     _selectionController.add(element?.item);
   }
 }

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -141,64 +141,64 @@ class SelectableTree<T> extends CoreElement {
 
   @visibleForTesting
   void handleKeyPress(KeyboardEvent e) {
-    void handleDownKey() {
-      if (_selectedItem != null) {
-        final nextElm = _selectedItem.getNextVisibleElement();
-        if (nextElm != null) {
-          select(nextElm);
-        }
-      } else {
-        if (treeItems.isNotEmpty) {
-          select(treeItems.first);
-        }
-      }
-    }
-
-    void handleUpKey() {
-      if (_selectedItem != null) {
-        final prevElm = selectedItem.getPreviousVisibleElement();
-        if (prevElm != null) {
-          select(prevElm);
-        }
-      } else {
-        if (treeItems.isNotEmpty) {
-          select(treeItems.last.getLastVisibleDescendant() ?? treeItems.last);
-        }
-      }
-    }
-
-    void handleRightKey() {
-      if (!_selectedItem.hasChildren) {
-        return;
-      }
-      if (!_selectedItem.isExpanded) {
-        _selectedItem.expand();
-      } else {
-        select(_selectedItem.visibleChildren.first);
-      }
-    }
-
-    void handleLeftKey() {
-      if (_selectedItem.isExpanded) {
-        _selectedItem.collapse();
-      } else if (_selectedItem.parent != null) {
-        select(_selectedItem.parent);
-      }
-    }
-
     if (e.keyCode == KeyCode.DOWN) {
-      handleDownKey();
+      _handleDownKey();
     } else if (e.keyCode == KeyCode.UP) {
-      handleUpKey();
+      _handleUpKey();
     } else if (e.keyCode == KeyCode.RIGHT) {
-      handleRightKey();
+      _handleRightKey();
     } else if (e.keyCode == KeyCode.LEFT) {
-      handleLeftKey();
+      _handleLeftKey();
     } else {
       return; // don't preventDefault if we were anything else.
     }
 
     e.preventDefault();
+  }
+
+  void _handleDownKey() {
+    if (_selectedItem != null) {
+      final nextElm = _selectedItem.getNextVisibleElement();
+      if (nextElm != null) {
+        select(nextElm);
+      }
+    } else {
+      if (treeItems.isNotEmpty) {
+        select(treeItems.first);
+      }
+    }
+  }
+
+  void _handleUpKey() {
+    if (_selectedItem != null) {
+      final prevElm = selectedItem.getPreviousVisibleElement();
+      if (prevElm != null) {
+        select(prevElm);
+      }
+    } else {
+      if (treeItems.isNotEmpty) {
+        select(treeItems.last.getLastVisibleDescendant() ?? treeItems.last);
+      }
+    }
+  }
+
+  void _handleRightKey() {
+    if (!_selectedItem.hasChildren) {
+      return;
+    }
+    if (!_selectedItem.isExpanded) {
+      _selectedItem.expand();
+    } else {
+      select(_selectedItem.visibleChildren.first);
+    }
+  }
+
+  void _handleLeftKey() {
+    if (_selectedItem.isExpanded) {
+      _selectedItem.collapse();
+    } else if (_selectedItem.parent != null) {
+      select(_selectedItem.parent);
+    }
   }
 
   List<T> items = <T>[];

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:html';
 
 import 'elements.dart';
 import 'trees.dart';
@@ -143,7 +144,23 @@ class SelectableTree<T> extends CoreElement
   SelectableTree() : super('ul') {
     // Ensure the tree can be tabbed into.
     element.tabIndex = 0;
-    element.onKeyDown.listen(handleKeyPress);
+    element.onKeyDown.listen(_handleKeyPress);
+  }
+
+  void _handleKeyPress(KeyboardEvent e) {
+    if (e.keyCode == KeyCode.DOWN) {
+      handleDownKey();
+    } else if (e.keyCode == KeyCode.UP) {
+      handleUpKey();
+    } else if (e.keyCode == KeyCode.RIGHT) {
+      handleRightKey();
+    } else if (e.keyCode == KeyCode.LEFT) {
+      handleLeftKey();
+    } else {
+      return; // don't preventDefault if we were anything else.
+    }
+
+    e.preventDefault();
   }
 
   List<T> items = <T>[];

--- a/packages/devtools/lib/src/ui/elements.dart
+++ b/packages/devtools/lib/src/ui/elements.dart
@@ -152,7 +152,7 @@ class CoreElement {
     } else if (child is Element) {
       element.children.add(child);
     } else {
-      throw ArgumentError('argument type not supported');
+      throw ArgumentError('argument type ${child.runtimeType} not supported');
     }
     return child;
   }

--- a/packages/devtools/lib/src/ui/elements.dart
+++ b/packages/devtools/lib/src/ui/elements.dart
@@ -149,6 +149,8 @@ class CoreElement {
       return child.map<dynamic>((dynamic c) => add(c)).toList();
     } else if (child is CoreElement) {
       element.children.add(child.element);
+    } else if (child is CoreElementView) {
+      element.children.add(child.element.element);
     } else if (child is Element) {
       element.children.add(child);
     } else {

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -71,7 +71,7 @@ mixin TreeNavigator<T> {
 
   TreeNode<T> _getPreviousVisibleElementAbove(TreeNode<T> node) {
     // The previous visible element above this one is first of:
-    // - Our previous sibling's last visible ancestor
+    // - Our previous sibling's last visible descendant
     // - Our previous sibling
     // - Our parent
 

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -4,8 +4,6 @@
 
 import 'dart:html';
 
-import 'elements.dart';
-
 mixin TreeKeyboardNavigation<T> {
   List<TreeNode<T>> get treeNodes;
   TreeNode<T> get selectedItem;
@@ -73,9 +71,9 @@ mixin TreeKeyboardNavigation<T> {
   }
 }
 
-class TreeNode<T> extends CoreElement {
-  TreeNode(CoreElement core, this.item) : super.from(core.element);
-  final T item;
+class TreeNode<T> {
+  TreeNode(this.data);
+  T data;
   bool isExpanded = false, hasChildren = false;
   Function() expand, collapse;
   TreeNode<T> parent;
@@ -83,7 +81,7 @@ class TreeNode<T> extends CoreElement {
   final List<TreeNode<T>> children = [];
   List<TreeNode<T>> get visibleChildren => isExpanded ? children : [];
 
-  TreeNode<T> getNextVisibleElement({includeChildren = true}) {
+  TreeNode<T> getNextVisibleElement({bool includeChildren = true}) {
     // The next visible element below this one is first of:
     // - Our first child
     // - Our next sibling

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -10,7 +10,7 @@ mixin TreeNavigator<T> {
 
   void moveDown() {
     if (selectedItem != null) {
-      final nextElm = _getNextVisibleElement(selectedItem);
+      final nextElm = _getNextVisibleElementBelow(selectedItem);
       if (nextElm != null) {
         select(nextElm);
       }
@@ -23,7 +23,7 @@ mixin TreeNavigator<T> {
 
   void moveUp() {
     if (selectedItem != null) {
-      final prevElm = _getPreviousVisibleElement(selectedItem);
+      final prevElm = _getPreviousVisibleElementAbove(selectedItem);
       if (prevElm != null) {
         select(prevElm);
       }
@@ -53,7 +53,7 @@ mixin TreeNavigator<T> {
     }
   }
 
-  TreeNode<T> _getNextVisibleElement(TreeNode<T> node,
+  TreeNode<T> _getNextVisibleElementBelow(TreeNode<T> node,
       {bool includeChildren = true}) {
     // The next visible element below this one is first of:
     // - Our first child
@@ -64,10 +64,12 @@ mixin TreeNavigator<T> {
       return node.visibleChildren.first;
     }
     return node.nextSibling ??
-        _getNextVisibleElement(node.parent, includeChildren: false);
+        (node.parent != null
+            ? _getNextVisibleElementBelow(node.parent, includeChildren: false)
+            : null);
   }
 
-  TreeNode<T> _getPreviousVisibleElement(TreeNode<T> node) {
+  TreeNode<T> _getPreviousVisibleElementAbove(TreeNode<T> node) {
     // The previous visible element above this one is first of:
     // - Our previous sibling's last visible ancestor
     // - Our previous sibling

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -1,0 +1,116 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+
+import 'elements.dart';
+
+mixin TreeKeyboardNavigation<T> {
+  List<TreeNode<T>> get treeNodes;
+  TreeNode<T> get selectedItem;
+  void select(TreeNode<T> node);
+
+  void handleKeyPress(KeyboardEvent e) {
+    if (e.keyCode == KeyCode.DOWN) {
+      _handleDownKey();
+    } else if (e.keyCode == KeyCode.UP) {
+      _handleUpKey();
+    } else if (e.keyCode == KeyCode.RIGHT) {
+      _handleRightKey();
+    } else if (e.keyCode == KeyCode.LEFT) {
+      _handleLeftKey();
+    } else {
+      return; // don't preventDefault if we were anything else.
+    }
+
+    e.preventDefault();
+  }
+
+  void _handleDownKey() {
+    if (selectedItem != null) {
+      final nextElm = selectedItem.getNextVisibleElement();
+      if (nextElm != null) {
+        select(nextElm);
+      }
+    } else {
+      if (treeNodes.isNotEmpty) {
+        select(treeNodes.first);
+      }
+    }
+  }
+
+  void _handleUpKey() {
+    if (selectedItem != null) {
+      final prevElm = selectedItem.getPreviousVisibleElement();
+      if (prevElm != null) {
+        select(prevElm);
+      }
+    } else {
+      if (treeNodes.isNotEmpty) {
+        select(treeNodes.last.getLastVisibleDescendant() ?? treeNodes.last);
+      }
+    }
+  }
+
+  void _handleRightKey() {
+    if (!selectedItem.hasChildren) {
+      return;
+    }
+    if (!selectedItem.isExpanded) {
+      selectedItem.expand();
+    } else {
+      select(selectedItem.visibleChildren.first);
+    }
+  }
+
+  void _handleLeftKey() {
+    if (selectedItem.isExpanded) {
+      selectedItem.collapse();
+    } else if (selectedItem.parent != null) {
+      select(selectedItem.parent);
+    }
+  }
+}
+
+class TreeNode<T> extends CoreElement {
+  TreeNode(CoreElement core, this.item) : super.from(core.element);
+  final T item;
+  bool isExpanded = false, hasChildren = false;
+  Function() expand, collapse;
+  TreeNode<T> parent;
+  TreeNode<T> previousSibling, nextSibling;
+  final List<TreeNode<T>> children = [];
+  List<TreeNode<T>> get visibleChildren => isExpanded ? children : [];
+
+  TreeNode<T> getNextVisibleElement({includeChildren = true}) {
+    // The next visible element below this one is first of:
+    // - Our first child
+    // - Our next sibling
+    // - The next sibling of our parent
+    // - The next sibling of our parents parent (recursive...)
+    if (includeChildren && isExpanded && visibleChildren.isNotEmpty) {
+      return visibleChildren.first;
+    }
+    return nextSibling ?? parent?.getNextVisibleElement(includeChildren: false);
+  }
+
+  TreeNode<T> getPreviousVisibleElement() {
+    // The previous visible element above this one is first of:
+    // - Our previous sibling's last visible ancestor
+    // - Our previous sibling
+    // - Our parent
+
+    return previousSibling?.getLastVisibleDescendant() ??
+        previousSibling ??
+        parent;
+  }
+
+  TreeNode<T> getLastVisibleDescendant() {
+    var node = this;
+    while (node.isExpanded && node.visibleChildren.isNotEmpty) {
+      node = node.visibleChildren.last;
+    }
+    return node;
+  }
+}

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -90,7 +90,7 @@ mixin TreeNavigator<T> {
   }
 }
 
-/// Provies shared functionality for trees.
+/// Provides shared functionality for trees.
 class Tree<T> {
   // Connects parents, children and sibling nodes required to be able to traverse
   // the tree.

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -71,6 +71,32 @@ mixin TreeKeyboardNavigation<T> {
   }
 }
 
+class Tree<T> {
+  // Connects parents, children and sibling nodes required to be able to traverse
+  // the tree.
+  void connectNodes(
+    TreeNode<T> parent,
+    List<TreeNode<T>> children,
+    bool Function(T) hasChildren,
+  ) {
+    TreeNode<T> previousNode;
+
+    for (TreeNode<T> node in children) {
+      node.parent = parent;
+      node.hasChildren = hasChildren(node.data);
+
+      if (previousNode != null) {
+        node.previousSibling = previousNode;
+        previousNode.nextSibling ??= node;
+      }
+
+      previousNode = node;
+    }
+
+    parent?.children?.addAll(children);
+  }
+}
+
 class TreeNode<T> {
   TreeNode(this.data);
   T data;

--- a/packages/devtools/lib/src/ui/trees.dart
+++ b/packages/devtools/lib/src/ui/trees.dart
@@ -2,30 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html';
-
+/// Provides functionality for moving around a tree using the keyboard.
 mixin TreeKeyboardNavigation<T> {
   List<TreeNode<T>> get treeNodes;
   TreeNode<T> get selectedItem;
   void select(TreeNode<T> node);
 
-  void handleKeyPress(KeyboardEvent e) {
-    if (e.keyCode == KeyCode.DOWN) {
-      _handleDownKey();
-    } else if (e.keyCode == KeyCode.UP) {
-      _handleUpKey();
-    } else if (e.keyCode == KeyCode.RIGHT) {
-      _handleRightKey();
-    } else if (e.keyCode == KeyCode.LEFT) {
-      _handleLeftKey();
-    } else {
-      return; // don't preventDefault if we were anything else.
-    }
-
-    e.preventDefault();
-  }
-
-  void _handleDownKey() {
+  void handleDownKey() {
     if (selectedItem != null) {
       final nextElm = selectedItem.getNextVisibleElement();
       if (nextElm != null) {
@@ -38,7 +21,7 @@ mixin TreeKeyboardNavigation<T> {
     }
   }
 
-  void _handleUpKey() {
+  void handleUpKey() {
     if (selectedItem != null) {
       final prevElm = selectedItem.getPreviousVisibleElement();
       if (prevElm != null) {
@@ -51,7 +34,7 @@ mixin TreeKeyboardNavigation<T> {
     }
   }
 
-  void _handleRightKey() {
+  void handleRightKey() {
     if (!selectedItem.hasChildren) {
       return;
     }
@@ -62,7 +45,7 @@ mixin TreeKeyboardNavigation<T> {
     }
   }
 
-  void _handleLeftKey() {
+  void handleLeftKey() {
     if (selectedItem.isExpanded) {
       selectedItem.collapse();
     } else if (selectedItem.parent != null) {
@@ -71,6 +54,7 @@ mixin TreeKeyboardNavigation<T> {
   }
 }
 
+/// Provies shared functionality for trees.
 class Tree<T> {
   // Connects parents, children and sibling nodes required to be able to traverse
   // the tree.
@@ -97,6 +81,7 @@ class Tree<T> {
   }
 }
 
+/// Represents a node in a tree that holds some [data].
 class TreeNode<T> {
   TreeNode(this.data);
   T data;

--- a/packages/devtools/lib/src/ui/trees_html.dart
+++ b/packages/devtools/lib/src/ui/trees_html.dart
@@ -1,0 +1,26 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:html';
+
+import 'trees.dart';
+
+/// Provides functionality for navigating around a tree with HTML keypresses.
+mixin HtmlTreeNavigator<T> on TreeNavigator<T> {
+  void handleKeyPress(KeyboardEvent e) {
+    if (e.keyCode == KeyCode.DOWN) {
+      moveDown();
+    } else if (e.keyCode == KeyCode.UP) {
+      moveUp();
+    } else if (e.keyCode == KeyCode.RIGHT) {
+      moveRight();
+    } else if (e.keyCode == KeyCode.LEFT) {
+      moveLeft();
+    } else {
+      return; // don't preventDefault if we were anything else.
+    }
+
+    e.preventDefault();
+  }
+}

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -72,7 +72,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        tree.handleDownKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -93,7 +93,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        tree.handleDownKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
   - Item 1.1 ***
@@ -111,7 +111,7 @@ void main() {
 - Item 3 ***
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        tree.handleDownKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -127,7 +127,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        tree.handleDownKey();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -143,7 +143,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        tree.handleUpKey();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -165,7 +165,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        tree.handleUpKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
   - Item 1.1
@@ -183,7 +183,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        tree.handleUpKey();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -209,7 +209,7 @@ void main() {
     - Item 3.3.3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        tree.handleUpKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -231,7 +231,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        tree.handleLeftKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -251,7 +251,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        tree.handleLeftKey();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
 - Item 1
@@ -272,7 +272,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        tree.handleLeftKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -307,7 +307,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        tree.handleRightKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -331,7 +331,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        tree.handleRightKey();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
 - Item 1
@@ -355,7 +355,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        tree.handleRightKey();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -382,12 +382,12 @@ class TestStringTreeView extends SelectableTree<String> {
     final StringBuffer output = StringBuffer();
 
     void addLevel(
-        int indent, List<TreeNode<SelectableTreeNodeItem<String>>> items) {
-      for (var item in items) {
+        int indent, List<TreeNode<SelectableTreeNodeItem<String>>> nodes) {
+      for (var node in nodes) {
         output.writeln(
-            '${' ' * indent * 2}- ${item.data.item} ${item == selectedItem ? '***' : ''}'
+            '${' ' * indent * 2}- ${node.data.item} ${node == selectedItem ? '***' : ''}'
                 .trimRight());
-        addLevel(indent + 1, item.visibleChildren);
+        addLevel(indent + 1, node.visibleChildren);
       }
     }
 

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -381,10 +381,11 @@ class TestStringTreeView extends SelectableTree<String> {
   String getTextTree() {
     final StringBuffer output = StringBuffer();
 
-    void addLevel(int indent, List<TreeNode<String>> items) {
+    void addLevel(
+        int indent, List<TreeNode<SelectableTreeNodeItem<String>>> items) {
       for (var item in items) {
         output.writeln(
-            '${' ' * indent * 2}- ${item.item} ${item == selectedItem ? '***' : ''}'
+            '${' ' * indent * 2}- ${item.data.item} ${item == selectedItem ? '***' : ''}'
                 .trimRight());
         addLevel(indent + 1, item.visibleChildren);
       }

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -7,6 +7,7 @@ import 'dart:html';
 
 import 'package:devtools/src/ui/custom.dart';
 import 'package:devtools/src/ui/elements.dart';
+import 'package:devtools/src/ui/trees.dart';
 import 'package:test/test.dart';
 
 import 'integration_tests/integration.dart';
@@ -34,7 +35,7 @@ void main() {
     });
 
     test('includes children when expanded', () async {
-      tree.treeItems[1].expand();
+      tree.treeNodes[1].expand();
       await shortDelay();
       final textTree = tree.getTextTree();
       const expectedTree = '''
@@ -49,9 +50,9 @@ void main() {
     });
 
     test('hides children when collapsed', () async {
-      tree.treeItems[1].expand();
+      tree.treeNodes[1].expand();
       await shortDelay();
-      tree.treeItems[1].collapse();
+      tree.treeNodes[1].collapse();
       await shortDelay();
       final textTree = tree.getTextTree();
       const expectedTree = '''
@@ -64,7 +65,7 @@ void main() {
 
     group('keyboard navigation', () {
       test('DOWN moves selection to next sibling if not expanded', () async {
-        tree.select(tree.treeItems.first);
+        tree.select(tree.treeNodes.first);
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -80,7 +81,7 @@ void main() {
       });
 
       test('DOWN moves selection to first child if expanded', () async {
-        tree.select(tree.treeItems.first);
+        tree.select(tree.treeNodes.first);
         tree.selectedItem.expand();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
@@ -103,7 +104,7 @@ void main() {
 '''));
       });
       test('DOWN sticks to the last item if nothing below it', () async {
-        tree.select(tree.treeItems.last);
+        tree.select(tree.treeNodes.last);
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -135,7 +136,7 @@ void main() {
       });
 
       test('UP moves selection to previous sibling if not expanded', () async {
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -152,9 +153,9 @@ void main() {
 
       test('UP moves selection to last child of previous sibling if expanded',
           () async {
-        tree.treeItems[0].expand();
+        tree.treeNodes[0].expand();
         await shortDelay();
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         expect(tree.getTextTree(), equals('''
 - Item 1
   - Item 1.1
@@ -175,7 +176,7 @@ void main() {
 '''));
       });
       test('UP sticks to the first item if nothing above it', () async {
-        tree.select(tree.treeItems.first);
+        tree.select(tree.treeNodes.first);
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -192,9 +193,9 @@ void main() {
 
       test('UP selects the last visible item if there is no selection',
           () async {
-        tree.treeItems.last.expand();
+        tree.treeNodes.last.expand();
         await shortDelay();
-        tree.treeItems.last.children.last.expand();
+        tree.treeNodes.last.children.last.expand();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
 - Item 1
@@ -223,7 +224,7 @@ void main() {
       });
 
       test('LEFT does nothing for level=1', () {
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -238,7 +239,7 @@ void main() {
 '''));
       });
       test('LEFT collapses an expanded node', () async {
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         tree.selectedItem.expand();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
@@ -259,9 +260,9 @@ void main() {
 '''));
       });
       test('LEFT moves to parent of a collapsed node', () async {
-        tree.treeItems[1].expand();
+        tree.treeNodes[1].expand();
         await shortDelay();
-        tree.select(tree.treeItems[1].children[1]);
+        tree.select(tree.treeNodes[1].children[1]);
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -283,7 +284,7 @@ void main() {
       });
       test('RIGHT does nothing for leaf node', () async {
         // Expand all the middle nodes to the leaf.
-        var children = tree.treeItems;
+        var children = tree.treeNodes;
         while (children[1].hasChildren) {
           children[1].expand();
           await shortDelay();
@@ -323,7 +324,7 @@ void main() {
 '''));
       });
       test('RIGHT expands a collapsed node', () async {
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -342,7 +343,7 @@ void main() {
 '''));
       });
       test('RIGHT moves to first child of expanded node', () async {
-        tree.select(tree.treeItems[1]);
+        tree.select(tree.treeNodes[1]);
         tree.selectedItem.expand();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
@@ -380,7 +381,7 @@ class TestStringTreeView extends SelectableTree<String> {
   String getTextTree() {
     final StringBuffer output = StringBuffer();
 
-    void addLevel(int indent, List<TreeItem<String>> items) {
+    void addLevel(int indent, List<TreeNode<String>> items) {
       for (var item in items) {
         output.writeln(
             '${' ' * indent * 2}- ${item.item} ${item == selectedItem ? '***' : ''}'
@@ -389,7 +390,7 @@ class TestStringTreeView extends SelectableTree<String> {
       }
     }
 
-    addLevel(0, treeItems);
+    addLevel(0, treeNodes);
     return output.toString();
   }
 }

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -72,7 +72,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleDownKey();
+        tree.moveDown();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -93,7 +93,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleDownKey();
+        tree.moveDown();
         expect(tree.getTextTree(), equals('''
 - Item 1
   - Item 1.1 ***
@@ -111,7 +111,7 @@ void main() {
 - Item 3 ***
 '''));
 
-        tree.handleDownKey();
+        tree.moveDown();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -127,7 +127,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleDownKey();
+        tree.moveDown();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -143,7 +143,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleUpKey();
+        tree.moveUp();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -165,7 +165,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleUpKey();
+        tree.moveUp();
         expect(tree.getTextTree(), equals('''
 - Item 1
   - Item 1.1
@@ -183,7 +183,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleUpKey();
+        tree.moveUp();
         expect(tree.getTextTree(), equals('''
 - Item 1 ***
 - Item 2
@@ -209,7 +209,7 @@ void main() {
     - Item 3.3.3
 '''));
 
-        tree.handleUpKey();
+        tree.moveUp();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -231,7 +231,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleLeftKey();
+        tree.moveLeft();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -251,7 +251,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleLeftKey();
+        tree.moveLeft();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
 - Item 1
@@ -272,7 +272,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleLeftKey();
+        tree.moveLeft();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2 ***
@@ -307,7 +307,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleRightKey();
+        tree.moveRight();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2
@@ -331,7 +331,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleRightKey();
+        tree.moveRight();
         await shortDelay();
         expect(tree.getTextTree(), equals('''
 - Item 1
@@ -355,7 +355,7 @@ void main() {
 - Item 3
 '''));
 
-        tree.handleRightKey();
+        tree.moveRight();
         expect(tree.getTextTree(), equals('''
 - Item 1
 - Item 2

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -1,0 +1,405 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('browser')
+import 'dart:html';
+
+import 'package:devtools/src/ui/custom.dart';
+import 'package:devtools/src/ui/elements.dart';
+import 'package:test/test.dart';
+
+import 'integration_tests/integration.dart';
+
+void main() {
+  group('tree views', () {
+    TestStringTreeView tree;
+
+    setUp(() async {
+      tree = new TestStringTreeView();
+      document.body.append(tree.element);
+      await window.animationFrame;
+      tree.element.focus();
+    });
+    tearDown(() => tree?.element?.remove());
+
+    test('renders only top level initially', () {
+      final textTree = tree.getTextTree();
+      const expectedTree = '''
+- Item 1
+- Item 2
+- Item 3
+''';
+      expect(textTree, equals(expectedTree));
+    });
+
+    test('includes children when expanded', () async {
+      tree.treeItems[1].expand();
+      await shortDelay();
+      final textTree = tree.getTextTree();
+      const expectedTree = '''
+- Item 1
+- Item 2
+  - Item 2.1
+  - Item 2.2
+  - Item 2.3
+- Item 3
+''';
+      expect(textTree, equals(expectedTree));
+    });
+
+    test('hides children when collapsed', () async {
+      tree.treeItems[1].expand();
+      await shortDelay();
+      tree.treeItems[1].collapse();
+      await shortDelay();
+      final textTree = tree.getTextTree();
+      const expectedTree = '''
+- Item 1
+- Item 2
+- Item 3
+''';
+      expect(textTree, equals(expectedTree));
+    });
+
+    group('keyboard navigation', () {
+      test('DOWN moves selection to next sibling if not expanded', () async {
+        tree.select(tree.treeItems.first);
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+- Item 2
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+      });
+
+      test('DOWN moves selection to first child if expanded', () async {
+        tree.select(tree.treeItems.first);
+        tree.selectedItem.expand();
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+  - Item 1.1
+  - Item 1.2
+  - Item 1.3
+- Item 2
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+  - Item 1.1 ***
+  - Item 1.2
+  - Item 1.3
+- Item 2
+- Item 3
+'''));
+      });
+      test('DOWN sticks to the last item if nothing below it', () async {
+        tree.select(tree.treeItems.last);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+- Item 3 ***
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+- Item 3 ***
+'''));
+      });
+
+      test('Down selects the first visible item if there is no selection',
+          () async {
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.DOWN));
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+- Item 2
+- Item 3
+'''));
+      });
+
+      test('UP moves selection to previous sibling if not expanded', () async {
+        tree.select(tree.treeItems[1]);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+- Item 2
+- Item 3
+'''));
+      });
+
+      test('UP moves selection to last child of previous sibling if expanded',
+          () async {
+        tree.treeItems[0].expand();
+        await shortDelay();
+        tree.select(tree.treeItems[1]);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+  - Item 1.1
+  - Item 1.2
+  - Item 1.3
+- Item 2 ***
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+  - Item 1.1
+  - Item 1.2
+  - Item 1.3 ***
+- Item 2
+- Item 3
+'''));
+      });
+      test('UP sticks to the first item if nothing above it', () async {
+        tree.select(tree.treeItems.first);
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+- Item 2
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        expect(tree.getTextTree(), equals('''
+- Item 1 ***
+- Item 2
+- Item 3
+'''));
+      });
+
+      test('UP selects the last visible item if there is no selection',
+          () async {
+        tree.treeItems.last.expand();
+        await shortDelay();
+        tree.treeItems.last.children.last.expand();
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+- Item 3
+  - Item 3.1
+  - Item 3.2
+  - Item 3.3
+    - Item 3.3.1
+    - Item 3.3.2
+    - Item 3.3.3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.UP));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+- Item 3
+  - Item 3.1
+  - Item 3.2
+  - Item 3.3
+    - Item 3.3.1
+    - Item 3.3.2
+    - Item 3.3.3 ***
+'''));
+      });
+
+      test('LEFT does nothing for level=1', () {
+        tree.select(tree.treeItems[1]);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+      });
+      test('LEFT collapses an expanded node', () async {
+        tree.select(tree.treeItems[1]);
+        tree.selectedItem.expand();
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+  - Item 2.1
+  - Item 2.2
+  - Item 2.3
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+      });
+      test('LEFT moves to parent of a collapsed node', () async {
+        tree.treeItems[1].expand();
+        await shortDelay();
+        tree.select(tree.treeItems[1].children[1]);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+  - Item 2.1
+  - Item 2.2 ***
+  - Item 2.3
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.LEFT));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+  - Item 2.1
+  - Item 2.2
+  - Item 2.3
+- Item 3
+'''));
+      });
+      test('RIGHT does nothing for leaf node', () async {
+        // Expand all the middle nodes to the leaf.
+        var children = tree.treeItems;
+        while (children[1].hasChildren) {
+          children[1].expand();
+          await shortDelay();
+          children = children[1].children;
+          tree.select(children[1]);
+        }
+
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+  - Item 2.1
+  - Item 2.2
+    - Item 2.2.1
+    - Item 2.2.2
+      - Item 2.2.2.1
+      - Item 2.2.2.2 ***
+      - Item 2.2.2.3
+    - Item 2.2.3
+  - Item 2.3
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+  - Item 2.1
+  - Item 2.2
+    - Item 2.2.1
+    - Item 2.2.2
+      - Item 2.2.2.1
+      - Item 2.2.2.2 ***
+      - Item 2.2.2.3
+    - Item 2.2.3
+  - Item 2.3
+- Item 3
+'''));
+      });
+      test('RIGHT expands a collapsed node', () async {
+        tree.select(tree.treeItems[1]);
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+  - Item 2.1
+  - Item 2.2
+  - Item 2.3
+- Item 3
+'''));
+      });
+      test('RIGHT moves to first child of expanded node', () async {
+        tree.select(tree.treeItems[1]);
+        tree.selectedItem.expand();
+        await shortDelay();
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2 ***
+  - Item 2.1
+  - Item 2.2
+  - Item 2.3
+- Item 3
+'''));
+
+        tree.handleKeyPress(new KeyEvent('keydown', keyCode: KeyCode.RIGHT));
+        expect(tree.getTextTree(), equals('''
+- Item 1
+- Item 2
+  - Item 2.1 ***
+  - Item 2.2
+  - Item 2.3
+- Item 3
+'''));
+      });
+    });
+  });
+}
+
+class TestStringTreeView extends SelectableTree<String> {
+  TestStringTreeView() {
+    setChildProvider(new StringChildProvider());
+    setItems(['Item 1', 'Item 2', 'Item 3']);
+    setRenderer((String value) => li(c: 'list-item')..add(span(text: value)));
+  }
+
+  /// Creates a text representation of the tree for comparing in tests.
+  /// Selected item is suffixed with '***'.
+  String getTextTree() {
+    final StringBuffer output = StringBuffer();
+
+    void addLevel(int indent, List<TreeItem<String>> items) {
+      for (var item in items) {
+        output.writeln(
+            '${' ' * indent * 2}- ${item.item} ${item == selectedItem ? '***' : ''}'
+                .trimRight());
+        addLevel(indent + 1, item.visibleChildren);
+      }
+    }
+
+    addLevel(0, treeItems);
+    return output.toString();
+  }
+}
+
+class StringChildProvider extends ChildProvider<String> {
+  @override
+  Future<List<String>> getChildren(String item) =>
+      Future.value(['$item.1', '$item.2', '$item.3']);
+
+  @override
+  bool hasChildren(String item) =>
+      item.length < 'Item 1.1.1.1'.length; // Only go to 4 levels
+}


### PR DESCRIPTION
This is (hopefully) an improved version of #261. All of the navigation of the tree is now moved out into mixins that will be easier to reuse (the goal being to align these with the Inspector tree classes and avoid having two implementations of things like keyboard navigation).

The tree classes/mixins are mostly in `trees.dart` but I made `trees_html` for the mixin that handles the keypresses to keep `dart:html` out of the other tree classes.

It's a bit annoying that because the `SelectableTree` is generic, we end up with this mouthfull:

```dart
TreeNode<SelectableTreeNodeItem<T>>
```

We need `SelectableTreeNodeItem` because we need to be able to access both the `item` and the `CoreElement` for each item in the tree.

I did try to make a `SelectableTreeNode extends TreeNode` to avoid the TreeNode having to wrap it, however I ended up hitting lots of type issues because the definition for `TreeNode` couldn't refer to the subtype for the definition of children:

```dart
class TreeNode {
   List<TreeNode> children; // <-- in a subtype, we'd want this to be List<SubType>
}

class SelectableTreeNode extends TreeNode {
  // children in this class is typed List<TreeNode>
}
```

And that meant traversing a tree required lots of casts. If anyone knows a better way to do this, I'm all ears!