### PR TITLE
Fix new pedantic lints

### DIFF
--- a/packages/devtools/lib/src/debugger/scripts_view.dart
+++ b/packages/devtools/lib/src/debugger/scripts_view.dart
@@ -68,11 +68,12 @@ class PopupView extends CoreElement {
         html.document.getElementsByClassName('CodeMirror-gutters');
     if (elems.length == 2) {
       final html.Element firstGutter = elems[0].firstChild as html.Element;
-      if (firstGutter.style.display != 'none')
+      if (firstGutter.style.display != 'none') {
         // Compute total gutter width (parent has both BP and line # gutters).
         // Offset left a little (5px) so it's not aligned to the gutter's edge
         // (hard to visualize).
         leftPosition = firstGutter.parent.getBoundingClientRect().width + 5;
+      }
     }
 
     // Set the sourcePathDiv text color to the background color (hide filename).
@@ -193,8 +194,9 @@ class ScriptsView implements CoreElementView {
     switch (direction) {
       case ListDirection.pageDown:
         int itemIndex = startRow + itemsVis;
-        if (itemIndex > _items.items.length - 1)
+        if (itemIndex > _items.items.length - 1) {
           itemIndex = _items.items.length - 1;
+        }
         childToScrollTo = itemIndex;
         final int scrollPosition = startRow > 0 ? startRow * itemHeight : 0;
         scrollAndHilight(childToScrollTo, scrollPosition, top: true);

--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -610,8 +610,9 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   Icon get icon {
     if (isProperty) return null;
     Icon icon = widget?.icon;
-    if (icon == null && widgetRuntimeType != null)
+    if (icon == null && widgetRuntimeType != null) {
       icon ??= iconMaker.fromWidgetName(widgetRuntimeType);
+    }
     return icon;
   }
 

--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -302,8 +302,9 @@ class Table<T> extends Object with SetStateMixin {
         currentRowIndex < _tbody.element.children.length) {
       // removeRange doesn't work in dart:html (UnimplementedError) so we have
       // to remove them one at a time.
-      while (_tbody.element.children.length >= currentRowIndex)
+      while (_tbody.element.children.length >= currentRowIndex) {
         _tbody.element.children.removeLast();
+      }
     }
     // Set the "after" spacer to the correct height to keep the scroll size
     // correct for the number of rows to come after.

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -277,23 +277,28 @@ Future<void> computeUserApplicationCustomGTagData() async {
     final macOS = await io.eval('Platform.isMacOS', isAlive: null);
     final windows = await io.eval('Platform.isWindows', isAlive: null);
 
-    if (android.valueAsString == 'true')
+    if (android.valueAsString == 'true') {
       userPlatformType = platformTypeAndroid;
-    else if (iOS.valueAsString == 'true')
+    } else if (iOS.valueAsString == 'true') {
       userPlatformType = platformTypeIOS;
-    else if (fuchsia.valueAsString == 'true')
+    } else if (fuchsia.valueAsString == 'true') {
       userPlatformType = platformTypeFuchsia;
-    else if (linux.valueAsString == 'true')
+    } else if (linux.valueAsString == 'true') {
       userPlatformType = platformTypeLinux;
-    else if (macOS.valueAsString == 'true')
+    } else if (macOS.valueAsString == 'true') {
       userPlatformType = platformTypeMac;
-    else if (windows.valueAsString == 'true')
+    } else if (windows.valueAsString == 'true') {
       userPlatformType = platformTypeWindows;
+    }
   }
 
   if (isAnyFlutterApp) {
-    if (isFlutter) userAppType = appTypeFlutter;
-    if (isWebApp) userAppType = appTypeWeb;
+    if (isFlutter) {
+      userAppType = appTypeFlutter;
+    }
+    if (isWebApp) {
+      userAppType = appTypeWeb;
+    }
   }
   userBuildType = isProfile ? buildTypeProfile : buildTypeDebug;
 

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -65,13 +65,14 @@ bool _computing = false;
 int _stillWaiting = 0;
 void waitForDimensionsComputed(String screenName) {
   Timer(const Duration(milliseconds: 100), () async {
-    if (ga.isDimensionsComputed)
+    if (ga.isDimensionsComputed) {
       ga.screen(screenName);
-    else {
-      if (_stillWaiting++ < 50)
+    } else {
+      if (_stillWaiting++ < 50) {
         waitForDimensionsComputed(screenName);
-      else
+      } else {
         print('Cancel waiting for dimensions.');
+      }
     }
   });
 }
@@ -83,8 +84,9 @@ void setupAndGaScreen(String screenName) async {
     if (!ga.isDimensionsComputed) {
       _stillWaiting++;
       waitForDimensionsComputed(screenName);
-    } else
+    } else {
       ga.screen(screenName);
+    }
   }
 }
 

--- a/packages/devtools/lib/src/ui/fake_flutter/dart_ui/geometry.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/dart_ui/geometry.dart
@@ -405,9 +405,12 @@ class Size extends OffsetBase {
   /// left-hand-side operand minus the [Offset.dy] dimension of the
   /// right-hand-side operand.
   OffsetBase operator -(OffsetBase other) {
-    if (other is Size)
+    if (other is Size) {
       return Offset(width - other.width, height - other.height);
-    if (other is Offset) return Size(width - other.dx, height - other.dy);
+    }
+    if (other is Offset) {
+      return Size(width - other.dx, height - other.dy);
+    }
     throw ArgumentError(other);
   }
 
@@ -831,8 +834,9 @@ class Rect {
   static Rect lerp(Rect a, Rect b, double t) {
     assert(t != null);
     if (a == null && b == null) return null;
-    if (a == null)
+    if (a == null) {
       return Rect.fromLTRB(b.left * t, b.top * t, b.right * t, b.bottom * t);
+    }
     if (b == null) {
       final double k = 1.0 - t;
       return Rect.fromLTRB(a.left * k, a.top * k, a.right * k, a.bottom * k);
@@ -1122,7 +1126,9 @@ class RRect {
   }
 
   RRect._fromList(List<double> list) {
-    for (int i = 0; i < _kDataSize; i += 1) _value[i] = list[i];
+    for (int i = 0; i < _kDataSize; i += 1) {
+      _value[i] = list[i];
+    }
   }
 
   static const int _kDataSize = 12;
@@ -1340,7 +1346,9 @@ class RRect {
       scale = _getMin(scale, scaled[8], scaled[10], width);
 
       if (scale < 1.0) {
-        for (int i = 4; i < _kDataSize; i += 1) scaled[i] *= scale;
+        for (int i = 4; i < _kDataSize; i += 1) {
+          scaled[i] *= scale;
+        }
       }
 
       _scaled = RRect._fromList(scaled);
@@ -1491,8 +1499,9 @@ class RRect {
         '${right.toStringAsFixed(1)}, '
         '${bottom.toStringAsFixed(1)}';
     if (tlRadius == trRadius && trRadius == brRadius && brRadius == blRadius) {
-      if (tlRadius.x == tlRadius.y)
+      if (tlRadius.x == tlRadius.y) {
         return 'RRect.fromLTRBR($rect, ${tlRadius.x.toStringAsFixed(1)})';
+      }
       return 'RRect.fromLTRBXY($rect, ${tlRadius.x.toStringAsFixed(1)}, ${tlRadius.y.toStringAsFixed(1)})';
     }
     return 'RRect.fromLTRBAndCorners('

--- a/packages/devtools/lib/src/ui/fake_flutter/dart_ui/hashcodes.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/dart_ui/hashcodes.dart
@@ -128,8 +128,9 @@ int hashValues(Object arg01, Object arg02,
 int hashList(Iterable<Object> arguments) {
   int result = 0;
   if (arguments != null) {
-    for (Object argument in arguments)
+    for (Object argument in arguments) {
       result = _Jenkins.combine(result, argument);
+    }
   }
   return _Jenkins.finish(result);
 }

--- a/packages/devtools/lib/src/ui/fake_flutter/dart_ui/text.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/dart_ui/text.dart
@@ -159,7 +159,9 @@ class TextDecoration {
   /// Creates a decoration that paints the union of all the given decorations.
   factory TextDecoration.combine(List<TextDecoration> decorations) {
     int mask = 0;
-    for (TextDecoration decoration in decorations) mask |= decoration._mask;
+    for (TextDecoration decoration in decorations) {
+      mask |= decoration._mask;
+    }
     return TextDecoration._(mask);
   }
 

--- a/packages/devtools/lib/src/ui/fake_flutter/diagnosticable.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/diagnosticable.dart
@@ -974,8 +974,9 @@ class TextRenderer {
     }
 
     final TextTreeConfiguration config = node.textTreeConfiguration;
-    if (prefixOtherLines.isEmpty)
+    if (prefixOtherLines.isEmpty) {
       prefixOtherLines += config.prefixOtherLinesRootNode;
+    }
 
     if (node.style == DiagnosticsTreeStyle.truncateChildren) {
       // This style is different enough that it isn't worthwhile to reuse the
@@ -1035,8 +1036,9 @@ class TextRenderer {
         builder.write(
             config.isNameOnOwnLine || description.contains('\n') ? '\n' : ' ');
         if (description.contains('\n') &&
-            node.style == DiagnosticsTreeStyle.singleLine)
+            node.style == DiagnosticsTreeStyle.singleLine) {
           builder.prefixOtherLines += '  ';
+        }
       }
       builder.prefixOtherLines += children.isEmpty
           ? config.propertyPrefixNoChildren
@@ -1055,8 +1057,9 @@ class TextRenderer {
     builder.write(config.afterDescription);
     if (properties.isNotEmpty ||
         children.isNotEmpty ||
-        node.emptyBodyDescription != null)
+        node.emptyBodyDescription != null) {
       builder.write(config.afterDescriptionIfBody);
+    }
 
     if (config.lineBreakProperties) builder.write(config.lineBreak);
 
@@ -1343,10 +1346,12 @@ abstract class DiagnosticsNode {
     if (!showSeparator) data['showSeparator'] = showSeparator;
     if (level != DiagnosticLevel.info) data['level'] = describeEnum(level);
     if (showName == false) data['showName'] = showName;
-    if (emptyBodyDescription != null)
+    if (emptyBodyDescription != null) {
       data['emptyBodyDescription'] = emptyBodyDescription;
-    if (style != DiagnosticsTreeStyle.sparse)
+    }
+    if (style != DiagnosticsTreeStyle.sparse) {
       data['style'] = describeEnum(style);
+    }
 
     final bool hasChildren = getChildren().isNotEmpty;
     if (hasChildren) data['hasChildren'] = hasChildren;
@@ -1371,9 +1376,10 @@ abstract class DiagnosticsNode {
   }) {
     assert(style != null);
     assert(minLevel != null);
-    if (style == DiagnosticsTreeStyle.singleLine)
+    if (style == DiagnosticsTreeStyle.singleLine) {
       return toStringDeep(
           parentConfiguration: parentConfiguration, minLevel: minLevel);
+    }
 
     final String description =
         toDescription(parentConfiguration: parentConfiguration);
@@ -2307,8 +2313,9 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
   @override
   Map<String, Object> toJsonMap() {
     final Map<String, Object> json = super.toJsonMap();
-    if (defaultValue != kNoDefaultValue)
+    if (defaultValue != kNoDefaultValue) {
       json['defaultValue'] = defaultValue.toString();
+    }
     if (ifEmpty != null) json['ifEmpty'] = ifEmpty;
     if (ifNull != null) json['ifNull'] = ifNull;
     if (tooltip != null) json['tooltip'] = tooltip;
@@ -2316,8 +2323,9 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
     if (exception != null) json['exception'] = exception.toString();
     json['propertyType'] = propertyType.toString();
     json['defaultLevel'] = describeEnum(_defaultLevel);
-    if (T is Diagnosticable || T is DiagnosticsNode)
+    if (T is Diagnosticable || T is DiagnosticsNode) {
       json['isDiagnosticableValue'] = true;
+    }
     if (!allowWrap) json['allowWrap'] = allowWrap;
     return json;
   }
@@ -2468,8 +2476,9 @@ class DiagnosticsProperty<T> extends DiagnosticsNode {
     if (value == null && missingIfNull) return DiagnosticLevel.warning;
 
     // Use a low level when the value matches the default value.
-    if (defaultValue != kNoDefaultValue && value == defaultValue)
+    if (defaultValue != kNoDefaultValue && value == defaultValue) {
       return DiagnosticLevel.fine;
+    }
 
     return _defaultLevel;
   }

--- a/packages/devtools/lib/src/ui/fake_flutter/print.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/print.dart
@@ -133,12 +133,16 @@ Iterable<String> debugWordWrap(String message, int width,
     switch (mode) {
       case _WordWrapParseMode
           .inSpace: // at start of break point (or start of line); can't break until next break
-        while ((index < message.length) && (message[index] == ' ')) index += 1;
+        while ((index < message.length) && (message[index] == ' ')) {
+          index += 1;
+        }
         lastWordStart = index;
         mode = _WordWrapParseMode.inWord;
         break;
       case _WordWrapParseMode.inWord: // looking for a good break point
-        while ((index < message.length) && (message[index] != ' ')) index += 1;
+        while ((index < message.length) && (message[index] != ' ')) {
+          index += 1;
+        }
         mode = _WordWrapParseMode.atBreak;
         break;
       case _WordWrapParseMode.atBreak: // at start of break point
@@ -162,8 +166,9 @@ Iterable<String> debugWordWrap(String message, int width,
           if (lastWordEnd == index) {
             // we broke at current position
             // eat all the spaces, then set our start point
-            while ((index < message.length) && (message[index] == ' '))
+            while ((index < message.length) && (message[index] == ' ')) {
               index += 1;
+            }
             start = index;
             mode = _WordWrapParseMode.inWord;
           } else {

--- a/packages/devtools/lib/src/ui/fake_flutter/text.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/text.dart
@@ -354,8 +354,9 @@ class TextStyle {
   }) {
     String newDebugLabel;
     assert(() {
-      if (this.debugLabel != null)
+      if (this.debugLabel != null) {
         newDebugLabel = debugLabel ?? '(${this.debugLabel}).copyWith';
+      }
       return true;
     }());
     return TextStyle(
@@ -490,9 +491,10 @@ class TextStyle {
 
     String mergedDebugLabel;
     assert(() {
-      if (other.debugLabel != null || debugLabel != null)
+      if (other.debugLabel != null || debugLabel != null) {
         mergedDebugLabel =
             '(${debugLabel ?? _kDefaultDebugLabel}).merge(${other.debugLabel ?? _kDefaultDebugLabel})';
+      }
       return true;
     }());
 

--- a/packages/devtools/lib/src/ui/gtags.dart
+++ b/packages/devtools/lib/src/ui/gtags.dart
@@ -32,8 +32,9 @@ class GTag {
   }
 
   static void exception(GtagException gaException) {
-    if (_gaCollectionAllowed())
+    if (_gaCollectionAllowed()) {
       _gTagCommandName(_event, _exception, gaException);
+    }
   }
 }
 

--- a/packages/devtools/test/matchers/fake_flutter_matchers.dart
+++ b/packages/devtools/test/matchers/fake_flutter_matchers.dart
@@ -214,12 +214,14 @@ class _HasGoodToStringDeep extends Matcher {
           0, descriptionWithPrefixes.length - 1);
     }
     final List<String> linesWithPrefixes = descriptionWithPrefixes.split('\n');
-    if (!linesWithPrefixes.first.startsWith(prefixLineOne))
+    if (!linesWithPrefixes.first.startsWith(prefixLineOne)) {
       prefixIssues.add('First line does not contain expected prefix.');
+    }
 
     for (int i = 1; i < linesWithPrefixes.length; ++i) {
-      if (!linesWithPrefixes[i].startsWith(prefixOtherLines))
+      if (!linesWithPrefixes[i].startsWith(prefixOtherLines)) {
         prefixIssues.add('Line ${i + 1} does not contain the expected prefix.');
+      }
     }
 
     final StringBuffer errorDescription = StringBuffer();

--- a/packages/devtools/test/matchers/fake_flutter_matchers.dart
+++ b/packages/devtools/test/matchers/fake_flutter_matchers.dart
@@ -175,25 +175,29 @@ class _HasGoodToStringDeep extends Matcher {
       issues.add('Not terminated with a line break.');
     }
 
-    if (description.trim() != description)
+    if (description.trim() != description) {
       issues.add('Has trailing whitespace.');
+    }
 
     final List<String> lines = description.split('\n');
     if (lines.length < 2) issues.add('Does not have multiple lines.');
 
-    if (description.contains('Instance of '))
+    if (description.contains('Instance of ')) {
       issues.add('Contains text "Instance of ".');
+    }
 
     for (int i = 0; i < lines.length; ++i) {
       final String line = lines[i];
       if (line.isEmpty) issues.add('Line ${i + 1} is empty.');
 
-      if (line.trimRight() != line)
+      if (line.trimRight() != line) {
         issues.add('Line ${i + 1} has trailing whitespace.');
+      }
     }
 
-    if (_isAllTreeConnectorCharacters(lines.last))
+    if (_isAllTreeConnectorCharacters(lines.last)) {
       issues.add('Last line is all tree connector characters.');
+    }
 
     // If a toStringDeep method doesn't properly handle nested values that
     // contain line breaks it can fail to add the required prefixes to all

--- a/packages/devtools/test/memory_service_test.dart
+++ b/packages/devtools/test/memory_service_test.dart
@@ -109,9 +109,10 @@ void main() async {
         else if (classStat.classRef.name == 'AppBar')
           checkHeapStat(classStat, 'AppBar',
               instanceCount: 1, accumulatorCount: 2);
-        else if (classStat.classRef.name == 'Center')
+        else if (classStat.classRef.name == 'Center') {
           checkHeapStat(classStat, 'Center',
               instanceCount: 1, accumulatorCount: 2);
+        }
       }
 
       await env.tearDownEnvironment();
@@ -135,9 +136,10 @@ void main() async {
         else if (classStat.classRef.name == 'AppBar')
           checkHeapStat(classStat, 'AppBar',
               instanceCount: 1, accumulatorCount: 0);
-        else if (classStat.classRef.name == 'Center')
+        else if (classStat.classRef.name == 'Center') {
           checkHeapStat(classStat, 'Center',
               instanceCount: 1, accumulatorCount: 0);
+        }
       }
 
       await env.tearDownEnvironment();

--- a/packages/devtools/test/support/flutter_test_driver.dart
+++ b/packages/devtools/test/support/flutter_test_driver.dart
@@ -369,8 +369,9 @@ class FlutterRunTestDriver extends FlutterTestDriver {
   Future<void> hotReload() => _restart(fullRestart: false);
 
   Future<void> _restart({bool fullRestart = false, bool pause = false}) async {
-    if (_currentRunningAppId == null)
+    if (_currentRunningAppId == null) {
       throw Exception('App has not started yet');
+    }
 
     final dynamic hotReloadResp = await _sendRequest(
       'app.restart',
@@ -381,9 +382,10 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       },
     );
 
-    if (hotReloadResp == null || hotReloadResp['code'] != 0)
+    if (hotReloadResp == null || hotReloadResp['code'] != 0) {
       _throwErrorResponse(
           'Hot ${fullRestart ? 'restart' : 'reload'} request failed');
+    }
   }
 
   Future<int> detach() async {
@@ -461,8 +463,9 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     _proc.stdin.writeln(jsonEncoded);
     final Map<String, dynamic> response = await responseFuture;
 
-    if (response['error'] != null || response['result'] == null)
+    if (response['error'] != null || response['result'] == null) {
       _throwErrorResponse('Unexpected error response');
+    }
 
     return response['result'];
   }

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -22,8 +22,9 @@ void main() {
     // Show the opt-in dialog for collection analytics?
     if (ga.isGtagsEnabled() &
         (!window.localStorage.containsKey(ga_platform.devToolsProperty()) ||
-            window.localStorage[ga_platform.devToolsProperty()].isEmpty))
+            window.localStorage[ga_platform.devToolsProperty()].isEmpty)) {
       framework.showAnalyticsDialog();
+    }
 
     if (!browser.isChrome) {
       final browserName =


### PR DESCRIPTION
Today's release of [pedantic](https://github.com/dart-lang/pedantic/releases/tag/v1.6.0) enabled `curly_braces_in_flow_control_structures` and we have lots of violations causing the main bot to fail.

This fixes all those it warned about, and the obvious ones it didn't (see https://github.com/dart-lang/linter/issues/1548).