### PR TITLE
Reformat files

### DIFF
--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -343,13 +343,13 @@ void main() async {
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
             '▼[R] root ]\n'
-                '  ▼[M] MyApp\n'
-                '    ▼[M] MaterialApp\n'
-                '      ▼[S] Scaffold\n'
-                '      ├───▼[C] Center\n'
-                '      │     ▼[/icons/inspector/textArea.png] Text\n'
-                '      └─▼[A] AppBar\n'
-                '          ▼[/icons/inspector/textArea.png] Text\n',
+            '  ▼[M] MyApp\n'
+            '    ▼[M] MaterialApp\n'
+            '      ▼[S] Scaffold\n'
+            '      ├───▼[C] Center\n'
+            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      └─▼[A] AppBar\n'
+            '          ▼[/icons/inspector/textArea.png] Text\n',
           ));
 
       expect(
@@ -464,13 +464,13 @@ void main() async {
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
             '▼[R] root ]\n'
-                '  ▼[M] MyApp\n'
-                '    ▼[M] MaterialApp\n'
-                '      ▼[S] Scaffold <-- selected\n'
-                '      ├───▼[C] Center\n'
-                '      │     ▼[/icons/inspector/textArea.png] Text\n'
-                '      └─▼[A] AppBar\n'
-                '          ▼[/icons/inspector/textArea.png] Text\n',
+            '  ▼[M] MyApp\n'
+            '    ▼[M] MaterialApp\n'
+            '      ▼[S] Scaffold <-- selected\n'
+            '      ├───▼[C] Center\n'
+            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      └─▼[A] AppBar\n'
+            '          ▼[/icons/inspector/textArea.png] Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -490,13 +490,13 @@ void main() async {
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
             '▼[R] root ]\n'
-                '  ▼[M] MyApp\n'
-                '    ▼[M] MaterialApp\n'
-                '      ▼[S] Scaffold\n'
-                '      ├───▼[C] Center <-- selected\n'
-                '      │     ▼[/icons/inspector/textArea.png] Text\n'
-                '      └─▼[A] AppBar\n'
-                '          ▼[/icons/inspector/textArea.png] Text\n',
+            '  ▼[M] MyApp\n'
+            '    ▼[M] MaterialApp\n'
+            '      ▼[S] Scaffold\n'
+            '      ├───▼[C] Center <-- selected\n'
+            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      └─▼[A] AppBar\n'
+            '          ▼[/icons/inspector/textArea.png] Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -513,13 +513,13 @@ void main() async {
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
             '▼[R] root ]\n'
-                '  ▼[M] MyApp\n'
-                '    ▼[M] MaterialApp\n'
-                '      ▼[S] Scaffold <-- selected\n'
-                '      ├───▼[C] Center\n'
-                '      │     ▼[/icons/inspector/textArea.png] Text\n'
-                '      └─▼[A] AppBar\n'
-                '          ▼[/icons/inspector/textArea.png] Text\n',
+            '  ▼[M] MyApp\n'
+            '    ▼[M] MaterialApp\n'
+            '      ▼[S] Scaffold <-- selected\n'
+            '      ├───▼[C] Center\n'
+            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      └─▼[A] AppBar\n'
+            '          ▼[/icons/inspector/textArea.png] Text\n',
           ));
 
       // Verify that the details tree scrolled back as well.
@@ -552,13 +552,13 @@ void main() async {
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
             '▼[R] root ]\n'
-                '  ▼[M] MyApp\n'
-                '    ▼[M] MaterialApp\n'
-                '      ▼[S] Scaffold\n'
-                '      ├───▼[C] Center\n'
-                '      │     ▼[/icons/inspector/textArea.png] Text\n'
-                '      └─▼[A] AppBar\n'
-                '          ▼[/icons/inspector/textArea.png] Text\n',
+            '  ▼[M] MyApp\n'
+            '    ▼[M] MaterialApp\n'
+            '      ▼[S] Scaffold\n'
+            '      ├───▼[C] Center\n'
+            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      └─▼[A] AppBar\n'
+            '          ▼[/icons/inspector/textArea.png] Text\n',
           ));
 
       // TODO(jacobr): would be nice to have some tests that trigger a hot

--- a/packages/devtools/test/inspector_service_test.dart
+++ b/packages/devtools/test/inspector_service_test.dart
@@ -104,13 +104,13 @@ void main() async {
           treeToDebugString(root),
           equalsIgnoringHashCodes(
             '[root]\n'
-                ' └─MyApp\n'
-                '   └─MaterialApp\n'
-                '     └─Scaffold\n'
-                '       ├─Center\n'
-                '       │ └─Text\n'
-                '       └─AppBar\n'
-                '         └─Text\n',
+            ' └─MyApp\n'
+            '   └─MaterialApp\n'
+            '     └─Scaffold\n'
+            '       ├─Center\n'
+            '       │ └─Text\n'
+            '       └─AppBar\n'
+            '         └─Text\n',
           ),
         );
         RemoteDiagnosticsNode nodeInSummaryTree =
@@ -120,11 +120,11 @@ void main() async {
           treeToDebugString(nodeInSummaryTree),
           equalsIgnoringHashCodes(
             'MaterialApp\n'
-                ' └─Scaffold\n'
-                '   ├─Center\n'
-                '   │ └─Text\n'
-                '   └─AppBar\n'
-                '     └─Text\n',
+            ' └─Scaffold\n'
+            '   ├─Center\n'
+            '   │ └─Text\n'
+            '   └─AppBar\n'
+            '     └─Text\n',
           ),
         );
         RemoteDiagnosticsNode nodeInDetailsTree =
@@ -150,22 +150,22 @@ void main() async {
           treeToDebugString(nodeInDetailsTree),
           equalsIgnoringHashCodes(
             'Text\n'
-                ' │ data: "Hello, World!"\n'
-                ' │ textAlign: null\n'
-                ' │ textDirection: null\n'
-                ' │ locale: null\n'
-                ' │ softWrap: null\n'
-                ' │ overflow: null\n'
-                ' │ textScaleFactor: null\n'
-                ' │ maxLines: null\n'
-                ' │ dependencies: [MediaQuery, DefaultTextStyle]\n'
-                ' │\n'
-                ' └─RichText\n'
-                '     softWrap: wrapping at box width\n'
-                '     maxLines: unlimited\n'
-                '     text: "Hello, World!"\n'
-                '     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]\n'
-                '     renderObject: RenderParagraph#00000 relayoutBoundary=up2\n',
+            ' │ data: "Hello, World!"\n'
+            ' │ textAlign: null\n'
+            ' │ textDirection: null\n'
+            ' │ locale: null\n'
+            ' │ softWrap: null\n'
+            ' │ overflow: null\n'
+            ' │ textScaleFactor: null\n'
+            ' │ maxLines: null\n'
+            ' │ dependencies: [MediaQuery, DefaultTextStyle]\n'
+            ' │\n'
+            ' └─RichText\n'
+            '     softWrap: wrapping at box width\n'
+            '     maxLines: unlimited\n'
+            '     text: "Hello, World!"\n'
+            '     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]\n'
+            '     renderObject: RenderParagraph#00000 relayoutBoundary=up2\n',
           ),
         );
         expect(nodeInDetailsTree.valueRef, equals(nodeInSummaryTree.valueRef));
@@ -179,7 +179,7 @@ void main() async {
           treeToDebugString(selection),
           equalsIgnoringHashCodes(
             'Text\n'
-                ' └─RichText\n',
+            ' └─RichText\n',
           ),
         );
 
@@ -190,7 +190,7 @@ void main() async {
           treeToDebugString(selection),
           equalsIgnoringHashCodes(
             'RenderParagraph#00000 relayoutBoundary=up2\n'
-                ' └─text: TextSpan\n',
+            ' └─text: TextSpan\n',
           ),
         );
 
@@ -213,7 +213,7 @@ void main() async {
           treeToDebugString(root),
           equalsIgnoringHashCodes(
             'RenderView#00000\n'
-                ' └─child: RenderSemanticsAnnotations#00000\n',
+            ' └─child: RenderSemanticsAnnotations#00000\n',
           ),
         );
         final child = findNodeMatching(root, 'RenderSemanticsAnnotations');
@@ -223,21 +223,21 @@ void main() async {
           treeToDebugString(childDetailsSubtree),
           equalsIgnoringHashCodes(
             'child: RenderSemanticsAnnotations#00000\n'
-                ' │ parentData: <none>\n'
-                ' │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
-                ' │ size: Size(800.0, 600.0)\n'
-                ' │\n'
-                ' └─child: RenderCustomPaint#00000\n'
-                '   │ parentData: <none> (can use size)\n'
-                '   │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
-                '   │ size: Size(800.0, 600.0)\n'
-                '   │\n'
-                '   └─child: RenderPointerListener#00000\n'
-                '       parentData: <none> (can use size)\n'
-                '       constraints: BoxConstraints(w=800.0, h=600.0)\n'
-                '       size: Size(800.0, 600.0)\n'
-                '       behavior: deferToChild\n'
-                '       listeners: down, up, cancel\n',
+            ' │ parentData: <none>\n'
+            ' │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
+            ' │ size: Size(800.0, 600.0)\n'
+            ' │\n'
+            ' └─child: RenderCustomPaint#00000\n'
+            '   │ parentData: <none> (can use size)\n'
+            '   │ constraints: BoxConstraints(w=800.0, h=600.0)\n'
+            '   │ size: Size(800.0, 600.0)\n'
+            '   │\n'
+            '   └─child: RenderPointerListener#00000\n'
+            '       parentData: <none> (can use size)\n'
+            '       constraints: BoxConstraints(w=800.0, h=600.0)\n'
+            '       size: Size(800.0, 600.0)\n'
+            '       behavior: deferToChild\n'
+            '       listeners: down, up, cancel\n',
           ),
         );
 
@@ -250,7 +250,7 @@ void main() async {
           treeToDebugString(selection),
           equalsIgnoringHashCodes(
             'RenderSemanticsAnnotations#00000\n'
-                ' └─child: RenderCustomPaint#00000\n',
+            ' └─child: RenderCustomPaint#00000\n',
           ),
         );
       });

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -16,8 +16,8 @@ void main() {
   if (!browser.isChrome) {
     framework.disableAppWithError(
       'ERROR: You are running DevTools on '
-          '${browser.name == Browser.UnknownBrowser.name ? 'an unknown browswer' : browser.name}, '
-          'but DevTools only runs on Chrome.',
+      '${browser.name == Browser.UnknownBrowser.name ? 'an unknown browswer' : browser.name}, '
+      'but DevTools only runs on Chrome.',
       'Reopen this url in a Chrome broswer to use DevTools.',
     );
     return;


### PR DESCRIPTION
New version of dartfmt formats these indented strings slightly differently which is causing builds to fail (since we download newer Dart releases on CI automatically).