### PR TITLE
some tweaks to the timeline UI

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -35,7 +35,6 @@ class EventDetails extends CoreElement {
     _title = div(text: defaultTitleText);
     _title.element.style
       ..borderRadius = '20px'
-      ..fontSize = 'large'
       ..fontWeight = 'bold'
       ..padding = '$verticalPadding $horizontalPadding'
       ..width = 'fit-content';

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -42,6 +42,7 @@ const gpuSectionBackground = Color(0xFFF3F3F3);
 
 final StreamController<TimelineEvent> _selectedEventController =
     StreamController<TimelineEvent>.broadcast();
+
 Stream<TimelineEvent> get onSelectedEvent => _selectedEventController.stream;
 
 class FrameFlameChart extends CoreElement {
@@ -78,6 +79,8 @@ class FrameFlameChart extends CoreElement {
   /// chart is drawn within view at minimum zoom level.
   static const num minZoomMultiplier = 0.75;
 
+  static const padding = 2;
+
   /// All flame chart items currently drawn on the chart.
   final List<FlameChartItem> _chartItems = [];
 
@@ -88,6 +91,7 @@ class FrameFlameChart extends CoreElement {
   final num _maxZoomLevel = 120;
   num _zoomLevel = 1;
   num _minZoomLevel;
+
   num get _zoomMultiplier => _zoomLevel * 0.075;
 
   num _currentMouseX;
@@ -161,9 +165,9 @@ class FrameFlameChart extends CoreElement {
         // TODO(kenzie): technically we will want to round to fraction of a px
         // for high dpi devices where 1 logical pixel may equal 2 physical
         // pixels, etc.
-        startPx.round(),
+        startPx.round() + padding,
         (endPx - startPx).round(),
-        row * rowHeight,
+        row * rowHeight + padding,
         section,
       );
 
@@ -184,8 +188,8 @@ class FrameFlameChart extends CoreElement {
       sectionTitle.element.style
         ..background = colorToCss(mainCpuColor)
         ..fontWeight = 'bold'
-        ..left = '0'
-        ..top = '0';
+        ..left = '${padding}px'
+        ..top = '${padding}px';
       _cpuSection.add(sectionTitle);
 
       drawRecursively(_frame.cpuEventFlow, 0, _cpuSection);
@@ -203,8 +207,8 @@ class FrameFlameChart extends CoreElement {
       sectionTitle.element.style
         ..background = colorToCss(mainGpuColor)
         ..fontWeight = 'bold'
-        ..left = '0'
-        ..top = '0';
+        ..left = '${padding}px'
+        ..top = '${padding}px';
       _gpuSection.add(sectionTitle);
 
       drawRecursively(_frame.gpuEventFlow, 0, _gpuSection);
@@ -329,8 +333,13 @@ class FrameFlameChart extends CoreElement {
 }
 
 class FlameChartItem {
-  FlameChartItem(this._event, this._startingLeft, this._startingWidth,
-      this._top, this._backgroundColor) {
+  FlameChartItem(
+    this._event,
+    this._startingLeft,
+    this._startingWidth,
+    this._top,
+    this._backgroundColor,
+  ) {
     currentLeft = _startingLeft;
     currentWidth = _startingWidth;
 

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -20,8 +20,7 @@ class FramesBarChart extends CoreElement {
     element.style
       ..alignItems = 'flex-end'
       ..height = '${chartHeight}px'
-      ..paddingTop = '${padding}px'
-      ..paddingBottom = '${padding}px';
+      ..paddingTop = '${topPadding}px';
 
     timelineController.onFrameAdded.listen((TimelineFrame frame) {
       final CoreElement frameUI = FrameBar(this, frame);
@@ -36,9 +35,9 @@ class FramesBarChart extends CoreElement {
     });
   }
 
-  static const int chartHeight = 200;
+  static const int chartHeight = 100;
   static const int maxFrames = 120;
-  static const padding = 5;
+  static const topPadding = 2;
 
   FrameBar selectedFrame;
 
@@ -74,9 +73,9 @@ class FrameBar extends CoreElement {
     });
   }
 
-  // Chart height minus padding on top and bottom.
+  // Chart height minus top padding.
   static const maxBarHeight =
-      FramesBarChart.chartHeight - (FramesBarChart.padding * 2);
+      FramesBarChart.chartHeight - FramesBarChart.topPadding;
 
   // Let a 16ms frame take up 1/3 of the [TimelineFramesUI] height, so we should
   // be able to fit 48ms (3x16) in [chartHeight] pixels.

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -133,7 +133,7 @@ class TimelineScreen extends Screen {
             [flameChart, eventDetails],
             horizontal: false,
             gutterSize: defaultSplitterWidth,
-            sizes: [70, 30],
+            sizes: [75, 25],
             minSize: [200, 60],
           );
           splitterConfigured = true;

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -128,7 +128,7 @@ class TimelineScreen extends Screen {
             [flameChart, eventDetails],
             horizontal: false,
             gutterSize: defaultSplitterWidth,
-            sizes: [80, 20],
+            sizes: [70, 30],
             minSize: [200, 60],
           );
           splitterConfigured = true;


### PR DESCRIPTION
- adjust some padding for timeline elements
- adjust the default splitter proportions
- make the fps frames view shorter

<img width="1499" alt="screen shot 2019-02-14 at 11 24 56 am" src="https://user-images.githubusercontent.com/1269969/52812615-bc852180-304c-11e9-914a-c5b3bd1bd965.png">
