### PR TITLE
catch streamListen failures

### DIFF
--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -187,7 +187,7 @@ class ServiceConnectionManager {
       try {
         await service.streamListen(id);
       } catch (e) {
-        print("Service client strem not supported: '$id'");
+        print("Service client stream not supported: '$id'");
         print('  $e');
       }
     }));

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -34,6 +34,7 @@ class ServiceConnectionManager {
   final Completer<Null> serviceAvailable = Completer();
 
   VmServiceCapabilities _serviceCapabilities;
+
   Future<VmServiceCapabilities> get serviceCapabilities async {
     if (_serviceCapabilities == null) {
       await serviceAvailable.future;
@@ -181,7 +182,15 @@ class ServiceConnectionManager {
       '_Logging',
       '_Service',
     ];
-    await Future.wait(streamIds.map((id) => service.streamListen(id)));
+
+    await Future.wait(streamIds.map((String id) async {
+      try {
+        await service.streamListen(id);
+      } catch (e) {
+        print("Service client strem not supported: '$id'");
+        print('  $e');
+      }
+    }));
   }
 
   void vmServiceClosed() {
@@ -687,6 +696,7 @@ class ServiceExtensionState {
 
 class VmServiceCapabilities {
   VmServiceCapabilities(this.version);
+
   final Version version;
 
   bool get supportsGetScripts =>


### PR DESCRIPTION
- catch streamListen failures; log those failures to stdout

Otherwise, for events that aren't universally supported (`_Graph`), we'd throw exceptions to the event loop. In the future, when we need to know if a capability is supported, we can add some detection.