### PR TITLE
Reduce Dart SDK requirement from >=2.1.0-dev to >=2.1.0-dev

### DIFF
--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -263,7 +263,11 @@ Set<String> get hiddenPages {
 Set<String> _lookupHiddenPages() {
   final queryString = html.window.location.search;
   if (queryString == null || queryString.length <= 1) {
-    return {};
+    // TODO(dantup): Remove this ignore, change to `{}` and bump SDK requirements
+    // in pubspec.yaml (devtools + devtools_server) once Flutter stable includes
+    // Dart SDK >= v2.2.
+    // ignore: prefer_collection_literals
+    return Set();
   }
   final qsParams = Uri.splitQueryString(queryString.substring(1));
   return (qsParams['hide'] ?? '').split(',').toSet();

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -27,7 +27,11 @@ class VmServiceWrapper implements VmService {
   final bool trackFutures;
   final Map<String, Future<Success>> _activeStreams = {};
 
-  final Set<TrackedFuture<Object>> activeFutures = {};
+  // TODO(dantup): Remove this ignore, change to `{}` and bump SDK requirements
+  // in pubspec.yaml (devtools + devtools_server) once Flutter stable includes
+  // Dart SDK >= v2.2.
+  // ignore: prefer_collection_literals
+  final Set<TrackedFuture<Object>> activeFutures = Set();
   Completer<bool> _allFuturesCompleter = Completer<bool>()
     // Mark the future as completed by default so if we don't track any
     // futures but someone tries to wait on [allFuturesCompleted] they don't

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.2.0-dev <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
   codemirror: ^0.5.3

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.2.0-dev <3.0.0'
+  sdk: '>=2.1.0-dev <3.0.0'
 
 dependencies:
   args: ^1.5.1


### PR DESCRIPTION
Current Flutter stable is `2.1.2-dev.0.0.flutter-0a7dcf17eb`.