### PR TITLE
Tweak dark buttons

### DIFF
--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -68,12 +68,17 @@ nav.menu .menu-item {
 
 /* Tweak how buttons look in the dark theme to not be so dark */
 .btn:not(.btn-primary), .btn:not(.btn-primary)[disabled] {
-    background-image: linear-gradient(-180deg, #3f3f3f 0%, #3f3f3f 90%);
+    border: 1px solid #222222;
+    border-radius: 3px;
+    background: linear-gradient(#5f5f5f 5%, #535353 10%, #4f4f4f 100%);
+    box-shadow: 1px 1px 1px rgba(0,0,0,0.2);
+    padding: 3px 10px;
 }
-
 .btn.selected:not(.btn-primary), .btn.selected:not(.btn-primary)[disabled] {
-    background-image: linear-gradient(-180deg, #1f1f1f 0%, #1f1f1f 90%);
-    box-shadow: none;
+    color: #cacbcc;
+    border: 1px solid #3c3c3c;
+    background: linear-gradient(#333333 0%, #2f2f2f 5%, #333333 90%, #3f3f3f 100%);
+    padding: 4px 9px 2px 11px;
 }
 /* /Tweak how buttons look in the dark theme to not be so dark */
 

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -72,13 +72,10 @@ nav.menu .menu-item {
     border-radius: 3px;
     background: linear-gradient(#5f5f5f 5%, #535353 10%, #4f4f4f 100%);
     box-shadow: 1px 1px 1px rgba(0,0,0,0.2);
-    padding: 3px 10px;
 }
 .btn.selected:not(.btn-primary), .btn.selected:not(.btn-primary)[disabled] {
-    color: #cacbcc;
-    border: 1px solid #3c3c3c;
-    background: linear-gradient(#333333 0%, #2f2f2f 5%, #333333 90%, #3f3f3f 100%);
-    padding: 4px 9px 2px 11px;
+    color: #ffffff;
+    background: linear-gradient(#1C547C 5%, #104870 90%, #0C446C 100%);
 }
 /* /Tweak how buttons look in the dark theme to not be so dark */
 


### PR DESCRIPTION
I tweaked these again... Still not entirely happy with the "down" state but I think it's an improvement. Feel free to tweak (or suggest tweaks)!

Before:

![Screenshot 2019-03-21 at 1 14 48 pm](https://user-images.githubusercontent.com/1078012/54754427-6b33f900-4bdb-11e9-98b6-ffa96b428bb5.png)

After:

![Screenshot 2019-03-21 at 1 15 10 pm](https://user-images.githubusercontent.com/1078012/54754428-6b33f900-4bdb-11e9-9515-6b437afdf56c.png)

You can't tell here, but the text shifts slightly as you click them, so it feels better to use than it looks - though the light theme doesn't do that so I'm not entirely sure if we want it (if so, should we do the same there?).