### PR TITLE
Add checkbox to collapse Native samples in Cpu Profile.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -36,9 +36,16 @@ class CpuProfileData {
 
   void _processStackFrames(Response response) {
     stackFramesJson.forEach((k, v) {
-      final stackFrame = CpuStackFrame(k, v['name'], v['category']);
-      final parent = stackFrames[v['parent']];
-      _processStackFrame(stackFrame, parent);
+      final String stackFrameName = v['name'];
+
+      // Do not process [Native] events. They do not provide any helpful
+      // profiling information to the user, and they distract from the important
+      // samples in the CPU flame chart.
+      if (!stackFrameName.startsWith('[Native]')) {
+        final stackFrame = CpuStackFrame(k, stackFrameName, v['category']);
+        final parent = stackFrames[v['parent']];
+        _processStackFrame(stackFrame, parent);
+      }
     });
   }
 

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -7,11 +7,6 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 import '../utils.dart';
 
-// TODO(kenzie): make this a user-toggle. If this is enabled, we should add a
-// top level stack frame called "[Native]" to parent all [Native] stack frames.
-/// Toggle this flag to include native samples in the CPU profile.
-bool includeNativeSamples = false;
-
 // TODO(kenzie): talk to VM team about why timeExtentMicros is different between
 // debug and profile builds. Do they use different clocks and does this also
 // affect the sampling rate? See https://github.com/dart-lang/sdk/issues/36583.

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -131,17 +131,6 @@ class CpuStackFrame {
     return root;
   }
 
-  bool hasAncestorWithId(String id) {
-    CpuStackFrame currentStackFrame = this;
-    while (currentStackFrame.parent != null) {
-      currentStackFrame = currentStackFrame.parent;
-      if (currentStackFrame.id == id) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   /// Returns the number of cpu samples this stack frame is a part of.
   ///
   /// This will be equal to the number of leaf nodes in this stack frame.

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -7,6 +7,11 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 import '../utils.dart';
 
+// TODO(kenzie): make this a user-toggle. If this is enabled, we should add a
+// top level stack frame called "[Native]" to parent all [Native] stack frames.
+/// Toggle this flag to include native samples in the CPU profile.
+bool includeNativeSamples = false;
+
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse)
       : sampleCount = cpuProfileResponse.json['sampleCount'],
@@ -41,7 +46,7 @@ class CpuProfileData {
       // Do not process [Native] events. They do not provide any helpful
       // profiling information to the user, and they distract from the important
       // samples in the CPU flame chart.
-      if (!stackFrameName.startsWith('[Native]')) {
+      if (includeNativeSamples || !stackFrameName.startsWith('[Native]')) {
         final stackFrame = CpuStackFrame(k, stackFrameName, v['category']);
         final parent = stackFrames[v['parent']];
         _processStackFrame(stackFrame, parent);

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -20,8 +20,6 @@ class CpuProfileData {
     _processStackFrames(cpuProfileResponse);
   }
 
-  static const nativeRootId = 'nativeRoot';
-
   final Response cpuProfileResponse;
   final Duration duration;
   final int sampleCount;
@@ -40,7 +38,7 @@ class CpuProfileData {
   Map<String, CpuStackFrame> stackFrames = {};
 
   void _processStackFrames(Response response) {
-    final nativeRoot = CpuStackFrame(nativeRootId, '[Native]', 'Dart');
+    final nativeRoot = CpuStackFrame('nativeRoot', '[Native]', 'Dart');
 
     stackFramesJson.forEach((k, v) {
       final String stackFrameName = v['name'];
@@ -52,6 +50,7 @@ class CpuProfileData {
       // once we get file paths in the stack frame json.
       if (stackFrameName.startsWith('[Native]')) {
         parent ??= nativeRoot;
+        stackFrame.isNative = true;
       }
 
       _processStackFrame(stackFrame, parent);
@@ -89,6 +88,8 @@ class CpuStackFrame {
   int index = -1;
 
   bool get isLeaf => children.isEmpty;
+
+  bool isNative = false;
 
   /// Depth of this CpuStackFrame tree, including [this].
   ///

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -1,6 +1,9 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:async';
+import 'dart:html' as html;
+
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../globals.dart';
@@ -17,15 +20,48 @@ import 'flame_chart_canvas.dart';
 import 'frame_flame_chart.dart';
 import 'timeline_protocol.dart';
 
+final _hideNativeSamplesController = StreamController<bool>.broadcast();
+
+Stream<bool> get onHideNativeSamplesEvent =>
+    _hideNativeSamplesController.stream;
+
 class EventDetails extends CoreElement {
   EventDetails() : super('div') {
     flex();
     layoutVertical();
 
+    _initContent();
+
+    assert(tabNav != null);
+    assert(content != null);
+
+    add([tabNav, content]);
+  }
+
+  static const defaultTitleText = '[No event selected]';
+  static const defaultTitleBackground = Color(0xFFF6F6F6);
+
+  PTabNav tabNav;
+  CoreElement content;
+  CoreElement hideNativeCheckbox;
+
+  TimelineEvent _event;
+  CoreElement _title;
+  _Details _details;
+
+  void _initContent() {
     _title = div(text: defaultTitleText, c: 'event-details-heading')
       ..element.style.backgroundColor = colorToCss(defaultTitleBackground);
     _details = _Details()..attribute('hidden');
 
+    content = div(c: 'event-details-section section-border')
+      ..flex()
+      ..add(<CoreElement>[_title, _details]);
+
+    _initTabNav();
+  }
+
+  void _initTabNav() {
     final flameChartTab = EventDetailsTabNavTab(
       'CPU Flame Chart',
       EventDetailsTabType.flameChart,
@@ -61,22 +97,27 @@ class EventDetails extends CoreElement {
       }
     });
 
-    content = div(c: 'event-details-section section-border')..flex();
-    content.add(<CoreElement>[_title, _details]);
+    // Add hide native checkbox to tab nav.
+    hideNativeCheckbox = CoreElement('input', classes: 'hide-native-checkbox')
+      ..setAttribute('type', 'checkbox');
 
-    add(tabNav);
-    add(content);
+    final html.InputElement checkbox = hideNativeCheckbox.element;
+    checkbox
+      ..checked = true
+      ..onChange
+          .listen((_) => _hideNativeSamplesController.add(checkbox.checked));
+
+    // Add checkbox and label to tab bar.
+    tabNav.element.children.first.children.addAll([
+      (div(c: 'hide-native-container')
+            ..flex()
+            ..add([
+              hideNativeCheckbox,
+              CoreElement('div', text: 'Hide native samples')
+            ]))
+          .element,
+    ]);
   }
-
-  static const defaultTitleText = '[No event selected]';
-  static const defaultTitleBackground = Color(0xFFF6F6F6);
-
-  PTabNav tabNav;
-  CoreElement content;
-
-  TimelineEvent _event;
-  CoreElement _title;
-  _Details _details;
 
   Future<void> update(FrameFlameChartItem item) async {
     _event = item.event;
@@ -254,6 +295,8 @@ class _UiEventDetails extends CoreElement {
     add(spinner);
 
     try {
+      // TODO(kenzie): add a timeout here so we don't appear to have an
+      // infinite spinner.
       await _drawFlameChart();
     } catch (e) {
       _updateFlameChartForError(div(

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -20,10 +20,10 @@ import 'flame_chart_canvas.dart';
 import 'frame_flame_chart.dart';
 import 'timeline_protocol.dart';
 
-final _hideNativeSamplesController = StreamController<bool>.broadcast();
+final _collapseNativeSamplesController = StreamController<bool>.broadcast();
 
-Stream<bool> get onHideNativeSamplesEvent =>
-    _hideNativeSamplesController.stream;
+Stream<bool> get onCollapseNativeSamplesEvent =>
+    _collapseNativeSamplesController.stream;
 
 class EventDetails extends CoreElement {
   EventDetails() : super('div') {
@@ -98,22 +98,23 @@ class EventDetails extends CoreElement {
     });
 
     // Add hide native checkbox to tab nav.
-    hideNativeCheckbox = CoreElement('input', classes: 'hide-native-checkbox')
-      ..setAttribute('type', 'checkbox');
+    hideNativeCheckbox =
+        CoreElement('input', classes: 'collapse-native-checkbox')
+          ..setAttribute('type', 'checkbox');
 
     final html.InputElement checkbox = hideNativeCheckbox.element;
     checkbox
       ..checked = true
-      ..onChange
-          .listen((_) => _hideNativeSamplesController.add(checkbox.checked));
+      ..onChange.listen(
+          (_) => _collapseNativeSamplesController.add(checkbox.checked));
 
     // Add checkbox and label to tab bar.
     tabNav.element.children.first.children.addAll([
-      (div(c: 'hide-native-container')
+      (div(c: 'collapse-native-container')
             ..flex()
             ..add([
               hideNativeCheckbox,
-              CoreElement('div', text: 'Hide native samples')
+              CoreElement('div', text: 'Collapse native samples')
             ]))
           .element,
     ]);

--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -69,7 +69,7 @@ abstract class FlameChart {
 
   FlameChartNode selectedNode;
 
-  bool shouldHideNativeSamples = true;
+  bool shouldCollapseNativeSamples = true;
 
   List<FlameChartRow> rows = [];
 
@@ -244,8 +244,8 @@ class FlameChartCanvas extends FlameChart {
 
     _viewportCanvas.element.element.onMouseWheel.listen(_handleMouseWheel);
 
-    onHideNativeSamplesEvent.listen((shouldHide) {
-      shouldHideNativeSamples = shouldHide;
+    onCollapseNativeSamplesEvent.listen((shouldCollapse) {
+      shouldCollapseNativeSamples = shouldCollapse;
       _viewportCanvas.rebuild(force: true);
     });
   }
@@ -294,9 +294,8 @@ class FlameChartCanvas extends FlameChart {
       if (node.rect.left + node.rect.width < visible.left) continue;
       if (node.rect.left > visible.right) break;
 
-      // Do not paint native frames if 'Hide native samples' is checked.
-      if (shouldHideNativeSamples &&
-          node.stackFrame.hasAncestorWithId(CpuProfileData.nativeRootId)) {
+      // Do not paint native frames if 'Collapse native samples' is checked.
+      if (shouldCollapseNativeSamples && node.stackFrame.isNative) {
         continue;
       }
 

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -176,13 +176,13 @@
     display: flex;
 }
 
-.hide-native-container {
+.collapse-native-container {
     display: flex;
     justify-content: flex-end;
     align-items: center;
 }
 
-.hide-native-checkbox {
+.collapse-native-checkbox {
     margin-left: 4px;
     margin-right: 4px;
 }

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -172,6 +172,21 @@
     height: calc(100% - 27px);
 }
 
+.tabnav-tabs {
+    display: flex;
+}
+
+.hide-native-container {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+}
+
+.hide-native-checkbox {
+    margin-left: 4px;
+    margin-right: 4px;
+}
+
 .ui-details-section {
     position: absolute;
     top: 0;

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -58,6 +58,13 @@ void main() {
         equals(testStackFrame.toStringDeep()),
       );
     });
+
+    test('hasAncestorWithId', () {
+      expect(stackFrame_1.hasAncestorWithId('id_0'), isTrue);
+      expect(stackFrame_5.hasAncestorWithId('id_0'), isTrue);
+      expect(stackFrame_5.hasAncestorWithId('id_3'), isTrue);
+      expect(stackFrame_2.hasAncestorWithId('id_3'), isFalse);
+    });
   });
 }
 

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -58,13 +58,6 @@ void main() {
         equals(testStackFrame.toStringDeep()),
       );
     });
-
-    test('hasAncestorWithId', () {
-      expect(stackFrame_1.hasAncestorWithId('id_0'), isTrue);
-      expect(stackFrame_5.hasAncestorWithId('id_0'), isTrue);
-      expect(stackFrame_5.hasAncestorWithId('id_3'), isTrue);
-      expect(stackFrame_2.hasAncestorWithId('id_3'), isFalse);
-    });
   });
 }
 


### PR DESCRIPTION
Checkbox is checked by default. These events do not provide helpful profiling information for the average user, and they distract from the important samples in the CPU flame chart.

![hideNativeFrames](https://user-images.githubusercontent.com/43759233/56056916-66fa8780-5d12-11e9-81b1-0291d05de24e.gif)