### PR TITLE
Fix profiler truncation bug and add tests.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.0.20 - 2019-05-??
 * Timeline debug information is available to supplement issue reports. Add query parameter `&debugCpu=true` or `&debugTimeline=true` to download debug files for the CPU profiler and frame timeline, respectively.
+* CPU profiler bug fixes and improvements.
 
 ## 0.0.19 - 2019-05-01
 * Update DevTools server to better handle failures when launching browsers.
 * Support additional formats for VM service uris.
+* Link to documentation from --track-widget-creation warning.
 
 ## 0.0.18 - 2019-04-30
 * Fix release bug (0.0.17-dev.1 did not include build folder).

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## 0.0.19 - 2019-05-01
 * Update DevTools server to better handle failures when launching browsers.
 * Support additional formats for VM service uris.
-* Link to documentation from --track-widget-creation warning.
+* Link to documentation from --track-widget-creation warning in the Inspector.
 
 ## 0.0.18 - 2019-04-30
 * Fix release bug (0.0.17-dev.1 did not include build folder).

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -110,6 +110,15 @@ class CpuProfileData {
 
     if (nativeTruncatedRoot.children.isNotEmpty) {
       nativeRoot.addChild(nativeTruncatedRoot);
+
+      // If we moved some samples over to [nativeTruncatedRoot], we could have
+      // a "[Truncated]" child under the "all" event that does not have any
+      // children. If so, remove the "[Truncated]" child.
+      final truncated = cpuProfileRoot.children
+          .firstWhere((frame) => frame.name == truncatedName);
+      if (truncated != null && truncated.children.isEmpty) {
+        cpuProfileRoot.children.remove(truncated);
+      }
     }
     if (nativeRoot.children.isNotEmpty) {
       cpuProfileRoot.addChild(nativeRoot);

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -23,6 +23,19 @@ void main() {
         equals(goldenCpuProfile),
       );
     });
+
+    test('process [Native] frames', () {
+      cpuProfileData = CpuProfileData(
+        sampleResponseWithNativeFrames,
+        const Duration(milliseconds: 10), // 10 is arbitrary.
+      );
+
+      expect(cpuProfileData.sampleCount, equals(3));
+      expect(
+        cpuProfileData.cpuProfileRoot.toStringDeep(),
+        equals(goldenCpuProfileWithNativeFrames),
+      );
+    });
   });
 
   group('CpuStackFrame', () {
@@ -141,8 +154,8 @@ final sampleResponse = Response.parse({
   'timeSpan': 0.003678,
   'timeOriginMicros': 47377796685,
   'timeExtentMicros': 3678,
-  // Root of new sample.
   'stackFrames': {
+    // Root of new sample.
     '140357727781376-1': {
       'category': 'Dart',
       'name': 'thread_start',
@@ -213,7 +226,7 @@ final sampleResponse = Response.parse({
       'category': 'Dart',
       'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
       'parent': '140357727781376-13',
-    }
+    },
   },
   'traceEvents': [
     {
@@ -256,5 +269,91 @@ final sampleResponse = Response.parse({
       'args': {'mode': 'basic'},
       'sf': '140357727781376-14'
     }
+  ]
+});
+
+const goldenCpuProfileWithNativeFrames = '''
+  cpuProfile - children: 2
+    140357727781376-1 - children: 1
+      140357727781376-2 - children: 0
+    nativeRoot - children: 2
+      140357727781376-6 - children: 0
+      nativeTruncatedRoot - children: 1
+        140357727781376-4 - children: 1
+          140357727781376-5 - children: 0
+''';
+
+final sampleResponseWithNativeFrames = Response.parse({
+  'type': '_CpuProfileTimeline',
+  'samplePeriod': 1000,
+  'stackDepth': 128,
+  'sampleCount': 3,
+  'timeSpan': 0.003678,
+  'timeOriginMicros': 47377796685,
+  'timeExtentMicros': 3678,
+  'stackFrames': {
+    // Root of new sample.
+    '140357727781376-1': {
+      'category': 'Dart',
+      'name': 'thread_start',
+    },
+    '140357727781376-2': {
+      'category': 'Dart',
+      'name': '_pthread_start',
+      'parent': '140357727781376-1',
+    },
+    // Root of new sample.
+    '140357727781376-3': {
+      'category': 'Dart',
+      'name': '[Truncated]',
+    },
+    '140357727781376-4': {
+      'category': 'Dart',
+      'name':
+          '[Native] RenderObject._getSemanticsForParent.<anonymous closure>',
+      'parent': '140357727781376-3',
+    },
+    '140357727781376-5': {
+      'category': 'Dart',
+      'name': '[Native] RenderObject._getSemanticsForParent',
+      'parent': '140357727781376-4',
+    },
+    // Root of new native sample.
+    '140357727781376-6': {
+      'category': 'Dart',
+      'name': '[Native] syscall',
+    },
+  },
+  'traceEvents': [
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377796685,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-2'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377797975,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-5'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377799063,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-6'
+    },
   ]
 });


### PR DESCRIPTION
We were adding an empty [Truncated] stack to the profile if the truncated stack frames were Native. This fixes that issue.

I also added a missing item to the changelog while I'm here.