### PR TITLE
Hide the coming soon text on when resetting event details.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -92,6 +92,7 @@ class _Details extends CoreElement {
 
   void reset() {
     _duration.text = '';
+    _comingSoon.attribute('hidden', true);
   }
 }
 


### PR DESCRIPTION
The coming soon text was still visible after selecting a new frame from the bar chart above. We want this to only show if a cpu event is selected. 