### PR TITLE
Suppress errors trying to load inspector libraries when not available

### DIFF
--- a/packages/devtools/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools/lib/src/eval_on_dart_library.dart
@@ -73,7 +73,7 @@ class EvalOnDartLibrary {
         }
       }
       assert(!_libraryRef.isCompleted);
-      _libraryRef.completeError('Library $libraryName not found');
+      _libraryRef.completeError(new LibraryNotFound(libraryName));
     } catch (e) {
       _handleError(e);
     }
@@ -229,4 +229,10 @@ class EvalOnDartLibrary {
       return value;
     });
   }
+}
+
+class LibraryNotFound implements Exception {
+  LibraryNotFound(this.library);
+  String library;
+  String get message => 'Library $library not found';
 }

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -52,7 +52,7 @@ class LoggingScreen extends Screen {
 
   bool hasPendingDomUpdates = false;
 
-  /// ObjectGroup for Flutter (null for non-Flutter apps).
+  /// ObjectGroup for Flutter (completes with null for non-Flutter apps).
   Future<ObjectGroup> objectGroup;
 
   @override

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -52,6 +52,7 @@ class LoggingScreen extends Screen {
 
   bool hasPendingDomUpdates = false;
 
+  /// ObjectGroup for Flutter (null for non-Flutter apps).
   Future<ObjectGroup> objectGroup;
 
   @override
@@ -182,7 +183,9 @@ class LoggingScreen extends Screen {
 
     await ensureInspectorServiceDependencies();
 
-    objectGroup = InspectorService.createGroup(service, 'console-group');
+    objectGroup = InspectorService.createGroup(service, 'console-group')
+        .catchError((e) => null,
+            test: (e) => e is FlutterInspectorLibraryNotFound);
   }
 
   void _handleExtensionEvent(Event e) async {

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -214,15 +214,11 @@ class ChromeTab {
       });
 
       onExceptionThrown.listen((ex) {
-        // TODO(dantup): Should we throw here, to fail tests? Currently we'd get
-        // failures like:
-        // Library package:flutter/src/widgets/widget_inspector.dart not found
-        // but this may need to be fixed for non-Flutter usage of DevTools anyway.
-        print('JavaScript exception occurred: ${ex.method}\n\n'
+        throw 'JavaScript exception occurred: ${ex.method}\n\n'
             '${ex.params}\n\n'
             '${ex.exceptionDetails?.text}\n\n'
             '${ex.exceptionDetails?.exception}\n\n'
-            '${ex.exceptionDetails?.stackTrace}');
+            '${ex.exceptionDetails?.stackTrace}';
       });
     }
 


### PR DESCRIPTION
This stops the error (fixes #277), however it doesn't actually disable/hide the inspector (see #283).

I don't know if this is the best way to handle this, but I needed something to stop it while trying to debug hangs on Travis so wrote code to suppress it anyway.