### PR TITLE
Tweak dark buttons

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -77,8 +77,7 @@ class DebuggerScreen extends Screen {
           ..disabled = true;
 
     final PButton pauseButton =
-        PButton.icon('Pause', FlutterIcons.pause_black_2x, invertDark: true)
-          ..small();
+        PButton.icon('Pause', FlutterIcons.pause_black_2x)..small();
 
     void _updateResumeButton({@required bool disabled}) {
       resumeButton.disabled = disabled;

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -77,20 +77,15 @@ class DebuggerScreen extends Screen {
           ..disabled = true;
 
     final PButton pauseButton =
-        PButton.icon('Pause', FlutterIcons.pause_black_2x)..small();
+        PButton.icon('Pause', FlutterIcons.pause_black_2x, invertDark: true)
+          ..small();
 
     void _updateResumeButton({@required bool disabled}) {
       resumeButton.disabled = disabled;
-      resumeButton.changeIcon(disabled
-          ? FlutterIcons.resume_white_disabled_2x.src
-          : FlutterIcons.resume_white_2x.src);
     }
 
     void _updatePauseButton({@required bool disabled}) {
       pauseButton.disabled = disabled;
-      pauseButton.changeIcon(disabled
-          ? FlutterIcons.pause_black_disabled_2x.src
-          : FlutterIcons.pause_black_2x.src);
     }
 
     resumeButton.click(() async {

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -73,9 +73,7 @@ class MemoryScreen extends Screen with SetStateMixin {
       ..small()
       ..disabled = true;
 
-    pauseButton =
-        PButton.icon('Pause', FlutterIcons.pause_black_2x, invertDark: true)
-          ..small();
+    pauseButton = PButton.icon('Pause', FlutterIcons.pause_black_2x)..small();
 
     // TODO(terry): Need to correctly handle enabled and disabled.
     vmMemorySnapshotButton = PButton.icon('Snapshot', FlutterIcons.snapshot,
@@ -86,19 +84,19 @@ class MemoryScreen extends Screen with SetStateMixin {
       ..disabled = true;
     resetAccumulatorsButton = PButton.icon(
         'Reset', FlutterIcons.resetAccumulators,
-        title: 'Reset Accumulators', invertDark: true)
+        title: 'Reset Accumulators')
       ..small()
       ..click(_resetAllocatorCounts)
       ..disabled = true;
-    filterLibrariesButton = PButton.icon('Filter', FlutterIcons.filter,
-        title: 'Filter', invertDark: true)
-      ..small()
-      ..disabled = true;
-    gcNowButton = PButton.icon('GC', FlutterIcons.gcNow,
-        title: 'Manual Garbage Collect', invertDark: true)
-      ..small()
-      ..click(_gcNow)
-      ..disabled = true;
+    filterLibrariesButton =
+        PButton.icon('Filter', FlutterIcons.filter, title: 'Filter')
+          ..small()
+          ..disabled = true;
+    gcNowButton =
+        PButton.icon('GC', FlutterIcons.gcNow, title: 'Manual Garbage Collect')
+          ..small()
+          ..click(_gcNow)
+          ..disabled = true;
 
     resumeButton.click(() {
       updateResumeButton(disabled: true);

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -58,16 +58,10 @@ class MemoryScreen extends Screen with SetStateMixin {
 
   void updateResumeButton({@required bool disabled}) {
     resumeButton.disabled = disabled;
-    resumeButton.changeIcon(disabled
-        ? FlutterIcons.resume_white_disabled_2x.src
-        : FlutterIcons.resume_white_2x.src);
   }
 
   void updatePauseButton({@required bool disabled}) {
     pauseButton.disabled = disabled;
-    pauseButton.changeIcon(disabled
-        ? FlutterIcons.pause_black_disabled_2x.src
-        : FlutterIcons.pause_black_2x.src);
   }
 
   @override
@@ -79,7 +73,9 @@ class MemoryScreen extends Screen with SetStateMixin {
       ..small()
       ..disabled = true;
 
-    pauseButton = PButton.icon('Pause', FlutterIcons.pause_black_2x)..small();
+    pauseButton =
+        PButton.icon('Pause', FlutterIcons.pause_black_2x, invertDark: true)
+          ..small();
 
     // TODO(terry): Need to correctly handle enabled and disabled.
     vmMemorySnapshotButton = PButton.icon('Snapshot', FlutterIcons.snapshot,
@@ -90,19 +86,19 @@ class MemoryScreen extends Screen with SetStateMixin {
       ..disabled = true;
     resetAccumulatorsButton = PButton.icon(
         'Reset', FlutterIcons.resetAccumulators,
-        title: 'Reset Accumulators')
+        title: 'Reset Accumulators', invertDark: true)
       ..small()
       ..click(_resetAllocatorCounts)
       ..disabled = true;
-    filterLibrariesButton =
-        PButton.icon('Filter', FlutterIcons.filter, title: 'Filter')
-          ..small()
-          ..disabled = true;
-    gcNowButton =
-        PButton.icon('GC', FlutterIcons.gcNow, title: 'Manual Garbage Collect')
-          ..small()
-          ..click(_gcNow)
-          ..disabled = true;
+    filterLibrariesButton = PButton.icon('Filter', FlutterIcons.filter,
+        title: 'Filter', invertDark: true)
+      ..small()
+      ..disabled = true;
+    gcNowButton = PButton.icon('GC', FlutterIcons.gcNow,
+        title: 'Manual Garbage Collect', invertDark: true)
+      ..small()
+      ..click(_gcNow)
+      ..disabled = true;
 
     resumeButton.click(() {
       updateResumeButton(disabled: true);

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -209,13 +209,6 @@ class TimelineScreen extends Screen {
   void _updateButtons({@required bool paused}) {
     pauseButton.disabled = paused;
     resumeButton.disabled = !paused;
-
-    pauseButton.changeIcon(paused
-        ? FlutterIcons.pause_white_disabled_2x.src
-        : FlutterIcons.pause_white_2x.src);
-    resumeButton.changeIcon(paused
-        ? FlutterIcons.resume_black_2x.src
-        : FlutterIcons.resume_black_disabled_2x.src);
   }
 
   void _updateListeningState() async {

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -98,10 +98,11 @@ class TimelineScreen extends Screen {
 //      PTabNavTab('Skia picture'),
 //    ]);
 
-    pauseButton = PButton.icon('Pause recording', FlutterIcons.pause_white_2x)
-      ..small()
-      ..primary()
-      ..click(_pauseRecording);
+    pauseButton =
+        PButton.icon('Pause recording', FlutterIcons.pause_white_2x_primary)
+          ..small()
+          ..primary()
+          ..click(_pauseRecording);
 
     resumeButton =
         PButton.icon('Resume recording', FlutterIcons.resume_black_disabled_2x)

--- a/packages/devtools/lib/src/ui/html_icon_renderer.dart
+++ b/packages/devtools/lib/src/ui/html_icon_renderer.dart
@@ -96,6 +96,9 @@ class _UrlIconRenderer extends HtmlIconRenderer<UrlIcon> {
       ..width = '${icon.iconWidth}px'
       ..height = '${icon.iconHeight}px'
       ..backgroundImage = 'url($src)';
+    if (icon.invertDark && isDarkTheme) {
+      element.style.filter = 'invert(1)';
+    }
     return element;
   }
 

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -142,6 +142,11 @@ class FlutterIcons {
       UrlIcon('/icons/general/pause_white@2x.png', invertDark: true);
   static const UrlIcon pause_white_disabled_2x =
       UrlIcon('/icons/general/pause_white_disabled@2x.png', invertDark: true);
+
+  /// Used on "primary" buttons that have colored backgrounds, so is not
+  /// inverted for Dark theme.
+  static const UrlIcon pause_white_2x_primary =
+      UrlIcon('/icons/general/pause_white@2x.png');
   static const UrlIcon resume_black_2x =
       UrlIcon('/icons/general/resume_black@2x.png');
   static const UrlIcon resume_black_disabled_2x =

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -25,9 +25,12 @@ abstract class Icon {
 }
 
 class UrlIcon extends Icon {
-  const UrlIcon(this.src);
+  const UrlIcon(this.src, {this.invertDark = false});
 
   final String src;
+
+  /// Whether the icon shout be inverted when rendered in the Dark theme.
+  final bool invertDark;
 }
 
 class FlutterIcons {
@@ -132,13 +135,13 @@ class FlutterIcons {
   static const Icon history = UrlIcon('/icons/history.svg');
 
   static const UrlIcon pause_black_2x =
-      UrlIcon('/icons/general/pause_black@2x.png');
+      UrlIcon('/icons/general/pause_black@2x.png', invertDark: true);
   static const UrlIcon pause_black_disabled_2x =
-      UrlIcon('/icons/general/pause_black_disabled@2x.png');
+      UrlIcon('/icons/general/pause_black_disabled@2x.png', invertDark: true);
   static const UrlIcon pause_white_2x =
-      UrlIcon('/icons/general/pause_white@2x.png');
+      UrlIcon('/icons/general/pause_white@2x.png', invertDark: true);
   static const UrlIcon pause_white_disabled_2x =
-      UrlIcon('/icons/general/pause_white_disabled@2x.png');
+      UrlIcon('/icons/general/pause_white_disabled@2x.png', invertDark: true);
   static const UrlIcon resume_black_2x =
       UrlIcon('/icons/general/resume_black@2x.png');
   static const UrlIcon resume_black_disabled_2x =
@@ -155,11 +158,11 @@ class FlutterIcons {
 
   static const UrlIcon snapshot = UrlIcon('/icons/memory/snapshot_color.png');
   static const UrlIcon resetAccumulators =
-      UrlIcon('/icons/memory/reset_icon.png');
+      UrlIcon('/icons/memory/reset_icon.png', invertDark: true);
   static const UrlIcon filter =
-      UrlIcon('/icons/memory/ic_filter_list_alt_black.png');
+      UrlIcon('/icons/memory/ic_filter_list_alt_black.png', invertDark: true);
   static const UrlIcon gcNow =
-      UrlIcon('/icons/memory/ic_delete_outline_black.png');
+      UrlIcon('/icons/memory/ic_delete_outline_black.png', invertDark: true);
 }
 
 class CustomIcon extends Icon {

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -136,6 +136,8 @@ class FlutterIcons {
 
   static const UrlIcon pause_black_2x =
       UrlIcon('/icons/general/pause_black@2x.png', invertDark: true);
+  // TODO(dantup): Remove the invertDark option from these...
+  // https://github.com/flutter/devtools/pull/423#pullrequestreview-214139125
   static const UrlIcon pause_black_disabled_2x =
       UrlIcon('/icons/general/pause_black_disabled@2x.png', invertDark: true);
   static const UrlIcon pause_white_2x =

--- a/packages/devtools/lib/src/ui/primer.dart
+++ b/packages/devtools/lib/src/ui/primer.dart
@@ -63,15 +63,11 @@ class PButton extends CoreElement {
     setAttribute('type', 'button');
   }
 
-  PButton.icon(String text, Icon icon,
-      {String title, List<String> classes, bool invertDark = false})
+  PButton.icon(String text, Icon icon, {String title, List<String> classes})
       : super('button', classes: 'btn optional-text') {
     setAttribute('type', 'button');
     setAttribute('title', title ?? text);
     classes?.forEach(clazz);
-    if (invertDark) {
-      clazz('invert-dark');
-    }
     if (icon != null) {
       _icon = icon;
       add(createIconElement(icon));

--- a/packages/devtools/lib/src/ui/primer.dart
+++ b/packages/devtools/lib/src/ui/primer.dart
@@ -63,11 +63,15 @@ class PButton extends CoreElement {
     setAttribute('type', 'button');
   }
 
-  PButton.icon(String text, Icon icon, {String title, List<String> classes})
+  PButton.icon(String text, Icon icon,
+      {String title, List<String> classes, bool invertDark = false})
       : super('button', classes: 'btn optional-text') {
     setAttribute('type', 'button');
     setAttribute('title', title ?? text);
     classes?.forEach(clazz);
+    if (invertDark) {
+      clazz('invert-dark');
+    }
     if (icon != null) {
       _icon = icon;
       add(createIconElement(icon));

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -75,8 +75,4 @@ nav.menu .menu-item {
     background-image: linear-gradient(-180deg, #1f1f1f 0%, #1f1f1f 90%);
     box-shadow: none;
 }
-
-.btn.invert-dark .flutter-icon {
-    filter: invert(1);
-}
 /* /Tweak how buttons look in the dark theme to not be so dark */

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -65,3 +65,18 @@ nav.menu .menu-item {
     fill: rgba(255, 255, 255, .6) !important;
     fill-opacity: 0.6 !important;
 }
+
+/* Tweak how buttons look in the dark theme to not be so dark */
+.btn:not(.btn-primary), .btn:not(.btn-primary)[disabled] {
+    background-image: linear-gradient(-180deg, #3f3f3f 0%, #3f3f3f 90%);
+}
+
+.btn.selected:not(.btn-primary), .btn.selected:not(.btn-primary)[disabled] {
+    background-image: linear-gradient(-180deg, #1f1f1f 0%, #1f1f1f 90%);
+    box-shadow: none;
+}
+
+.btn.invert-dark .flutter-icon {
+    filter: invert(1);
+}
+/* /Tweak how buttons look in the dark theme to not be so dark */


### PR DESCRIPTION
This tweaks the colours of dark buttons slightly, as well as inverts the colours of the icons (@jacob314 I couldn't get a coloured tint working, so just added a flag to invert them when using the dark theme, but if you have ideas for how to do this better, lmk!).

I removed the code that swapped disabled buttons out, because we already have a opacity of 0.5 for disabled buttons, and in the dark theme, the disabled button + 0.5 opacity made the icons impossible to see.

The green buttons are still weird (I think because of the reversed light/dark), I'll look at them in another PR too.

![Screenshot 2019-03-13 at 5 26 11 pm](https://user-images.githubusercontent.com/1078012/54300877-b33c9580-45b5-11e9-9040-c9beba2b4332.png)
![Screenshot 2019-03-13 at 5 26 21 pm](https://user-images.githubusercontent.com/1078012/54300878-b3d52c00-45b5-11e9-8bfb-c86a921f3bb0.png)
![Screenshot 2019-03-13 at 5 26 37 pm](https://user-images.githubusercontent.com/1078012/54300879-b3d52c00-45b5-11e9-92f3-0ed867c1e874.png)
![Screenshot 2019-03-13 at 5 26 44 pm](https://user-images.githubusercontent.com/1078012/54300880-b3d52c00-45b5-11e9-99c9-759a60905355.png)
![Screenshot 2019-03-13 at 5 26 53 pm](https://user-images.githubusercontent.com/1078012/54300881-b3d52c00-45b5-11e9-86dc-7dd09ca5c296.png)
![Screenshot 2019-03-13 at 5 27 01 pm](https://user-images.githubusercontent.com/1078012/54300883-b3d52c00-45b5-11e9-819c-dca7bcde304b.png)
![Screenshot 2019-03-13 at 5 27 19 pm](https://user-images.githubusercontent.com/1078012/54300884-b3d52c00-45b5-11e9-9755-ac84a9d1886e.png)
