### PR TITLE
Track futures to give better errors

### DIFF
--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -27,7 +27,7 @@ class VmServiceWrapper implements VmService {
   final bool trackFutures;
   final Map<String, Future<Success>> _activeStreams = {};
 
-  final Set<TrackedFuture<Object>> activeFutures = Set();
+  final Set<TrackedFuture<Object>> activeFutures = {};
   Completer<bool> _allFuturesCompleter = Completer<bool>()
     // Mark the future as completed by default so if we don't track any
     // futures but someone tries to wait on [allFuturesCompleted] they don't

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -23,8 +23,9 @@ class VmServiceWrapper implements VmService {
   final Map<String, Future<Success>> _activeStreams = {};
 
   // ignore: prefer_collection_literals
-  final Set<Future<Object>> _activeFutures = Set();
-  Completer<bool> allFuturesCompleted = Completer<bool>();
+  final Set<TrackedFuture<Object>> activeFutures = Set();
+  Completer<bool> _allFuturesCompleter = Completer<bool>();
+  Future<void> get allFuturesCompleted => _allFuturesCompleter.future;
 
   @override
   Future<Breakpoint> addBreakpoint(
@@ -33,13 +34,14 @@ class VmServiceWrapper implements VmService {
     int line, {
     int column,
   }) {
-    return _trackFuture(
+    return _trackFuture('addBreakpoint',
         _vmService.addBreakpoint(isolateId, scriptId, line, column: column));
   }
 
   @override
   Future<Breakpoint> addBreakpointAtEntry(String isolateId, String functionId) {
-    return _trackFuture(_vmService.addBreakpointAtEntry(isolateId, functionId));
+    return _trackFuture('addBreakpointAtEntry',
+        _vmService.addBreakpointAtEntry(isolateId, functionId));
   }
 
   @override
@@ -49,17 +51,19 @@ class VmServiceWrapper implements VmService {
     int line, {
     int column,
   }) {
-    return _trackFuture(_vmService.addBreakpointWithScriptUri(
-      isolateId,
-      scriptUri,
-      line,
-      column: column,
-    ));
+    return _trackFuture(
+        'addBreakpointWithScriptUri',
+        _vmService.addBreakpointWithScriptUri(
+          isolateId,
+          scriptUri,
+          line,
+          column: column,
+        ));
   }
 
   @override
   Future<Response> callMethod(String method, {String isolateId, Map args}) {
-    return _trackFuture(
+    return _trackFuture('callMethod $method',
         _vmService.callMethod(method, isolateId: isolateId, args: args));
   }
 
@@ -69,26 +73,30 @@ class VmServiceWrapper implements VmService {
     String isolateId,
     Map args,
   }) {
-    return _trackFuture(_vmService.callServiceExtension(
-      method,
-      isolateId: isolateId,
-      args: args,
-    ));
+    return _trackFuture(
+        'callServiceExtension $method',
+        _vmService.callServiceExtension(
+          method,
+          isolateId: isolateId,
+          args: args,
+        ));
   }
 
   @override
   Future<Success> clearCpuProfile(String isolateId) {
-    return _trackFuture(_vmService.clearCpuProfile(isolateId));
+    return _trackFuture(
+        'clearCpuProfile', _vmService.clearCpuProfile(isolateId));
   }
 
   @override
   Future<Success> clearVMTimeline() {
-    return _trackFuture(_vmService.clearVMTimeline());
+    return _trackFuture('clearVMTimeline', _vmService.clearVMTimeline());
   }
 
   @override
   Future<Success> collectAllGarbage(String isolateId) {
-    return _trackFuture(_vmService.collectAllGarbage(isolateId));
+    return _trackFuture(
+        'collectAllGarbage', _vmService.collectAllGarbage(isolateId));
   }
 
   @override
@@ -102,13 +110,15 @@ class VmServiceWrapper implements VmService {
     Map<String, String> scope,
     bool disableBreakpoints,
   }) {
-    return _trackFuture(_vmService.evaluate(
-      isolateId,
-      targetId,
-      expression,
-      scope: scope,
-      disableBreakpoints: disableBreakpoints,
-    ));
+    return _trackFuture(
+        'evaluate $expression',
+        _vmService.evaluate(
+          isolateId,
+          targetId,
+          expression,
+          scope: scope,
+          disableBreakpoints: disableBreakpoints,
+        ));
   }
 
   @override
@@ -119,13 +129,15 @@ class VmServiceWrapper implements VmService {
     Map<String, String> scope,
     bool disableBreakpoints,
   }) {
-    return _trackFuture(_vmService.evaluateInFrame(
-      isolateId,
-      frameIndex,
-      expression,
-      scope: scope,
-      disableBreakpoints: disableBreakpoints,
-    ));
+    return _trackFuture(
+        'evaluateInFrame $expression',
+        _vmService.evaluateInFrame(
+          isolateId,
+          frameIndex,
+          expression,
+          scope: scope,
+          disableBreakpoints: disableBreakpoints,
+        ));
   }
 
   @override
@@ -134,12 +146,14 @@ class VmServiceWrapper implements VmService {
     String gc,
     bool reset,
   }) {
-    return _trackFuture(_vmService.getAllocationProfile(isolateId));
+    return _trackFuture(
+        'getAllocationProfile', _vmService.getAllocationProfile(isolateId));
   }
 
   @override
   Future<CpuProfile> getCpuProfile(String isolateId, String tags) {
-    return _trackFuture(_vmService.getCpuProfile(isolateId, tags));
+    return _trackFuture(
+        'getCpuProfile', _vmService.getCpuProfile(isolateId, tags));
   }
 
   // TODO(kenzie): keep track of all private methods we are currently using to
@@ -158,16 +172,18 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<FlagList> getFlagList() => _trackFuture(_vmService.getFlagList());
+  Future<FlagList> getFlagList() =>
+      _trackFuture("getFlagList", _vmService.getFlagList());
 
   @override
   Future<ObjRef> getInstances(String isolateId, String classId, int limit) {
-    return _trackFuture(_vmService.getInstances(isolateId, classId, limit));
+    return _trackFuture(
+        'getInstances', _vmService.getInstances(isolateId, classId, limit));
   }
 
   @override
   Future getIsolate(String isolateId) {
-    return _trackFuture(_vmService.getIsolate(isolateId));
+    return _trackFuture('getIsolate', _vmService.getIsolate(isolateId));
   }
 
   @override
@@ -177,12 +193,12 @@ class VmServiceWrapper implements VmService {
     int offset,
     int count,
   }) {
-    return _trackFuture(_vmService.getObject(isolateId, objectId));
+    return _trackFuture('getObject', _vmService.getObject(isolateId, objectId));
   }
 
   @override
   Future<ScriptList> getScripts(String isolateId) {
-    return _trackFuture(_vmService.getScripts(isolateId));
+    return _trackFuture('getScripts', _vmService.getScripts(isolateId));
   }
 
   @override
@@ -194,29 +210,33 @@ class VmServiceWrapper implements VmService {
     int endTokenPos,
     bool forceCompile,
   }) {
-    return _trackFuture(_vmService.getSourceReport(
-      isolateId,
-      reports,
-      scriptId: scriptId,
-      tokenPos: tokenPos,
-      endTokenPos: endTokenPos,
-      forceCompile: forceCompile,
-    ));
+    return _trackFuture(
+        'getSourceReport',
+        _vmService.getSourceReport(
+          isolateId,
+          reports,
+          scriptId: scriptId,
+          tokenPos: tokenPos,
+          endTokenPos: endTokenPos,
+          forceCompile: forceCompile,
+        ));
   }
 
   @override
   Future<Stack> getStack(String isolateId) {
-    return _trackFuture(_vmService.getStack(isolateId));
+    return _trackFuture('getStack', _vmService.getStack(isolateId));
   }
 
   @override
-  Future<VM> getVM() => _trackFuture(_vmService.getVM());
+  Future<VM> getVM() => _trackFuture('getVM', _vmService.getVM());
 
   @override
-  Future<Response> getVMTimeline() => _trackFuture(_vmService.getVMTimeline());
+  Future<Response> getVMTimeline() =>
+      _trackFuture('getVMTimeline', _vmService.getVMTimeline());
 
   @override
-  Future<Version> getVersion() => _trackFuture(_vmService.getVersion());
+  Future<Version> getVersion() =>
+      _trackFuture('getVersion', _vmService.getVersion());
 
   @override
   Future invoke(
@@ -226,18 +246,20 @@ class VmServiceWrapper implements VmService {
     List<String> argumentIds, {
     bool disableBreakpoints,
   }) {
-    return _trackFuture(_vmService.invoke(
-      isolateId,
-      targetId,
-      selector,
-      argumentIds,
-      disableBreakpoints: disableBreakpoints,
-    ));
+    return _trackFuture(
+        'invoke $selector',
+        _vmService.invoke(
+          isolateId,
+          targetId,
+          selector,
+          argumentIds,
+          disableBreakpoints: disableBreakpoints,
+        ));
   }
 
   @override
   Future<Success> kill(String isolateId) {
-    return _trackFuture(_vmService.kill(isolateId));
+    return _trackFuture('kill', _vmService.kill(isolateId));
   }
 
   @override
@@ -278,12 +300,13 @@ class VmServiceWrapper implements VmService {
 
   @override
   Future<Success> pause(String isolateId) {
-    return _trackFuture(_vmService.pause(isolateId));
+    return _trackFuture('pause', _vmService.pause(isolateId));
   }
 
   @override
   Future<Success> registerService(String service, String alias) {
-    return _trackFuture(_vmService.registerService(service, alias));
+    return _trackFuture(
+        'registerService $service', _vmService.registerService(service, alias));
   }
 
   @override
@@ -299,18 +322,21 @@ class VmServiceWrapper implements VmService {
     String rootLibUri,
     String packagesUri,
   }) {
-    return _trackFuture(_vmService.reloadSources(
-      isolateId,
-      force: force,
-      pause: pause,
-      rootLibUri: rootLibUri,
-      packagesUri: packagesUri,
-    ));
+    return _trackFuture(
+        'reloadSources',
+        _vmService.reloadSources(
+          isolateId,
+          force: force,
+          pause: pause,
+          rootLibUri: rootLibUri,
+          packagesUri: packagesUri,
+        ));
   }
 
   @override
   Future<Success> removeBreakpoint(String isolateId, String breakpointId) {
-    return _trackFuture(_vmService.removeBreakpoint(isolateId, breakpointId));
+    return _trackFuture('removeBreakpoint',
+        _vmService.removeBreakpoint(isolateId, breakpointId));
   }
 
   @override
@@ -319,24 +345,25 @@ class VmServiceWrapper implements VmService {
     String roots,
     bool collectGarbage,
   ) {
-    return _trackFuture(
+    return _trackFuture('requestHeapSnapshot',
         _vmService.requestHeapSnapshot(isolateId, roots, collectGarbage));
   }
 
   @override
   Future<Success> resume(String isolateId, {String step, int frameIndex}) {
-    return _trackFuture(
+    return _trackFuture('resume',
         _vmService.resume(isolateId, step: step, frameIndex: frameIndex));
   }
 
   @override
   Future<Success> setExceptionPauseMode(String isolateId, String mode) {
-    return _trackFuture(_vmService.setExceptionPauseMode(isolateId, mode));
+    return _trackFuture('setExceptionPauseMode',
+        _vmService.setExceptionPauseMode(isolateId, mode));
   }
 
   @override
   Future<Success> setFlag(String name, String value) {
-    return _trackFuture(_vmService.setFlag(name, value));
+    return _trackFuture('setFlag', _vmService.setFlag(name, value));
   }
 
   @override
@@ -345,29 +372,30 @@ class VmServiceWrapper implements VmService {
     String libraryId,
     bool isDebuggable,
   ) {
-    return _trackFuture(
+    return _trackFuture('setLibraryDebuggable',
         _vmService.setLibraryDebuggable(isolateId, libraryId, isDebuggable));
   }
 
   @override
   Future<Success> setName(String isolateId, String name) {
-    return _trackFuture(_vmService.setName(isolateId, name));
+    return _trackFuture('setName', _vmService.setName(isolateId, name));
   }
 
   @override
   Future<Success> setVMName(String name) {
-    return _trackFuture(_vmService.setVMName(name));
+    return _trackFuture('setVMName', _vmService.setVMName(name));
   }
 
   @override
   Future<Success> setVMTimelineFlags(List<String> recordedStreams) {
-    return _trackFuture(_vmService.setVMTimelineFlags(recordedStreams));
+    return _trackFuture(
+        'setVMTimelineFlags', _vmService.setVMTimelineFlags(recordedStreams));
   }
 
   @override
   Future<Success> streamCancel(String streamId) {
     _activeStreams.remove(streamId);
-    return _trackFuture(_vmService.streamCancel(streamId));
+    return _trackFuture('streamCancel', _vmService.streamCancel(streamId));
   }
 
   // We tweaked this method so that we do not try to listen to the same stream
@@ -377,7 +405,7 @@ class VmServiceWrapper implements VmService {
   Future<Success> streamListen(String streamId) {
     if (!_activeStreams.containsKey(streamId)) {
       final Future<Success> future =
-          _trackFuture(_vmService.streamListen(streamId));
+          _trackFuture('streamListen', _vmService.streamListen(streamId));
       _activeStreams[streamId] = future;
       return future;
     } else {
@@ -393,21 +421,22 @@ class VmServiceWrapper implements VmService {
   /// used after a hot restart to avoid bugs where we have zombie futures lying
   /// around causing tests to flake.
   void doNotWaitForPendingFuturesBeforeExit() {
-    allFuturesCompleted = Completer<bool>();
-    allFuturesCompleted.complete(true);
-    _activeFutures.clear();
+    _allFuturesCompleter = Completer<bool>();
+    _allFuturesCompleter.complete(true);
+    activeFutures.clear();
   }
 
-  Future<T> _trackFuture<T>(Future<T> future) {
-    if (allFuturesCompleted.isCompleted) {
-      allFuturesCompleted = Completer<bool>();
+  Future<T> _trackFuture<T>(String name, Future<T> future) {
+    final trackedFuture = new TrackedFuture(name, future);
+    if (_allFuturesCompleter.isCompleted) {
+      _allFuturesCompleter = Completer<bool>();
     }
-    _activeFutures.add(future);
+    activeFutures.add(trackedFuture);
 
     void futureComplete() {
-      _activeFutures.remove(future);
-      if (_activeFutures.isEmpty && !allFuturesCompleted.isCompleted) {
-        allFuturesCompleted.complete(true);
+      activeFutures.remove(trackedFuture);
+      if (activeFutures.isEmpty && !_allFuturesCompleter.isCompleted) {
+        _allFuturesCompleter.complete(true);
       }
     }
 
@@ -417,4 +446,11 @@ class VmServiceWrapper implements VmService {
     );
     return future;
   }
+}
+
+class TrackedFuture<T> {
+  TrackedFuture(this.name, this.future);
+
+  final String name;
+  final Future<T> future;
 }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -23,7 +23,8 @@ class VmServiceWrapper implements VmService {
   final Map<String, Future<Success>> _activeStreams = {};
 
   // ignore: prefer_collection_literals
-  final Set<TrackedFuture<Object>> activeFutures = Set();
+  final Set<Future<Object>> activeFutures = Set();
+  final Map<Future, String> activeFutureDescriptions = {};
   Completer<bool> _allFuturesCompleter = Completer<bool>();
   Future<void> get allFuturesCompleted => _allFuturesCompleter.future;
 
@@ -173,7 +174,7 @@ class VmServiceWrapper implements VmService {
 
   @override
   Future<FlagList> getFlagList() =>
-      _trackFuture("getFlagList", _vmService.getFlagList());
+      _trackFuture('getFlagList', _vmService.getFlagList());
 
   @override
   Future<ObjRef> getInstances(String isolateId, String classId, int limit) {
@@ -424,17 +425,19 @@ class VmServiceWrapper implements VmService {
     _allFuturesCompleter = Completer<bool>();
     _allFuturesCompleter.complete(true);
     activeFutures.clear();
+    activeFutureDescriptions.clear();
   }
 
   Future<T> _trackFuture<T>(String name, Future<T> future) {
-    final trackedFuture = new TrackedFuture(name, future);
     if (_allFuturesCompleter.isCompleted) {
       _allFuturesCompleter = Completer<bool>();
     }
-    activeFutures.add(trackedFuture);
+    activeFutures.add(future);
+    activeFutureDescriptions.putIfAbsent(future, () => name);
 
     void futureComplete() {
-      activeFutures.remove(trackedFuture);
+      activeFutures.remove(future);
+      activeFutureDescriptions.remove(future);
       if (activeFutures.isEmpty && !_allFuturesCompleter.isCompleted) {
         _allFuturesCompleter.complete(true);
       }
@@ -446,11 +449,4 @@ class VmServiceWrapper implements VmService {
     );
     return future;
   }
-}
-
-class TrackedFuture<T> {
-  TrackedFuture(this.name, this.future);
-
-  final String name;
-  final Future<T> future;
 }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -27,7 +27,7 @@ class VmServiceWrapper implements VmService {
   final bool trackFutures;
   final Map<String, Future<Success>> _activeStreams = {};
 
-  final Set<TrackedFuture<Object>> activeFutures = {};
+  final Set<TrackedFuture<Object>> activeFutures = Set();
   Completer<bool> _allFuturesCompleter = Completer<bool>()
     // Mark the future as completed by default so if we don't track any
     // futures but someone tries to wait on [allFuturesCompleted] they don't

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -168,15 +168,17 @@ class VmServiceWrapper implements VmService {
   // share with the VM team and request that they be made public.
   Future<Response> getCpuProfileTimeline(
       String isolateId, int origin, int extent) async {
-    return _trackFuture(callMethod(
-      '_getCpuProfileTimeline',
-      isolateId: isolateId,
-      args: {
-        'tags': 'None',
-        'timeOriginMicros': origin,
-        'timeExtentMicros': extent,
-      },
-    ));
+    return _trackFuture(
+        'getCpuProfileTimeline',
+        callMethod(
+          '_getCpuProfileTimeline',
+          isolateId: isolateId,
+          args: {
+            'tags': 'None',
+            'timeOriginMicros': origin,
+            'timeExtentMicros': extent,
+          },
+        ));
   }
 
   @override

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -28,7 +28,11 @@ class VmServiceWrapper implements VmService {
   final Map<String, Future<Success>> _activeStreams = {};
 
   final Set<TrackedFuture<Object>> activeFutures = {};
-  Completer<bool> _allFuturesCompleter = Completer<bool>();
+  Completer<bool> _allFuturesCompleter = Completer<bool>()
+    // Mark the future as completed by default so if we don't track any
+    // futures but someone tries to wait on [allFuturesCompleted] they don't
+    // hang. The first tracked future will replace this with a new completer.
+    ..complete(true);
   Future<void> get allFuturesCompleted => _allFuturesCompleter.future;
 
   @override

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.1.0-dev <3.0.0'
+  sdk: '>=2.2.0-dev <3.0.0'
 
 dependencies:
   args: ^1.5.1

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -281,7 +281,7 @@ void main() {
     });
 
     tearDown(() async {
-      await service.allFuturesCompleted.future;
+      await service.allFuturesCompleted;
       await _flutter.stop();
     });
 

--- a/packages/devtools/test/support/flutter_test_driver.dart
+++ b/packages/devtools/test/support/flutter_test_driver.dart
@@ -327,7 +327,9 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       _vmServiceWsUri = getVmServiceUriFromObservatoryUri(_vmServiceWsUri);
 
       vmService = VmServiceWrapper(
-          await vmServiceConnectUri(_vmServiceWsUri.toString()));
+        await vmServiceConnectUri(_vmServiceWsUri.toString()),
+        trackFutures: true,
+      );
       vmService.onSend.listen((String s) => _debugPrint('==> $s'));
       vmService.onReceive.listen((String s) => _debugPrint('<== $s'));
       await Future.wait(<Future<Success>>[

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -89,7 +89,12 @@ class FlutterTestEnvironment {
     }
     if (_beforeTearDown != null) await _beforeTearDown();
 
-    await _service.allFuturesCompleted.future;
+    await _service.allFuturesCompleted.timeout(Duration(seconds: 20),
+        onTimeout: () {
+      throw 'Timed out waiting for futures to complete during teardown. '
+          '${_service.activeFutures.length} futures remained:\n\n'
+          '  ${_service.activeFutures.map((tf) => tf.name).join('\n  ')}';
+    });
     await _flutter.stop();
     _flutter = null;
 

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -89,7 +89,7 @@ class FlutterTestEnvironment {
     }
     if (_beforeTearDown != null) await _beforeTearDown();
 
-    await _service.allFuturesCompleted.timeout(Duration(seconds: 20),
+    await _service.allFuturesCompleted.timeout(const Duration(seconds: 20),
         onTimeout: () {
       throw 'Timed out waiting for futures to complete during teardown. '
           '${_service.activeFutures.length} futures remained:\n\n'

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -91,9 +91,11 @@ class FlutterTestEnvironment {
 
     await _service.allFuturesCompleted.timeout(Duration(seconds: 20),
         onTimeout: () {
+      final List<String> remainingFutures =
+          _service.activeFutureDescriptions.values.toList();
       throw 'Timed out waiting for futures to complete during teardown. '
-          '${_service.activeFutures.length} futures remained:\n\n'
-          '  ${_service.activeFutures.map((tf) => tf.name).join('\n  ')}';
+          '${remainingFutures.length} futures remained:\n\n'
+          '  ${remainingFutures.join('\n  ')}';
     });
     await _flutter.stop();
     _flutter = null;

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -91,11 +91,9 @@ class FlutterTestEnvironment {
 
     await _service.allFuturesCompleted.timeout(Duration(seconds: 20),
         onTimeout: () {
-      final List<String> remainingFutures =
-          _service.activeFutureDescriptions.values.toList();
       throw 'Timed out waiting for futures to complete during teardown. '
-          '${remainingFutures.length} futures remained:\n\n'
-          '  ${remainingFutures.join('\n  ')}';
+          '${_service.activeFutures.length} futures remained:\n\n'
+          '  ${_service.activeFutures.map((tf) => tf.name).join('\n  ')}';
     });
     await _flutter.stop();
     _flutter = null;


### PR DESCRIPTION
This is the code I was using to track which futures aren't being completed. Do you think we should land it? (it's slightly weird that this is in non-test code, but since we're already tracking them, I don't think adding a name to them is much of an issue).

(I also added a getter to avoid having access to the completer outside this class as that felt a bit weird).

I'll open another issue about the specific things this is logging, this PR is just to see if you think it's worth having this in the repo always, to help diagnose failures in the future (previously it'd just hang on the teardown on the `await`).