### PR TITLE
Increase frame-tracking epsilon and fix pendingFrame removal bug.

### DIFF
--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -285,8 +285,10 @@ class TimelineData {
     // do event times extend slightly beyond the times we get from frame start
     // and end flow events.
 
-    // Epsilon in microseconds.
-    const int epsilon = 50;
+    // Epsilon in microseconds. If more than half of the event fits in bounds,
+    // then we consider the event as fitting. If the event has a large duration,
+    // consider it as fitting if it fits within 500 ms of the frame bound.
+    final int epsilon = min(e.duration ~/ 2, 500);
 
     // Allow the event to extend the frame boundaries by [epsilon] microseconds.
     final bool fitsStartBoundary = f.startTime - e.startTime - epsilon < 0;
@@ -324,7 +326,7 @@ class TimelineData {
   void _maybeAddCompletedFrame(TimelineFrame frame) {
     if (frame.isReadyForTimeline && frame.addedToTimeline == null) {
       _frameCompleteController.add(frame);
-      _pendingFrames.remove(frame);
+      _pendingFrames.remove(frame.id);
       frame.addedToTimeline = true;
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -254,10 +254,6 @@ class TimelineData {
   bool _maybeAddEventToFrame(TimelineEvent event, TimelineFrame frame) {
     assert(frame.isWellFormed);
 
-    // TODO(kenzie): consider trimming VSYNC layer from pipelineProduceFlow. It
-    // can start outside of the frame's time boundaries and could pose a risk
-    // for us missing a frame.
-
     // Ensure the event fits within the frame's time boundaries.
     if (!_eventOccursWithinFrameBoundaries(event, frame)) {
       return false;
@@ -287,7 +283,7 @@ class TimelineData {
 
     // Epsilon in microseconds. If more than half of the event fits in bounds,
     // then we consider the event as fitting. If the event has a large duration,
-    // consider it as fitting if it fits within 500 ms of the frame bound.
+    // consider it as fitting if it fits within 500 micros of the frame bound.
     final int epsilon = min(e.duration ~/ 2, 500);
 
     // Allow the event to extend the frame boundaries by [epsilon] microseconds.


### PR DESCRIPTION
Working on the frame-tracking logic in a broader sense, but wanted to send out a couple bug fixes while I'm digging.

The epsilon of 50 microseconds was too small. I have seen several examples needing an epsilon of ~300-400 microseconds. I have reached out to the engine team to see why this is necessary, but it seems that is. The PipelineItem timestamps from the engine are not always a source of truth for frame start and end times.