### PR TITLE
move some debugger controls

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -163,8 +163,8 @@ class DebuggerScreen extends Screen {
                         ])
                         ..small(),
                     ]),
-                  breakOnExceptionControl,
                   div()..flex(),
+                  breakOnExceptionControl,
                   div(c: 'btn-group margin-left')
                     ..add([
                       createTipsButton('Debugger'),


### PR DESCRIPTION
Move some debugger controls:

- dock the break on exception controls to the right side of the toolbar

@kenzieschmoll 

