### PR TITLE
Handle missing getScripts

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -430,7 +430,7 @@ class DebuggerScreen extends Screen {
       breakpointsView.element,
       PNavMenuItem('Scripts')
         ..add(
-          scriptCountDiv = span(text: '0', c: 'counter'),
+          scriptCountDiv = span(text: 'Unavailable', c: 'counter'),
         )
         ..click(() => scriptsView.element.toggleAttribute('hidden')),
       scriptsView.element,
@@ -499,24 +499,28 @@ class DebuggerScreen extends Screen {
   }
 
   void _populateFromIsolate(Isolate isolate) async {
-    final ScriptList scriptList =
-        await serviceManager.service.getScripts(isolate.id);
-    final List<ScriptRef> scripts = scriptList.scripts.toList();
-
-    debuggerState.scripts = scripts;
-
     debuggerState.setRootLib(isolate.rootLib);
     debuggerState.updateFrom(isolate);
 
     final bool isRunning = isolate.pauseEvent == null ||
         isolate.pauseEvent.kind == EventKind.kResume;
 
-    scriptsView.showScripts(
-      scripts,
-      debuggerState.rootLib.uri,
-      debuggerState.commonScriptPrefix,
-      selectRootScript: isRunning,
-    );
+    final scriptsAvailable =
+        (await serviceManager.serviceCapabilities).supportsGetScripts;
+    if (scriptsAvailable) {
+      final ScriptList scriptList =
+          await serviceManager.service.getScripts(isolate.id);
+      final List<ScriptRef> scripts = scriptList.scripts.toList();
+
+      debuggerState.scripts = scripts;
+
+      scriptsView.showScripts(
+        scripts,
+        debuggerState.rootLib.uri,
+        debuggerState.commonScriptPrefix,
+        selectRootScript: isRunning,
+      );
+    }
   }
 
   void _displaySource(Script script) {

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -430,7 +430,7 @@ class DebuggerScreen extends Screen {
       breakpointsView.element,
       PNavMenuItem('Scripts')
         ..add(
-          scriptCountDiv = span(text: 'Unavailable', c: 'counter'),
+          scriptCountDiv = span(text: '-', c: 'counter'),
         )
         ..click(() => scriptsView.element.toggleAttribute('hidden')),
       scriptsView.element,

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -505,9 +505,9 @@ class DebuggerScreen extends Screen {
     final bool isRunning = isolate.pauseEvent == null ||
         isolate.pauseEvent.kind == EventKind.kResume;
 
-    final scriptsAvailable =
+    final getScriptsSupport =
         (await serviceManager.serviceCapabilities).supportsGetScripts;
-    if (scriptsAvailable) {
+    if (getScriptsSupport) {
       final ScriptList scriptList =
           await serviceManager.service.getScripts(isolate.id);
       final List<ScriptRef> scripts = scriptList.scripts.toList();

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -16,6 +16,7 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../debugger/debugger.dart';
 import '../framework/framework.dart';
+import '../globals.dart';
 import '../logging/logging.dart';
 import '../main.dart';
 
@@ -44,6 +45,7 @@ class App {
     _register<void>(
         'debugger.setExceptionPauseMode', debuggerSetExceptionPauseMode);
     _register<List<String>>('debugger.getBreakpoints', debuggerGetBreakpoints);
+    _register<bool>('debugger.supportsScripts', debuggerSupportsScripts);
     _register<List<String>>('debugger.getScripts', debuggerGetScripts);
     _register<List<String>>(
         'debugger.getCallStackFrames', debuggerGetCallStackFrames);
@@ -160,6 +162,10 @@ class App {
     return screen.debuggerState.breakpoints.map((Breakpoint breakpoint) {
       return breakpoint.id;
     }).toList();
+  }
+
+  Future<bool> debuggerSupportsScripts([dynamic _]) async {
+    return (await serviceManager.serviceCapabilities).supportsGetScripts;
   }
 
   Future<List<String>> debuggerGetScripts([dynamic _]) async {

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -35,9 +35,11 @@ class ServiceConnectionManager {
 
   VmServiceCapabilities _serviceCapabilities;
   Future<VmServiceCapabilities> get serviceCapabilities async {
-    await serviceAvailable.future;
-    final version = await service.getVersion();
-    _serviceCapabilities ??= new VmServiceCapabilities(version);
+    if (_serviceCapabilities == null) {
+      await serviceAvailable.future;
+      final version = await service.getVersion();
+      _serviceCapabilities = new VmServiceCapabilities(version);
+    }
     return _serviceCapabilities;
   }
 

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -33,6 +33,14 @@ class ServiceConnectionManager {
 
   final Completer<Null> serviceAvailable = Completer();
 
+  VmServiceCapabilities _serviceCapabilities;
+  Future<VmServiceCapabilities> get serviceCapabilities async {
+    await serviceAvailable.future;
+    final version = await service.getVersion();
+    _serviceCapabilities ??= new VmServiceCapabilities(version);
+    return _serviceCapabilities;
+  }
+
   final Map<String, StreamController<bool>> _serviceRegistrationController =
       <String, StreamController<bool>>{};
   final Map<String, List<String>> _registeredMethodsForService = {};
@@ -660,4 +668,12 @@ class ServiceExtensionState {
   // For boolean service extensions, [enabled] should equal [value].
   final bool enabled;
   final dynamic value;
+}
+
+class VmServiceCapabilities {
+  VmServiceCapabilities(this.version);
+  final Version version;
+
+  bool get supportsGetScripts =>
+      version.major > 3 || (version.major == 3 && version.minor >= 12);
 }

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -33,6 +33,13 @@ void debuggingTests() {
 
     final DebuggingManager debuggingManager = DebuggingManager(tools);
 
+    // TODO(dantup): This check can be removed on the next stable Dart release
+    // since we'll only be running the tests where getScripts is supported.
+    if (!(await debuggingManager.supportsScripts())) {
+      print('=== VM does not support getScripts, skipping test ===');
+      return;
+    }
+
     // Get the list of scripts.
     final List<String> scripts = await debuggingManager.getScripts();
     expect(scripts, isNotEmpty);
@@ -59,6 +66,14 @@ void debuggingTests() {
     // clear and verify breakpoints
     List<String> breakpoints = await debuggingManager.getBreakpoints();
     expect(breakpoints, isEmpty);
+
+    // TODO(dantup): This check can be removed on the next stable Dart release
+    // since we'll only be running the tests where getScripts is supported.
+    if (!(await debuggingManager.supportsScripts())) {
+      print(
+          '=== VM does not support getScripts, required by addBreakpoint, skipping test ===');
+      return;
+    }
 
     // set and verify breakpoints
     for (int line in breakpointLines) {
@@ -123,6 +138,14 @@ void debuggingTests() {
     // clear and verify breakpoints
     List<String> breakpoints = await debuggingManager.getBreakpoints();
     expect(breakpoints, isEmpty);
+
+    // TODO(dantup): This check can be removed on the next stable Dart release
+    // since we'll only be running the tests where getScripts is supported.
+    if (!(await debuggingManager.supportsScripts())) {
+      print(
+          '=== VM does not support getScripts, required by addBreakpoint, skipping test ===');
+      return;
+    }
 
     // set and verify breakpoint
     await debuggingManager.addBreakpoint(
@@ -350,6 +373,13 @@ class DebuggingManager {
         await tools.tabInstance.send('debugger.getScripts');
     final List<dynamic> result = response.result;
     return result.cast<String>();
+  }
+
+  Future<bool> supportsScripts() async {
+    final AppResponse response =
+        await tools.tabInstance.send('debugger.supportsScripts');
+    final bool result = response.result;
+    return result;
   }
 
   Future<List<String>> getCallStackFrames() async {


### PR DESCRIPTION
This checks the VM service version before using getScripts to populate the Scripts pane. It sets the badge text to `Unavailable` as a default, which will change to the number only when it successfully gets scripts (which it won't for older VMs).

Also bails out of the tests (as late as possible, so the earlier parts are still running) in this case, though I'll remove this after the next Dart stable roll, since we won't need it.