### PR TITLE
Drag and drop to import timeline.

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -48,7 +48,7 @@ class Framework {
 
   Screen current;
 
-  Screen previous;
+  Screen _previous;
 
   StatusLine globalStatus;
   StatusLine pageStatus;
@@ -134,7 +134,7 @@ class Framework {
       mainElement.clear();
       screens.removeWhere((screen) => screen.id == timelineScreenId);
     } else {
-      navigateTo(previous.id);
+      navigateTo(_previous.id);
     }
   }
 
@@ -205,14 +205,14 @@ class Framework {
     }
 
     if (current != null) {
-      previous = current;
+      _previous = current;
       current = null;
-      previous.exiting();
-      previous.visible = false;
+      _previous.exiting();
+      _previous.visible = false;
 
       pageStatus.removeAll();
 
-      _screenContents[previous].hidden(true);
+      _screenContents[_previous].hidden(true);
     }
 
     current = screen;

--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -20,10 +20,6 @@ import '../ui/ui_utils.dart';
 import '../utils.dart';
 import 'framework_core.dart';
 
-bool get importMode => _importMode;
-
-bool _importMode = false;
-
 class Framework {
   Framework() {
     window.onPopState.listen(handlePopState);
@@ -108,7 +104,7 @@ class Framework {
           }
           connectDialog.hide();
           importMessage.hide();
-          _importMode = true;
+          importMode = true;
           navigateTo(timelineScreenId);
           timelineScreen.loadFromImport(import);
           break;
@@ -131,7 +127,7 @@ class Framework {
   }
 
   void exitImportMode() {
-    _importMode = false;
+    importMode = false;
     if (serviceManager.connectedApp == null) {
       showConnectionDialog();
       showImportMessage();

--- a/packages/devtools/lib/src/globals.dart
+++ b/packages/devtools/lib/src/globals.dart
@@ -5,6 +5,8 @@
 import 'core/message_bus.dart';
 import 'service_manager.dart';
 
+bool importMode = false;
+
 final Map<Type, dynamic> globals = <Type, dynamic>{};
 
 ServiceConnectionManager get serviceManager =>

--- a/packages/devtools/lib/src/globals.dart
+++ b/packages/devtools/lib/src/globals.dart
@@ -5,6 +5,8 @@
 import 'core/message_bus.dart';
 import 'service_manager.dart';
 
+/// Import mode is an offline mode where DevTools can operate on an imported
+/// data file.
 bool importMode = false;
 
 final Map<Type, dynamic> globals = <Type, dynamic>{};

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -14,6 +14,8 @@ import 'service_extensions.dart' as extensions;
 import 'service_registrations.dart' as registrations;
 import 'vm_service_wrapper.dart';
 
+// TODO(kenzie): add an offline service manager implementation.
+
 class ServiceConnectionManager {
   ServiceConnectionManager() {
     final isolateManager = IsolateManager();

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -74,9 +74,7 @@ class TimelineController {
     );
 
     timelineData.onFrameCompleted.listen((frame) {
-      if (!importMode) {
-        _frameAddedController.add(frame);
-      }
+      _frameAddedController.add(frame);
     });
 
     _timelineData = timelineData;
@@ -98,13 +96,7 @@ class TimelineController {
     );
 
     timelineData.onFrameCompleted.listen((frame) {
-      // Only add frames from the imported file. If DevTools is already
-      // connected to a Flutter app, interacting with the app will attempt to
-      // add frames to the timeline. This check prevents us from adding
-      // unrelated frames to a timeline import.
-      if (importMode && traceEvents.contains(frame.pipelineItemStartTrace)) {
-        _frameAddedController.add(frame);
-      }
+      _frameAddedController.add(frame);
     });
 
     _timelineData = timelineData;

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -5,7 +5,6 @@ import 'dart:async';
 
 import 'package:vm_service_lib/vm_service_lib.dart' hide TimelineEvent;
 
-import '../framework/framework.dart';
 import '../globals.dart';
 import 'timeline_protocol.dart';
 

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -19,11 +19,16 @@ class TimelineController {
   Stream<TimelineFrame> get onFrameAdded => _frameAddedController.stream;
 
   TimelineData _timelineData;
+
   TimelineData get timelineData => _timelineData;
+
   bool get hasStarted => timelineData != null;
 
   bool get paused => _paused;
+
   bool _paused = false;
+
+  bool _viewingTimelineImport = false;
 
   void pause() {
     _paused = true;
@@ -34,6 +39,7 @@ class TimelineController {
   }
 
   Future<void> startTimeline() async {
+    await serviceManager.serviceAvailable.future;
     await serviceManager.service
         .setVMTimelineFlags(<String>['GC', 'Dart', 'Embedder']);
     await serviceManager.service.clearVMTimeline();
@@ -64,13 +70,59 @@ class TimelineController {
       }
     }
 
-    final TimelineData timelineData =
-        TimelineData(uiThreadId: uiThreadId, gpuThreadId: gpuThreadId);
+    final TimelineData timelineData = TimelineData(
+      uiThreadId: uiThreadId,
+      gpuThreadId: gpuThreadId,
+    );
 
     timelineData.onFrameCompleted.listen((frame) {
-      _frameAddedController.add(frame);
+      if (!_viewingTimelineImport) {
+        _frameAddedController.add(frame);
+      }
     });
 
     _timelineData = timelineData;
+  }
+
+  void loadTimelineFromImport(
+    List<TraceEvent> traceEvents,
+    Map<String, dynamic> cpuProfile,
+  ) {
+    _viewingTimelineImport = true;
+
+    // TODO(kenzie): once each trace event has a ui/gpu distinction bit added to
+    // the trace, we will not need to infer thread ids. Since we control the
+    // format of the input, this is okay for now.
+    final uiThreadId = traceEvents.first.threadId;
+    final gpuThreadId = traceEvents.last.threadId;
+
+    final TimelineData timelineData = TimelineData(
+      uiThreadId: uiThreadId,
+      gpuThreadId: gpuThreadId,
+    );
+
+    timelineData.onFrameCompleted.listen((frame) {
+      // Only add frames from the imported file. If DevTools is already
+      // connected to a Flutter app, interacting with the app will attempt to
+      // add frames to the timeline. This check prevents us from adding
+      // unrelated frames to a timeline import.
+      if (traceEvents.contains(frame.pipelineItemStartTrace)) {
+        _frameAddedController.add(frame);
+      }
+    });
+
+    _timelineData = timelineData;
+
+    for (TraceEvent event in traceEvents) {
+      timelineData.processTraceEvent(event, immediate: true);
+    }
+    // Make a final call to [maybeAddPendingEvents] so that we complete the
+    // processing for every frame in the import.
+    timelineData.maybeAddPendingEvents();
+  }
+
+  void exitImportMode() {
+    _viewingTimelineImport = false;
+    startTimeline();
   }
 }

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -10,6 +10,7 @@ import 'dart:html' as html;
 
 import 'package:js/js.dart';
 
+import '../globals.dart';
 import '../ui/analytics.dart' as ga;
 
 @JS('getDevToolsPropertyID')
@@ -91,7 +92,10 @@ void setupAndGaScreen(String screenName) async {
 }
 
 void setupDimensions() async {
-  if (ga.isGtagsEnabled() && !ga.isDimensionsComputed && !_computing) {
+  if (serviceManager.connectedApp != null &&
+      ga.isGtagsEnabled() &&
+      !ga.isDimensionsComputed &&
+      !_computing) {
     _computing = true;
     // While spinning up DevTools first time wait until dimensions data is
     // available before first GA event sent.

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -144,7 +144,8 @@ CoreElement createHotRestartButton(Framework framework) {
 }
 
 Future<void> maybeShowDebugWarning(Framework framework) async {
-  if (!await serviceManager.connectedApp.isProfileBuild) {
+  if (serviceManager.connectedApp != null &&
+      !await serviceManager.connectedApp.isProfileBuild) {
     framework.showWarning(children: <CoreElement>[
       div(
           text: 'You are running your app in debug mode. Debug mode frame '

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -144,7 +144,8 @@ CoreElement createHotRestartButton(Framework framework) {
 }
 
 Future<void> maybeShowDebugWarning(Framework framework) async {
-  if (serviceManager.connectedApp != null &&
+  if (!importMode &&
+      serviceManager.connectedApp != null &&
       !await serviceManager.connectedApp.isProfileBuild) {
     framework.showWarning(children: <CoreElement>[
       div(

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -110,6 +110,7 @@
 
 <form id="ga-dialog" class="container"></form>
 <form id="connect-dialog" class="container"></form>
+<form id="import-message" class="container"></form>
 
 <div id="content" class="container" flex layout vertical style="overflow: auto;">
     <div class="blankslate">

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -45,6 +45,7 @@ void main() {
     }).then((bool connected) {
       if (!connected) {
         framework.showConnectionDialog();
+        framework.showImportMessage();
         // Clear the main element so it stops displaying "Loading..."
         // TODO(jacobr): display a message explaining how to launch a Flutter
         // application from the command line and connect to it with DevTools.


### PR DESCRIPTION
You can now drag and drop from any screen to import files to DevTools. The timeline export is the only DevTools exportable file that is currently available, but this can be extended to other use cases such as inspector or memory.

Importing a timeline file looks like this:
![Screen Shot 2019-05-08 at 10 32 12 AM](https://user-images.githubusercontent.com/43759233/57395293-95864980-717c-11e9-956b-00129e295836.png)

Clicking exit import mode will return the user to the previous screen they were on.

TODO: implement cpu profile import