### PR TITLE
Added Google Analytics and opt-in dialog.

### DIFF
--- a/packages/devtools/lib/src/debugger/breakpoints_view.dart
+++ b/packages/devtools/lib/src/debugger/breakpoints_view.dart
@@ -9,9 +9,9 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../debugger/debugger.dart';
 import '../debugger/debugger_state.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 
 typedef URIDescriber = String Function(String uri);
 
@@ -131,12 +131,12 @@ class BreakOnExceptionControl extends CoreElement {
     ]);
 
     unhandledExceptionsElement.element.onChange.listen((_) {
-      gaSelect(gaDebugger, gaUnhandledExceptions);
+      ga.select(ga.debugger, ga.unhandledExceptions);
       _pauseModeController.add(exceptionPauseMode);
     });
 
     allExceptionsElement.element.onChange.listen((_) {
-      gaSelect(gaDebugger, gaAllExceptions);
+      ga.select(ga.debugger, ga.allExceptions);
       if (_allElement.checked) {
         unhandledExceptionsElement.enabled = false;
         _unhandledElement.checked = true;

--- a/packages/devtools/lib/src/debugger/breakpoints_view.dart
+++ b/packages/devtools/lib/src/debugger/breakpoints_view.dart
@@ -11,6 +11,7 @@ import '../debugger/debugger.dart';
 import '../debugger/debugger_state.dart';
 import '../ui/custom.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 
 typedef URIDescriber = String Function(String uri);
 
@@ -130,10 +131,12 @@ class BreakOnExceptionControl extends CoreElement {
     ]);
 
     unhandledExceptionsElement.element.onChange.listen((_) {
+      gaSelect(gaDebugger, gaUnhandledExceptions);
       _pauseModeController.add(exceptionPauseMode);
     });
 
     allExceptionsElement.element.onChange.listen((_) {
+      gaSelect(gaDebugger, gaAllExceptions);
       if (_allElement.checked) {
         unhandledExceptionsElement.enabled = false;
         _unhandledElement.checked = true;

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -21,6 +21,7 @@ import '../debugger/variables_view.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -75,6 +76,8 @@ class DebuggerScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
+    gaScreen(gaDebugger);
+
     final CoreElement screenDiv = div()..layoutVertical();
 
     CoreElement sourceArea;
@@ -99,12 +102,14 @@ class DebuggerScreen extends Screen {
     }
 
     resumeButton.click(() async {
+      gaSelect(gaDebugger, gaResume);
       _updateResumeButton(disabled: true);
       await debuggerState.resume();
       _updateResumeButton(disabled: false);
     });
 
     pauseButton.click(() async {
+      gaSelect(gaDebugger, gaPause);
       _updatePauseButton(disabled: true);
       await debuggerState.pause();
       _updatePauseButton(disabled: false);
@@ -398,6 +403,8 @@ class DebuggerScreen extends Screen {
             // Open a file set focus to the 'popup_script_name' textfield
             // accepts key strokes.
             _popupView.popupTextfield.element.focus();
+
+            gaSelect(gaDebugger, gaOpenShortcut);
 
             e.preventDefault();
             break;

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -20,8 +20,8 @@ import '../debugger/scripts_view.dart';
 import '../debugger/variables_view.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -76,7 +76,7 @@ class DebuggerScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    gaScreen(gaDebugger);
+    ga.screen(ga.debugger);
 
     final CoreElement screenDiv = div()..layoutVertical();
 
@@ -102,14 +102,14 @@ class DebuggerScreen extends Screen {
     }
 
     resumeButton.click(() async {
-      gaSelect(gaDebugger, gaResume);
+      ga.select(ga.debugger, ga.resume);
       _updateResumeButton(disabled: true);
       await debuggerState.resume();
       _updateResumeButton(disabled: false);
     });
 
     pauseButton.click(() async {
-      gaSelect(gaDebugger, gaPause);
+      ga.select(ga.debugger, ga.pause);
       _updatePauseButton(disabled: true);
       await debuggerState.pause();
       _updatePauseButton(disabled: false);
@@ -404,7 +404,7 @@ class DebuggerScreen extends Screen {
             // accepts key strokes.
             _popupView.popupTextfield.element.focus();
 
-            gaSelect(gaDebugger, gaOpenShortcut);
+            ga.select(ga.debugger, ga.openShortcut);
 
             e.preventDefault();
             break;

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -21,6 +21,7 @@ import '../debugger/variables_view.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
@@ -76,7 +77,7 @@ class DebuggerScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    ga.screen(ga.debugger);
+    ga_platform.setupDimensions();
 
     final CoreElement screenDiv = div()..layoutVertical();
 

--- a/packages/devtools/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools/lib/src/debugger/debugger_state.dart
@@ -8,7 +8,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../debugger/debugger.dart';
-import '../ui/gtags.dart';
+import '../ui/analytics.dart' as ga;
 
 class DebuggerState {
   VmService _service;
@@ -86,7 +86,7 @@ class DebuggerState {
   Future<Success> resume() => _service.resume(isolateRef.id);
 
   Future<Success> stepOver() {
-    gaSelect(gaDebugger, gaStepOver);
+    ga.select(ga.debugger, ga.stepOver);
 
     // Handle async suspensions; issue StepOption.kOverAsyncSuspension.
     final bool useAsyncStepping = lastEvent?.atAsyncSuspension == true;
@@ -97,13 +97,13 @@ class DebuggerState {
   }
 
   Future<Success> stepIn() {
-    gaSelect(gaDebugger, gaStepIn);
+    ga.select(ga.debugger, ga.stepIn);
 
     return _service.resume(isolateRef.id, step: StepOption.kInto);
   }
 
   Future<Success> stepOut() {
-    gaSelect(gaDebugger, gaStepOut);
+    ga.select(ga.debugger, ga.stepOut);
 
     return _service.resume(isolateRef.id, step: StepOption.kOut);
   }

--- a/packages/devtools/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools/lib/src/debugger/debugger_state.dart
@@ -8,6 +8,7 @@ import 'package:rxdart/rxdart.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../debugger/debugger.dart';
+import '../ui/gtags.dart';
 
 class DebuggerState {
   VmService _service;
@@ -85,6 +86,8 @@ class DebuggerState {
   Future<Success> resume() => _service.resume(isolateRef.id);
 
   Future<Success> stepOver() {
+    gaSelect(gaDebugger, gaStepOver);
+
     // Handle async suspensions; issue StepOption.kOverAsyncSuspension.
     final bool useAsyncStepping = lastEvent?.atAsyncSuspension == true;
     return _service.resume(isolateRef.id,
@@ -93,11 +96,17 @@ class DebuggerState {
             : StepOption.kOver);
   }
 
-  Future<Success> stepIn() =>
-      _service.resume(isolateRef.id, step: StepOption.kInto);
+  Future<Success> stepIn() {
+    gaSelect(gaDebugger, gaStepIn);
 
-  Future<Success> stepOut() =>
-      _service.resume(isolateRef.id, step: StepOption.kOut);
+    return _service.resume(isolateRef.id, step: StepOption.kInto);
+  }
+
+  Future<Success> stepOut() {
+    gaSelect(gaDebugger, gaStepOut);
+
+    return _service.resume(isolateRef.id, step: StepOption.kOut);
+  }
 
   Future<void> clearBreakpoints() async {
     final List<Breakpoint> breakpoints = _breakpoints.value.toList();

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -8,6 +8,7 @@ import 'dart:html' hide Screen;
 import 'package:meta/meta.dart';
 
 import '../main.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
@@ -48,6 +49,7 @@ class Framework {
   }
 
   void navigateTo(String id) {
+    ga.screen(id);
     final Screen screen = getScreen(id);
     assert(screen != null);
 

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -9,6 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../main.dart';
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
@@ -83,6 +84,7 @@ class Framework {
       Screen screen = getScreen(id, onlyEnabled: true);
       screen ??= screens.first;
       if (screen != null) {
+        ga_platform.setupAndGaScreen(id);
         load(screen);
       } else {
         load(NotFoundScreen());
@@ -617,13 +619,13 @@ class AnalyticsOptInDialog {
     ]);
 
     acceptButton.click(() {
-      ga.setAllowAnalytics();
+      ga_platform.setAllowAnalytics();
       hide();
       ga.initializeGA();
     });
 
     dontAcceptButton.click(() {
-      ga.setDontAllowAnalytics();
+      ga_platform.setDontAllowAnalytics();
       hide();
     });
 

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -606,7 +606,7 @@ class AnalyticsOptInDialog {
             ]),
           CoreElement('dd')
             ..add([
-              p(text: 'Do you accept statistics collection for Dart DevTools?'),
+              p(text: 'Do you accept analytics collection for Dart DevTools?'),
               acceptButton = PButton('I Accept')
                 ..small()
                 ..clazz('margin-left'),

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -28,6 +28,8 @@ class Framework {
         ActionsContainer(CoreElement.from(queryId('global-actions')));
 
     connectDialog = new ConnectDialog(this);
+
+    analyticsDialog = AnalyticsOptInDialog(this);
   }
 
   final List<Screen> screens = <Screen>[];
@@ -41,6 +43,7 @@ class Framework {
   StatusLine auxiliaryStatus;
   ActionsContainer globalActions;
   ConnectDialog connectDialog;
+  AnalyticsOptInDialog analyticsDialog;
 
   final Map<Screen, CoreElement> _screenContents = {};
 
@@ -58,6 +61,10 @@ class Framework {
     window.history.pushState(null, screen.name, ref);
 
     load(screen);
+  }
+
+  void showAnalyticsDialog() {
+    analyticsDialog.show();
   }
 
   void showConnectionDialog() {
@@ -563,4 +570,80 @@ class ConnectDialog {
       throw 'not connected';
     }
   }
+}
+
+class AnalyticsOptInDialog {
+  AnalyticsOptInDialog(this.framework) {
+    parent = CoreElement.from(queryId('ga-dialog'));
+    parent.layoutVertical();
+
+    parent.add([
+      h2(text: 'Analytics Data Collection'),
+      CoreElement('dl', classes: 'form-group')
+        ..add([
+          CoreElement('dt')
+            ..add([
+              label(text: 'Welcome to Dart DevTools')
+                ..setAttribute('for', 'uri-field'),
+            ]),
+          CoreElement('dd')
+            ..add([
+              p(
+                text: 'Dart DevTools anonymously reports features usage '
+                    'statistics and basic crash reports to Google in order '
+                    'to help Google contribute improvements to Dart DevTools '
+                    'over time.',
+              )..add([
+                  br(),
+                  a(
+                      text: 'See Google\'s privacy policy',
+                      c: 'note',
+                      href: 'https://www.google.com/intl/en/policies/privacy',
+                      target: '_blank'),
+                ]),
+            ]),
+          CoreElement('dd')
+            ..add([
+              p(text: 'Do you accept statistics collection for Dart DevTools?'),
+              acceptButton = PButton('I Accept')
+                ..small()
+                ..clazz('margin-left'),
+              dontAcceptButton = PButton('I Do Not Accept')
+                ..small()
+                ..clazz('margin-left')
+                ..setAttribute('tabindex', '0'),
+            ]),
+        ]),
+    ]);
+
+    acceptButton.click(() {
+      ga.setAllowAnalytics();
+      hide();
+      ga.initializeGA();
+    });
+
+    dontAcceptButton.click(() {
+      ga.setDontAllowAnalytics();
+      hide();
+    });
+
+    hide();
+  }
+
+  final Framework framework;
+
+  CoreElement parent;
+  CoreElement acceptButton;
+  CoreElement dontAcceptButton;
+
+  void show() {
+    parent.display = 'initial';
+    dontAcceptButton.element.focus();
+  }
+
+  void hide() {
+    parent.display = 'none';
+  }
+
+  bool isVisible() => parent.display != 'none';
 }

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -15,6 +15,7 @@ import '../globals.dart';
 import '../service_extensions.dart' as extensions;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -52,6 +53,8 @@ class InspectorScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
+    gaScreen(gaInspector);
+
     final CoreElement screenDiv = div(c: 'custom-scrollbar inspector-page')
       ..layoutVertical();
 
@@ -208,6 +211,7 @@ To fix this, relaunch your application by running 'flutter run
   }
 
   void _refreshInspector() async {
+    gaSelect(gaInspector, gaRefresh);
     refreshTreeButton.disabled = true;
     await inspectorController?.onForceRefresh();
     refreshTreeButton.disabled = false;

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -14,6 +14,7 @@ import '../framework/framework.dart';
 import '../globals.dart';
 import '../service_extensions.dart' as extensions;
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/icons.dart';
@@ -53,7 +54,7 @@ class InspectorScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    ga.screen(ga.inspector);
+    ga_platform.setupDimensions();
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar inspector-page')
       ..layoutVertical();

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -13,9 +13,9 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../service_extensions.dart' as extensions;
+import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -53,7 +53,7 @@ class InspectorScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    gaScreen(gaInspector);
+    ga.screen(ga.inspector);
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar inspector-page')
       ..layoutVertical();
@@ -211,7 +211,7 @@ To fix this, relaunch your application by running 'flutter run
   }
 
   void _refreshInspector() async {
-    gaSelect(gaInspector, gaRefresh);
+    ga.select(ga.inspector, ga.refresh);
     refreshTreeButton.disabled = true;
     await inspectorController?.onForceRefresh();
     refreshTreeButton.disabled = false;

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -17,8 +17,8 @@ import '../inspector/inspector_service.dart';
 import '../inspector/inspector_tree.dart';
 import '../inspector/inspector_tree_html.dart';
 import '../tables.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
 import '../utils.dart';
@@ -58,7 +58,7 @@ class LoggingScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    gaScreen(gaLogging);
+    ga.screen(ga.logging);
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
@@ -155,7 +155,7 @@ class LoggingScreen extends Screen {
   }
 
   void _clear() {
-    gaSelect(gaLogging, gaClearLogs);
+    ga.select(ga.logging, ga.clearLogs);
     data.clear();
     logDetailsUI?.setData(null);
     loggingTable.setRows(data);

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -18,6 +18,7 @@ import '../inspector/inspector_tree.dart';
 import '../inspector/inspector_tree_html.dart';
 import '../tables.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
 import '../utils.dart';
@@ -57,6 +58,8 @@ class LoggingScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
+    gaScreen(gaLogging);
+
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     this.framework = framework;
@@ -152,6 +155,7 @@ class LoggingScreen extends Screen {
   }
 
   void _clear() {
+    gaSelect(gaLogging, gaClearLogs);
     data.clear();
     logDetailsUI?.setData(null);
     loggingTable.setRows(data);

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -18,6 +18,7 @@ import '../inspector/inspector_tree.dart';
 import '../inspector/inspector_tree_html.dart';
 import '../tables.dart';
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -58,7 +59,7 @@ class LoggingScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    ga.screen(ga.logging);
+    ga_platform.setupDimensions();
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -19,6 +19,7 @@ import 'performance/performance.dart';
 import 'service_registrations.dart' as registrations;
 import 'timeline/timeline.dart';
 import 'ui/analytics.dart' as ga;
+import 'ui/analytics_platform.dart' as ga_platform;
 import 'ui/custom.dart';
 import 'ui/elements.dart';
 import 'ui/icons.dart';
@@ -158,7 +159,9 @@ class PerfToolFramework extends Framework {
           ' available in your code editor';
     }
 
-    ga.computeUserApplicationCustomGTagData();
+    // Collect all platform information flutter, web, chrome, versions, etc. for
+    // possible GA collection.
+    ga_platform.setupDimensions();
 
     addScreen(InspectorScreen(
       disabled: !_isAnyFlutterApp || _isProfileBuild,

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -18,9 +18,9 @@ import 'model/model.dart';
 import 'performance/performance.dart';
 import 'service_registrations.dart' as registrations;
 import 'timeline/timeline.dart';
+import 'ui/analytics.dart' as ga;
 import 'ui/custom.dart';
 import 'ui/elements.dart';
-import 'ui/gtags.dart';
 import 'ui/icons.dart';
 import 'ui/primer.dart';
 import 'ui/ui_utils.dart';
@@ -43,7 +43,7 @@ class PerfToolFramework extends Framework {
 
   void _gAReportExceptions(html.Event e) {
     final html.ErrorEvent errorEvent = e as html.ErrorEvent;
-    gaError(
+    ga.error(
         '${errorEvent.message}\n'
         '${errorEvent.filename}@${errorEvent.lineno}:${errorEvent.colno}\n'
         '${errorEvent.error}',
@@ -119,7 +119,7 @@ class PerfToolFramework extends Framework {
 
     // Listen for clicks on the 'send feedback' button.
     queryId('send-feedback-button').onClick.listen((_) {
-      gaSelect(gaDevTools, gaFeedback);
+      ga.select(ga.devToolsMain, ga.feedback);
       // TODO(devoncarew): Fill in useful product info here, like the Flutter
       // SDK version and the version of DevTools in use.
       html.window
@@ -159,13 +159,7 @@ class PerfToolFramework extends Framework {
           ' available in your code editor';
     }
 
-    computeApplicationState(
-      _isAnyFlutterApp,
-      _isFlutterApp,
-      _isFlutterWebApp,
-      _isProfileBuild,
-      true, // TODO(terry): Need iOS or Android
-    );
+    computeApplicationState();
 
     addScreen(InspectorScreen(
       disabled: !_isAnyFlutterApp || _isProfileBuild,
@@ -285,7 +279,7 @@ class PerfToolFramework extends Framework {
         messageBus.addEvent(BusEvent('reload.end', data: message));
         status.setText(message);
 
-        gaSelect(gaDevTools, gaHotReload, timer.elapsed.inMilliseconds);
+        ga.select(ga.devToolsMain, ga.hotReload, timer.elapsed.inMilliseconds);
       } catch (_) {
         const String message = 'error performing reload';
         messageBus.addEvent(BusEvent('reload.end', data: message));
@@ -323,7 +317,7 @@ class PerfToolFramework extends Framework {
         final String message = 'restarted in ${_renderDuration(timer.elapsed)}';
         messageBus.addEvent(BusEvent('restart.end', data: message));
         status.setText(message);
-        gaSelect(gaDevTools, gaHotRestart, timer.elapsed.inMilliseconds);
+        ga.select(ga.devToolsMain, ga.hotRestart, timer.elapsed.inMilliseconds);
       } catch (_) {
         const String message = 'error performing restart';
         messageBus.addEvent(BusEvent('restart.end', data: message));

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -159,7 +159,7 @@ class PerfToolFramework extends Framework {
           ' available in your code editor';
     }
 
-    computeApplicationState();
+    ga.computeUserApplicationCustomGTagData();
 
     addScreen(InspectorScreen(
       disabled: !_isAnyFlutterApp || _isProfileBuild,

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -166,7 +166,7 @@ class PerfToolFramework extends Framework {
           ? 'This screen is disabled because you are not running a Flutter '
               'application'
           : 'This screen is disabled because you are running a profile build '
-          'of your application',
+              'of your application',
     ));
     addScreen(TimelineScreen(
       disabled: !_isFlutterApp,
@@ -174,7 +174,7 @@ class PerfToolFramework extends Framework {
           ? 'This screen is disabled because it is not yet ready for Flutter'
               ' Web'
           : 'This screen is disabled because you are not running a '
-          'Flutter application',
+              'Flutter application',
     ));
     addScreen(MemoryScreen(
       disabled: _isFlutterWebApp,

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -28,7 +28,6 @@ import 'utils.dart';
 
 // TODO(devoncarew): make the screens more robust through restarts
 
-const bool showMemoryPage = false;
 const bool showPerformancePage = false;
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -12,6 +12,7 @@ import '../globals.dart';
 import '../tables.dart';
 import '../ui/custom.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -77,6 +78,8 @@ class MemoryScreen extends Screen with SetStateMixin {
 
   @override
   CoreElement createContent(Framework framework) {
+    gaScreen(gaMemory);
+
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     resumeButton = PButton.icon('Resume', FlutterIcons.resume_white_disabled_2x)
@@ -110,6 +113,8 @@ class MemoryScreen extends Screen with SetStateMixin {
           ..disabled = true;
 
     resumeButton.click(() {
+      gaSelect(gaMemory, gaResume);
+
       updateResumeButton(disabled: true);
       updatePauseButton(disabled: false);
 
@@ -117,6 +122,8 @@ class MemoryScreen extends Screen with SetStateMixin {
     });
 
     pauseButton.click(() {
+      gaSelect(gaMemory, gaPause);
+
       updatePauseButton(disabled: true);
       updateResumeButton(disabled: false);
 
@@ -192,6 +199,8 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _resetAllocatorCounts() async {
+    gaSelect(gaMemory, gaReset);
+
     memoryChart.plotReset();
 
     resetAccumulatorsButton.disabled = true;
@@ -213,6 +222,8 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _loadAllocationProfile({bool reset = false}) async {
+    gaSelect(gaMemory, gaSnapshot);
+
     memoryChart.plotSnapshot();
 
     vmMemorySnapshotButton.disabled = true;
@@ -234,6 +245,8 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<Null> _gcNow() async {
+    gaSelect(gaMemory, gaGC);
+
     gcNowButton.disabled = true;
 
     try {
@@ -291,6 +304,8 @@ class MemoryScreen extends Screen with SetStateMixin {
     table.setSortColumn(table.columns.first);
 
     table.onSelect.listen((ClassHeapDetailStats row) async {
+      gaSelect(gaMemory, gaInspectClass);
+
       final Table<InstanceSummary> newTable =
           row == null ? null : await _createInstanceListTableView(row);
       _pushNextTable(table, newTable);
@@ -316,6 +331,12 @@ class MemoryScreen extends Screen with SetStateMixin {
     } catch (e) {
       framework.toast('Problem fetching instances $e', title: 'Error');
     }
+
+    table.onSelect.listen((InstanceSummary row) async {
+      gaSelect(gaMemory, gaInspectInstance);
+      // TODO(terry): Handle clicking on an instance bring up variable inspector
+    });
+
 
     return table;
   }

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -10,9 +10,9 @@ import 'package:meta/meta.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../tables.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -78,7 +78,7 @@ class MemoryScreen extends Screen with SetStateMixin {
 
   @override
   CoreElement createContent(Framework framework) {
-    gaScreen(gaMemory);
+    ga.screen(ga.memory);
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
@@ -113,7 +113,7 @@ class MemoryScreen extends Screen with SetStateMixin {
           ..disabled = true;
 
     resumeButton.click(() {
-      gaSelect(gaMemory, gaResume);
+      ga.select(ga.memory, ga.resume);
 
       updateResumeButton(disabled: true);
       updatePauseButton(disabled: false);
@@ -122,7 +122,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     });
 
     pauseButton.click(() {
-      gaSelect(gaMemory, gaPause);
+      ga.select(ga.memory, ga.pause);
 
       updatePauseButton(disabled: true);
       updateResumeButton(disabled: false);
@@ -199,7 +199,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _resetAllocatorCounts() async {
-    gaSelect(gaMemory, gaReset);
+    ga.select(ga.memory, ga.reset);
 
     memoryChart.plotReset();
 
@@ -222,7 +222,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<void> _loadAllocationProfile({bool reset = false}) async {
-    gaSelect(gaMemory, gaSnapshot);
+    ga.select(ga.memory, ga.snapshot);
 
     memoryChart.plotSnapshot();
 
@@ -245,7 +245,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   Future<Null> _gcNow() async {
-    gaSelect(gaMemory, gaGC);
+    ga.select(ga.memory, ga.gC);
 
     gcNowButton.disabled = true;
 
@@ -304,7 +304,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     table.setSortColumn(table.columns.first);
 
     table.onSelect.listen((ClassHeapDetailStats row) async {
-      gaSelect(gaMemory, gaInspectClass);
+      ga.select(ga.memory, ga.inspectClass);
 
       final Table<InstanceSummary> newTable =
           row == null ? null : await _createInstanceListTableView(row);
@@ -333,7 +333,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     }
 
     table.onSelect.listen((InstanceSummary row) async {
-      gaSelect(gaMemory, gaInspectInstance);
+      ga.select(ga.memory, ga.inspectInstance);
       // TODO(terry): Handle clicking on an instance bring up variable inspector
     });
 

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -11,6 +11,7 @@ import '../framework/framework.dart';
 import '../globals.dart';
 import '../tables.dart';
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/icons.dart';
@@ -78,7 +79,7 @@ class MemoryScreen extends Screen with SetStateMixin {
 
   @override
   CoreElement createContent(Framework framework) {
-    ga.screen(ga.memory);
+    ga_platform.setupDimensions();
 
     final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -337,7 +337,6 @@ class MemoryScreen extends Screen with SetStateMixin {
       // TODO(terry): Handle clicking on an instance bring up variable inspector
     });
 
-
     return table;
   }
 

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -4,6 +4,7 @@
 
 library service_extensions;
 
+import 'ui/analytics.dart' as ga;
 import 'ui/icons.dart';
 
 // Each service extension needs to be added to [_extensionDescriptions].
@@ -16,6 +17,8 @@ class ToggleableServiceExtensionDescription<T> {
     this.disabledValue,
     this.enabledTooltip,
     this.disabledTooltip,
+    this.gaScreenName,
+    this.gaItem,
   });
 
   final String extension;
@@ -25,6 +28,8 @@ class ToggleableServiceExtensionDescription<T> {
   final T disabledValue;
   final String enabledTooltip;
   final String disabledTooltip;
+  final String gaScreenName;  // Analytics screen (screen name where item lives).
+  final String gaItem;  // Analytics item name (toggleable item's name).
 }
 
 const debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
@@ -35,6 +40,8 @@ const debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Debug Banner',
   disabledTooltip: 'Show Debug Banner',
+  gaScreenName: ga.inspector,
+  gaItem: ga.debugBanner,
 );
 
 const debugPaint = ToggleableServiceExtensionDescription<bool>._(
@@ -45,6 +52,8 @@ const debugPaint = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Debug Paint',
   disabledTooltip: 'Show Debug Paint',
+  gaScreenName: ga.inspector,
+  gaItem: ga.debugPaint,
 );
 
 const debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
@@ -55,6 +64,8 @@ const debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Paint Baselines',
   disabledTooltip: 'Show Paint Baselines',
+  gaScreenName: ga.inspector,
+  gaItem: ga.paintBaseline,
 );
 
 const performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
@@ -65,6 +76,8 @@ const performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Performance Overlay',
   disabledTooltip: 'Show Performance Overlay',
+  gaScreenName: ga.inspector,
+  gaItem: ga.performanceOverlay,
 );
 
 const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
@@ -75,6 +88,8 @@ const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Do Not Track Widget Rebuilds',
   disabledTooltip: 'Track Widget Rebuilds',
+  gaScreenName: ga.inspector,
+  gaItem: ga.trackRebuilds,
 );
 
 const repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
@@ -85,6 +100,8 @@ const repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Repaint Rainbow',
   disabledTooltip: 'Show Repaint Rainbow',
+  gaScreenName: ga.inspector,
+  gaItem: ga.repaintRainbow,
 );
 
 const slowAnimations = ToggleableServiceExtensionDescription<num>._(
@@ -95,6 +112,8 @@ const slowAnimations = ToggleableServiceExtensionDescription<num>._(
   disabledValue: 1.0,
   enabledTooltip: 'Disable Slow Animations',
   disabledTooltip: 'Enable Slow Animations',
+  gaScreenName: ga.inspector,
+  gaItem: ga.slowAnimation,
 );
 
 const togglePlatformMode = ToggleableServiceExtensionDescription<String>._(
@@ -105,6 +124,8 @@ const togglePlatformMode = ToggleableServiceExtensionDescription<String>._(
   disabledValue: 'android',
   enabledTooltip: 'Toggle iOS Platform',
   disabledTooltip: 'Toggle iOS Platform',
+  gaScreenName: ga.inspector,
+  gaItem: ga.toggleIoS,
 );
 
 const toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
@@ -115,6 +136,8 @@ const toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Disable Select Widget Mode',
   disabledTooltip: 'Enable Select Widget Mode',
+  gaScreenName: ga.inspector,
+  gaItem: ga.selectWidgetMode,
 );
 
 // This extension should never be displayed as a button so does not need a

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -4,6 +4,8 @@
 
 library service_extensions;
 
+import 'package:meta/meta.dart';
+
 import 'ui/analytics.dart' as ga;
 import 'ui/icons.dart';
 
@@ -17,8 +19,8 @@ class ToggleableServiceExtensionDescription<T> {
     this.disabledValue,
     this.enabledTooltip,
     this.disabledTooltip,
-    this.gaScreenName,
-    this.gaItem,
+    @required this.gaScreenName,
+    @required this.gaItem,
   });
 
   final String extension;
@@ -28,8 +30,8 @@ class ToggleableServiceExtensionDescription<T> {
   final T disabledValue;
   final String enabledTooltip;
   final String disabledTooltip;
-  final String gaScreenName;  // Analytics screen (screen name where item lives).
-  final String gaItem;  // Analytics item name (toggleable item's name).
+  final String gaScreenName; // Analytics screen (screen name where item lives).
+  final String gaItem; // Analytics item name (toggleable item's name).
 }
 
 const debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
@@ -88,7 +90,7 @@ const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Do Not Track Widget Rebuilds',
   disabledTooltip: 'Track Widget Rebuilds',
-  gaScreenName: ga.inspector,
+  gaScreenName: ga.performance,
   gaItem: ga.trackRebuilds,
 );
 

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -13,6 +13,7 @@ import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
+import '../ui/gtags.dart';
 import '../ui/primer.dart';
 import '../ui/theme.dart';
 import '../utils.dart';
@@ -153,6 +154,7 @@ class EventDetails extends CoreElement {
   }
 
   Future<void> update(FrameFlameChartItem item) async {
+    gaSelect(gaTimeline, gaTimelineFlame);
     _event = item.event;
 
     _title.text = '${_event.name} - ${msText(_event.time.duration)}';

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -9,11 +9,11 @@ import 'package:js/js.dart';
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../globals.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
-import '../ui/gtags.dart';
 import '../ui/primer.dart';
 import '../ui/theme.dart';
 import '../utils.dart';
@@ -154,7 +154,7 @@ class EventDetails extends CoreElement {
   }
 
   Future<void> update(FrameFlameChartItem item) async {
-    gaSelect(gaTimeline, gaTimelineFlame);
+    ga.select(ga.timeline, ga.timelineFlame);
     _event = item.event;
 
     _title.text = '${_event.name} - ${msText(_event.time.duration)}';

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -156,15 +156,6 @@ class EventDetails extends CoreElement {
   Future<void> update(FrameFlameChartItem item) async {
     _event = item.event;
 
-    String gaTimeLineFlame;
-    if (_event.isGpuEvent) {
-      gaTimeLineFlame = ga.timelineFlameGpu;
-    } else {
-      gaTimeLineFlame = ga.timelineFlameUi;
-    }
-    ga.select(
-        ga.timeline, gaTimeLineFlame, _event.time.duration.inMilliseconds);
-
     _title.text = '${_event.name} - ${msText(_event.time.duration)}';
     _title.element.style
       ..backgroundColor = colorToCss(item.backgroundColor)

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -154,8 +154,16 @@ class EventDetails extends CoreElement {
   }
 
   Future<void> update(FrameFlameChartItem item) async {
-    ga.select(ga.timeline, ga.timelineFlame);
     _event = item.event;
+
+    String gaTimeLineFlame;
+    if (_event.isGpuEvent) {
+      gaTimeLineFlame = ga.timelineFlameGpu;
+    } else {
+      gaTimeLineFlame = ga.timelineFlameUi;
+    }
+    ga.select(
+        ga.timeline, gaTimeLineFlame, _event.time.duration.inMilliseconds);
 
     _title.text = '${_event.name} - ${msText(_event.time.duration)}';
     _title.element.style

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -9,7 +9,6 @@ import 'package:js/js.dart';
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../globals.dart';
-import '../ui/analytics.dart' as ga;
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import '../framework/framework.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/elements.dart';
-import '../ui/gtags.dart';
 import '../ui/plotly.dart';
 import 'frames_bar_plotly.dart';
 import 'timeline_controller.dart';
@@ -138,7 +138,7 @@ class PlotlyDivGraph extends CoreElement {
       if (_frames.containsKey(xPosition)) {
         final TimelineFrame timelineFrame = _frames[xPosition];
         framesBarChart.setSelected(timelineFrame);
-        gaSelect(gaTimeline, gaTimelineFrame);
+        ga.select(ga.timeline, ga.timelineFrame);
       }
     }
   }

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -60,6 +60,13 @@ class FramesBarChart extends CoreElement with SetStateMixin {
 
     selectedFrame = frame;
     _selectedFrameController.add(frame);
+
+    ga.selectFrame(
+      ga.timeline,
+      ga.timelineFrame,
+      frame.gpuDuration,
+      frame.uiDuration,
+    );
   }
 }
 
@@ -138,7 +145,6 @@ class PlotlyDivGraph extends CoreElement {
       if (_frames.containsKey(xPosition)) {
         final TimelineFrame timelineFrame = _frames[xPosition];
         framesBarChart.setSelected(timelineFrame);
-        ga.select(ga.timeline, ga.timelineFrame);
       }
     }
   }

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import '../framework/framework.dart';
 import '../ui/elements.dart';
+import '../ui/gtags.dart';
 import '../ui/plotly.dart';
 import 'frames_bar_plotly.dart';
 import 'timeline_controller.dart';
@@ -137,6 +138,7 @@ class PlotlyDivGraph extends CoreElement {
       if (_frames.containsKey(xPosition)) {
         final TimelineFrame timelineFrame = _frames[xPosition];
         framesBarChart.setSelected(timelineFrame);
+        gaSelect(gaTimeline, gaTimelineFrame);
       }
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -1,15 +1,16 @@
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 import 'package:meta/meta.dart';
 import 'package:split/split.dart' as split;
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../ui/analytics.dart' as ga;
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
-import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/theme.dart';
@@ -87,7 +88,7 @@ class TimelineScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    gaScreen(gaTimeline);
+    ga.screen(ga.timeline);
 
     final CoreElement screenDiv = div()..layoutVertical();
 
@@ -220,7 +221,7 @@ class TimelineScreen extends Screen {
   }
 
   void _pauseRecording() {
-    gaSelect(gaTimeline, gaPause);
+    ga.select(ga.timeline, ga.pause);
 
     _updateButtons(paused: true);
     _paused = true;
@@ -228,7 +229,7 @@ class TimelineScreen extends Screen {
   }
 
   void _resumeRecording() {
-    gaSelect(gaTimeline, gaResume);
+    ga.select(ga.timeline, ga.resume);
     _updateButtons(paused: false);
     _paused = false;
     _updateListeningState();

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -194,7 +194,10 @@ class TimelineScreen extends Screen {
         gaTimeLineFlame = ga.timelineFlameUi;
       }
       ga.select(
-          ga.timeline, gaTimeLineFlame, event.time.duration.inMilliseconds);
+        ga.timeline,
+        gaTimeLineFlame,
+        event.time.duration.inMicroseconds,
+      );
 
       await eventDetails.update(item);
     });

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -184,7 +184,20 @@ class TimelineScreen extends Screen {
       }
     });
 
-    onSelectedFrameFlameChartItem.listen(eventDetails.update);
+    onSelectedFrameFlameChartItem.listen((FrameFlameChartItem item) async {
+      final TimelineEvent event = item.event;
+
+      String gaTimeLineFlame;
+      if (event.isGpuEvent) {
+        gaTimeLineFlame = ga.timelineFlameGpu;
+      } else {
+        gaTimeLineFlame = ga.timelineFlameUi;
+      }
+      ga.select(
+          ga.timeline, gaTimeLineFlame, event.time.duration.inMilliseconds);
+
+      await eventDetails.update(item);
+    });
 
     maybeShowDebugWarning(framework);
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -9,6 +9,7 @@ import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../ui/analytics.dart' as ga;
+import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/icons.dart';
@@ -88,7 +89,7 @@ class TimelineScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
-    ga.screen(ga.timeline);
+    ga_platform.setupDimensions();
 
     final CoreElement screenDiv = div()..layoutVertical();
 
@@ -186,17 +187,10 @@ class TimelineScreen extends Screen {
 
     onSelectedFrameFlameChartItem.listen((FrameFlameChartItem item) async {
       final TimelineEvent event = item.event;
-
-      String gaTimeLineFlame;
-      if (event.isGpuEvent) {
-        gaTimeLineFlame = ga.timelineFlameGpu;
-      } else {
-        gaTimeLineFlame = ga.timelineFlameUi;
-      }
       ga.select(
         ga.timeline,
-        gaTimeLineFlame,
-        event.time.duration.inMicroseconds,
+        event.isGpuEvent ? ga.timelineFlameGpu : ga.timelineFlameUi,
+        event.time.duration.inMicroseconds, // No inMilliseconds loses precision
       );
 
       await eventDetails.update(item);

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -9,6 +9,7 @@ import '../framework/framework.dart';
 import '../globals.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
+import '../ui/gtags.dart';
 import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/theme.dart';
@@ -86,6 +87,8 @@ class TimelineScreen extends Screen {
 
   @override
   CoreElement createContent(Framework framework) {
+    gaScreen(gaTimeline);
+
     final CoreElement screenDiv = div()..layoutVertical();
 
     FrameFlameChart flameChart;
@@ -217,12 +220,15 @@ class TimelineScreen extends Screen {
   }
 
   void _pauseRecording() {
+    gaSelect(gaTimeline, gaPause);
+
     _updateButtons(paused: true);
     _paused = true;
     _updateListeningState();
   }
 
   void _resumeRecording() {
+    gaSelect(gaTimeline, gaResume);
     _updateButtons(paused: false);
     _paused = false;
     _updateListeningState();

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -7,9 +7,6 @@ library gtags;
 
 // ignore_for_file: non_constant_identifier_names
 
-import 'dart:async';
-import 'dart:html' as html;
-
 import 'package:devtools/devtools.dart' as devtools show version;
 import 'package:js/js.dart';
 import 'package:vm_service_lib/vm_service_lib.dart';
@@ -38,35 +35,15 @@ const String devToolsPlatformTypeWindows = 'Windows';
 // Start with Android_n.n.n
 const String devToolsPlatformTypeAndroid = 'Android_';
 // Dimension5 devToolsChrome starts with
-const String devToolsChrome = 'Chrome/'; // starts with and ends with n.n.n
+const String devToolsChromeName = 'Chrome/'; // starts with and ends with n.n.n
 const String devToolsChromeIos = 'Crios/'; // starts with and ends with n.n.n
 // Dimension6 devToolsVersion
 
 @JS('gtagsEnabled')
 external bool isGtagsEnabled();
 
-@JS('getDevToolsPropertyID')
-external String devToolsProperty();
-
 @JS('_initializeGA')
 external void initializeGA();
-
-@JS('gaStorageCollect')
-external String storageCollectValue();
-
-@JS('gaStorageDontCollect')
-external String storageDontCollectValue();
-
-bool isAnalyticsAllowed() =>
-    html.window.localStorage[devToolsProperty()] == storageCollectValue();
-
-void setAllowAnalytics() {
-  html.window.localStorage[devToolsProperty()] = storageCollectValue();
-}
-
-void setDontAllowAnalytics() {
-  html.window.localStorage[devToolsProperty()] = storageDontCollectValue();
-}
 
 @JS()
 @anonymous
@@ -217,7 +194,7 @@ const String allExceptions = 'allExceptions';
 // Logging UX actions:
 const String clearLogs = 'clearLogs';
 
-void _screen(
+void screen(
   String screenName, [
   int value = 0,
 ]) {
@@ -226,27 +203,12 @@ void _screen(
       GtagEventDevTools(
           event_category: screenViewEvent,
           value: value,
-          user_app: _userAppType,
-          user_build: _userBuildType,
-          user_platform: _userPlatformType,
-          devtools_platform: _devtoolsPlatformType,
-          devtools_chrome: _devtoolsChrome,
+          user_app: userAppType,
+          user_build: userBuildType,
+          user_platform: userPlatformType,
+          devtools_platform: devtoolsPlatformType,
+          devtools_chrome: devtoolsChrome,
           devtools_version: devtoolsVersion));
-}
-
-void screen(
-  String screenName, [
-  int value = 0,
-]) {
-  if (!isDimensionsComputed) {
-    // While spinning up DevTools first time wait until dimensions data is
-    // available before first GA event sent.
-    Timer(const Duration(milliseconds: 1000), () {
-      computeUserApplicationCustomGTagData();
-      _screen(screenName, value);
-    });
-  } else
-    _screen(screenName, value);
 }
 
 void select(
@@ -260,11 +222,11 @@ void select(
           event_category: selectEvent,
           event_label: selectedItem,
           value: value,
-          user_app: _userAppType,
-          user_build: _userBuildType,
-          user_platform: _userPlatformType,
-          devtools_platform: _devtoolsPlatformType,
-          devtools_chrome: _devtoolsChrome,
+          user_app: userAppType,
+          user_build: userBuildType,
+          user_platform: userPlatformType,
+          devtools_platform: devtoolsPlatformType,
+          devtools_chrome: devtoolsChrome,
           devtools_version: devtoolsVersion));
 }
 
@@ -282,11 +244,11 @@ void selectFrame(
           event_label: selectedItem,
           gpu_duration: gpuDuration,
           ui_duration: uiDuration,
-          user_app: _userAppType,
-          user_build: _userBuildType,
-          user_platform: _userPlatformType,
-          devtools_platform: _devtoolsPlatformType,
-          devtools_chrome: _devtoolsChrome,
+          user_app: userAppType,
+          user_build: userBuildType,
+          user_platform: userPlatformType,
+          devtools_platform: devtoolsPlatformType,
+          devtools_chrome: devtoolsChrome,
           devtools_version: devtoolsVersion));
 }
 
@@ -303,11 +265,11 @@ void error(
   GTag.exception(GtagExceptionDevTools(
       description: errorMessage,
       fatal: fatal,
-      user_app: _userAppType,
-      user_build: _userBuildType,
-      user_platform: _userPlatformType,
-      devtools_platform: _devtoolsPlatformType,
-      devtools_chrome: _devtoolsChrome,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
       devtools_version: devtoolsVersion));
 }
 
@@ -323,64 +285,43 @@ String _userPlatformType = ''; // dimension3
 String _devtoolsPlatformType =
     ''; // dimension4 MacIntel/Linux/Windows/Android_n
 String _devtoolsChrome = ''; // dimension5 Chrome/n.n.n  or Crios/n.n.n
+
 const String devtoolsVersion = devtools.version; //dimension6 n.n.n
 
-String get userAppType {
-  if (!isDimensionsComputed) computeUserApplicationCustomGTagData();
-  return _userAppType;
+String get userAppType => _userAppType;
+set userAppType(String __userAppType) {
+  _userAppType = __userAppType;
 }
 
-String get userBuildType {
-  if (!isDimensionsComputed) computeUserApplicationCustomGTagData();
-  return _userBuildType;
+String get userBuildType => _userBuildType;
+set userBuildType(String __userBuildType) {
+  _userBuildType = __userBuildType;
 }
 
-String get userPlatformType {
-  if (!isDimensionsComputed) computeUserApplicationCustomGTagData();
-  return _userPlatformType;
+String get userPlatformType => _userPlatformType;
+set userPlatformType(String __userPlatformType) {
+  _userPlatformType = __userPlatformType;
 }
 
-String get devtoolsPlatformType {
-  if (!isDimensionsComputed) computeUserApplicationCustomGTagData();
-  return _devtoolsPlatformType;
+String get devtoolsPlatformType => _devtoolsPlatformType;
+set devtoolsPlatformType(String __devtoolsPlatformType) {
+  _devtoolsPlatformType = __devtoolsPlatformType;
 }
 
-String get devtoolsChrome {
-  if (!isDimensionsComputed) computeUserApplicationCustomGTagData();
-  return _devtoolsChrome;
+String get devtoolsChrome => _devtoolsChrome;
+set devtoolsChrome(String __devtoolsChrome) {
+  _devtoolsChrome = __devtoolsChrome;
 }
 
 bool _analyticsComputed = false;
 bool get isDimensionsComputed => _analyticsComputed;
-
-/// Computes the DevTools application. Fills in the devtoolsPlatformType and
-/// devtoolsChrome.
-void _computeDevToolsCustomGTagsData() {
-  // Platform
-  final String platform = html.window.navigator.platform;
-  platform.replaceAll(' ', '_');
-  _devtoolsPlatformType = platform;
-
-  final String appVersion = html.window.navigator.appVersion;
-  final List<String> splits = appVersion.split(' ');
-  final len = splits.length;
-  for (int index = 0; index < len; index++) {
-    final String value = splits[index];
-    // Chrome or Chrome iOS
-    if (value.startsWith(devToolsChrome) ||
-        value.startsWith(devToolsChromeIos)) {
-      _devtoolsChrome = value;
-    } else if (value.startsWith('Android')) {
-      // appVersion for Android is 'Android n.n.n'
-      _devtoolsPlatformType =
-          '$devToolsPlatformTypeAndroid${splits[index + 1]}';
-    }
-  }
+void dimensionsComputed() {
+  _analyticsComputed = true;
 }
 
 // Computes the running application.
 void computeUserApplicationCustomGTagData() async {
-  if (_analyticsComputed) return;
+  if (isDimensionsComputed) return;
 
   final isFlutter = await serviceManager.connectedApp.isFlutterApp;
   final isWebApp = await serviceManager.connectedApp.isFlutterWebApp;
@@ -401,26 +342,24 @@ void computeUserApplicationCustomGTagData() async {
     final windows = await io.eval('Platform.isWindows', isAlive: null);
 
     if (android.valueAsString == 'true')
-      _userPlatformType = platformTypeAndroid;
+      userPlatformType = platformTypeAndroid;
     else if (iOS.valueAsString == 'true')
-      _userPlatformType = platformTypeIOS;
+      userPlatformType = platformTypeIOS;
     else if (fuchsia.valueAsString == 'true')
-      _userPlatformType = platformTypeFuchsia;
+      userPlatformType = platformTypeFuchsia;
     else if (linux.valueAsString == 'true')
-      _userPlatformType = platformTypeLinux;
+      userPlatformType = platformTypeLinux;
     else if (macOS.valueAsString == 'true')
-      _userPlatformType = platformTypeMac;
+      userPlatformType = platformTypeMac;
     else if (windows.valueAsString == 'true')
-      _userPlatformType = platformTypeWindows;
+      userPlatformType = platformTypeWindows;
   }
 
   if (isAnyFlutterApp) {
-    if (isFlutter) _userAppType = appTypeFlutter;
-    if (isWebApp) _userAppType = appTypeWeb;
+    if (isFlutter) userAppType = appTypeFlutter;
+    if (isWebApp) userAppType = appTypeWeb;
   }
-  _userBuildType = isProfile ? buildTypeProfile : buildTypeDebug;
-
-  _computeDevToolsCustomGTagsData();
+  userBuildType = isProfile ? buildTypeProfile : buildTypeDebug;
 
   _analyticsComputed = true;
 }

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -321,7 +321,7 @@ void dimensionsComputed() {
 }
 
 // Computes the running application.
-void computeUserApplicationCustomGTagData() async {
+Future<void> computeUserApplicationCustomGTagData() async {
   if (isDimensionsComputed) return;
 
   final isFlutter = await serviceManager.connectedApp.isFlutterApp;

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -40,6 +40,32 @@ const String devToolsChrome = 'Chrome/'; // starts with and ends with n.n.n
 const String devToolsChromeIos = 'Crios/'; // starts with and ends with n.n.n
 // Dimension6 devToolsVersion
 
+@JS('gtagsEnabled')
+external bool isGtagsEnabled();
+
+@JS('getDevToolsPropertyID')
+external String devToolsProperty();
+
+@JS('_initializeGA')
+external void initializeGA();
+
+@JS('gaStorageCollect')
+external String storageCollectValue();
+
+@JS('gaStorageDontCollect')
+external String storageDontCollectValue();
+
+bool isAnalyticsAllowed() =>
+  html.window.localStorage[devToolsProperty()] == storageCollectValue();
+
+void setAllowAnalytics() {
+  html.window.localStorage[devToolsProperty()] = storageCollectValue();
+}
+
+void setDontAllowAnalytics() {
+  html.window.localStorage[devToolsProperty()] = storageDontCollectValue();
+}
+
 @JS()
 @anonymous
 class GtagEventDevTools extends GtagEvent {
@@ -173,9 +199,10 @@ const String exceptionEvent = 'exception'; // Any Dart exception in DevTools
 const String devToolsMain = 'main';
 const String debugger = 'debugger';
 const String inspector = 'inspector';
-const String memory = 'memory';
-const String timeline = 'timeline';
 const String logging = 'logging';
+const String memory = 'memory';
+const String performance = 'performance';
+const String timeline = 'timeline';
 
 // DevTools UI action selected (clicked).
 

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -1,0 +1,282 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library gtags;
+
+import 'dart:async';
+import 'package:js/js.dart';
+
+import '../ui/gtags.dart';
+import '../ui/ui_utils.dart';
+
+// Dimensions1 AppType values:
+const String appTypeFlutter = 'flutter';
+const String appTypeWeb = 'web';
+// Dimensions2 BuildType values:
+const String buildTypeDebug = 'debug';
+const String buildTypeProfile = 'profile';
+// Dimensions3 PlatformType values:
+const String platformTypeAndroid = 'android_flutter';
+const String platformTypeIOS = 'ios_flutter';
+const String platformTypeFuchsia = 'fuchsia';
+const String platformTypeLinux = 'linux';
+const String platformTypeMac = 'mac';
+const String platformTypeWindows = 'windows';
+// Dimension4 devToolsPlatformType values:
+const String devToolsPlatformTypeMac = 'MacIntel';
+const String devToolsPlatformTypeLinux = 'Linux';
+const String devToolsPlatformTypeWindows = 'Windows';
+// Start with Android_n.n.n
+const String devToolsPlatformTypeAndroid = 'Android_';
+// Dimension5 devToolsChrome starts with
+const String devToolsChrome = 'Chrome/'; // starts with and ends with n.n.n
+const String devToolsChromeIos = 'Crios/'; // starts with and ends with n.n.n
+// Dimension6 devToolsVersion
+
+@JS()
+@anonymous
+class GtagEventDevTools extends GtagEvent {
+  external factory GtagEventDevTools({
+    // ignore: non_constant_identifier_names
+    String event_category,
+    // ignore: non_constant_identifier_names
+    String event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
+    // ignore: non_constant_identifier_names
+    String send_to, // UA ID of target GA property to receive event data.
+
+    int value,
+
+    // ignore: non_constant_identifier_names
+    bool non_interaction,
+
+    // ignore: non_constant_identifier_names
+    dynamic custom_map,
+
+    // ignore: non_constant_identifier_names
+    String user_app, // dimension1 (flutter or web)
+    // ignore: non_constant_identifier_names
+    String user_build, // dimension2 (debug or profile)
+    // ignore: non_constant_identifier_names
+    String user_platform, // dimension3 (android/ios/fuchsia/linux/mac/windows)
+    // ignore: non_constant_identifier_names
+    String devtools_platform, // dimension4 linux/android/mac/windows
+    // ignore: non_constant_identifier_names
+    String devtools_chrome, // dimension5 Chrome version #
+    // ignore: non_constant_identifier_names
+    String devtools_version, // dimension6 DevTools version #
+  });
+
+  @override
+  // ignore: non_constant_identifier_names
+  external String get event_category;
+  @override
+  // ignore: non_constant_identifier_names
+  external String get event_label;
+  @override
+  // ignore: non_constant_identifier_names
+  external String get send_to;
+  @override
+  // ignore: non_constant_identifier_names
+  external int get value; // Positive number.
+  @override
+  // ignore: non_constant_identifier_names
+  external bool get non_interaction;
+  @override
+  // ignore: non_constant_identifier_names
+  external dynamic get custom_map;
+
+  // Custom dimensions:
+  // ignore: non_constant_identifier_names
+  external String get user_app;
+  // ignore: non_constant_identifier_names
+  external String get user_build;
+  // ignore: non_constant_identifier_names
+  external String get user_platform;
+  // ignore: non_constant_identifier_names
+  external String get devtools_platform;
+  // ignore: non_constant_identifier_names
+  external String get devtools_chrome;
+  // ignore: non_constant_identifier_names
+  external String get devtools_version;
+}
+
+@JS()
+@anonymous
+class GtagExceptionDevTools extends GtagException {
+  external factory GtagExceptionDevTools({
+    String description,
+    bool fatal,
+
+    // ignore: non_constant_identifier_names
+    String user_app, // dimension1 (flutter or web)
+    // ignore: non_constant_identifier_names
+    String user_build, // dimension2 (debug or profile)
+    // ignore: non_constant_identifier_names
+    String user_platform, // dimension3 (android or ios)
+    // ignore: non_constant_identifier_names
+    String devtools_platform, // dimension4 linux/android/mac/windows
+    // ignore: non_constant_identifier_names
+    String devtools_chrome, // dimension5 Chrome version #
+    // ignore: non_constant_identifier_names
+    String devtools_version, // dimension6 DevTools version #
+  });
+
+  @override
+  external String get description; // Description of the error.
+  @override
+  external bool get fatal; // Fatal error.
+
+  // Custom dimensions:
+  // ignore: non_constant_identifier_names
+  external String get user_app;
+  // ignore: non_constant_identifier_names
+  external String get user_build;
+  // ignore: non_constant_identifier_names
+  external String get user_platform;
+  // ignore: non_constant_identifier_names
+  external String get devtools_platform;
+  // ignore: non_constant_identifier_names
+  external String get devtools_chrome;
+  // ignore: non_constant_identifier_names
+  external String get devtools_version;
+}
+
+// Type of events (event_category):
+const String applicationEvent = 'application'; // visible/hidden
+const String screenViewEvent = 'screen'; // Active screen (tab selected).
+const String selectEvent = 'select'; // User selected something.
+
+const String errorError = 'onerror'; // Browser onError detected in DevTools
+const String exceptionEvent = 'exception'; // Any Dart exception in DevTools
+
+// DevTools GA screenNames:
+
+// GA events not associated with a any screen e.g., hotReload, hotRestart, etc
+const String devToolsMain = 'main';
+const String debugger = 'debugger';
+const String inspector = 'inspector';
+const String memory = 'memory';
+const String timeline = 'timeline';
+const String logging = 'logging';
+
+// DevTools UI action selected (clicked).
+
+// Main bar UX actions:
+const String hotReload = 'hotReload';
+const String hotRestart = 'hotRestart';
+const String feedback = 'feedback';
+
+// Common UX actions:
+const String pause = 'pause'; // Memory, Timeline, Debugger
+const String resume = 'resume'; // Memory, Timeline, Debugger
+
+// Inspector UX actions:
+const String widgetMode = 'widgetMode';
+const String refresh = 'refresh';
+const String performanceOverlay = 'performanceOverlay';
+const String debugPaint = 'debugPaint';
+const String paintBaseline = 'paintBaseline';
+const String slowAnimation = 'slowAnimation';
+const String repaintRainbow = 'repaintRainbow';
+const String debugBanner = 'debugBanner';
+const String trackRebuilds = 'trackRebuilds';
+const String iOS = 'iOS';
+const String selectWidgetMode = 'selectWidgetMode';
+
+// Timeline UX actions:
+const String timelineFrame = 'frame'; // Frame selected in frame chart
+const String timelineFlame = 'flame'; // Select a UI/GPU flame
+
+// Memory UX actions:
+const String snapshot = 'snapshot';
+const String reset = 'reset';
+const String gC = 'gc';
+const String inspectClass = 'inspectClass'; // inspect a class from snapshot
+const String inspectInstance = 'inspectInstance'; // inspect an instance
+const String inspectData = 'inspectData'; // inspect data of the instance
+
+// Debugger UX actions:
+const String openShortcut = 'openShortcut';
+const String stepIn = 'stepIn';
+const String stepOver = 'stepOver';
+const String stepOut = 'stepOut';
+const String bP = 'bp';
+const String unhandledExceptions = 'unhandledExceptions';
+const String allExceptions = 'allExceptions';
+
+// Logging UX actions:
+const String clearLogs = 'clearLogs';
+
+void _screen(
+  String screenName, [
+  int value = 0,
+]) {
+  GTag.event(
+      screenName,
+      GtagEventDevTools(
+          event_category: screenViewEvent,
+          value: value,
+          user_app: userAppType,
+          user_build: userBuildType,
+          user_platform: userPlatformType,
+          devtools_platform: devtoolsPlatformType,
+          devtools_chrome: devtoolsChrome,
+          devtools_version: devtoolsVersion));
+}
+
+void screen(
+  String screenName, [
+  int value = 0,
+]) {
+  if (!isDimensionsComputed) {
+    // This can happening while spinning up DevTools first time wait until our
+    // dimensions data is available before fir GA event sent.
+    Timer(const Duration(milliseconds: 500), () {
+      computeApplicationState();
+      _screen(screenName, value);
+    });
+  } else
+    _screen(screenName, value);
+}
+
+void select(
+  String screenName,
+  String selectedItem, [
+  int value = 0,
+]) {
+  GTag.event(
+      screenName,
+      GtagEventDevTools(
+          event_category: selectEvent,
+          event_label: selectedItem,
+          value: value,
+          user_app: userAppType,
+          user_build: userBuildType,
+          user_platform: userPlatformType,
+          devtools_platform: devtoolsPlatformType,
+          devtools_chrome: devtoolsChrome,
+          devtools_version: devtoolsVersion));
+}
+
+String _lastGaError;
+
+void error(
+  String errorMessage,
+  bool fatal,
+) {
+  // Don't keep recording same last error.
+  if (_lastGaError == errorMessage) return;
+  _lastGaError = errorMessage;
+
+  GTag.exception(GtagExceptionDevTools(
+      description: errorMessage,
+      fatal: fatal,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
+      devtools_version: devtoolsVersion));
+}

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -5,6 +5,8 @@
 @JS()
 library gtags;
 
+// ignore_for_file: non_constant_identifier_names
+
 import 'dart:async';
 import 'dart:html' as html;
 
@@ -70,77 +72,52 @@ void setDontAllowAnalytics() {
 @anonymous
 class GtagEventDevTools extends GtagEvent {
   external factory GtagEventDevTools({
-    // ignore: non_constant_identifier_names
     String event_category,
-    // ignore: non_constant_identifier_names
     String event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
-    // ignore: non_constant_identifier_names
     String send_to, // UA ID of target GA property to receive event data.
 
     int value,
-
-    // ignore: non_constant_identifier_names
     bool non_interaction,
-
-    // ignore: non_constant_identifier_names
     dynamic custom_map,
-
-    // ignore: non_constant_identifier_names
     String user_app, // dimension1 (flutter or web)
-    // ignore: non_constant_identifier_names
     String user_build, // dimension2 (debug or profile)
-    // ignore: non_constant_identifier_names
     String user_platform, // dimension3 (android/ios/fuchsia/linux/mac/windows)
-    // ignore: non_constant_identifier_names
     String devtools_platform, // dimension4 linux/android/mac/windows
-    // ignore: non_constant_identifier_names
     String devtools_chrome, // dimension5 Chrome version #
-    // ignore: non_constant_identifier_names
     String devtools_version, // dimension6 DevTools version #
 
-    // ignore: non_constant_identifier_names
     int gpu_duration,
-    // ignore: non_constant_identifier_names
     int ui_duration,
   });
 
   @override
-  // ignore: non_constant_identifier_names
   external String get event_category;
+
   @override
-  // ignore: non_constant_identifier_names
   external String get event_label;
+
   @override
-  // ignore: non_constant_identifier_names
   external String get send_to;
+
   @override
-  // ignore: non_constant_identifier_names
   external int get value; // Positive number.
+
   @override
-  // ignore: non_constant_identifier_names
   external bool get non_interaction;
+
   @override
-  // ignore: non_constant_identifier_names
   external dynamic get custom_map;
 
   // Custom dimensions:
-  // ignore: non_constant_identifier_names
   external String get user_app;
-  // ignore: non_constant_identifier_names
   external String get user_build;
-  // ignore: non_constant_identifier_names
   external String get user_platform;
-  // ignore: non_constant_identifier_names
   external String get devtools_platform;
-  // ignore: non_constant_identifier_names
   external String get devtools_chrome;
-  // ignore: non_constant_identifier_names
   external String get devtools_version;
 
   // Custom metrics:
-  // ignore: non_constant_identifier_names
   external int get gpu_duration;
-  // ignore: non_constant_identifier_names
   external int get ui_duration;
 }
 
@@ -150,18 +127,11 @@ class GtagExceptionDevTools extends GtagException {
   external factory GtagExceptionDevTools({
     String description,
     bool fatal,
-
-    // ignore: non_constant_identifier_names
     String user_app, // dimension1 (flutter or web)
-    // ignore: non_constant_identifier_names
     String user_build, // dimension2 (debug or profile)
-    // ignore: non_constant_identifier_names
     String user_platform, // dimension3 (android or ios)
-    // ignore: non_constant_identifier_names
     String devtools_platform, // dimension4 linux/android/mac/windows
-    // ignore: non_constant_identifier_names
     String devtools_chrome, // dimension5 Chrome version #
-    // ignore: non_constant_identifier_names
     String devtools_version, // dimension6 DevTools version #
   });
 
@@ -171,17 +141,11 @@ class GtagExceptionDevTools extends GtagException {
   external bool get fatal; // Fatal error.
 
   // Custom dimensions:
-  // ignore: non_constant_identifier_names
   external String get user_app;
-  // ignore: non_constant_identifier_names
   external String get user_build;
-  // ignore: non_constant_identifier_names
   external String get user_platform;
-  // ignore: non_constant_identifier_names
   external String get devtools_platform;
-  // ignore: non_constant_identifier_names
   external String get devtools_chrome;
-  // ignore: non_constant_identifier_names
   external String get devtools_version;
 }
 

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -56,7 +56,7 @@ external String storageCollectValue();
 external String storageDontCollectValue();
 
 bool isAnalyticsAllowed() =>
-  html.window.localStorage[devToolsProperty()] == storageCollectValue();
+    html.window.localStorage[devToolsProperty()] == storageCollectValue();
 
 void setAllowAnalytics() {
   html.window.localStorage[devToolsProperty()] = storageCollectValue();

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -37,6 +37,7 @@ const String devToolsPlatformTypeAndroid = 'Android_';
 // Dimension5 devToolsChrome starts with
 const String devToolsChromeName = 'Chrome/'; // starts with and ends with n.n.n
 const String devToolsChromeIos = 'Crios/'; // starts with and ends with n.n.n
+const String devToolsChromeOS = 'CrOS'; // Chrome OS
 // Dimension6 devToolsVersion
 
 @JS('gtagsEnabled')

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -53,6 +53,9 @@ void computeDevToolsCustomGTagsData() {
       // appVersion for Android is 'Android n.n.n'
       ga.devtoolsPlatformType =
           '${ga.devToolsPlatformTypeAndroid}${splits[index + 1]}';
+    } else if (value == ga.devToolsChromeOS) {
+      // Chrome OS will return a platform e.g., CrOS_Linux_x86_64
+      ga.devtoolsPlatformType = '${ga.devToolsChromeOS}_$platform';
     }
   }
 }

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -71,7 +71,7 @@ void waitForDimensionsComputed(String screenName) {
       if (_stillWaiting++ < 50)
         waitForDimensionsComputed(screenName);
       else
-        print("Cancel waiting for dimensions.");
+        print('Cancel waiting for dimensions.');
     }
   });
 }

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -1,0 +1,97 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library analytics_platform;
+
+import 'dart:async';
+import 'dart:html' as html;
+
+import 'package:js/js.dart';
+
+import '../ui/analytics.dart' as ga;
+
+@JS('getDevToolsPropertyID')
+external String devToolsProperty();
+
+@JS('gaStorageCollect')
+external String storageCollectValue();
+
+@JS('gaStorageDontCollect')
+external String storageDontCollectValue();
+
+bool isAnalyticsAllowed() =>
+    html.window.localStorage[devToolsProperty()] == storageCollectValue();
+
+void setAllowAnalytics() {
+  html.window.localStorage[devToolsProperty()] = storageCollectValue();
+}
+
+void setDontAllowAnalytics() {
+  html.window.localStorage[devToolsProperty()] = storageDontCollectValue();
+}
+
+/// Computes the DevTools application. Fills in the devtoolsPlatformType and
+/// devtoolsChrome.
+void computeDevToolsCustomGTagsData() {
+  // Platform
+  final String platform = html.window.navigator.platform;
+  platform.replaceAll(' ', '_');
+  ga.devtoolsPlatformType = platform;
+
+  final String appVersion = html.window.navigator.appVersion;
+  final List<String> splits = appVersion.split(' ');
+  final len = splits.length;
+  for (int index = 0; index < len; index++) {
+    final String value = splits[index];
+    // Chrome or Chrome iOS
+    if (value.startsWith(ga.devToolsChromeName) ||
+        value.startsWith(ga.devToolsChromeIos)) {
+      ga.devtoolsChrome = value;
+    } else if (value.startsWith('Android')) {
+      // appVersion for Android is 'Android n.n.n'
+      ga.devtoolsPlatformType =
+          '${ga.devToolsPlatformTypeAndroid}${splits[index + 1]}';
+    }
+  }
+}
+
+bool _computing = false;
+
+int _stillWaiting = 0;
+void waitForDimensionsComputed(String screenName) {
+  Timer(const Duration(milliseconds: 100), () async {
+    if (ga.isDimensionsComputed)
+      ga.screen(screenName);
+    else {
+      if (_stillWaiting++ < 50)
+        waitForDimensionsComputed(screenName);
+      else
+        print("Cancel waiting for dimensions.");
+    }
+  });
+}
+
+// Loading screen from a hash code, can't collect GA (if enabled) until we have
+// all the dimension data.
+void setupAndGaScreen(String screenName) async {
+  if (ga.isGtagsEnabled()) {
+    if (!ga.isDimensionsComputed) {
+      _stillWaiting++;
+      waitForDimensionsComputed(screenName);
+    } else
+      ga.screen(screenName);
+  }
+}
+
+void setupDimensions() async {
+  if (ga.isGtagsEnabled() && !ga.isDimensionsComputed && !_computing) {
+    _computing = true;
+    // While spinning up DevTools first time wait until dimensions data is
+    // available before first GA event sent.
+    await ga.computeUserApplicationCustomGTagData();
+    computeDevToolsCustomGTagsData();
+    ga.dimensionsComputed();
+  }
+}

--- a/packages/devtools/lib/src/ui/elements.dart
+++ b/packages/devtools/lib/src/ui/elements.dart
@@ -13,6 +13,8 @@ CoreElement a({String text, String c, String a, String href, String target}) =>
       ..setAttribute('href', href)
       ..setAttribute('target', target);
 
+CoreElement br() => CoreElement('br');
+
 CoreElement button({String text, String c, String a}) =>
     CoreElement('button', text: text, classes: c, attributes: a);
 

--- a/packages/devtools/lib/src/ui/gtags.dart
+++ b/packages/devtools/lib/src/ui/gtags.dart
@@ -1,0 +1,221 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library gtags;
+
+import 'package:js/js.dart';
+import '../ui/ui_utils.dart';
+
+/// For gtags API see https://developers.google.com/gtagjs/reference/api
+/// For debugging install the Chrome Plugin "Google Analytics Debugger".
+
+/// Analytic's DevTools Property ID 'UA-nnn'.
+@JS('_GA_DEVTOOLS_PROPERTY')
+external String get gaDevToolsPropertyTrackingID;
+
+@JS('gtag')
+external void _gTagCommandName(String command, String name, [dynamic params]);
+
+@JS('gaCollectionAllowed')
+external bool gaCollectionAllowed();
+
+/// Google Analytics ready to collect.
+@JS('isGaInitialized')
+external bool isGaInitialized();
+
+class GTag {
+  static const String _event = 'event';
+  static const String _exception = 'exception';
+
+  /// Collect the analytic's event and its parameters.
+  static void event(String eventName, GtagEvent gaEvent) {
+    if (gaCollectionAllowed()) _gTagCommandName(_event, eventName, gaEvent);
+  }
+
+  static void exception(GtagException gaException) {
+    if (gaCollectionAllowed())
+      _gTagCommandName(_event, _exception, gaException);
+  }
+}
+
+@JS()
+@anonymous
+class GtagEvent {
+  external factory GtagEvent({
+    // ignore: non_constant_identifier_names
+    String event_category,
+    // ignore: non_constant_identifier_names
+    String event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
+    // ignore: non_constant_identifier_names
+    String send_to, // UA ID of target GA property to receive event data.
+
+    int value,
+
+    // ignore: non_constant_identifier_names
+    bool non_interaction,
+
+    // ignore: non_constant_identifier_names
+    dynamic custom_map,
+
+    // ignore: non_constant_identifier_names
+    String app_type, // dimension1 (flutter or web)
+    // ignore: non_constant_identifier_names
+    String build_type, // dimension2 (debug or profile)
+    // ignore: non_constant_identifier_names
+    String platform_type, // dimension3 (android or ios)
+  });
+
+  // ignore: non_constant_identifier_names
+  external String get event_category;
+  // ignore: non_constant_identifier_names
+  external String get event_label;
+  // ignore: non_constant_identifier_names
+  external String get send_to;
+  // ignore: non_constant_identifier_names
+  external int get value; // Positive number.
+  // ignore: non_constant_identifier_names
+  external bool get non_interaction;
+  // ignore: non_constant_identifier_names
+  external dynamic get custom_map;
+
+  // Custom dimensions:
+  // ignore: non_constant_identifier_names
+  external String get app_type;
+  // ignore: non_constant_identifier_names
+  external String get build_type;
+  // ignore: non_constant_identifier_names
+  external String get platform_type;
+}
+
+@JS()
+@anonymous
+class GtagException {
+  external factory GtagException({
+    String description,
+    bool fatal,
+
+    // ignore: non_constant_identifier_names
+    String app_type, // dimension1 (flutter or web)
+    // ignore: non_constant_identifier_names
+    String build_type, // dimension2 (debug or profile)
+    // ignore: non_constant_identifier_names
+    String platform_type, // dimension3 (android or ios)
+  });
+
+  external String get description; // Description of the error.
+  external bool get fatal; // Fatal error.
+  // Custom dimensions:
+  // ignore: non_constant_identifier_names
+  external String get app_type;
+  // ignore: non_constant_identifier_names
+  external String get build_type;
+  // ignore: non_constant_identifier_names
+  external String get platform_type;
+}
+
+/// ****************************************************************************
+/// *** DevTools Property Specific QA events and dimensions.                 ***
+/// ****************************************************************************
+
+// Type of events (event_category):
+const String gaApplicationState = 'application_state'; // type, build, platform
+const String gaScreenViewEvent = 'screen'; // Active screen (tab selected).
+const String gaSelectEvent = 'select'; // User selected something.
+
+const String gaOnError = 'onerror'; // Browser onError detected in DevTools
+const String gaException = 'exception'; // Any Dart exception in DevTools
+
+// DevTools GA screenNames
+const String gaDevTools = 'main';
+const String gaDebugger = 'debugger';
+const String gaInspector = 'inspector';
+const String gaMemory = 'memory';
+const String gaTimeline = 'timeline';
+const String gaLogging = 'loggimng';
+
+// DevTools UI action selected (clicked).
+
+// Main bar UX actions:
+const String gaHotReload = 'hotReload';
+const String gaHotRestart = 'hotRestart';
+const String gaFeedback = 'feedback';
+
+// Common UX actions:
+const String gaPause = 'pause'; // Memory, Timeline, Debugger
+const String gaResume = 'resume'; // Memory, Timeline, Debugger
+
+// Inspector UX actions:
+const String gaWidgetMode = 'widgetMode';
+const String gaRefresh = 'refresh';
+const String gaPerformanceOverlay = 'overlay';
+const String gaDebugPaint = 'debugPaint';
+const String gaPaintBaseline = 'paintBaseline';
+const String gaSlowAnimation = 'slowAnimation';
+const String gaRepaintRainbow = 'repaintRainbow';
+const String gaDebugBanner = 'debugBanner';
+const String gaTrackRebuilds = 'rebuilds';
+const String gaIOS = 'iOS';
+const String gaSelectWidgeMode = 'selectWidgeMode';
+
+// Timeline UX actions:
+const String gaTimelineFrame = 'frame'; // Frame selected in frame chart
+const String gaTimelineFlame = 'flame'; // Select a UI/GPU flame
+
+// Memory UX actions:
+const String gaSnapshot = 'snapshot';
+const String gaReset = 'reset';
+const String gaGC = 'gc';
+const String gaInspectClass = 'inspectClass'; // inspect a class from snapshot
+const String gaInspectInstance = 'inspectInstance'; // inspect an instance
+const String gaInspectData = 'inspectData'; // inspect data of the instance
+
+// Debugger UX actions:
+const String gaOpenShortcut = 'openShortcut';
+const String gaStepIn = 'stepIn';
+const String gaStepOver = 'stepOver';
+const String gaStepOut = 'stepOut';
+const String gaBP = 'bp';
+const String gaUnhandledExceptions = 'unhandledExceptions';
+const String gaAllExceptions = 'allExceptions';
+
+// Logging UX actions:
+const String gaClearLogs = 'clearLogs';
+
+void gaScreen(String screenName, [int value = 0]) => GTag.event(
+    screenName,
+    GtagEvent(
+        event_category: gaScreenViewEvent,
+        value: value,
+        app_type: userAppType,
+        build_type: userBuildType,
+        platform_type: userPlatformType));
+
+void gaSelect(String screenName, String selectedItem, [int value = 0]) =>
+    GTag.event(
+        screenName,
+        GtagEvent(
+            event_category: gaSelectEvent,
+            event_label: selectedItem,
+            value: value,
+            app_type: userAppType,
+            build_type: userBuildType,
+            platform_type: userPlatformType));
+
+void gaError(String errorMessage, bool fatal) => GTag.exception(GtagException(
+    description: errorMessage,
+    fatal: fatal,
+    app_type: userAppType,
+    build_type: userBuildType,
+    platform_type: userPlatformType));
+
+// Dimensions1 AppType values:
+const String gaAppTypeFlutter = 'flutter';
+const String gaAppTypeWeb = 'web';
+// Dimensions2 BuildType values:
+const String gaBuildTypeDebug = 'debug';
+const String gaBuildTypeProfile = 'profile';
+// Dimensions3 PlatformType values:
+const String gaPlatformTypeAndroid = 'android';
+const String gaPlatformTypeIOS = 'ios';

--- a/packages/devtools/lib/src/ui/gtags.dart
+++ b/packages/devtools/lib/src/ui/gtags.dart
@@ -10,10 +10,6 @@ import 'package:js/js.dart';
 /// For gtags API see https://developers.google.com/gtagjs/reference/api
 /// For debugging install the Chrome Plugin "Google Analytics Debugger".
 
-/// Analytic's DevTools Property ID 'UA-nnn'.
-//@JS('_GA_DEVTOOLS_PROPERTY')
-//external String get gaDevToolsPropertyTrackingID;
-
 @JS('gtag')
 external void _gTagCommandName(String command, String name, [dynamic params]);
 
@@ -70,7 +66,7 @@ class GtagEvent {
   // ignore: non_constant_identifier_names
   external bool get non_interaction;
   // ignore: non_constant_identifier_names
-  external dynamic get custom_map;
+  external dynamic get custom_map; // Custom metrics
 }
 
 @JS()

--- a/packages/devtools/lib/src/ui/gtags.dart
+++ b/packages/devtools/lib/src/ui/gtags.dart
@@ -6,20 +6,19 @@
 library gtags;
 
 import 'package:js/js.dart';
-import '../ui/ui_utils.dart';
 
 /// For gtags API see https://developers.google.com/gtagjs/reference/api
 /// For debugging install the Chrome Plugin "Google Analytics Debugger".
 
 /// Analytic's DevTools Property ID 'UA-nnn'.
-@JS('_GA_DEVTOOLS_PROPERTY')
-external String get gaDevToolsPropertyTrackingID;
+//@JS('_GA_DEVTOOLS_PROPERTY')
+//external String get gaDevToolsPropertyTrackingID;
 
 @JS('gtag')
 external void _gTagCommandName(String command, String name, [dynamic params]);
 
 @JS('gaCollectionAllowed')
-external bool gaCollectionAllowed();
+external bool _gaCollectionAllowed();
 
 /// Google Analytics ready to collect.
 @JS('isGaInitialized')
@@ -31,11 +30,11 @@ class GTag {
 
   /// Collect the analytic's event and its parameters.
   static void event(String eventName, GtagEvent gaEvent) {
-    if (gaCollectionAllowed()) _gTagCommandName(_event, eventName, gaEvent);
+    if (_gaCollectionAllowed()) _gTagCommandName(_event, eventName, gaEvent);
   }
 
   static void exception(GtagException gaException) {
-    if (gaCollectionAllowed())
+    if (_gaCollectionAllowed())
       _gTagCommandName(_event, _exception, gaException);
   }
 }
@@ -58,13 +57,6 @@ class GtagEvent {
 
     // ignore: non_constant_identifier_names
     dynamic custom_map,
-
-    // ignore: non_constant_identifier_names
-    String app_type, // dimension1 (flutter or web)
-    // ignore: non_constant_identifier_names
-    String build_type, // dimension2 (debug or profile)
-    // ignore: non_constant_identifier_names
-    String platform_type, // dimension3 (android or ios)
   });
 
   // ignore: non_constant_identifier_names
@@ -79,14 +71,6 @@ class GtagEvent {
   external bool get non_interaction;
   // ignore: non_constant_identifier_names
   external dynamic get custom_map;
-
-  // Custom dimensions:
-  // ignore: non_constant_identifier_names
-  external String get app_type;
-  // ignore: non_constant_identifier_names
-  external String get build_type;
-  // ignore: non_constant_identifier_names
-  external String get platform_type;
 }
 
 @JS()
@@ -95,127 +79,8 @@ class GtagException {
   external factory GtagException({
     String description,
     bool fatal,
-
-    // ignore: non_constant_identifier_names
-    String app_type, // dimension1 (flutter or web)
-    // ignore: non_constant_identifier_names
-    String build_type, // dimension2 (debug or profile)
-    // ignore: non_constant_identifier_names
-    String platform_type, // dimension3 (android or ios)
   });
 
   external String get description; // Description of the error.
   external bool get fatal; // Fatal error.
-  // Custom dimensions:
-  // ignore: non_constant_identifier_names
-  external String get app_type;
-  // ignore: non_constant_identifier_names
-  external String get build_type;
-  // ignore: non_constant_identifier_names
-  external String get platform_type;
 }
-
-/// ****************************************************************************
-/// *** DevTools Property Specific QA events and dimensions.                 ***
-/// ****************************************************************************
-
-// Type of events (event_category):
-const String gaApplicationState = 'application_state'; // type, build, platform
-const String gaScreenViewEvent = 'screen'; // Active screen (tab selected).
-const String gaSelectEvent = 'select'; // User selected something.
-
-const String gaOnError = 'onerror'; // Browser onError detected in DevTools
-const String gaException = 'exception'; // Any Dart exception in DevTools
-
-// DevTools GA screenNames
-const String gaDevTools = 'main';
-const String gaDebugger = 'debugger';
-const String gaInspector = 'inspector';
-const String gaMemory = 'memory';
-const String gaTimeline = 'timeline';
-const String gaLogging = 'loggimng';
-
-// DevTools UI action selected (clicked).
-
-// Main bar UX actions:
-const String gaHotReload = 'hotReload';
-const String gaHotRestart = 'hotRestart';
-const String gaFeedback = 'feedback';
-
-// Common UX actions:
-const String gaPause = 'pause'; // Memory, Timeline, Debugger
-const String gaResume = 'resume'; // Memory, Timeline, Debugger
-
-// Inspector UX actions:
-const String gaWidgetMode = 'widgetMode';
-const String gaRefresh = 'refresh';
-const String gaPerformanceOverlay = 'overlay';
-const String gaDebugPaint = 'debugPaint';
-const String gaPaintBaseline = 'paintBaseline';
-const String gaSlowAnimation = 'slowAnimation';
-const String gaRepaintRainbow = 'repaintRainbow';
-const String gaDebugBanner = 'debugBanner';
-const String gaTrackRebuilds = 'rebuilds';
-const String gaIOS = 'iOS';
-const String gaSelectWidgeMode = 'selectWidgeMode';
-
-// Timeline UX actions:
-const String gaTimelineFrame = 'frame'; // Frame selected in frame chart
-const String gaTimelineFlame = 'flame'; // Select a UI/GPU flame
-
-// Memory UX actions:
-const String gaSnapshot = 'snapshot';
-const String gaReset = 'reset';
-const String gaGC = 'gc';
-const String gaInspectClass = 'inspectClass'; // inspect a class from snapshot
-const String gaInspectInstance = 'inspectInstance'; // inspect an instance
-const String gaInspectData = 'inspectData'; // inspect data of the instance
-
-// Debugger UX actions:
-const String gaOpenShortcut = 'openShortcut';
-const String gaStepIn = 'stepIn';
-const String gaStepOver = 'stepOver';
-const String gaStepOut = 'stepOut';
-const String gaBP = 'bp';
-const String gaUnhandledExceptions = 'unhandledExceptions';
-const String gaAllExceptions = 'allExceptions';
-
-// Logging UX actions:
-const String gaClearLogs = 'clearLogs';
-
-void gaScreen(String screenName, [int value = 0]) => GTag.event(
-    screenName,
-    GtagEvent(
-        event_category: gaScreenViewEvent,
-        value: value,
-        app_type: userAppType,
-        build_type: userBuildType,
-        platform_type: userPlatformType));
-
-void gaSelect(String screenName, String selectedItem, [int value = 0]) =>
-    GTag.event(
-        screenName,
-        GtagEvent(
-            event_category: gaSelectEvent,
-            event_label: selectedItem,
-            value: value,
-            app_type: userAppType,
-            build_type: userBuildType,
-            platform_type: userPlatformType));
-
-void gaError(String errorMessage, bool fatal) => GTag.exception(GtagException(
-    description: errorMessage,
-    fatal: fatal,
-    app_type: userAppType,
-    build_type: userBuildType,
-    platform_type: userPlatformType));
-
-// Dimensions1 AppType values:
-const String gaAppTypeFlutter = 'flutter';
-const String gaAppTypeWeb = 'web';
-// Dimensions2 BuildType values:
-const String gaBuildTypeDebug = 'debug';
-const String gaBuildTypeProfile = 'profile';
-// Dimensions3 PlatformType values:
-const String gaPlatformTypeAndroid = 'android';
-const String gaPlatformTypeIOS = 'ios';

--- a/packages/devtools/lib/src/ui/gtags.dart
+++ b/packages/devtools/lib/src/ui/gtags.dart
@@ -5,6 +5,8 @@
 @JS()
 library gtags;
 
+// ignore_for_file: non_constant_identifier_names
+
 import 'package:js/js.dart';
 
 /// For gtags API see https://developers.google.com/gtagjs/reference/api
@@ -39,33 +41,20 @@ class GTag {
 @anonymous
 class GtagEvent {
   external factory GtagEvent({
-    // ignore: non_constant_identifier_names
     String event_category,
-    // ignore: non_constant_identifier_names
     String event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
-    // ignore: non_constant_identifier_names
     String send_to, // UA ID of target GA property to receive event data.
 
     int value,
-
-    // ignore: non_constant_identifier_names
     bool non_interaction,
-
-    // ignore: non_constant_identifier_names
     dynamic custom_map,
   });
 
-  // ignore: non_constant_identifier_names
   external String get event_category;
-  // ignore: non_constant_identifier_names
   external String get event_label;
-  // ignore: non_constant_identifier_names
   external String get send_to;
-  // ignore: non_constant_identifier_names
   external int get value; // Positive number.
-  // ignore: non_constant_identifier_names
   external bool get non_interaction;
-  // ignore: non_constant_identifier_names
   external dynamic get custom_map; // Custom metrics
 }
 

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -15,6 +15,7 @@ import '../utils.dart';
 import 'elements.dart';
 import 'environment.dart' as environment;
 import 'fake_flutter/dart_ui/dart_ui.dart';
+import 'gtags.dart';
 import 'html_icon_renderer.dart';
 import 'material_icons.dart';
 import 'primer.dart';
@@ -22,6 +23,26 @@ import 'primer.dart';
 const int defaultSplitterWidth = 10;
 const String runInProfileModeDocsUrl =
     'https://flutter.dev/docs/testing/ui-performance#run-in-profile-mode';
+
+// GA dimensions:
+String userAppType = ''; // dimension1
+String userBuildType = ''; // dimension2
+String userPlatformType = ''; // dimension3
+
+void computeApplicationState(
+  bool isAnyFlutterApp,
+  bool isFlutter,
+  bool isWebApp,
+  bool isProfile,
+  bool isAndroid,
+) {
+  if (isAnyFlutterApp) {
+    if (isFlutter) userAppType = gaAppTypeFlutter;
+    if (isWebApp) userAppType = gaAppTypeWeb;
+  }
+  userBuildType = isProfile ? gaBuildTypeProfile : gaBuildTypeDebug;
+  userPlatformType = isAndroid ? gaPlatformTypeAndroid : gaPlatformTypeIOS;
+}
 
 CoreElement createExtensionCheckBox(
     ToggleableServiceExtensionDescription extensionDescription) {
@@ -187,6 +208,36 @@ class ServiceExtensionButton {
   PButton button;
 
   void _click() {
+    switch (extensionDescription.extension) {
+      case 'ext.flutter.debugAllowBanner':
+        gaSelect(gaInspector, gaDebugBanner);
+        break;
+      case 'ext.flutter.debugPaint':
+        gaSelect(gaInspector, gaDebugPaint);
+        break;
+      case 'ext.flutter.debugPaintBaselinesEnabled':
+        gaSelect(gaInspector, gaPaintBaseline);
+        break;
+      case 'ext.flutter.showPerformanceOverlay':
+        gaSelect(gaInspector, gaPerformanceOverlay);
+        break;
+      case 'ext.flutter.profileWidgetBuilds':
+        gaSelect(gaInspector, gaTrackRebuilds);
+        break;
+      case 'ext.flutter.repaintRainbow':
+        gaSelect(gaInspector, gaRepaintRainbow);
+        break;
+      case 'ext.flutter.timeDilation':
+        gaSelect(gaInspector, gaSlowAnimation);
+        break;
+      case 'ext.flutter.platformOverride':
+        gaSelect(gaInspector, gaIOS);
+        break;
+      case 'ext.flutter.inspector.show':
+        gaSelect(gaInspector, gaSelectWidgeMode);
+        break;
+    }
+
     final bool wasSelected = button.element.classes.contains('selected');
     serviceManager.serviceExtensionManager.setServiceExtensionState(
       extensionDescription.extension,

--- a/packages/devtools/web/devtools_analytics.js
+++ b/packages/devtools/web/devtools_analytics.js
@@ -20,9 +20,9 @@ function gtag() {
 // Parse the URI parameters.
 let _gtagsValue = new URLSearchParams(window.location.search).get('gtags');
 let _gtagsReset = _gtagsValue == 'reset';
-let _gtagsEnabled = _gtagsValue == 'enabled' ? true : false;
+let _gtagsEnabled = _gtagsValue == 'enabled';
 // Default is disabled if &gtags= is not specified
-let _gtagsDisabled = _gtagsValue == null || _gtagsValue == 'disabled' ? true : false;
+let _gtagsDisabled = _gtagsValue == null || _gtagsValue == 'disabled';
 
 // Disabled or resetting we're disabled.
 if (_gtagsDisabled | _gtagsReset) {

--- a/packages/devtools/web/devtools_analytics.js
+++ b/packages/devtools/web/devtools_analytics.js
@@ -4,145 +4,84 @@
 
 // URI parameter to control DevTools analytics collection:
 //
-//   &gtags=enabled                 // Analytics will run but ga-confirm and opt-in must work (see ga-confirm below).
-//   &gtags=disabled                // Default is disabled implies no GA will run (even opt-in dialog won't display).
-//
-//   &ga-confirm=?                  // Displays the GA collection confirmation dialog, to change answer.
-//   &ga-confirm=reset              // Resets/deletes user's collection answer in local storage.
-//   &ga-confirm=true               // Analytics COLLECT opt-in answer from an outside application e.g., VSCode.
-//   &ga-confirm=false              // Analytics DO NOT COLLECT opt-in answer from an outside application e.g., VSCode.
+//   &gtags=enabled                 // Analytics will display opt-in dialog, if accepted when enabled collects GA.
+//   &gtags=disabled                // Default is disabled implies no GA, opt-in not displayed even if opt-in accepted
+//                                  // gtags=disabled GA will NEVER be collected.
+//   &gtags=reset                   // Resets/deletes user's collection answer in local storage.
 
+// Used for GA collecting (communicating to https://www.googletagmanager.com/gtag/js script).
 window.dataLayer = window.dataLayer || [];
-
 function gtag() {
-    if (gtagsEnabled()) {
-        dataLayer.push(arguments);
-    }
+  if (gtagsEnabled()) {
+      dataLayer.push(arguments);
+  }
 }
 
-function _getUrlVars() {
-    let allVars = {};
-    window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(_, key, value) {
-        allVars[key] = value;
-    });
-    return allVars;
+// Parse the URI parameters.
+let _gtagsValue = new URLSearchParams(window.location.search).get('gtags');
+let _gtagsReset = _gtagsValue == 'reset';
+let _gtagsEnabled = _gtagsValue == 'enabled' ? true : false;
+// Default is disabled if &gtags= is not specified
+let _gtagsDisabled = _gtagsValue == null || _gtagsValue == 'disabled' ? true : false;
+
+// Disabled or resetting we're disabled.
+if (_gtagsDisabled | _gtagsReset) {
+  console.log("Google Analytics DevTools is disabled.")
 }
 
-let _urlVars = _getUrlVars();
-
-let _gtagsEnabled = _urlVars['gtags'] == 'enabled' ? true : false;
 function gtagsEnabled() {
-    return _gtagsEnabled
+  return _gtagsEnabled
 }
 
-let gaConfirmation = _urlVars['ga-confirm'];
-
-let _initializedGA = false;
-function isGaInitialized() {
-    return gtagsEnabled() && _initializedGA;
-}
-
-// InitializeGA with our dimensions. Both the name and order (dimension #) should match the those in gtags.dart
-function _initializeGA() {
-    if (gtagsEnabled() && !_initializedGA && gaCollectionAllowed()) {
-        gtag('js', new Date());
-        gtag('config', _GA_DEVTOOLS_PROPERTY, {
-            'custom_map': {
-                // Custom dimensions:
-                dimension1: 'user_app',
-                dimension2: 'user_build',
-                dimension3: 'user_platform',
-                dimension4: 'devtools_platform',
-                dimension5: 'devtools_chrome',
-                dimension6: 'devtools_version',
-
-                // Custom metrics:
-                metric1: 'gpu_duration',
-                metric2: 'ui_duration',
-            }
-        });
-
-        _initializedGA = true;
-    }
+if (_gtagsReset) {
+  localStorage.removeItem(GA_DEVTOOLS_PROPERTY);
+  console.log("Google Analytics DevTools opt-in has been reset.");
 }
 
 // Values in local storage:
 const _GA_COLLECT = 'collect';
+function gaStorageCollect() {
+  return _GA_COLLECT;
+}
 const _GA_DONT_COLLECT = 'do-not-collect';
+function gaStorageDontCollect() {
+  return _GA_DONT_COLLECT;
+}
 
 function gaCollectionAllowed() {
-    return localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == _GA_COLLECT;
+  return localStorage.getItem(GA_DEVTOOLS_PROPERTY) == _GA_COLLECT;
 }
 
-let gaDialog = document.getElementById('devtools_analytics');
-
-if (!gtagsEnabled()) {
-    gaDialog.close();
-    console.log("gtags not enabled.");
+let _initializedGA = false;
+function isGaInitialized() {
+  return gtagsEnabled() && _initializedGA;
 }
 
-gaDialog.style.zIndex = '1000';
+// InitializeGA with our dimensions. Both the name and order (dimension #) should match the those in gtags.dart
+function _initializeGA() {
+  if (gtagsEnabled() && gaCollectionAllowed() && !_initializedGA) {
+    gtag('js', new Date());
+    gtag('config', GA_DEVTOOLS_PROPERTY, {
+           'custom_map': {
+             // Custom dimensions:
+             dimension1: 'user_app',
+             dimension2: 'user_build',
+             dimension3: 'user_platform',
+             dimension4: 'devtools_platform',
+             dimension5: 'devtools_chrome',
+             dimension6: 'devtools_version',
 
-// '?' to ga-confirm URI parameter to display GA acceptance dialog e.g.,  &ga-confirm=?
-if (gtagsEnabled()) {
-    if (gaConfirmation != null) {
-        console.log("GA &ga-confirm = " + gaConfirmation);
-    }
-    console.log("GA Dart DevTools Property " + _GA_DEVTOOLS_PROPERTY + " opt-in = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
-}
+             // Custom metrics:
+             metric1: 'gpu_duration',
+             metric2: 'ui_duration',
+           }
+         });
 
-if (gaConfirmation == '?' || localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
-    let gaAcceptButton = document.getElementById('devtools-ga-accept');
-    gaAcceptButton.addEventListener('click', function (_) {
-        // Collect statistics.
-        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_COLLECT);
-        gaDialog.close();
-        _initializeGA();
-    });
-
-    let gaDoNotAcceptButton = document.getElementById('devtools-ga-do-not-accept');
-    gaDoNotAcceptButton.addEventListener('click', function (_) {
-        // Do NOT collect statistics.
-        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
-        gaDialog.close();
-    });
-
-    // Ensure focus doesn't leave GA confirmation dialog.
-    gaDialog.addEventListener('focusout', function (e) {
-        // Collect statistics.
-        let cancelEvent = false;
-        let relatedTarget = e.relatedTarget;
-        if (relatedTarget != null) {
-            let id = relatedTarget.getAttribute('id');
-            cancelEvent = id == null || !id.startsWith('devtools-ga-');
-        } else {
-            cancelEvent = true;
-        }
-        if (cancelEvent) {
-            e.srcElement.focus();
-            e.stopPropagation();
-            e.preventDefault();
-            return false;
-        }
-    });
-} else if (gaConfirmation == 'reset') {
-    // Delete the local storage value.
-    localStorage.removeItem(_GA_DEVTOOLS_PROPERTY);
-    gaDialog.style.display = 'none';
-    console.log("Reset localStorage = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
-} else {
-    gaDialog.style.display = 'none';
-
-    // If gaConfirmation is passed in e.g., VSCode and DevTools GA Collection not defined then use VSCode's collection
-    // authorization.  Otherwise, DevTools GA collection, if explicitly defined use DevTools regardless if VSCode's
-    // is different.
-    if (gaConfirmation == 'true' && localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
-        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, gaConfirmation == 'true' ? _GA_COLLECT : _GA_DONT_COLLECT);
-    } else if (gaConfirmation == 'false') {
-        // If GA confirmation is to not collect statistics then immediately force no collection regardless of what
-        // DevTools GA Confirmation was always default to DO NOT COLLECT if anyone up the line has do not collect.
-        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
-    }
+    _initializedGA = true;
+    console.log("Google Analytics collecting DevTools " + GA_DEVTOOLS_PROPERTY);
+  } else if (gaCollectionAllowed) {
+    console.log("Google Analytics NOT collecting DevTools " + GA_DEVTOOLS_PROPERTY);
+  }
 }
 
 _initializeGA();

--- a/packages/devtools/web/devtools_analytics.js
+++ b/packages/devtools/web/devtools_analytics.js
@@ -1,0 +1,159 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// URI parameter to control DevTools analytics collection:
+//
+//   &gtags=enabled                 // Analytics will run but ga-confirm and opt-in must work (see ga-confirm below).
+//   &gtags=disabled                // Default is disabled implies no GA will run (even opt-in dialog won't display).
+//
+//   &ga-confirm=?                  // Displays the GA collection confirmation dialog, to change answer.
+//   &ga-confirm=reset              // Resets/deletes user's collection answer in local storage.
+//   &ga-confirm=true               // Analytics COLLECT opt-in answer from an outside application e.g., VSCode.
+//   &ga-confirm=false              // Analytics DO NOT COLLECT opt-in answer from an outside application e.g., VSCode.
+
+window.dataLayer = window.dataLayer || [];
+
+function gtag() {
+    if (gtagsEnabled()) {
+        dataLayer.push(arguments);
+    }
+}
+
+function _getUrlVars() {
+    let allVars = {};
+    window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(_, key, value) {
+        allVars[key] = value;
+    });
+    return allVars;
+}
+
+let _urlVars = _getUrlVars();
+
+let _gtagsEnabled = _urlVars['gtags'] == 'enabled' ? true : false;
+function gtagsEnabled() {
+    return _gtagsEnabled
+}
+
+let gaConfirmation = _urlVars['ga-confirm'];
+
+let _initializedGA = false;
+function isGaInitialized() {
+    return gtagsEnabled() && _initializedGA;
+}
+
+// InitializeGA with our dimensions. Both the name and order (dimension #) should match the those in gtags.dart
+function _initializeGA() {
+    if (gtagsEnabled() && !_initializedGA && gaCollectionAllowed()) {
+        gtag('js', new Date());
+        gtag('config', _GA_DEVTOOLS_PROPERTY, {
+            'custom_map': {
+                // Custom dimensions:
+                dimension1: 'user_app',
+                dimension2: 'user_build',
+                dimension3: 'user_platform',
+                dimension4: 'devtools_platform',
+                dimension5: 'devtools_chrome',
+                dimension6: 'devtools_version',
+
+                // Custom metrics:
+                metric1: 'gpu_duration',
+                metric2: 'ui_duration',
+            }
+        });
+
+        _initializedGA = true;
+    }
+}
+
+// Values in local storage:
+const _GA_COLLECT = 'collect';
+const _GA_DONT_COLLECT = 'do-not-collect';
+
+function gaCollectionAllowed() {
+    return localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == _GA_COLLECT;
+}
+
+let gaDialog = document.getElementById('devtools_analytics');
+
+if (!gtagsEnabled()) {
+    gaDialog.close();
+    console.log("gtags not enabled.");
+}
+
+gaDialog.style.zIndex = '1000';
+
+// '?' to ga-confirm URI parameter to display GA acceptance dialog e.g.,  &ga-confirm=?
+if (gtagsEnabled()) {
+    if (gaConfirmation != null) {
+        console.log("GA &ga-confirm = " + gaConfirmation);
+    }
+    console.log("GA Dart DevTools Property " + _GA_DEVTOOLS_PROPERTY + " opt-in = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
+}
+
+if (gaConfirmation == '?' || localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
+    let gaAcceptButton = document.getElementById('devtools-ga-accept');
+    gaAcceptButton.addEventListener('click', function (_) {
+        // Collect statistics.
+        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_COLLECT);
+        gaDialog.close();
+        _initializeGA();
+    });
+
+    let gaDoNotAcceptButton = document.getElementById('devtools-ga-do-not-accept');
+    gaDoNotAcceptButton.addEventListener('click', function (_) {
+        // Do NOT collect statistics.
+        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
+        gaDialog.close();
+    });
+
+    // Ensure focus doesn't leave GA confirmation dialog.
+    gaDialog.addEventListener('focusout', function (e) {
+        // Collect statistics.
+        let cancelEvent = false;
+        let relatedTarget = e.relatedTarget;
+        if (relatedTarget != null) {
+            let id = relatedTarget.getAttribute('id');
+            cancelEvent = id == null || !id.startsWith('devtools-ga-');
+        } else {
+            cancelEvent = true;
+        }
+        if (cancelEvent) {
+            e.srcElement.focus();
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+        }
+    });
+} else if (gaConfirmation == 'reset') {
+    // Delete the local storage value.
+    localStorage.removeItem(_GA_DEVTOOLS_PROPERTY);
+    gaDialog.style.display = 'none';
+    console.log("Reset localStorage = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
+} else {
+    gaDialog.style.display = 'none';
+
+    // If gaConfirmation is passed in e.g., VSCode and DevTools GA Collection not defined then use VSCode's collection
+    // authorization.  Otherwise, DevTools GA collection, if explicitly defined use DevTools regardless if VSCode's
+    // is different.
+    if (gaConfirmation == 'true' && localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
+        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, gaConfirmation == 'true' ? _GA_COLLECT : _GA_DONT_COLLECT);
+    } else if (gaConfirmation == 'false') {
+        // If GA confirmation is to not collect statistics then immediately force no collection regardless of what
+        // DevTools GA Confirmation was always default to DO NOT COLLECT if anyone up the line has do not collect.
+        localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
+    }
+}
+
+_initializeGA();
+
+if (gtagsEnabled()) {
+// Record when DevTools browser tab is selected (visible), not selected (hidden) or browser minimized.
+    document.addEventListener("visibilitychange", function (e) {
+        if (gaCollectionAllowed()) {
+            gtag('event', document.visibilityState, {
+                event_category: 'application',
+            });
+        }
+    });
+}

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -12,10 +12,10 @@
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-33"></script>
 
     <dialog open id="devtools_analytics" class="ga-dialog" style="width: 100%;">
-      <p>Welcome to Flutter DevTools</p>
+      <p>Welcome to Dart DevTools</p>
       <span class="ga-collection" disabled>
-        Flutter DevTools anonymously reports features usage statistics and basic crash reports to Google in order
-        to help Google contribute improvements to Flutter DevTools over time.
+        Dart DevTools anonymously reports features usage statistics and basic crash reports to Google in order
+        to help Google contribute improvements to Dart DevTools over time.
         <br/>
         See Google's private policy
       </span>
@@ -44,15 +44,18 @@
         return _initializedGA;
       }
 
-      // InitializeGA with our dimensions.
+      // InitializeGA with our dimensions. Both the name and order (dimension #) should match the those in gtags.dart
       function _initializeGA() {
         if (!_initializedGA && gaCollectionAllowed()) {
           gtag('js', new Date());
           gtag('config', _GA_DEVTOOLS_PROPERTY, {
             'custom_map': {
-              dimension1: 'app_type',
-              dimension2: 'build_type',
-              dimension3: 'platform_type',
+              dimension1: 'user_app',
+              dimension2: 'user_build',
+              dimension3: 'user_platform',
+              dimension4: 'devtools_platform',
+              dimension5: 'devtools_chrome',
+              dimension6: 'devtools_version',
             }
           });
 

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -11,27 +11,19 @@
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script>
       // TODO(terry): Remove below line, UA-26406144-33 below is a GA property for testing ONLY.
-      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-33';
+      const GA_DEVTOOLS_PROPERTY = 'UA-26406144-33';
       // TODO(terry): Uncomment the below line, is the real GA property for DevTools collecting.
-      //      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-34'; // Dart DevTools GA Property UA.
+      //      const GA_DEVTOOLS_PROPERTY = 'UA-26406144-34'; // Dart DevTools GA Property UA.
+
+      function getDevToolsPropertyID() {
+        return GA_DEVTOOLS_PROPERTY;
+      }
     </script>
     <!-- TODO(terry): Below URI id query must match the GA_DEVTOOLS_PROPERTY above. -->
+<!--
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-34"></script>
+-->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-33"></script>
-
-    <dialog open id="devtools_analytics" class="ga-dialog" style="width: 100%;">
-      <p>Welcome to Dart DevTools</p>
-      <span class="ga-collection" disabled>
-        Dart DevTools anonymously reports features usage statistics and basic crash reports to Google in order
-        to help Google contribute improvements to Dart DevTools over time.
-        <br/>
-        See Google's private policy
-      </span>
-      <a id="devtools-ga-link" href="https://www.google.com/intl/en/policies/privacy" target="_blank" tabindex="1">https://www.google.com/intl/en/policies/privacy</a>
-      <br/><br/>
-      <p>Do you accept statistics collection for DevTools?</p>
-      <button id="devtools-ga-accept" value="accept" tabindex="2">I Accept</button>
-      <button id="devtools-ga-do-not-accept" value="do-not-accept" tabindex="3" autofocus>I Do Not Accept</button>
-    </dialog>
 
     <script type="text/javascript" src="devtools_analytics.js"></script>
 
@@ -80,7 +72,9 @@
                 )
             }
         })();
+    </script>
 
+    <script type="text/javascript">
         // Plotly wrappers.
         // TODO(terry): Remove JS code move to Dart JS interop.
         function hookupPlotlyClick(domName, jsFunction) {
@@ -246,6 +240,7 @@
 
 <div id="messages-container" class="container"></div>
 
+<form id="ga-dialog" class="container"></form>
 <form id="connect-dialog" class="container"></form>
 
 <div id="content" class="container" flex layout vertical style="overflow: auto;">

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -9,6 +9,13 @@
 <html>
 <head>
     <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script>
+      // TODO(terry): Remove below line, UA-26406144-33 below is a GA property for testing ONLY.
+      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-33';
+      // TODO(terry): Uncomment the below line, is the real GA property for DevTools collecting.
+      //      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-34'; // Dart DevTools GA Property UA.
+    </script>
+    <!-- TODO(terry): Below URI id query must match the GA_DEVTOOLS_PROPERTY above. -->
     <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-33"></script>
 
     <dialog open id="devtools_analytics" class="ga-dialog" style="width: 100%;">
@@ -26,138 +33,9 @@
       <button id="devtools-ga-do-not-accept" value="do-not-accept" tabindex="3" autofocus>I Do Not Accept</button>
     </dialog>
 
-    <script>
-      // URI parameter to control DevTools analytics collection:
-      //
-      //   &ga-confirm=?           // Displays the GA collection confirmation dialog, to change answer.
-      //   &ga-confirm=reset       // Resets/deletes user's collection answer in local storage.
-      //   &ga-confirm=true        // Analytics COLLECT opt-in answer from an outside application e.g., VSCode.
-      //   &ga-confirm=false       // Analytics DO NOT COLLECT opt-in answer from an outside application e.g., VSCode.
+    <script type="text/javascript" src="devtools_analytics.js"></script>
 
-// TODO(terry): Remove below line, UA-26406144-33 below is a GA property for testing ONLY.
-      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-33';
-// TODO(terry): Uncomment the below line, is the real GA property for DevTools collecting.
-//      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-34'; // Dart DevTools GA Property UA.
-
-      let _initializedGA = false;
-      function isGaInitialized() {
-        return _initializedGA;
-      }
-
-      // InitializeGA with our dimensions. Both the name and order (dimension #) should match the those in gtags.dart
-      function _initializeGA() {
-        if (!_initializedGA && gaCollectionAllowed()) {
-          gtag('js', new Date());
-          gtag('config', _GA_DEVTOOLS_PROPERTY, {
-            'custom_map': {
-              dimension1: 'user_app',
-              dimension2: 'user_build',
-              dimension3: 'user_platform',
-              dimension4: 'devtools_platform',
-              dimension5: 'devtools_chrome',
-              dimension6: 'devtools_version',
-            }
-          });
-
-          _initializedGA = true;
-        }
-      }
-
-      const _GA_COLLECT = 'collect';
-      const _GA_DONT_COLLECT = 'do-not-collect';
-
-      function gaCollectionAllowed() {
-        return localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == _GA_COLLECT;
-      }
-
-      function _getUrlVars() {
-        let allVars = {};
-        window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(_, key, value) {
-          allVars[key] = value;
-        });
-        return allVars;
-      }
-
-      // Add ? to ga-confirm URI parameter to display GA acceptance dialog e.g.,  &ga-confirm=?
-      let gaDialog = document.getElementById('devtools_analytics');
-      gaDialog.style.zIndex = '1000';
-      let gaConfirmation = _getUrlVars()['ga-confirm'];
-
-      if (gaConfirmation != null) {
-        console.log("GA &ga-confirm = " + gaConfirmation);
-      }
-      console.log("GA Dart DevTools Property " +_GA_DEVTOOLS_PROPERTY + " opt-in = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
-
-      if (gaConfirmation == '?' || localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
-        let gaAcceptButton = document.getElementById('devtools-ga-accept');
-        gaAcceptButton.addEventListener('click', function (_) {
-          // Collect statistics.
-          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_COLLECT);
-          gaDialog.close();
-          _initializeGA();
-        });
-
-        let gaDoNotAcceptButton = document.getElementById('devtools-ga-do-not-accept');
-        gaDoNotAcceptButton.addEventListener('click', function (_) {
-          // Do NOT collect statistics.
-          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
-          gaDialog.close();
-        });
-
-        // Ensure focus doesn't leave GA confirmation dialog.
-        gaDialog.addEventListener('focusout', function (e) {
-          // Collect statistics.
-          let cancelEvent = false;
-          let relatedTarget = e.relatedTarget;
-          if (relatedTarget != null) {
-            let id = relatedTarget.getAttribute('id');
-            cancelEvent = id == null || !id.startsWith('devtools-ga-');
-          } else {
-            cancelEvent = true;
-          }
-          if (cancelEvent) {
-            e.srcElement.focus();
-            e.stopPropagation();
-            e.preventDefault();
-            return false;
-          }
-        });
-      } else if (gaConfirmation == 'reset') {
-        // Delete the local storage value.
-        localStorage.removeItem(_GA_DEVTOOLS_PROPERTY);
-        gaDialog.style.display = 'none';
-        console.log("Reset localStorage = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
-      } else {
-        gaDialog.style.display = 'none';
-
-        // If gaConfirmation is passed in e.g., VSCode and DevTools GA Collection not defined then use VSCode's collection
-        // authorization.  Otherwise, DevTools GA collection, if explicitly defined use DevTools regardless if VSCode's
-        // is different.
-        if (gaConfirmation == 'true' && localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
-          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, gaConfirmation == 'true' ? _GA_COLLECT : _GA_DONT_COLLECT);
-        } else if (gaConfirmation == 'false') {
-          // If GA confirmation is to not collect statistics then immediately force no collection regardless of what
-          // DevTools GA Confirmation was always default to DO NOT COLLECT if anyone up the line has do not collect.
-          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
-        }
-      }
-
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-
-      _initializeGA();
-
-      // Record when DevTools browser tab is selected (visible), not selected (hidden) or browser minimized.
-      document.addEventListener("visibilitychange", function (e) {
-        if (gaCollectionAllowed()) {
-          gtag('event', document.visibilityState, {
-            event_category: 'application',
-          });
-        }
-      });
-    </script>
+    <!-- End of DevTools Google Analytics -->
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -8,6 +8,154 @@
 
 <html>
 <head>
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-33"></script>
+
+    <dialog open id="devtools_analytics" class="ga-dialog" style="width: 100%;">
+      <p>Welcome to Flutter DevTools</p>
+      <span class="ga-collection" disabled>
+        Flutter DevTools anonymously reports features usage statistics and basic crash reports to Google in order
+        to help Google contribute improvements to Flutter DevTools over time.
+        <br/>
+        See Google's private policy
+      </span>
+      <a id="devtools-ga-link" href="https://www.google.com/intl/en/policies/privacy" target="_blank" tabindex="1">https://www.google.com/intl/en/policies/privacy</a>
+      <br/><br/>
+      <p>Do you accept statistics collection for DevTools?</p>
+      <button id="devtools-ga-accept" value="accept" tabindex="2">I Accept</button>
+      <button id="devtools-ga-do-not-accept" value="do-not-accept" tabindex="3" autofocus>I Do Not Accept</button>
+    </dialog>
+
+    <script>
+      // URI parameter to control DevTools analytics collection:
+      //
+      //   &ga-confirm=?           // Displays the GA collection confirmation dialog, to change answer.
+      //   &ga-confirm=reset       // Resets/deletes user's collection answer in local storage.
+      //   &ga-confirm=true        // Analytics COLLECT opt-in answer from an outside application e.g., VSCode.
+      //   &ga-confirm=false       // Analytics DO NOT COLLECT opt-in answer from an outside application e.g., VSCode.
+
+// TODO(terry): Remove below line, UA-26406144-33 below is a GA property for testing ONLY.
+      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-33';
+// TODO(terry): Uncomment the below line, is the real GA property for DevTools collecting.
+//      const _GA_DEVTOOLS_PROPERTY = 'UA-26406144-34'; // Dart DevTools GA Property UA.
+
+      let _initializedGA = false;
+      function isGaInitialized() {
+        return _initializedGA;
+      }
+
+      // InitializeGA with our dimensions.
+      function _initializeGA() {
+        if (!_initializedGA && gaCollectionAllowed()) {
+          gtag('js', new Date());
+          gtag('config', _GA_DEVTOOLS_PROPERTY, {
+            'custom_map': {
+              dimension1: 'app_type',
+              dimension2: 'build_type',
+              dimension3: 'platform_type',
+            }
+          });
+
+          _initializedGA = true;
+        }
+      }
+
+      const _GA_COLLECT = 'collect';
+      const _GA_DONT_COLLECT = 'do-not-collect';
+
+      function gaCollectionAllowed() {
+        return localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == _GA_COLLECT;
+      }
+
+      function _getUrlVars() {
+        let allVars = {};
+        window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(_, key, value) {
+          allVars[key] = value;
+        });
+        return allVars;
+      }
+
+      // Add ? to ga-confirm URI parameter to display GA acceptance dialog e.g.,  &ga-confirm=?
+      let gaDialog = document.getElementById('devtools_analytics');
+      gaDialog.style.zIndex = '1000';
+      let gaConfirmation = _getUrlVars()['ga-confirm'];
+
+      if (gaConfirmation != null) {
+        console.log("GA &ga-confirm = " + gaConfirmation);
+      }
+      console.log("GA Dart DevTools Property " +_GA_DEVTOOLS_PROPERTY + " opt-in = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
+
+      if (gaConfirmation == '?' || localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
+        let gaAcceptButton = document.getElementById('devtools-ga-accept');
+        gaAcceptButton.addEventListener('click', function (_) {
+          // Collect statistics.
+          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_COLLECT);
+          gaDialog.close();
+          _initializeGA();
+        });
+
+        let gaDoNotAcceptButton = document.getElementById('devtools-ga-do-not-accept');
+        gaDoNotAcceptButton.addEventListener('click', function (_) {
+          // Do NOT collect statistics.
+          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
+          gaDialog.close();
+        });
+
+        // Ensure focus doesn't leave GA confirmation dialog.
+        gaDialog.addEventListener('focusout', function (e) {
+          // Collect statistics.
+          let cancelEvent = false;
+          let relatedTarget = e.relatedTarget;
+          if (relatedTarget != null) {
+            let id = relatedTarget.getAttribute('id');
+            cancelEvent = id == null || !id.startsWith('devtools-ga-');
+          } else {
+            cancelEvent = true;
+          }
+          if (cancelEvent) {
+            e.srcElement.focus();
+            e.stopPropagation();
+            e.preventDefault();
+            return false;
+          }
+        });
+      } else if (gaConfirmation == 'reset') {
+        // Delete the local storage value.
+        localStorage.removeItem(_GA_DEVTOOLS_PROPERTY);
+        gaDialog.style.display = 'none';
+        console.log("Reset localStorage = " + localStorage.getItem(_GA_DEVTOOLS_PROPERTY));
+      } else {
+        gaDialog.style.display = 'none';
+
+        // If gaConfirmation is passed in e.g., VSCode and DevTools GA Collection not defined then use VSCode's collection
+        // authorization.  Otherwise, DevTools GA collection, if explicitly defined use DevTools regardless if VSCode's
+        // is different.
+        if (gaConfirmation == 'true' && localStorage.getItem(_GA_DEVTOOLS_PROPERTY) == null) {
+          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, gaConfirmation == 'true' ? _GA_COLLECT : _GA_DONT_COLLECT);
+        } else if (gaConfirmation == 'false') {
+          // If GA confirmation is to not collect statistics then immediately force no collection regardless of what
+          // DevTools GA Confirmation was always default to DO NOT COLLECT if anyone up the line has do not collect.
+          localStorage.setItem(_GA_DEVTOOLS_PROPERTY, _GA_DONT_COLLECT);
+        }
+      }
+
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+
+      _initializeGA();
+
+      // Record when DevTools browser tab is selected (visible), not selected (hidden) or browser minimized.
+      document.addEventListener("visibilitychange", function (e) {
+        if (gaCollectionAllowed()) {
+          gtag('event', document.visibilityState, {
+            event_category: 'application',
+          });
+        }
+      });
+    </script>
+
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -21,6 +169,7 @@
     <link rel="stylesheet" href="packages/devtools/src/inspector/inspector.css">
     <link rel="stylesheet" href="packages/devtools/src/logging/logging.css">
     <link rel="stylesheet" href="packages/devtools/src/timeline/timeline.css">
+
 
     <script type="text/javascript">
         function supportsES6Classes() {
@@ -220,7 +369,7 @@
 
 <div id="content" class="container" flex layout vertical style="overflow: auto;">
     <div class="blankslate">
-        <p>Loading…</p>
+        <p>Loading...</p>
     </div>
 </div>
 

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -8,7 +8,7 @@ import 'package:devtools/src/main.dart';
 import 'package:devtools/src/ui/analytics.dart' as ga;
 import 'package:platform_detect/platform_detect.dart';
 
-void _gAReportDartExceptions(Exception e, StackTrace stack) {
+void _gaReportDartExceptions(Exception e, StackTrace stack) {
   ga.error('${e.toString()}\n${stack.toString()}', true);
 }
 
@@ -46,6 +46,6 @@ void main() {
     framework.loadScreenFromLocation();
   }, onError: (error, stack) {
     // Report the exception to GA.
-    _gAReportDartExceptions(error, stack);
+    _gaReportDartExceptions(error, stack);
   });
 }

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -2,38 +2,48 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'package:devtools/src/framework/framework_core.dart';
 import 'package:devtools/src/main.dart';
+import 'package:devtools/src/ui/gtags.dart';
 import 'package:platform_detect/platform_detect.dart';
 
+void _gAReportDartExceptions(Exception e, StackTrace stack) {
+  gaError('${e.toString()}\n${stack.toString()}', true);
+}
+
 void main() {
-  // Initialize the core framework.
-  FrameworkCore.init();
+  runZoned(() {
+    // Initialize the core framework.
+    FrameworkCore.init();
 
-  // Load the web app framework.
-  final PerfToolFramework framework = PerfToolFramework();
+    // Load the web app framework.
+    final PerfToolFramework framework = PerfToolFramework();
 
-  if (!browser.isChrome) {
-    final browserName =
-        // Edge shows up as IE, so we replace it's name to avoid confusion.
-        browser.isInternetExplorer || browser == Browser.UnknownBrowser
-            ? 'an unsupported browser'
-            : browser.name;
-    framework.disableAppWithError(
-      'ERROR: You are running DevTools on $browserName, '
-          'but DevTools only runs on Chrome.',
-      'Reopen this url in a Chrome browser to use DevTools.',
-    );
-    return;
-  }
-
-  FrameworkCore.initVmService(errorReporter: (String title, dynamic error) {
-    framework.showError(title, error);
-  }).then((bool connected) {
-    if (!connected) {
-      framework.showConnectionDialog();
+    if (!browser.isChrome) {
+      final browserName =
+          // Edge shows up as IE, so we replace it's name to avoid confusion.
+          browser.isInternetExplorer || browser == Browser.UnknownBrowser
+              ? 'an unsupported browser'
+              : browser.name;
+      framework.disableAppWithError(
+        'ERROR: You are running DevTools on $browserName, '
+            'but DevTools only runs on Chrome.',
+        'Reopen this url in a Chrome browser to use DevTools.',
+      );
+      return;
     }
-  });
 
-  framework.loadScreenFromLocation();
+    FrameworkCore.initVmService(errorReporter: (String title, dynamic error) {
+      framework.showError(title, error);
+    }).then((bool connected) {
+      if (!connected) {
+        framework.showConnectionDialog();
+      }
+    });
+
+    framework.loadScreenFromLocation();
+  }, onError: (error, stack) {
+    _gAReportDartExceptions(error, stack);
+  });
 }

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:html';
 import 'package:devtools/src/framework/framework_core.dart';
 import 'package:devtools/src/main.dart';
 import 'package:devtools/src/ui/analytics.dart' as ga;
@@ -20,6 +21,12 @@ void main() {
 
     // Load the web app framework.
     final PerfToolFramework framework = PerfToolFramework();
+
+    // Show the opt-in dialog?
+    if (ga.isGtagsEnabled() &
+        (!window.localStorage.containsKey(ga.devToolsProperty()) ||
+            window.localStorage[ga.devToolsProperty()].isEmpty))
+      framework.showAnalyticsDialog();
 
     if (!browser.isChrome) {
       final browserName =

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -5,14 +5,15 @@
 import 'dart:async';
 import 'package:devtools/src/framework/framework_core.dart';
 import 'package:devtools/src/main.dart';
-import 'package:devtools/src/ui/gtags.dart';
+import 'package:devtools/src/ui/analytics.dart' as ga;
 import 'package:platform_detect/platform_detect.dart';
 
 void _gAReportDartExceptions(Exception e, StackTrace stack) {
-  gaError('${e.toString()}\n${stack.toString()}', true);
+  ga.error('${e.toString()}\n${stack.toString()}', true);
 }
 
 void main() {
+  // Need to catch all Dart exceptions - done via an isolate.
   runZoned(() {
     // Initialize the core framework.
     FrameworkCore.init();
@@ -44,6 +45,7 @@ void main() {
 
     framework.loadScreenFromLocation();
   }, onError: (error, stack) {
+    // Report the exception to GA.
     _gAReportDartExceptions(error, stack);
   });
 }

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -7,11 +7,8 @@ import 'dart:html';
 import 'package:devtools/src/framework/framework_core.dart';
 import 'package:devtools/src/main.dart';
 import 'package:devtools/src/ui/analytics.dart' as ga;
+import 'package:devtools/src/ui/analytics_platform.dart' as ga_platform;
 import 'package:platform_detect/platform_detect.dart';
-
-void _gaReportDartExceptions(Exception e, StackTrace stack) {
-  ga.error('${e.toString()}\n${stack.toString()}', true);
-}
 
 void main() {
   // Need to catch all Dart exceptions - done via an isolate.
@@ -24,8 +21,8 @@ void main() {
 
     // Show the opt-in dialog for collection analytics?
     if (ga.isGtagsEnabled() &
-        (!window.localStorage.containsKey(ga.devToolsProperty()) ||
-            window.localStorage[ga.devToolsProperty()].isEmpty))
+        (!window.localStorage.containsKey(ga_platform.devToolsProperty()) ||
+            window.localStorage[ga_platform.devToolsProperty()].isEmpty))
       framework.showAnalyticsDialog();
 
     if (!browser.isChrome) {
@@ -54,6 +51,6 @@ void main() {
   }, onError: (error, stack) {
     // Report exceptions with DevTools to GA, any user's Flutter app exceptions
     // are not collected.
-    _gaReportDartExceptions(error, stack);
+    ga.error('${error.toString()}\n$stack.toString()', true);
   });
 }

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -22,7 +22,7 @@ void main() {
     // Load the web app framework.
     final PerfToolFramework framework = PerfToolFramework();
 
-    // Show the opt-in dialog?
+    // Show the opt-in dialog for collection analytics?
     if (ga.isGtagsEnabled() &
         (!window.localStorage.containsKey(ga.devToolsProperty()) ||
             window.localStorage[ga.devToolsProperty()].isEmpty))
@@ -52,7 +52,8 @@ void main() {
 
     framework.loadScreenFromLocation();
   }, onError: (error, stack) {
-    // Report the exception to GA.
+    // Report exceptions with DevTools to GA, any user's Flutter app exceptions
+    // are not collected.
     _gaReportDartExceptions(error, stack);
   });
 }

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -832,6 +832,8 @@ html [full] {
 }
 
 ga-dialog {
+    background-color: var(--default-background);
+    color: var(--default-color);
     padding-bottom: 10px;
     border-bottom: 1px solid var(--border-color);
     margin-bottom: 20px;

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -831,6 +831,12 @@ html [full] {
     margin-left: 8px;
 }
 
+ga-dialog {
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--border-color);
+    margin-bottom: 20px;
+}
+
 #connect-dialog {
     display: none;
     padding-bottom: 10px;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/439

To allow GA to run you must add **`&gtags=enabled`** the default is disabled.

The opt-in dialog light mode:

![image](https://user-images.githubusercontent.com/2055873/56936595-196d7100-6aad-11e9-9418-ee272a16312b.png)

dark mode:

![image](https://user-images.githubusercontent.com/2055873/56936550-d0b5b800-6aac-11e9-8f4d-edad7d3bb204.png)

Additionally, there is an URI parameter **`&gtags=`** to control opt-in:

**`&gtags=reset`**&emsp;&emsp;&emsp;&emsp;_Deletes the user's answer (locally stored) to the opt-in dialog._
**`&gtags=enabled`**&emsp;&emsp;&emsp;_Allows Analytics to run iff opt-in dialog accepted._
**`&gtags=disabled`**&emsp;&emsp;&nbsp;&nbsp;_Disables Analytics regardless of the user accepted opt-in dialog to collect analytics._

