### PR TITLE
Work around pubspec problem of pulling in alpha with 'any' dependency.

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.3.0
-  build_web_compilers: any
+  build_web_compilers: ^1.0.0
   matcher: ^0.12.3
   test: ^1.0.0
   webkit_inspection_protocol: ^0.3.6


### PR DESCRIPTION
pubspec for dev_dependencies on build_web_compilers uses 'any' however, its pulling in alpha (even though ' pub global activate' wasn't done).

Workaround explicitly use 1.0.0 for build_web_compilers.
