### PR TITLE
Cleanup Dark mode to match Material Dark colors (less intense).

### DIFF
--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -53,9 +53,6 @@ class MemoryPlotly {
     AxisLayout getYAxis(List<num> range) {
       return AxisLayout(
         domain: range,
-        title: Title(
-          text: 'Heap',
-        ),
         titlefont: Font(
           family: fontFamily,
           color: colorToCss(defaultForeground),
@@ -114,6 +111,7 @@ class MemoryPlotly {
             text: 'Events',
             font: Font(
               family: fontFamily,
+              color: colorToCss(defaultForeground),
               size: 10,
             ),
           ),
@@ -409,6 +407,16 @@ class MemoryPlotly {
 class EventTimeline {
   EventTimeline(this._domName, this._chart);
 
+  // Light blue and Dark Blue 600 dark mode colors see
+  // https://standards.google/guidelines/google-material/color/dark-theme.html#style
+  static String snapshotColor =
+      colorToCss(const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1)));
+  static String resetColor =
+      colorToCss(const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1)));
+  // Light is Browser's 'lightblue' color, Dark is Blue 300 dark mode colors.
+  static String eventBgColor =
+      colorToCss(const ThemedColor(Color(0xFFABD2DF), Color(0xFF79B6F6)));
+
   final String _domName;
   dynamic _chart;
 
@@ -437,7 +445,6 @@ class EventTimeline {
   static const int SNAPSHOT_TRACE_INDEX = 1;
   List<Data> getEventTimelineTraces() {
     // Create traces for the event timeline subplot.
-
     final Data resetTrace = Data(
       // Null is needed so the trace legend entry appears w/o data.
       x: [Null],
@@ -447,9 +454,9 @@ class EventTimeline {
       mode: 'markers',
       yaxis: 'y2',
       marker: Marker(
-        color: 'blue',
+        color: resetColor,
         line: Line(
-          color: 'lightblue',
+          color: eventBgColor,
           width: 2,
         ),
         size: 5,
@@ -468,9 +475,9 @@ class EventTimeline {
       mode: 'markers',
       yaxis: 'y2',
       marker: Marker(
-        color: 'blue',
+        color: snapshotColor,
         line: Line(
-          color: 'lightblue',
+          color: eventBgColor,
           width: 2,
         ),
         size: 10,

--- a/packages/devtools/lib/src/memory/memory_plotly.dart
+++ b/packages/devtools/lib/src/memory/memory_plotly.dart
@@ -407,15 +407,19 @@ class MemoryPlotly {
 class EventTimeline {
   EventTimeline(this._domName, this._chart);
 
-  // Light blue and Dark Blue 600 dark mode colors see
+  // Light theme is Blue and dark theme is Dark Blue 600. See
   // https://standards.google/guidelines/google-material/color/dark-theme.html#style
-  static String snapshotColor =
-      colorToCss(const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1)));
-  static String resetColor =
-      colorToCss(const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1)));
-  // Light is Browser's 'lightblue' color, Dark is Blue 300 dark mode colors.
-  static String eventBgColor =
-      colorToCss(const ThemedColor(Color(0xFFABD2DF), Color(0xFF79B6F6)));
+  static ThemedColor snapshotColor =
+      const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1));
+  static ThemedColor resetColor =
+      const ThemedColor(Color(0xFF0000FF), Color(0xFF185AE1));
+  // Light theme is Browser's lightblue color, Dark theme is Dark Blue 300.
+  static ThemedColor eventBgColor =
+      const ThemedColor(Color(0xFFABD2DF), Color(0xFF79B6F6));
+
+  final String _snapshotColorCss = colorToCss(snapshotColor);
+  final String _resetColorCss = colorToCss(resetColor);
+  final String _eventBgColorCss = colorToCss(eventBgColor);
 
   final String _domName;
   dynamic _chart;
@@ -454,9 +458,9 @@ class EventTimeline {
       mode: 'markers',
       yaxis: 'y2',
       marker: Marker(
-        color: resetColor,
+        color: _resetColorCss,
         line: Line(
-          color: eventBgColor,
+          color: _eventBgColorCss,
           width: 2,
         ),
         size: 5,
@@ -475,9 +479,9 @@ class EventTimeline {
       mode: 'markers',
       yaxis: 'y2',
       marker: Marker(
-        color: snapshotColor,
+        color: _snapshotColorCss,
         line: Line(
-          color: eventBgColor,
+          color: _eventBgColorCss,
           width: 2,
         ),
         size: 10,

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -22,7 +22,7 @@ import 'timeline_protocol.dart';
 
 // Light mode is Light Blue 50 palette and Dark mode is Blue 50 palette.
 // https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
+const mainUiColorLight = Color(0xFF9EBEF9); // Blue 200 Material Dark
 const mainUiColorSelectedLight = Color(0xFFD4D7DA); // Lighter grey.
 
 const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
@@ -31,7 +31,7 @@ const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
 const mainUiColorDark = Color(0xFFBBDEFB); // Blue 50 - 100
 const mainUiColorSelectedDark = Colors.white;
 
-const mainGpuColorDark = Color(0xFF1E88E5); // Blue 50 - 600
+const mainGpuColorDark = Color(0xFF336AEC); // Blue 500 Material Dark
 const mainGpuColorSelectedDark = Color(0xFFC9C9C9); // Grey.
 
 const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);
@@ -42,15 +42,13 @@ const Color selectedUiColor =
 const Color selectedGpuColor =
     ThemedColor(mainGpuColorSelectedLight, mainGpuColorSelectedDark);
 
-const jankGlowInside =
-    ThemedColor(Color.fromRGBO(255, 0, 0, .2), Color.fromRGBO(255, 0, 0, .2));
-const jankGlowEdge =
-    ThemedColor(Color.fromRGBO(255, 0, 0, .5), Color.fromRGBO(255, 0, 0, .6));
+// Light is Red @ .2 opacity, Dark is Red 200 Marterial Dark @ .2 opacity.
+const jankGlowInside = ThemedColor(Color(0x33FF0000), Color(0x33F29C99));
+// Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
+const jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C));
 
 // Red 50 - 400 is light at 1/2 opacity, Red 500 - 600 is dark at full opacity.
 const highwater16msColor = ThemedColor(Color(0x7FEF5350), Color(0xFFE53935));
-
-const Color slowFrameColor = Color(0xFFE50C0C);
 
 const Color hoverTextHighContrastColor = Colors.white;
 const Color hoverTextColor = Colors.black;

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -22,13 +22,13 @@ import 'timeline_protocol.dart';
 
 // Light mode is Light Blue 50 palette and Dark mode is Blue 50 palette.
 // https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-const mainUiColorLight = Color(0xFF9EBEF9); // Blue 200 Material Dark
+const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
 const mainUiColorSelectedLight = Color(0xFFD4D7DA); // Lighter grey.
 
 const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
 const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
 
-const mainUiColorDark = Color(0xFFBBDEFB); // Blue 50 - 100
+const mainUiColorDark = Color(0xFF9EBEF9); // Blue 200 Material Dark
 const mainUiColorSelectedDark = Colors.white;
 
 const mainGpuColorDark = Color(0xFF336AEC); // Blue 500 Material Dark
@@ -42,7 +42,7 @@ const Color selectedUiColor =
 const Color selectedGpuColor =
     ThemedColor(mainGpuColorSelectedLight, mainGpuColorSelectedDark);
 
-// Light is Red @ .2 opacity, Dark is Red 200 Marterial Dark @ .2 opacity.
+// Light is Red @ .2 opacity, Dark is Red 200 Material Dark @ .2 opacity.
 const jankGlowInside = ThemedColor(Color(0x33FF0000), Color(0x33F29C99));
 // Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
 const jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C));

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -47,8 +47,8 @@ const jankGlowInside = ThemedColor(Color(0x33FF0000), Color(0x33F29C99));
 // Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
 const jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C));
 
-// Red 50 - 400 is light at 1/2 opacity, Red 500 - 600 is dark at full opacity.
-const highwater16msColor = ThemedColor(Color(0x7FEF5350), Color(0xFFE53935));
+// Red 50 - 400 is light at 1/2 opacity, Dark Red 500 Material Dark.
+const highwater16msColor = ThemedColor(Color(0x7FEF5350), Color(0xFFe02a28));
 
 const Color hoverTextHighContrastColor = Colors.white;
 const Color hoverTextColor = Colors.black;


### PR DESCRIPTION
Old dark mode timeline before:

![image](https://user-images.githubusercontent.com/2055873/56313021-68f38a80-6106-11e9-8149-bca2c3afeaca.png)

New dark mode timeline (less intense):

![image](https://user-images.githubusercontent.com/2055873/56322030-ca265880-611c-11e9-9830-c56c351a06e2.png)

Old memory view dark mode:

![image](https://user-images.githubusercontent.com/2055873/56313334-3d24d480-6107-11e9-8987-ded5dd3d6ca0.png)

New memory view dark mode:

![image](https://user-images.githubusercontent.com/2055873/56313392-5b8ad000-6107-11e9-9fa0-12cc9330e7a0.png)


- Memory Y-axis, right side, title "Events" had the wrong font color.
- Memory snapshot and reset markers hard to see in legend for dark mode.
- Memory Y-axis, left side, title "Heap" removed.  Most thought it wasn't necessary.