### PR TITLE
enforce dart:html Element type in split API

### DIFF
--- a/third_party/packages/split/lib/split.dart
+++ b/third_party/packages/split/lib/split.dart
@@ -65,14 +65,14 @@ class Splitter {
 /// The underlying split.js library supports splitting elements that use layout
 /// schemes other than flexbox but we don't need that flexibility.
 Splitter flexSplit(
-  List parts, {
+  List<Element> parts, {
   bool horizontal = true,
   gutterSize = 5,
   List<num> sizes,
   List<num> minSize,
 }) {
   return _split(
-    parts.toList(),
+    parts,
     _SplitOptions(
       elementStyle: allowInterop((dimension, size, gutterSize, index) {
         return js_util.jsify({
@@ -100,7 +100,7 @@ Splitter flexSplit(
 /// To avoid memory leaks, cancel the stream subscription when the splitter is
 /// no longer being used.
 StreamSubscription<Object> flexSplitBidirectional(
-  List parts, {
+  List<Element> parts, {
   gutterSize = 5,
   List<num> verticalSizes,
   List<num> horizontalSizes,

--- a/third_party/packages/split/pubspec.yaml
+++ b/third_party/packages/split/pubspec.yaml
@@ -2,7 +2,7 @@ name: split
 description: Minimal package containing 'split' third_party dependency used by package:devtools.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/split
-version: 0.0.2
+version: 0.0.3
 
 dependencies:
   js: ^0.6.1+1


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/588 to avoid using the incorrect type

This isn't required for #588, just a quick fix