### PR TITLE
Fix bug where exceptions from the VMService were showing up as uncaught exceptions in the console.

### DIFF
--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -355,12 +355,18 @@ class VmServiceWrapper implements VmService {
       allFuturesCompleted = Completer<bool>();
     }
     _activeFutures.add(future);
-    future.whenComplete(() {
+
+    void futureComplete() {
       _activeFutures.remove(future);
       if (_activeFutures.isEmpty && !allFuturesCompleted.isCompleted) {
         allFuturesCompleted.complete(true);
       }
-    });
+    }
+
+    future.then(
+      (value) => futureComplete(),
+      onError: (error) => futureComplete(),
+    );
     return future;
   }
 }

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -53,7 +53,7 @@ void main() {
       );
       expect(serviceManager.callService('fakeMethod'), throwsException);
 
-      Completer<Object> testDone = Completer();
+      final Completer<Object> testDone = Completer();
       Object testError;
       runZoned(() {
         Future<void> asyncTestMethod() async {

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -44,6 +44,48 @@ void main() {
       await env.tearDownEnvironment();
     });
 
+    test('invalid setBreakpoint throws exception', () async {
+      await env.setupEnvironment();
+      // Service with more than 1 registration.
+      serviceManager.registeredMethodsForService.putIfAbsent(
+        'fakeMethod',
+        () => ['registration1.fakeMethod', 'registration2.fakeMethod'],
+      );
+      expect(serviceManager.callService('fakeMethod'), throwsException);
+
+      Completer<Object> testDone = Completer();
+      Object testError;
+      runZoned(() {
+        Future<void> asyncTestMethod() async {
+          // Service with less than 1 registration.
+          bool caughtException = false;
+          // TODO(jacobr): there is a simpler pattern for writing this I'm
+          // forgetting.
+          try {
+            await serviceManager.service.addBreakpoint(
+                serviceManager.isolateManager.selectedIsolate.id,
+                'fake-script-id',
+                1);
+          } catch (e) {
+            caughtException = true;
+          }
+          expect(caughtException, isTrue);
+
+          await env.tearDownEnvironment();
+        }
+
+        testDone.complete(asyncTestMethod());
+      }, onError: ([error]) {
+        testError = error;
+      });
+      await testDone.future;
+      // Verify that no uncaught exceptions were thrown in an async manner
+      // while running the test.
+      // This case catches a regression where a setting a breakpoint at an
+      // invalid line would throw an uncaught exception.
+      expect(testError, isNull);
+    });
+
     test('toggle boolean service extension', () async {
       await env.setupEnvironment();
 


### PR DESCRIPTION
This fixes the setBreakpoint at an invalid line case.

Special thanks to Jenny who went above and beyond helping look through the DDC internals to track down the cause of the bug.
Added a test  repro the bug.