### PR TITLE
Remove obsolete code handling of file scheme for importUri.

### DIFF
--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -683,6 +683,13 @@ class InspectorSourceLocation {
 
   String get path => JsonUtils.getStringMember(json, 'file');
 
+  String getFile() {
+    final fileName = path;
+    if (fileName == null) {
+      return parent != null ? parent.getFile() : null;
+    }
+  }
+
   int getLine() => JsonUtils.getIntMember(json, 'line');
 
   String getName() => JsonUtils.getStringMember(json, 'name');
@@ -690,7 +697,8 @@ class InspectorSourceLocation {
   int getColumn() => JsonUtils.getIntMember(json, 'column');
 
   SourcePosition getXSourcePosition() {
-    if (path == null) {
+    final file = getFile();
+    if (file == null) {
       return null;
     }
     final int line = getLine();
@@ -698,7 +706,7 @@ class InspectorSourceLocation {
     if (line < 0 || column < 0) {
       return null;
     }
-    return SourcePosition(file: path, line: line - 1, column: column - 1);
+    return SourcePosition(file: file, line: line - 1, column: column - 1);
   }
 
   List<InspectorSourceLocation> getParameterLocations() {

--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -683,21 +683,6 @@ class InspectorSourceLocation {
 
   String get path => JsonUtils.getStringMember(json, 'file');
 
-  String getFile() {
-    final fileName = path;
-    if (fileName == null) {
-      return parent != null ? parent.getFile() : null;
-    }
-
-    // We have to strip the file:// or file:/// prefix depending on the
-    // operating system to convert from paths stored as URIs to local operating
-    // system paths.
-    // TODO(jacobr): remove this workaround after the code in package:flutter
-    // is fixed to return operating system paths instead of URIs.
-    // https://github.com/flutter/flutter-intellij/issues/2217
-    return fromSourceLocationUri(fileName);
-  }
-
   int getLine() => JsonUtils.getIntMember(json, 'line');
 
   String getName() => JsonUtils.getStringMember(json, 'name');
@@ -705,8 +690,7 @@ class InspectorSourceLocation {
   int getColumn() => JsonUtils.getIntMember(json, 'column');
 
   SourcePosition getXSourcePosition() {
-    final file = getFile();
-    if (file == null) {
+    if (path == null) {
       return null;
     }
     final int line = getLine();
@@ -714,7 +698,7 @@ class InspectorSourceLocation {
     if (line < 0 || column < 0) {
       return null;
     }
-    return SourcePosition(file: file, line: line - 1, column: column - 1);
+    return SourcePosition(file: path, line: line - 1, column: column - 1);
   }
 
   List<InspectorSourceLocation> getParameterLocations() {

--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -688,6 +688,8 @@ class InspectorSourceLocation {
     if (fileName == null) {
       return parent != null ? parent.getFile() : null;
     }
+
+    return fileName;
   }
 
   int getLine() => JsonUtils.getIntMember(json, 'line');

--- a/packages/devtools/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools/lib/src/inspector/inspector_service.dart
@@ -865,27 +865,6 @@ class ObjectGroup {
   }
 }
 
-// TODO(jacobr): can we get the host OS from VMService.
-// Ideally we don't need this.
-String getFileUriPrefix() {
-  // if (SystemInfo.isWindows) return 'file:///';
-  return 'file://';
-}
-
-// TODO(jacobr): remove this method as soon as the
-// track-widget-creation kernel transformer is fixed to return paths instead
-// of URIs.
-String toSourceLocationUri(String path) {
-  return getFileUriPrefix() + path;
-}
-
-String fromSourceLocationUri(String path) {
-  final String filePrefix = getFileUriPrefix();
-  return (path.startsWith(filePrefix))
-      ? path.substring(filePrefix.length)
-      : path;
-}
-
 enum FlutterTreeType {
   widget, // ('Widget'),
   renderObject // ('Render');


### PR DESCRIPTION
Fixes https://github.com/flutter/flutter/issues/26615
Requires Flutter Dev Release 1.4.12 or newer that has the VM change.