### PR TITLE
Arbitrary fixes for devtools_server (typo, unused import, wrong license year)

### DIFF
--- a/packages/devtools_server/README.md
+++ b/packages/devtools_server/README.md
@@ -1,4 +1,4 @@
 ## What is this?
 
-The is a server that supports [Dart DevTools](https://pub.dartlang.org/packages/devtools).
+This is a server that supports [Dart DevTools](https://pub.dartlang.org/packages/devtools).
 This package contains shared code for performing functions with DevTools, like launching it, for example.

--- a/packages/devtools_server/lib/devtools_server.dart
+++ b/packages/devtools_server/lib/devtools_server.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_server/lib/devtools_server.dart
+++ b/packages/devtools_server/lib/devtools_server.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_server/lib/src/chrome.dart
+++ b/packages/devtools_server/lib/src/chrome.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart';


### PR DESCRIPTION
Fixes typo, fixes incorrect year in license file, and removes unused import.