### PR TITLE
Use event duration for cpu profile timeline.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -7,6 +7,10 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 import '../utils.dart';
 
+// TODO(kenzie): talk to VM team about why timeExtentMicros is different between
+// debug and profile builds. Do they use different clocks and does this also
+// affect the sampling rate?
+
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse, this.duration)
       : sampleCount = cpuProfileResponse.json['sampleCount'],

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -9,7 +9,7 @@ import '../utils.dart';
 
 // TODO(kenzie): talk to VM team about why timeExtentMicros is different between
 // debug and profile builds. Do they use different clocks and does this also
-// affect the sampling rate?
+// affect the sampling rate? See https://github.com/dart-lang/sdk/issues/36583.
 
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse, this.duration)

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -8,19 +8,18 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 import '../utils.dart';
 
 class CpuProfileData {
-  CpuProfileData(this.cpuProfileResponse)
+  CpuProfileData(this.cpuProfileResponse, this.duration)
       : sampleCount = cpuProfileResponse.json['sampleCount'],
         samplePeriod = cpuProfileResponse.json['samplePeriod'],
-        timeExtentMicros = cpuProfileResponse.json['timeExtentMicros'],
         stackFramesJson = cpuProfileResponse.json['stackFrames'],
         stackTraceEvents = cpuProfileResponse.json['traceEvents'] {
     _processStackFrames(cpuProfileResponse);
   }
 
   final Response cpuProfileResponse;
+  final Duration duration;
   final int sampleCount;
   final int samplePeriod;
-  final int timeExtentMicros;
   final Map<String, dynamic> stackFramesJson;
 
   /// Trace events associated with the last stackFrame in each sample (i.e. the
@@ -30,7 +29,7 @@ class CpuProfileData {
   /// stack frame.
   final List<dynamic> stackTraceEvents;
 
-  var cpuProfileRoot = CpuStackFrame('cpuProfile', 'all', 'Dart');
+  final cpuProfileRoot = CpuStackFrame('cpuProfile', 'all', 'Dart');
 
   Map<String, CpuStackFrame> stackFrames = {};
 

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -208,7 +208,10 @@ class _UiEventDetails extends CoreElement {
       event.duration,
     );
 
-    cpuProfileData = CpuProfileData(response);
+    cpuProfileData = CpuProfileData(
+      response,
+      Duration(microseconds: event.duration),
+    );
 
     if (cpuProfileData.stackFrames.isEmpty) {
       _updateFlameChartForError(div(

--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -50,7 +50,7 @@ abstract class FlameChart {
     @required this.data,
     @required this.flameChartWidth,
     @required this.flameChartHeight,
-  }) : timelineGrid = TimelineGrid(data.timeExtentMicros, flameChartWidth) {
+  }) : timelineGrid = TimelineGrid(data.duration, flameChartWidth) {
     _initRows();
   }
 
@@ -520,8 +520,7 @@ class TimelineGrid {
     Color(0xFFFAFBFC),
   );
 
-  /// Frame duration in micros.
-  final num _duration;
+  final Duration _duration;
 
   num currentInterval = baseGridIntervalPx;
 
@@ -619,7 +618,9 @@ class TimelineGrid {
   /// Returns the timestamp rounded to the nearest microsecond for the
   /// x-position.
   int getTimestampForPosition(num gridItemEnd) {
-    return ((gridItemEnd - _flameChartInset) / _flameChartWidth * _duration)
+    return ((gridItemEnd - _flameChartInset) /
+            _flameChartWidth *
+            _duration.inMicroseconds)
         .round();
   }
 

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -9,7 +9,7 @@ void main() {
   CpuProfileData cpuProfileData;
 
   setUp(() {
-    cpuProfileData = CpuProfileData(sampleResponse);
+    cpuProfileData = CpuProfileData(sampleResponse, Duration(milliseconds: 10));
   });
 
   group('CpuProfileData', () {

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -9,7 +9,10 @@ void main() {
   CpuProfileData cpuProfileData;
 
   setUp(() {
-    cpuProfileData = CpuProfileData(sampleResponse, Duration(milliseconds: 10));
+    cpuProfileData = CpuProfileData(
+      sampleResponse,
+      const Duration(milliseconds: 10), // 10 is arbitrary.
+    );
   });
 
   group('CpuProfileData', () {


### PR DESCRIPTION
 'timeExtentMicros' in the response json is inconsistent between debug and profile builds, so we should not depend on it.

Added a todo to get to the bottom of this.