### PR TITLE
some UI tweaks to the timeline page

### DIFF
--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -58,7 +58,6 @@ class FrameFlameChart extends CoreElement {
     element.style
       ..backgroundColor = colorToCss(gpuSectionBackground)
       ..position = 'relative'
-      ..marginTop = '4px'
       ..overflow = 'hidden';
 
     _dragScroll.enableDragScrolling(this);
@@ -386,6 +385,7 @@ class FlameChartItem {
 
   static const defaultTextColor = Color(0xFF000000);
   static const selectedTextColor = Color(0xFFFFFFFF);
+
   // Pixels of padding to place on the right side of the label to ensure label
   // text does not get too close to the right hand size of each bar.
   static const labelPaddingRight = 4;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -58,7 +58,6 @@
 .flame-chart-section {
     min-width: 100%;
     position: absolute;
-    box-shadow: inset 4px 4px 9px -7px #bbbbbb;
 }
 
 .flame-chart-section .flame-chart-item {
@@ -68,6 +67,7 @@
     position: absolute;
     white-space: nowrap;
     height: 24px;
+    z-index: 1;
 }
 
 .flame-chart-item-label-wrapper {
@@ -107,8 +107,7 @@
 
 .flame-chart-grid-item .grid-line {
     top: 0;
-    background-color: black;
-    opacity: 0.15;
+    background-color: var(--light-background);
     min-height: 100%;
     width: 1px;
     position: absolute;

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -67,7 +67,6 @@
     position: absolute;
     white-space: nowrap;
     height: 24px;
-    z-index: 1;
 }
 
 .flame-chart-item-label-wrapper {
@@ -108,6 +107,7 @@
 .flame-chart-grid-item .grid-line {
     top: 0;
     background-color: var(--light-background);
+    opacity: 0.5;
     min-height: 100%;
     width: 1px;
     position: absolute;

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -107,7 +107,7 @@ class TimelineScreen extends Screen {
 
     screenDiv.add(<CoreElement>[
       upperButtonSection,
-      div(c: 'section')
+      div(c: 'section section-border')
         ..add(framesBarChart = FramesBarChart(timelineController)),
       div(c: 'section')
         ..layoutVertical()

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -19,7 +19,7 @@ import 'html_icon_renderer.dart';
 import 'material_icons.dart';
 import 'primer.dart';
 
-const int defaultSplitterWidth = 12;
+const int defaultSplitterWidth = 10;
 
 CoreElement createExtensionCheckBox(
     ToggleableServiceExtensionDescription extensionDescription) {


### PR DESCRIPTION
- make some paddings consistent
- have the timeline events paint on top of the time marker lines (this makes the timeline events seem more physical)
- give the top chart a border, for consistency with other UI elements

<img width="1499" alt="screen shot 2019-03-05 at 8 53 56 pm" src="https://user-images.githubusercontent.com/1269969/53903844-96262680-3ff9-11e9-9bef-07dde9259c40.png">
