### PR TITLE
Use default foreground color for FPS chart Y-axis.

### DIFF
--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -80,6 +80,8 @@ class FramesBarPlotly {
     title: Title(
       text: 'Milliseconds',
     ),
+    titlefont: Font(color: colorToCss(defaultForeground)),
+    tickfont: Font(color: colorToCss(defaultForeground)),
     fixedrange: true,
   );
 


### PR DESCRIPTION
Before:
![Screen Shot 2019-05-03 at 11 08 41 AM](https://user-images.githubusercontent.com/43759233/57158281-eae6e300-6d97-11e9-856f-6f0be5389e15.png)
After:
![Screen Shot 2019-05-03 at 11 38 23 AM](https://user-images.githubusercontent.com/43759233/57158316-fc2fef80-6d97-11e9-8089-04510b314195.png)
