### PR TITLE
Enable tests on Stable versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,7 @@ os:
 language: dart
 dart:
   - "dev/raw/latest"
-# Disable testing on stable; it creates many more bots, and we generally only need
-# test coverage for the SDK version we're developing and distributing against.
-#  - stable
+  - stable
 addons:
   chrome: stable
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ dart:
 addons:
   chrome: stable
 
+matrix:
+  exclude:
+  # Skip main bot for Stable build since it does formatting/building checks;
+  # - Formatting will fail on old SDK if the formatter changed in latest.
+  # - Builds are always done by us on latest SDKs so we don't need to ensure
+  #     we can build on an older SDK.
+  - dart: stable
+    env: BOT=main
+
 env:
   - BOT=main
   - BOT=test_ddc

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold.txt
@@ -1,0 +1,98 @@
+▼[S] Scaffold <-- selected
+│   dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality, _InheritedTheme, MediaQuery]
+│   ▶state: ScaffoldState#00000(tickers: tracking 1 ticker)
+└─▼[S] _ScaffoldScope
+    ▼[P] PrimaryScrollController
+    │   ScrollController#00000(no clients)
+    └─▼[M] Material
+      │   type: canvas
+      │   color: [#00000aff]#00000a
+      │   dependencies: [_LocalizationsScope-[GlobalKey#00000], _InheritedTheme]
+      │   state: _MaterialState#00000
+      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
+        │   duration: 200ms
+        │   shape: rectangle
+        │   borderRadius: BorderRadius.zero
+        │   elevation: 0.0
+        │   color: [#00000aff]#00000a
+        │   animateColor: false
+        │   shadowColor: [#000000ff]#000000
+        │   animateShadowColor: true
+        │   ▶state: _AnimatedPhysicalModelState#00000(ticker inactive)
+        └─▼[P] PhysicalModel
+          │   shape: rectangle
+          │   borderRadius: BorderRadius.zero
+          │   elevation: 0.0
+          │   color: [#00000aff]#00000a
+          │   shadowColor: [#000000ff]#000000
+          │   ▶renderObject: RenderPhysicalModel#00000
+          └─▼[N] NotificationListener <LayoutChangedNotification>
+              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
+              │   ▶renderObject: _RenderInkFeatures#00000
+              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
+                │   duration: 200ms
+                │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
+                │   inherit: false
+                │   color: [#000000dd]#00000000
+                │   family: Roboto
+                │   size: 14.0
+                │   weight: 400
+                │   baseline: alphabetic
+                │   decoration: TextDecoration.none
+                │   softWrap: wrapping at box width
+                │   overflow: clip
+                │   ▶state: _AnimatedDefaultTextStyleState#00000(ticker inactive)
+                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
+                  │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
+                  │   inherit: false
+                  │   color: [#000000dd]#00000000
+                  │   family: Roboto
+                  │   size: 14.0
+                  │   weight: 400
+                  │   baseline: alphabetic
+                  │   decoration: TextDecoration.none
+                  │   softWrap: wrapping at box width
+                  │   overflow: clip
+                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
+                    │   animation: AnimationController#00000(⏭ 1.000; paused)
+                    │   state: _AnimatedState#00000
+                    └─▼[C] CustomMultiChildLayout
+                      │   ▶renderObject: RenderCustomMultiChildLayoutBox#00000
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
+                      │   │   id: _ScaffoldSlot.body
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: falsedisableAnimations: falseinvertColors: falseboldText: false)
+                      │     └─▶[C] Center
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
+                      │   │   id: _ScaffoldSlot.appBar
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: falsedisableAnimations: falseinvertColors: falseboldText: false)
+                      │     └─▼[C] ConstrainedBox
+                      │       │   BoxConstraints(0.0<=w<=Infinity, 0.0<=h<=56.0)
+                      │       │   ▶renderObject: RenderConstrainedBox#00000 relayoutBoundary=up1
+                      │       └─▼[F] FlexibleSpaceBarSettings
+                      │           ▶[A] AppBar
+                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
+                        │   id: _ScaffoldSlot.floatingActionButton
+                        └─▼[/icons/inspector/atrule.png] MediaQuery
+                          │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: falsedisableAnimations: falseinvertColors: falseboldText: false)
+                          └─▼[F] _FloatingActionButtonTransition
+                            │   ▶state: _FloatingActionButtonTransitionState#00000(tickers: tracking 2 tickers)
+                            └─▼[/icons/inspector/value.png] Stack
+                              │   alignment: centerRight
+                              │   fit: loose
+                              │   overflow: clip
+                              │   dependencies: [Directionality]
+                              │   ▶renderObject: RenderStack#00000 relayoutBoundary=up1
+                              └─▼[/icons/inspector/resume.png] ScaleTransition
+                                │   animation: AnimationMin<double>(_AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: FlippedCurve(Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00)))➩1.0➪ReverseAnimation, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00))➩1.0), AnimationController#00000(⏮ 0.000; paused)➩Cubic(0.42, 0.00, 1.00, 1.00))
+                                │   state: _AnimatedState#00000
+                                └─▼[/icons/inspector/colors.png] Transform
+                                  │   dependencies: [Directionality]
+                                  │   ▶renderObject: RenderTransform#00000 relayoutBoundary=up2
+                                  └─▼[/icons/inspector/resume.png] RotationTransition
+                                    │   animation: AnimationController#00000(⏮ 0.000; paused)➩CurveTween(curve: Cubic(0.42, 0.00, 1.00, 1.00))➩Tween<double>(0.875 → 1.0)➩0.875➩TrainHoppingAnimation(next: _AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩Tween<double>(0.75 → 1.0)➩1.0, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Threshold)➩1.0➪ReverseAnimation))
+                                    │   state: _AnimatedState#00000
+                                    └─▼[/icons/inspector/colors.png] Transform
+                                        dependencies: [Directionality]
+                                        ▶renderObject: RenderTransform#00000 relayoutBoundary=up3

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_expanded.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_expanded.txt
@@ -1,0 +1,29 @@
+▼[S] Scaffold <-- selected
+└─▼[S] _ScaffoldScope
+    ▼[P] PrimaryScrollController
+    └─▼[M] Material
+      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
+        └─▼[P] PhysicalModel
+          └─▼[N] NotificationListener <LayoutChangedNotification>
+              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
+                    └─▼[C] CustomMultiChildLayout
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     └─▼[C] Center
+                      │       └─▶[/icons/inspector/textArea.png] Text
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     └─▼[C] ConstrainedBox
+                      │       └─▼[F] FlexibleSpaceBarSettings
+                      │           ▶[A] AppBar
+                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png] MediaQuery
+                          └─▼[F] _FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png] Stack
+                              └─▼[/icons/inspector/resume.png] ScaleTransition
+                                └─▼[/icons/inspector/colors.png] Transform
+                                  └─▼[/icons/inspector/resume.png] RotationTransition
+                                    └─▼[/icons/inspector/colors.png] Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_with_styles.txt
@@ -1,0 +1,29 @@
+▼[S]<grayed> </grayed><bold>Scaffold</bold> <-- selected
+└─▼[S]<grayed> </grayed>_ScaffoldScope
+    ▼[P]<grayed> </grayed>PrimaryScrollController
+    └─▼[M]<grayed> </grayed>Material
+      └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedPhysicalModel
+        └─▼[P]<grayed> </grayed>PhysicalModel
+          └─▼[N]<grayed> </grayed>NotificationListener <grayed><LayoutChangedNotification></grayed>
+              ▼[I]<grayed> </grayed>_InkFeatures <grayed>[GlobalKey#00000 ink renderer]</grayed>
+              └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]<grayed> </grayed>DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedBuilder
+                    └─▼[C]<grayed> </grayed>CustomMultiChildLayout
+                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.body>]</grayed>
+                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
+                      │     └─▼[C]<grayed> </grayed><bold>Center</bold>
+                      │       └─▶[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold>
+                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.appBar>]</grayed>
+                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
+                      │     └─▼[C]<grayed> </grayed>ConstrainedBox
+                      │       └─▼[F]<grayed> </grayed>FlexibleSpaceBarSettings
+                      │           ▶[A]<grayed> </grayed><bold>AppBar</bold>
+                      └─▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.floatingActionButton>]</grayed>
+                        └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
+                          └─▼[F]<grayed> </grayed>_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]<grayed> </grayed>Stack
+                              └─▼[/icons/inspector/resume.png]<grayed> </grayed>ScaleTransition
+                                └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform
+                                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>RotationTransition
+                                    └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scrolled_to_center.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scrolled_to_center.txt
@@ -1,0 +1,29 @@
+▼[S] Scaffold
+└─▼[S] _ScaffoldScope
+    ▼[P] PrimaryScrollController
+    └─▼[M] Material
+      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
+        └─▼[P] PhysicalModel
+          └─▼[N] NotificationListener <LayoutChangedNotification>
+              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
+                    └─▼[C] CustomMultiChildLayout
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     └─▼[C] Center <-- selected
+                      │       └─▶[/icons/inspector/textArea.png] Text
+                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │     └─▼[C] ConstrainedBox
+                      │       └─▼[F] FlexibleSpaceBarSettings
+                      │           ▶[A] AppBar
+                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png] MediaQuery
+                          └─▼[F] _FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png] Stack
+                              └─▼[/icons/inspector/resume.png] ScaleTransition
+                                └─▼[/icons/inspector/colors.png] Transform
+                                  └─▼[/icons/inspector/resume.png] RotationTransition
+                                    └─▼[/icons/inspector/colors.png] Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
@@ -1,0 +1,8 @@
+▼[R]<grayed> </grayed>root <grayed>]</grayed>
+  ▼[M]<grayed> </grayed>MyApp
+    ▼[M]<grayed> </grayed>MaterialApp
+      ▼[S]<grayed> </grayed>Scaffold
+      ├───▼[C]<grayed> </grayed>Center
+      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+      └─▼[A]<grayed> </grayed>AppBar
+          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
@@ -1,0 +1,8 @@
+▼[R]<grayed> </grayed>root <grayed>]</grayed>
+  ▼[M]<grayed> </grayed>MyApp
+    ▼[M]<grayed> </grayed>MaterialApp
+      ▼[S]<grayed> </grayed>Scaffold
+      ├───▼[C]<grayed> </grayed>Center
+      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
+      └─▼[A]<grayed> </grayed>AppBar
+          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree.txt
@@ -1,0 +1,16 @@
+▼[/icons/inspector/textArea.png] Text <-- selected
+│   "Hello, World!"
+│   textAlign: null [D]
+│   textDirection: null [D]
+│   locale: null [D]
+│   softWrap: null [D]
+│   overflow: null [D]
+│   textScaleFactor: null [D]
+│   maxLines: null [D]
+│   dependencies: [MediaQuery, DefaultTextStyle]
+└─▼[/icons/inspector/textArea.png] RichText
+    softWrap: wrapping at box width
+    maxLines: unlimited
+    text: "Hello, World!"
+    dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+    ▶renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_richtext_selected.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_richtext_selected.txt
@@ -1,0 +1,16 @@
+▼[/icons/inspector/textArea.png] Text
+│   "Hello, World!"
+│   textAlign: null [D]
+│   textDirection: null [D]
+│   locale: null [D]
+│   softWrap: null [D]
+│   overflow: null [D]
+│   textScaleFactor: null [D]
+│   maxLines: null [D]
+│   dependencies: [MediaQuery, DefaultTextStyle]
+└─▼[/icons/inspector/textArea.png] RichText <-- selected
+    softWrap: wrapping at box width
+    maxLines: unlimited
+    text: "Hello, World!"
+    dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+    ▶renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_with_styles.txt
@@ -1,0 +1,16 @@
+▼[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold> <-- selected
+│   "Hello, World!"
+│   textAlign: null [D]
+│   textDirection: null [D]
+│   locale: null [D]
+│   softWrap: null [D]
+│   overflow: null [D]
+│   textScaleFactor: null [D]
+│   maxLines: null [D]
+│   dependencies: [MediaQuery, DefaultTextStyle]
+└─▼[/icons/inspector/textArea.png]<grayed> </grayed>RichText
+    softWrap: wrapping at box width
+    maxLines: unlimited
+    text: "Hello, World!"
+    dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+    ▶renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/goldens_stable/inspector_service_details_tree.txt
+++ b/packages/devtools/test/goldens_stable/inspector_service_details_tree.txt
@@ -1,0 +1,31 @@
+MaterialApp
+ │ state: _MaterialAppState#00000
+ │
+ └─ScrollConfiguration
+   │ behavior: _MaterialScrollBehavior
+   │
+   └─WidgetsApp-[GlobalObjectKey _MaterialAppState#00000]
+     │ state: _WidgetsAppState#00000
+     │
+     └─MediaQuery
+       │ data: MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio:
+       │   3.0, textScaleFactor: 1.0, platformBrightness:
+       │   Brightness.light, padding: EdgeInsets.zero, viewInsets:
+       │   EdgeInsets.zero, alwaysUse24HourFormat: false,
+       │   accessibleNavigation: falsedisableAnimations:
+       │   falseinvertColors: falseboldText: false)
+       │
+       └─Localizations
+         │ locale: en_US
+         │ delegates: DefaultMaterialLocalizations.delegate(en_US),
+         │   DefaultCupertinoLocalizations.delegate(en_US),
+         │   DefaultWidgetsLocalizations.delegate(en_US)
+         │ state: _LocalizationsState#00000
+         │
+         └─Semantics
+           │ container: false
+           │ properties: SemanticsProperties
+           │ label: null
+           │ value: null
+           │ hint: null
+...

--- a/packages/devtools/test/goldens_stable/inspector_service_text_details_tree.txt
+++ b/packages/devtools/test/goldens_stable/inspector_service_text_details_tree.txt
@@ -1,0 +1,17 @@
+Text
+ │ data: "Hello, World!"
+ │ textAlign: null
+ │ textDirection: null
+ │ locale: null
+ │ softWrap: null
+ │ overflow: null
+ │ textScaleFactor: null
+ │ maxLines: null
+ │ dependencies: [MediaQuery, DefaultTextStyle]
+ │
+ └─RichText
+     softWrap: wrapping at box width
+     maxLines: unlimited
+     text: "Hello, World!"
+     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+     renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -514,6 +514,14 @@ void main() async {
     });
 
     test('hotReload', () async {
+      if (flutterVersion == '1.2.1') {
+        // This test can be flaky in Flutter 1.2.1 because of
+        // https://github.com/dart-lang/sdk/issues/33838
+        // so we just skip it. This block of code can be removed after the next
+        // stable flutter release.
+        // TODO(dantup): Remove this.
+        return;
+      }
       await env.setupEnvironment();
 
       await serviceManager.performHotReload();

--- a/packages/devtools/test/support/flutter_test_environment.dart
+++ b/packages/devtools/test/support/flutter_test_environment.dart
@@ -12,6 +12,8 @@ import 'package:devtools/src/vm_service_wrapper.dart';
 
 import 'flutter_test_driver.dart';
 
+final flutterVersion = Platform.environment['FLUTTER_VERSION'];
+
 class FlutterTestEnvironment {
   FlutterTestEnvironment(
     this._runConfig, {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -19,11 +19,11 @@ export PATH=$PATH:~/.pub-cache/bin
 # We should be using dart from /Users/travis/dart-sdk/bin/dart.
 echo "which dart: " `which dart`
 
-# Provision our packages.
-pub get
-pub global activate webdev
-
 if [ "$BOT" = "main" ]; then
+
+    # Provision our packages.
+    pub get
+    pub global activate webdev
 
     # Verify that dartfmt has been run.
     echo "Checking dartfmt..."
@@ -45,10 +45,18 @@ if [ "$BOT" = "main" ]; then
 
 elif [ "$BOT" = "test_ddc" ]; then
 
+    # Provision our packages.
+    pub get
+    pub global activate webdev
+
     pub run test --reporter expanded --exclude-tags useFlutterSdk
     pub run test --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "test_dart2js" ]; then
+
+    # Provision our packages.
+    pub get
+    pub global activate webdev
 
     WEBDEV_RELEASE=true pub run test --reporter expanded --exclude-tags useFlutterSdk
     WEBDEV_RELEASE=true pub run test --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
@@ -73,6 +81,10 @@ elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
     # Return to the devtools directory.
     cd devtools
+
+    # Provision our packages using Flutter's version of Dart.
+    pub get
+    pub global activate webdev
 
     # Run tests that require the Flutter SDK.
     pub run test -j1 --reporter expanded --tags useFlutterSdk

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -56,7 +56,13 @@ elif [ "$BOT" = "test_dart2js" ]; then
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
     # Get Flutter.
-    git clone https://github.com/flutter/flutter.git ../flutter
+    if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
+        echo "Cloning stable Flutter branch"
+        git clone https://github.com/flutter/flutter.git --branch stable ../flutter
+    else
+        echo "Cloning master Flutter branch"
+        git clone https://github.com/flutter/flutter.git ../flutter
+    fi
     cd ..
     export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
     flutter config --no-analytics

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -25,13 +25,23 @@ pub global activate webdev
 
 if [ "$BOT" = "main" ]; then
 
-    # Verify that dartfmt has been run.
-    echo "Checking dartfmt..."
+    if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
 
-    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
-        echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
-        dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
-        exit 1
+        echo "Skipping dartfmt on Stable, because if there's a change to the"
+        echo "formatter we won't be able to simultaneously pass on both"
+        echo "Stable+Dev, so we assume Dev is the one we're following"
+
+    else
+
+        # Verify that dartfmt has been run.
+        echo "Checking dartfmt..."
+
+        if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
+            echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
+            dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
+            exit 1
+        fi
+
     fi
 
     # Make sure the app versions are in sync.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -79,6 +79,15 @@ elif [ "$BOT" = "flutter_sdk_tests" ]; then
     flutter config --no-analytics
     flutter doctor
 
+    # Put the Flutter version into a variable.
+    # First awk extracts "Flutter x.y.z-pre.a":
+    #   -F '•'         uses the bullet as field separator
+    #   NR==1          says only take the first record (line)
+    #   { print $1}    prints just the first field
+    # Second awk splits on space (default) and takes the second field (the version)
+    export FLUTTER_VERSION=$(flutter --version | awk -F '•' 'NR==1{print $1}' | awk '{print $2}')
+    echo "Flutter version is '$FLUTTER_VERSION'"
+
     # We should be using dart from ../flutter/bin/cache/dart-sdk/bin/dart.
     echo "which dart: " `which dart`
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -25,23 +25,13 @@ pub global activate webdev
 
 if [ "$BOT" = "main" ]; then
 
-    if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
+    # Verify that dartfmt has been run.
+    echo "Checking dartfmt..."
 
-        echo "Skipping dartfmt on Stable, because if there's a change to the"
-        echo "formatter we won't be able to simultaneously pass on both"
-        echo "Stable+Dev, so we assume Dev is the one we're following"
-
-    else
-
-        # Verify that dartfmt has been run.
-        echo "Checking dartfmt..."
-
-        if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
-            echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
-            dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
-            exit 1
-        fi
-
+    if [[ $(dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/) ]]; then
+        echo "Failed dartfmt check: run dartfmt -w bin/ lib/ test/ web/"
+        dartfmt -n --set-exit-if-changed bin/ lib/ test/ web/
+        exit 1
     fi
 
     # Make sure the app versions are in sync.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -67,6 +67,9 @@ elif [ "$BOT" = "flutter_sdk_tests" ]; then
     if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
         echo "Cloning stable Flutter branch"
         git clone https://github.com/flutter/flutter.git --branch stable ../flutter
+
+        # Set the suffix so we use stable goldens.
+        export DART_VM_OPTIONS="-DGOLDENS_SUFFIX=_stable"
     else
         echo "Cloning master Flutter branch"
         git clone https://github.com/flutter/flutter.git ../flutter


### PR DESCRIPTION
We disabled this in the past because of the increased time, however since we managed to make a build that didn't work for current Flutter stable, I think the value outweighs the cost. It did show up in the stable runs of [Dart Code's integration tests](https://dartcode.org/test-results/?master/c7a9044a73633c5281f0e4fa5d15d6c390978a49) but only after it was released.

Changes are:

- User stable Dart SDK
- Checkout flutter stable branch when using stable Dart SDK
- Skip the "main" bot for stable builds - this is mostly things that don't affect end users, like formatting, tuneup, which may legitimately fail (for ex. if the formatter changes and we update our source, it will fail to pass dartfmt check on stable until it catches up).

I expect some of the builds to fail against this PR because of the SDK constraints until https://github.com/flutter/devtools/pull/547 lands (if they don't, then this isn't working right). After landing that, I'll rebase this, and it should then go green.

@devoncarew @jacob314 