### PR TITLE
Allow disabling tabs based on querystring values

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -35,7 +35,12 @@ import '../utils.dart';
 class DebuggerScreen extends Screen {
   DebuggerScreen()
       : debuggerState = DebuggerState(),
-        super(name: 'Debugger', id: 'debugger', iconClass: 'octicon-bug') {
+        super(
+          name: 'Debugger',
+          id: 'debugger',
+          iconClass: 'octicon-bug',
+          disabled: shouldHideTab('debugger'),
+        ) {
     deviceStatus = StatusItem();
     addStatusItem(deviceStatus);
   }

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -33,13 +33,13 @@ import '../utils.dart';
 // TODO(devoncarew): handle displaying large lists, maps, in the variables view
 
 class DebuggerScreen extends Screen {
-  DebuggerScreen()
+  DebuggerScreen({bool disabled})
       : debuggerState = DebuggerState(),
         super(
           name: 'Debugger',
           id: 'debugger',
           iconClass: 'octicon-bug',
-          disabled: shouldHideTab('debugger'),
+          disabled: disabled,
         ) {
     deviceStatus = StatusItem();
     addStatusItem(deviceStatus);

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -276,11 +276,13 @@ abstract class Screen {
     @required this.name,
     @required this.id,
     this.iconClass,
+    this.disabled = false,
   });
 
   final String name;
   final String id;
   final String iconClass;
+  final bool disabled;
 
   Framework framework;
 

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -67,7 +67,7 @@ class Framework {
       assert(id[0] == '#');
       id = id.substring(1);
     }
-    Screen screen = getScreen(id);
+    Screen screen = getScreen(id, onlyEnabled: true);
     screen ??= screens.first;
     if (screen != null) {
       load(screen);
@@ -76,8 +76,10 @@ class Framework {
     }
   }
 
-  Screen getScreen(String id) {
-    return screens.firstWhere((Screen screen) => screen.id == id,
+  Screen getScreen(String id, {bool onlyEnabled = false}) {
+    return screens.firstWhere(
+        (Screen screen) =>
+            screen.id == id && (!onlyEnabled || !screen.disabled),
         orElse: () => null);
   }
 

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:html' hide Screen;
 
+import 'package:devtools/src/ui/ui_utils.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import 'core/message_bus.dart';
@@ -32,7 +33,7 @@ class PerfToolFramework extends Framework {
   PerfToolFramework() {
     addScreen(InspectorScreen());
     addScreen(TimelineScreen());
-    addScreen(DebuggerScreen());
+    addScreen(DebuggerScreen(disabled: shouldDisableTab('debugger')));
     if (showMemoryPage) {
       addScreen(MemoryScreen());
     }
@@ -66,7 +67,7 @@ class PerfToolFramework extends Framework {
       if (screen.disabled) {
         link
           ..tooltip =
-              'This section is disabled because it is available in your editor';
+              'This section is disabled because it provides functionality already available in your code editor';
       } else {
         link
           ..attributes['href'] = screen.ref

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -64,10 +64,14 @@ class PerfToolFramework extends Framework {
         ..add(<CoreElement>[
           span(c: 'octicon ${screen.iconClass}'),
           span(text: ' ${screen.name}')
-        ])
-        ..disabled = screen.disabled;
+        ]);
       if (screen.disabled) {
         link
+          ..onClick.listen((MouseEvent e) {
+            e.preventDefault();
+            toast(link.tooltip);
+          })
+          ..toggleClass('disabled', true)
           ..tooltip =
               'This section is disabled because it provides functionality already available in your code editor';
       } else {

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -58,15 +58,23 @@ class PerfToolFramework extends Framework {
 
     for (Screen screen in screens) {
       final CoreElement link = CoreElement('a')
-        ..attributes['href'] = screen.ref
-        ..onClick.listen((MouseEvent e) {
-          e.preventDefault();
-          navigateTo(screen.id);
-        })
         ..add(<CoreElement>[
           span(c: 'octicon ${screen.iconClass}'),
           span(text: ' ${screen.name}')
-        ]);
+        ])
+        ..disabled = screen.disabled;
+      if (screen.disabled) {
+        link
+          ..tooltip =
+              'This section is disabled because it is available in your editor';
+      } else {
+        link
+          ..attributes['href'] = screen.ref
+          ..onClick.listen((MouseEvent e) {
+            e.preventDefault();
+            navigateTo(screen.id);
+          });
+      }
       mainNav.add(link);
     }
 

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -42,6 +42,8 @@ class PerfToolFramework extends Framework {
     }
     addScreen(LoggingScreen());
 
+    sortScreens();
+
     initGlobalUI();
 
     initTestingModel();
@@ -113,6 +115,16 @@ class PerfToolFramework extends Framework {
 
   void initTestingModel() {
     App.register(this);
+  }
+
+  void sortScreens() {
+    // Move disabled screens to the end, but otherwise preserve order.
+    final sortedScreens = screens
+        .where((screen) => !screen.disabled)
+        .followedBy(screens.where((screen) => screen.disabled))
+        .toList();
+    screens.clear();
+    screens.addAll(sortedScreens);
   }
 
   IsolateRef get currentIsolate =>

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -204,3 +204,8 @@ class RegisteredServiceExtensionButton {
     }
   }
 }
+
+bool shouldHideTab(String key) {
+  final qs = Uri.splitQueryString(html.window.location.search.substring(1));
+  return qs['hide']?.split(',')?.contains(key) ?? false;
+}

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -205,7 +205,7 @@ class RegisteredServiceExtensionButton {
   }
 }
 
-bool shouldHideTab(String key) {
+bool shouldDisableTab(String key) {
   final queryString = html.window.location.search;
   if (queryString == null || queryString.length <= 1) {
     return false;

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -206,6 +206,11 @@ class RegisteredServiceExtensionButton {
 }
 
 bool shouldHideTab(String key) {
-  final qs = Uri.splitQueryString(html.window.location.search.substring(1));
-  return qs['hide']?.split(',')?.contains(key) ?? false;
+  final queryString = html.window.location.search;
+  if (queryString == null || queryString.length <= 1) {
+    return false;
+  }
+
+  final qsParams = Uri.splitQueryString(queryString.substring(1));
+  return qsParams['hide']?.split(',')?.contains(key) ?? false;
 }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -100,7 +100,8 @@ body {
     text-decoration: none;
 }
 
-.masthead a[disabled] {
+.masthead a.disabled {
+    cursor: default;
     opacity: 0.5;
 }
 

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -39,7 +39,7 @@
     --subtle: #777;
     --table-border: #dfe2e5;
     --title: #555;
-    --toast-background: f9f9f9;
+    --toast-background: #f9f9f9;
     --toast-border: #d8dee2;
 }
 

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -97,11 +97,15 @@ body {
 .masthead .masthead-item {
     color: rgba(var(--header-item-rgb), 0.5) !important;
     font-size: 1rem;
+    text-decoration: none;
 }
 
-.masthead a:hover {
+.masthead a[disabled] {
+    opacity: 0.5;
+}
+
+.masthead a:hover:not([disabled]) {
     color: var(--header-item) !important;;
-    text-decoration: none;
 }
 
 .masthead-nav .active {


### PR DESCRIPTION
@devoncarew WDYT to this? It disables buttons but leaves them there with a tooltip (I'm assuming for now that we'll only disable them based on being available in your editor; we may need to tweak this for non-flutter apps when we decide exactly how to handle that).

<img width="591" alt="screenshot 2019-02-14 at 11 18 39 am" src="https://user-images.githubusercontent.com/1078012/52783664-834bb200-304a-11e9-83a4-50cc42151846.png">

I allowed the querystring key to be passed in by the string in case we want to have keys that hide multiple items together, but we could push that down into `Screen` based on `id` if that isn't likely to be the case.