### PR TITLE
Spawn native Chrome on ChromeOS

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -210,8 +210,16 @@ Future<void> registerLaunchDevToolsService(
       // Add the URI to the VM service
       uriParams['uri'] = vmServiceUri.toString();
 
-      final uriToLaunch =
-          Uri.parse(devToolsUrl).replace(queryParameters: uriParams);
+      final devToolsUri = Uri.parse(devToolsUrl);
+      final uriToLaunch = devToolsUri.replace(
+        // If path is empty, we generate 'http://foo:8000?uri=' (missing `/`) and
+        // ChromeOS fails to detect that it's a port that's tunneled, and will
+        // quietly replace the IP with "penguin.linux.test". This is not valid
+        // for us since the server isn't bound to the containers IP (it's bound
+        // to the containers loopback IP).
+        path: devToolsUri.path ?? '/',
+        queryParameters: uriParams,
+      );
 
       // TODO(dantup): When ChromeOS has support for tunneling all ports we
       // can change this to always use the native browser for ChromeOS

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -262,6 +262,7 @@ Future<void> registerLaunchDevToolsService(
 final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();
 
 bool _isAccessibleToChromeOSNativeBrowser(Uri uri) {
+  // TODO(dantup): Change to Set literal when supported.
   const tunneledPorts = {
     8000: true,
     8008: true,

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -260,18 +260,20 @@ Future<void> registerLaunchDevToolsService(
 }
 
 final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();
-const tunneledPorts = {
-  8000: true,
-  8008: true,
-  8080: true,
-  8085: true,
-  8888: true,
-  9005: true,
-  3000: true,
-  4200: true,
-  5000: true,
-};
+
 bool _isAccessibleToChromeOSNativeBrowser(Uri uri) {
+  const tunneledPorts = {
+    8000: true,
+    8008: true,
+    8080: true,
+    8085: true,
+    8888: true,
+    9005: true,
+    3000: true,
+    4200: true,
+    5000: true,
+  };
+
   return uri != null && uri.hasPort && tunneledPorts[uri.port] == true;
 }
 


### PR DESCRIPTION
For ChromeOS users where everything is accessible on tunnelled ports, we should use the ChromeOS browser (using Chrome.start() will attempt to run Chrome for Linux in the container).

Also added a `/` as `path` in the URI we launch. Without this, Dart was generating a URL like `http://127.0.0.1:8000?uri=xxx` (there's no `/` for the path) which ChromeOS was failing to realise was a bound port, and then rewriting as `penguin.linux.test` as we launched. We could've fixed this by adding a trailing slash to `devToolsUrl` but it would be easy to regress, so this ensures this will never happen regardless of changes further up.

(also removed a TODO that was done)

Fixes #582.