### PR TITLE
Workaround for ResizeObserver bug.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -42,7 +42,7 @@ class EventDetails extends CoreElement {
     // is moved. Observe resizing so that we can rebuild the flame chart canvas
     // as necessary.
     // TODO(kenzie): clean this code up when
-    // https://github.com/dart-lang/html/issues/102 is fixed.
+    // https://github.com/dart-lang/html/issues/104 is fixed.
     final observer =
         html.ResizeObserver(allowInterop((List<dynamic> entries, _) {
       _details.uiEventDetails.flameChart.updateForContainerResize();

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -41,7 +41,8 @@ class EventDetails extends CoreElement {
     // The size of the event details section will change as the splitter is
     // is moved. Observe resizing so that we can rebuild the flame chart canvas
     // as necessary.
-    final observer = html.ResizeObserver(allowInterop((entries, _) {
+    final observer =
+        html.ResizeObserver(allowInterop((List<dynamic> entries, _) {
       _details.uiEventDetails.flameChart.updateForContainerResize();
     }));
     observer.observe(element);

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -41,6 +41,8 @@ class EventDetails extends CoreElement {
     // The size of the event details section will change as the splitter is
     // is moved. Observe resizing so that we can rebuild the flame chart canvas
     // as necessary.
+    // TODO(kenzie): clean this code up when
+    // https://github.com/dart-lang/html/issues/102 is fixed.
     final observer =
         html.ResizeObserver(allowInterop((List<dynamic> entries, _) {
       _details.uiEventDetails.flameChart.updateForContainerResize();


### PR DESCRIPTION
In dart2js version of devtools, this exception was being thrown:

```
Uncaught TypeError: Instance of 'JSArray': type 'JSArray' is not a subtype of type 'List<ResizeObserverEntry>'
    at Object.wrapException (main.dart.js:1115)
    at Object.assertSubtype (main.dart.js:1975)
    at EventDetails_closure.call$2 (main.dart.js:42132)
    at Object.Primitives_applyFunction (main.dart.js:1001)
    at Object.Function_apply (main.dart.js:5440)
    at _callDartFunctionFast (main.dart.js:7374)
    at main.dart.js:7365
    at Function.call$2 (main.dart.js:54318)
    at invokeClosure (main.dart.js:1307)
    at ResizeObserver.<anonymous> (main.dart.js:1325)
```