### PR TITLE
RangeSlider should be one more than data items.

### DIFF
--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -268,7 +268,7 @@ class FramesBarPlotly {
       ],
     );
 
-    if (!paused) rangeSliderToLast(dataIndexes.last);
+    if (!paused) rangeSliderToLast(dataIndexes.last + 1);
   }
 
   void rangeSliderToLast(int dataIndex) {


### PR DESCRIPTION
RangeSlider if not larger than last X displays just enough of the last bar chart.  The slider should show the entire last bar so make the range 1 more than last bar S value.

Fixes https://github.com/flutter/devtools/issues/360