### PR TITLE
make parts of the debugger UI more compact

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -202,8 +202,7 @@ class DebuggerScreen extends Screen {
 
       // Only enable step over and step out if we're paused at a frame. When
       // paused w/o a frame (in the message loop), step over and out aren't
-      // meaningful (and also crash the vm:
-      // https://github.com/dart-lang/sdk/issues/35601).
+      // meaningful.
       stepOver.enabled = value && (debuggerState._lastEvent.topFrame != null);
       stepOut.enabled = value && (debuggerState._lastEvent.topFrame != null);
     });
@@ -565,14 +564,14 @@ class DebuggerState {
 
   final Map<String, Script> _scriptCache = <String, Script>{};
 
-  final BehaviorSubject<bool> _paused = BehaviorSubject<bool>(seedValue: false);
+  final BehaviorSubject<bool> _paused = BehaviorSubject<bool>.seeded(false);
   final BehaviorSubject<bool> _supportsStepping =
-      BehaviorSubject<bool>(seedValue: false);
+      BehaviorSubject<bool>.seeded(false);
 
   Event _lastEvent;
 
   final BehaviorSubject<List<Breakpoint>> _breakpoints =
-      BehaviorSubject<List<Breakpoint>>(seedValue: <Breakpoint>[]);
+      BehaviorSubject<List<Breakpoint>>.seeded(<Breakpoint>[]);
 
   final BehaviorSubject<String> _exceptionPauseMode = BehaviorSubject();
 
@@ -1375,37 +1374,38 @@ class VariablesChildProvider extends ChildProvider<BoundVariable> {
 class BreakOnExceptionControl extends CoreElement {
   BreakOnExceptionControl()
       : super('div', classes: 'break-on-exceptions margin-left flex-no-wrap') {
-    final CoreElement unhandled = CoreElement('input')
+    final CoreElement unhandledExceptionsElement = CoreElement('input')
       ..setAttribute('type', 'checkbox');
-    _unhandledElement = unhandled.element;
+    _unhandledElement = unhandledExceptionsElement.element;
 
-    final CoreElement all = CoreElement('input')
+    final CoreElement allExceptionsElement = CoreElement('input')
       ..setAttribute('type', 'checkbox');
-    _allElement = all.element;
+    _allElement = allExceptionsElement.element;
 
     add([
+      span(text: 'Break on exceptions: ', c: 'strong'),
       CoreElement('label')
         ..add(<CoreElement>[
-          unhandled,
-          span(text: ' Break on unhandled exceptions')
+          unhandledExceptionsElement,
+          span(text: ' unhandled')
         ]),
       CoreElement('label')
         ..add(<CoreElement>[
-          all,
-          span(text: ' Break on all exceptions'),
+          allExceptionsElement,
+          span(text: ' all'),
         ]),
     ]);
 
-    unhandled.element.onChange.listen((_) {
+    unhandledExceptionsElement.element.onChange.listen((_) {
       _pauseModeController.add(exceptionPauseMode);
     });
 
-    all.element.onChange.listen((_) {
+    allExceptionsElement.element.onChange.listen((_) {
       if (_allElement.checked) {
-        unhandled.enabled = false;
+        unhandledExceptionsElement.enabled = false;
         _unhandledElement.checked = true;
       } else {
-        unhandled.enabled = true;
+        unhandledExceptionsElement.enabled = true;
       }
       _pauseModeController.add(exceptionPauseMode);
     });

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -16,10 +16,10 @@ dependencies:
   meta: ^1.1.0
   path: ^1.6.0
   pedantic: ^1.4.0
+  rxdart: ^0.21.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  rxdart: ^0.20.0
-  vm_service_lib: ^3.14.1
+  vm_service_lib: ^3.14.2
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1
@@ -39,7 +39,6 @@ dependencies:
 
 dev_dependencies:
   build_runner: 1.0.0
-  build_test: any
   build_web_compilers: any
   matcher: ^0.12.3
   test: ^1.0.0

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -778,3 +778,7 @@ html [full] {
     position: relative;
     font-weight: bold;
 }
+
+span.strong {
+    font-weight: 600;
+}


### PR DESCRIPTION
- make parts of the debugger UI more compact
- upgrade to the latest `rxdart`

The debugger UI change is motivated by some dogfooding I did on a smaller-screened laptop.

<img width="389" alt="screen shot 2019-02-25 at 9 16 33 am" src="https://user-images.githubusercontent.com/1269969/53357806-8add4780-38e3-11e9-9842-15198e104e00.png">
