### PR TITLE
Tweaks to Dark mode colours/buttons

### DIFF
--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -63,7 +63,7 @@ class InspectorScreen extends Screen {
               extensions.toggleSelectWidgetMode,
             ).button,
             refreshTreeButton =
-                PButton.icon('Refresh Tree', FlutterIcons.forceRefresh)
+                PButton.icon('Refresh Tree', FlutterIcons.refresh)
                   ..small()
                   ..disabled = true
                   ..click(_refreshInspector),

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -105,11 +105,10 @@ class TimelineScreen extends Screen {
 //      PTabNavTab('Skia picture'),
 //    ]);
 
-    pauseButton =
-        PButton.icon('Pause recording', FlutterIcons.pause_white_2x_primary)
-          ..small()
-          ..primary()
-          ..click(_pauseRecording);
+    pauseButton = PButton.icon('Pause recording', FlutterIcons.pause_white_2x)
+      ..small()
+      ..primary()
+      ..click(_pauseRecording);
 
     resumeButton =
         PButton.icon('Resume recording', FlutterIcons.resume_black_disabled_2x)

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -129,7 +129,7 @@ class FlutterIcons {
   // Icons matching IntelliJ core icons.
   static const Icon locate = UrlIcon('/icons/general/locate.png');
   static const Icon forceRefresh = UrlIcon('/icons/actions/forceRefresh.svg');
-  // TODO: Do we want these dynamic? :/
+  // TODO(dantup): Make a ThemedIcon class to handle this.
   static Icon get refresh => isDarkTheme
       ? const MaterialIcon('refresh', Color.fromARGB(255, 137, 181, 248))
       : const MaterialIcon('refresh', Color.fromARGB(255, 0, 0, 0));

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -13,6 +13,8 @@
 /// of code that uses icons can run on the Dart VM.
 library icons;
 
+import 'package:devtools/src/ui/material_icons.dart';
+import 'package:devtools/src/ui/theme.dart';
 import 'package:meta/meta.dart';
 
 import 'fake_flutter/fake_flutter.dart';
@@ -127,6 +129,10 @@ class FlutterIcons {
   // Icons matching IntelliJ core icons.
   static const Icon locate = UrlIcon('/icons/general/locate.png');
   static const Icon forceRefresh = UrlIcon('/icons/actions/forceRefresh.svg');
+  // TODO: Do we want these dynamic? :/
+  static Icon get refresh => isDarkTheme
+      ? const MaterialIcon('refresh', Color.fromARGB(255, 137, 181, 248))
+      : const MaterialIcon('refresh', Color.fromARGB(255, 0, 0, 0));
   static const Icon performanceOverlay =
       UrlIcon('/icons/general/performance_overlay.svg');
   static const Icon debugPaint = UrlIcon('/icons/debug_paint.png');
@@ -144,19 +150,17 @@ class FlutterIcons {
       UrlIcon('/icons/general/pause_white@2x.png', invertDark: true);
   static const UrlIcon pause_white_disabled_2x =
       UrlIcon('/icons/general/pause_white_disabled@2x.png', invertDark: true);
+  static const UrlIcon resume_white_2x =
+      UrlIcon('/icons/general/resume_white@2x.png', invertDark: true);
+  static const UrlIcon resume_white_disabled_2x =
+      UrlIcon('/icons/general/resume_white_disabled@2x.png', invertDark: true);
 
   /// Used on "primary" buttons that have colored backgrounds, so is not
   /// inverted for Dark theme.
-  static const UrlIcon pause_white_2x_primary =
-      UrlIcon('/icons/general/pause_white@2x.png');
   static const UrlIcon resume_black_2x =
       UrlIcon('/icons/general/resume_black@2x.png');
   static const UrlIcon resume_black_disabled_2x =
       UrlIcon('/icons/general/resume_black_disabled@2x.png');
-  static const UrlIcon resume_white_2x =
-      UrlIcon('/icons/general/resume_white@2x.png');
-  static const UrlIcon resume_white_disabled_2x =
-      UrlIcon('/icons/general/resume_white_disabled@2x.png');
 
   static const UrlIcon lightbulb =
       UrlIcon('/icons/general/lightbulb_outline.png');

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -546,6 +546,7 @@ div.tabnav-tab {
 .btn-group .btn:first-child:not(:last-child) {
     border-top-right-radius: 0;
     border-bottom-right-radius: 0;
+    border-right-width: 0;
 }
 
 .btn-group .btn:not(:first-child):not(:last-child) {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -9,7 +9,7 @@
     --border-color: #484848;
     --counter-color: #999;
     --dark-shadow-color: #999;
-    --default-background-rgb: 47, 43, 43;
+    --default-background-rgb: 32, 33, 36;
     --default-background: rgba(var(--default-background-rgb), 1);
     --default-color-thumb: #888;
     --default-color: #fff;
@@ -25,7 +25,7 @@
     --header-item: rgba(var(--header-item-rgb), 1);
     --hint-background: #4b4b3f;
     --light-background: #585858;
-    --masthead-background: #525050;
+    --masthead-background: #394959;
     --list-background: #3f3f3f;
     --menu-item-border: #484541;
     --row-hover-background: #2b2d2e;
@@ -66,18 +66,60 @@ nav.menu .menu-item {
     fill-opacity: 0.6 !important;
 }
 
-/* Tweak how buttons look in the dark theme to not be so dark */
-.btn:not(.btn-primary), .btn:not(.btn-primary)[disabled] {
-    border: 1px solid #222222;
-    border-radius: 3px;
-    background: linear-gradient(#5f5f5f 5%, #535353 10%, #4f4f4f 100%);
-    box-shadow: 1px 1px 1px rgba(0,0,0,0.2);
+/* Set defaults for buttons (mostly removing Primer styles) */
+.btn, .btn[disabled], .btn:hover, .btn.hover, .btn:active, .btn.selected {
+    border-radius: 2px;
+    border-width: 1px;
+    border-color: rgba(var(--white-rgb), 0.08);
+    background-image: none;
+    box-shadow: none;
+    position: relative;
 }
-.btn.selected:not(.btn-primary), .btn.selected:not(.btn-primary)[disabled] {
-    color: #ffffff;
-    background: linear-gradient(#1C547C 5%, #104870 90%, #0C446C 100%);
+
+.btn {
+    background-color: transparent;
+    border: 1px solid #5f6368;
+    font-weight: normal;
+    color: #89b5f8;
 }
-/* /Tweak how buttons look in the dark theme to not be so dark */
+
+.btn[disabled] {
+    /* ??? */
+}
+
+.btn:active, .btn.selected {
+    background-color: #3a4556;
+    border-color: #3a4556;
+}
+
+.btn:hover, .btn.hover {
+    background-color: #3b3b3e;
+    border-color: #3b3b3e;
+}
+
+.btn:hover:active, .btn.hover:active, .btn.selected:hover, .btn.selected.hover {
+    /* This needs a better colour - I made this one up and it's bad */
+    background-color: #394959;
+    border-color: #394959;
+}
+
+.btn.btn-primary {
+    background-color: #89b5f8;
+    border-color: #89b5f8;
+    color: #202124;
+}
+
+.btn.btn-primary:active, .btn.btn-primary.selected {
+    /* What should primary selected buttons look like (can we have them?) */
+}
+
+.btn.btn-primary:hover, .btn.btn-primary.hover {
+    /* What is the primary hover state? */
+}
+
+.btn.btn-primary:hover:active, .btn.btn-primary.hover:active, .btn.btn-primary.selected:hover, .btn.btn-primary.selected.hover {
+    /* What should primary selected+hover buttons look like (can we have them?) */
+}
 
 .flash-warn {
     background-color: #fffbdd;

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -66,25 +66,25 @@ nav.menu .menu-item {
     fill-opacity: 0.6 !important;
 }
 
-/* Set defaults for buttons (mostly removing Primer styles) */
+/* Set defaults for buttons (inc removing Primer styles) */
 .btn, .btn[disabled], .btn:hover, .btn.hover, .btn:active, .btn.selected {
+    background-color: transparent;
+    background-image: none;
     border-radius: 2px;
     border-width: 1px;
-    border-color: rgba(var(--white-rgb), 0.08);
-    background-image: none;
+    border: 1px solid #5f6368;
     box-shadow: none;
+    color: #89b5f8;
+    font-weight: normal;
     position: relative;
 }
 
-.btn {
-    background-color: transparent;
-    border: 1px solid #5f6368;
-    font-weight: normal;
-    color: #89b5f8;
-}
-
 .btn[disabled] {
-    /* ??? */
+    /* !important to override all other states (like hover) */
+    opacity: 0.5 !important;
+    background-color: transparent !important;
+    border: 1px solid #5f6368 !important;
+    color: #89b5f8 !important;
 }
 
 .btn:active, .btn.selected {
@@ -93,14 +93,11 @@ nav.menu .menu-item {
 }
 
 .btn:hover, .btn.hover {
-    background-color: #3b3b3e;
-    border-color: #3b3b3e;
+    background-color: #3a4556;
 }
 
 .btn:hover:active, .btn.hover:active, .btn.selected:hover, .btn.selected.hover {
-    /* This needs a better colour - I made this one up and it's bad */
-    background-color: #394959;
-    border-color: #394959;
+    background-color: #3b3b3e;
 }
 
 .btn.btn-primary {
@@ -109,16 +106,20 @@ nav.menu .menu-item {
     color: #202124;
 }
 
-.btn.btn-primary:active, .btn.btn-primary.selected {
-    /* What should primary selected buttons look like (can we have them?) */
+.btn.btn-primary[disabled] {
+    /* !important to override all other states (like hover) */
+    opacity: 0.5 !important;
+    background-color: #89b5f8 !important;
+    border-color: #89b5f8 !important;
+    color: #202124 !important;
 }
 
-.btn.btn-primary:hover, .btn.btn-primary.hover {
-    /* What is the primary hover state? */
+.btn.btn-primary:active, .btn.btn-primary.selected, .btn.btn-primary:hover, .btn.btn-primary.hover {
+    background-color: #7aa2de; /* Not picked from spec */
 }
 
 .btn.btn-primary:hover:active, .btn.btn-primary.hover:active, .btn.btn-primary.selected:hover, .btn.btn-primary.selected.hover {
-    /* What should primary selected+hover buttons look like (can we have them?) */
+    background-color: #6c8fc4; /* Not picked from spec */
 }
 
 .flash-warn {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -69,51 +69,56 @@ nav.menu .menu-item {
 /* Set defaults for buttons (mostly removing Primer styles) */
 .btn, .btn[disabled], .btn:hover, .btn.hover, .btn:active, .btn.selected {
     border-radius: 2px;
-    border-color: #9f9f9f !important; /* Used only as separator for btn-groups */
-    border-width: 0;
+    border-width: 1px;
+    border-color: rgba(var(--white-rgb), 0.08);
     background-image: none;
     box-shadow: none;
-    background-color: #6f6f6f;
-    font-weight: normal;
-    color: #fff;
+    position: relative;
 }
 
-/* Show separators on all right-edges of not-last buttons in groups */
-.btn-group .btn:not(:last-child) {
-    border-right-width: 2px !important;
+.btn {
+    background-color: transparent;
+    border: 1px solid #5f6368;
+    font-weight: normal;
+    color: #89b5f8;
 }
 
 .btn[disabled] {
-    background-color: #3f3f3f !important;
+    /* ??? */
 }
 
 .btn:active, .btn.selected {
-    background-color: #aeaeae;
+    background-color: #3a4556;
+    border-color: #3a4556;
 }
 
 .btn:hover, .btn.hover {
-    background-color: #aeaeae;
+    background-color: #3b3b3e;
+    border-color: #3b3b3e;
 }
 
 .btn:hover:active, .btn.hover:active, .btn.selected:hover, .btn.selected.hover {
-    background-color: #b8b8b8;
+    /* This needs a better colour - I made this one up and it's bad */
+    background-color: #394959;
+    border-color: #394959;
 }
 
 .btn.btn-primary {
-    background-color: #1a73e8;
-    color: #fff;
+    background-color: #89b5f8;
+    border-color: #89b5f8;
+    color: #202124;
 }
 
 .btn.btn-primary:active, .btn.btn-primary.selected {
-    background-color: #408aec;
+    /* What should primary selected buttons look like (can we have them?) */
 }
 
 .btn.btn-primary:hover, .btn.btn-primary.hover {
-    background-color: #408aec;
+    /* What is the primary hover state? */
 }
 
 .btn.btn-primary:hover:active, .btn.btn-primary.hover:active, .btn.btn-primary.selected:hover, .btn.btn-primary.selected.hover {
-    background-color: #5796ee;
+    /* What should primary selected+hover buttons look like (can we have them?) */
 }
 
 .flash-warn {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -69,56 +69,51 @@ nav.menu .menu-item {
 /* Set defaults for buttons (mostly removing Primer styles) */
 .btn, .btn[disabled], .btn:hover, .btn.hover, .btn:active, .btn.selected {
     border-radius: 2px;
-    border-width: 1px;
-    border-color: rgba(var(--white-rgb), 0.08);
+    border-color: #9f9f9f !important; /* Used only as separator for btn-groups */
+    border-width: 0;
     background-image: none;
     box-shadow: none;
-    position: relative;
+    background-color: #6f6f6f;
+    font-weight: normal;
+    color: #fff;
 }
 
-.btn {
-    background-color: transparent;
-    border: 1px solid #5f6368;
-    font-weight: normal;
-    color: #89b5f8;
+/* Show separators on all right-edges of not-last buttons in groups */
+.btn-group .btn:not(:last-child) {
+    border-right-width: 2px !important;
 }
 
 .btn[disabled] {
-    /* ??? */
+    background-color: #3f3f3f !important;
 }
 
 .btn:active, .btn.selected {
-    background-color: #3a4556;
-    border-color: #3a4556;
+    background-color: #aeaeae;
 }
 
 .btn:hover, .btn.hover {
-    background-color: #3b3b3e;
-    border-color: #3b3b3e;
+    background-color: #aeaeae;
 }
 
 .btn:hover:active, .btn.hover:active, .btn.selected:hover, .btn.selected.hover {
-    /* This needs a better colour - I made this one up and it's bad */
-    background-color: #394959;
-    border-color: #394959;
+    background-color: #b8b8b8;
 }
 
 .btn.btn-primary {
-    background-color: #89b5f8;
-    border-color: #89b5f8;
-    color: #202124;
+    background-color: #1a73e8;
+    color: #fff;
 }
 
 .btn.btn-primary:active, .btn.btn-primary.selected {
-    /* What should primary selected buttons look like (can we have them?) */
+    background-color: #408aec;
 }
 
 .btn.btn-primary:hover, .btn.btn-primary.hover {
-    /* What is the primary hover state? */
+    background-color: #408aec;
 }
 
 .btn.btn-primary:hover:active, .btn.btn-primary.hover:active, .btn.btn-primary.selected:hover, .btn.btn-primary.selected.hover {
-    /* What should primary selected+hover buttons look like (can we have them?) */
+    background-color: #5796ee;
 }
 
 .flash-warn {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -70,7 +70,6 @@ nav.menu .menu-item {
 .btn, .btn[disabled], .btn:hover, .btn.hover, .btn:active, .btn.selected {
     background-color: transparent;
     background-image: none;
-    border-radius: 2px;
     border-width: 1px;
     border: 1px solid #5f6368;
     box-shadow: none;
@@ -115,11 +114,11 @@ nav.menu .menu-item {
 }
 
 .btn.btn-primary:active, .btn.btn-primary.selected, .btn.btn-primary:hover, .btn.btn-primary.hover {
-    background-color: #7aa2de; /* Not picked from spec */
+    background-color: #7aa2de; /* Not picked from material design spec */
 }
 
 .btn.btn-primary:hover:active, .btn.btn-primary.hover:active, .btn.btn-primary.selected:hover, .btn.btn-primary.selected.hover {
-    background-color: #6c8fc4; /* Not picked from spec */
+    background-color: #6c8fc4; /* Not picked material design from spec */
 }
 
 .flash-warn {


### PR DESCRIPTION
This still needs work, opening for easier feedback (it's hard to show hover states etc. in screenshots)

Things outstanding:

- Hover colour for select buttons is bad
- Primary buttons don't have selected/hover/select+hover colours
- Borders on the buttons look a bit weird when buttons of different states are next to each other

Also unsure whether making the Refresh icon conditionally return a different colour like I have is the best way.

![Screenshot 2019-04-02 at 4 49 01 pm](https://user-images.githubusercontent.com/1078012/55416749-4b9bb980-5567-11e9-9c8a-20e237134fa9.png)
![Screenshot 2019-04-02 at 4 49 09 pm](https://user-images.githubusercontent.com/1078012/55416750-4b9bb980-5567-11e9-97b8-a7312e574bda.png)
![Screenshot 2019-04-02 at 4 49 25 pm](https://user-images.githubusercontent.com/1078012/55416751-4c345000-5567-11e9-9885-38ebd96ae1e6.png)
