### PR TITLE
move back to dev releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
 
 language: dart
 dart:
-  - "dev/release/2.2.0-dev.1.1"
-#  - "dev/raw/latest"
+ - "dev/raw/latest"
 addons:
   chrome: stable
 

--- a/packages/devtools/build.yaml
+++ b/packages/devtools/build.yaml
@@ -1,0 +1,7 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        options:
+          dart2js_args:
+          - -O1

--- a/packages/devtools/build.yaml
+++ b/packages/devtools/build.yaml
@@ -1,7 +1,0 @@
-targets:
-  $default:
-    builders:
-      build_web_compilers|entrypoint:
-        options:
-          dart2js_args:
-          - -O0


### PR DESCRIPTION
- move back to regular dev releases
- delete the build configuration file (which just set us up to run dart2js with no optimizations enabled; `-O0`)

The flag to disable optimizations was causing issues with the latest dev sdk when dart2js tried to compile our app.

cc @sigmundch