### PR TITLE
More dark tweaks

### DIFF
--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -86,7 +86,7 @@ StatusItem createLinkStatusItem(
   // TODO(jacobr): cleanup icon rendering so the icon changes color on hover.
   final icon = createIconElement(const MaterialIcon(
     'open_in_new',
-    Colors.black45,
+    Colors.grey,
   ));
   // TODO(jacobr): add this style to the css for all icons displayed as HTML
   // once we verify there are not unintended consequences.

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -17,7 +17,7 @@
     --error-background: #7c1c05;
     --even-row-background: #1e1e1e;
     --footer-color: #858585;
-    --footer-link-hover: #0366d6;
+    --footer-link-hover: wheat;
     --footer-strong: #ccc;
     --header-background: #282828;
     --header-color: #ccc;

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -76,3 +76,8 @@ nav.menu .menu-item {
     box-shadow: none;
 }
 /* /Tweak how buttons look in the dark theme to not be so dark */
+
+.flash-warn {
+    background-color: #fffbdd;
+    color: #735c0f;
+}


### PR DESCRIPTION
Fixes a few issues from #418.

I'm not sure about `flash-warn`... This sets it back to what it was in the light theme (which looks fine IMO). However it makes me wonder whether reversing all of the light/dark colours around in the dark theme was best, or we should've just done for the black/whites. I think either way we'll have to fix up a bunch of things - though I'm not sure which would result in the least.