### PR TITLE
[DevTools Server] Listen for URIs and register launchDevTools service.

### DIFF
--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -81,31 +81,14 @@ class ServiceConnectionManager {
     Map args,
   }) async {
     final registered = _registeredMethodsForService[name] ?? const [];
-    if (registered.length != 1) {
-      throw Exception('Expected one registered service for "$name" but found '
-          '${registered.length}');
-    }
-    return service.callMethod(registered.first,
-        isolateId: isolateId, args: args);
-  }
-
-  /// Call a service that may have been registered by multiple clients.
-  ///
-  /// For example, a service to navigate a code editor to a specific line and
-  /// column might be registered by multiple code editors.
-  Future<List<Response>> callMulticastService(
-    String name, {
-    String isolateId,
-    Map args,
-  }) async {
-    final registered = _registeredMethodsForService[name] ?? const [];
-    if (registered.isNotEmpty) {
-      return Future.wait(registered.map((String method) {
-        return service.callMethod(method, isolateId: isolateId, args: args);
-      }));
-    } else {
+    if (registered.isEmpty) {
       throw Exception('There are no registered methods for service "$name"');
     }
+    return service.callMethod(
+      registered.first,
+      isolateId: isolateId,
+      args: args,
+    );
   }
 
   StreamSubscription<bool> hasRegisteredService(
@@ -212,7 +195,7 @@ class ServiceConnectionManager {
 
   /// This can throw an [RPCError].
   Future<void> performHotReload() async {
-    await callMulticastService(
+    await callService(
       registrations.hotReload.service,
       isolateId: _isolateManager.selectedIsolate.id,
     );
@@ -220,7 +203,7 @@ class ServiceConnectionManager {
 
   /// This can throw an [RPCError].
   Future<void> performHotRestart() async {
-    await callMulticastService(
+    await callService(
       registrations.hotRestart.service,
       isolateId: _isolateManager.selectedIsolate.id,
     );

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   codemirror: ^0.5.3
   collection: ^1.14.11
   devtools_server: ^0.0.2
+#    path: ../devtools_server
   http: ^0.12.0+1
   intl: ^0.15.0
   js: ^0.6.1+1
@@ -46,7 +47,7 @@ dev_dependencies:
   build_web_compilers: ^1.2.0
   matcher: ^0.12.3
   test: ^1.0.0
-  webkit_inspection_protocol: ^0.3.6
+  webkit_inspection_protocol: ^0.4.0
 
 executables:
   devtools:

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -198,7 +198,7 @@ void main() {
           const [];
       expect(registeredService, isNotEmpty);
 
-      await serviceManager.callMulticastService(
+      await serviceManager.callService(
         registrations.hotReload.service,
         isolateId: serviceManager.isolateManager.selectedIsolate.id,
       );

--- a/packages/devtools/test/service_manager_test.dart
+++ b/packages/devtools/test/service_manager_test.dart
@@ -177,38 +177,7 @@ void main() {
     test('callService throws exception', () async {
       await env.setupEnvironment();
 
-      // Service with less than 1 registration.
-      await expectLater(
-          serviceManager.callService('fakeMethod'), throwsException);
-
-      // Service with more than 1 registration.
-      serviceManager.registeredMethodsForService.putIfAbsent('fakeMethod',
-          () => ['registration1.fakeMethod', 'registration2.fakeMethod']);
-      await expectLater(
-          serviceManager.callService('fakeMethod'), throwsException);
-
-      await env.tearDownEnvironment();
-    });
-
-    test('callMulticastService', () async {
-      await env.setupEnvironment();
-
-      final registeredService = serviceManager
-              .registeredMethodsForService[registrations.hotReload.service] ??
-          const [];
-      expect(registeredService, isNotEmpty);
-
-      await serviceManager.callService(
-        registrations.hotReload.service,
-        isolateId: serviceManager.isolateManager.selectedIsolate.id,
-      );
-
-      await env.tearDownEnvironment();
-    });
-
-    test('callMulticastService throws exception', () async {
-      await env.setupEnvironment();
-
+      // Service with 0 registrations.
       await expectLater(
           serviceManager.callService('fakeMethod'), throwsException);
 

--- a/packages/devtools_server/lib/src/chrome.dart
+++ b/packages/devtools_server/lib/src/chrome.dart
@@ -74,7 +74,7 @@ class Chrome {
     List<String> args = const [],
     int port,
   }) async {
-    final processArgs = List.from(urls)..addAll(args);
+    final processArgs = args.toList()..addAll(urls);
     await Process.start(_executable, processArgs);
   }
 }

--- a/packages/devtools_server/lib/src/chrome.dart
+++ b/packages/devtools_server/lib/src/chrome.dart
@@ -1,0 +1,146 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';
+
+// TODO(kenzie): move this code to dart-lang/browser_launcher. This code was
+// copied from https://github.com/dart-lang/webdev/blob/master/webdev/lib/src/serve/chrome.dart
+
+const _chromeEnvironment = 'CHROME_EXECUTABLE';
+const _linuxExecutable = 'google-chrome';
+const _macOSExecutable =
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+const _windowsExecutable = r'Google\Chrome\Application\chrome.exe';
+
+String get _executable {
+  if (Platform.environment.containsKey(_chromeEnvironment)) {
+    return Platform.environment[_chromeEnvironment];
+  }
+  if (Platform.isLinux) return _linuxExecutable;
+  if (Platform.isMacOS) return _macOSExecutable;
+  if (Platform.isWindows) return _windowsExecutable;
+  throw StateError('Unexpected platform type.');
+}
+
+var _currentCompleter = Completer<Chrome>();
+
+/// A class for managing an instance of Chrome.
+class Chrome {
+  final int debugPort;
+  final Process _process;
+  final Directory _dataDir;
+
+  final ChromeConnection chromeConnection;
+
+  Chrome._(
+      this.debugPort,
+      this.chromeConnection, {
+        Process process,
+        Directory dataDir,
+      })  : _process = process,
+        _dataDir = dataDir;
+
+  Future<void> close() async {
+    if (_currentCompleter.isCompleted) _currentCompleter = Completer<Chrome>();
+    chromeConnection.close();
+    _process?.kill();
+    await _process?.exitCode;
+    await _dataDir?.delete(recursive: true);
+  }
+
+  /// Connects to an instance of Chrome with an open debug port.
+  static Future<Chrome> fromExisting(int port) async =>
+      _connect(Chrome._(port, ChromeConnection('localhost', port)));
+
+  static Future<Chrome> get connectedInstance => _currentCompleter.future;
+
+  /// Starts Chrome with the remote debug port enabled.
+  ///
+  /// Each url in [urls] will be loaded in a separate tab.
+  static Future<Chrome> start(List<String> urls, {int port}) async {
+    var dataDir = Directory.systemTemp.createTempSync();
+    port = port == null || port == 0 ? await findUnusedPort() : port;
+    var args = [
+      // Using a tmp directory ensures that a new instance of chrome launches
+      // allowing for the remote debug port to be enabled.
+      '--user-data-dir=${dataDir.path}',
+      '--remote-debugging-port=$port',
+      // When the DevTools has focus we don't want to slow down the application.
+      '--disable-background-timer-throttling',
+      // Since we are using a temp profile, disable features that slow the
+      // Chrome launch.
+      '--disable-extensions',
+      '--disable-popup-blocking',
+      '--bwsi',
+      '--no-first-run',
+      '--no-default-browser-check',
+      '--disable-default-apps',
+      '--disable-translate',
+    ]..addAll(urls);
+
+    var process = await Process.start(_executable, args);
+
+    // Wait until the DevTools are listening before trying to connect.
+    await process.stderr
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .firstWhere((line) => line.startsWith('DevTools listening'));
+
+    return _connect(Chrome._(
+      port,
+      ChromeConnection('localhost', port),
+      process: process,
+      dataDir: dataDir,
+    ));
+  }
+
+  static Future<Chrome> _connect(Chrome chrome) async {
+    if (_currentCompleter.isCompleted) {
+      throw ChromeError('Only one instance of chrome can be started.');
+    }
+    // The connection is lazy. Try a simple call to make sure the provided
+    // connection is valid.
+    try {
+      await chrome.chromeConnection.getTabs();
+    } catch (e) {
+      await chrome.close();
+      throw ChromeError(
+          'Unable to connect to Chrome debug port: ${chrome.debugPort}\n $e');
+    }
+    _currentCompleter.complete(chrome);
+    return chrome;
+  }
+}
+
+class ChromeError extends Error {
+  final String details;
+  ChromeError(this.details);
+
+  @override
+  String toString() {
+    return 'ChromeError: $details';
+  }
+}
+
+/// Returns a port that is probably, but not definitely, not in use.
+///
+/// This has a built-in race condition: another process may bind this port at
+/// any time after this call has returned.
+Future<int> findUnusedPort() async {
+  int port;
+  ServerSocket socket;
+  try {
+    socket =
+    await ServerSocket.bind(InternetAddress.loopbackIPv6, 0, v6Only: true);
+  } on SocketException {
+    socket = await ServerSocket.bind(InternetAddress.loopbackIPv4, 0);
+  }
+  port = socket.port;
+  await socket.close();
+  return port;
+}

--- a/packages/devtools_server/lib/src/chrome.dart
+++ b/packages/devtools_server/lib/src/chrome.dart
@@ -71,13 +71,11 @@ class Chrome {
   /// Each url in [urls] will be loaded in a separate tab.
   static Future<void> start(
     List<String> urls, {
-    List<String> args,
+    List<String> args = const [],
     int port,
   }) async {
-    args ??= [];
-    args.addAll(urls);
-
-    await Process.start(_executable, args);
+    final processArgs = List.from(urls)..addAll(args);
+    await Process.start(_executable, processArgs);
   }
 }
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -167,7 +167,9 @@ Future<void> registerLaunchDevToolsService(
     final VmService service = await _connectToVmService(uri);
 
     service.registerServiceCallback(launchDevToolsService, (request) async {
-      final url = '$devToolsUrl/url=${Uri.encodeComponent(uri.toString())}#';
+      // TODO(kenzie): modify this to append arguments (i.e. theme=dark). This
+      // likely will require passing in args.
+      final url = '$devToolsUrl/?url=${Uri.encodeComponent(uri.toString())}#';
 
       // TODO(kenzie): depend on the browser_launcher package for this once it
       // is complete.
@@ -195,7 +197,6 @@ Future<void> registerLaunchDevToolsService(
       },
       machineMode: machineMode,
     );
-    return;
   }
 }
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -169,7 +169,7 @@ Future<void> registerLaunchDevToolsService(
     service.registerServiceCallback(launchDevToolsService, (request) async {
       // TODO(kenzie): modify this to append arguments (i.e. theme=dark). This
       // likely will require passing in args.
-      final url = '$devToolsUrl/?url=${Uri.encodeComponent(uri.toString())}#';
+      final url = '$devToolsUrl/?uri=${Uri.encodeComponent(uri.toString())}';
 
       // TODO(kenzie): depend on the browser_launcher package for this once it
       // is complete.

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -16,3 +16,5 @@ dependencies:
   pedantic: ^1.4.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
+  vm_service_lib: ^3.14.3-dev.4
+  webkit_inspection_protocol: ^0.4.0


### PR DESCRIPTION
- Listens for URIs over stdin
- Connects to vm service port provided in URI and registers launchDevTools service / method
- Adds code to launch chrome (this will be moved to dart-lang/browser_launcher when I create that package)
- Fixes a bug with callMulticastService - delete method as it is not needed