### PR TITLE
Determine flutter vs flutter_web from isolate libraries.

### DIFF
--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -37,7 +37,9 @@ class ConnectedApp {
     assert(serviceManager.serviceAvailable.isCompleted);
     await serviceManager.isolateManager.selectedIsolateAvailable.future;
 
-    return serviceManager.isolateManager.selectedIsolateLibraryUris
+    return serviceManager.isolateManager.selectedIsolateLibraries
+        .map((ref) => ref.uri)
+        .toList()
         .contains(flutterLibraryUri);
   }
 
@@ -48,7 +50,9 @@ class ConnectedApp {
     // TODO(kenzie): change this if screens should still be disabled when
     // flutter merges with flutter_web. See
     // https://github.com/flutter/devtools/issues/466.
-    return serviceManager.isolateManager.selectedIsolateLibraryUris
+    return serviceManager.isolateManager.selectedIsolateLibraries
+        .map((ref) => ref.uri)
+        .toList()
         .contains(flutterWebLibraryUri);
   }
 

--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:vm_service_lib/vm_service_lib.dart';
 
-import 'eval_on_dart_library.dart';
 import 'globals.dart';
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';

--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -15,12 +15,15 @@ class ConnectedApp {
   ConnectedApp();
 
   Future<bool> get isFlutterApp async =>
-      _isFlutterApp ?? await _connectedToFlutterApp();
+      _isFlutterApp ?? await _libraryUriAvailable(flutterLibraryUri);
 
   bool _isFlutterApp;
 
+  // TODO(kenzie): change this if screens should still be disabled when
+  // flutter merges with flutter_web. See
+  // https://github.com/flutter/devtools/issues/466.
   Future<bool> get isFlutterWebApp async =>
-      _isFlutterWebApp ?? await _connectedToFlutterWebApp();
+      _isFlutterWebApp ?? await _libraryUriAvailable(flutterWebLibraryUri);
 
   bool _isFlutterWebApp;
 
@@ -31,29 +34,6 @@ class ConnectedApp {
 
   Future<bool> get isAnyFlutterApp async =>
       await isFlutterApp || await isFlutterWebApp;
-
-  Future<bool> _connectedToFlutterApp() async {
-    assert(serviceManager.serviceAvailable.isCompleted);
-    await serviceManager.isolateManager.selectedIsolateAvailable.future;
-
-    return serviceManager.isolateManager.selectedIsolateLibraries
-        .map((ref) => ref.uri)
-        .toList()
-        .contains(flutterLibraryUri);
-  }
-
-  Future<bool> _connectedToFlutterWebApp() async {
-    assert(serviceManager.serviceAvailable.isCompleted);
-    await serviceManager.isolateManager.selectedIsolateAvailable.future;
-
-    // TODO(kenzie): change this if screens should still be disabled when
-    // flutter merges with flutter_web. See
-    // https://github.com/flutter/devtools/issues/466.
-    return serviceManager.isolateManager.selectedIsolateLibraries
-        .map((ref) => ref.uri)
-        .toList()
-        .contains(flutterWebLibraryUri);
-  }
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
@@ -77,5 +57,15 @@ class ConnectedApp {
     } on RPCError catch (_) {
       return true;
     }
+  }
+
+  Future<bool> _libraryUriAvailable(String uri) async {
+    assert(serviceManager.serviceAvailable.isCompleted);
+    await serviceManager.isolateManager.selectedIsolateAvailable.future;
+
+    return serviceManager.isolateManager.selectedIsolateLibraries
+        .map((ref) => ref.uri)
+        .toList()
+        .contains(uri);
   }
 }

--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -35,37 +35,21 @@ class ConnectedApp {
 
   Future<bool> _connectedToFlutterApp() async {
     assert(serviceManager.serviceAvailable.isCompleted);
+    await serviceManager.isolateManager.selectedIsolateAvailable.future;
 
-    final flutterLibrary = EvalOnDartLibrary(
-      [flutterLibraryUri],
-      serviceManager.service,
-    );
-
-    try {
-      await flutterLibrary.libraryRef;
-    } on LibraryNotFound catch (_) {
-      return false;
-    }
-    return true;
+    return serviceManager.isolateManager.selectedIsolateLibraryUris
+        .contains(flutterLibraryUri);
   }
 
   Future<bool> _connectedToFlutterWebApp() async {
     assert(serviceManager.serviceAvailable.isCompleted);
+    await serviceManager.isolateManager.selectedIsolateAvailable.future;
 
-    // TODO(kenzie): change this if screens should still be disabled when flutter
-    // merges with flutter_web. See
+    // TODO(kenzie): change this if screens should still be disabled when
+    // flutter merges with flutter_web. See
     // https://github.com/flutter/devtools/issues/466.
-    final flutterWebLibrary = EvalOnDartLibrary(
-      [flutterWebLibraryUri],
-      serviceManager.service,
-    );
-
-    try {
-      await flutterWebLibrary.libraryRef;
-    } on LibraryNotFound catch (_) {
-      return false;
-    }
-    return true;
+    return serviceManager.isolateManager.selectedIsolateLibraryUris
+        .contains(flutterWebLibraryUri);
   }
 
   Future<bool> _connectedToProfileBuild() async {

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -302,6 +302,13 @@ class ActionsContainer {
   final List<ActionButton> _actions = [];
 
   void addAction(ActionButton action) {
+    for (ActionButton _action in _actions) {
+      if (_action.tooltip == action.tooltip) {
+        // This action is a duplicate. Do not add it.
+        return;
+      }
+    }
+
     if (_actions.isEmpty) {
       // add a visual separator
       element.add(span(

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -232,8 +232,8 @@ class Framework {
     globalActions.addAction(action);
   }
 
-  void removeGlobalAction(String name) {
-    globalActions.removeAction(name);
+  void removeGlobalAction(String id) {
+    globalActions.removeAction(id);
   }
 }
 
@@ -303,7 +303,7 @@ class ActionsContainer {
 
   void addAction(ActionButton action) {
     for (ActionButton _action in _actions) {
-      if (_action.tooltip == action.tooltip) {
+      if (_action.id == action.id) {
         // This action is a duplicate. Do not add it.
         return;
       }
@@ -319,8 +319,8 @@ class ActionsContainer {
     element.add(action.element);
   }
 
-  void removeAction(String name) {
-    _actions.removeWhere((ActionButton button) => button.tooltip == name);
+  void removeAction(String id) {
+    _actions.removeWhere((ActionButton button) => button.id == id);
   }
 
   void clearActions() {

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -45,8 +45,8 @@ class PerfToolFramework extends Framework {
   StatusItem connectionStatus;
   Status reloadStatus;
 
-  static const _reloadTooltip = 'Hot Reload';
-  static const _restartTooltip = 'Hot Restart';
+  static const _reloadActionId = 'reload-action';
+  static const _restartActionId = 'restart-action';
 
   void initGlobalUI() async {
     await serviceManager.serviceAvailable.future;
@@ -216,7 +216,7 @@ class PerfToolFramework extends Framework {
         if (reloadServiceAvailable) {
           _buildReloadButton();
         } else {
-          removeGlobalAction(_reloadTooltip);
+          removeGlobalAction(_reloadActionId);
         }
       },
     );
@@ -227,7 +227,7 @@ class PerfToolFramework extends Framework {
         if (reloadServiceAvailable) {
           _buildRestartButton();
         } else {
-          removeGlobalAction(_restartTooltip);
+          removeGlobalAction(_restartActionId);
         }
       },
     );
@@ -240,8 +240,11 @@ class PerfToolFramework extends Framework {
     // them in the UI. That will mean that our UI will update appropriately
     // even when other clients (the CLI, and IDE) initial the hot reload.
 
-    final ActionButton reloadAction =
-        ActionButton(FlutterIcons.hotReloadWhite, _reloadTooltip);
+    final ActionButton reloadAction = ActionButton(
+      _reloadActionId,
+      FlutterIcons.hotReloadWhite,
+      'Hot Reload',
+    );
     reloadAction.click(() async {
       // Hide any previous status related to / restart.
       reloadStatus?.dispose();
@@ -274,8 +277,11 @@ class PerfToolFramework extends Framework {
   }
 
   void _buildRestartButton() async {
-    final ActionButton restartAction =
-        ActionButton(FlutterIcons.hotRestartWhite, _restartTooltip);
+    final ActionButton restartAction = ActionButton(
+      _restartActionId,
+      FlutterIcons.hotRestartWhite,
+      'Hot Restart',
+    );
     restartAction.click(() async {
       // Hide any previous status related to reload / restart.
       reloadStatus?.dispose();

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -225,7 +225,7 @@ class IsolateManager {
 
   Completer<Null> selectedIsolateAvailable = Completer();
 
-  List<String> selectedIsolateLibraryUris;
+  List<LibraryRef> selectedIsolateLibraries;
 
   List<IsolateRef> get isolates => List<IsolateRef>.unmodifiable(_isolates);
 
@@ -328,8 +328,7 @@ class IsolateManager {
 
     // Store the library uris for the selected isolate.
     final Isolate isolate = await _service.getIsolate(ref.id);
-    selectedIsolateLibraryUris =
-        isolate.libraries.map((ref) => ref.uri).toList();
+    selectedIsolateLibraries = isolate.libraries;
 
     _selectedIsolate = ref;
     if (!selectedIsolateAvailable.isCompleted) {

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -360,12 +360,13 @@ CoreElement _defaultRenderer<T>(T item) {
 }
 
 class ActionButton implements CoreElementView {
-  ActionButton(this.icon, this.tooltip) {
+  ActionButton(this.id, this.icon, this.tooltip) {
     _element = div(c: 'masthead-item action-button')
       ..tooltip = tooltip
       ..add(createIconElement(icon));
   }
 
+  final String id;
   final Icon icon;
   final String tooltip;
 


### PR DESCRIPTION
On selecting a new isolate, get and store the library uris for the isolate. Fixes https://github.com/flutter/devtools/issues/554.

- Also fixes https://github.com/flutter/devtools/issues/498, where the global actions were being added twice.