### PR TITLE
Fix type of id after bad rebase/merge

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -191,7 +191,7 @@ Future<void> _handleVmRegister(dynamic id, Map<String, dynamic> params,
 
 Future<void> registerLaunchDevToolsService(
   Uri vmServiceUri,
-  int id,
+  dynamic id,
   String devToolsUrl,
   bool machineMode,
 ) async {


### PR DESCRIPTION
When rebasing, I picked the `int` over `dynamic` since it seemed more specific, but this was the wrong choice (ints and strings are both valid - I had deliberately changed it to `dynamic`!).

Not sure why this generates no errors (implicit upcasts?) but it's wrong.