### PR TITLE
Fix broken integration test.

### DIFF
--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -320,7 +320,7 @@ class WebdevFixture {
       }
 
       // Serving `web` on http://localhost:8080
-      if (line.startsWith(r'Serving `web`')) {
+      if (line.contains('Serving `web`')) {
         final String url = line.substring(line.indexOf('http://'));
         hasUrl.complete(url);
       }


### PR DESCRIPTION
The line changed from 'Serving web on http://localhost:8080' to '[INFO] Serving web on http://localhost:8080'. 

Changed the detection code to use `contains` instead of `startsWith` to prevent against a similar breakage in the future.