### PR TITLE
More FPS chart cleanup.

### DIFF
--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -75,8 +75,10 @@ class PlotlyDivGraph extends CoreElement {
 
   FramesBarPlotly plotlyChart;
 
-  int _frameIndex = 0;
-  int _lastPlottedFrameIndex = 0;
+  // X coordinate 0 for real data (xCoordNotUsed is reserved for each trace
+  // since first bar color isn't shown when x coord is xCoordNotUsed.
+  int _frameIndex = FramesBarPlotly.xCoordFirst;
+  int _lastPlottedFrameIndex = -1;
   bool _createdPlot = false;
 
   /// These lists are batch updated to the plotly chart to reduce chart lag
@@ -101,6 +103,23 @@ class PlotlyDivGraph extends CoreElement {
     }
   }
 
+  void _plotlyHover(DataEvent data) {
+    final List<HoverFX> hoverDisplay = [];
+
+    for (Point pt in data.points) {
+      final int ptNumber = pt.pointNumber;
+      final int x = pt.data.x[ptNumber];
+      // Only display the hover if its not the first data pointfor each trace
+      // (curveNumber). Works around first bar in a trace color not rendered.
+    if (x != FramesBarPlotly.xCoordNotUsed) {
+        hoverDisplay.add(
+            HoverFX(curveNumber: pt.curveNumber, pointNumber: pt.pointNumber));
+      }
+    }
+
+    plotFXHover(frameGraph, hoverDisplay);
+  }
+
   void process(
       TimelineController timelineController, TimelineFrame frame) async {
     if (!_createdPlot) {
@@ -111,6 +130,7 @@ class PlotlyDivGraph extends CoreElement {
 
       // Hookup clicks in the plotly chart.
       plotlyChart.chartClick(frameGraph, _plotlyClick);
+      plotlyChart.chartHover(frameGraph, _plotlyHover);
 
       if (!_processDatum) {
         // Only update data 6 times a second.

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -109,9 +109,9 @@ class PlotlyDivGraph extends CoreElement {
     for (Point pt in data.points) {
       final int ptNumber = pt.pointNumber;
       final int x = pt.data.x[ptNumber];
-      // Only display the hover if its not the first data pointfor each trace
+      // Only display the hover if its not the first data point for each trace
       // (curveNumber). Works around first bar in a trace color not rendered.
-    if (x != FramesBarPlotly.xCoordNotUsed) {
+      if (x != FramesBarPlotly.xCoordNotUsed) {
         hoverDisplay.add(
             HoverFX(curveNumber: pt.curveNumber, pointNumber: pt.pointNumber));
       }

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -17,6 +17,13 @@ class FramesBarPlotly {
   static const int cpuJankTraceIndex = 2;
   static const int gpuJankTraceIndex = 3;
 
+  // Careful if changing this to something other than -1 because of
+  // rangemode: nonnegative
+  static const int xCoordNotUsed = -1;
+  static const int yCoordNotUsed = 0;
+
+  static const int xCoordFirst = 0;
+
   // Default number of bars displayed in zoom (range slider).
   static const int ticksInRangeSlider = 90;
 
@@ -25,12 +32,10 @@ class FramesBarPlotly {
   Layout getFPSTimeseriesLayout() {
     return Layout(
       xaxis: AxisLayout(
-        ticks: '',
-        showgrid: false,
-        showticklabels: false,
-        rangeslider: RangeSlider(
-          rangemode: 'nonnegative',
-          autorange: true,
+        rangeslider: RangeSlider(),
+        // Hide ticks by using font color of bgColor.
+        tickfont: Font(
+          color: 'white',
         ),
         rangemode: 'nonnegative',
         autorange: true,
@@ -57,11 +62,11 @@ class FramesBarPlotly {
     // Strange plotly bug with initial setup of x,y.  If x and y are empty array
     // then the first entry, for each trace, isn't rendered but hover does
     // display the Y value.  So prime each trace with some data.  Added
-    // at x-axis -1 (hide rangemode: nonnegative displays at 0 and greater)
-    // and y is zero.
+    // at x-axis coord of xCoordNotUsed (-1) (hide rangemode: nonnegative
+    // displays at 0 and greater) and y is zero.
     final Data traceCpuGood = Data(
-      y: [0],
-      x: [-1],
+      y: [yCoordNotUsed],
+      x: [xCoordNotUsed],
       type: 'bar',
       legendgroup: 'good_group',
       name: 'CPU',
@@ -73,8 +78,8 @@ class FramesBarPlotly {
     );
 
     final Data traceGpuGood = Data(
-      y: [0],
-      x: [-1],
+      y: [yCoordNotUsed],
+      x: [xCoordNotUsed],
       type: 'bar',
       legendgroup: 'good_group',
       name: 'GPU',
@@ -86,8 +91,8 @@ class FramesBarPlotly {
     );
 
     final Data traceCpuJank = Data(
-      y: [0],
-      x: [-1],
+      y: [yCoordNotUsed],
+      x: [xCoordNotUsed],
       type: 'bar',
       legendgroup: 'jank_group',
       name: 'CPU Jank',
@@ -106,8 +111,8 @@ class FramesBarPlotly {
     );
 
     final Data traceGpuJank = Data(
-      y: [0],
-      x: [-1],
+      y: [yCoordNotUsed],
+      x: [xCoordNotUsed],
       type: 'bar',
       legendgroup: 'jank_group',
       name: 'GPU Jank',
@@ -262,25 +267,31 @@ class FramesBarPlotly {
   }
 
   void rangeSliderToLast(int dataIndex) {
-    if (dataIndex > ticksInRangeSlider) {
-      Plotly.update(
-        _domName,
-        Data(),
-        Layout(
-          xaxis: AxisLayout(
+    Plotly.update(
+      _domName,
+      Data(),
+      Layout(
+        xaxis: AxisLayout(
+          // Hide ticks by using font color of bgColor as we slide.
+          tickfont: Font(
+            color: 'white',
+          ),
+          rangemode: 'nonnegative',
+          range: [dataIndex - ticksInRangeSlider, dataIndex],
+          rangeslider: RangeSlider(
             rangemode: 'nonnegative',
-            range: [dataIndex - ticksInRangeSlider, dataIndex],
-            rangeslider: RangeSlider(
-              rangemode: 'nonnegative',
-              autorange: true,
-            ),
+            autorange: true,
           ),
         ),
-      );
-    }
+      ),
+    );
   }
 
   void chartClick(String domName, Function f) {
     mouseClick(domName, f);
+  }
+
+  void chartHover(String domName, Function f) {
+    hoverOver(domName, f);
   }
 }

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -33,6 +33,7 @@ class FramesBarPlotly {
     return Layout(
       xaxis: AxisLayout(
         rangeslider: RangeSlider(),
+        // TODO(terry): Need ThemedColor for dark theme.
         // Hide ticks by using font color of bgColor.
         tickfont: Font(
           color: 'white',
@@ -272,6 +273,7 @@ class FramesBarPlotly {
       Data(),
       Layout(
         xaxis: AxisLayout(
+          // TODO(terry): Need ThemedColor for dark theme too.
           // Hide ticks by using font color of bgColor as we slide.
           tickfont: Font(
             color: 'white',

--- a/packages/devtools/lib/src/ui/plotly.dart
+++ b/packages/devtools/lib/src/ui/plotly.dart
@@ -21,6 +21,12 @@ external void _hookupPlotlyClick(
   Function jsFunction,
 );
 
+@JS('hookupPlotlyHover')
+external void _hookupPlotlyHover(
+  String domName,
+  Function jsFunction,
+);
+
 @JS()
 external void myExtendTraces(
   String domName,
@@ -55,6 +61,9 @@ class Plotly {
     List<int> traceindex,
   ]);
 }
+
+@JS('Plotly.Fx.hover')
+external void plotFXHover(String domName, List<HoverFX> hoverInfo);
 
 @JS()
 @anonymous
@@ -231,6 +240,7 @@ class AxisLayout {
     RangeSelector rangeselector,
     bool showgrid,
     bool showticklabels,
+    Font tickfont,
   });
 
   external String get tickformat;
@@ -245,6 +255,7 @@ class AxisLayout {
   external RangeSelector get rangeselector;
   external bool get showgrid;
   external bool get showticklabels;
+  external Font get tickfont;
 }
 
 @JS()
@@ -303,6 +314,7 @@ class RangeSlider {
     num thickness,
     bool visible,
     String rangemode,
+    Font tickfont,
   });
 
   external String get bgcolor;
@@ -313,6 +325,7 @@ class RangeSlider {
   external num get thickness;
   external bool get visible;
   external String get rangemode;
+  external Font get tickfont;
 }
 
 @JS()
@@ -343,7 +356,7 @@ class DataEvent {
 class Point {
   external factory Point({
     int curveNumber,
-    List<Data> data,
+    Data data,
     int pointIndex,
     int pointNumber,
     AxisLayout xaxis,
@@ -353,7 +366,7 @@ class Point {
   });
 
   external int get curveNumber;
-  external List<Data> get data;
+  external Data get data;
   external int get pointIndex;
   external int get pointNumber;
   external AxisLayout get xaxis;
@@ -362,10 +375,29 @@ class Point {
   external num get y;
 }
 
+@JS()
+@anonymous
+class HoverFX {
+  external factory HoverFX({
+    int curveNumber,
+    int pointNumber,
+  });
+
+  external int get curveNumber;
+  external int get pointNumber;
+}
+
 void mouseClick(
   String domName,
   Function f,
 ) {
   // Hookup clicks in the plotly chart.
   _hookupPlotlyClick(domName, allowInterop(f));
+}
+
+void hoverOver(
+  String domName,
+  Function f,
+) {
+  _hookupPlotlyHover(domName, allowInterop(f));
 }

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -38,9 +38,15 @@
         })();
 
         // Plotly wrappers.
+        // TODO(terry): Remove JS code move to Dart JS interop.
         function hookupPlotlyClick(domName, jsFunction) {
             var graph = document.getElementById(domName);
             graph.on('plotly_click', jsFunction);
+        }
+
+        function hookupPlotlyHover(domName, jsFunction) {
+            var graph = document.getElementById(domName);
+            graph.on('plotly_hover', jsFunction);
         }
 
         function _copyTrace(x, y, orgTrace, xData, yData, traces) {


### PR DESCRIPTION
- Fixed hover to show first data points at x coord -1.
- Hide xaxis ticks and labels while using rangeslider.
- Always show bar charts with consistent width.