### PR TITLE
Print unhandled JS exceptions during integration tests

### DIFF
--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -212,6 +212,18 @@ class ChromeTab {
         print('chrome • console:${entry.type} • '
             '${entry.args.map((a) => a.value).join(', ')}');
       });
+
+      onExceptionThrown.listen((ex) {
+        // TODO(dantup): Should we throw here, to fail tests? Currently we'd get
+        // failures like:
+        // Library package:flutter/src/widgets/widget_inspector.dart not found
+        // but this may need to be fixed for non-Flutter usage of DevTools anyway.
+        print('JavaScript exception occurred: ${ex.method}\n\n'
+            '${ex.params}\n\n'
+            '${ex.exceptionDetails?.text}\n\n'
+            '${ex.exceptionDetails?.exception}\n\n'
+            '${ex.exceptionDetails?.stackTrace}');
+      });
     }
 
     return _wip;


### PR DESCRIPTION
The output isn't fantastic (the important bit could be in any of these fields - in the case I'm debugging it's nested inside `params`) but at least it might make tracking down failures a little easier.

I'd like to make it `throw` but we have to fix the inspector error when connecting to a non-Flutter project before we could do that.