### PR TITLE
Support for opening scripts using a matcher to match script names to keystrokes.

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -1163,10 +1163,6 @@ class BreakpointsView implements CoreElementView {
   }
 }
 
-class NullTreeSanitizer implements html.NodeTreeSanitizer {
-  void sanitizeTree(html.Node node) {}
-}
-
 class ScriptsView implements CoreElementView {
   ScriptsView(URIDescriber uriDescriber) {
     _items = SelectableList<ScriptRef>()
@@ -1198,8 +1194,7 @@ class ScriptsView implements CoreElementView {
         // Construct the HTML with the bold tag and ensure that the HTML
         // constructed is safe from attacks e.g., XSS, etc.
         final String safeElement = html.Element.html(
-                '<div>$firstPart<strong class="strong-match">$boldPart</strong>$endPart</div>',
-                treeSanitizer: NullTreeSanitizer())
+                '<div>$firstPart<strong class="strong-match">$boldPart</strong>$endPart</div>')
             .innerHtml;
         element = li(html: safeElement, c: 'list-item');
       } else {

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -440,7 +440,7 @@ class DebuggerScreen extends Screen {
         CoreElement('input', classes: 'form-control input-sm')
           ..setAttribute('type', 'text')
           ..setAttribute('placeholder', 'script_name')
-          ..element.style.width = 'calc(100% - 90px)'
+          ..element.style.width = 'calc(100% - 95px)'
           ..element.style.marginLeft = '10px'
           ..id = 'script_name';
     final CoreElement scriptCountDiv = span(text: '-', c: 'counter');

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -520,9 +520,7 @@ class DebuggerScreen extends Screen {
                   }
                   _matcher.displayMatchingScripts(value);
               }
-            })
-            ..onCut.listen((html.ClipboardEvent e) => e.preventDefault())
-            ..onPaste.listen((html.ClipboardEvent e) => e.preventDefault()),
+            }),
           scriptCountDiv,
         ])
         ..click(() => scriptsView.element.toggleAttribute('hidden')),

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -22,8 +22,6 @@ import '../ui/split.dart' as split;
 import '../ui/ui_utils.dart';
 import '../utils.dart';
 
-import 'dart:developer';
-
 // TODO(devoncarew): improve selection behavior in the left nav area
 
 // TODO(devoncarew): have the console area be collapsible

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -1206,10 +1206,6 @@ class ScriptsView implements CoreElementView {
         element = li(text: name, c: 'list-item');
       }
 
-      if (name != uri) {
-        element.add(span(text: ' $uri', c: 'subtle'));
-      }
-
       element.tooltip = uri;
       return element;
     });

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -10,8 +10,6 @@ import 'html_icon_renderer.dart';
 import 'trees.dart';
 import 'trees_html.dart';
 
-import 'dart:developer';
-
 class ProgressElement extends CoreElement {
   ProgressElement() : super('div') {
     clazz('progress-element');
@@ -85,15 +83,15 @@ class SelectableList<T> extends CoreElement {
       final childrenElements = element.children;
       for (var i = 0; i < childrenElements.length; i++) {
         final elem = childrenElements[i];
-        if (elem.classes.contains('selected'))
-          return items[i];
+        if (elem.classes.contains('selected')) return items[i];
       }
     }
 
     return null;
   }
 
-  void setItems(List<T> items, {T selection, bool scrollSelectionIntoView = false}) {
+  void setItems(List<T> items,
+      {T selection, bool scrollSelectionIntoView = false}) {
     this.items = items;
 
     final bool hadSelection = _selectedElement != null;
@@ -162,8 +160,12 @@ class SelectableList<T> extends CoreElement {
     setItems(<T>[]);
   }
 
-  void _select(CoreElement element, T item,
-      {bool clear = false, bool clicked = false,}) {
+  void _select(
+    CoreElement element,
+    T item, {
+    bool clear = false,
+    bool clicked = false,
+  }) {
     _selectedElement?.toggleClass('selected', false);
 
     if (clear) {

--- a/packages/devtools/lib/src/ui/elements.dart
+++ b/packages/devtools/lib/src/ui/elements.dart
@@ -74,7 +74,8 @@ CoreElement td({String text, String c}) =>
 CoreElement form() => CoreElement('form');
 
 class CoreElement {
-  CoreElement(String tag, {String text, String html, String classes, String attributes})
+  CoreElement(String tag,
+      {String text, String html, String classes, String attributes})
       : element = Element.tag(tag) {
     if (text != null) {
       element.text = text;

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -29,7 +29,8 @@
     --header-item: rgba(var(--header-item-rgb), 1);
     --hint-background: lightgoldenrodyellow;
     --light-background: #ccc;
-    --light-text-color: #fff;
+    --light-text-color: #f5f5dc;
+    --match-color: #fff;
     --masthead-background: #4078c0;
     --menu-item-border: #e1e4e8;
     --row-hover-background: #f2f4fa;
@@ -629,6 +630,10 @@ nav.menu li {
     white-space: nowrap;
 }
 
+.strong-match {
+    color: var(--default-color);
+}
+
 .list-item.subtle {
     color: var(--subtle);
 }
@@ -645,6 +650,10 @@ nav.menu li {
 
 .list-item.selected .subtle {
     color: var(--light-background);
+}
+
+.list-item.selected .strong-match {
+    color: var(--match-color);
 }
 
 .tree-list {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -27,6 +27,8 @@
     --light-background: #585858;
     --masthead-background: #525050;
     --list-background: #3f3f3f;
+    --list-color: #abb2ba;
+    --match-color: #fff;
     --menu-item-border: #484541;
     --row-hover-background: #2b2d2e;
     --selected-background: #545454;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/313

Added an InputElement in the ScriptsView to help finding the name of a script to open.  This input element has a matcher to filter the script names that match the value in the input element.

Added shortcut CTRL + o  (letter o) this sets focus to the InputElement.  Any keystrokes will start matching the files and display that list in the ScriptsView lists area.  Using arrow keys (up/down), HOME, END, PAGE Up/Down, will highlight the script name. Pressing ENTER will select the script highlighted.
Pressing ESC will cancel autocomplete.

Clicking in the InputElement will also start matching.

![image](https://user-images.githubusercontent.com/2055873/55493091-2d789c80-55ed-11e9-97d3-67a3f67b538f.png)
