### PR TITLE
Fix webdev path for launching Chrome OS

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -217,7 +217,7 @@ Future<void> registerLaunchDevToolsService(
         // quietly replace the IP with "penguin.linux.test". This is not valid
         // for us since the server isn't bound to the containers IP (it's bound
         // to the containers loopback IP).
-        path: devToolsUri.path ?? '/',
+        path: devToolsUri.path == '' ? '/' : devToolsUri.path,
         queryParameters: uriParams,
       );
 


### PR DESCRIPTION
I didn't test this properly on CrOS after refactoring to use `??` because `path` is empty string (it's even documented as such).

This fixes it, so it path is `''` it's replaced with `'/'` to fix the CrOS localhost->pengiun.linux.test rewrite because it doesn't recognise when it's a bound port.