### PR TITLE
Improve handling of narrow screens

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -295,7 +295,8 @@ class ActionsContainer {
   void addAction(ActionButton action) {
     if (_actions.isEmpty) {
       // add a visual separator
-      element.add(span(text: '•', a: 'horiz-padding', c: 'masthead-item'));
+      element.add(span(
+          text: '•', a: 'horiz-padding', c: 'masthead-item action-separator'));
     }
 
     _actions.add(action);

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -320,7 +320,9 @@ abstract class Screen {
     this.iconClass,
     this.disabled = false,
   }) : helpStatus = createLinkStatusItem(
-          '$name Docs',
+          span()
+            ..add(span(text: '$name', c: 'optional-700'))
+            ..add(span(text: ' Docs')),
           href: 'https://flutter.github.io/devtools/$id',
           title: 'Documentation on using the $name page',
         );

--- a/packages/devtools/lib/src/inspector/inspector.css
+++ b/packages/devtools/lib/src/inspector/inspector.css
@@ -47,32 +47,6 @@
     margin-left: 25px;
 }
 
-/*
-TODO(jacobr): make these styles only apply to the inspector toolbar as the
-thresholds are specific to the inspector UI.
- */
-@media all and (max-width: 1220px) {
-    .btn-group.collapsible .optional-text span {
-        display: none;
-    }
-
-    .btn-group.collapsible .btn .flutter-icon {
-        margin-right: 0;
-        box-sizing: content-box;
-    }
-}
-
-@media all and (max-width: 1410px) {
-    .btn-group.collapsible.overflow .optional-text span {
-        display: none;
-    }
-
-    .btn-group.collapsible.overflow .btn .flutter-icon {
-        margin-right: 0;
-        box-sizing: content-box;
-    }
-}
-
 
 /*
 Styles for rendering html versions of the inspector tree.

--- a/packages/devtools/lib/src/inspector/inspector.css
+++ b/packages/devtools/lib/src/inspector/inspector.css
@@ -15,22 +15,11 @@
 }
 
 .inspector-container {
-    height: 100%;
-    width: 100%;
-    display: flex;
     overflow: hidden;
     margin-top: 10px;
     align-items: center;
     flex: 1 1 auto;
-    flex-direction: column;
     box-sizing: border-box;
-}
-
-/* Minimum aspect ratio */
-@media (min-aspect-ratio: 1/1) {
-    .inspector-container {
-        flex-direction: row;
-    }
 }
 
 .inspector-no-wrap {

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -49,12 +49,13 @@ class InspectorScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar inspector-page')
+      ..layoutVertical();
 
     final CoreElement buttonSection = div(c: 'section')
       ..layoutHorizontal()
       ..add(<CoreElement>[
-        div(c: 'btn-group')
+        div(c: 'btn-group collapsible-700 nowrap')
           ..add([
             ServiceExtensionButton(
               extensions.toggleSelectWidgetMode,

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -75,7 +75,7 @@ class InspectorScreen extends Screen {
 
     screenDiv.add(<CoreElement>[
       buttonSection,
-      inspectorContainer = div(c: 'inspector-container'),
+      inspectorContainer = div(c: 'inspector-container bidirectional'),
     ]);
 
     serviceManager.onConnectionAvailable.listen(_handleConnectionStart);

--- a/packages/devtools/lib/src/logging/logging.css
+++ b/packages/devtools/lib/src/logging/logging.css
@@ -9,6 +9,7 @@ td.log-label-column {
 
 .log-area {
     overflow-y: hidden;
+    flex: 1 1 auto;
 }
 
 .log-details {

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -75,28 +75,24 @@ class LoggingScreen extends Screen {
                 ..click(_clear),
             ])
         ]),
-      div(c: 'section log-area')
+      div(c: 'section log-area bidirectional')
         ..flex()
         ..add(<CoreElement>[
           _createTableView()
             ..layoutHorizontal()
             ..clazz('section')
+            ..clazz('full-size')
             ..flex(),
           logDetailsUI = LogDetailsUI(),
-        ])
-        ..layoutHorizontal(),
+        ]),
     ]);
 
-    // Needed otherwise the splitter is broken if the details view wants a
-    // larger width than expected. TODO(jacobr): find a cleaner solution.
-    logDetailsUI.element.style.width = '0';
     // configure the table / details splitter
-    split.flexSplit(
+    split.flexSplitBidirectional(
       [loggingTable.element, logDetailsUI],
       gutterSize: defaultSplitterWidth,
-      sizes: [60, 40],
-      horizontal: true,
-      minSize: [200, 60],
+      horizontalSizes: [60, 40],
+      verticalSizes: [50, 50],
     );
 
     loggingTable.onSelect.listen((LogData selection) {
@@ -619,7 +615,7 @@ String getCssClassForEventKind(LogData item) {
 }
 
 class LogDetailsUI extends CoreElement {
-  LogDetailsUI() : super('div') {
+  LogDetailsUI() : super('div', classes: 'full-size') {
     layoutVertical();
     flex();
 

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -64,7 +64,7 @@ class PerfToolFramework extends Framework {
     for (Screen screen in screens) {
       final CoreElement link = CoreElement('a')
         ..add(<CoreElement>[
-          span(c: 'octicon ${screen.iconClass}'),
+          span(c: 'octicon ${screen.iconClass} optional-800'),
           span(text: ' ${screen.name}')
         ]);
       if (screen.disabled) {

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -64,8 +64,8 @@ class PerfToolFramework extends Framework {
     for (Screen screen in screens) {
       final CoreElement link = CoreElement('a')
         ..add(<CoreElement>[
-          span(c: 'octicon ${screen.iconClass} optional-800'),
-          span(text: ' ${screen.name}')
+          span(c: 'octicon ${screen.iconClass}'),
+          span(text: ' ${screen.name}', c: 'optional-950')
         ]);
       if (screen.disabled) {
         link

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -125,7 +125,7 @@ class MemoryScreen extends Screen with SetStateMixin {
                   resumeButton,
                 ]),
               div()..flex(),
-              div(c: 'btn-group flex-no-wrap margin-left')
+              div(c: 'btn-group collapsible-700 flex-no-wrap margin-left')
                 ..add(<CoreElement>[
                   vmMemorySnapshotButton,
                   resetAccumulatorsButton,

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -56,21 +56,21 @@ CoreElement createExtensionCheckBox(
 
 List<CoreElement> getServiceExtensionButtons() {
   return [
-    div(c: 'btn-group collapsible')
+    div(c: 'btn-group collapsible-1200 nowrap margin-left')
       ..add(<CoreElement>[
         ServiceExtensionButton(performanceOverlay).button,
         ServiceExtensionButton(togglePlatformMode).button,
       ]),
-    div(c: 'btn-group collapsible margin-left')
+    div(c: 'btn-group collapsible-1200 nowrap margin-left')
       ..add(<CoreElement>[
         ServiceExtensionButton(debugPaint).button,
         ServiceExtensionButton(debugPaintBaselines).button,
       ]),
-    div(c: 'btn-group collapsible margin-left')
+    div(c: 'btn-group collapsible-1200 nowrap margin-left')
       ..add(<CoreElement>[
         ServiceExtensionButton(slowAnimations).button,
       ]),
-    div(c: 'btn-group collapsible overflow margin-left')
+    div(c: 'btn-group collapsible-1400 nowrap margin-left')
       ..add(<CoreElement>[
         ServiceExtensionButton(repaintRainbow).button,
         ServiceExtensionButton(debugAllowBanner).button,

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -79,7 +79,7 @@ List<CoreElement> getServiceExtensionButtons() {
 }
 
 StatusItem createLinkStatusItem(
-  String text, {
+  CoreElement textElement, {
   @required String href,
   @required String title,
 }) {
@@ -94,7 +94,7 @@ StatusItem createLinkStatusItem(
     ..verticalAlign = 'text-bottom'
     ..marginBottom = '0';
   final element = CoreElement('a')
-    ..add(<CoreElement>[icon, span(text: text)])
+    ..add(<CoreElement>[icon, textElement])
     ..setAttribute('href', href)
     ..setAttribute('target', '_blank')
     ..element.title = title;

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -157,21 +157,19 @@
 <body fullbleed layout vertical>
 
 <header flex wrap none class="masthead" id="header" layout horizontal>
-    <a class="masthead-logo" id="title"><span class="optional-850">Dart</span> DevTools</a>
+    <a class="masthead-logo" id="title"><span class="optional-550">Dart DevTools</span></a>
 
     <div flex horiz-padding></div>
 
     <nav class="masthead-nav" id="main-nav">
         <!-- add the known pages -->
-        <a disabled><span class="octicon octicon-device-mobile optional-800"></span><span> Flutter Inspector</span></a>
-        <a disabled><span class="octicon octicon-pulse optional-800"></span><span> Timeline</span></a>
-        <a disabled><span class="octicon octicon-package optional-800"></span><span> Memory</span></a>
-        <a disabled><span class="octicon octicon-bug optional-800"></span><span> Debugger</span></a>
-        <!-- a disabled><span class="octicon octicon-dashboard optional-800"></span><span> Performance</span></a -->
-        <a disabled><span class="octicon octicon-clippy optional-800"></span><span> Logging</span></a>
+        <a disabled><span class="octicon octicon-device-mobile"></span><span> <span class="optional-950">Flutter Inspector</span></span></a>
+        <a disabled><span class="octicon octicon-pulse"></span><span> <span class="optional-950">Timeline</span></span></a>
+        <a disabled><span class="octicon octicon-package"></span><span> <span class="optional-950">Memory</span></span></a>
+        <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-950">Debugger</span></span></a>
+        <!-- a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-950">Performance</span></span></a -->
+        <a disabled><span class="octicon octicon-clippy"></span><span> <span class="optional-950">Logging</span></span></a>
     </nav>
-
-    <div class="force-wrap"></div>
 
     <div id="global-actions" class="masthead-nav"></div>
 

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -15,8 +15,6 @@
     <title>Dart DevTools</title>
     <link rel="icon" sizes="64x64" href="favicon.png">
 
-
-
     <link rel="stylesheet" href="packages/octicons_css/octicons_4.4.0.css">
     <link rel="stylesheet" href="packages/polymer_css/flex.css">
     <link rel="stylesheet" href="packages/devtools/src/debugger/debugger.css">
@@ -158,27 +156,29 @@
 
 <body fullbleed layout vertical>
 
-<header flex none class="masthead" id="header" layout horizontal>
-    <a class="masthead-logo" id="title">Dart DevTools</a>
+<header flex wrap none class="masthead" id="header" layout horizontal>
+    <a class="masthead-logo" id="title"><span class="optional-850">Dart</span> DevTools</a>
 
     <div flex horiz-padding></div>
 
     <nav class="masthead-nav" id="main-nav">
         <!-- add the known pages -->
-        <a disabled><span class="octicon octicon-device-mobile"></span><span> Flutter Inspector</span></a>
-        <a disabled><span class="octicon octicon-pulse"></span><span> Timeline</span></a>
-        <a disabled><span class="octicon octicon-package"></span><span> Memory</span></a>
-        <a disabled><span class="octicon octicon-bug"></span><span> Debugger</span></a>
-        <!-- a disabled><span class="octicon octicon-dashboard"></span><span> Performance</span></a -->
-        <a disabled><span class="octicon octicon-clippy"></span><span> Logging</span></a>
+        <a disabled><span class="octicon octicon-device-mobile optional-800"></span><span> Flutter Inspector</span></a>
+        <a disabled><span class="octicon octicon-pulse optional-800"></span><span> Timeline</span></a>
+        <a disabled><span class="octicon octicon-package optional-800"></span><span> Memory</span></a>
+        <a disabled><span class="octicon octicon-bug optional-800"></span><span> Debugger</span></a>
+        <!-- a disabled><span class="octicon octicon-dashboard optional-800"></span><span> Performance</span></a -->
+        <a disabled><span class="octicon octicon-clippy optional-800"></span><span> Logging</span></a>
     </nav>
+
+    <div class="force-wrap"></div>
 
     <div id="global-actions" class="masthead-nav"></div>
 
     <div class="masthead-nav">
         <span horiz-padding class="masthead-item">•</span>
         <div class="masthead-item action-button active" id="send-feedback-button"
-             title="Send Feedback">
+            title="Send Feedback">
             <span class="octicon octicon-comment"></span>
         </div>
     </div>

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -346,6 +346,11 @@ form[horizontal] {
     width: 100%;
 }
 
+.full-size {
+    width: 100%;
+    height: 100%;
+}
+
 .footer {
     padding: 10px var(--page-outer-padding);
     margin-top: 20px;
@@ -870,5 +875,18 @@ span.strong {
     .btn-group.collapsible-1400 .btn .flutter-icon {
         margin-right: 0;
         box-sizing: content-box;
+    }
+}
+
+/* Bidirectional splitters that change direction when window is wider/taller  */
+.bidirectional {
+    height: 100%;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+}
+@media (min-aspect-ratio: 1/1) {
+    .bidirectional {
+        flex-direction: row;
     }
 }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -46,6 +46,20 @@
     --toast-border: #d8dee2;
 }
 
+/*
+ * Variables used in media queries (not themes) to handle different screen
+ * sizes better
+ */
+:root {
+    --page-outer-padding: 30px;
+}
+
+@media all and (max-width: 600px) {
+    :root {
+        --page-outer-padding: 20px;
+    }
+}
+
 .lead, .page-title + .markdown-body > p:first-child {
     margin-bottom: 30px;
     font-size: 20px;
@@ -61,15 +75,14 @@ body {
 
 .container {
     width: initial;
-    margin-right: 30px;
-    margin-left: 30px;
+    margin-right: var(--page-outer-padding);
+    margin-left: var(--page-outer-padding);
 }
 
 .masthead {
-    padding: 16px 20px;
+    padding: 16px var(--page-outer-padding);
     margin-bottom: 20px;
     text-align: center;
-    white-space: nowrap;
     background-color: var(--masthead-background);
 }
 
@@ -82,6 +95,7 @@ body {
 
 .masthead-nav {
     margin-top: .5rem;
+    white-space: nowrap;
     display: inline-flex;
 }
 
@@ -91,6 +105,20 @@ body {
 
 .masthead .mega-octicon {
     font-size: 1.5rem;
+}
+
+.masthead .force-wrap {
+    display: none;
+    flex-basis: 100%;
+}
+@media all and (max-width: 1000px) {
+    .masthead .force-wrap {
+        display: block;
+    }
+    /* Hide the separator since it's now on next line */
+    #global-actions .action-separator {
+        display: none;
+    }
 }
 
 .small-octicon {
@@ -333,7 +361,7 @@ form[horizontal] {
 }
 
 .footer {
-    padding: 10px 30px;
+    padding: 10px var(--page-outer-padding);
     margin-top: 20px;
     color: var(--footer-color);
     border-top: 1px solid var(--border-color);
@@ -361,6 +389,7 @@ form[horizontal] {
     padding-left: 15px;
     padding-right: 15px;
 }
+
 
 .footer-status {
     display: inline-block;
@@ -790,6 +819,11 @@ html [full] {
     margin-bottom: 20px;
 }
 
+#connect-dialog #port-field {
+    /* Override the max-width to take the button into account */
+    max-width: calc(100% - 100px);
+}
+
 .masthead-item .octicon {
     top: 1px;
     position: relative;
@@ -798,4 +832,56 @@ html [full] {
 
 span.strong {
     font-weight: 600;
+}
+
+/*
+ * Support tagging elements with collapsible that can have children tagged
+ * with optional-text to be hidden when the page is below a certain threshold.
+ *
+ * Also support optional directly on elements to be hidden.
+ */
+
+@media all and (max-width: 700px) { .optional-700 { display: none; } }
+@media all and (max-width: 800px) { .optional-800 { display: none; } }
+@media all and (max-width: 850px) { .optional-850 { display: none; } }
+@media all and (max-width: 1200px) { .optional-1200 { display: none; } }
+@media all and (max-width: 1400px) { .optional-1400 { display: none; } }
+
+
+/*
+ * Support tagging btn-groups with collapsible that can have children tagged
+ * with optional-text to be hidden when the page is below a certain threshold.
+ */
+
+@media all and (max-width: 700px) {
+    .btn-group.collapsible-700 .optional-text span {
+        display: none;
+    }
+
+    .btn-group.collapsible-700 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 1200px) {
+    .btn-group.collapsible-1200 .optional-text span {
+        display: none;
+    }
+
+    .btn-group.collapsible-1200 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 1400px) {
+    .btn-group.collapsible-1400 .optional-text span {
+        display: none;
+    }
+
+    .btn-group.collapsible-1400 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
 }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -107,20 +107,6 @@ body {
     font-size: 1.5rem;
 }
 
-.masthead .force-wrap {
-    display: none;
-    flex-basis: 100%;
-}
-@media all and (max-width: 1000px) {
-    .masthead .force-wrap {
-        display: block;
-    }
-    /* Hide the separator since it's now on next line */
-    #global-actions .action-separator {
-        display: none;
-    }
-}
-
 .small-octicon {
   font-size: 13px;
 }
@@ -841,9 +827,10 @@ span.strong {
  * Also support optional directly on elements to be hidden.
  */
 
+@media all and (max-width: 550px) { .optional-550 { display: none; } }
 @media all and (max-width: 700px) { .optional-700 { display: none; } }
-@media all and (max-width: 800px) { .optional-800 { display: none; } }
 @media all and (max-width: 850px) { .optional-850 { display: none; } }
+@media all and (max-width: 950px) { .optional-950 { display: none; } }
 @media all and (max-width: 1200px) { .optional-1200 { display: none; } }
 @media all and (max-width: 1400px) { .optional-1400 { display: none; } }
 


### PR DESCRIPTION
It tweaks some existing CSS we had to collapse the inspector buttons, making them a bit more generic (using the widths to collapse at in the class names - I can't think of a better way to handle this?).

Here's some screenshots resizing down to 500px (getting below 500px will mean doing something more than just trimming things down, like scrolling the nav of having it expand/collapse).

![Screenshot 2019-03-19 at 5 39 05 pm](https://user-images.githubusercontent.com/1078012/54628778-1c1c8580-4a6e-11e9-8193-3b5d80e001d6.png)
---
![Screenshot 2019-03-19 at 5 39 21 pm](https://user-images.githubusercontent.com/1078012/54628780-1c1c8580-4a6e-11e9-9ce7-32ed969d7412.png)
---
![Screenshot 2019-03-19 at 5 39 37 pm](https://user-images.githubusercontent.com/1078012/54628781-1c1c8580-4a6e-11e9-966d-6b44dc11ee35.png)
---
![Screenshot 2019-03-19 at 5 39 53 pm](https://user-images.githubusercontent.com/1078012/54628782-1c1c8580-4a6e-11e9-805b-33bda6786012.png)
---
![Screenshot 2019-03-19 at 5 40 16 pm](https://user-images.githubusercontent.com/1078012/54628783-1c1c8580-4a6e-11e9-8e1a-75d0be64bf3b.png)
