### PR TITLE
show micros in the event details

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -4,7 +4,6 @@
 
 import '../ui/elements.dart';
 import '../ui/flutter_html_shim.dart';
-import '../utils.dart';
 import 'frame_flame_chart.dart';
 import 'timeline_protocol.dart';
 
@@ -73,11 +72,19 @@ class _Details extends CoreElement {
   void update(TimelineEvent event) {
     attribute('hidden', false);
     _duration.text = 'Duration:'
-        ' ${microsAsMsText(event.duration)} - '
+        ' ${_microsAsMsText(event.duration)} - '
         '[${event.startTime} - ${event.endTime}]';
   }
 
   void reset() {
     _duration.text = '';
   }
+}
+
+String _microsAsMsText(num micros, {bool includeUnit = true}) {
+  return _msAsText(micros / 1000, includeUnit: includeUnit);
+}
+
+String _msAsText(num milliseconds, {bool includeUnit = true}) {
+  return '${milliseconds.toStringAsFixed(3)}${includeUnit ? ' ms' : ''}';
 }


### PR DESCRIPTION
- show micros in the event details (this helps for shorter duration events)

<img width="227" alt="screen shot 2019-02-18 at 7 58 57 am" src="https://user-images.githubusercontent.com/1269969/52962814-1a6a7f80-3353-11e9-8300-e0320abe4fb1.png">
