### PR TITLE
organize imports

### DIFF
--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -16,7 +16,6 @@ import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
 import '../utils.dart';
-
 import 'memory_chart.dart';
 import 'memory_controller.dart';
 import 'memory_detail.dart';

--- a/packages/devtools/lib/src/memory/memory_chart.dart
+++ b/packages/devtools/lib/src/memory/memory_chart.dart
@@ -6,7 +6,6 @@ import 'dart:html';
 
 import '../timeline/frames_bar_chart.dart';
 import '../ui/elements.dart';
-
 import 'memory_controller.dart';
 import 'memory_plotly.dart';
 import 'memory_protocol.dart';

--- a/packages/devtools/lib/src/memory/memory_controller.dart
+++ b/packages/devtools/lib/src/memory/memory_controller.dart
@@ -7,7 +7,6 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../globals.dart';
 import '../vm_service_wrapper.dart';
-
 import 'memory_protocol.dart';
 
 /// This class contains the business logic for [memory.dart].

--- a/packages/devtools/lib/src/memory/memory_detail.dart
+++ b/packages/devtools/lib/src/memory/memory_detail.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import '../tables.dart';
-
 import 'memory_protocol.dart';
 
 class MemoryRow {

--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -8,7 +8,6 @@ import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/plotly.dart';
 import '../ui/theme.dart';
-
 import 'memory_chart.dart';
 
 class MemoryPlotly {

--- a/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 import 'dart:async';
 import 'dart:math' as math;
+
 import '../ui/drag_scroll.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import 'cpu_profile_protocol.dart';

--- a/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
@@ -27,7 +27,7 @@ export 'dart_ui/dart_ui.dart' hide TextStyle;
 
 part 'assertions.dart';
 part 'diagnosticable.dart';
-part 'text.dart';
-part 'text_span.dart';
 part 'foundation.dart';
 part 'print.dart';
+part 'text.dart';
+part 'text_span.dart';

--- a/packages/devtools/lib/src/ui/material_icons.dart
+++ b/packages/devtools/lib/src/ui/material_icons.dart
@@ -5,7 +5,6 @@
 library material_icons;
 
 import 'fake_flutter/fake_flutter.dart';
-
 import 'icons.dart';
 import 'theme.dart';
 

--- a/packages/devtools/test/matchers/fake_flutter_matchers.dart
+++ b/packages/devtools/test/matchers/fake_flutter_matchers.dart
@@ -8,9 +8,8 @@ library fake_flutter_matchers;
 
 import 'dart:math' as math;
 
-import 'package:meta/meta.dart';
-
 import 'package:devtools/src/ui/fake_flutter/fake_flutter.dart';
+import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 
 /// Asserts that an object's toString() is a plausible one-line description.

--- a/packages/devtools/test/memory_service_test.dart
+++ b/packages/devtools/test/memory_service_test.dart
@@ -5,7 +5,6 @@
 @TestOn('vm')
 import 'package:devtools/src/memory/memory_controller.dart';
 import 'package:devtools/src/memory/memory_protocol.dart';
-
 import 'package:test/test.dart';
 
 import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;

--- a/packages/devtools/test/ui/theme_test.dart
+++ b/packages/devtools/test/ui/theme_test.dart
@@ -2,11 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
-
-import 'package:devtools/src/ui/theme.dart';
 import 'package:devtools/src/ui/fake_flutter/fake_flutter.dart';
 import 'package:devtools/src/ui/flutter_html_shim.dart';
+import 'package:devtools/src/ui/theme.dart';
+import 'package:test/test.dart';
 
 void main() {
   const Color customLight = Color.fromARGB(200, 202, 191, 69);


### PR DESCRIPTION
- sort directives in `lib/` and `test/` using the analysis server functionality

(I don't understand why the `directives_ordering` lint isn't firing here...)
