### PR TITLE
Fix NPE in cpu profile

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -122,6 +122,13 @@ class CpuProfileData {
   void _setExclusiveSampleCounts() {
     for (Map<String, dynamic> traceEvent in stackTraceEvents) {
       final leafId = traceEvent[stackFrameId];
+      assert(
+        stackFrames[leafId] != null,
+        'No StackFrame found for id $leafId. If you see this assertion, please '
+        'export the timeline trace and send to kenzieschmoll@google.com. Note: '
+        'you must export the timeline immediately after the AssertionError is '
+        'thrown.',
+      );
       stackFrames[leafId]?.exclusiveSampleCount++;
     }
   }

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -122,10 +122,6 @@ class CpuProfileData {
   void _setExclusiveSampleCounts() {
     for (Map<String, dynamic> traceEvent in stackTraceEvents) {
       final leafId = traceEvent[stackFrameId];
-      print('cpuProfileResponse == ${cpuProfileResponse.json}');
-      print('stackTraceEvents.length == ${stackTraceEvents.length}');
-      print('stackFrames.length == ${stackFrames.length}');
-      print('stackFrames[$leafId] == null? ${stackFrames[leafId] == null}');
       assert(
         stackFrames[leafId] != null,
         'No StackFrame found for id $leafId. If you see this assertion, please '

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -122,7 +122,7 @@ class CpuProfileData {
   void _setExclusiveSampleCounts() {
     for (Map<String, dynamic> traceEvent in stackTraceEvents) {
       final leafId = traceEvent[stackFrameId];
-      stackFrames[leafId].exclusiveSampleCount++;
+      stackFrames[leafId]?.exclusiveSampleCount++;
     }
   }
 }

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -122,6 +122,10 @@ class CpuProfileData {
   void _setExclusiveSampleCounts() {
     for (Map<String, dynamic> traceEvent in stackTraceEvents) {
       final leafId = traceEvent[stackFrameId];
+      print('cpuProfileResponse == ${cpuProfileResponse.json}');
+      print('stackTraceEvents.length == ${stackTraceEvents.length}');
+      print('stackFrames.length == ${stackFrames.length}');
+      print('stackFrames[$leafId] == null? ${stackFrames[leafId] == null}');
       assert(
         stackFrames[leafId] != null,
         'No StackFrame found for id $leafId. If you see this assertion, please '

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -35,10 +35,12 @@ void main() {
 
     test('process response with missing leaf frame', () async {
       expect(
-        () => CpuProfileData(
-              sampleResponseWithMissingLeafFrame,
-              const Duration(milliseconds: 10), // 10 is arbitrary.
-            ),
+        () {
+          CpuProfileData(
+            sampleResponseWithMissingLeafFrame,
+            const Duration(milliseconds: 10), // 10 is arbitrary.
+          );
+        },
         // TODO(kenzie): replace with [isAssertionError] once
         // https://github.com/dart-lang/matcher/pull/112 lands and is available
         // in version of dart-lang/matcher we use.

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -32,6 +32,19 @@ void main() {
         equals(goldenCpuProfileWithNativeFrames),
       );
     });
+
+    test('process response with missing leaf frame', () {
+      final cpuProfileDataWithMissingLeafFrame = CpuProfileData(
+        sampleResponseWithMissingLeafFrame,
+        const Duration(milliseconds: 10), // 10 is arbitrary.
+      );
+      expect(cpuProfileDataWithMissingLeafFrame.stackFrames.length, equals(4));
+      expect(cpuProfileDataWithMissingLeafFrame.sampleCount, equals(3));
+      expect(
+        cpuProfileDataWithMissingLeafFrame.cpuProfileRoot.inclusiveSampleCount,
+        equals(2),
+      );
+    });
   });
 
   group('CpuStackFrame', () {
@@ -408,6 +421,69 @@ final sampleResponseWithNativeFrames = Response.parse({
       'cat': 'Dart',
       'args': {'mode': 'basic'},
       'sf': '140357727781376-6'
+    },
+  ]
+});
+
+final sampleResponseWithMissingLeafFrame = Response.parse({
+  'type': '_CpuProfileTimeline',
+  'samplePeriod': 1000,
+  'stackDepth': 128,
+  'sampleCount': 3,
+  'timeSpan': 0.003678,
+  'timeOriginMicros': 47377796685,
+  'timeExtentMicros': 3678,
+  'stackFrames': {
+    // Missing stack frame 140357727781376-0
+    '140357727781376-1': {
+      'category': 'Dart',
+      'name': 'thread_start',
+    },
+    '140357727781376-2': {
+      'category': 'Dart',
+      'name': '_pthread_start',
+      'parent': '140357727781376-1',
+    },
+    '140357727781376-3': {
+      'category': 'Dart',
+      'name': '_WidgetsFlutterBinding&BindingBase',
+    },
+    '140357727781376-4': {
+      'category': 'Dart',
+      'name': 'BuildOwner.buildScope',
+      'parent': '140357727781376-3',
+    },
+  },
+  'traceEvents': [
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377796685,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-0'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377797975,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-2'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 47377799063,
+      'cat': 'Dart',
+      'args': {'mode': 'basic'},
+      'sf': '140357727781376-4'
     },
   ]
 });

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -34,18 +34,24 @@ void main() {
     });
 
     test('process response with missing leaf frame', () async {
-      expect(
-        () {
-          CpuProfileData(
-            sampleResponseWithMissingLeafFrame,
-            const Duration(milliseconds: 10), // 10 is arbitrary.
-          );
-        },
-        // TODO(kenzie): replace with [isAssertionError] once
-        // https://github.com/dart-lang/matcher/pull/112 lands and is available
-        // in version of dart-lang/matcher we use.
-        throwsA(const TypeMatcher<AssertionError>()),
-      );
+      bool _runTest() {
+        expect(
+          () {
+            CpuProfileData(
+              sampleResponseWithMissingLeafFrame,
+              const Duration(milliseconds: 10), // 10 is arbitrary.
+            );
+          },
+          // TODO(kenzie): replace with [isAssertionError] once
+          // https://github.com/dart-lang/matcher/pull/112 lands and is available
+          // in version of dart-lang/matcher we use.
+          throwsA(const TypeMatcher<AssertionError>()),
+        );
+        return true;
+      }
+
+      // Only run this test if asserts are enabled.
+      assert(_runTest());
     });
   });
 

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -33,16 +33,16 @@ void main() {
       );
     });
 
-    test('process response with missing leaf frame', () {
-      final cpuProfileDataWithMissingLeafFrame = CpuProfileData(
-        sampleResponseWithMissingLeafFrame,
-        const Duration(milliseconds: 10), // 10 is arbitrary.
-      );
-      expect(cpuProfileDataWithMissingLeafFrame.stackFrames.length, equals(4));
-      expect(cpuProfileDataWithMissingLeafFrame.sampleCount, equals(3));
+    test('process response with missing leaf frame', () async {
       expect(
-        cpuProfileDataWithMissingLeafFrame.cpuProfileRoot.inclusiveSampleCount,
-        equals(2),
+        () => CpuProfileData(
+              sampleResponseWithMissingLeafFrame,
+              const Duration(milliseconds: 10), // 10 is arbitrary.
+            ),
+        // TODO(kenzie): replace with [isAssertionError] once
+        // https://github.com/dart-lang/matcher/pull/112 lands and is available
+        // in version of dart-lang/matcher we use.
+        throwsA(const TypeMatcher<AssertionError>()),
       );
     });
   });

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,7 +59,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub global activate webdev
 
     WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
-    pub run build_runner test --enable-asserts -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    pub run build_runner test -r -- --enable-asserts --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,7 +59,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub global activate webdev
 
     WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
-   # pub run build_runner test -r -- --enable-asserts --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    pub run build_runner test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -58,8 +58,8 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub get
     pub global activate webdev
 
-    WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
-    pub run build_runner --enable-asserts test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    WEBDEV_RELEASE=true pub run test --enable-asserts --reporter expanded --exclude-tags useFlutterSdk
+    pub run build_runner test --enable-asserts -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -58,7 +58,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub get
     pub global activate webdev
 
-    WEBDEV_RELEASE=true pub run test --enable-asserts --reporter expanded --exclude-tags useFlutterSdk
+    WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
     pub run build_runner test --enable-asserts -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -58,7 +58,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub get
     pub global activate webdev
 
-    WEBDEV_RELEASE=true pub run test --reporter expanded --exclude-tags useFlutterSdk
+    WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
     pub run build_runner test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,7 +59,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub global activate webdev
 
     WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
-    pub run build_runner test -r -- --enable-asserts --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+   # pub run build_runner test -r -- --enable-asserts --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -59,7 +59,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
     pub global activate webdev
 
     WEBDEV_RELEASE=true pub run --enable-asserts test --reporter expanded --exclude-tags useFlutterSdk
-    pub run build_runner test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
+    pub run build_runner --enable-asserts test -r -- --reporter expanded --exclude-tags useFlutterSdk --platform chrome-no-sandbox
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 


### PR DESCRIPTION
Sometimes we can get a traceEvent with a stack frame id that we don't actually have a stackFrame for.

In my observation, this is usually the trace event for what should be the first stack frame in the response. I'm talking to @bkonyi about this, but this will protect against the NPE for now. I haven't seen this happen until recently so maybe it is a recent regression with the path _getCpuProfileTimeline triggers.