### PR TITLE
update styling for the timeline details area

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -5,19 +5,13 @@
 import '../ui/elements.dart';
 import '../ui/flutter_html_shim.dart';
 import '../utils.dart';
-import 'timeline.dart';
+import 'frame_flame_chart.dart';
 import 'timeline_protocol.dart';
 
 class EventDetails extends CoreElement {
   EventDetails() : super('div', classes: 'section-border') {
     flex();
     layoutVertical();
-    element.style
-      ..clipPath = 'inset(0px 0px 0px 0px)'
-      ..padding = '8px'
-      ..marginTop = '4px'
-      ..marginBottom = '4px'
-      ..position = 'relative';
 
     addTitle();
     addDetails();
@@ -31,13 +25,12 @@ class EventDetails extends CoreElement {
 
   void addTitle() {
     const horizontalPadding = '12px';
-    const verticalPadding = '4px';
+    const verticalPadding = '3px';
+
     _title = div(text: defaultTitleText);
     _title.element.style
-      ..borderRadius = '20px'
       ..fontWeight = 'bold'
-      ..padding = '$verticalPadding $horizontalPadding'
-      ..width = 'fit-content';
+      ..padding = '$verticalPadding $horizontalPadding';
     add(_title);
   }
 
@@ -46,16 +39,15 @@ class EventDetails extends CoreElement {
     add(_details);
   }
 
-  void update(TimelineEvent event) {
-    _event = event;
+  void update(FlameChartItem item) {
+    _event = item.event;
 
     // Update title.
     _title.text = '${_event.name}';
-    _title.element.style.backgroundColor =
-        event.isCpuEvent ? colorToCss(mainCpuColor) : colorToCss(mainGpuColor);
+    _title.element.style.backgroundColor = colorToCss(item.backgroundColor);
 
     // Update details.
-    _details.update(event);
+    _details.update(item.event);
   }
 
   void reset() {

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -182,10 +182,10 @@ class FrameFlameChart extends CoreElement {
         ..height = '${cpuSectionHeight}px'
         ..backgroundColor = colorToCss(cpuSectionBackground);
 
-      final sectionTitle = div(text: 'CPU', c: 'flame-chart-item');
+      final sectionTitle =
+          div(text: 'CPU', c: 'flame-chart-item flame-chart-title');
       sectionTitle.element.style
         ..background = colorToCss(mainCpuColor)
-        ..fontWeight = 'bold'
         ..left = '${padding}px'
         ..top = '${padding}px';
       _cpuSection.add(sectionTitle);
@@ -201,10 +201,10 @@ class FrameFlameChart extends CoreElement {
         ..height = '${gpuSectionHeight}px'
         ..top = '${cpuSectionHeight}px';
 
-      final sectionTitle = div(text: 'GPU', c: 'flame-chart-item');
+      final sectionTitle =
+          div(text: 'GPU', c: 'flame-chart-item flame-chart-title');
       sectionTitle.element.style
         ..background = colorToCss(mainGpuColor)
-        ..fontWeight = 'bold'
         ..left = '${padding}px'
         ..top = '${padding}px';
       _gpuSection.add(sectionTitle);
@@ -382,6 +382,10 @@ class FlameChartItem {
 
   num currentLeft;
   num currentWidth;
+
+  TimelineEvent get event => _event;
+
+  Color get backgroundColor => _backgroundColor;
 
   void updateForZoomLevel(num zoom) {
     currentLeft = leftOffset + (_startingLeft * zoom).round();

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -70,6 +70,13 @@
     color: black;
 }
 
+.flame-chart-item.flame-chart-title {
+    font-weight: bold;
+    padding-left: 4px;
+    padding-right: 4px;
+    cursor: default;
+}
+
 .section-border {
     border: 1px solid;
     border-color: var(--light-background);

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -96,10 +96,7 @@ class TimelineScreen extends Screen {
         div()..flex(),
       ]);
     upperButtonSection.add(
-      div(c: 'btn-group collapsible')
-        ..add(<CoreElement>[
-          ServiceExtensionButton(performanceOverlay).button,
-        ]),
+      ServiceExtensionButton(performanceOverlay).button,
     );
 
     screenDiv.add(<CoreElement>[

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -7,6 +7,7 @@ import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../service_extensions.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/icons.dart';
@@ -35,8 +36,6 @@ const Color selectedFrameColor = Color(0xFF4078C0);
 // TODO(devoncarew): show the list of widgets re-drawn during a frame
 
 // TODO(devoncarew): display whether running in debug or profile
-
-// TODO(devoncarew): use colors for the category
 
 // TODO:(devoncarew): show the total frame count
 
@@ -96,11 +95,15 @@ class TimelineScreen extends Screen {
           ]),
         div()..flex(),
       ]);
-    upperButtonSection.add(getServiceExtensionButtons());
+    upperButtonSection.add(
+      div(c: 'btn-group collapsible')
+        ..add(<CoreElement>[
+          ServiceExtensionButton(performanceOverlay).button,
+        ]),
+    );
 
     screenDiv.add(<CoreElement>[
       upperButtonSection,
-      div(c: 'section'),
       div(c: 'section')
         ..add(framesBarChart = FramesBarChart(timelineController)),
       div(c: 'section')
@@ -141,7 +144,7 @@ class TimelineScreen extends Screen {
       }
     });
 
-    onSelectedEvent.listen(eventDetails.update);
+    flameChart.onSelectedChartItem.listen(eventDetails.update);
 
     return screenDiv;
   }


### PR DESCRIPTION
update styling for the timeline details area:
- slightly more padding for the CPU and GPU titles
- change the look of the details area title
- adjusted some top and bottom margins for the timeline page areas (we had some spurious 10px and 4px margins)
- reduce the number of flutter framework buttons (down to just the toggle performance overlay one)

<img width="490" alt="screen shot 2019-02-14 at 4 30 06 pm" src="https://user-images.githubusercontent.com/1269969/52826472-d6872a00-3075-11e9-92b6-11f1caf76757.png">

<img width="804" alt="screen shot 2019-02-14 at 4 01 12 pm" src="https://user-images.githubusercontent.com/1269969/52826478-dbe47480-3075-11e9-9d75-23c28f710dd8.png">

