### PR TITLE
several UI tweaks to the timeline frames chart

### DIFF
--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -3,38 +3,51 @@
 /* found in the LICENSE file. */
 
 .timeline-frames {
-    overflow-x: auto;
-    overflow-y: hidden;
+    position: relative;
+    overflow: hidden;
+}
+
+.timeline-frames .frames-container {
+    overflow-x: hidden;
     white-space: nowrap;
     direction: rtl;
 }
 
+.timeline-frames .divider-line {
+    height: 1px;
+    border-bottom: 1px solid;
+    left: 0;
+    right: 0;
+    position: absolute;
+    border-color: var(--light-background);
+    opacity: 0.5;
+}
+
+.timeline-frames .divider-line.subtle {
+    opacity: 0.2;
+}
+
 .timeline-frame {
-    width: 22px;
-    border-radius: 1px;
+    width: 18px;
     cursor: pointer;
     position: relative;
     direction: initial;
     user-select: none;
-}
-
-.timeline-frame + .timeline-frame {
-    margin-right: 8px;
+    margin: 0 3px;
+    z-index: 1;
 }
 
 .timeline-frame .bar {
-    width: 22px;
+    width: 18px;
 }
 
 .timeline-frame .bar.bottom {
-    border-left: 1px solid;
-    border-right: 1px solid;
-    border-bottom: 1px solid;
-    border-color: var(--light-background);
 }
 
 .timeline-frame .bar.top {
-    border: 1px solid;
+    border-top-left-radius: 2px;
+    border-top-right-radius: 2px;
+    border-bottom: 1px solid;
     border-color: var(--light-background);
 }
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -37,8 +37,6 @@ const Color selectedColor = Color(0xFF4078C0);
 
 // TODO(devoncarew): display whether running in debug or profile
 
-// TODO:(devoncarew): show the total frame count
-
 // TODO(devoncarew): Have a timeline view thumbnail overview.
 
 // TODO(devoncarew): Switch to showing all timeline events, but highlighting the
@@ -79,7 +77,7 @@ class TimelineScreen extends Screen {
       ..click(_pauseRecording);
 
     resumeButton =
-        PButton.icon('Resume Recording', FlutterIcons.resume_black_disabled_2x)
+        PButton.icon('Resume recording', FlutterIcons.resume_black_disabled_2x)
           ..small()
           ..clazz('margin-left')
           ..disabled = true


### PR DESCRIPTION
Several UI tweaks to the timeline frames chart:

- have the CPU frames on top (to mirror the ordering in the flame chart)
- have rounded corners for the top of the bar; square corners for the bottom
- make the bars slightly more narrow
- adjust the height a bit (to be able to fit 3 * 16.7ms)
- add faint horizontal bars for frame target times

<img width="662" alt="screen shot 2019-02-18 at 8 09 24 am" src="https://user-images.githubusercontent.com/1269969/52963679-4d157780-3355-11e9-9380-b9478127a576.png">
