### PR TITLE
Improvements for narrow screens

### DIFF
--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -92,7 +92,7 @@ class LoggingScreen extends Screen {
       [loggingTable.element, logDetailsUI],
       gutterSize: defaultSplitterWidth,
       horizontalSizes: [60, 40],
-      verticalSizes: [50, 50],
+      verticalSizes: [70, 30],
     );
 
     loggingTable.onSelect.listen((LogData selection) {

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -107,6 +107,17 @@ body {
     font-size: 1.5rem;
 }
 
+@media all and (max-width: 550px) {
+    /* At 550px we hide "Dart DevTools" from the title, so we can reduce spacing
+     * around the icons */
+    .masthead {
+        padding: 8px var(--page-outer-padding);
+    }
+    .masthead-nav {
+        margin-top: 0;
+    }
+}
+
 .small-octicon {
   font-size: 13px;
 }


### PR DESCRIPTION
## 1. Reduces padding around icons when the "Dart DevTools" text is hidden (550px)

![Screenshot 2019-03-25 at 3 42 43 pm](https://user-images.githubusercontent.com/1078012/54933592-d56ad780-4f14-11e9-912d-0295d5bb14c6.png)

## 2. Changes the default proportions for the logging view when vertical to 70/30.

![Screenshot 2019-03-25 at 3 43 55 pm](https://user-images.githubusercontent.com/1078012/54933593-d56ad780-4f14-11e9-93d8-03cd48a76cb9.png)
