### PR TITLE
Add option to download cpu profile for debugging.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.20 - 2019-05-??
+* Timeline debug information is available to supplement issue reports. Add query parameter `&debugCpu=true` or `&debugTimeline=true` to download debug files for the CPU profiler and frame timeline, respectively.
+
 ## 0.0.19 - 2019-05-01
 * Update DevTools server to better handle failures when launching browsers.
 * Support additional formats for VM service uris.

--- a/packages/devtools/lib/src/framework/framework_core.dart
+++ b/packages/devtools/lib/src/framework/framework_core.dart
@@ -12,6 +12,8 @@ import '../core/message_bus.dart';
 import '../globals.dart';
 import '../service.dart';
 import '../service_manager.dart';
+import '../timeline/cpu_profile_protocol.dart';
+import '../timeline/timeline_protocol.dart';
 import '../ui/theme.dart' as theme;
 import '../vm_service_wrapper.dart';
 
@@ -26,11 +28,33 @@ class FrameworkCore {
     theme.initializeTheme(uri.queryParameters['theme']);
 
     _setGlobals();
+    _setDebugFlags();
   }
 
   static void _setGlobals() {
     setGlobal(ServiceConnectionManager, ServiceConnectionManager());
     setGlobal(MessageBus, MessageBus());
+  }
+
+  static void _setDebugFlags() {
+    if (window.location.search.isEmpty) {
+      return;
+    }
+    final queryParams = Uri.parse(window.location.toString()).queryParameters;
+
+    // TODO(kenzie): register a service on the devtools server that will dump
+    // all debug files behind the [debugTimeline] and [debugCpuProfile] flags.
+    // If we could automate this into some sort of bug report, we can probably
+    // remove this query param all together, but for now enabling manual dumps
+    // is fine.
+    final _debugTimeline = queryParams['debugTimeline'];
+    if (_debugTimeline != null && _debugTimeline == 'true') {
+      debugTimeline = true;
+    }
+    final _debugCpuProfile = queryParams['debugCpu'];
+    if (_debugCpuProfile != null && _debugCpuProfile == 'true') {
+      debugCpuProfile = true;
+    }
   }
 
   /// Returns true if we're able to connect to a device and false otherwise.

--- a/packages/devtools/lib/src/framework/framework_core.dart
+++ b/packages/devtools/lib/src/framework/framework_core.dart
@@ -47,14 +47,8 @@ class FrameworkCore {
     // If we could automate this into some sort of bug report, we can probably
     // remove this query param all together, but for now enabling manual dumps
     // is fine.
-    final _debugTimeline = queryParams['debugTimeline'];
-    if (_debugTimeline != null && _debugTimeline == 'true') {
-      debugTimeline = true;
-    }
-    final _debugCpuProfile = queryParams['debugCpu'];
-    if (_debugCpuProfile != null && _debugCpuProfile == 'true') {
-      debugCpuProfile = true;
-    }
+    debugTimeline = queryParams['debugTimeline'] == 'true';
+    debugCpuProfile = queryParams['debugCpu'] == 'true';
   }
 
   /// Returns true if we're able to connect to a device and false otherwise.

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -16,8 +16,9 @@ import '../utils.dart';
 /// Switch this flag to true collect debug info from the latest cpu profile.
 ///
 /// This will add a button to the timeline page that will download the debug
-/// info on click.
-const bool debugCpuProfile = false;
+/// info on click. At runtime, this flag can be enabled by adding the query
+/// parameter 'debugCpu=true'.
+bool debugCpuProfile = false;
 
 /// Buffer that will store the latest cpu profile response json.
 ///
@@ -37,7 +38,8 @@ class CpuProfileData {
 
     if (debugCpuProfile) {
       _debugCpuProfileResponse.clear();
-      if (cpuProfileRoot.sampleCount != sampleCount) {
+      if (cpuProfileRoot.sampleCount != sampleCount &&
+          stackFramesJson.isNotEmpty) {
         _debugCpuProfileResponse.writeln('Sample count from response '
             '($sampleCount) != sample count from root stack frame '
             '(${cpuProfileRoot.sampleCount})\n');

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -13,16 +13,19 @@ import '../utils.dart';
 // debug and profile builds. Do they use different clocks and does this also
 // affect the sampling rate? See https://github.com/dart-lang/sdk/issues/36583.
 
-// Switch this flag to true collect debug info from the latest cpu profile. This
-// will also add a button to the timeline page that will download the debug info
-// on click.
 const bool debugCpuProfile = false;
+/// Switch this flag to true collect debug info from the latest cpu profile.
+///
+/// This will add a button to the timeline page that will download the debug
+/// info on click.
 
 /// Buffer that will store the latest cpu profile response json.
 ///
 /// This buffer is for debug purposes. When [debugCpuProfile] is true, we will
 /// be able to dump this buffer to a downloadable json file.
-StringBuffer debugCpuProfileResponse = StringBuffer();
+StringBuffer _debugCpuProfileResponse = StringBuffer();
+
+String get debugCpuProfileResponse => _debugCpuProfileResponse.toString();
 
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse, this.duration)
@@ -33,13 +36,13 @@ class CpuProfileData {
     _processStackFrames(cpuProfileResponse);
 
     if (debugCpuProfile) {
-      debugCpuProfileResponse.clear();
+      _debugCpuProfileResponse.clear();
       if (cpuProfileRoot.sampleCount != sampleCount) {
-        debugCpuProfileResponse.writeln('Sample count from response '
+        _debugCpuProfileResponse.writeln('Sample count from response '
             '($sampleCount) != sample count from root stack frame '
             '(${cpuProfileRoot.sampleCount})\n');
       }
-      debugCpuProfileResponse.writeln(jsonEncode(cpuProfileResponse.json));
+      _debugCpuProfileResponse.writeln(jsonEncode(cpuProfileResponse.json));
     }
   }
 

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -35,7 +35,6 @@ class CpuProfileData {
     if (debugCpuProfile) {
       debugCpuProfileResponse.clear();
       if (cpuProfileRoot.sampleCount != sampleCount) {
-        print('duplicates');
         debugCpuProfileResponse.writeln('Sample count from response '
             '($sampleCount) != sample count from root stack frame '
             '(${cpuProfileRoot.sampleCount})\n');

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -13,11 +13,11 @@ import '../utils.dart';
 // debug and profile builds. Do they use different clocks and does this also
 // affect the sampling rate? See https://github.com/dart-lang/sdk/issues/36583.
 
-const bool debugCpuProfile = false;
 /// Switch this flag to true collect debug info from the latest cpu profile.
 ///
 /// This will add a button to the timeline page that will download the debug
 /// info on click.
+const bool debugCpuProfile = false;
 
 /// Buffer that will store the latest cpu profile response json.
 ///

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -16,7 +16,7 @@ import '../utils.dart';
 // Switch this flag to true collect debug info from the latest cpu profile. This
 // will also add a button to the timeline page that will download the debug info
 // on click.
-const bool debugCpuProfile = true;
+const bool debugCpuProfile = false;
 
 /// Buffer that will store the latest cpu profile response json.
 ///

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -17,6 +17,7 @@ import '../ui/primer.dart';
 import '../ui/theme.dart';
 import '../ui/ui_utils.dart';
 import '../vm_service_wrapper.dart';
+import 'cpu_profile_protocol.dart';
 import 'event_details.dart';
 import 'frame_flame_chart.dart';
 import 'frames_bar_chart.dart';
@@ -277,7 +278,7 @@ class TimelineScreen extends Screen {
   /// is true.
   void _maybeAddDebugDumpButton() {
     if (debugTimeline) {
-      upperButtonSection.add(PButton('Debug dump')
+      upperButtonSection.add(PButton('Debug dump timeline')
         ..small()
         ..click(() {
           // Trace event json in the order we received the events.
@@ -348,6 +349,14 @@ class TimelineScreen extends Screen {
             }
           }
           downloadFile(buf.toString(), 'pending_frame_tracking_status.txt');
+        }));
+    }
+    if (debugCpuProfile) {
+      upperButtonSection.add(PButton('Debug dump CPU profile')
+        ..small()
+        ..click(() {
+          // Download the current cpu profile as a json file.
+          downloadFile(debugCpuProfileResponse.toString(), 'cpu_profile.json');
         }));
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -356,7 +356,7 @@ class TimelineScreen extends Screen {
         ..small()
         ..click(() {
           // Download the current cpu profile as a json file.
-          downloadFile(debugCpuProfileResponse.toString(), 'cpu_profile.json');
+          downloadFile(debugCpuProfileResponse, 'cpu_profile.json');
         }));
     }
   }

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -87,6 +87,7 @@ class TimelineScreen extends Screen {
   PButton pauseButton;
   PButton resumeButton;
   CoreElement upperButtonSection;
+  CoreElement debugButtonSection;
 
   @override
   CoreElement createContent(Framework framework) {
@@ -127,9 +128,10 @@ class TimelineScreen extends Screen {
             resumeButton,
           ]),
         div()..flex(),
+        debugButtonSection = div(c: 'btn-group'),
       ]);
 
-    _maybeAddDebugDumpButton();
+    _maybeAddDebugButtons();
 
     screenDiv.add(<CoreElement>[
       upperButtonSection,
@@ -273,12 +275,12 @@ class TimelineScreen extends Screen {
     }
   }
 
-  /// Adds a button to the timeline that will dump debug information to text
-  /// files and download them. This will only appear if the [debugTimeline] flag
-  /// is true.
-  void _maybeAddDebugDumpButton() {
+  /// Adds buttons to the timeline that will dump debug information to text
+  /// files and download them. This will only appear if either the
+  /// [debugTimeline] flag is true or the [debugCpuProfile] flag is true.
+  void _maybeAddDebugButtons() {
     if (debugTimeline) {
-      upperButtonSection.add(PButton('Debug dump timeline')
+      debugButtonSection.add(PButton('Debug dump timeline')
         ..small()
         ..click(() {
           // Trace event json in the order we received the events.
@@ -352,7 +354,7 @@ class TimelineScreen extends Screen {
         }));
     }
     if (debugCpuProfile) {
-      upperButtonSection.add(PButton('Debug dump CPU profile')
+      debugButtonSection.add(PButton('Debug dump CPU profile')
         ..small()
         ..click(() {
           // Download the current cpu profile as a json file.

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -17,9 +17,11 @@ import '../utils.dart';
 // engine. That dependency is tracked at
 // https://github.com/flutter/flutter/issues/27609.
 
-// Switch this flag to true collect debug info from the timeline protocol. This
-// will also add a button to the timeline page that will download files with
-// debug info on click.
+/// Switch this flag to true collect debug info from the timeline protocol.
+///
+/// This will add a button to the timeline page that will download files with
+/// debug info on click. At runtime, this flag can be enabled by adding the
+/// query parameter 'debugTimeline=true'.
 bool debugTimeline = false;
 
 /// Buffer that will store trace event json in the order we receive the events.


### PR DESCRIPTION
Adds a button to the timeline page that, when clicked, downloads a json file with the current cpu profile response.