### PR TITLE
 Keep existing query params when connecting through the dialog

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -499,10 +499,12 @@ class ConnectDialog {
     );
 
     if (connected) {
-      // Re-write the url to include the new port
+      // Re-write the url to include the new port. Keep existing query params.
       final Location location = window.location;
       Uri uri = Uri.parse(location.href);
-      uri = uri.replace(queryParameters: {'port': port.toString()});
+      uri = uri.replace(
+          queryParameters: {'port': port.toString()}
+            ..addAll(uri.queryParameters));
       window.history.pushState(null, null, uri.toString());
 
       // Hide the dialog

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
 
 dependencies:
   args: ^1.5.1
-  codemirror: ^0.5.0+5.43.0
+  codemirror: ^0.5.2+5.44.0
   http: ^0.12.0+1
   intl: ^0.15.0
   js: ^0.6.1+1


### PR DESCRIPTION
If query params like `hide=debugger` or `theme=dark` were in the url before connecting through the connect dialog, they were stripped out upon adding the port. We should keep these params in the url.