### PR TITLE
Address frame tracking bug.

### DIFF
--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -144,7 +144,8 @@ class PlotlyDivGraph extends CoreElement {
         _frameIndex++;
       } else {
         // TODO(terry): HACK - Ignore the event.
-        print('WARNING: Ignored onFrameAdded - bad data');
+        print('WARNING: Ignored onFrameAdded - bad data.\n [cpuDuration: '
+            '${frame.cpuDuration}, gpuDuration: ${frame.gpuDuration}');
       }
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -20,10 +20,6 @@ enum TimelineEventType {
 class TimelineData {
   TimelineData({this.cpuThreadId, this.gpuThreadId});
 
-  /// Threshold for determining whether we will log a warning for a duplicate
-  /// trace event.
-  static const duplicateTraceWarningThreshold = 10;
-
   // TODO(kenzie): Remove the following members once cpu/gpu distinction changes
   //  and frame ids are available in the engine.
   final int cpuThreadId;
@@ -93,29 +89,15 @@ class TimelineData {
   void _handleFrameStartEvent(TraceEvent event) {
     if (event.id != null) {
       final String id = _getFrameId(event);
-      if (_pendingFrames[id] == null) {
-        // Create a new TimelineFrame if we do not already have one for this id.
-        _pendingFrames[id] = TimelineFrame(id);
-      }
+      final pendingFrame =
+          _pendingFrames.putIfAbsent(id, () => TimelineFrame(id));
 
-      // Drop any duplicate trace events. Log a warning to console if the
-      // timestamp delta exceeds [duplicateTraceWarningThreshold].
-      if (_pendingFrames[id].startTime != null) {
-        final delta =
-            (_pendingFrames[id].startTime - event.timestampMicros).abs();
-        if (delta > duplicateTraceWarningThreshold) {
-          print('Warning - received duplicate FrameStart event for frame $id.\n'
-              'Attempting to overwrite startTime '
-              '${_pendingFrames[id].startTime} with new value: '
-              '${event.timestampMicros}.\n Delta = $delta.\n If you see this'
-              'warning, please copy and paste this message into a new issue at '
-              'https://github.com/flutter/devtools/issues/new, and CC '
-              '@kenzieschmoll.');
-        }
-        return;
-      }
+      // If we receive a duplicate event for the same frame id, take the minimum
+      // start time to be the truth.
+      pendingFrame.startTime = pendingFrame.startTime != null
+          ? min(pendingFrame.startTime, event.timestampMicros)
+          : event.timestampMicros;
 
-      _pendingFrames[id].startTime = event.timestampMicros;
       _maybeAddPendingEvents();
     }
   }
@@ -123,30 +105,15 @@ class TimelineData {
   void _handleFrameEndEvent(TraceEvent event) async {
     if (event.id != null) {
       final String id = _getFrameId(event);
-      if (_pendingFrames[id] == null) {
-        // Sometimes frame end events can come in before frame start events, so
-        // create a new TimelineFrame if we do not already have one for this id.
-        _pendingFrames[id] = TimelineFrame(id);
-      }
+      final pendingFrame =
+          _pendingFrames.putIfAbsent(id, () => TimelineFrame(id));
 
-      // Drop any duplicate trace events. Log a warning to console if the
-      // timestamp delta exceeds [duplicateTraceWarningThreshold].
-      if (_pendingFrames[id].endTime != null) {
-        final delta =
-            (_pendingFrames[id].endTime - event.timestampMicros).abs();
-        if (delta > duplicateTraceWarningThreshold) {
-          print('Warning - received duplicate FrameEnd event for frame $id.\n'
-              'Attempting to overwrite endTime '
-              '${_pendingFrames[id].endTime} with new value: '
-              '${event.timestampMicros}.\n Delta = $delta.\n If you see this'
-              'warning, please copy and paste this message into a new issue at '
-              'https://github.com/flutter/devtools/issues/new, and CC '
-              '@kenzieschmoll.');
-        }
-        return;
-      }
+      // If we receive a duplicate event for the same frame id, take the maximum
+      // end time to be the truth.
+      pendingFrame.endTime = pendingFrame.endTime != null
+          ? max(pendingFrame.endTime, event.timestampMicros)
+          : event.timestampMicros;
 
-      _pendingFrames[id].endTime = event.timestampMicros;
       _maybeAddPendingEvents();
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -403,11 +403,7 @@ class TimelineFrame {
   int get startTime =>
       cpuStartTime != null ? min(cpuStartTime, _startTime) : _startTime;
   int _startTime;
-
-  set startTime(int time) {
-    assert(_startTime == null);
-    _startTime = time;
-  }
+  set startTime(int time) => _startTime = time;
 
   /// Frame end time in micros.
   ///
@@ -418,11 +414,7 @@ class TimelineFrame {
       ? max(gpuEndTime, _endTime)
       : _endTime;
   int _endTime;
-
-  set endTime(int time) {
-    assert(_endTime == null);
-    _endTime = time;
-  }
+  set endTime(int time) => _endTime = time;
 
   bool get isWellFormed => _startTime != null && _endTime != null;
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -91,13 +91,7 @@ class TimelineData {
       final String id = _getFrameId(event);
       final pendingFrame =
           _pendingFrames.putIfAbsent(id, () => TimelineFrame(id));
-
-      // If we receive a duplicate event for the same frame id, take the minimum
-      // start time to be the truth.
-      pendingFrame.startTime = pendingFrame.startTime != null
-          ? min(pendingFrame.startTime, event.timestampMicros)
-          : event.timestampMicros;
-
+      pendingFrame.startTime = event.timestampMicros;
       _maybeAddPendingEvents();
     }
   }
@@ -107,13 +101,7 @@ class TimelineData {
       final String id = _getFrameId(event);
       final pendingFrame =
           _pendingFrames.putIfAbsent(id, () => TimelineFrame(id));
-
-      // If we receive a duplicate event for the same frame id, take the maximum
-      // end time to be the truth.
-      pendingFrame.endTime = pendingFrame.endTime != null
-          ? max(pendingFrame.endTime, event.timestampMicros)
-          : event.timestampMicros;
-
+      pendingFrame.endTime = event.timestampMicros;
       _maybeAddPendingEvents();
     }
   }
@@ -403,7 +391,7 @@ class TimelineFrame {
   int get startTime =>
       cpuStartTime != null ? min(cpuStartTime, _startTime) : _startTime;
   int _startTime;
-  set startTime(int time) => _startTime = time;
+  set startTime(int time) => _startTime = min(_startTime, time);
 
   /// Frame end time in micros.
   ///
@@ -414,7 +402,7 @@ class TimelineFrame {
       ? max(gpuEndTime, _endTime)
       : _endTime;
   int _endTime;
-  set endTime(int time) => _endTime = time;
+  set endTime(int time) => _endTime = max(_endTime, time);
 
   bool get isWellFormed => _startTime != null && _endTime != null;
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -391,7 +391,9 @@ class TimelineFrame {
   int get startTime =>
       cpuStartTime != null ? min(cpuStartTime, _startTime) : _startTime;
   int _startTime;
-  set startTime(int time) => _startTime = min(_startTime, time);
+  set startTime(int time) {
+    _startTime = _startTime != null ? min(_startTime, time) : time;
+  }
 
   /// Frame end time in micros.
   ///
@@ -402,7 +404,9 @@ class TimelineFrame {
       ? max(gpuEndTime, _endTime)
       : _endTime;
   int _endTime;
-  set endTime(int time) => _endTime = max(_endTime, time);
+  set endTime(int time) {
+    _endTime = _endTime != null ? max(_endTime, time) : time;
+  }
 
   bool get isWellFormed => _startTime != null && _endTime != null;
 


### PR DESCRIPTION
Addresses https://github.com/flutter/devtools/issues/301.

We were determining frame uniqueness solely based on the frame start/end flow event ids. We could be receiving other flow events that are not matched to the PipelineItem flow events we care about. Each flow event type has its own global counter for ids, so we were seeing collisions between different flow event types. This issue will be solved by including the event name as part of the frame-id (i.e. 'PipelineItem-e45').

This does not completely solve the problem, however. We are receiving duplicate trace events from the engine. Some trace events have identical JSON, and some trace events have almost-identical JSON differing only on the event timestamp. Take the minimum startTime and maximum endTime from the duplicate events to be the truth.

@devoncarew @terrylucas @jacob314 