### PR TITLE
Improve experience in Internet Explorer + tweak Edge message

### DIFF
--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -23,6 +23,17 @@
     <link rel="stylesheet" href="packages/devtools/src/timeline/timeline.css">
 
     <script type="text/javascript">
+        function supportsES6Classes() {
+          "use strict";
+          try { eval("class Foo {}"); }
+          catch (e) { return false; }
+          return true;
+        }
+
+        if (!supportsES6Classes()) {
+          window.location.href = '/unsupported-browser.html';
+        }
+
         (function() {
             var params = new URLSearchParams(window.location.search);
             if (params.get('theme') == 'dark') {

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -15,7 +15,7 @@ void main() {
 
   if (!browser.isChrome) {
     final browserName =
-        // Edge shows up as IE, so we replace it's name too to avoid confusion.
+        // Edge shows up as IE, so we replace it's name to avoid confusion.
         browser.isInternetExplorer || browser == Browser.UnknownBrowser
             ? 'an unsupported browser'
             : browser.name;

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -14,9 +14,13 @@ void main() {
   final PerfToolFramework framework = PerfToolFramework();
 
   if (!browser.isChrome) {
+    final browserName =
+        // Edge shows up as IE, so we replace it's name too to avoid confusion.
+        browser.isInternetExplorer || browser == Browser.UnknownBrowser
+            ? 'an unsupported browser'
+            : browser.name;
     framework.disableAppWithError(
-      'ERROR: You are running DevTools on '
-          '${browser.name == Browser.UnknownBrowser.name ? 'an unknown browswer' : browser.name}, '
+      'ERROR: You are running DevTools on $browserName, '
           'but DevTools only runs on Chrome.',
       'Reopen this url in a Chrome browser to use DevTools.',
     );

--- a/packages/devtools/web/unsupported-browser.html
+++ b/packages/devtools/web/unsupported-browser.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Dart DevTools - Unsupported Browser</title>
+    <style>
+      body {
+        margin: 50px 30px;
+        font-family: "Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+      }
+    </style>
+</head>
+<body>
+  <h1>Unsupported Browser</h1>
+  <p>Your browser is not supported by DevTools. Please try using Google Chrome.</p>
+</body>
+</html>


### PR DESCRIPTION
There's some JS that checks whether ES6 classes are supported (I think it's a pre-req for latest dart2js, and IE doesn't support that), and redirects to a really bare-bones "unsupported page".

![Untitled](https://user-images.githubusercontent.com/1078012/56229345-a0fcbe00-6071-11e9-98e2-4e462857ac4a.png)

Also tweaked the message shown in Edge since it categorises Edge as IE and the message is a bit confusing. It's now just called "an supported browser".

![edge](https://user-images.githubusercontent.com/1078012/56229354-a4904500-6071-11e9-8a4c-04531b847cd9.png)

Fixes #66.