### PR TITLE
Support flutter_web.

### DIFF
--- a/packages/devtools/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools/lib/src/inspector/inspector_service.dart
@@ -17,7 +17,13 @@ import '../globals.dart';
 import 'diagnostics_node.dart';
 import 'flutter_widget.dart';
 
-const inspectorLibraryUri = 'package:flutter/src/widgets/widget_inspector.dart';
+// TODO(jacobr): remove flutter_web entry once flutter_web and flutter are
+// unified.
+const inspectorLibraryUriCandidates = [
+  'package:flutter/src/widgets/widget_inspector.dart',
+  'package:flutter_web/src/widgets/widget_inspector.dart',
+];
+
 bool _inspectorDependenciesLoaded = false;
 // This method must be called before any methods on the Inspector are used.
 Future<void> ensureInspectorServiceDependencies() async {
@@ -65,7 +71,7 @@ class InspectorService {
     assert(serviceManager.hasConnection);
     assert(serviceManager.service != null);
     final inspectorLibrary = EvalOnDartLibrary(
-      inspectorLibraryUri,
+      inspectorLibraryUriCandidates,
       vmService,
     );
 
@@ -1009,5 +1015,5 @@ class InspectorObjectGroupManager {
 }
 
 class FlutterInspectorLibraryNotFound extends LibraryNotFound {
-  FlutterInspectorLibraryNotFound() : super(inspectorLibraryUri);
+  FlutterInspectorLibraryNotFound() : super(inspectorLibraryUriCandidates);
 }

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -438,7 +438,10 @@ class ServiceExtensionManager {
               value != null && value.json['enabled'] == 'true';
         } else {
           final EvalOnDartLibrary flutterLibrary = EvalOnDartLibrary(
-            'package:flutter/src/widgets/binding.dart',
+            [
+              'package:flutter/src/widgets/binding.dart',
+              'package:flutter_web/src/widgets/binding.dart',
+            ],
             _service,
           );
           final InstanceRef value = await flutterLibrary.eval(

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -86,7 +86,10 @@ void main() {
       final extensionName = extensions.debugPaint.extension;
       const evalExpression = 'debugPaintSizeEnabled';
       final library = EvalOnDartLibrary(
-        'package:flutter/src/rendering/debug.dart',
+        [
+          'package:flutter/src/rendering/debug.dart',
+          'package:flutter_web/src/rendering/debug.dart',
+        ],
         env.service,
       );
 
@@ -112,7 +115,10 @@ void main() {
       final extensionName = extensions.togglePlatformMode.extension;
       const evalExpression = 'defaultTargetPlatform.toString()';
       final library = EvalOnDartLibrary(
-        'package:flutter/src/foundation/platform.dart',
+        [
+          'package:flutter_web/src/foundation/platform.dart',
+          'package:flutter/src/foundation/platform.dart',
+        ],
         env.service,
       );
 
@@ -146,7 +152,10 @@ void main() {
       final extensionName = extensions.slowAnimations.extension;
       const evalExpression = 'timeDilation';
       final library = EvalOnDartLibrary(
-        'package:flutter/src/scheduler/binding.dart',
+        [
+          'package:flutter_web/src/scheduler/binding.dart',
+          'package:flutter/src/scheduler/binding.dart',
+        ],
         env.service,
       );
 
@@ -331,7 +340,10 @@ void main() {
       final boolArgs = {'enabled': true};
       const boolEvalExpression = 'debugPaintSizeEnabled';
       final boolLibrary = EvalOnDartLibrary(
-        'package:flutter/src/rendering/debug.dart',
+        [
+          'package:flutter/src/rendering/debug.dart',
+          'package:flutter_web/src/rendering/debug.dart',
+        ],
         service,
         isolateId: _flutterIsolateId,
       );
@@ -347,7 +359,10 @@ void main() {
       final stringArgs = {'value': 'iOS'};
       const stringEvalExpression = 'defaultTargetPlatform.toString()';
       final stringLibrary = EvalOnDartLibrary(
-        'package:flutter/src/foundation/platform.dart',
+        [
+          'package:flutter/src/foundation/platform.dart',
+          'package:flutter_web/src/foundation/platform.dart',
+        ],
         service,
         isolateId: _flutterIsolateId,
       );
@@ -369,7 +384,10 @@ void main() {
       };
       const numericEvalExpression = 'timeDilation';
       final numericLibrary = EvalOnDartLibrary(
-        'package:flutter/src/scheduler/binding.dart',
+        [
+          'package:flutter/src/scheduler/binding.dart',
+          'package:flutter_web/src/scheduler/binding.dart',
+        ],
         service,
         isolateId: _flutterIsolateId,
       );


### PR DESCRIPTION
Made it an explicit list of candidates instead of hard coding Flutter Web
as multiple candidates could be useful in the future to deal with breaking
changes where libraries move within package:flutter.