### PR TITLE
Bug fix and some clean up in timeline_protocol

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -81,8 +81,7 @@ class EventDetails extends CoreElement {
   Future<void> update(FrameFlameChartItem item) async {
     _event = item.event;
 
-    _title.text =
-        '${_event.name} - ${msText(_event.timeRange.duration)}';
+    _title.text = '${_event.name} - ${msText(_event.timeRange.duration)}';
     _title.element.style
       ..backgroundColor = colorToCss(item.backgroundColor)
       ..color = colorToCss(_event.isGpuEvent ? Colors.white : Colors.black);

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -81,7 +81,7 @@ class EventDetails extends CoreElement {
   Future<void> update(FrameFlameChartItem item) async {
     _event = item.event;
 
-    _title.text = '${_event.name} - ${msText(_event.timeRange.duration)}';
+    _title.text = '${_event.name} - ${msText(_event.time.duration)}';
     _title.element.style
       ..backgroundColor = colorToCss(item.backgroundColor)
       ..color = colorToCss(_event.isGpuEvent ? Colors.white : Colors.black);
@@ -203,19 +203,20 @@ class _UiEventDetails extends CoreElement {
     final Response response =
         await serviceManager.service.getCpuProfileTimeline(
       serviceManager.isolateManager.selectedIsolate.id,
-      event.startTime,
-      event.timeRange.duration.inMicroseconds,
+      event.time.start.inMicroseconds,
+      event.time.duration.inMicroseconds,
     );
 
     cpuProfileData = CpuProfileData(
       response,
-      event.timeRange.duration,
+      event.time.duration,
     );
 
     if (cpuProfileData.stackFrames.isEmpty) {
       _updateFlameChartForError(div(
         text: 'CPU profile unavailable for time range'
-            ' [${event.startTime} - ${event.endTime}]',
+            ' [${event.time.start.inMicroseconds} - '
+            '${event.time.end.inMicroseconds}]',
         c: 'message',
       ));
       return;

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -82,7 +82,7 @@ class EventDetails extends CoreElement {
     _event = item.event;
 
     _title.text =
-        '${_event.name} - ${msText(Duration(microseconds: _event.duration))}';
+        '${_event.name} - ${msText(_event.timeRange.duration)}';
     _title.element.style
       ..backgroundColor = colorToCss(item.backgroundColor)
       ..color = colorToCss(_event.isGpuEvent ? Colors.white : Colors.black);
@@ -205,12 +205,12 @@ class _UiEventDetails extends CoreElement {
         await serviceManager.service.getCpuProfileTimeline(
       serviceManager.isolateManager.selectedIsolate.id,
       event.startTime,
-      event.duration,
+      event.timeRange.duration.inMicroseconds,
     );
 
     cpuProfileData = CpuProfileData(
       response,
-      Duration(microseconds: event.duration),
+      event.timeRange.duration,
     );
 
     if (cpuProfileData.stackFrames.isEmpty) {

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -92,9 +92,9 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
     /// Subtract 2 * [sectionLabelOffset] to account for extra space at the
     /// beginning/end of the chart.
     final double pxPerMicro = (element.clientWidth - 2 * flameChartInset) /
-        frame.timeRange.duration.inMicroseconds;
+        frame.time.duration.inMicroseconds;
 
-    final int frameStartOffset = frame.timeRange.start.inMicroseconds;
+    final int frameStartOffset = frame.time.start.inMicroseconds;
     final uiSectionHeight =
         frame.uiEventFlow.depth * FlameChart.rowHeight + sectionSpacing;
     final gpuSectionHeight = frame.gpuEventFlow.depth * FlameChart.rowHeight;
@@ -110,8 +110,10 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
       // Do not round these values. Rounding the left could cause us to have
       // inaccurately placed events on the chart. Rounding the width could cause
       // us to lose very small events if the width rounds to zero.
-      final double startPx = (event.startTime - frameStartOffset) * pxPerMicro;
-      final double endPx = (event.endTime - frameStartOffset) * pxPerMicro;
+      final double startPx =
+          (event.time.start.inMicroseconds - frameStartOffset) * pxPerMicro;
+      final double endPx =
+          (event.time.end.inMicroseconds - frameStartOffset) * pxPerMicro;
 
       _drawFlameChartItem(
         event,
@@ -183,7 +185,7 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
 
     void drawTimelineGrid() {
       _timelineGrid = TimelineGrid(
-        frame.timeRange.duration,
+        frame.time.duration,
         getFlameChartWidth(),
       );
       _timelineGrid.element.style.height = '${flameChartHeight}px';
@@ -272,7 +274,7 @@ class FrameFlameChartItem extends FlameChartItem {
 
   @override
   void setText() {
-    final durationText = msText(event.timeRange.duration);
+    final durationText = msText(event.time.duration);
 
     String title = _event.name;
     element.title = '$title ($durationText)';

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -91,10 +91,10 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
     ///
     /// Subtract 2 * [sectionLabelOffset] to account for extra space at the
     /// beginning/end of the chart.
-    final double pxPerMicro =
-        (element.clientWidth - 2 * flameChartInset) / frame.duration;
+    final double pxPerMicro = (element.clientWidth - 2 * flameChartInset) /
+        frame.timeRange.duration.inMicroseconds;
 
-    final int frameStartOffset = frame.startTime;
+    final int frameStartOffset = frame.timeRange.start.inMicroseconds;
     final uiSectionHeight =
         frame.uiEventFlow.depth * FlameChart.rowHeight + sectionSpacing;
     final gpuSectionHeight = frame.gpuEventFlow.depth * FlameChart.rowHeight;
@@ -182,7 +182,10 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
     }
 
     void drawTimelineGrid() {
-      _timelineGrid = TimelineGrid(frame.duration, getFlameChartWidth());
+      _timelineGrid = TimelineGrid(
+        frame.timeRange.duration,
+        getFlameChartWidth(),
+      );
       _timelineGrid.element.style.height = '${flameChartHeight}px';
       add(_timelineGrid);
     }
@@ -269,7 +272,7 @@ class FrameFlameChartItem extends FlameChartItem {
 
   @override
   void setText() {
-    final durationText = msText(Duration(microseconds: _event.duration));
+    final durationText = msText(event.timeRange.duration);
 
     String title = _event.name;
     element.title = '$title ($durationText)';
@@ -302,8 +305,7 @@ class TimelineGrid extends CoreElement {
 
   static const baseGridInterval = 150;
 
-  /// Frame duration in micros.
-  final num _frameDuration;
+  final Duration _frameDuration;
 
   num _zoomLevel = 1;
 
@@ -343,7 +345,7 @@ class TimelineGrid extends CoreElement {
   int getTimestampForPosition(num gridItemEnd) {
     return ((gridItemEnd - _flameChartInset) /
             _flameChartWidth *
-            _frameDuration)
+            _frameDuration.inMicroseconds)
         .round();
   }
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -665,10 +665,9 @@ class TimelineFrame {
 class TimelineEvent {
   TimelineEvent(TraceEventWrapper firstTraceEvent)
       : traceEvents = [firstTraceEvent],
-        type = firstTraceEvent.event.type,
-        time = TimeRange()
-          ..start =
-              Duration(microseconds: firstTraceEvent.event.timestampMicros);
+        type = firstTraceEvent.event.type {
+    time.start = Duration(microseconds: firstTraceEvent.event.timestampMicros);
+  }
 
   /// Trace events associated with this [TimelineEvent].
   ///
@@ -680,7 +679,7 @@ class TimelineEvent {
   @visibleForTesting
   TimelineEventType type;
 
-  final TimeRange time;
+  TimeRange time = TimeRange();
 
   TimelineEvent parent;
 

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -8,7 +8,6 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:intl/intl.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 bool collectionEquals(e1, e2) => const DeepCollectionEquality().equals(e1, e2);

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -321,3 +321,35 @@ class RateLimiter {
     _activeTimer?.cancel();
   }
 }
+
+// If the need arises, this enum can be expanded to include any of the remaining
+// time units supported by [Duration] - (milliseconds, seconds, etc.). If you
+// add a unit of time to this enum, modify the toString() method in [TimeRange]
+// to handle the new case.
+enum TimeUnit {
+  microseconds,
+  milliseconds,
+}
+
+class TimeRange {
+  TimeRange({this.unit = TimeUnit.microseconds, this.start, this.end});
+
+  final TimeUnit unit;
+
+  Duration start;
+  Duration end;
+
+  Duration get duration =>
+      Duration(microseconds: end.inMicroseconds - start.inMicroseconds);
+
+  @override
+  String toString() {
+    switch (unit) {
+      case TimeUnit.microseconds:
+        return '[${start.inMicroseconds} - ${end.inMicroseconds}]';
+      case TimeUnit.milliseconds:
+      default:
+        return '[${start.inMilliseconds} - ${end.inMilliseconds}]';
+    }
+  }
+}

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:vm_service_lib/vm_service_lib.dart';
 
@@ -322,34 +323,47 @@ class RateLimiter {
   }
 }
 
-// If the need arises, this enum can be expanded to include any of the remaining
-// time units supported by [Duration] - (milliseconds, seconds, etc.). If you
-// add a unit of time to this enum, modify the toString() method in [TimeRange]
-// to handle the new case.
+/// Time unit for displaying time ranges.
+///
+/// If the need arises, this enum can be expanded to include any of the
+/// remaining time units supported by [Duration] - (seconds, minutes, etc.). If
+/// you add a unit of time to this enum, modify the toString() method in
+/// [TimeRange] to handle the new case.
 enum TimeUnit {
   microseconds,
   milliseconds,
 }
 
 class TimeRange {
-  TimeRange({this.unit = TimeUnit.microseconds, this.start, this.end});
+  Duration get start => _start;
 
-  final TimeUnit unit;
+  Duration _start;
 
-  Duration start;
-  Duration end;
+  set start(Duration value) {
+    assert(_start == null);
+    _start = value;
+  }
 
-  Duration get duration =>
-      Duration(microseconds: end.inMicroseconds - start.inMicroseconds);
+  Duration get end => _end;
+
+  Duration _end;
+
+  set end(Duration value) {
+    assert(_end == null);
+    _end = value;
+  }
+
+  Duration get duration => end - start;
 
   @override
-  String toString() {
+  String toString({TimeUnit unit}) {
+    unit ??= TimeUnit.microseconds;
     switch (unit) {
       case TimeUnit.microseconds:
-        return '[${start.inMicroseconds} - ${end.inMicroseconds}]';
+        return '[${_start.inMicroseconds} μs - ${end.inMicroseconds} μs]';
       case TimeUnit.milliseconds:
       default:
-        return '[${start.inMilliseconds} - ${end.inMilliseconds}]';
+        return '[${_start.inMilliseconds} ms - ${end.inMilliseconds} ms]';
     }
   }
 }

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -96,54 +96,54 @@ void main() {
       const frameStartTime = 2000;
       const frameEndTime = 8000;
       final frame = TimelineFrame('frameId')
-        ..pipelineItemStartTime = frameStartTime
-        ..pipelineItemEndTime = frameEndTime;
+        ..pipelineItemTime.start = const Duration(microseconds: frameStartTime)
+        ..pipelineItemTime.end = const Duration(microseconds: frameEndTime);
 
       final event = goldenUiTimelineEvent.deepCopy()
-        ..timeRange.start = const Duration(microseconds: frameStartTime)
-        ..timeRange.end = const Duration(microseconds: 5000);
+        ..time.start = const Duration(microseconds: frameStartTime)
+        ..time.end = const Duration(microseconds: 5000);
 
       // Event fits within frame timestamps.
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event fits within epsilon of frame start.
-      event.timeRange.start = Duration(
+      event.time.start = Duration(
           microseconds: frameStartTime - traceEventEpsilon.inMicroseconds);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event does not fit within epsilon of frame start.
-      event.timeRange.start = Duration(
+      event.time.start = Duration(
           microseconds: frameStartTime - traceEventEpsilon.inMicroseconds - 1);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Event with small duration uses smaller epsilon.
       event
-        ..timeRange.start = const Duration(microseconds: frameStartTime - 100)
-        ..timeRange.end = const Duration(microseconds: frameStartTime + 100);
+        ..time.start = const Duration(microseconds: frameStartTime - 100)
+        ..time.end = const Duration(microseconds: frameStartTime + 100);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       event
-        ..timeRange.start = const Duration(microseconds: frameStartTime - 101)
-        ..timeRange.end = const Duration(microseconds: frameStartTime + 100);
+        ..time.start = const Duration(microseconds: frameStartTime - 101)
+        ..time.end = const Duration(microseconds: frameStartTime + 100);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Event fits within epsilon of frame end.
-      event.timeRange.end = Duration(
+      event.time.end = Duration(
           microseconds: frameEndTime + traceEventEpsilon.inMicroseconds);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event does not fit within epsilon of frame end.
-      event.timeRange.end = Duration(
+      event.time.end = Duration(
           microseconds: frameEndTime + traceEventEpsilon.inMicroseconds + 1);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Satisfies UI / GPU order.
       final uiEvent = event
-        ..timeRange.start = const Duration(microseconds: 5000)
-        ..timeRange.end = const Duration(microseconds: 6000);
+        ..time.start = const Duration(microseconds: 5000)
+        ..time.end = const Duration(microseconds: 6000);
       final gpuEvent = goldenGpuTimelineEvent.deepCopy()
-        ..timeRange.start = const Duration(microseconds: 4000)
-        ..timeRange.end = const Duration(microseconds: 8000);
+        ..time.start = const Duration(microseconds: 4000)
+        ..time.end = const Duration(microseconds: 8000);
 
       expect(timelineData.eventOccursWithinFrameBounds(uiEvent, frame), isTrue);
       expect(
@@ -358,7 +358,7 @@ void main() {
 
       // Add child [animate] to a leaf [engineBeginFrame].
       final animate = testTimelineEvent(_animateJson)
-        ..timeRange.end = const Duration(microseconds: 118039650871);
+        ..time.end = const Duration(microseconds: 118039650871);
       engineBeginFrame.addChild(animate);
       expect(engineBeginFrame.children.length, equals(1));
       expect(engineBeginFrame.children.first.name, equals(animateEvent.name));
@@ -366,14 +366,14 @@ void main() {
       // Add child [layout] where child is sibling of existing children
       // [animate].
       final layout = testTimelineEvent(_layoutJson)
-        ..timeRange.end = const Duration(microseconds: 118039651087);
+        ..time.end = const Duration(microseconds: 118039651087);
       engineBeginFrame.addChild(layout);
       expect(engineBeginFrame.children.length, equals(2));
       expect(engineBeginFrame.children.last.name, equals(layoutEvent.name));
 
       // Add child [build] where existing child [layout] is parent of child.
       final build = testTimelineEvent(_buildJson)
-        ..timeRange.end = const Duration(microseconds: 118039651017);
+        ..time.end = const Duration(microseconds: 118039651017);
       engineBeginFrame.addChild(build);
       expect(engineBeginFrame.children.length, equals(2));
       expect(layout.children.length, equals(1));
@@ -382,7 +382,7 @@ void main() {
       // Add child [frame] child is parent of existing children [animate] and
       // [layout].
       final frame = testTimelineEvent(_frameJson)
-        ..timeRange.end = const Duration(microseconds: 118039652334);
+        ..time.end = const Duration(microseconds: 118039652334);
       engineBeginFrame.addChild(frame);
       expect(engineBeginFrame.children.length, equals(1));
       expect(engineBeginFrame.children.first.name, equals(frameEvent.name));
@@ -440,59 +440,59 @@ final frameEndEvent = testTraceEvent({
 // None of the following data should be modified. If you have a need to modify
 // any of the below events for a test, make a copy and modify the copy.
 final TimelineEvent vsyncEvent = testTimelineEvent(_vsyncJson)
-  ..timeRange.end = const Duration(microseconds: 118039652422)
+  ..time.end = const Duration(microseconds: 118039652422)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent animatorBeginFrameEvent =
     testTimelineEvent(_animatorBeginFrameJson)
-      ..timeRange.end = const Duration(microseconds: 118039652421)
+      ..time.end = const Duration(microseconds: 118039652421)
       ..type = TimelineEventType.ui;
 
 final TimelineEvent frameworkWorkloadEvent =
     testTimelineEvent(_frameworkWorkloadJson)
-      ..timeRange.end = const Duration(microseconds: 118039652412)
+      ..time.end = const Duration(microseconds: 118039652412)
       ..type = TimelineEventType.ui;
 
 final TimelineEvent engineBeginFrameEvent =
     testTimelineEvent(_engineBeginFrameJson)
-      ..timeRange.end = const Duration(microseconds: 118039652411)
+      ..time.end = const Duration(microseconds: 118039652411)
       ..type = TimelineEventType.ui;
 
 final TimelineEvent frameEvent = testTimelineEvent(_frameJson)
-  ..timeRange.end = const Duration(microseconds: 118039652334)
+  ..time.end = const Duration(microseconds: 118039652334)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent animateEvent = testTimelineEvent(_animateJson)
-  ..timeRange.end = const Duration(microseconds: 118039650871)
+  ..time.end = const Duration(microseconds: 118039650871)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent layoutEvent = testTimelineEvent(_layoutJson)
-  ..timeRange.end = const Duration(microseconds: 118039651087)
+  ..time.end = const Duration(microseconds: 118039651087)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent buildEvent = testTimelineEvent(_buildJson)
-  ..timeRange.end = const Duration(microseconds: 118039651017)
+  ..time.end = const Duration(microseconds: 118039651017)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent compositingBitsEvent =
     testTimelineEvent(_compositingBitsJson)
-      ..timeRange.end = const Duration(microseconds: 118039651090)
+      ..time.end = const Duration(microseconds: 118039651090)
       ..type = TimelineEventType.ui;
 
 final TimelineEvent paintEvent = testTimelineEvent(_paintJson)
-  ..timeRange.end = const Duration(microseconds: 118039651165)
+  ..time.end = const Duration(microseconds: 118039651165)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent compositingEvent = testTimelineEvent(_compositingJson)
-  ..timeRange.end = const Duration(microseconds: 118039651460)
+  ..time.end = const Duration(microseconds: 118039651460)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent semanticsEvent = testTimelineEvent(_semanticsJson)
-  ..timeRange.end = const Duration(microseconds: 118039652210)
+  ..time.end = const Duration(microseconds: 118039652210)
   ..type = TimelineEventType.ui;
 
 final TimelineEvent finalizeTreeEvent = testTimelineEvent(_finalizeTreeJson)
-  ..timeRange.end = const Duration(microseconds: 118039652308)
+  ..time.end = const Duration(microseconds: 118039652308)
   ..type = TimelineEventType.ui;
 
 final goldenUiTimelineEvent = vsyncEvent
@@ -736,12 +736,12 @@ const Map<String, dynamic> _endEngineBeginFrameJson = {
 // any of the below events for a test, make a copy and modify the copy.
 final TimelineEvent gpuRasterizerDrawEvent =
     testTimelineEvent(_gpuRasterizerDrawJson)
-      ..timeRange.end = const Duration(microseconds: 118039679873)
+      ..time.end = const Duration(microseconds: 118039679873)
       ..type = TimelineEventType.gpu;
 
 final TimelineEvent pipelineConsumeEvent =
     testTimelineEvent(_pipelineConsumeJson)
-      ..timeRange.end = const Duration(microseconds: 118039679870)
+      ..time.end = const Duration(microseconds: 118039679870)
       ..type = TimelineEventType.gpu;
 
 final goldenGpuTimelineEvent = gpuRasterizerDrawEvent

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -95,7 +95,7 @@ void main() {
     test('event occurs within frame boundaries', () {
       const frameStartTime = 2000;
       const frameEndTime = 8000;
-      final frame = TimelineFrame('frameId')
+      TimelineFrame frame = TimelineFrame('frameId')
         ..pipelineItemTime.start = const Duration(microseconds: frameStartTime)
         ..pipelineItemTime.end = const Duration(microseconds: frameEndTime);
 
@@ -163,6 +163,10 @@ void main() {
       frame.setEventFlow(uiEvent, type: TimelineEventType.ui);
       expect(
           timelineData.eventOccursWithinFrameBounds(gpuEvent, frame), isFalse);
+
+      frame = TimelineFrame('frameId')
+        ..pipelineItemTime.start = const Duration(microseconds: frameStartTime)
+        ..pipelineItemTime.end = const Duration(microseconds: frameEndTime);
 
       frame
         ..setEventFlow(null, type: TimelineEventType.ui)

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -96,8 +96,8 @@ void main() {
       const frameStartTime = 2000;
       const frameEndTime = 8000;
       final frame = TimelineFrame('frameId')
-        ..startTime = frameStartTime
-        ..endTime = frameEndTime;
+        ..pipelineItemStartTime = frameStartTime
+        ..pipelineItemEndTime = frameEndTime;
 
       final event = goldenUiTimelineEvent.deepCopy()
         ..startTime = frameStartTime

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -100,50 +100,61 @@ void main() {
         ..pipelineItemTime.end = const Duration(microseconds: frameEndTime);
 
       final event = goldenUiTimelineEvent.deepCopy()
-        ..time.start = const Duration(microseconds: frameStartTime)
-        ..time.end = const Duration(microseconds: 5000);
+        ..time = (TimeRange()
+          ..start = const Duration(microseconds: frameStartTime)
+          ..end = const Duration(microseconds: 5000));
 
       // Event fits within frame timestamps.
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event fits within epsilon of frame start.
-      event.time.start = Duration(
-          microseconds: frameStartTime - traceEventEpsilon.inMicroseconds);
+      event.time = TimeRange()
+        ..start = Duration(
+            microseconds: frameStartTime - traceEventEpsilon.inMicroseconds)
+        ..end = const Duration(microseconds: 5000);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event does not fit within epsilon of frame start.
-      event.time.start = Duration(
-          microseconds: frameStartTime - traceEventEpsilon.inMicroseconds - 1);
+      event.time = TimeRange()
+        ..start = Duration(
+            microseconds: frameStartTime - traceEventEpsilon.inMicroseconds - 1)
+        ..end = const Duration(microseconds: 5000);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Event with small duration uses smaller epsilon.
-      event
-        ..time.start = const Duration(microseconds: frameStartTime - 100)
-        ..time.end = const Duration(microseconds: frameStartTime + 100);
+      event.time = TimeRange()
+        ..start = const Duration(microseconds: frameStartTime - 100)
+        ..end = const Duration(microseconds: frameStartTime + 100);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
-      event
-        ..time.start = const Duration(microseconds: frameStartTime - 101)
-        ..time.end = const Duration(microseconds: frameStartTime + 100);
+      event.time = TimeRange()
+        ..start = const Duration(microseconds: frameStartTime - 101)
+        ..end = const Duration(microseconds: frameStartTime + 100);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Event fits within epsilon of frame end.
-      event.time.end = Duration(
-          microseconds: frameEndTime + traceEventEpsilon.inMicroseconds);
+      event.time = TimeRange()
+        ..start = const Duration(microseconds: frameStartTime - 101)
+        ..end = Duration(
+            microseconds: frameEndTime + traceEventEpsilon.inMicroseconds);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isTrue);
 
       // Event does not fit within epsilon of frame end.
-      event.time.end = Duration(
-          microseconds: frameEndTime + traceEventEpsilon.inMicroseconds + 1);
+      event.time = TimeRange()
+        ..start = const Duration(microseconds: frameStartTime - 101)
+        ..end = Duration(
+            microseconds: frameEndTime + traceEventEpsilon.inMicroseconds + 1);
       expect(timelineData.eventOccursWithinFrameBounds(event, frame), isFalse);
 
       // Satisfies UI / GPU order.
       final uiEvent = event
-        ..time.start = const Duration(microseconds: 5000)
-        ..time.end = const Duration(microseconds: 6000);
+        ..time = (TimeRange()
+          ..start = const Duration(microseconds: 5000)
+          ..end = const Duration(microseconds: 6000));
       final gpuEvent = goldenGpuTimelineEvent.deepCopy()
-        ..time.start = const Duration(microseconds: 4000)
-        ..time.end = const Duration(microseconds: 8000);
+        ..time = (TimeRange()
+          ..start = const Duration(microseconds: 4000)
+          ..end = const Duration(microseconds: 8000));
 
       expect(timelineData.eventOccursWithinFrameBounds(uiEvent, frame), isTrue);
       expect(

--- a/packages/devtools/test/utils_test.dart
+++ b/packages/devtools/test/utils_test.dart
@@ -114,20 +114,16 @@ void main() {
     });
 
     test('timeRange', () {
-      final timeRangeMicros = TimeRange(
-        start: const Duration(microseconds: 1000),
-        end: const Duration(microseconds: 8000),
-      );
-      expect(timeRangeMicros.duration.inMicroseconds, equals(7000));
-      expect(timeRangeMicros.toString(), equals('[1000 - 8000]'));
+      final timeRangeMicros = TimeRange()
+        ..start = const Duration(microseconds: 1000)
+        ..end = const Duration(microseconds: 8000);
 
-      final timeRangeMillis = TimeRange(
-        unit: TimeUnit.milliseconds,
-        start: const Duration(microseconds: 1000),
-        end: const Duration(microseconds: 8000),
+      expect(timeRangeMicros.duration.inMicroseconds, equals(7000));
+      expect(timeRangeMicros.toString(), equals('[1000 μs - 8000 μs]'));
+      expect(
+        timeRangeMicros.toString(unit: TimeUnit.milliseconds),
+        equals('[1 ms - 8 ms]'),
       );
-      expect(timeRangeMillis.duration.inMicroseconds, equals(7000));
-      expect(timeRangeMillis.toString(), equals('[1 - 8]'));
     });
   });
 }

--- a/packages/devtools/test/utils_test.dart
+++ b/packages/devtools/test/utils_test.dart
@@ -112,5 +112,22 @@ void main() {
       // can be increased if this test starts to flake.
       expect(end - start, lessThan(200));
     });
+
+    test('timeRange', () {
+      final timeRangeMicros = TimeRange(
+        start: const Duration(microseconds: 1000),
+        end: const Duration(microseconds: 8000),
+      );
+      expect(timeRangeMicros.duration.inMicroseconds, equals(7000));
+      expect(timeRangeMicros.toString(), equals('[1000 - 8000]'));
+
+      final timeRangeMillis = TimeRange(
+        unit: TimeUnit.milliseconds,
+        start: const Duration(microseconds: 1000),
+        end: const Duration(microseconds: 8000),
+      );
+      expect(timeRangeMillis.duration.inMicroseconds, equals(7000));
+      expect(timeRangeMillis.toString(), equals('[1 - 8]'));
+    });
   });
 }


### PR DESCRIPTION
Saw an instance of https://github.com/flutter/devtools/issues/315. This should no longer happen, as we are now using the start time of the UI event flow to determine where to start the flame chart.