### PR TITLE
Fix some flakes in service_manager_test 🤞

### DIFF
--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -18,6 +18,8 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 import 'support/flutter_test_driver.dart';
 import 'support/flutter_test_environment.dart';
 
+const jsonRpcInvalidParamsCode = -32602;
+
 void main() {
   group('serviceManagerTests', () {
     final FlutterTestEnvironment env = FlutterTestEnvironment(
@@ -46,38 +48,17 @@ void main() {
 
     test('invalid setBreakpoint throws exception', () async {
       await env.setupEnvironment();
-      // Service with more than 1 registration.
-      serviceManager.registeredMethodsForService.putIfAbsent(
-        'fakeMethod',
-        () => ['registration1.fakeMethod', 'registration2.fakeMethod'],
+
+      await expectLater(
+        serviceManager.service.addBreakpoint(
+            serviceManager.isolateManager.selectedIsolate.id,
+            'fake-script-id',
+            1),
+        throwsA(const TypeMatcher<RPCError>()
+            .having((e) => e.code, 'code', equals(jsonRpcInvalidParamsCode))),
       );
-      expect(serviceManager.callService('fakeMethod'), throwsException);
 
-      final Completer<Object> testDone = Completer();
-      Object testError;
-      runZoned(() {
-        Future<void> asyncTestMethod() async {
-          // Service with less than 1 registration.
-          expect(
-              serviceManager.service.addBreakpoint(
-                  serviceManager.isolateManager.selectedIsolate.id,
-                  'fake-script-id',
-                  1),
-              throwsException);
-
-          await env.tearDownEnvironment();
-        }
-
-        testDone.complete(asyncTestMethod());
-      }, onError: ([error]) {
-        testError = error;
-      });
-      await testDone.future;
-      // Verify that no uncaught exceptions were thrown in an async manner
-      // while running the test.
-      // This case catches a regression where a setting a breakpoint at an
-      // invalid line would throw an uncaught exception.
-      expect(testError, isNull);
+      await env.tearDownEnvironment();
     });
 
     test('toggle boolean service extension', () async {
@@ -186,12 +167,14 @@ void main() {
       await env.setupEnvironment();
 
       // Service with less than 1 registration.
-      expect(serviceManager.callService('fakeMethod'), throwsException);
+      await expectLater(
+          serviceManager.callService('fakeMethod'), throwsException);
 
       // Service with more than 1 registration.
       serviceManager.registeredMethodsForService.putIfAbsent('fakeMethod',
           () => ['registration1.fakeMethod', 'registration2.fakeMethod']);
-      expect(serviceManager.callService('fakeMethod'), throwsException);
+      await expectLater(
+          serviceManager.callService('fakeMethod'), throwsException);
 
       await env.tearDownEnvironment();
     });
@@ -215,7 +198,8 @@ void main() {
     test('callMulticastService throws exception', () async {
       await env.setupEnvironment();
 
-      expect(serviceManager.callService('fakeMethod'), throwsException);
+      await expectLater(
+          serviceManager.callService('fakeMethod'), throwsException);
 
       await env.tearDownEnvironment();
     });

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -18,6 +18,8 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 import 'support/flutter_test_driver.dart';
 import 'support/flutter_test_environment.dart';
 
+// Error codes defined by
+// https://www.jsonrpc.org/specification#error_object
 const jsonRpcInvalidParamsCode = -32602;
 
 void main() {


### PR DESCRIPTION
I believe the fixes some of our flakes in service_manager_test. I've run them a lot of times with these changes and all were green (except for one, which I believe to be https://github.com/dart-lang/sdk/issues/33838):

![screenshot 2019-03-06 at 11 07 16 am](https://user-images.githubusercontent.com/1078012/53877036-06d04180-4000-11e9-9549-1c8275fe4ad0.png)

There are three changes here:

## 1. Use expectLater for async test code

While investigating, I found there seemed to be test code overlapping (new tests starting while other tests are still doing things). There's some code in tearDown that tries to stop this (by waiting for known futures to complete), but that's skipped if we're reusing the test environment.

For example:

```dart
expect(serviceManager.callService('fakeMethod'), throwsException);
await env.tearDownEnvironment();
```

This code doesn't seem to wait for fakeMethod to actually throw before the test method completes (tearDownEnvironment skips awaiting the futures, so it just exists early). I believe this is what resulted in the tests overlapping, and that causes some bad behaviour. I've changed test code like that to this:

```dart
await expectLater(serviceManager.callService('fakeMethod'), throwsException);
```

This causes the test method not to finish before the test has completed, which stops the overlapping. It's *possible* that by having the tests this way, the waiting for futures in `tearDown` is not required, but I don't know for sure, it'd need some testing.

## 2. Removed duplicated "Service with more than 1 registration" test code

There was code in the test "invalid setBreakpoint throws exception" that seems unrelated to the test, and was also an exact copy of code in the test "callService throws exception" so I think this was a bad copy/paste and the code shouldn't be there. I removed it.

## 3. Simplified breakpoint test to not use zones

This test doesn't seem to need zones, and it made the test much more complicated. I think it also had an issues if errors occurred because it might not complete the future. I've simplified this to just call the code directly and also made it assert the returned exception is the expected type (an RPCError with the code for InvalidParams).
