### PR TITLE
Add support for stable goldens

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,4 +25,4 @@
 *.zip    binary
 
 # Preserve \n line endings in Golden files.
-**/test/goldens/* eol=lf
+**/test/goldens*/* eol=lf

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,13 @@ file output still looks reasonable and execute the following command to update t
 ./tool/update_goldens.sh
 ```
 
+To update the Stable versions of the Golden files, switch to Flutter's current stable
+branch and run with the `--stable` switch.
+
+```
+./tool/update_goldens.sh --stable
+```
+
 ### third_party dependencies
 
 All content not authored by the Flutter team must go in the third_party

--- a/packages/devtools/test/matchers/matchers.dart
+++ b/packages/devtools/test/matchers/matchers.dart
@@ -48,10 +48,6 @@ String treeToDebugStringTruncated(RemoteDiagnosticsNode node, int maxLines) {
 /// ```
 /// tool/update_goldens.sh
 /// ```
-/// or for the Stable goldens, switch to the Flutter stable branch and run:
-/// ```
-/// tool/update_goldens.sh --stable
-/// ```
 ///
 /// A `#` followed by 5 hexadecimal digits is assumed to be a short hash code
 /// and is normalized to #00000.
@@ -130,9 +126,7 @@ class _EqualsGoldenIgnoringHashCodes extends Matcher {
           .add('\nbut got\n  ')
           .addDescriptionOf(actualValue)
           .add('\nTo update golden files run:\n')
-          .add('  tool/update_goldens.sh"\n')
-          .add('or"\n')
-          .add('  tool/update_goldens.sh --stable"\n');
+          .add('  tool/update_goldens.sh"\n');
     }
     return null;
   }

--- a/packages/devtools/test/matchers/matchers.dart
+++ b/packages/devtools/test/matchers/matchers.dart
@@ -44,11 +44,13 @@ String treeToDebugStringTruncated(RemoteDiagnosticsNode node, int maxLines) {
 ///
 /// Paths are assumed to reference files within the `test/goldens` directory.
 ///
-/// To rebaseline all golden files run tests with:
+/// To rebaseline all golden files run:
 /// ```
-/// export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
-/// pub run test test/your_vm_test.dart
-/// unset DART_VM_OPTIONS
+/// tool/update_goldens.sh
+/// ```
+/// or for the Stable goldens, switch to the Flutter stable branch and run:
+/// ```
+/// tool/update_goldens.sh --stable
 /// ```
 ///
 /// A `#` followed by 5 hexadecimal digits is assumed to be a short hash code
@@ -64,7 +66,7 @@ Matcher equalsGoldenIgnoringHashCodes(String path) {
 
 class _EqualsGoldenIgnoringHashCodes extends Matcher {
   _EqualsGoldenIgnoringHashCodes(String pathWithinGoldenDirectory) {
-    path = 'test/goldens/$pathWithinGoldenDirectory';
+    path = 'test/goldens$_goldensSuffix/$pathWithinGoldenDirectory';
     try {
       _value = io.File(path).readAsStringSync();
     } catch (e) {
@@ -77,6 +79,8 @@ class _EqualsGoldenIgnoringHashCodes extends Matcher {
   static final Object _mismatchedValueKey = Object();
 
   static bool _updateGoldens;
+  static const String _goldensSuffix =
+      String.fromEnvironment('GOLDENS_SUFFIX', defaultValue: '');
 
   static bool get updateGoldens {
     _updateGoldens ??=
@@ -126,9 +130,9 @@ class _EqualsGoldenIgnoringHashCodes extends Matcher {
           .add('\nbut got\n  ')
           .addDescriptionOf(actualValue)
           .add('\nTo update golden files run:\n')
-          .add('export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"\n')
-          .add('pub run test test/\n')
-          .add('unset DART_VM_OPTIONS\n');
+          .add('  tool/update_goldens.sh"\n')
+          .add('or"\n')
+          .add('  tool/update_goldens.sh --stable"\n');
     }
     return null;
   }

--- a/tool/update_goldens.sh
+++ b/tool/update_goldens.sh
@@ -6,15 +6,15 @@
 
 echo "Checking flutter version..."
 if flutter --version | tee /dev/tty | grep -q 'channel stable'; then
-	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true -DGOLDENS_SUFFIX=_stable"
-	echo ""
-	echo "Updating STABLE goldens because you are on the Stable flutter channel"
-	echo ""
+  export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true -DGOLDENS_SUFFIX=_stable"
+  echo ""
+  echo "Updating STABLE goldens because you are on the Stable flutter channel"
+  echo ""
 else
-	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
-	echo ""
-	echo "Updating MASTER goldens"
-	echo ""
+  export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
+  echo ""
+  echo "Updating MASTER goldens"
+  echo ""
 fi
 
 

--- a/tool/update_goldens.sh
+++ b/tool/update_goldens.sh
@@ -6,9 +6,11 @@
 
 if [ $1 = "--stable" ]; then
 	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true -DGOLDENS_SUFFIX=_stable"
+	# TODO(dantup): We should try to automate a check for this
 	echo "Make sure your flutter is the current live STABLE branch"
 else
 	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
+	# TODO(dantup): We should try to automate a check for this
 	echo "Make sure your flutter is the tip of trunk Flutter"
 fi
 

--- a/tool/update_goldens.sh
+++ b/tool/update_goldens.sh
@@ -4,9 +4,14 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
+if [ $1 = "--stable" ]; then
+	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true -DGOLDENS_SUFFIX=_stable"
+	echo "Make sure your flutter is the current live STABLE branch"
+else
+	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
+	echo "Make sure your flutter is the tip of trunk Flutter"
+fi
 
-echo "Make sure your flutter is the tip of trunk Flutter"
 
 set -x #echo on
 which flutter

--- a/tool/update_goldens.sh
+++ b/tool/update_goldens.sh
@@ -4,14 +4,17 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-if [ $1 = "--stable" ]; then
+echo "Checking flutter version..."
+if flutter --version | tee /dev/tty | grep -q 'channel stable'; then
 	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true -DGOLDENS_SUFFIX=_stable"
-	# TODO(dantup): We should try to automate a check for this
-	echo "Make sure your flutter is the current live STABLE branch"
+	echo ""
+	echo "Updating STABLE goldens because you are on the Stable flutter channel"
+	echo ""
 else
 	export DART_VM_OPTIONS="-DUPDATE_GOLDENS=true"
-	# TODO(dantup): We should try to automate a check for this
-	echo "Make sure your flutter is the tip of trunk Flutter"
+	echo ""
+	echo "Updating MASTER goldens"
+	echo ""
 fi
 
 


### PR DESCRIPTION
This is to help with #548. There's now a `--stable` flag you can pass to `update-goldens` and also if you set `-DGOLDENS_SUFFIX` in `DART_VM_OPTIONS` it'll use them at runtime (currently no code does this, but I'll be rebasing #548 on top of this to use it soon).
