### PR TITLE
Tweaks to browser-launching service

### DIFF
--- a/packages/devtools/lib/src/framework/framework_core.dart
+++ b/packages/devtools/lib/src/framework/framework_core.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 import 'dart:html' hide Screen;
 
-import 'package:devtools/src/utils.dart';
+import 'package:vm_service_lib/utils.dart';
 
 import '../../devtools.dart' as devtools show version;
 import '../core/message_bus.dart';
@@ -45,7 +45,7 @@ class FrameworkCore {
 
       // Map the URI (which may be Observatory web app) to a WebSocket URI for
       // the VM service.
-      uri = getVmServiceUriFromObservatoryUri(uri);
+      uri = convertToWebSocketUrl(serviceProtocolUrl: uri);
 
       try {
         final VmServiceWrapper service = await connect(uri, finishedCompleter);

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -163,20 +163,6 @@ class Property<T> {
   Stream<T> get onValueChange => _changeController.stream;
 }
 
-/// Map the URI (which may already be Observatory web app) to a WebSocket URI
-/// for the VM service. If the URI is already a VM Service WebSocket URI it
-/// will not be modified.
-Uri getVmServiceUriFromObservatoryUri(Uri uri) {
-  final isSecure = uri.isScheme('wss') || uri.isScheme('https');
-  final scheme = isSecure ? 'wss' : 'ws';
-
-  final path = uri.path.endsWith('/ws')
-      ? uri.path
-      : (uri.path.endsWith('/') ? '${uri.path}ws' : '${uri.path}/ws');
-
-  return uri.replace(scheme: scheme, path: path);
-}
-
 /// A typedef to represent a function taking no arguments and with no return
 /// value.
 typedef VoidFunction = void Function();

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   pedantic: ^1.4.0
   platform_detect: ^1.3.5
   rxdart: ^0.21.0
-  vm_service_lib: ^3.14.3-dev.4
+  vm_service_lib: ^3.15.1+1
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1

--- a/packages/devtools/test/support/cli_test_driver.dart
+++ b/packages/devtools/test/support/cli_test_driver.dart
@@ -6,8 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:devtools/src/utils.dart';
 import 'package:devtools/src/vm_service_wrapper.dart';
+import 'package:vm_service_lib/utils.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:vm_service_lib/vm_service_lib_io.dart';
 
@@ -105,7 +105,7 @@ class CliAppFixture extends AppFixture {
     }
 
     // Map to WS URI.
-    uri = getVmServiceUriFromObservatoryUri(uri);
+    uri = convertToWebSocketUrl(serviceProtocolUrl: uri);
 
     final VmServiceWrapper serviceConnection =
         VmServiceWrapper(await vmServiceConnectUri(uri.toString()));

--- a/packages/devtools/test/support/flutter_test_driver.dart
+++ b/packages/devtools/test/support/flutter_test_driver.dart
@@ -6,9 +6,9 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:devtools/src/utils.dart';
 import 'package:devtools/src/vm_service_wrapper.dart';
 import 'package:pedantic/pedantic.dart';
+import 'package:vm_service_lib/utils.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 import 'package:vm_service_lib/vm_service_lib_io.dart';
 
@@ -324,7 +324,8 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       _vmServiceWsUri = Uri.parse(wsUriString);
 
       // Map to WS URI.
-      _vmServiceWsUri = getVmServiceUriFromObservatoryUri(_vmServiceWsUri);
+      _vmServiceWsUri =
+          convertToWebSocketUrl(serviceProtocolUrl: _vmServiceWsUri);
 
       vmService = VmServiceWrapper(
         await vmServiceConnectUri(_vmServiceWsUri.toString()),

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -150,7 +150,7 @@ void serveDevTools({
   });
 }
 
-Future _handleVmRegister(dynamic id, Map<String, dynamic> params,
+Future<void> _handleVmRegister(dynamic id, Map<String, dynamic> params,
     bool machineMode, String devToolsUrl) async {
   if (!params.containsKey('uri')) {
     printOutput(

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -129,6 +129,7 @@ void serveDevTools({
   //   }
   // }
   _stdinCommandStream.listen((Map<String, dynamic> json) async {
+    // ID can be String, int or null
     final dynamic id = json['id'];
     final Map<String, dynamic> params = json['params'];
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -164,7 +164,7 @@ Future<void> _handleVmRegister(dynamic id, Map<String, dynamic> params,
   }
 
   // json['uri'] should contain a vm service uri.
-  final uri = Uri.parse(params['uri']);
+  final uri = Uri.tryParse(params['uri']);
 
   // Lots of things are considered valid URIs (including empty strings
   // and single letters) since they can be relative, so we need to do some
@@ -174,8 +174,18 @@ Future<void> _handleVmRegister(dynamic id, Map<String, dynamic> params,
       (uri.isScheme('ws') ||
           uri.isScheme('wss') ||
           uri.isScheme('http') ||
-          uri.isScheme('https')))
+          uri.isScheme('https'))) {
     await registerLaunchDevToolsService(uri, id, devToolsUrl, machineMode);
+  } else {
+    printOutput(
+      'Uri must be absolute with a http, https, ws or wss scheme',
+      {
+        'id': id,
+        'error': 'Uri must be absolute with a http, https, ws or wss scheme',
+      },
+      machineMode: machineMode,
+    );
+  }
 }
 
 Future<void> registerLaunchDevToolsService(

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -13,6 +13,7 @@ import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_static/shelf_static.dart';
+import 'package:vm_service_lib/utils.dart';
 import 'package:vm_service_lib/vm_service_lib.dart' hide Isolate;
 
 import 'chrome.dart';
@@ -235,7 +236,7 @@ Future<void> registerLaunchDevToolsService(
 
 Future<VmService> _connectToVmService(Uri uri) async {
   // Fix up the various acceptable URI formats into a WebSocket URI to connect.
-  uri = getVmServiceUriFromObservatoryUri(uri);
+  uri = convertToWebSocketUrl(serviceProtocolUrl: uri);
 
   final WebSocket ws = await WebSocket.connect(uri.toString());
 
@@ -268,21 +269,4 @@ void printOutput(
   @required bool machineMode,
 }) {
   print(machineMode ? jsonEncode(json) : message);
-}
-
-/// Map the URI (which may already be Observatory web app) to a WebSocket URI
-/// for the VM service.
-///
-/// If the URI is already a VM Service WebSocket URI it will not be modified.
-Uri getVmServiceUriFromObservatoryUri(Uri uri) {
-  // TODO(dantup): We have two copies of this and should move it to vm_service_lib
-  // then switch to that.
-  final isSecure = uri.isScheme('wss') || uri.isScheme('https');
-  final scheme = isSecure ? 'wss' : 'ws';
-
-  final path = uri.path.endsWith('/ws')
-      ? uri.path
-      : (uri.path.endsWith('/') ? '${uri.path}ws' : '${uri.path}/ws');
-
-  return uri.replace(scheme: scheme, path: path);
 }

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -275,6 +275,8 @@ void printOutput(
 ///
 /// If the URI is already a VM Service WebSocket URI it will not be modified.
 Uri getVmServiceUriFromObservatoryUri(Uri uri) {
+  // TODO(dantup): We have two copies of this and should move it to vm_service_lib
+  // then switch to that.
   final isSecure = uri.isScheme('wss') || uri.isScheme('https');
   final scheme = isSecure ? 'wss' : 'ws';
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -102,6 +102,10 @@ void serveDevTools({
   printOutput(
     'Serving DevTools at $devToolsUrl',
     {
+      'event': 'server.started',
+      // TODO(dantup): Remove this `method` field when we're sure VS Code users
+      // are all on a newer version that uses `event`. We incorrectly used
+      // `method` for the original releases.
       'method': 'server.started',
       'params': {'host': server.address.host, 'port': server.port, 'pid': pid}
     },

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -128,31 +128,49 @@ void serveDevTools({
     final dynamic id = json['id'];
     final Map<String, dynamic> params = json['params'];
 
-    if (!params.containsKey('uri')) {
-      printOutput(
-        'Invalid input: $params does not contain the key \'uri\'',
-        {
-          'id': id,
-          'error': 'Invalid input: $params does not contain the key \'uri\'',
-        },
-        machineMode: machineMode,
-      );
+    switch (json['method']) {
+      case 'vm.register':
+        await _handleVmRegister(id, params, machineMode, devToolsUrl);
+        break;
+      default:
+        printOutput(
+          'Unknown command ${json['method']}',
+          {
+            'id': id,
+            'error': 'Unknown method ${json['method']}',
+          },
+          machineMode: machineMode,
+        );
     }
-
-    // json['uri'] should contain a vm service uri.
-    final uri = Uri.parse(params['uri']);
-
-    // Lots of things are considered valid URIs (including empty strings
-    // and single letters) since they can be relative, so we need to do some
-    // extra checks.
-    if (uri != null &&
-        uri.isAbsolute &&
-        (uri.isScheme('ws') ||
-            uri.isScheme('wss') ||
-            uri.isScheme('http') ||
-            uri.isScheme('https')))
-      await registerLaunchDevToolsService(uri, id, devToolsUrl, machineMode);
   });
+}
+
+Future _handleVmRegister(dynamic id, Map<String, dynamic> params,
+    bool machineMode, String devToolsUrl) async {
+  if (!params.containsKey('uri')) {
+    printOutput(
+      'Invalid input: $params does not contain the key \'uri\'',
+      {
+        'id': id,
+        'error': 'Invalid input: $params does not contain the key \'uri\'',
+      },
+      machineMode: machineMode,
+    );
+  }
+
+  // json['uri'] should contain a vm service uri.
+  final uri = Uri.parse(params['uri']);
+
+  // Lots of things are considered valid URIs (including empty strings
+  // and single letters) since they can be relative, so we need to do some
+  // extra checks.
+  if (uri != null &&
+      uri.isAbsolute &&
+      (uri.isScheme('ws') ||
+          uri.isScheme('wss') ||
+          uri.isScheme('http') ||
+          uri.isScheme('https')))
+    await registerLaunchDevToolsService(uri, id, devToolsUrl, machineMode);
 }
 
 Future<void> registerLaunchDevToolsService(

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -125,7 +125,7 @@ void serveDevTools({
   //   }
   // }
   _stdinCommandStream.listen((Map<String, dynamic> json) async {
-    final int id = json['id'];
+    final dynamic id = json['id'];
     final Map<String, dynamic> params = json['params'];
 
     if (!params.containsKey('uri')) {
@@ -157,7 +157,7 @@ void serveDevTools({
 
 Future<void> registerLaunchDevToolsService(
   Uri uri,
-  int id,
+  dynamic id,
   String devToolsUrl,
   bool machineMode,
 ) async {

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -184,7 +184,7 @@ Future<void> registerLaunchDevToolsService(
       'Successfully registered launchDevTools service',
       {
         'id': id,
-        'result': Success().toJson(),
+        'result': {'success': true},
       },
       machineMode: machineMode,
     );

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -140,7 +140,7 @@ void serveDevTools({
         break;
       default:
         printOutput(
-          'Unknown command ${json['method']}',
+          'Unknown method ${json['method']}',
           {
             'id': id,
             'error': 'Unknown method ${json['method']}',

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -271,8 +271,9 @@ void printOutput(
 }
 
 /// Map the URI (which may already be Observatory web app) to a WebSocket URI
-/// for the VM service. If the URI is already a VM Service WebSocket URI it
-/// will not be modified.
+/// for the VM service.
+///
+/// If the URI is already a VM Service WebSocket URI it will not be modified.
 Uri getVmServiceUriFromObservatoryUri(Uri uri) {
   final isSecure = uri.isScheme('wss') || uri.isScheme('https');
   final scheme = isSecure ? 'wss' : 'ws';

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -16,5 +16,5 @@ dependencies:
   pedantic: ^1.4.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  vm_service_lib: ^3.14.3-dev.4
+  vm_service_lib: ^3.15.1+1
   webkit_inspection_protocol: ^0.4.0


### PR DESCRIPTION
I made some tweaks while wiring this up in VS Code.

- `id` field now supports any type (as per JSON-RPC) - specifically, VS Code was using strings for all the other services (not for any good reason, but it seemed better to support this than fail)
- The success flag is a simple boolean rather than using the VM-Service `Success()` class (since this didn't seem to match the other stdio services we have). `Success()` is still used for the response of the VM-Service handler though.
- Handle all valid URIs (for ex. `http://` without the `/ws`- what was accepted, but failed)
- Check the `method` field before processing the incoming message (and provide a useful message if the method is not recognised)

