### PR TITLE
Bump web compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
   #     we can build on an older SDK.
   - dart: stable
     env: BOT=main
+  # TODO(dantup): Temporarily skip stable DDC builds until the interop fix is
+  # live in stable (>= v2.3.3-dev).
+  - dart: stable
+    env: BOT=test_ddc
 
 env:
   - BOT=main

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ^0.10.0
-  build_web_compilers: ^1.2.0
+  build_web_compilers: '>=1.2.0 <3.0.0'
   matcher: ^0.12.3
   test: ^1.0.0
   webkit_inspection_protocol: ^0.4.0


### PR DESCRIPTION
@jakemac53 @jacob314  This PR bumps the build_web_compilers version, which breaks the build. I found that there are JavaScript errors occurring that were being silently swallowed, so I've also:

1. Wrapped analytics setup in try/catch so we never stop the app loading for analytics failures
2. Logged any other errors to console.error so they're not silent

In the new results, there are many failures - all which seem related to things using external JavaScript:

> exception: {type: object, subtype: error, className: TypeError, description: TypeError: src__ui__analytics.isGtagsEnabled is not a function

And even stranger:

```
chrome • console:log • DevTools version 0.1.0.
chrome • console:error • null
chrome • console:error • null
chrome • console:error • null
chrome • console:error • null
```

I'm not sure what's going on there 🤷‍♂️

I don't know if these are issues in DevTools, or might be breaking changes in `build_web_compilers`. Any ideas?