### PR TITLE
update to use build_runner test for precompiled tests (#633)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,3 +29,4 @@ script: ./tool/travis.sh
 cache:
   directories:
   - $HOME/.pub-cache
+  - packages/devtools/.dart_tool/build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ pub run test -j1 --tags useFlutterSdk
 ```
 cd packages/devtools
 pub run test --exclude-tags useFlutterSdk
-pub run test --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+pub run build_runner test -- --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 ```
 
 ### Updating golden files

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -45,7 +45,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ^0.10.0
-  build_web_compilers: '>=1.2.0 <3.0.0'
+  build_web_compilers: ^1.2.0
   matcher: ^0.12.3
   test: ^1.0.0
   webkit_inspection_protocol: ^0.4.0

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -44,7 +44,8 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.3.0
-  build_web_compilers: ^1.2.0
+  build_test: ^0.10.0
+  build_web_compilers: '>=1.2.0 <3.0.0'
   matcher: ^0.12.3
   test: ^1.0.0
   webkit_inspection_protocol: ^0.4.0

--- a/packages/devtools/test/integration_tests/debugger.dart
+++ b/packages/devtools/test/integration_tests/debugger.dart
@@ -6,6 +6,7 @@ import 'package:test/test.dart';
 
 import '../support/cli_test_driver.dart';
 import 'integration.dart';
+import 'util.dart';
 
 void debuggingTests() {
   CliAppFixture appFixture;

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -13,6 +13,7 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 
 import '../support/chrome.dart';
 import '../support/cli_test_driver.dart';
+import 'util.dart';
 
 const bool verboseTesting = false;
 
@@ -35,14 +36,6 @@ Future<void> waitFor(
   }
 
   throw timeoutMessage;
-}
-
-Future delay() {
-  return Future.delayed(const Duration(milliseconds: 500));
-}
-
-Future shortDelay() {
-  return Future.delayed(const Duration(milliseconds: 100));
 }
 
 class DevtoolsManager {

--- a/packages/devtools/test/integration_tests/util.dart
+++ b/packages/devtools/test/integration_tests/util.dart
@@ -1,0 +1,13 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+Future delay() {
+  return Future.delayed(const Duration(milliseconds: 500));
+}
+
+Future shortDelay() {
+  return Future.delayed(const Duration(milliseconds: 100));
+}

--- a/packages/devtools/test/timeline_controller_test.dart
+++ b/packages/devtools/test/timeline_controller_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('vm')
 import 'package:devtools/src/timeline/timeline_controller.dart';
 import 'package:test/test.dart';
 

--- a/packages/devtools/test/tree_test.dart
+++ b/packages/devtools/test/tree_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools/src/ui/elements.dart';
 import 'package:devtools/src/ui/trees.dart';
 import 'package:test/test.dart';
 
-import 'integration_tests/integration.dart';
+import 'integration_tests/util.dart';
 
 void main() {
   group('tree views', () {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -50,7 +50,7 @@ elif [ "$BOT" = "test_ddc" ]; then
     pub global activate webdev
 
     pub run test --reporter expanded --exclude-tags useFlutterSdk
-    pub run test --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    pub run build_runner test -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "test_dart2js" ]; then
 
@@ -59,7 +59,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub global activate webdev
 
     WEBDEV_RELEASE=true pub run test --reporter expanded --exclude-tags useFlutterSdk
-    WEBDEV_RELEASE=true pub run test --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    pub run build_runner test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 


### PR DESCRIPTION
This is a re-land of @jakemac53's recent changes (#633) that were backed out (#641), to see what the state is against current master (which has had some other fixes). Everything passes for me locally so we might have to debug on Travis.

If it does still fail, I might try  removing the suspected change and land the rest, then we can work on the failure for just that change separately.