### PR TITLE
Move the documentation links to the status bar.

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -165,10 +165,6 @@ class DebuggerScreen extends Screen {
                     ]),
                   div()..flex(),
                   breakOnExceptionControl,
-                  div(c: 'btn-group margin-left')
-                    ..add([
-                      createTipsButton('Debugger'),
-                    ]),
                 ]),
               sourceArea = div(c: 'section table-border')
                 ..layoutVertical()

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -37,7 +37,6 @@ class InspectorScreen extends Screen {
           id: 'inspector',
           iconClass: 'octicon-device-mobile',
         );
-
   PButton refreshTreeButton;
 
   SetStateMixin inspectorStateMixin = SetStateMixin();
@@ -72,11 +71,6 @@ class InspectorScreen extends Screen {
         div()..flex(),
       ]);
     getServiceExtensionButtons().forEach(buttonSection.add);
-
-    buttonSection.add(div(c: 'btn-group collapsible margin-left')
-      ..add([
-        createTipsButton('Inspector'),
-      ]));
 
     screenDiv.add(<CoreElement>[
       buttonSection,

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -33,7 +33,7 @@ bool _verboseDebugging = false;
 
 class LoggingScreen extends Screen {
   LoggingScreen()
-      : super(name: 'Logging', id: 'logs', iconClass: 'octicon-clippy') {
+      : super(name: 'Logging', id: 'logging', iconClass: 'octicon-clippy') {
     logCountStatus = StatusItem();
     logCountStatus.element.text = '';
     addStatusItem(logCountStatus);
@@ -73,8 +73,6 @@ class LoggingScreen extends Screen {
               PButton('Clear logs')
                 ..small()
                 ..click(_clear),
-              span()..flex(),
-              createTipsButton('Logging'),
             ])
         ]),
       div(c: 'section log-area')

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -31,8 +31,8 @@ class App {
     _register<void>('connectDialog.connectTo', connectDialogConnectTo);
 
     // LoggingScreen
-    _register<void>('logs.clearLogs', logsClearLogs);
-    _register<int>('logs.logCount', logsLogCount);
+    _register<void>('logging.clearLogs', logsClearLogs);
+    _register<int>('logging.logCount', logsLogCount);
 
     // DebuggerScreen
     _register<String>('debugger.getState', debuggerGetState);
@@ -105,12 +105,12 @@ class App {
   }
 
   Future<void> logsClearLogs([dynamic _]) async {
-    final LoggingScreen screen = framework.getScreen('logs');
+    final LoggingScreen screen = framework.getScreen('logging');
     screen.loggingTable.setRows(<LogData>[]);
   }
 
   Future<int> logsLogCount([dynamic _]) async {
-    final LoggingScreen screen = framework.getScreen('logs');
+    final LoggingScreen screen = framework.getScreen('logging');
     return screen.loggingTable.rowCount;
   }
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -7,7 +7,6 @@ import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../framework/framework.dart';
 import '../globals.dart';
-import '../service_extensions.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/icons.dart';
@@ -100,13 +99,6 @@ class TimelineScreen extends Screen {
           ]),
         div()..flex(),
       ]);
-    upperButtonSection.add([
-      ServiceExtensionButton(performanceOverlay).button,
-      div(c: 'btn-group margin-left')
-        ..add([
-          createTipsButton('Timeline'),
-        ]),
-    ]);
 
     screenDiv.add(<CoreElement>[
       upperButtonSection,

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -4,6 +4,8 @@
 
 import 'dart:html' as html;
 
+import 'package:meta/meta.dart';
+
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../service_extensions.dart';
@@ -75,19 +77,27 @@ List<CoreElement> getServiceExtensionButtons() {
   ];
 }
 
-CoreElement createTipsButton(String pageName) {
-  return PButton.icon(
-    '$pageName Docs',
-    const MaterialIcon(
-      'description',
-      Colors.black45,
-    ),
-    title: 'Documentation on using the $pageName page',
-    classes: ['btn-outline'],
-  )
-    ..small()
-    ..click(() => html.window.open(
-        'https://flutter.github.io/devtools/${pageName.toLowerCase()}', null));
+StatusItem createLinkStatusItem(
+  String text, {
+  @required String href,
+  @required String title,
+}) {
+  // TODO(jacobr): cleanup icon rendering so the icon changes color on hover.
+  final icon = createIconElement(const MaterialIcon(
+    'open_in_new',
+    Colors.black45,
+  ));
+  // TODO(jacobr): add this style to the css for all icons displayed as HTML
+  // once we verify there are not unintended consequences.
+  icon.element.style
+    ..verticalAlign = 'text-bottom'
+    ..marginBottom = '0';
+  final element = CoreElement('a')
+    ..add(<CoreElement>[icon, span(text: text)])
+    ..setAttribute('href', href)
+    ..setAttribute('target', '_blank')
+    ..element.title = title;
+  return StatusItem()..element.add(element);
 }
 
 CoreElement createHotReloadRestartGroup(Framework framework) {

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools
 description: A suite of web-based performance tooling for Dart and Flutter.
-version: 0.0.9
+version: 0.0.10
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools/test/integration_tests/app.dart
+++ b/packages/devtools/test/integration_tests/app.dart
@@ -25,10 +25,10 @@ void appTests() {
     final DevtoolsManager tools =
         DevtoolsManager(tabInstance, webdevFixture.baseUri);
     await tools.start(appFixture);
-    await tools.switchPage('logs');
+    await tools.switchPage('logging');
 
     final String currentPageId = await tools.currentPageId();
-    expect(currentPageId, 'logs');
+    expect(currentPageId, 'logging');
   });
 
   test('connect dialog displays', () async {

--- a/packages/devtools/test/integration_tests/logging.dart
+++ b/packages/devtools/test/integration_tests/logging.dart
@@ -25,10 +25,10 @@ void loggingTests() {
     final DevtoolsManager tools =
         DevtoolsManager(tabInstance, webdevFixture.baseUri);
     await tools.start(appFixture);
-    await tools.switchPage('logs');
+    await tools.switchPage('logging');
 
     final String currentPageId = await tools.currentPageId();
-    expect(currentPageId, 'logs');
+    expect(currentPageId, 'logging');
 
     // Cause app to log.
     final LoggingManager logs = LoggingManager(tools);
@@ -45,10 +45,10 @@ void loggingTests() {
     final DevtoolsManager tools =
         DevtoolsManager(tabInstance, webdevFixture.baseUri);
     await tools.start(appFixture);
-    await tools.switchPage('logs');
+    await tools.switchPage('logging');
 
     final String currentPageId = await tools.currentPageId();
-    expect(currentPageId, 'logs');
+    expect(currentPageId, 'logging');
 
     final LoggingManager logs = LoggingManager(tools);
 
@@ -65,7 +65,7 @@ void loggingTests() {
     expect(await logs.logCount(), 0);
 
     // Switch to the logs page.
-    await tools.switchPage('logs');
+    await tools.switchPage('logging');
 
     // Verify the log data shows up in the UI.
     await waitFor(() async => await logs.logCount() > 0);
@@ -79,11 +79,12 @@ class LoggingManager {
   final DevtoolsManager tools;
 
   Future<void> clearLogs() async {
-    await tools.tabInstance.send('logs.clearLogs');
+    await tools.tabInstance.send('logging.clearLogs');
   }
 
   Future<int> logCount() async {
-    final AppResponse response = await tools.tabInstance.send('logs.logCount');
+    final AppResponse response =
+        await tools.tabInstance.send('logging.logCount');
     return response.result;
   }
 }


### PR DESCRIPTION
Here's an attempt to move the documentation links to the status bar.
The links have grey text by default and 
This allows the links to display as regular links which feels more natural to me.
The separators between status bar icons didn't look good and in the debugging page the empty status item on startup messed with the layout so I tweaked the status bar item code a bit allowing some status items to opt out of a separator if they don't need it (e.g. because they have their own icon).
Here's a screenshot showing that the status bar still looks reasonable in the debugger.
<img width="1439" alt="screen shot 2019-02-22 at 7 57 51 pm" src="https://user-images.githubusercontent.com/1226812/53281432-120c9e80-36dd-11e9-89ba-b84dcf8d242f.png">
Animation going through the pages to make sure the UI isn't bouncing around too much switching pages.
![switch_animation](https://user-images.githubusercontent.com/1226812/53281509-7b40e180-36de-11e9-8ed1-516dea23c09d.gif)

