### PR TITLE
avoid an npe on failures from setSelection call

### DIFF
--- a/packages/devtools/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools/lib/src/eval_on_dart_library.dart
@@ -134,7 +134,7 @@ class EvalOnDartLibrary {
 
     switch (e.runtimeType) {
       case RPCError:
-        print('RPCError ${e.code}: ${e.details}');
+        print('RPCError: $e');
         break;
       case Error:
         print('${e.kind}: ${e.message}');
@@ -251,6 +251,8 @@ class EvalOnDartLibrary {
 
 class LibraryNotFound implements Exception {
   LibraryNotFound(this.candidateNames);
+
   Iterable<String> candidateNames;
+
   String get message => 'Library matchining one of $candidateNames not found';
 }

--- a/packages/devtools/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools/lib/src/inspector/inspector_service.dart
@@ -805,7 +805,7 @@ class ObjectGroup {
     final instanceRef = await setSelectionResult;
     if (disposed) return;
     handleSetSelectionHelper(
-        'true' == instanceRef.valueAsString, uiAlreadyUpdated);
+        'true' == instanceRef?.valueAsString, uiAlreadyUpdated);
   }
 
   void handleSetSelectionHelper(bool selectionChanged, bool uiAlreadyUpdated) {


### PR DESCRIPTION
- avoid an npe on failures from setSelection call

Some work to troubleshoot https://github.com/flutter/devtools/issues/562; this will address this part of the issue:

```
main.dart.js:19738 Uncaught TypeError: Cannot read property 'valueAsString' of undefined
    at main.dart.js:35021
```

@jacob314 