### PR TITLE
Canvas optimization for TimelineGrid.

### DIFF
--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -529,8 +529,6 @@ class TimelineGrid {
 
   num _zoomLevel = 1;
 
-  final Map<String, num> _timestampMeasurements = {};
-
   void paint(CanvasRenderingContext2D canvas, Rect viewport, Rect visible) {
     // Draw the background for the section that will contain the timestamps.
     // This section will be sticky to the top of the viewport.
@@ -612,9 +610,10 @@ class TimelineGrid {
     num width,
     CanvasRenderingContext2D canvas,
   ) {
-    final textWidth = _timestampMeasurements[timestampText] ??=
-        canvas.measureText(timestampText).width;
-    return left + width - textWidth - timestampOffsetX;
+    return left +
+        width -
+        canvas.measureText(timestampText).width -
+        timestampOffsetX;
   }
 
   /// Returns the timestamp rounded to the nearest microsecond for the

--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -529,6 +529,8 @@ class TimelineGrid {
 
   num _zoomLevel = 1;
 
+  final Map<String, num> _timestampMeasurements = {};
+
   void paint(CanvasRenderingContext2D canvas, Rect viewport, Rect visible) {
     // Draw the background for the section that will contain the timestamps.
     // This section will be sticky to the top of the viewport.
@@ -610,10 +612,9 @@ class TimelineGrid {
     num width,
     CanvasRenderingContext2D canvas,
   ) {
-    return left +
-        width -
-        canvas.measureText(timestampText).width -
-        timestampOffsetX;
+    final textWidth = _timestampMeasurements[timestampText] ??=
+        canvas.measureText(timestampText).width;
+    return left + width - textWidth - timestampOffsetX;
   }
 
   /// Returns the timestamp rounded to the nearest microsecond for the


### PR DESCRIPTION
- Group similar paints to avoid switching canvas style
- Remove TimelineGridNode class and merge functionality into TimelineGrid
- Fix small bug causing index OOB exception when flame graph node is very small.