### PR TITLE
Use same analysis_options.yaml as devtools.

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -14,8 +14,7 @@ environment:
 dependencies:
   codemirror: ^0.5.3
   collection: ^1.14.11
-  devtools_server:
-    path: ../devtools_server
+  devtools_server: ^0.0.1
   http: ^0.12.0+1
   intl: ^0.15.0
   js: ^0.6.1+1

--- a/packages/devtools_server/analysis_options.yaml
+++ b/packages/devtools_server/analysis_options.yaml
@@ -1,2 +1,136 @@
-# Use the same analysis options that we use in package:devtools
-include: package:devtools/analysis_options.yaml
+# Start with a base-line of the package:pedantic lints.
+include: package:pedantic/analysis_options.yaml
+
+analyzer:
+  #  strong-mode:
+  #    implicit-casts: false
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+  exclude:
+    - build/**
+
+linter:
+  rules:
+    # Added on top of the flutter/flutter lints:
+    - prefer_generic_function_type_aliases
+
+    # From flutter/flutter:
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    - always_declare_return_types
+    # - always_put_control_body_on_new_line
+    # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
+    - always_require_non_null_named_parameters
+    # - always_specify_types
+    - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    # - avoid_as # we use 'as' in this codebase
+    # - avoid_bool_literals_in_conditional_expressions # not yet tested
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
+    - avoid_classes_with_only_static_members
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
+    - avoid_empty_else
+    - avoid_field_initializers_in_const_classes
+    - avoid_function_literals_in_foreach_calls
+    - avoid_init_to_null
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_relative_lib_imports
+    - avoid_renaming_method_parameters
+    - avoid_return_types_on_setters
+    # - avoid_returning_null # we do this commonly
+    # - avoid_returning_this # https://github.com/dart-lang/linter/issues/842
+    # - avoid_setters_without_getters # not yet tested
+    # - avoid_single_cascade_in_expression_statements # not yet tested
+    - avoid_slow_async_io
+    # - avoid_types_as_parameter_names # https://github.com/dart-lang/linter/pull/954/files
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    # - avoid_unused_constructor_parameters # https://github.com/dart-lang/linter/pull/847
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    # - cascade_invocations # not yet tested
+    # - close_sinks # https://github.com/flutter/flutter/issues/5789
+    # - comment_references # blocked on https://github.com/dart-lang/dartdoc/issues/1153
+    # - constant_identifier_names # https://github.com/dart-lang/linter/issues/204
+    - control_flow_in_finally
+    - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    - empty_statements
+    - hash_and_equals
+    - implementation_imports
+    # - invariant_booleans # https://github.com/flutter/flutter/issues/5790
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not yet tested
+    - library_names
+    - library_prefixes
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # https://github.com/flutter/flutter/issues/5791
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    - non_constant_identifier_names
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    - prefer_collection_literals
+    - prefer_conditional_assignment
+    - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # not yet tested
+    - prefer_contains
+    - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    - prefer_final_fields
+    - prefer_final_locals
+    - prefer_foreach
+    # - prefer_function_declarations_over_variables # not yet tested
+    - prefer_initializing_formals
+    # - prefer_interpolation_to_compose_strings # not yet tested
+    # - prefer_iterable_whereType # https://github.com/dart-lang/sdk/issues/32463
+    - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_single_quotes
+    - prefer_typing_uninitialized_variables
+    - recursive_getters
+    - slash_for_doc_comments
+    - sort_constructors_first
+    - sort_unnamed_constructors_first
+    - test_types_in_equals
+    - throw_in_finally
+    # - type_annotate_public_apis # subset of always_specify_types
+    - type_init_formals
+    - unawaited_futures
+    - unnecessary_brace_in_string_interps
+    - unnecessary_const
+    - unnecessary_getters_setters
+    # - unnecessary_lambdas # https://github.com/dart-lang/linter/issues/498
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    - unnecessary_overrides
+    - unnecessary_parenthesis
+    - unnecessary_statements
+    - unnecessary_this
+    - unrelated_type_equality_checks
+    - use_rethrow_when_possible
+    # - use_setters_to_change_properties # not yet tested
+    # - use_string_buffers # https://github.com/dart-lang/linter/pull/664
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    # - void_checks # not yet tested


### PR DESCRIPTION
TODO: create a check similar to version_check.dart that will ensure devtools_server/analysis_options.yaml is identical to devtools/analysis_options.yaml.

We are doing it this way to avoid a codependency between devtools and devtools_server.