### PR TITLE
Set height of timeline grid

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -243,6 +243,8 @@ class FrameFlameChart extends CoreElement {
 
     void drawTimelineGrid() {
       _timelineGrid = TimelineGrid(_frame.durationMs, getFlameChartWidth());
+      _timelineGrid.element.style.height =
+          '${2 * rowHeight + cpuSectionHeight + gpuSectionHeight}px';
       add(_timelineGrid);
     }
 


### PR DESCRIPTION
- Explicitly set height of timeline grid so that grid lines extend to bottom of flame chart. Previously, if the timeline page is being viewed on a small screen or in a small window, the grid lines only extended as far down as the initial height of the flame chart div. 
- Add bottom padding of `rowHeight` so that vertical chart placement is symmetric within the view (the timestamp values at the top also have height of `rowHeight`).

Before:
<img width="936" alt="screen shot 2019-02-25 at 2 13 16 pm" src="https://user-images.githubusercontent.com/43759233/53372369-875bb780-3907-11e9-9523-05f2ed5ccd46.png">
After:
<img width="930" alt="screen shot 2019-02-25 at 2 10 13 pm" src="https://user-images.githubusercontent.com/43759233/53372327-67c48f00-3907-11e9-9415-a45904e9f177.png">

