### PR TITLE
Improve debugger page at narrow widths

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.css
+++ b/packages/devtools/lib/src/debugger/debugger.css
@@ -33,7 +33,7 @@
 }
 
 .break-on-exceptions {
-    line-height: 28px;
+    line-height: 32px;
 }
 
 .break-on-exceptions label {
@@ -47,4 +47,18 @@
 .flex-no-wrap {
     flex-wrap: nowrap;
     white-space: nowrap;
+}
+
+/* Octicons CSS fixes (make 16px and centered) */
+/* These icons are 8px wide and have 8px padding on the right, so offset
+ * by 4px to the left */
+ .octicon-chevron-right {
+    margin-left: 4px;
+    margin-right: -4px;
+}
+/* These icons are 10px wide and have 6px padding on the right, so offset
+ * by 3px to the left */
+ .octicon-chevron-down, .octicon-chevron-up {
+    margin-left: 3px;
+    margin-right: -3px;
 }

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -132,33 +132,22 @@ class DebuggerScreen extends Screen {
             ..element.style.overflowX = 'hidden'
             ..layoutVertical()
             ..add(<CoreElement>[
-              div(c: 'section')
+              div(c: 'section flex-wrap')
                 ..layoutHorizontal()
                 ..add(<CoreElement>[
-                  pauseButton,
-                  resumeButton,
-                  div(c: 'btn-group flex-no-wrap margin-left')
+                  div(c: 'btn-group collapsible-700 flex-no-wrap')
                     ..add(<CoreElement>[
-                      stepIn = PButton()
-                        ..add(<CoreElement>[
-                          span(c: 'octicon octicon-chevron-down'),
-                          span(text: 'Step in'),
-                        ])
-                        ..small(),
-                      stepOver = PButton()
-                        ..add(<CoreElement>[
-                          span(c: 'octicon octicon-chevron-right'),
-                          span(text: 'Step over'),
-                        ])
-                        ..small(),
-                      stepOut = PButton()
-                        ..add(<CoreElement>[
-                          span(c: 'octicon octicon-chevron-up'),
-                          span(text: 'Step out'),
-                        ])
-                        ..small(),
+                      pauseButton,
+                      resumeButton,
                     ]),
-                  div()..flex(),
+                  div(c: 'btn-group flex-no-wrap margin-left collapsible-1000')
+                    ..add(<CoreElement>[
+                      stepIn = PButton.octicon('Step in', icon: 'chevron-down'),
+                      stepOver =
+                          PButton.octicon('Step over', icon: 'chevron-right'),
+                      stepOut = PButton.octicon('Step out', icon: 'chevron-up'),
+                    ]),
+                  div(c: 'margin-right')..flex(),
                   breakOnExceptionControl,
                 ]),
               sourceArea = div(c: 'section table-border')
@@ -1376,7 +1365,7 @@ class VariablesChildProvider extends ChildProvider<BoundVariable> {
 
 class BreakOnExceptionControl extends CoreElement {
   BreakOnExceptionControl()
-      : super('div', classes: 'break-on-exceptions margin-left flex-no-wrap') {
+      : super('div', classes: 'break-on-exceptions flex-no-wrap') {
     final CoreElement unhandledExceptionsElement = CoreElement('input')
       ..setAttribute('type', 'checkbox');
     _unhandledElement = unhandledExceptionsElement.element;
@@ -1386,7 +1375,9 @@ class BreakOnExceptionControl extends CoreElement {
     _allElement = allExceptionsElement.element;
 
     add([
-      span(text: 'Break on exceptions: ', c: 'strong'),
+      span(text: 'Break on', c: 'strong'),
+      span(text: ' exceptions', c: 'strong optional-1000'),
+      span(text: ': ', c: 'strong'),
       CoreElement('label')
         ..add(<CoreElement>[
           unhandledExceptionsElement,

--- a/packages/devtools/lib/src/ui/primer.dart
+++ b/packages/devtools/lib/src/ui/primer.dart
@@ -67,6 +67,7 @@ class PButton extends CoreElement {
 
   PButton.octicon(String text, {@required String icon})
       : super('button', classes: 'btn optional-text') {
+    tooltip = text;
     add(<CoreElement>[
       span(c: 'octicon octicon-$icon'),
       span(c: 'optional-text', text: text),

--- a/packages/devtools/lib/src/ui/primer.dart
+++ b/packages/devtools/lib/src/ui/primer.dart
@@ -5,6 +5,8 @@
 import 'dart:async';
 import 'dart:html';
 
+import 'package:meta/meta.dart';
+
 import 'elements.dart';
 import 'html_icon_renderer.dart';
 import 'icons.dart';
@@ -61,6 +63,15 @@ class PTooltip {
 class PButton extends CoreElement {
   PButton([String text]) : super('button', text: text, classes: 'btn') {
     setAttribute('type', 'button');
+  }
+
+  PButton.octicon(String text, {@required String icon})
+      : super('button', classes: 'btn optional-text') {
+    add(<CoreElement>[
+      span(c: 'octicon octicon-$icon'),
+      span(c: 'optional-text', text: text),
+    ]);
+    small();
   }
 
   PButton.icon(String text, Icon icon, {String title, List<String> classes})

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -889,11 +889,6 @@ span.strong {
         margin-right: 0;
         box-sizing: content-box;
     }
-
-    .btn-group.collapsible-1200 .btn .flutter-icon {
-        margin-right: 0;
-        box-sizing: content-box;
-    }
 }
 
 @media all and (max-width: 1400px) {

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -688,6 +688,7 @@ but a more subtle solution would be better. */
 .btn {
     display: inline-flex;
     align-items: center;
+    height: 30px; /* Force height to 22px even when there's no text (2x3px padding + 2x1px margin) */
 }
 
 /* Increase line height so standard sized icons look ok in buttons. */
@@ -847,6 +848,7 @@ span.strong {
 @media all and (max-width: 700px) { .optional-700 { display: none; } }
 @media all and (max-width: 850px) { .optional-850 { display: none; } }
 @media all and (max-width: 950px) { .optional-950 { display: none; } }
+@media all and (max-width: 1000px) { .optional-1000 { display: none; } }
 @media all and (max-width: 1200px) { .optional-1200 { display: none; } }
 @media all and (max-width: 1400px) { .optional-1400 { display: none; } }
 
@@ -857,7 +859,7 @@ span.strong {
  */
 
 @media all and (max-width: 700px) {
-    .btn-group.collapsible-700 .optional-text span {
+    .btn-group.collapsible-700 .optional-text span:not(.octicon) {
         display: none;
     }
 
@@ -867,9 +869,25 @@ span.strong {
     }
 }
 
-@media all and (max-width: 1200px) {
-    .btn-group.collapsible-1200 .optional-text span {
+@media all and (max-width: 1000px) {
+    .btn-group.collapsible-1000 .optional-text span:not(.octicon) {
         display: none;
+    }
+
+    .btn-group.collapsible-1000 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 1200px) {
+    .btn-group.collapsible-1200 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-1200 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
     }
 
     .btn-group.collapsible-1200 .btn .flutter-icon {
@@ -879,7 +897,7 @@ span.strong {
 }
 
 @media all and (max-width: 1400px) {
-    .btn-group.collapsible-1400 .optional-text span {
+    .btn-group.collapsible-1400 .optional-text span:not(.octicon) {
         display: none;
     }
 


### PR DESCRIPTION
Includes various tweaks to support collapsing Octicons buttons (our others all use our own icons). I added a `PButton.octicon` constructor to simplify the code slightly, though so far I've only applied it in the debugger page - if these changes look good I can update the other places to use it too.

![Screenshot 2019-03-26 at 5 59 44 pm](https://user-images.githubusercontent.com/1078012/55021724-3071fc80-4ff1-11e9-81ad-fc15c083d0f3.png)

![Screenshot 2019-03-26 at 5 59 52 pm](https://user-images.githubusercontent.com/1078012/55021725-3071fc80-4ff1-11e9-88d2-c33a3e3a2d48.png)

![Screenshot 2019-03-26 at 6 00 01 pm](https://user-images.githubusercontent.com/1078012/55021727-3071fc80-4ff1-11e9-9f73-15a07f8fab8b.png)

![Screenshot 2019-03-26 at 6 00 10 pm](https://user-images.githubusercontent.com/1078012/55021729-3071fc80-4ff1-11e9-8970-c9dc8ae0d96a.png)
