### PR TITLE
Account for all leaf frames in cpu profile.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -17,12 +17,17 @@ class CpuProfileData {
     _processStackFrames(cpuProfileResponse);
     _setLeafCounts();
 
-    assert(
-      sampleCount != cpuProfileRoot.sampleCount,
-      'SampleCount from response ($sampleCount) != sample count from root'
-      ' (${cpuProfileRoot.sampleCount})',
-    );
+    // This should not happen, but if it does, print to console so we can catch
+    // the bug and investigate.
+    print('SampleCount from response ($sampleCount) != sample count from root'
+        ' (${cpuProfileRoot.sampleCount})');
   }
+
+  // Key fields from the response JSON.
+  static const name = 'name';
+  static const category = 'category';
+  static const parentId = 'parent';
+  static const stackFrameId = 'sf';
 
   final Response cpuProfileResponse;
   final Duration duration;
@@ -61,14 +66,14 @@ class CpuProfileData {
     );
 
     stackFramesJson.forEach((k, v) {
-      final String stackFrameName = v['name'];
+      final String stackFrameName = v[name];
 
       final stackFrame = CpuStackFrame(
         id: k,
         name: stackFrameName,
-        category: v['category'],
+        category: v[category],
       );
-      CpuStackFrame parent = stackFrames[v['parent']];
+      CpuStackFrame parent = stackFrames[v[parentId]];
 
       // TODO(kenzie): detect other native frames like "syscall" and "malloc"
       // once we get file paths in the stack frame json.
@@ -115,7 +120,7 @@ class CpuProfileData {
 
   void _setLeafCounts() {
     for (Map<String, dynamic> traceEvent in stackTraceEvents) {
-      final leafId = traceEvent['sf'];
+      final leafId = traceEvent[stackFrameId];
       stackFrames[leafId].leafCount++;
     }
   }

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -386,6 +386,8 @@ class _CpuFlameChart extends CoreElement {
           stackFrameDetails.text = stackFrameDetailsDefaultText;
           stackFrameDetails.attribute('hidden', false);
         }
+      } on AssertionError catch (e) {
+        _updateChartWithError(e.toString());
       } catch (e) {
         _updateChartWithError('Error retrieving CPU profile: ${e.toString()}');
       }

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -6,18 +6,14 @@ import 'package:test/test.dart';
 import 'package:vm_service_lib/vm_service_lib.dart' show Response;
 
 void main() {
-  CpuProfileData cpuProfileData;
-
-  setUp(() {
-    cpuProfileData = CpuProfileData(
-      sampleResponse,
-      const Duration(milliseconds: 10), // 10 is arbitrary.
-    );
-  });
+  final cpuProfileData = CpuProfileData(
+    sampleResponse,
+    const Duration(milliseconds: 10), // 10 is arbitrary.
+  );
 
   group('CpuProfileData', () {
     test('processCpuProfile', () {
-      expect(cpuProfileData.sampleCount, equals(4));
+      expect(cpuProfileData.sampleCount, equals(8));
       expect(
         cpuProfileData.cpuProfileRoot.toStringDeep(),
         equals(goldenCpuProfile),
@@ -25,14 +21,14 @@ void main() {
     });
 
     test('process [Native] frames', () {
-      cpuProfileData = CpuProfileData(
+      final cpuProfileDataWithNative = CpuProfileData(
         sampleResponseWithNativeFrames,
         const Duration(milliseconds: 10), // 10 is arbitrary.
       );
 
-      expect(cpuProfileData.sampleCount, equals(3));
+      expect(cpuProfileDataWithNative.sampleCount, equals(3));
       expect(
-        cpuProfileData.cpuProfileRoot.toStringDeep(),
+        cpuProfileDataWithNative.cpuProfileRoot.toStringDeep(),
         equals(goldenCpuProfileWithNativeFrames),
       );
     });
@@ -46,7 +42,7 @@ void main() {
 
     test('sampleCount', () {
       expect(testStackFrame.sampleCount, equals(3));
-      expect(cpuProfileData.cpuProfileRoot.sampleCount, equals(4));
+      expect(cpuProfileData.cpuProfileRoot.sampleCount, equals(8));
     });
 
     test('cpuConsumptionRatio', () {
@@ -86,32 +82,32 @@ final CpuStackFrame stackFrame_0 = CpuStackFrame(
   id: 'id_0',
   name: '0',
   category: 'Dart',
-);
+)..leafCount = 0;
 final CpuStackFrame stackFrame_1 = CpuStackFrame(
   id: 'id_1',
   name: '1',
   category: 'Dart',
-);
+)..leafCount = 0;
 final CpuStackFrame stackFrame_2 = CpuStackFrame(
   id: 'id_2',
   name: '2',
   category: 'Dart',
-);
+)..leafCount = 1;
 final CpuStackFrame stackFrame_3 = CpuStackFrame(
   id: 'id_3',
   name: '3',
   category: 'Dart',
-);
+)..leafCount = 0;
 final CpuStackFrame stackFrame_4 = CpuStackFrame(
   id: 'id_4',
   name: '4',
   category: 'Dart',
-);
+)..leafCount = 1;
 final CpuStackFrame stackFrame_5 = CpuStackFrame(
   id: 'id_5',
   name: '5',
   category: 'Dart',
-);
+)..leafCount = 1;
 
 final testStackFrame = stackFrame_0
   ..children = [
@@ -129,28 +125,31 @@ final testStackFrame = stackFrame_0
   ];
 
 const goldenCpuProfile = '''
-  cpuProfile - children: 2
-    140357727781376-1 - children: 1
-      140357727781376-2 - children: 1
-        140357727781376-3 - children: 2
-          140357727781376-4 - children: 1
-            140357727781376-5 - children: 0
-          140357727781376-6 - children: 1
-            140357727781376-7 - children: 1
-              140357727781376-8 - children: 0
-    140357727781376-9 - children: 2
-      140357727781376-10 - children: 1
-        140357727781376-11 - children: 0
-      140357727781376-12 - children: 1
-        140357727781376-13 - children: 1
-          140357727781376-14 - children: 0
+  cpuProfile - children: 2 - leafCount: 0
+    140357727781376-1 - children: 1 - leafCount: 0
+      140357727781376-2 - children: 1 - leafCount: 0
+        140357727781376-3 - children: 2 - leafCount: 0
+          140357727781376-4 - children: 1 - leafCount: 0
+            140357727781376-5 - children: 0 - leafCount: 1
+          140357727781376-6 - children: 1 - leafCount: 0
+            140357727781376-7 - children: 1 - leafCount: 0
+              140357727781376-8 - children: 0 - leafCount: 1
+    140357727781376-9 - children: 2 - leafCount: 0
+      140357727781376-10 - children: 1 - leafCount: 0
+        140357727781376-11 - children: 0 - leafCount: 1
+      140357727781376-12 - children: 1 - leafCount: 0
+        140357727781376-13 - children: 1 - leafCount: 0
+          140357727781376-14 - children: 2 - leafCount: 3
+            140357727781376-15 - children: 0 - leafCount: 1
+            140357727781376-16 - children: 1 - leafCount: 0
+              140357727781376-17 - children: 0 - leafCount: 1
 ''';
 
 final sampleResponse = Response.parse({
   'type': '_CpuProfileTimeline',
   'samplePeriod': 1000,
   'stackDepth': 128,
-  'sampleCount': 4,
+  'sampleCount': 8,
   'timeSpan': 0.003678,
   'timeOriginMicros': 47377796685,
   'timeExtentMicros': 3678,
@@ -227,6 +226,21 @@ final sampleResponse = Response.parse({
       'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
       'parent': '140357727781376-13',
     },
+    '140357727781376-15': {
+      'category': 'Dart',
+      'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
+      'parent': '140357727781376-14',
+    },
+    '140357727781376-16': {
+      'category': 'Dart',
+      'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
+      'parent': '140357727781376-14',
+    },
+    '140357727781376-17': {
+      'category': 'Dart',
+      'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
+      'parent': '140357727781376-16',
+    },
   },
   'traceEvents': [
     {
@@ -268,19 +282,59 @@ final sampleResponse = Response.parse({
       'cat': 'Dart',
       'args': {'mode': 'basic'},
       'sf': '140357727781376-14'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377800463,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-14'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377800563,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-14'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377800663,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-15'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377800763,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-17'
     }
   ]
 });
 
 const goldenCpuProfileWithNativeFrames = '''
-  cpuProfile - children: 2
-    140357727781376-1 - children: 1
-      140357727781376-2 - children: 0
-    nativeRoot - children: 2
-      140357727781376-6 - children: 0
-      nativeTruncatedRoot - children: 1
-        140357727781376-4 - children: 1
-          140357727781376-5 - children: 0
+  cpuProfile - children: 2 - leafCount: 0
+    140357727781376-1 - children: 1 - leafCount: 0
+      140357727781376-2 - children: 0 - leafCount: 1
+    nativeRoot - children: 2 - leafCount: 0
+      140357727781376-6 - children: 0 - leafCount: 1
+      nativeTruncatedRoot - children: 1 - leafCount: 0
+        140357727781376-4 - children: 1 - leafCount: 0
+          140357727781376-5 - children: 0 - leafCount: 1
 ''';
 
 final sampleResponseWithNativeFrames = Response.parse({

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -41,8 +41,8 @@ void main() {
     });
 
     test('sampleCount', () {
-      expect(testStackFrame.sampleCount, equals(3));
-      expect(cpuProfileData.cpuProfileRoot.sampleCount, equals(8));
+      expect(testStackFrame.inclusiveSampleCount, equals(3));
+      expect(cpuProfileData.cpuProfileRoot.inclusiveSampleCount, equals(8));
     });
 
     test('cpuConsumptionRatio', () {
@@ -82,32 +82,32 @@ final CpuStackFrame stackFrame_0 = CpuStackFrame(
   id: 'id_0',
   name: '0',
   category: 'Dart',
-)..leafCount = 0;
+)..exclusiveSampleCount = 0;
 final CpuStackFrame stackFrame_1 = CpuStackFrame(
   id: 'id_1',
   name: '1',
   category: 'Dart',
-)..leafCount = 0;
+)..exclusiveSampleCount = 0;
 final CpuStackFrame stackFrame_2 = CpuStackFrame(
   id: 'id_2',
   name: '2',
   category: 'Dart',
-)..leafCount = 1;
+)..exclusiveSampleCount = 1;
 final CpuStackFrame stackFrame_3 = CpuStackFrame(
   id: 'id_3',
   name: '3',
   category: 'Dart',
-)..leafCount = 0;
+)..exclusiveSampleCount = 0;
 final CpuStackFrame stackFrame_4 = CpuStackFrame(
   id: 'id_4',
   name: '4',
   category: 'Dart',
-)..leafCount = 1;
+)..exclusiveSampleCount = 1;
 final CpuStackFrame stackFrame_5 = CpuStackFrame(
   id: 'id_5',
   name: '5',
   category: 'Dart',
-)..leafCount = 1;
+)..exclusiveSampleCount = 1;
 
 final testStackFrame = stackFrame_0
   ..children = [
@@ -125,24 +125,24 @@ final testStackFrame = stackFrame_0
   ];
 
 const goldenCpuProfile = '''
-  cpuProfile - children: 2 - leafCount: 0
-    140357727781376-1 - children: 1 - leafCount: 0
-      140357727781376-2 - children: 1 - leafCount: 0
-        140357727781376-3 - children: 2 - leafCount: 0
-          140357727781376-4 - children: 1 - leafCount: 0
-            140357727781376-5 - children: 0 - leafCount: 1
-          140357727781376-6 - children: 1 - leafCount: 0
-            140357727781376-7 - children: 1 - leafCount: 0
-              140357727781376-8 - children: 0 - leafCount: 1
-    140357727781376-9 - children: 2 - leafCount: 0
-      140357727781376-10 - children: 1 - leafCount: 0
-        140357727781376-11 - children: 0 - leafCount: 1
-      140357727781376-12 - children: 1 - leafCount: 0
-        140357727781376-13 - children: 1 - leafCount: 0
-          140357727781376-14 - children: 2 - leafCount: 3
-            140357727781376-15 - children: 0 - leafCount: 1
-            140357727781376-16 - children: 1 - leafCount: 0
-              140357727781376-17 - children: 0 - leafCount: 1
+  cpuProfile - children: 2 - exclusiveSampleCount: 0
+    140357727781376-1 - children: 1 - exclusiveSampleCount: 0
+      140357727781376-2 - children: 1 - exclusiveSampleCount: 0
+        140357727781376-3 - children: 2 - exclusiveSampleCount: 0
+          140357727781376-4 - children: 1 - exclusiveSampleCount: 0
+            140357727781376-5 - children: 0 - exclusiveSampleCount: 1
+          140357727781376-6 - children: 1 - exclusiveSampleCount: 0
+            140357727781376-7 - children: 1 - exclusiveSampleCount: 0
+              140357727781376-8 - children: 0 - exclusiveSampleCount: 1
+    140357727781376-9 - children: 2 - exclusiveSampleCount: 0
+      140357727781376-10 - children: 1 - exclusiveSampleCount: 0
+        140357727781376-11 - children: 0 - exclusiveSampleCount: 1
+      140357727781376-12 - children: 1 - exclusiveSampleCount: 0
+        140357727781376-13 - children: 1 - exclusiveSampleCount: 0
+          140357727781376-14 - children: 2 - exclusiveSampleCount: 3
+            140357727781376-15 - children: 0 - exclusiveSampleCount: 1
+            140357727781376-16 - children: 1 - exclusiveSampleCount: 0
+              140357727781376-17 - children: 0 - exclusiveSampleCount: 1
 ''';
 
 final sampleResponse = Response.parse({
@@ -327,14 +327,14 @@ final sampleResponse = Response.parse({
 });
 
 const goldenCpuProfileWithNativeFrames = '''
-  cpuProfile - children: 2 - leafCount: 0
-    140357727781376-1 - children: 1 - leafCount: 0
-      140357727781376-2 - children: 0 - leafCount: 1
-    nativeRoot - children: 2 - leafCount: 0
-      140357727781376-6 - children: 0 - leafCount: 1
-      nativeTruncatedRoot - children: 1 - leafCount: 0
-        140357727781376-4 - children: 1 - leafCount: 0
-          140357727781376-5 - children: 0 - leafCount: 1
+  cpuProfile - children: 2 - exclusiveSampleCount: 0
+    140357727781376-1 - children: 1 - exclusiveSampleCount: 0
+      140357727781376-2 - children: 0 - exclusiveSampleCount: 1
+    nativeRoot - children: 2 - exclusiveSampleCount: 0
+      140357727781376-6 - children: 0 - exclusiveSampleCount: 1
+      nativeTruncatedRoot - children: 1 - exclusiveSampleCount: 0
+        140357727781376-4 - children: 1 - exclusiveSampleCount: 0
+          140357727781376-5 - children: 0 - exclusiveSampleCount: 1
 ''';
 
 final sampleResponseWithNativeFrames = Response.parse({


### PR DESCRIPTION
We were dropping samples in the CPU profile when we had duplicate leaf frames or when the same leaf frame in sample A was not a leaf in sample B. This is now fixed.