### PR TITLE
Dark mode for Timelne FPS chart.

### DIFF
--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -9,9 +9,6 @@ import '../ui/theme.dart';
 
 import 'memory_chart.dart';
 
-const ThemedColor chartBackground =
-    ThemedColor(Colors.white, Color.fromRGBO(47, 43, 43, 1));
-
 class MemoryPlotly {
   MemoryPlotly(this._domName, this._memoryChart);
 

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -176,9 +176,9 @@ class PlotlyDivGraph extends CoreElement {
 
       if (color == colorToCss(cpuJankColor) ||
           color == colorToCss(gpuJankColor)) {
-        // Flip to cpuGoodColor/gpuGoodColor
-        newCpuColor = colorToCss(mainCpuColor);
-        newGpuColor = colorToCss(mainGpuColor);
+        // Flip to cpuChartColor/gpuChartColor
+        newCpuColor = colorToCss(cpuChartColor);
+        newGpuColor = colorToCss(gpuChartColor);
       } else {
         // Flip back to cpuJankColor/gpuJankColor
         newCpuColor = colorToCss(cpuJankColor);

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -7,6 +7,7 @@ import 'package:js/js_util.dart';
 import '../timeline/timeline.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/plotly.dart';
+import '../ui/theme.dart';
 
 class FramesBarPlotly {
   FramesBarPlotly(this._domName, [this.useLogScale = true]);
@@ -50,6 +51,10 @@ class FramesBarPlotly {
     type: 'log',
     range: [0, 2],
     nticks: 3,
+    titlefont: Font(color: colorToCss(defaultForeground)),
+    tickfont: Font(
+      color: colorToCss(defaultForeground),
+    ),
     tickmode: 'array',
     tickvals: [
       1,
@@ -71,12 +76,14 @@ class FramesBarPlotly {
 
   Layout getFPSTimeseriesLayout() {
     return Layout(
+      plot_bgcolor: colorToCss(chartBackground),
+      paper_bgcolor: colorToCss(chartBackground),
+      legend: Legend(font: Font(color: colorToCss(defaultForeground))),
       xaxis: AxisLayout(
         rangeslider: RangeSlider(),
-        // TODO(terry): Need ThemedColor for dark theme.
         // Hide ticks by using font color of bgColor.
         tickfont: Font(
-          color: 'white',
+          color: colorToCss(chartBackground),
           size: 1,
         ),
         rangemode: 'nonnegative',
@@ -101,7 +108,7 @@ class FramesBarPlotly {
           y1: 8,
           line: Line(
             dash: 'dot',
-            color: colorToCss(mainGpuColor),
+            color: colorToCss(gpuChartColor),
             width: 1,
           ),
         ),
@@ -116,7 +123,7 @@ class FramesBarPlotly {
           y1: 16,
           line: Line(
             dash: 'longdash',
-            color: colorToCss(mainCpuColor),
+            color: colorToCss(cpuChartColor),
             width: 1,
           ),
         ),
@@ -160,7 +167,7 @@ class FramesBarPlotly {
         name: 'GPU',
         hoverinfo: 'y+name',
         marker: Marker(
-          color: colorToCss(mainGpuColor),
+          color: colorToCss(gpuChartColor),
         ),
         width: [0],
       ),
@@ -177,8 +184,7 @@ class FramesBarPlotly {
         name: 'GPU Jank',
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
-          // TODO(terry): font color needs be be a ThemedColor.
-          font: Font(color: 'black'),
+          font: Font(color: colorToCss(defaultBackground)),
           bordercolor: colorToCss(hoverJankColor),
         ),
         marker: Marker(
@@ -195,11 +201,17 @@ class FramesBarPlotly {
         y: [yCoordNotUsed],
         x: [xCoordNotUsed],
         hoverinfo: 'y+name',
+        hoverlabel: HoverLabel(
+          bgcolor: colorToCss(selectedGpuColor),
+          font: Font(
+            color: colorToCss(defaultForeground),
+          ),
+          bordercolor: colorToCss(selectedGpuColor),
+        ),
         showlegend: false,
         type: 'bar',
         marker: Marker(
-          color: colorToCss(
-              selectedGpuColor), // TODO(terry): Handle ThemedColor dart mode.
+          color: colorToCss(selectedGpuColor),
         ),
       ),
     );
@@ -215,7 +227,7 @@ class FramesBarPlotly {
         name: 'CPU',
         hoverinfo: 'y+name',
         marker: Marker(
-          color: colorToCss(mainCpuColor),
+          color: colorToCss(cpuChartColor),
         ),
         width: [0],
       ),
@@ -233,8 +245,7 @@ class FramesBarPlotly {
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
           font: Font(
-            // TODO(terry): font color needs be be a ThemedColor.
-            color: 'white',
+            color: colorToCss(defaultForeground),
           ),
           bordercolor: colorToCss(hoverJankColor),
         ),
@@ -252,11 +263,17 @@ class FramesBarPlotly {
         y: [yCoordNotUsed],
         x: [xCoordNotUsed],
         hoverinfo: 'y+name',
+        hoverlabel: HoverLabel(
+          bgcolor: colorToCss(selectedCpuColor),
+          font: Font(
+            color: colorToCss(defaultForeground),
+          ),
+          bordercolor: colorToCss(selectedCpuColor),
+        ),
         showlegend: false,
         type: 'bar',
         marker: Marker(
-          color: colorToCss(
-              selectedCpuColor), // TODO(terry): Handle ThemedColor dart mode.
+          color: colorToCss(selectedCpuColor),
         ),
       ),
     );
@@ -402,10 +419,9 @@ class FramesBarPlotly {
       [Data()],
       Layout(
         xaxis: AxisLayout(
-          // TODO(terry): Need ThemedColor for dark theme too.
           // Hide ticks by using font color of bgColor as we slide.
           tickfont: Font(
-            color: 'white',
+            color: colorToCss(chartBackground),
           ),
           rangemode: 'nonnegative',
           range: [dataIndex - ticksInRangeSlider, dataIndex],

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -266,7 +266,7 @@ class FramesBarPlotly {
         hoverlabel: HoverLabel(
           bgcolor: colorToCss(selectedCpuColor),
           font: Font(
-            color: colorToCss(defaultForeground),
+            color: colorToCss(hoverTextColor),
           ),
           bordercolor: colorToCss(selectedCpuColor),
         ),

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -50,9 +50,11 @@ const hoverJankColor = ThemedColor(Color(0xFFF44336), Color(0xFFD32F2F));
 const Color slowFrameColor = Color(0xFFE50C0C);
 
 // Blue A700 is light, Indigo A400 is dark
-const Color selectedGpuColor = ThemedColor(Color(0xFF2962FF), Color(0xFF3D5AFE));
+const Color selectedGpuColor =
+    ThemedColor(Color(0xFF2962FF), Color(0xFF3D5AFE));
 // Dark Blue is light, Indigo A200 is dark
-const Color selectedCpuColor = ThemedColor(Color(0xFF09007E), Color(0xFF536DFE));
+const Color selectedCpuColor =
+    ThemedColor(Color(0xFF09007E), Color(0xFF536DFE));
 
 // TODO(devoncarew): show the Skia picture (gpu drawing commands) for a frame
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -35,19 +35,24 @@ const mainGpuColor = ThemedColor(mainGpuLight, mainGpuDark);
 const selectedFlameChartItemColor =
     ThemedColor(Color(0xFF4078C0), Color(0xFFFFFFFF));
 
-// Red 300
-const Color gpuJankColor = Color(0xFFE57373);
-// Red 800
-const Color cpuJankColor = Color(0xFFC62828);
-// Red 500
-const Color hoverJankColor = Color(0xFFF44336);
+// Chart is Teal 300 is light, Teal 500 is dark
+const gpuChartColor = ThemedColor(mainGpuLight, Color(0xFF009688));
+// Chart is Blue 300 is light, Blue 500 is dark
+const cpuChartColor = ThemedColor(mainCpuLight, Color(0xFF03A9F4));
+
+// Red 300 is light, Red 500 is dark
+const gpuJankColor = ThemedColor(Color(0xFFE57373), Color(0xFFF44336));
+// Red 800 is light, Red 800 is dark
+const cpuJankColor = ThemedColor(Color(0xFFC62828), Color(0xFFC62828));
+// Red 500 is light, Red 700 is dark
+const hoverJankColor = ThemedColor(Color(0xFFF44336), Color(0xFFD32F2F));
 
 const Color slowFrameColor = Color(0xFFE50C0C);
 
-// Blue A700
-const Color selectedGpuColor = Color(0xFF2962FF);
-// Dark Blue
-const Color selectedCpuColor = Color(0xFF09007E);
+// Blue A700 is light, Indigo A400 is dark
+const Color selectedGpuColor = ThemedColor(Color(0xFF2962FF), Color(0xFF3D5AFE));
+// Dark Blue is light, Indigo A200 is dark
+const Color selectedCpuColor = ThemedColor(Color(0xFF09007E), Color(0xFF536DFE));
 
 // TODO(devoncarew): show the Skia picture (gpu drawing commands) for a frame
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -55,6 +55,8 @@ const Color selectedGpuColor =
 // Dark Blue is light, Indigo A200 is dark
 const Color selectedCpuColor =
     ThemedColor(Color(0xFF09007E), Color(0xFF536DFE));
+// Selection is high-contrast need white font.
+const Color hoverTextColor = ThemedColor(Colors.white, defaultForeground);
 
 // TODO(devoncarew): show the Skia picture (gpu drawing commands) for a frame
 

--- a/packages/devtools/lib/src/ui/theme.dart
+++ b/packages/devtools/lib/src/ui/theme.dart
@@ -26,6 +26,10 @@ const ThemedColor defaultForeground =
 const ThemedColor grey = ThemedColor(
     Color.fromARGB(255, 128, 128, 128), Color.fromARGB(255, 128, 128, 128));
 
+// Background colors for charts.
+const ThemedColor chartBackground =
+    ThemedColor(Colors.white, Color.fromRGBO(47, 43, 43, 1));
+
 /// Color that behaves differently depending on whether a light or dark theme
 /// is used.
 ///


### PR DESCRIPTION
Timeline FPS chart in dark mode:

![image](https://user-images.githubusercontent.com/2055873/54327296-d4f24880-45c6-11e9-9b4e-49463d0b02d3.png)
