### PR TITLE
Fix some races in tests

### DIFF
--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -80,6 +80,8 @@ void debuggingTests() {
       return;
     }
 
+    await delay();
+
     // set and verify breakpoints
     for (int line in breakpointLines) {
       await debuggingManager.addBreakpoint(appFixture.appScriptPath, line);
@@ -91,7 +93,7 @@ void debuggingTests() {
     // wait for paused state
     await waitFor(() async => await debuggingManager.getState() == 'paused');
 
-    await shortDelay();
+    await delay();
 
     // verify location
     expect(
@@ -152,6 +154,8 @@ void debuggingTests() {
       return;
     }
 
+    await delay();
+
     // set and verify breakpoint
     await debuggingManager.addBreakpoint(
         appFixture.appScriptPath, breakpointLine);
@@ -178,7 +182,7 @@ void debuggingTests() {
       // wait for paused state
       await waitFor(() async => await debuggingManager.getState() == 'paused');
 
-      await shortDelay();
+      await delay();
 
       // verify location
       expect(
@@ -231,7 +235,7 @@ void debuggingTests() {
     // wait for paused state
     await waitFor(() async => await debuggingManager.getState() == 'paused');
 
-    await shortDelay();
+    await delay();
 
     // verify location
     expect(

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -205,6 +205,8 @@ void debuggingTests() {
     await debuggingManager.clearBreakpoints();
     await debuggingManager.resume();
 
+    await delay();
+
     // verify state resumed
     expect(await debuggingManager.getState(), 'running');
   });

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -255,6 +255,8 @@ void debuggingTests() {
     await debuggingManager.setExceptionPauseMode('Unhandled');
     await debuggingManager.resume();
 
+    await delay();
+
     // verify state resumed
     expect(await debuggingManager.getState(), 'running');
   });

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -317,6 +317,8 @@ void debuggingTests() {
     // resume
     await debuggingManager.resume();
 
+    await delay();
+
     // verify state resumed
     expect(await debuggingManager.getState(), 'running');
   });

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -119,6 +119,8 @@ void debuggingTests() {
     await debuggingManager.clearBreakpoints();
     await debuggingManager.resume();
 
+    await delay();
+
     // verify state resumed
     expect(await debuggingManager.getState(), 'running');
   });


### PR DESCRIPTION
This adds a delay between waiting for the debugger state to change to paused and then reading the location. My guess is that there's delay between the pause event being received in the debugger tab
and the code that updates the marked position in the file source view, so if we immediately try to read the location when it pauses, we might be too early.

This isn't a terribly robust fix, but I'm not sure we could make the state/location update synchronous in the debugger page, so the only other fixes may be to set the pause state flag after updating the location, or using `waitFor` here to allow a short period while polling for the location.