### PR TITLE
Fixed hover text, CPU selection and dark mode colors not matching flame chart.

### DIFF
--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -177,8 +177,8 @@ class PlotlyDivGraph extends CoreElement {
       if (color == colorToCss(cpuJankColor) ||
           color == colorToCss(gpuJankColor)) {
         // Flip to cpuChartColor/gpuChartColor
-        newCpuColor = colorToCss(cpuChartColor);
-        newGpuColor = colorToCss(gpuChartColor);
+        newCpuColor = colorToCss(mainCpuColor);
+        newGpuColor = colorToCss(mainGpuColor);
       } else {
         // Flip back to cpuJankColor/gpuJankColor
         newCpuColor = colorToCss(cpuJankColor);

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -190,7 +190,7 @@ class FramesBarPlotly {
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
           font: Font(
-            color: colorToCss(hoverTextHiContrastColor),
+            color: colorToCss(hoverTextHighContrastColor),
           ),
           bordercolor: colorToCss(hoverJankColor),
         ),
@@ -211,7 +211,7 @@ class FramesBarPlotly {
         hoverlabel: HoverLabel(
           bgcolor: colorToCss(selectedGpuColor),
           font: Font(
-            color: colorToCss(hoverTextHiContrastColor),
+            color: colorToCss(hoverTextHighContrastColor),
           ),
           bordercolor: colorToCss(selectedGpuColor),
         ),
@@ -257,7 +257,7 @@ class FramesBarPlotly {
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
           font: Font(
-            color: colorToCss(hoverTextHiContrastColor),
+            color: colorToCss(hoverTextHighContrastColor),
           ),
           bordercolor: colorToCss(hoverJankColor),
         ),
@@ -278,7 +278,7 @@ class FramesBarPlotly {
         hoverlabel: HoverLabel(
           bgcolor: colorToCss(selectedCpuColor),
           font: Font(
-            color: colorToCss(hoverTextHiContrastColor),
+            color: colorToCss(hoverTextHighContrastColor),
           ),
           bordercolor: colorToCss(selectedCpuColor),
         ),

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -108,7 +108,7 @@ class FramesBarPlotly {
           y1: 8,
           line: Line(
             dash: 'dot',
-            color: colorToCss(gpuChartColor),
+            color: colorToCss(mainGpuColor),
             width: 1,
           ),
         ),
@@ -123,7 +123,7 @@ class FramesBarPlotly {
           y1: 16,
           line: Line(
             dash: 'longdash',
-            color: colorToCss(cpuChartColor),
+            color: colorToCss(mainCpuColor),
             width: 1,
           ),
         ),
@@ -166,8 +166,13 @@ class FramesBarPlotly {
         legendgroup: 'good_group',
         name: 'GPU',
         hoverinfo: 'y+name',
+        hoverlabel: HoverLabel(
+          font: Font(
+            color: colorToCss(hoverTextColor),
+          ),
+        ),
         marker: Marker(
-          color: colorToCss(gpuChartColor),
+          color: colorToCss(mainGpuColor),
         ),
         width: [0],
       ),
@@ -184,7 +189,9 @@ class FramesBarPlotly {
         name: 'GPU Jank',
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
-          font: Font(color: colorToCss(defaultBackground)),
+          font: Font(
+            color: colorToCss(hoverTextHiContrastColor),
+          ),
           bordercolor: colorToCss(hoverJankColor),
         ),
         marker: Marker(
@@ -204,7 +211,7 @@ class FramesBarPlotly {
         hoverlabel: HoverLabel(
           bgcolor: colorToCss(selectedGpuColor),
           font: Font(
-            color: colorToCss(defaultForeground),
+            color: colorToCss(hoverTextHiContrastColor),
           ),
           bordercolor: colorToCss(selectedGpuColor),
         ),
@@ -226,8 +233,13 @@ class FramesBarPlotly {
         legendgroup: 'good_group',
         name: 'CPU',
         hoverinfo: 'y+name',
+        hoverlabel: HoverLabel(
+          font: Font(
+            color: colorToCss(hoverTextColor),
+          ),
+        ),
         marker: Marker(
-          color: colorToCss(cpuChartColor),
+          color: colorToCss(mainCpuColor),
         ),
         width: [0],
       ),
@@ -245,7 +257,7 @@ class FramesBarPlotly {
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
           font: Font(
-            color: colorToCss(defaultForeground),
+            color: colorToCss(hoverTextHiContrastColor),
           ),
           bordercolor: colorToCss(hoverJankColor),
         ),
@@ -266,7 +278,7 @@ class FramesBarPlotly {
         hoverlabel: HoverLabel(
           bgcolor: colorToCss(selectedCpuColor),
           font: Font(
-            color: colorToCss(hoverTextColor),
+            color: colorToCss(hoverTextHiContrastColor),
           ),
           bordercolor: colorToCss(selectedCpuColor),
         ),

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -51,13 +51,8 @@ const Color selectedGpuColor =
 const Color selectedCpuColor =
     ThemedColor(Color(0xFF09007E), Color(0xFF7C4DFF));
 
-// Text color defaultForeground is too gray hard to read text, make it a little
-// whitter, not jarring white #FFFFFF.
-const ThemedColor contrastForeground =
-    ThemedColor(Colors.black, Color.fromARGB(255, 240, 240, 240));
-
 // Jank/Selection is high-contrast need white-ish font.
-const Color hoverTextHiContrastColor =
+const Color hoverTextHighContrastColor =
     ThemedColor(Colors.white, contrastForeground);
 // Other hovers are not as contrasty (good frames) black text looks best in both
 // light and dark mode.

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -35,11 +35,6 @@ const mainGpuColor = ThemedColor(mainGpuLight, mainGpuDark);
 const selectedFlameChartItemColor =
     ThemedColor(Color(0xFF4078C0), Color(0xFFFFFFFF));
 
-// Chart is Teal 300 is light, Teal 500 is dark
-const gpuChartColor = ThemedColor(mainGpuLight, Color(0xFF009688));
-// Chart is Blue 300 is light, Blue 500 is dark
-const cpuChartColor = ThemedColor(mainCpuLight, Color(0xFF03A9F4));
-
 // Red 300 is light, Red 500 is dark
 const gpuJankColor = ThemedColor(Color(0xFFE57373), Color(0xFFF44336));
 // Red 800 is light, Red 800 is dark
@@ -52,11 +47,21 @@ const Color slowFrameColor = Color(0xFFE50C0C);
 // Blue A700 is light, Indigo A400 is dark
 const Color selectedGpuColor =
     ThemedColor(Color(0xFF2962FF), Color(0xFF3D5AFE));
-// Dark Blue is light, Indigo A200 is dark
+// Dark Blue is light, Deep Purple A200 is dark
 const Color selectedCpuColor =
-    ThemedColor(Color(0xFF09007E), Color(0xFF536DFE));
-// Selection is high-contrast need white font.
-const Color hoverTextColor = ThemedColor(Colors.white, defaultForeground);
+    ThemedColor(Color(0xFF09007E), Color(0xFF7C4DFF));
+
+// Text color defaultForeground is too gray hard to read text, make it a little
+// whitter, not jarring white #FFFFFF.
+const ThemedColor contrastForeground =
+    ThemedColor(Colors.black, Color.fromARGB(255, 240, 240, 240));
+
+// Jank/Selection is high-contrast need white-ish font.
+const Color hoverTextHiContrastColor =
+    ThemedColor(Colors.white, contrastForeground);
+// Other hovers are not as contrasty (good frames) black text looks best in both
+// light and dark mode.
+const Color hoverTextColor = ThemedColor(Colors.black, Colors.black);
 
 // TODO(devoncarew): show the Skia picture (gpu drawing commands) for a frame
 

--- a/packages/devtools/lib/src/ui/theme.dart
+++ b/packages/devtools/lib/src/ui/theme.dart
@@ -23,6 +23,13 @@ void initializeTheme(String theme) {
 const ThemedColor defaultBackground = ThemedColor(Colors.white, Colors.black);
 const ThemedColor defaultForeground =
     ThemedColor(Colors.black, Color.fromARGB(255, 187, 187, 187));
+
+// Text color [defaultForeground] is too gray, making it hard to read the text
+// in dark theme. We should use a more white color for dark theme, but not
+// jarring white #FFFFFF.
+const ThemedColor contrastForeground =
+    ThemedColor(Colors.black, Color.fromARGB(255, 240, 240, 240));
+
 const ThemedColor grey = ThemedColor(
     Color.fromARGB(255, 128, 128, 128), Color.fromARGB(255, 128, 128, 128));
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/434

Also, fixes hover text inconsistencies, dark mode for high contrast hover was not readable.  Now a little whiter not bright white.

Also matches Kenzie's suggestion for matching flame chart colors for good cpu/gpu colors.

Below are light and dark mode variations:

Selection hover:
![image](https://user-images.githubusercontent.com/2055873/54452383-438fed00-4712-11e9-881c-829b5c7d3fb5.png)
![image](https://user-images.githubusercontent.com/2055873/54452763-24458f80-4713-11e9-9779-f8568afd6a8d.png)


Jank hover:
![image](https://user-images.githubusercontent.com/2055873/54452447-70440480-4712-11e9-8ce3-52c0b80063e2.png)
![image](https://user-images.githubusercontent.com/2055873/54452840-4ccd8980-4713-11e9-893c-992299f94486.png)


Good FPS hover:
![image](https://user-images.githubusercontent.com/2055873/54452575-b4370980-4712-11e9-9f69-8c317a83d13b.png)
![image](https://user-images.githubusercontent.com/2055873/54452926-738bc000-4713-11e9-9a26-b192a8fb4620.png)


