### PR TITLE
Modify recorded trace so that it scrubs bad data.

### DIFF
--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -406,6 +406,45 @@ void main() {
       expect(frame.children.last.name, equals(layoutEvent.name));
     });
   });
+
+  test('recordTrace', () {
+    timelineTraceEvents.clear();
+    goldenUiTimelineEvent.recordTrace();
+    expect(
+      timelineTraceEvents,
+      equals([
+        _vsyncJson,
+        _animatorBeginFrameJson,
+        _frameworkWorkloadJson,
+        _engineBeginFrameJson,
+        _frameJson,
+        _animateJson,
+        _layoutJson,
+        _buildJson,
+        _compositingBitsJson,
+        _paintJson,
+        _compositingJson,
+        _semanticsJson,
+        _finalizeTreeJson,
+        _endEngineBeginFrameJson,
+        _endFrameworkWorkloadJson,
+        _endAnimatorBeginFrameJson,
+        _endVsyncJson,
+      ]),
+    );
+
+    timelineTraceEvents.clear();
+    goldenGpuTimelineEvent.recordTrace();
+    expect(
+      timelineTraceEvents,
+      equals([
+        _gpuRasterizerDrawJson,
+        _pipelineConsumeJson,
+        _endPipelineConsumeJson,
+        _endGpuRasterizerDrawJson,
+      ]),
+    );
+  });
 }
 
 Future<void> delayForEventProcessing() async {


### PR DESCRIPTION
Confirmed that our timeline export can now be successfully loaded into other trace viewers such as chrome://tracing.