### PR TITLE
Added EventTimeline graph to memory profiler.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -7,6 +7,9 @@
 
 ## 0.0.1
 - initial (pre-release) release
+
+<!--
+List of possible sections to use for areas that have changed. 
 ### Documentation
 ### Debugger
 ### Inspector
@@ -14,3 +17,4 @@
 ### Memory
 ### Table
 ### Timeline
+-->

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -125,8 +125,11 @@ class Framework {
 
       _screenContents[current] = screenContent;
 
-      // Only resize the screens that isn't the current screen.
       screenContent.element.onResize.listen((e) {
+        // Need to stop event listeners, within the screen from getting the
+        // resize event. This doesn't stop event listeners higher up in the tree
+        // from receiving the resize event.  Plotly can chart get's resized even
+        // though its in a div with a 'display:none' and will resize improperly.
         e.stopImmediatePropagation(); // Don't bubble up the resize event.
 
         _screenContents.forEach((Screen theScreen, CoreElement content) {

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -110,6 +110,9 @@ class Framework {
 
     if (_screenContents.containsKey(current)) {
       _screenContents[current].hidden(false);
+      // Fire a resize an active plotly chart (transitioning from display:none).
+      // Computation
+      _screenContents[current].element.dispatchEvent(new Event('resize'));
     } else {
       current.framework = this;
 

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -179,6 +179,8 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _resetAllocatorCounts() async {
+    memoryChart.plotReset();
+
     resetAccumulatorsButton.disabled = true;
     tableStack.first.element.display = null;
     final Spinner spinner =
@@ -198,6 +200,8 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _loadAllocationProfile({bool reset = false}) async {
+    memoryChart.plotSnapshot();
+
     vmMemorySnapshotButton.disabled = true;
     tableStack.first.element.display = null;
     final Spinner spinner =

--- a/packages/devtools/lib/src/memory/memory_chart.dart
+++ b/packages/devtools/lib/src/memory/memory_chart.dart
@@ -76,4 +76,12 @@ class MemoryChart extends CoreElement {
   void resume() {
     _plotlyChart.liveUpdate = true;
   }
+
+  void plotSnapshot() {
+    _plotlyChart.plotSnapshot();
+  }
+
+  void plotReset() {
+    _plotlyChart.plotReset();
+  }
 }

--- a/packages/devtools/lib/src/memory/memory_chart.dart
+++ b/packages/devtools/lib/src/memory/memory_chart.dart
@@ -84,14 +84,18 @@ class MemoryChart extends CoreElement {
   }
 
   void plotSnapshot() {
-    element.style..height = '${_memoryGraphEventTimelineHeight}px';
-    element.dispatchEvent(new Event('resize'));
+    if (element.style.height != '${_memoryGraphEventTimelineHeight}px') {
+      element.style..height = '${_memoryGraphEventTimelineHeight}px';
+      element.dispatchEvent(new Event('resize'));
+    }
     _plotlyChart.plotSnapshot();
   }
 
   void plotReset() {
-    element.style..height = '${_memoryGraphEventTimelineHeight}px';
-    element.dispatchEvent(new Event('resize'));
+    if (element.style.height != '${_memoryGraphEventTimelineHeight}px') {
+      element.style..height = '${_memoryGraphEventTimelineHeight}px';
+      element.dispatchEvent(new Event('resize'));
+    }
     _plotlyChart.plotReset();
   }
 }

--- a/packages/devtools/lib/src/memory/memory_chart.dart
+++ b/packages/devtools/lib/src/memory/memory_chart.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:html';
+
 import '../timeline/frames_bar_chart.dart';
 import '../ui/elements.dart';
 
@@ -17,7 +19,8 @@ class MemoryChart extends CoreElement {
     element.id = _memoryGraph;
     element.style
       ..boxSizing = 'content-box' // border-box causes right/left border cut.
-      ..height = '${FramesBarChart.chartHeight}px';
+      ..height = '${FramesBarChart.chartHeight}px'
+      ..width = '100%';
 
     _memoryController.onMemory.listen((MemoryTracker memoryTracker) {
       if (_memoryController.memoryTracker.hasConnection) {
@@ -27,6 +30,9 @@ class MemoryChart extends CoreElement {
   }
 
   static const String _memoryGraph = 'memory_timeline';
+
+  // Height of chart when event timeline is visible.
+  final int _memoryGraphEventTimelineHeight = 230;
 
   final MemoryController _memoryController;
 
@@ -78,10 +84,14 @@ class MemoryChart extends CoreElement {
   }
 
   void plotSnapshot() {
+    element.style..height = '${_memoryGraphEventTimelineHeight}px';
+    element.dispatchEvent(new Event('resize'));
     _plotlyChart.plotSnapshot();
   }
 
   void plotReset() {
+    element.style..height = '${_memoryGraphEventTimelineHeight}px';
+    element.dispatchEvent(new Event('resize'));
     _plotlyChart.plotReset();
   }
 }

--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -11,8 +11,6 @@ import '../ui/theme.dart';
 
 import 'memory_chart.dart';
 
-import 'dart:developer';
-
 class MemoryPlotly {
   MemoryPlotly(this._domName, this._memoryChart);
 
@@ -80,7 +78,7 @@ class MemoryPlotly {
                 family: fontFamily,
                 color: colorToCss(defaultForeground),
               ),
-              orientation: "v",
+              orientation: 'v',
               x: 1.03,
               xanchor: 'left',
               y: 1.1,
@@ -126,16 +124,16 @@ class MemoryPlotly {
         shapes: [
           // Background of event timeline subplot
           Shape(
-            fillcolor: "#ccc",
+            fillcolor: '#ccc',
             line: Line(
               width: 0,
             ),
             opacity: .5,
-            type: "rect",
-            xref: "paper",
+            type: 'rect',
+            xref: 'paper',
             x0: 0,
             x1: 1,
-            yref: "y2",
+            yref: 'y2',
             y0: 0,
             y1: 2,
             layer: 'below',
@@ -281,7 +279,7 @@ class MemoryPlotly {
   void _doubleClick(DataEvent data) => _memoryChart.resume();
 
   void plotMemory([createEventTimeline = false]) {
-    List<Data> memoryTraces = createMemoryTraces();
+    final List<Data> memoryTraces = createMemoryTraces();
 
     if (createEventTimeline) {
       eventTimeline = EventTimeline(_domName, _memoryChart.element);
@@ -305,10 +303,10 @@ class MemoryPlotly {
   bool get hasEventTimeline => eventTimeline != null;
 
   void createEventTimeline() {
-    List<Data> memoryTraces = createMemoryTraces();
+    final List<Data> memoryTraces = createMemoryTraces();
 
     eventTimeline = EventTimeline(_domName, _memoryChart.element);
-    List<Data> eventTraces = eventTimeline.getEventTimelineTraces();
+    final List<Data> eventTraces = eventTimeline.getEventTimelineTraces();
 
     eventTimeline.computeTraceIndexes(memoryTraces);
 
@@ -386,8 +384,8 @@ class MemoryPlotly {
     if (!hasEventTimeline) createEventTimeline();
 
     final List data = getProperty(_memoryChart.element, 'data');
-    var capacityTrace = data[MEMORY_CAPACITY_TRACE];
-    var timestamp = capacityTrace.x[capacityTrace.x.length - 1];
+    final Data capacityTrace = data[MEMORY_CAPACITY_TRACE];
+    final int timestamp = capacityTrace.x[capacityTrace.x.length - 1];
 
     eventTimeline.plotSnapshot(timestamp);
   }
@@ -396,22 +394,24 @@ class MemoryPlotly {
     if (!hasEventTimeline) createEventTimeline();
 
     final List data = getProperty(_memoryChart.element, 'data');
-    var capacityTrace = data[MEMORY_CAPACITY_TRACE];
-    var timestamp = capacityTrace.x[capacityTrace.x.length - 1];
+    final Data capacityTrace = data[MEMORY_CAPACITY_TRACE];
+    final int timestamp = capacityTrace.x[capacityTrace.x.length - 1];
 
     eventTimeline.plotReset(timestamp);
   }
 }
 
 class EventTimeline {
-  dynamic _chart;
   EventTimeline(this._domName, this._chart);
+
+  final String _domName;
+  dynamic _chart;
 
   // Trace index within the traces passed to addEventTimelineTo
   int resetTraceIndex;
   int snapshotTraceIndex;
   List<Data> addEventTimelineTo(List<Data> traces) {
-    List<Data> eventTraces = getEventTimelineTraces();
+    final List<Data> eventTraces = getEventTimelineTraces();
 
     resetTraceIndex = traces.length;
     traces.add(eventTraces[RESET_TRACE_INDEX]); // Reset trace.
@@ -427,15 +427,13 @@ class EventTimeline {
     snapshotTraceIndex = resetTraceIndex + 1;
   }
 
-  final String _domName;
-
   // Indexes for traces returned from getEventTimelineTraces
   static const int RESET_TRACE_INDEX = 0;
   static const int SNAPSHOT_TRACE_INDEX = 1;
   List<Data> getEventTimelineTraces() {
     // Create traces for the event timeline subplot.
 
-    Data resetTrace = Data(
+    final Data resetTrace = Data(
       x: [Null], // Trace legend entry appears w/o data.
       y: [Null], // Trace legend entry appears w/o data.
       name: 'Reset',
@@ -449,13 +447,13 @@ class EventTimeline {
           width: 2,
         ),
         size: 5,
-        symbol: "hexagon2-open-dot",
+        symbol: 'hexagon2-open-dot',
       ),
       hoverinfo: 'name+x',
       showlegend: true,
     );
 
-    Data snapshotTrace = Data(
+    final Data snapshotTrace = Data(
       x: [Null], // Trace legend entry appears w/o data.
       y: [Null], // Trace legend entry appears w/o data.
       name: 'Snapshot',
@@ -469,7 +467,7 @@ class EventTimeline {
           width: 2,
         ),
         size: 10,
-        symbol: "hexagon2-open",
+        symbol: 'hexagon2-open',
       ),
       hoverinfo: 'name+x',
       showlegend: true,
@@ -495,21 +493,9 @@ class EventTimeline {
     final Layout layout = getProperty(_chart, 'layout');
     final List<Shape> shapes = layout.shapes;
 
-    int nextShape = shapes.length;
+    final int nextShape = shapes.length;
 
-    Shape lastShape = shapes[nextShape - 1];
-
-    bool isPaperShape = false;
-    bool isSnapshotShape = false;
-    bool isResetShape = false;
-    if (lastShape.xref == 'paper') {
-      // First shape that colors the entire event timeline chart.
-      isPaperShape = true;
-    } else if (lastShape.yref == 'y2') {
-      // We're a snapshot or reset.
-    }
-
-    var jsShape = createEventShape(
+    final jsShape = createEventShape(
         '$_EVENT_MEMORY: $lastEventType > $eventType',
         nextShape,
         lastEventTime,

--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:js/js_util.dart';
+
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/plotly.dart';
@@ -9,38 +11,149 @@ import '../ui/theme.dart';
 
 import 'memory_chart.dart';
 
+import 'dart:developer';
+
 class MemoryPlotly {
   MemoryPlotly(this._domName, this._memoryChart);
+
+  static const String fontFamily = 'sans-serif';
 
   final String _domName;
   final MemoryChart _memoryChart;
 
-  Layout getMemoryLayout(chartTitle) {
-    return Layout(
+  // We're going to dynamically add the Event timeline chart to our memory
+  // profiler chart.
+  EventTimeline eventTimeline;
+
+  AxisLayout getXAxisLayout([int startTime = -1, int endTime = -1]) {
+    return AxisLayout(
+      type: 'date',
+      tickformat: '%-I:%M:%S %p',
+      hoverformat: '%H:%M:%S.%L %p',
+      titlefont: Font(
+        family: fontFamily,
+        color: colorToCss(defaultForeground),
+      ),
+      tickfont: Font(
+        family: fontFamily,
+        color: colorToCss(defaultForeground),
+      ),
+      showgrid: true,
+      gridcolor: colorToCss(defaultForeground.withAlpha(50)),
+      gridwidth: 1,
+      range: startTime == -1 ? [] : [startTime, endTime],
+      rangeslider: startTime == -1
+          ? RangeSlider()
+          : RangeSlider(
+              autorange: true,
+            ),
+    );
+  }
+
+  Layout getMemoryLayout(String chartTitle, [bool addEventTimeline = false]) {
+    Layout layout;
+
+    AxisLayout getYAxis(List<num> range) {
+      return AxisLayout(
+        domain: range,
+        title: Title(
+          text: 'Heap',
+        ),
+        titlefont: Font(
+          family: fontFamily,
+          color: colorToCss(defaultForeground),
+        ),
+        fixedrange: true,
+        tickfont: Font(
+          family: fontFamily,
+          color: colorToCss(defaultForeground),
+        ),
+        showgrid: false,
+        zeroline: false,
+      );
+    }
+
+    Legend getLegend([bool events = false]) {
+      return events
+          ? Legend(
+              font: Font(
+                family: fontFamily,
+                color: colorToCss(defaultForeground),
+              ),
+              orientation: "v",
+              x: 1.03,
+              xanchor: 'left',
+              y: 1.1,
+            )
+          : Legend(
+              font: Font(
+                family: fontFamily,
+                color: colorToCss(defaultForeground),
+              ),
+            );
+    }
+
+    final Margin margins = Margin(l: 80, r: 5, b: 5, t: 5, pad: 5);
+
+    if (addEventTimeline) {
+      layout = Layout(
         plot_bgcolor: colorToCss(chartBackground),
         paper_bgcolor: colorToCss(chartBackground),
         title: chartTitle,
-        legend: Legend(font: Font(color: colorToCss(defaultForeground))),
-        xaxis: AxisLayout(
-          type: 'date',
-          tickformat: '%-I:%M:%S %p',
-          hoverformat: '%M:%S.%L %p',
-          titlefont: Font(color: colorToCss(defaultForeground)),
-          tickfont: Font(
-            color: colorToCss(defaultForeground),
+        xaxis: getXAxisLayout(),
+        yaxis: getYAxis([0, 0.90]),
+        yaxis2: AxisLayout(
+          domain: [.90, 1],
+          anchor: 'y',
+          side: 'right',
+          showgrid: false,
+          zeroline: false,
+          showline: false,
+          ticks: '',
+          showticklabels: false,
+          range: [.50, 1.50],
+          type: 'linear',
+          title: Title(
+            text: 'Events',
+            font: Font(
+              family: fontFamily,
+              size: 10,
+            ),
           ),
-          range: [],
-          rangeslider: RangeSlider(),
         ),
-        yaxis: AxisLayout(
-          title: 'Heap',
-          titlefont: Font(color: colorToCss(defaultForeground)),
-          fixedrange: true,
-          tickfont: Font(
-            color: colorToCss(defaultForeground),
+        legend: getLegend(true),
+        margin: margins,
+        shapes: [
+          // Background of event timeline subplot
+          Shape(
+            fillcolor: "#ccc",
+            line: Line(
+              width: 0,
+            ),
+            opacity: .5,
+            type: "rect",
+            xref: "paper",
+            x0: 0,
+            x1: 1,
+            yref: "y2",
+            y0: 0,
+            y1: 2,
+            layer: 'below',
           ),
-        ),
-        margin: Margin(l: 80, r: 5, b: 5, t: 5, pad: 5));
+        ],
+      );
+    } else {
+      layout = Layout(
+          plot_bgcolor: colorToCss(chartBackground),
+          paper_bgcolor: colorToCss(chartBackground),
+          title: chartTitle,
+          legend: getLegend(),
+          xaxis: getXAxisLayout(),
+          yaxis: getYAxis([]),
+          margin: margins);
+    }
+
+    return layout;
   }
 
   static const int MEMORY_GC_TRACE = 0;
@@ -105,8 +218,8 @@ class MemoryPlotly {
 
     if (marker == null) {
       return Data(
-        x: [],
-        y: [],
+        x: [Null], // Trace legend entry appears w/o data.
+        y: [Null], // Trace legend entry appears w/o data.
         text: [],
         line: line,
         type: 'scatter',
@@ -117,8 +230,8 @@ class MemoryPlotly {
       );
     } else {
       return Data(
-        x: [],
-        y: [],
+        x: [Null], // Trace legend entry appears w/o data.
+        y: [Null], // Trace legend entry appears w/o data.
         text: [],
         marker: marker,
         type: 'scatter',
@@ -167,11 +280,18 @@ class MemoryPlotly {
   // Resetting to live view, it's an autoscale back to full view.
   void _doubleClick(DataEvent data) => _memoryChart.resume();
 
-  void plotMemory() {
+  void plotMemory([createEventTimeline = false]) {
+    List<Data> memoryTraces = createMemoryTraces();
+
+    if (createEventTimeline) {
+      eventTimeline = EventTimeline(_domName, _memoryChart.element);
+      eventTimeline.addEventTimelineTo(memoryTraces);
+    }
+
     Plotly.newPlot(
       _domName,
-      createMemoryTraces(),
-      getMemoryLayout(''),
+      memoryTraces,
+      getMemoryLayout('', createEventTimeline),
       Configuration(
         responsive: true,
         displaylogo: false,
@@ -180,6 +300,24 @@ class MemoryPlotly {
     );
 
     doubleClick(_domName, _doubleClick);
+  }
+
+  bool get hasEventTimeline => eventTimeline != null;
+
+  void createEventTimeline() {
+    List<Data> memoryTraces = createMemoryTraces();
+
+    eventTimeline = EventTimeline(_domName, _memoryChart.element);
+    List<Data> eventTraces = eventTimeline.getEventTimelineTraces();
+
+    eventTimeline.computeTraceIndexes(memoryTraces);
+
+    Plotly.relayout(_domName, getMemoryLayout('', true));
+
+    Plotly.addTraces(_domName, eventTraces, [
+      eventTimeline.resetTraceIndex,
+      eventTimeline.snapshotTraceIndex,
+    ]);
   }
 
   void plotMarkersDataList(List<int> timestamps, List<num> gces) {
@@ -233,18 +371,7 @@ class MemoryPlotly {
       _domName,
       [Data()],
       Layout(
-        xaxis: AxisLayout(
-          tickfont: Font(
-            color: colorToCss(defaultForeground),
-          ),
-          range: [startTime, endTime],
-          rangeslider: RangeSlider(
-            autorange: true,
-          ),
-          type: 'date',
-          tickformat: '%-I:%M:%S %p',
-          hoverformat: '%-I:%M:%S.%L %p',
-        ),
+        xaxis: getXAxisLayout(startTime, endTime),
       ),
     );
   }
@@ -253,5 +380,153 @@ class MemoryPlotly {
 
   void setLiveUpdate({bool live}) {
     liveUpdate = live;
+  }
+
+  void plotSnapshot() {
+    if (!hasEventTimeline) createEventTimeline();
+
+    final List data = getProperty(_memoryChart.element, 'data');
+    var capacityTrace = data[MEMORY_CAPACITY_TRACE];
+    var timestamp = capacityTrace.x[capacityTrace.x.length - 1];
+
+    eventTimeline.plotSnapshot(timestamp);
+  }
+
+  void plotReset() {
+    if (!hasEventTimeline) createEventTimeline();
+
+    final List data = getProperty(_memoryChart.element, 'data');
+    var capacityTrace = data[MEMORY_CAPACITY_TRACE];
+    var timestamp = capacityTrace.x[capacityTrace.x.length - 1];
+
+    eventTimeline.plotReset(timestamp);
+  }
+}
+
+class EventTimeline {
+  dynamic _chart;
+  EventTimeline(this._domName, this._chart);
+
+  // Trace index within the traces passed to addEventTimelineTo
+  int resetTraceIndex;
+  int snapshotTraceIndex;
+  List<Data> addEventTimelineTo(List<Data> traces) {
+    List<Data> eventTraces = getEventTimelineTraces();
+
+    resetTraceIndex = traces.length;
+    traces.add(eventTraces[RESET_TRACE_INDEX]); // Reset trace.
+
+    snapshotTraceIndex = traces.length;
+    traces.add(eventTraces[SNAPSHOT_TRACE_INDEX]); // Snapshot trace.
+
+    return traces;
+  }
+
+  void computeTraceIndexes(List<Data> traces) {
+    resetTraceIndex = traces.length;
+    snapshotTraceIndex = resetTraceIndex + 1;
+  }
+
+  final String _domName;
+
+  // Indexes for traces returned from getEventTimelineTraces
+  static const int RESET_TRACE_INDEX = 0;
+  static const int SNAPSHOT_TRACE_INDEX = 1;
+  List<Data> getEventTimelineTraces() {
+    // Create traces for the event timeline subplot.
+
+    Data resetTrace = Data(
+      x: [Null], // Trace legend entry appears w/o data.
+      y: [Null], // Trace legend entry appears w/o data.
+      name: 'Reset',
+      type: 'scatter',
+      mode: 'markers',
+      yaxis: 'y2',
+      marker: Marker(
+        color: 'blue',
+        line: Line(
+          color: 'lightblue',
+          width: 2,
+        ),
+        size: 5,
+        symbol: "hexagon2-open-dot",
+      ),
+      hoverinfo: 'name+x',
+      showlegend: true,
+    );
+
+    Data snapshotTrace = Data(
+      x: [Null], // Trace legend entry appears w/o data.
+      y: [Null], // Trace legend entry appears w/o data.
+      name: 'Snapshot',
+      type: 'scatter',
+      mode: 'markers',
+      yaxis: 'y2',
+      marker: Marker(
+        color: 'blue',
+        line: Line(
+          color: 'lightblue',
+          width: 2,
+        ),
+        size: 10,
+        symbol: "hexagon2-open",
+      ),
+      hoverinfo: 'name+x',
+      showlegend: true,
+    );
+
+    return [resetTrace, snapshotTrace];
+  }
+
+  static const String _EVENT_MEMORY = 'mem';
+  static const String _SNAPSHOT_EVENT = 's';
+  static const String _RESET_EVENT = 'r';
+
+  String lastEventType = '';
+  int lastEventTime = -1;
+
+  void displayDuration(int time, String eventType) {
+    if (eventType == _SNAPSHOT_EVENT) {
+      lastEventType = eventType;
+      lastEventTime = time;
+      return;
+    }
+
+    final Layout layout = getProperty(_chart, 'layout');
+    final List<Shape> shapes = layout.shapes;
+
+    int nextShape = shapes.length;
+
+    Shape lastShape = shapes[nextShape - 1];
+
+    bool isPaperShape = false;
+    bool isSnapshotShape = false;
+    bool isResetShape = false;
+    if (lastShape.xref == 'paper') {
+      // First shape that colors the entire event timeline chart.
+      isPaperShape = true;
+    } else if (lastShape.yref == 'y2') {
+      // We're a snapshot or reset.
+    }
+
+    var jsShape = createEventShape(
+        '$_EVENT_MEMORY: $lastEventType > $eventType',
+        nextShape,
+        lastEventTime,
+        time);
+    Plotly.relayout(_domName, jsShape);
+
+    lastEventTime = time;
+    lastEventType = eventType;
+  }
+
+  void plotSnapshot(int timestamp) {
+    extendTraces1(_domName, [timestamp], [1], [snapshotTraceIndex]);
+    displayDuration(timestamp, _SNAPSHOT_EVENT);
+  }
+
+  void plotReset(int timestamp) {
+    extendTraces1(_domName, [timestamp], [1], [resetTraceIndex]);
+    displayDuration(timestamp, _RESET_EVENT);
   }
 }

--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -216,8 +216,9 @@ class MemoryPlotly {
 
     if (marker == null) {
       return Data(
-        x: [Null], // Trace legend entry appears w/o data.
-        y: [Null], // Trace legend entry appears w/o data.
+        // Null is needed so the trace legend entry appears w/o data.
+        x: [Null],
+        y: [Null],
         text: [],
         line: line,
         type: 'scatter',
@@ -228,8 +229,9 @@ class MemoryPlotly {
       );
     } else {
       return Data(
-        x: [Null], // Trace legend entry appears w/o data.
-        y: [Null], // Trace legend entry appears w/o data.
+        // Null is needed so the trace legend entry appears w/o data.
+        x: [Null],
+        y: [Null],
         text: [],
         marker: marker,
         type: 'scatter',
@@ -401,6 +403,10 @@ class MemoryPlotly {
   }
 }
 
+/// Create an Event Timeline subplot, notice it is associated with y2.  This
+/// requires that the layout these traces exist in the 'yaxis2' area.  For an
+/// example, look at MemoryPloty's getMemoryLayout method it creates a yaxis2
+/// positioned above yaxis.
 class EventTimeline {
   EventTimeline(this._domName, this._chart);
 
@@ -434,8 +440,9 @@ class EventTimeline {
     // Create traces for the event timeline subplot.
 
     final Data resetTrace = Data(
-      x: [Null], // Trace legend entry appears w/o data.
-      y: [Null], // Trace legend entry appears w/o data.
+      // Null is needed so the trace legend entry appears w/o data.
+      x: [Null],
+      y: [Null],
       name: 'Reset',
       type: 'scatter',
       mode: 'markers',
@@ -454,8 +461,9 @@ class EventTimeline {
     );
 
     final Data snapshotTrace = Data(
-      x: [Null], // Trace legend entry appears w/o data.
-      y: [Null], // Trace legend entry appears w/o data.
+      // Null is needed so the trace legend entry appears w/o data.
+      x: [Null],
+      y: [Null],
       name: 'Snapshot',
       type: 'scatter',
       mode: 'markers',

--- a/packages/devtools/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools/lib/src/memory/memory_protocol.dart
@@ -60,6 +60,7 @@ class MemoryTracker {
     }
 
     final VM vm = await service.getVM();
+    // TODO(terry): Need to handle a possible Sentinel being returned.
     final List<Isolate> isolates =
         await Future.wait(vm.isolates.map((IsolateRef ref) async {
       return await service.getIsolate(ref.id);

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -40,7 +40,7 @@ class FramesBarChart extends CoreElement with SetStateMixin {
     });
   }
 
-  static const int chartHeight = 160;
+  static const int chartHeight = 230;
   static const int maxFrames = 500;
   static const topPadding = 2;
 

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -22,6 +22,7 @@ class FramesBarChart extends CoreElement with SetStateMixin {
     element.style
       ..alignItems = 'flex-end'
       ..height = '${chartHeight}px'
+      ..width = '100%'
       ..paddingTop = '${topPadding}px';
 
     frameUIgraph = PlotlyDivGraph(this, timelineController);
@@ -40,7 +41,7 @@ class FramesBarChart extends CoreElement with SetStateMixin {
     });
   }
 
-  static const int chartHeight = 230;
+  static const int chartHeight = 170;
   static const int maxFrames = 500;
   static const topPadding = 2;
 

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -46,7 +46,9 @@ class FramesBarPlotly {
   final bool useLogScale;
 
   final _yAxisLogScale = AxisLayout(
-    title: 'Milliseconds',
+    title: Title(
+      text: 'Milliseconds',
+    ),
     tickformat: '.0f',
     type: 'log',
     range: [0, 2],
@@ -70,7 +72,9 @@ class FramesBarPlotly {
   );
 
   final _yAxisLinearScale = AxisLayout(
-    title: 'Milliseconds',
+    title: Title(
+      text: 'Milliseconds',
+    ),
     fixedrange: true,
   );
 

--- a/packages/devtools/lib/src/ui/plotly.dart
+++ b/packages/devtools/lib/src/ui/plotly.dart
@@ -72,7 +72,20 @@ external void extendTraces4(
 );
 
 @JS()
+external Shape createEventShape(
+  devToolEvent,
+  shapeIndex,
+  lastEventTime,
+  time,
+);
+
+@JS()
 class Plotly {
+  external static void addTraces(
+    String domName,
+    List<Data> traces,
+    List<int> traceindex,
+  );
   external static void newPlot(
     String domName,
     List<Data> traces, [
@@ -84,19 +97,23 @@ class Plotly {
     TraceData traceData,
     List<int> traceindex,
   );
-  external static void update(
+  external static void relayout(
     String domName,
-    List<Data> data,
-    Layout layout, [
-    List<int> traceindex,
-  ]);
-
+//    Shape shape,
+    dynamic layout,
+  );
   external static void restyle(
     String domName,
     String style,
     List update,
     List<int> traces,
   );
+  external static void update(
+    String domName,
+    List<Data> data,
+    Layout layout, [
+    List<int> traceindex,
+  ]);
 }
 
 @JS('Plotly.Fx.hover')
@@ -134,6 +151,7 @@ class Data {
     String legendgroup,
     List<int> width,
     String visible,
+    String yaxis,
   });
 
   external List get x;
@@ -152,7 +170,9 @@ class Data {
   external String get legendgroup;
   external List<int> get width;
   external String get visible;
+  external String get yaxis;
 
+  // Setters.
   external set visible(String value);
   external set hoverinfo(String value);
 }
@@ -209,12 +229,28 @@ class Transform {
 
 @JS()
 @anonymous
+class Title {
+  external factory Title({
+    String text,
+    Font font,
+    int size,
+  });
+
+  external String get text;
+  external Font get font;
+  external int get size;
+}
+
+@JS()
+@anonymous
 class Layout {
   external factory Layout({
     String title,
     bool showlegend,
     AxisLayout xaxis,
     AxisLayout yaxis,
+    AxisLayout yaxis2,
+    AxisLayout yaxis3,
     bool autosize,
     Margin margin,
     String hovermode,
@@ -236,6 +272,8 @@ class Layout {
   external bool get showlegend;
   external AxisLayout get xaxis;
   external AxisLayout get yaxis;
+  external AxisLayout get yaxis2;
+  external AxisLayout get yaxis3;
   external bool get autosize;
   external Margin get margin;
   external String get hovermode;
@@ -258,22 +296,28 @@ class Shape {
   external factory Shape({
     String type,
     String xref,
+    String yref,
     String layer,
     int x0,
     int y0,
     int x1,
     int y1,
     Line line,
+    String fillcolor,
+    num opacity,
   });
 
   external String get type;
   external String get xref;
+  external String get yref;
   external String get layer;
   external int get x0;
   external int get y0;
   external int get x1;
   external int get y1;
   external Line get line;
+  external String get fillcolor;
+  external num get opacity;
 }
 
 @JS()
@@ -284,12 +328,14 @@ class Legend {
     num x,
     num y,
     Font font,
+    String xanchor,
   });
 
   external String get orientation;
   external num get x;
   external num get y;
   external Font get font;
+  external String get xanchor;
 }
 
 @JS()
@@ -326,7 +372,7 @@ class AxisLayout {
   external factory AxisLayout({
     String tickformat,
     String ticks,
-    String title,
+    Title title,
     bool fixedrange,
     String type,
     bool autorange,
@@ -345,11 +391,19 @@ class AxisLayout {
     String showticksuffix,
     String hoverformat,
     Font titlefont,
+    List<num> domain,
+    bool zeroline,
+    String anchor,
+    String side,
+    bool showline,
+    Legend legend,
+    String gridcolor,
+    int gridwidth,
   });
 
   external String get tickformat;
   external String get ticks;
-  external String get title;
+  external Title get title;
   external bool get fixedrange;
   external String get type;
   external bool get autorange;
@@ -369,6 +423,14 @@ class AxisLayout {
   external String get hoverformat;
   external String get hockerformat;
   external Font get titlefont;
+  external List<num> get domain;
+  external bool get zeroline;
+  external String get anchor;
+  external String get side;
+  external bool get showline;
+  external Legend get legend;
+  external String get gridcolor;
+  external int get gridwidth;
 }
 
 @JS()

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -45,25 +45,24 @@
         // Plotly wrappers.
         // TODO(terry): Remove JS code move to Dart JS interop.
         function hookupPlotlyClick(domName, jsFunction) {
-            var graph = document.getElementById(domName);
-            graph.on('plotly_click', jsFunction);
+          var graph = document.getElementById(domName);
+          graph.on('plotly_click', jsFunction);
         }
 
         function hookupPlotlyHover(domName, jsFunction) {
-            var graph = document.getElementById(domName);
-            graph.on('plotly_hover', jsFunction);
+          var graph = document.getElementById(domName);
+          graph.on('plotly_hover', jsFunction);
         }
 
         // Return false to cancel default handling, true to cause default handling.
         function hookupPlotlyLegendClick(domName, jsFunction) {
-            var graph = document.getElementById(domName);
-            graph.on('plotly_legendclick', jsFunction);
+          var graph = document.getElementById(domName);
+          graph.on('plotly_legendclick', jsFunction);
         }
 
-
         function hookupPlotlyDoubleClick(domName, jsFunction) {
-            var graph = document.getElementById(domName);
-            graph.on('plotly_doubleclick', jsFunction);
+          var graph = document.getElementById(domName);
+          graph.on('plotly_doubleclick', jsFunction);
         }
 
         function _copyTrace(x, y, orgTrace, xData, yData, traces) {
@@ -82,30 +81,30 @@
 
         // TODO(terry): Used instead of normal JS interop (reified List).  Need to eliminate.
         function extendTraces1(domName, x0, y0, orgTraces) {
-            var data = {};
-            var xData = [];
-            var yData = [];
-            var traces = [];
+          var data = {};
+          var xData = [];
+          var yData = [];
+          var traces = [];
 
-            _copyTrace(x0, y0, orgTraces[0], xData, yData, traces);
+          _copyTrace(x0, y0, orgTraces[0], xData, yData, traces);
 
-            data = {x: xData, y: yData};
+          data = {x: xData, y: yData};
 
-            Plotly.extendTraces(domName, data, traces);
+          Plotly.extendTraces(domName, data, traces);
         }
 
         function extendTraces2(domName, x0, x1, y0, y1, orgTraces) {
-            var data = {};
-            var xData = [];
-            var yData = [];
-            var traces = [];
+          var data = {};
+          var xData = [];
+          var yData = [];
+          var traces = [];
 
-            _copyTrace(x0, y0, orgTraces[0], xData, yData, traces);
-            _copyTrace(x1, y1, orgTraces[1], xData, yData, traces);
+          _copyTrace(x0, y0, orgTraces[0], xData, yData, traces);
+          _copyTrace(x1, y1, orgTraces[1], xData, yData, traces);
 
-            data = {x: xData, y: yData};
+           data = {x: xData, y: yData};
 
-            Plotly.extendTraces(domName, data, traces);
+          Plotly.extendTraces(domName, data, traces);
         }
 
         function extendTraces4(domName, x0, x1, x2, x3, y0, y1, y2, y3, orgTraces) {
@@ -122,6 +121,28 @@
           data = {x: xData, y: yData};
 
           Plotly.extendTraces(domName, data, traces);
+        }
+
+        // Need to create dynamic key/value pair for Shape.
+        function createEventShape(devToolEvent, shapeIndex, lastEventTime, time) {
+          var jsShape = {};
+          jsShape['shapes[' + shapeIndex + ']'] = {
+            'devtool_event_type': devToolEvent,
+            'fillcolor': 'lightblue',
+              'line': {
+                'width': 0,
+              },
+              'opacity': .8,
+              'type': "rect",
+              'x0': lastEventTime,
+              'x1': time,
+              'yref': 'y2',
+              'y0': '.80',
+              'y1': '1.20',
+              layer: 'below',
+          };
+
+          return jsShape;
         }
     </script>
 


### PR DESCRIPTION
Added the Event timeline to the memory profile.  When "Snapshot" or "Reset" button is clicked the "Event Timeline" subplot is displayed and time of the event is record .  Reset's are semi-attached to the last snapshot (the accumulators are reset to zero).

To do allow charts to be re-sized and retrieve history snapshot/accumulator values - click on the snapshot marker, in the event chart, to fetch the old values at that timestamp.

The event timeline can be added to any chart and the contents are also dynamic (vertical grows).

Supports both light and dark mode.

![image](https://user-images.githubusercontent.com/2055873/54699961-44989400-4aef-11e9-8d52-82df6229655c.png)

Also, added proper font-family to match fonts on the memory page.

