### PR TITLE
Add event details section to timeline page.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -1,0 +1,91 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../ui/elements.dart';
+import '../ui/flutter_html_shim.dart';
+import '../utils.dart';
+import 'timeline.dart';
+import 'timeline_protocol.dart';
+
+class EventDetails extends CoreElement {
+  EventDetails() : super('div', classes: 'section-border') {
+    flex();
+    layoutVertical();
+    element.style
+      ..padding = '8px'
+      ..marginTop = '4px'
+      ..marginBottom = '4px'
+      ..position = 'relative';
+
+    addTitle();
+    addDetails();
+  }
+
+  static const defaultTitleText = 'Event Details - [no event selected]';
+
+  TimelineEvent _event;
+  CoreElement _title;
+  _Details _details;
+
+  void addTitle() {
+    const horizontalPadding = '12px';
+    const verticalPadding = '4px';
+    _title = div(text: defaultTitleText);
+    _title.element.style
+      ..borderRadius = '20px'
+      ..fontSize = 'large'
+      ..fontWeight = 'bold'
+      ..padding = '$verticalPadding $horizontalPadding'
+      ..width = 'fit-content';
+    add(_title);
+  }
+
+  void addDetails() {
+    _details = _Details()..attribute('hidden');
+    add(_details);
+  }
+
+  void update(TimelineEvent event) {
+    _event = event;
+
+    // Update title.
+    _title.text = '${_event.name}';
+    _title.element.style.backgroundColor =
+        event.isCpuEvent ? colorToCss(mainCpuColor) : colorToCss(mainGpuColor);
+
+    // Update details.
+    _details.update(event);
+  }
+
+  void reset() {
+    _title.text = defaultTitleText;
+    _title.element.style.backgroundColor = 'transparent';
+    _details.reset();
+  }
+}
+
+class _Details extends CoreElement {
+  _Details() : super('div') {
+    element.style
+      ..marginTop = '6px'
+      ..marginLeft = '12px';
+
+    add(_duration = div());
+
+    // TODO(kenzie): query vm for samples.
+  }
+
+  CoreElement _duration;
+
+  void update(TimelineEvent event) {
+    attribute('hidden', false);
+    _duration.text = 'Duration:'
+        ' ${microsAsMsText(event.duration)} - '
+        '[${event.startTime} - ${event.endTime}]';
+  }
+
+  void reset() {
+    _duration.text = '';
+  }
+}

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -13,6 +13,7 @@ class EventDetails extends CoreElement {
     flex();
     layoutVertical();
     element.style
+      ..clipPath = 'inset(0px 0px 0px 0px)'
       ..padding = '8px'
       ..marginTop = '4px'
       ..marginBottom = '4px'

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:html';
 import 'dart:math';
 
@@ -9,6 +10,7 @@ import '../ui/drag_scroll.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
+import '../utils.dart';
 import 'timeline.dart';
 import 'timeline_protocol.dart';
 
@@ -38,8 +40,12 @@ const gpuColorPalette = [
 const cpuSectionBackground = Color(0xFFF9F9F9);
 const gpuSectionBackground = Color(0xFFF3F3F3);
 
+final StreamController<TimelineEvent> _selectedEventController =
+    StreamController<TimelineEvent>.broadcast();
+Stream<TimelineEvent> get onSelectedEvent => _selectedEventController.stream;
+
 class FrameFlameChart extends CoreElement {
-  FrameFlameChart() : super('div') {
+  FrameFlameChart() : super('div', classes: 'section-border') {
     flex();
     layoutVertical();
     element.style
@@ -329,7 +335,7 @@ class FlameChartItem {
     currentWidth = _startingWidth;
 
     e = Element.div()..className = 'flame-chart-item';
-    e.title = '${_event.durationMs}ms';
+    e.title = microsAsMsText(_event.duration);
 
     _labelWrapper = Element.div()..className = 'flame-chart-item-label-wrapper';
     _labelWrapper.append(Element.span()
@@ -349,6 +355,8 @@ class FlameChartItem {
       _labelWrapper.style.maxWidth = '${_startingWidth}px';
     }
     style.top = '${_top}px';
+
+    e.onClick.listen((e) => _selectedEventController.add(_event));
   }
 
   /// Offset to account for section titles (i.e 'CPU' and 'GPU').

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -356,6 +356,7 @@ class FlameChartItem {
     }
     style.top = '${_top}px';
 
+    // TODO(kenzie): make flame chart item appear selected.
     e.onClick.listen((e) => _selectedEventController.add(_event));
   }
 

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -8,13 +8,14 @@ import 'dart:math' as math;
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
+import '../utils.dart';
 import 'timeline.dart';
 import 'timeline_controller.dart';
 import 'timeline_protocol.dart';
 
 class FramesBarChart extends CoreElement {
   FramesBarChart(TimelineController timelineController)
-      : super('div', classes: 'timeline-frames') {
+      : super('div', classes: 'timeline-frames section-border') {
     layoutHorizontal();
     element.style
       ..alignItems = 'flex-end'
@@ -94,12 +95,12 @@ class FrameBar extends CoreElement {
     final gpuBarHeight =
         math.min(maxBarHeight - cpuBarHeight, frame.gpuDurationMs * pxPerMs);
 
-    final cpuTooltip = frame.isCpuSlow
-        ? _slowFrameWarning('GPU', frame.gpuAsMs)
-        : 'GPU: ${frame.gpuAsMs}';
-    final gpuTooltip = frame.isCpuSlow
-        ? _slowFrameWarning('GPU', frame.gpuAsMs)
-        : 'GPU: ${frame.gpuAsMs}';
+    final cpuMs = microsAsMsText(frame.cpuDuration);
+    final gpuMs = microsAsMsText(frame.gpuDuration);
+    final cpuTooltip =
+        frame.isCpuSlow ? _slowFrameWarning('GPU', cpuMs) : 'GPU: $cpuMs';
+    final gpuTooltip =
+        frame.isCpuSlow ? _slowFrameWarning('GPU', gpuMs) : 'GPU: ${gpuMs}';
 
     _cpuBar = div(c: 'bar bottom');
     _cpuBar.element.title = cpuTooltip;

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -95,12 +95,12 @@ class FrameBar extends CoreElement {
     final gpuBarHeight =
         math.min(maxBarHeight - cpuBarHeight, frame.gpuDurationMs * pxPerMs);
 
-    final cpuMs = microsAsMsText(frame.cpuDuration);
-    final gpuMs = microsAsMsText(frame.gpuDuration);
-    final cpuTooltip =
-        frame.isCpuSlow ? _slowFrameWarning('GPU', cpuMs) : 'GPU: $cpuMs';
-    final gpuTooltip =
-        frame.isCpuSlow ? _slowFrameWarning('GPU', gpuMs) : 'GPU: $gpuMs';
+    final cpuTooltip = frame.isCpuSlow
+        ? _slowFrameWarning('CPU', msAsText(frame.cpuDurationMs))
+        : 'CPU: ${msAsText(frame.cpuDurationMs)}';
+    final gpuTooltip = frame.isGpuSlow
+        ? _slowFrameWarning('GPU', msAsText(frame.gpuDurationMs))
+        : 'GPU: ${msAsText(frame.gpuDurationMs)}';
 
     _cpuBar = div(c: 'bar bottom');
     _cpuBar.element.title = cpuTooltip;

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -100,7 +100,7 @@ class FrameBar extends CoreElement {
     final cpuTooltip =
         frame.isCpuSlow ? _slowFrameWarning('GPU', cpuMs) : 'GPU: $cpuMs';
     final gpuTooltip =
-        frame.isCpuSlow ? _slowFrameWarning('GPU', gpuMs) : 'GPU: ${gpuMs}';
+        frame.isCpuSlow ? _slowFrameWarning('GPU', gpuMs) : 'GPU: $gpuMs';
 
     _cpuBar = div(c: 'bar bottom');
     _cpuBar.element.title = cpuTooltip;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -50,6 +50,7 @@
 
 .flame-chart-section .flame-chart-item {
     border-radius: 2px;
+    cursor: pointer;
     padding: 0 2px;
     position: absolute;
     white-space: nowrap;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -6,9 +6,6 @@
     overflow-x: auto;
     overflow-y: hidden;
     white-space: nowrap;
-    border: 1px solid;
-    border-color: var(--light-background);
-    border-radius: 3px;
     direction: rtl;
 }
 
@@ -71,4 +68,10 @@
 .flame-chart-item-label {
     display: inline-block;
     color: black;
+}
+
+.section-border {
+    border: 1px solid;
+    border-color: var(--light-background);
+    border-radius: 3px;
 }

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -413,18 +413,6 @@ class TimelineFrame {
   bool get isCpuSlow => cpuDurationMs > targetMaxDuration / 2;
   bool get isGpuSlow => gpuDurationMs > targetMaxDuration / 2;
 
-  String get cpuAsMs {
-    return _durationAsMsText(cpuDurationMs);
-  }
-
-  String get gpuAsMs {
-    return _durationAsMsText(gpuDurationMs);
-  }
-
-  String _durationAsMsText(double durationMs) {
-    return '${durationMs.toStringAsFixed(1)}ms';
-  }
-
   @override
   String toString() {
     return 'Frame $id - start: $startTime end: $endTime total dur: $duration '
@@ -446,7 +434,6 @@ class TimelineEvent {
   List<TimelineEvent> children = <TimelineEvent>[];
 
   int get duration => (endTime != null) ? endTime - startTime : null;
-  double get durationMs => duration / 1000;
 
   bool get isCpuEvent => type == TimelineEventType.cpu;
   bool get isGpuEvent => type == TimelineEventType.gpu;

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -57,6 +57,10 @@ String printMb(num bytes, [int fractionDigits = 1]) {
   return (bytes / (1024 * 1024)).toStringAsFixed(fractionDigits);
 }
 
+String microsAsMsText(int micros, {bool includeUnit = true}) {
+  return '${(micros / 1000).toStringAsFixed(1)}${includeUnit ? ' ms' : ''}';
+}
+
 String isolateName(IsolateRef ref) {
   // analysis_server.dart.snapshot$main
   String name = ref.name;

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -57,8 +57,12 @@ String printMb(num bytes, [int fractionDigits = 1]) {
   return (bytes / (1024 * 1024)).toStringAsFixed(fractionDigits);
 }
 
-String microsAsMsText(int micros, {bool includeUnit = true}) {
-  return '${(micros / 1000).toStringAsFixed(1)}${includeUnit ? ' ms' : ''}';
+String microsAsMsText(num micros, {bool includeUnit = true}) {
+  return msAsText(micros / 1000, includeUnit: includeUnit);
+}
+
+String msAsText(num milliseconds, {bool includeUnit = true}) {
+  return '${milliseconds.toStringAsFixed(1)}${includeUnit ? ' ms' : ''}';
 }
 
 String isolateName(IsolateRef ref) {


### PR DESCRIPTION
Clicking a flame chart event populates this section with data. A splitter separates the flame chart section from the event details section.

![screen shot 2019-02-13 at 2 47 24 pm](https://user-images.githubusercontent.com/43759233/52750180-60fd5a00-2fa0-11e9-909c-b91c30da4013.png)
![screen shot 2019-02-13 at 2 47 10 pm](https://user-images.githubusercontent.com/43759233/52750185-665aa480-2fa0-11e9-83fe-68435716da9b.png)

Future work: 
- query VM for samples and display the call stack in this section.
- increase VM sampling so that this data is useful
- implement "My code only" functionality to only display call stack from user code down.