### PR TITLE
fix some lints about const constructors

### DIFF
--- a/fixtures/flutter_app/lib/main.dart
+++ b/fixtures/flutter_app/lib/main.dart
@@ -15,10 +15,10 @@ class MyApp extends StatelessWidget {
       ),
       home: Scaffold(
         appBar: AppBar(
-          title: Text('Hello, World'),
+          title: const Text('Hello, World'),
         ),
         body: Center(
-          child: Text('Hello, World!'),
+          child: const Text('Hello, World!'),
         ),
       ),
     );


### PR DESCRIPTION
These show up in the vscode problems window which was driving me a little crazy :D.

Fwiw there should be a presubmit check for lints if they are going to be enabled, but there must not be? I tried to enable that but I see this package uses tuneup and I don't see an option to fail on lints. 