### PR TITLE
Dark mode tweaks for timeline.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -42,7 +42,7 @@ class EventDetails extends CoreElement {
   static const defaultTitleText = '[No event selected]';
   static const defaultTitleBackground = ThemedColor(
     Color(0xFFF6F6F6),
-    Color(0xFF323232),
+    Color(0xFF2D2E31), // Material Dark Grey 900+2
   );
 
   PTabNav tabNav;

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -12,6 +12,7 @@ import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/primer.dart';
+import '../ui/theme.dart';
 import '../utils.dart';
 import 'cpu_bottom_up.dart';
 import 'cpu_call_tree.dart';
@@ -39,7 +40,10 @@ class EventDetails extends CoreElement {
   }
 
   static const defaultTitleText = '[No event selected]';
-  static const defaultTitleBackground = Color(0xFFF6F6F6);
+  static const defaultTitleBackground = ThemedColor(
+    Color(0xFFF6F6F6),
+    Color(0xFF323232),
+  );
 
   PTabNav tabNav;
   CoreElement content;
@@ -50,8 +54,10 @@ class EventDetails extends CoreElement {
   _Details _details;
 
   void _initContent() {
-    _title = div(text: defaultTitleText, c: 'event-details-heading')
-      ..element.style.backgroundColor = colorToCss(defaultTitleBackground);
+    _title = div(text: defaultTitleText, c: 'event-details-heading');
+    _title.element.style
+      ..color = colorToCss(contrastForeground)
+      ..backgroundColor = colorToCss(defaultTitleBackground);
     _details = _Details()..attribute('hidden');
 
     content = div(c: 'event-details-section section-border')
@@ -115,6 +121,7 @@ class EventDetails extends CoreElement {
             ..add([
               hideNativeCheckbox,
               CoreElement('div', text: 'Collapse native samples')
+                ..element.style.color = colorToCss(contrastForeground),
             ]))
           .element,
     ]);
@@ -126,15 +133,16 @@ class EventDetails extends CoreElement {
     _title.text = '${_event.name} - ${msText(_event.time.duration)}';
     _title.element.style
       ..backgroundColor = colorToCss(item.backgroundColor)
-      ..color = colorToCss(_event.isGpuEvent ? Colors.white : Colors.black);
+      ..color = colorToCss(item.defaultTextColor);
 
     await _details.update(item.event);
   }
 
   void reset() {
     _title.text = defaultTitleText;
-    _title.element.style.color = colorToCss(Colors.black);
-    _title.element.style.backgroundColor = colorToCss(defaultTitleBackground);
+    _title.element.style
+      ..color = colorToCss(contrastForeground)
+      ..backgroundColor = colorToCss(defaultTitleBackground);
     _details.reset();
   }
 }

--- a/packages/devtools/lib/src/timeline/flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart.dart
@@ -17,7 +17,7 @@ import 'timeline.dart';
 // TODO(kenzie): delete this file once frame_flame_chart is ported to canvas.
 
 const selectedFlameChartItemColor =
-    ThemedColor(mainUiColorSelectedLight, mainUiColorSelectedDark);
+    ThemedColor(mainUiColorSelectedLight, mainUiColorSelectedLight);
 
 /// Flame chart superclass that houses zooming, scrolling, and selection logic,
 /// among other data handling methods like `update` and `reset`.

--- a/packages/devtools/lib/src/timeline/frame_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_flame_chart.dart
@@ -17,20 +17,20 @@ import 'timeline_protocol.dart';
 
 // TODO(kenzie): port all of this code to use flame_chart_canvas.dart.
 
-// Light Blue 50 - 200-400 (light mode) or Blue 50 - 100-300 (dark mode) color
-// palette from https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Light Blue 50: 200-400 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Blue Material Dark: 200-400 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
 final uiColorPalette = [
   const ThemedColor(mainUiColorLight, mainUiColorDark),
-  const ThemedColor(Color(0xFF4FC3F7), Color(0xFF90CAF9)),
-  const ThemedColor(Color(0xFF29B6F6), Color(0xFF64B5F6)),
+  const ThemedColor(Color(0xFF4FC3F7), Color(0xFF8AB4F7)),
+  const ThemedColor(Color(0xFF29B6F6), Color(0xFF669CF6)),
 ];
 
-// Light Blue 50 - 700-900 (light mode) or Blue 50 - 600-800 (dark mode) color
-// palette from https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Light Blue 50: 700-900 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Blue Material Dark: 500-700 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
 final gpuColorPalette = [
   const ThemedColor(mainGpuColorLight, mainGpuColorDark),
-  const ThemedColor(Color(0xFF0277BD), Color(0xFF1976D2)),
-  const ThemedColor(Color(0xFF01579B), Color(0xFF1565C0)),
+  const ThemedColor(Color(0xFF0277BD), Color(0xFF1966D2)),
+  const ThemedColor(Color(0xFF01579B), Color(0xFF1859BD)),
 ];
 
 final StreamController<FrameFlameChartItem>
@@ -220,7 +220,7 @@ class FrameFlameChart extends FlameChart<TimelineFrame> {
       width,
       top,
       event.isUiEvent ? nextUiColor() : nextGpuColor(),
-      event.isUiEvent ? Colors.black : Colors.white,
+      event.isUiEvent ? Colors.black : contrastForegroundWhite,
       Colors.black,
       includeDuration: includeDuration,
     );
@@ -415,7 +415,8 @@ class TimelineGridItem extends CoreElement {
     gridLine = div(c: 'grid-line');
     add(gridLine);
 
-    timestampLabel = div(c: 'timestamp');
+    timestampLabel = div(c: 'timestamp')
+      ..element.style.color = colorToCss(contrastForeground);
     // TODO(kenzie): add more advanced logic for rounding the timestamps. See
     // https://github.com/flutter/devtools/issues/329.
     timestampLabel.text = msText(

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -160,9 +160,7 @@
 }
 
 .event-details-heading {
-    background-color: var(--shaded-background-darker);
     padding: 3px 12px;
-    font-weight: bold;
     min-width: 100%;
 }
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -31,7 +31,7 @@ const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
 const mainUiColorDark = Color(0xFF9EBEF9); // Blue 200 Material Dark
 const mainUiColorSelectedDark = Colors.white;
 
-const mainGpuColorDark = Color(0xFF336AEC); // Blue 500 Material Dark
+const mainGpuColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
 const mainGpuColorSelectedDark = Color(0xFFC9C9C9); // Grey.
 
 const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);

--- a/packages/devtools/lib/src/ui/theme.dart
+++ b/packages/devtools/lib/src/ui/theme.dart
@@ -27,8 +27,9 @@ const ThemedColor defaultForeground =
 // Text color [defaultForeground] is too gray, making it hard to read the text
 // in dark theme. We should use a more white color for dark theme, but not
 // jarring white #FFFFFF.
+const Color contrastForegroundWhite = Color.fromARGB(255, 240, 240, 240);
 const ThemedColor contrastForeground =
-    ThemedColor(Colors.black, Color.fromARGB(255, 240, 240, 240));
+    ThemedColor(Colors.black, contrastForegroundWhite);
 
 const ThemedColor grey = ThemedColor(
     Color.fromARGB(255, 128, 128, 128), Color.fromARGB(255, 128, 128, 128));

--- a/packages/devtools/lib/src/ui/theme.dart
+++ b/packages/devtools/lib/src/ui/theme.dart
@@ -35,8 +35,10 @@ const ThemedColor grey = ThemedColor(
     Color.fromARGB(255, 128, 128, 128), Color.fromARGB(255, 128, 128, 128));
 
 // Background colors for charts.
-const ThemedColor chartBackground =
-    ThemedColor(Colors.white, Color.fromRGBO(47, 43, 43, 1));
+const ThemedColor chartBackground = ThemedColor(
+  Colors.white,
+  Color(0xFF2D2E31), // Material Dark Grey 900+2
+);
 
 /// Color that behaves differently depending on whether a light or dark theme
 /// is used.

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -35,7 +35,7 @@
     --selected-background: #545454;
     --selected-line: #626d7b;
     --shadow-color: #585858;
-    --shaded-background-lighter: #323232;
+    --shaded-background-lighter: #2d2e31;
     --shaded-background-darker: var(--default-background);
     --subtle: #888;
     --table-border: #484848;


### PR DESCRIPTION
- Modify UI/GPU color palettes to match Terry's changes in #552 
- Use contrastForegroundWhite instead of jarring white #FFFFFF
- General cleanup
<img width="1123" alt="Screen Shot 2019-04-19 at 8 26 52 AM" src="https://user-images.githubusercontent.com/43759233/56430962-0670ca80-627d-11e9-817c-384d7ec5c59f.png">
