### PR TITLE
relax the restriction on using 'as'

### DIFF
--- a/packages/devtools/analysis_options.yaml
+++ b/packages/devtools/analysis_options.yaml
@@ -26,7 +26,7 @@ linter:
     # - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
+    # - avoid_as # we use 'as' in this codebase
     # - avoid_bool_literals_in_conditional_expressions # not yet tested
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -327,26 +327,26 @@ class DebuggingManager {
   Future<String> getLocation() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getLocation');
-    return response.result;
+    return response.result as String;
   }
 
   Future<List<String>> getVariables() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getVariables');
-    final List<dynamic> result = response.result;
+    final List<dynamic> result = response.result as List;
     return result.cast<String>();
   }
 
   Future<String> getState() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getState');
-    return response.result;
+    return response.result as String;
   }
 
   Future<String> getConsoleContents() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getConsoleContents');
-    return response.result;
+    return response.result as String;
   }
 
   Future<void> clearBreakpoints() async {
@@ -364,28 +364,27 @@ class DebuggingManager {
   Future<List<String>> getBreakpoints() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getBreakpoints');
-    final List<dynamic> result = response.result;
+    final List<dynamic> result = response.result as List;
     return result.cast<String>();
   }
 
   Future<List<String>> getScripts() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getScripts');
-    final List<dynamic> result = response.result;
+    final List<dynamic> result = response.result as List;
     return result.cast<String>();
   }
 
   Future<bool> supportsScripts() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.supportsScripts');
-    final bool result = response.result;
-    return result;
+    return response.result as bool;
   }
 
   Future<List<String>> getCallStackFrames() async {
     final AppResponse response =
         await tools.tabInstance.send('debugger.getCallStackFrames');
-    final List<dynamic> result = response.result;
+    final List<dynamic> result = response.result as List;
     return result.cast<String>();
   }
 }


### PR DESCRIPTION
- relax the restriction on using 'as'

This will likely be more necessary if we choose to disallow implicit casts.