### PR TITLE
Wait a short period for scripts to appear to reduce test flake

### DIFF
--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -40,7 +40,12 @@ void debuggingTests() {
       return;
     }
 
-    // Get the list of scripts.
+    // Allow some time for the scripts view to be populated, as it requires
+    // some isolate events to fire that we have not already waited for.
+    await waitFor(
+      () async => (await debuggingManager.getScripts()).isNotEmpty,
+      timeoutMessage: 'Scripts view was not populated',
+    );
     final List<String> scripts = await debuggingManager.getScripts();
     expect(scripts, isNotEmpty);
     expect(scripts, anyElement(endsWith(appFixture.appScriptPath)));


### PR DESCRIPTION
I believe this fixes #320. The issue is that the test starts the app and then assumes the scripts list is populated, but there is async work that needs to happen first (isolates created and events fired). We may prefer to fix a different way (see https://github.com/flutter/devtools/issues/320#issuecomment-469221770 for some other possible ideas) but this way was the simplest I could think of. I've run it a bunch of times on Travis with no failures (at least, not because of empty script lists).

![screenshot 2019-03-04 at 2 21 29 pm](https://user-images.githubusercontent.com/1078012/53739208-1bd69480-3e89-11e9-9ebe-4894abdb5a52.png)
