### PR TITLE
Update devtools_server to latest + set version to 0.0.17-dev

### DIFF
--- a/packages/devtools/lib/devtools.dart
+++ b/packages/devtools/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.0.16';
+const String version = '0.0.17-dev';

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -3,7 +3,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 
 # Note: when updating this version, please update the corresponding entry in
 # lib/devtools.dart.
-version: 0.0.16
+version: 0.0.17-dev
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
@@ -14,7 +14,7 @@ environment:
 dependencies:
   codemirror: ^0.5.3
   collection: ^1.14.11
-  devtools_server: ^0.0.2
+  devtools_server: 0.1.0
 #    path: ../devtools_server
   http: ^0.12.0+1
   intl: ^0.15.0


### PR DESCRIPTION
Also made devtools_server an exact match to make publishing new server versions less risky (we can test with the new server then publish a new devtools that references it).