### PR TITLE
Relax SDK constraint to include Flutter stable (v1.0)

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -5,7 +5,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
   args: ^1.5.1

--- a/third_party/packages/octicons/pubspec.yaml
+++ b/third_party/packages/octicons/pubspec.yaml
@@ -3,4 +3,4 @@ description: Stub pubspec file for octicons third_party dependency
 version: 0.0.1
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'

--- a/third_party/packages/polymer_css/pubspec.yaml
+++ b/third_party/packages/polymer_css/pubspec.yaml
@@ -3,4 +3,4 @@ description: Stub pubspec file for polymer_css third_party dependency
 version: 0.0.1
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'

--- a/third_party/packages/primer_css/pubspec.yaml
+++ b/third_party/packages/primer_css/pubspec.yaml
@@ -3,4 +3,4 @@ description: Stub pubspec file for primer_css third_party dependency
 version: 0.0.1
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'

--- a/third_party/packages/split/pubspec.yaml
+++ b/third_party/packages/split/pubspec.yaml
@@ -3,4 +3,4 @@ description: Stub pubspec file for split third_party dependency
 version: 0.0.1
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'


### PR DESCRIPTION
Flutter shipped with a v2.1.0-dev version, which is considered earlier-than v2.1.0. This change reduces the lower bound to allow any v2.1.0-dev builds.

(https://github.com/flutter/devtools/pull/80#discussion_r258117231)