### PR TITLE
Export timeline functionality.

### DIFF
--- a/packages/devtools/lib/src/framework/framework_core.dart
+++ b/packages/devtools/lib/src/framework/framework_core.dart
@@ -12,8 +12,6 @@ import '../core/message_bus.dart';
 import '../globals.dart';
 import '../service.dart';
 import '../service_manager.dart';
-import '../timeline/cpu_profile_protocol.dart';
-import '../timeline/timeline_protocol.dart';
 import '../ui/theme.dart' as theme;
 import '../vm_service_wrapper.dart';
 
@@ -28,27 +26,11 @@ class FrameworkCore {
     theme.initializeTheme(uri.queryParameters['theme']);
 
     _setGlobals();
-    _setDebugFlags();
   }
 
   static void _setGlobals() {
     setGlobal(ServiceConnectionManager, ServiceConnectionManager());
     setGlobal(MessageBus, MessageBus());
-  }
-
-  static void _setDebugFlags() {
-    if (window.location.search.isEmpty) {
-      return;
-    }
-    final queryParams = Uri.parse(window.location.toString()).queryParameters;
-
-    // TODO(kenzie): register a service on the devtools server that will dump
-    // all debug files behind the [debugTimeline] and [debugCpuProfile] flags.
-    // If we could automate this into some sort of bug report, we can probably
-    // remove this query param all together, but for now enabling manual dumps
-    // is fine.
-    debugTimeline = queryParams['debugTimeline'] == 'true';
-    debugCpuProfile = queryParams['debugCpu'] == 'true';
   }
 
   /// Returns true if we're able to connect to a device and false otherwise.

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -9,24 +9,14 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 import '../utils.dart';
 
-// TODO(kenzie): talk to VM team about why timeExtentMicros is different between
-// debug and profile builds. Do they use different clocks and does this also
-// affect the sampling rate? See https://github.com/dart-lang/sdk/issues/36583.
-
-/// Switch this flag to true collect debug info from the latest cpu profile.
-///
-/// This will add a button to the timeline page that will download the debug
-/// info on click. At runtime, this flag can be enabled by adding the query
-/// parameter 'debugCpu=true'.
-bool debugCpuProfile = false;
+// TODO(kenzie): once the sample count mismatch bug is fixed, remove this string
+// buffer entirely, and access [cpuProfileResponse.json] for exporting the
+// timeline.
 
 /// Buffer that will store the latest cpu profile response json.
 ///
-/// This buffer is for debug purposes. When [debugCpuProfile] is true, we will
-/// be able to dump this buffer to a downloadable json file.
-StringBuffer _debugCpuProfileResponse = StringBuffer();
-
-String get debugCpuProfileResponse => _debugCpuProfileResponse.toString();
+/// When the export timeline button is clicked, this will be part of the output.
+StringBuffer debugCpuProfileResponse = StringBuffer();
 
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse, this.duration)
@@ -36,16 +26,14 @@ class CpuProfileData {
         stackTraceEvents = cpuProfileResponse.json['traceEvents'] {
     _processStackFrames(cpuProfileResponse);
 
-    if (debugCpuProfile) {
-      _debugCpuProfileResponse.clear();
-      if (cpuProfileRoot.sampleCount != sampleCount &&
-          stackFramesJson.isNotEmpty) {
-        _debugCpuProfileResponse.writeln('Sample count from response '
-            '($sampleCount) != sample count from root stack frame '
-            '(${cpuProfileRoot.sampleCount})\n');
-      }
-      _debugCpuProfileResponse.writeln(jsonEncode(cpuProfileResponse.json));
+    debugCpuProfileResponse.clear();
+    if (cpuProfileRoot.sampleCount != sampleCount &&
+        stackFramesJson.isNotEmpty) {
+      debugCpuProfileResponse.writeln('Sample count from response '
+          '($sampleCount) != sample count from root stack frame '
+          '(${cpuProfileRoot.sampleCount})\n');
     }
+    debugCpuProfileResponse.writeln(jsonEncode(cpuProfileResponse.json));
   }
 
   final Response cpuProfileResponse;

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:meta/meta.dart';

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -9,15 +9,6 @@ import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 import '../utils.dart';
 
-// TODO(kenzie): once the sample count mismatch bug is fixed, remove this string
-// buffer entirely, and access [cpuProfileResponse.json] for exporting the
-// timeline.
-
-/// Buffer that will store the latest cpu profile response json.
-///
-/// When the export timeline button is clicked, this will be part of the output.
-StringBuffer debugCpuProfileResponse = StringBuffer();
-
 class CpuProfileData {
   CpuProfileData(this.cpuProfileResponse, this.duration)
       : sampleCount = cpuProfileResponse.json['sampleCount'],
@@ -25,15 +16,6 @@ class CpuProfileData {
         stackFramesJson = cpuProfileResponse.json['stackFrames'],
         stackTraceEvents = cpuProfileResponse.json['traceEvents'] {
     _processStackFrames(cpuProfileResponse);
-
-    debugCpuProfileResponse.clear();
-    if (cpuProfileRoot.sampleCount != sampleCount &&
-        stackFramesJson.isNotEmpty) {
-      debugCpuProfileResponse.writeln('Sample count from response '
-          '($sampleCount) != sample count from root stack frame '
-          '(${cpuProfileRoot.sampleCount})\n');
-    }
-    debugCpuProfileResponse.writeln(jsonEncode(cpuProfileResponse.json));
   }
 
   final Response cpuProfileResponse;

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -75,6 +75,9 @@ class EventDetails extends CoreElement {
 
   _Details _details;
 
+  CpuProfileData get cpuProfileData =>
+      _details.uiEventDetails.flameChart.cpuProfileData;
+
   void _initContent() {
     _title = div(text: defaultTitleText, c: 'event-details-heading');
     _title.element.style
@@ -444,7 +447,6 @@ class _CpuFlameChart extends CoreElement {
     showingError = false;
 
     cpuProfileData = null;
-    debugCpuProfileResponse.clear();
   }
 }
 

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -444,6 +444,7 @@ class _CpuFlameChart extends CoreElement {
     showingError = false;
 
     cpuProfileData = null;
+    debugCpuProfileResponse.clear();
   }
 }
 

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -20,7 +20,6 @@ import '../ui/primer.dart';
 import '../ui/theme.dart';
 import '../ui/ui_utils.dart';
 import '../vm_service_wrapper.dart';
-import 'cpu_profile_protocol.dart';
 import 'event_details.dart';
 import 'frame_flame_chart.dart';
 import 'frames_bar_chart.dart';

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -298,9 +298,10 @@ class TimelineScreen extends Screen {
   void _exportTimeline() {
     // There will be a trailing comma on [debugTraceEvents]. Remove so that we
     // do not have to deal with json formatting errors later.
-    final traceEvents = debugTraceEvents
-        .toString()
-        .replaceRange(debugTraceEvents.length - 1, debugTraceEvents.length, '');
+    final traceEvents = debugTraceEvents.isEmpty
+        ? ''
+        : debugTraceEvents.toString().replaceRange(
+            debugTraceEvents.length - 1, debugTraceEvents.length, '');
     final String json = '{'
         '"traceEvents":[$traceEvents],'
         '"cpuProfile":[${debugCpuProfileResponse.toString()}]}';

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:meta/meta.dart';
 import 'package:split/split.dart' as split;
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
@@ -296,16 +298,16 @@ class TimelineScreen extends Screen {
   }
 
   void _exportTimeline() {
-    // There will be a trailing comma on [debugTraceEvents]. Remove so that we
-    // do not have to deal with json formatting errors later.
-    final traceEvents = debugTraceEvents.isEmpty
-        ? ''
-        : debugTraceEvents.toString().replaceRange(
-            debugTraceEvents.length - 1, debugTraceEvents.length, '');
-    final String json = '{'
-        '"traceEvents":[$traceEvents],'
-        '"cpuProfile":[${debugCpuProfileResponse.toString()}]}';
-    downloadFile(json, 'timeline_${DateTime.now().toString()}.json');
+    final Map<String, dynamic> json = {
+      'traceEvents': debugTraceEvents,
+      'cpuProfile': eventDetails.cpuProfileData != null
+          ? eventDetails.cpuProfileData.cpuProfileResponse.json
+          : {},
+    };
+    final now = DateTime.now();
+    final timestamp =
+        '${now.year}_${now.month}_${now.day}-${now.microsecondsSinceEpoch}';
+    downloadFile(jsonEncode(json), 'timeline_$timestamp.json');
   }
 
   /// Adds a button to the timeline that will dump debug information to text

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -297,8 +297,10 @@ class TimelineScreen extends Screen {
   }
 
   void _exportTimeline() {
+    // TODO(kenzie): add analytics for this. It would be helpful to know how
+    // complex the problems are that users are trying to solve.
     final Map<String, dynamic> json = {
-      'traceEvents': debugTraceEvents,
+      'traceEvents': timelineTraceEvents,
       'cpuProfile': eventDetails.cpuProfileData != null
           ? eventDetails.cpuProfileData.cpuProfileResponse.json
           : {},

--- a/packages/devtools/lib/src/timeline/timeline.dart
+++ b/packages/devtools/lib/src/timeline/timeline.dart
@@ -319,15 +319,19 @@ class TimelineScreen extends Screen {
         ..small()
         ..click(() {
           // Trace event json in the order we handled the events.
-          String handledTraceEvents = debugHandledTraceEvents.toString();
-          handledTraceEvents = handledTraceEvents.replaceRange(
-              handledTraceEvents.length - 1, handledTraceEvents.length, ']}');
+          final handledTraceEventsJson = {
+            'traceEvents': debugHandledTraceEvents
+          };
           downloadFile(
-              handledTraceEvents.toString(), 'handled_trace_output.json');
+            jsonEncode(handledTraceEventsJson),
+            'handled_trace_output.json',
+          );
 
           // Significant events in the frame tracking process.
           downloadFile(
-              debugFrameTracking.toString(), 'frame_tracking_output.txt');
+            debugFrameTracking.toString(),
+            'frame_tracking_output.txt',
+          );
 
           // Current status of our frame tracking elements (i.e. pendingEvents,
           // pendingFrames).

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -26,9 +26,8 @@ bool debugTimeline = false;
 
 /// Buffer that will store trace event json in the order we receive the events.
 ///
-/// This buffer is for debug purposes. When [debugTimeline] is true, we will
-/// be able to dump this buffer to a downloadable text file.
-StringBuffer debugTraceEvents = StringBuffer()..write('{"traceEvents":[');
+/// When the export timeline button is clicked, this will be part of the output.
+StringBuffer debugTraceEvents = StringBuffer();
 
 /// Buffer that will store trace event json in the order we handle the events.
 ///
@@ -105,9 +104,7 @@ class TimelineData {
 
     if (!_shouldProcessTraceEvent(event)) return;
 
-    if (debugTimeline) {
-      debugTraceEvents.write('${jsonEncode(event.json)},');
-    }
+    debugTraceEvents.write('${jsonEncode(event.json)},');
 
     // Process flow events now. Process Duration events after a delay. Only
     // process flow events whose name is PipelineItem, as these events mark the

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -26,7 +26,7 @@ bool debugTimeline = false;
 /// List that will store trace events in the order we receive them.
 ///
 /// When the export timeline button is clicked, this will be part of the output.
-List<Map<String, dynamic>> debugTraceEvents = [];
+List<Map<String, dynamic>> timelineTraceEvents = [];
 
 /// List that will store trace event json in the order we handle the events.
 ///
@@ -102,7 +102,7 @@ class TimelineData {
 
     if (!_shouldProcessTraceEvent(event)) return;
 
-    debugTraceEvents.add(event.json);
+    timelineTraceEvents.add(event.json);
 
     // Process flow events now. Process Duration events after a delay. Only
     // process flow events whose name is PipelineItem, as these events mark the

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
@@ -24,17 +23,16 @@ import '../utils.dart';
 /// query parameter 'debugTimeline=true'.
 bool debugTimeline = false;
 
-/// Buffer that will store trace event json in the order we receive the events.
+/// List that will store trace events in the order we receive them.
 ///
 /// When the export timeline button is clicked, this will be part of the output.
-StringBuffer debugTraceEvents = StringBuffer();
+List<Map<String, dynamic>> debugTraceEvents = [];
 
-/// Buffer that will store trace event json in the order we handle the events.
+/// List that will store trace event json in the order we handle the events.
 ///
-/// This buffer is for debug purposes. When [debugTimeline] is true, we will
-/// be able to dump this buffer to a downloadable text file.
-StringBuffer debugHandledTraceEvents = StringBuffer()
-  ..write('{"traceEvents":[');
+/// This list is for debug purposes. When [debugTimeline] is true, we will be
+/// able to dump this data to a downloadable text file.
+List<Map<String, dynamic>> debugHandledTraceEvents = [];
 
 /// Buffer that will store significant events in the frame tracking process.
 ///
@@ -104,7 +102,7 @@ class TimelineData {
 
     if (!_shouldProcessTraceEvent(event)) return;
 
-    debugTraceEvents.write('${jsonEncode(event.json)},');
+    debugTraceEvents.add(event.json);
 
     // Process flow events now. Process Duration events after a delay. Only
     // process flow events whose name is PipelineItem, as these events mark the
@@ -166,7 +164,7 @@ class TimelineData {
     }
 
     if (debugTimeline) {
-      debugHandledTraceEvents.write('${jsonEncode(event.json)},');
+      debugHandledTraceEvents.add(event.json);
       debugFrameTracking.writeln('Handling - ${event.json}');
     }
 
@@ -204,7 +202,7 @@ class TimelineData {
       );
 
       if (debugTimeline) {
-        debugHandledTraceEvents.write('${jsonEncode(event.json)},');
+        debugHandledTraceEvents.add(event.json);
         debugFrameTracking.writeln('Frame Start: $id - ${event.json}');
       }
 
@@ -225,7 +223,7 @@ class TimelineData {
       );
 
       if (debugTimeline) {
-        debugHandledTraceEvents.write('${jsonEncode(event.json)},');
+        debugHandledTraceEvents.add(event.json);
         debugFrameTracking.writeln('Frame End: $id');
       }
 


### PR DESCRIPTION
Adds an export button to the timeline:
![Screen Shot 2019-05-02 at 11 47 49 AM](https://user-images.githubusercontent.com/43759233/57100237-43a07800-6cd3-11e9-8f9a-fc3bb62d71a4.png)
![Screen Shot 2019-05-02 at 11 36 38 AM](https://user-images.githubusercontent.com/43759233/57100243-469b6880-6cd3-11e9-959a-f9c3b49cb966.png)

Clicking this button downloads a json file in the form:
```
{
  "traceEvents":[...],
  "cpuProfile":[...],
}
```

This PR also removes the query param options `debugCpu` and `debugTimeline` as they are no longer needed. The `debugTimeline` flag and debug timeline file downloads will stay for development purposes.