### PR TITLE
Inspector polish

### DIFF
--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -425,11 +425,17 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   Map<String, Object> get valuePropertiesJson => json['valueProperties'];
 
   bool get hasChildren {
-    if (getBooleanMember('hasChildren', false)) {
-      return true;
-    }
+    // In the summary tree, json['hasChildren']==true when the node has details
+    // tree children so we need to first check whether the list of children for
+    // the node in the tree was specified. If there is an empty list of children
+    // that indicates the node should have no children in the tree while if the
+    // 'children' property is not specified it means we do not know whether
+    // there is a list of children and need to query the server to find out.
     final List children = json['children'];
-    return children?.isNotEmpty == true;
+    if (children != null) {
+      return children.isNotEmpty;
+    }
+    return getBooleanMember('hasChildren', false);
   }
 
   bool get isCreatedByLocalProject {

--- a/packages/devtools/lib/src/inspector/inspector_tree_canvas.dart
+++ b/packages/devtools/lib/src/inspector/inspector_tree_canvas.dart
@@ -4,6 +4,7 @@
 
 import 'dart:html';
 import 'dart:math' as math;
+import 'dart:math';
 
 import 'package:meta/meta.dart';
 
@@ -219,8 +220,14 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
       onTap: onTap,
       onMouseMove: onMouseMove,
       onMouseLeave: onMouseLeave,
+      onSizeChange: _updateForContainerResize,
       classes: 'inspector-tree inspector-tree-container',
     );
+  }
+
+  void _updateForContainerResize(Size size) {
+    _viewportCanvas.setContentSize(_computeContentWidth(size),
+        (rowHeight * numRows + verticalPadding * 2).toDouble());
   }
 
   void _paintCallback(CanvasRenderingContext2D canvas, Rect rect) {
@@ -244,14 +251,22 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
     }
   }
 
+  double _computeContentWidth(Size size) {
+    double maxIndent = 0;
+    for (int i = 0; i < numRows; i++) {
+      final InspectorTreeRow row = root?.getRow(i, selection: selection);
+      if (row != null) {
+        maxIndent = max(maxIndent, getDepthIndent(row.depth));
+      }
+    }
+    return maxIndent + size.width;
+  }
+
   void _rebuildData() {
     if (_recomputeRows) {
       _recomputeRows = false;
       if (root != null) {
-        const contentWidth = 2000.0 +
-            horizontalPadding * 2; // TODO(jacobr): calculate max subtree depth
-        _viewportCanvas.setContentSize(contentWidth,
-            (rowHeight * numRows + verticalPadding * 2).toDouble());
+        _updateForContainerResize(_viewportCanvas.viewport.size);
       } else {
         _viewportCanvas.setContentSize(0, 0);
       }

--- a/packages/devtools/lib/src/ui/viewport_canvas.dart
+++ b/packages/devtools/lib/src/ui/viewport_canvas.dart
@@ -176,9 +176,7 @@ class ViewportCanvas extends Object with SetStateMixin {
     // TODO(jacobr): clean this code up when
     // https://github.com/dart-lang/html/issues/104 is fixed.
     final observer = ResizeObserver(allowInterop((List<dynamic> entries, _) {
-      // XXX _scheduleRebuild();
-      _hasPendingRebuild = false;
-      rebuild(force: false);
+      _scheduleRebuild();
     }));
     observer.observe(_element.element);
 

--- a/packages/devtools/test/goldens/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_initial_tree_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold
       ├───▼[C]<grayed> </grayed>Center
-      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text
       └─▼[A]<grayed> </grayed>AppBar
-          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+          [/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/goldens/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_selection_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold
       ├───▼[C]<grayed> </grayed>Center
-      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
+      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
       └─▼[A]<grayed> </grayed>AppBar
-          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+          [/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold
       ├───▼[C]<grayed> </grayed>Center
-      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text
       └─▼[A]<grayed> </grayed>AppBar
-          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+          [/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]<grayed> </grayed>MaterialApp
       ▼[S]<grayed> </grayed>Scaffold
       ├───▼[C]<grayed> </grayed>Center
-      │     ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
+      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
       └─▼[A]<grayed> </grayed>AppBar
-          ▼[/icons/inspector/textArea.png]<grayed> </grayed>Text
+          [/icons/inspector/textArea.png]<grayed> </grayed>Text

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -437,9 +437,9 @@ void main() async {
             '    ▼[M] MaterialApp\n'
             '      ▼[S] Scaffold <-- selected\n'
             '      ├───▼[C] Center\n'
-            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      │     [/icons/inspector/textArea.png] Text\n'
             '      └─▼[A] AppBar\n'
-            '          ▼[/icons/inspector/textArea.png] Text\n',
+            '          [/icons/inspector/textArea.png] Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -463,9 +463,9 @@ void main() async {
             '    ▼[M] MaterialApp\n'
             '      ▼[S] Scaffold\n'
             '      ├───▼[C] Center <-- selected\n'
-            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      │     [/icons/inspector/textArea.png] Text\n'
             '      └─▼[A] AppBar\n'
-            '          ▼[/icons/inspector/textArea.png] Text\n',
+            '          [/icons/inspector/textArea.png] Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -486,9 +486,9 @@ void main() async {
             '    ▼[M] MaterialApp\n'
             '      ▼[S] Scaffold <-- selected\n'
             '      ├───▼[C] Center\n'
-            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      │     [/icons/inspector/textArea.png] Text\n'
             '      └─▼[A] AppBar\n'
-            '          ▼[/icons/inspector/textArea.png] Text\n',
+            '          [/icons/inspector/textArea.png] Text\n',
           ));
 
       // Verify that the details tree scrolled back as well.

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -345,9 +345,9 @@ void main() async {
             '    ▼[M] MaterialApp\n'
             '      ▼[S] Scaffold\n'
             '      ├───▼[C] Center\n'
-            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      │     [/icons/inspector/textArea.png] Text\n'
             '      └─▼[A] AppBar\n'
-            '          ▼[/icons/inspector/textArea.png] Text\n',
+            '          [/icons/inspector/textArea.png] Text\n',
           ));
 
       expect(
@@ -371,9 +371,9 @@ void main() async {
           '    ▼[M] MaterialApp\n'
           '      ▼[S] Scaffold\n'
           '      ├───▼[C] Center\n'
-          '      │     ▼[/icons/inspector/textArea.png] Text <-- selected\n'
+          '      │     [/icons/inspector/textArea.png] Text <-- selected\n'
           '      └─▼[A] AppBar\n'
-          '          ▼[/icons/inspector/textArea.png] Text\n';
+          '          [/icons/inspector/textArea.png] Text\n';
 
       expect(tree.toStringDeep(), equalsIgnoringHashCodes(textSelected));
       expect(
@@ -536,9 +536,9 @@ void main() async {
             '    ▼[M] MaterialApp\n'
             '      ▼[S] Scaffold\n'
             '      ├───▼[C] Center\n'
-            '      │     ▼[/icons/inspector/textArea.png] Text\n'
+            '      │     [/icons/inspector/textArea.png] Text <-- selected\n'
             '      └─▼[A] AppBar\n'
-            '          ▼[/icons/inspector/textArea.png] Text\n',
+            '          [/icons/inspector/textArea.png] Text\n',
           ));
 
       // TODO(jacobr): would be nice to have some tests that trigger a hot


### PR DESCRIPTION
Correctly display which inspector tree nodes are expandable.
Computer inspector width based on max tree depth.
Switch to simpler ResizeObserver scheme.

There was a bug where the summary tree always showed expand-collapse icons even when they weren't needed. Fixed the bug and updated the goldens to reflect the correct state.
Fixed bug where the inspector tree width didn't update to reflect very deep trees.
Example with track widget creation off showing a deep tree is fine:
<img width="1656" alt="Screen Shot 2019-05-02 at 12 16 52 AM" src="https://user-images.githubusercontent.com/1226812/57061606-55056800-6c72-11e9-9b86-dfa6886dc02e.png">
