### PR TITLE
don't reference dart:io in code compiling for the web

### DIFF
--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -4,12 +4,10 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:io';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
 import 'package:intl/intl.dart';
-import 'package:path/path.dart' as path;
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 bool collectionEquals(e1, e2) => const DeepCollectionEquality().equals(e1, e2);
@@ -135,19 +133,6 @@ class Property<T> {
   }
 
   Stream<T> get onValueChange => _changeController.stream;
-}
-
-/// The directory used to store per-user settings for Dart tooling.
-Directory getDartPrefsDirectory() {
-  return Directory(path.join(getUserHomeDir(), '.dart'));
-}
-
-/// Return the user's home directory.
-String getUserHomeDir() {
-  final String envKey =
-      Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
-  final String value = Platform.environment[envKey];
-  return value == null ? '.' : value;
 }
 
 /// Map the URI (which may already be Observatory web app) to a WebSocket URI

--- a/packages/devtools/lib/src/utils_io.dart
+++ b/packages/devtools/lib/src/utils_io.dart
@@ -1,0 +1,20 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+
+/// The directory used to store per-user settings for Dart tooling.
+Directory getDartPrefsDirectory() {
+  return Directory(path.join(getUserHomeDir(), '.dart'));
+}
+
+/// Return the user's home directory.
+String getUserHomeDir() {
+  final String envKey =
+      Platform.operatingSystem == 'windows' ? 'APPDATA' : 'HOME';
+  final String value = Platform.environment[envKey];
+  return value == null ? '.' : value;
+}

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:devtools/src/utils.dart';
+import 'package:devtools/src/utils_io.dart';
 import 'package:path/path.dart' as path;
 import 'package:pedantic/pedantic.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'


### PR DESCRIPTION
- don't reference dart:io in code compiling for the web

A recent version of package:build_web_compilers will refuse to compile web.main.dart without this change:

```
[WARNING] build_web_compilers:entrypoint on web/main.dart: Skipping compiling devtools|web/main.dart with ddc because some of its
transitive libraries have sdk dependencies that not supported on this platform:

devtools|lib/src/utils.dart

https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-skipped-compiling-warnings
```
