### PR TITLE
Update Dark theme to use our dark version of Primer

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:html' as html;
 
 import 'package:codemirror/codemirror.dart';
+import 'package:devtools/src/ui/theme.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -219,7 +220,7 @@ class DebuggerScreen extends Screen {
     final CodeMirror codeMirror =
         CodeMirror.fromElement(sourceArea.element, options: options);
     codeMirror.setReadOnly(true);
-    if (useDarkTheme) {
+    if (isDarkTheme) {
       codeMirror.setTheme('darcula');
     }
     final codeMirrorElement = _sourcePathDiv.element.parent.children[1];

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -219,6 +219,9 @@ class DebuggerScreen extends Screen {
     final CodeMirror codeMirror =
         CodeMirror.fromElement(sourceArea.element, options: options);
     codeMirror.setReadOnly(true);
+    if (useDarkTheme) {
+      codeMirror.setTheme('darcula');
+    }
     final codeMirrorElement = _sourcePathDiv.element.parent.children[1];
     codeMirrorElement.setAttribute('flex', '');
 

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -243,16 +243,6 @@ bool shouldDisableTab(String key) {
   return qsParams['hide']?.split(',')?.contains(key) ?? false;
 }
 
-bool get useDarkTheme {
-  final queryString = html.window.location.search;
-  if (queryString == null || queryString.length <= 1) {
-    return false;
-  }
-
-  final qsParams = Uri.splitQueryString(queryString.substring(1));
-  return qsParams['theme'] == 'dark';
-}
-
 /// Creates a canvas scaled to match the device's devicePixelRatio.
 ///
 /// A default canvas will look pixelated on high devicePixelRatio screens so it

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -243,6 +243,16 @@ bool shouldDisableTab(String key) {
   return qsParams['hide']?.split(',')?.contains(key) ?? false;
 }
 
+bool get useDarkTheme {
+  final queryString = html.window.location.search;
+  if (queryString == null || queryString.length <= 1) {
+    return false;
+  }
+
+  final qsParams = Uri.splitQueryString(queryString.substring(1));
+  return qsParams['theme'] == 'dark';
+}
+
 /// Creates a canvas scaled to match the device's devicePixelRatio.
 ///
 /// A default canvas will look pixelated on high devicePixelRatio screens so it

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
     ^0.0.1
 #    path: ../../third_party/packages/polymer_css
   primer_css:
-     ^0.0.1
+     ^0.0.2
 #    path: ../../third_party/packages/primer_css
   split:
     ^0.0.1

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -15,11 +15,10 @@
     <title>Dart DevTools</title>
     <link rel="icon" sizes="64x64" href="favicon.png">
 
-    <link rel="stylesheet" href="packages/primer_css/primer_11.0.0.css">
+
 
     <link rel="stylesheet" href="packages/octicons_css/octicons_4.4.0.css">
     <link rel="stylesheet" href="packages/polymer_css/flex.css">
-    <link rel="stylesheet" href="styles.css">
     <link rel="stylesheet" href="packages/devtools/src/debugger/debugger.css">
     <link rel="stylesheet" href="packages/devtools/src/inspector/inspector.css">
     <link rel="stylesheet" href="packages/devtools/src/logging/logging.css">
@@ -30,10 +29,15 @@
             var params = new URLSearchParams(window.location.search);
             if (params.get('theme') == 'dark') {
                 document.write(
-   // TODO(jacobr): find a dark primer theme with the right licensing terms.
-   //                 '<link rel="stylesheet" href="packages/devtools/src/ui/github-dark.css">' +
+                    '<link rel="stylesheet" href="packages/primer_css/primer_12.1.0_dark.css">' +
+                    '<link rel="stylesheet" href="styles.css">' +
                     '<link rel="stylesheet" href="styles_dark.css">'
                 );
+            } else {
+                document.write(
+                    '<link rel="stylesheet" href="packages/primer_css/primer_12.1.0.css">' +
+                    '<link rel="stylesheet" href="styles.css">'
+                )
             }
         })();
 

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -10,6 +10,7 @@
 /* If you add a CSS variable here, be sure to also add it to styles_dart.css */
 :root {
     --border-color: #eee;
+    --chart-bar-color: #4078c0;
     --counter-color: #666;
     --dark-shadow-color: #666;
     --default-background-rgb: 255, 255, 255;
@@ -288,7 +289,7 @@ input:disabled+label {
 }
 
 .frame-bar {
-    background: var(--masthead-background);
+    background: var(--chart-bar-color);
     height: 12px;
     display: inline-block;
     border-radius: 1px;

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -793,3 +793,8 @@ html [full] {
 span.strong {
     font-weight: 600;
 }
+
+.CodeMirror {
+    /* Override the CodeMirror theme to use our own background color */
+    background: var(--default-background) !important;
+}

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -4,6 +4,7 @@
 
 /* If you add a CSS variable here, be sure to also add it to styles.css */
 :root {
+    --chart-bar-color: #4078c0;
     --border-color-dark: #484848;
     --border-color: #484848;
     --counter-color: #999;


### PR DESCRIPTION
This switches to using the v0.0.2 of the primer_css package which includes v12 CSS files (including a the Dark version built from https://github.com/DanTup/primer-css/tree/dark).

It also separates out a colour where we used the same variable for the header and a bar on the logging view (since the header is grey and the bar was barely visible in that colour).

It also sets the CodeMirror theme to `darcula` which was the least-bad one I could find quickly (though feel free to try others out and change it!). Unfortunately the demo page they have seems to miss half the content, so some that looked reasonable in the online demo had additional hideous colours when applied to real code here!
