### PR TITLE
tweaks to the app header and in-line dialogs

### DIFF
--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -69,6 +69,7 @@ body {
     padding: 16px 20px;
     margin-bottom: 20px;
     text-align: center;
+    white-space: nowrap;
     background-color: var(--masthead-background);
 }
 
@@ -732,9 +733,12 @@ html [full] {
 }
 
 .flash div {
-    max-width: 70em;
     margin-left: auto;
     margin-right: auto;
+}
+
+.flash-close {
+    line-height: 1.5;
 }
 
 #messages-container div+div {


### PR DESCRIPTION
- tweaks to the app header and in-line dialogs

From a demo, I noticed that the app header layout didn't work well at smaller page widths, and that the close boxes for in-line alerts weren't aligned with their content.