### PR TITLE
Prefetch CPU profiles on adding a frame to the timeline.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:async';
 import 'dart:math' as math;
 
 import '../globals.dart';
@@ -131,7 +130,7 @@ class CpuFlameChart extends CoreElement {
       add(spinner);
 
       try {
-        await timelineController.fetchCpuProfileForSelectedEvent();
+        await timelineController.getCpuProfileForSelectedEvent();
         _drawFlameChart();
       } catch (e) {
         _updateChartWithMessage(

--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:async';
 import 'dart:html' as html;
 
 import 'package:js/js.dart';
@@ -119,7 +118,7 @@ class EventDetails extends CoreElement {
 
     _selectedTab = flameChartTab;
 
-    tabNav.onTabSelected.listen((PTabNavTab tab) {
+    tabNav.onTabSelected.listen((PTabNavTab tab) async {
       // Return early if this tab is already selected.
       if (tab == _selectedTab) {
         return;
@@ -129,13 +128,13 @@ class EventDetails extends CoreElement {
       assert(tab is EventDetailsTabNavTab);
       switch ((tab as EventDetailsTabNavTab).type) {
         case EventDetailsTabType.flameChart:
-          uiEventDetails.showTab(EventDetailsTabType.flameChart);
+          await uiEventDetails.showTab(EventDetailsTabType.flameChart);
           break;
         case EventDetailsTabType.bottomUp:
-          uiEventDetails.showTab(EventDetailsTabType.bottomUp);
+          await uiEventDetails.showTab(EventDetailsTabType.bottomUp);
           break;
         case EventDetailsTabType.callTree:
-          uiEventDetails.showTab(EventDetailsTabType.callTree);
+          await uiEventDetails.showTab(EventDetailsTabType.callTree);
           break;
       }
     });
@@ -149,7 +148,8 @@ class EventDetails extends CoreElement {
       titleTextColor = item.defaultTextColor;
     });
 
-    timelineController.onSelectedTimelineEvent.listen((_) => update());
+    timelineController.onSelectedTimelineEvent
+        .listen((_) async => await update());
 
     timelineController.onLoadOfflineData.listen((_) async {
       if (timelineController.timelineData.selectedEvent != null) {
@@ -204,10 +204,10 @@ class _UiEventDetails extends CoreElement {
 
   CpuCallTree callTree;
 
-  void showTab(EventDetailsTabType tabType) {
+  Future<void> showTab(EventDetailsTabType tabType) async {
     switch (tabType) {
       case EventDetailsTabType.flameChart:
-        flameChart.show();
+        await flameChart.show();
         bottomUp.attribute('hidden', true);
         callTree.attribute('hidden', true);
         break;

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 import 'dart:async';
 
+import 'cpu_profile_model.dart';
 import 'cpu_profile_protocol.dart';
 import 'timeline_model.dart';
 import 'timeline_protocol.dart';
@@ -124,12 +125,15 @@ class TimelineController {
     _selectedTimelineEventController.add(event);
   }
 
-  Future<void> fetchCpuProfileForSelectedEvent() async {
+  Future<void> getCpuProfileForSelectedEvent() async {
     if (!timelineData.selectedEvent.isUiEvent) return;
 
-    timelineData.cpuProfileData = await timelineService.getCpuProfile(
-      startMicros: timelineData.selectedEvent.time.start.inMicroseconds,
-      extentMicros: timelineData.selectedEvent.time.duration.inMicroseconds,
+    assert(timelineData.selectedEvent.frameId == timelineData.selectedFrame.id);
+    await timelineData.selectedFrame.cpuProfileReady.future;
+
+    timelineData.cpuProfileData = CpuProfileData.subProfile(
+      timelineData.selectedFrame.cpuProfileData,
+      timelineData.selectedEvent.time,
     );
     cpuProfileProtocol.processData(timelineData.cpuProfileData);
   }

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -487,7 +487,7 @@ class TimelineProtocol {
     return true;
   }
 
-  void _maybeAddCompletedFrame(TimelineFrame frame) {
+  void _maybeAddCompletedFrame(TimelineFrame frame) async {
     if (frame.isReadyForTimeline && frame.addedToTimeline == null) {
       if (debugTimeline) {
         debugFrameTracking.writeln('Completing ${frame.id}');
@@ -502,6 +502,14 @@ class TimelineProtocol {
       timelineController.addFrame(frame);
       pendingFrames.remove(frame.id);
       frame.addedToTimeline = true;
+
+      // Pre-fetch the cpu profile for this frame.
+      frame.cpuProfileData =
+          await timelineController.timelineService.getCpuProfile(
+        startMicros: frame.uiEventFlow.time.start.inMicroseconds,
+        extentMicros: frame.uiEventFlow.time.duration.inMicroseconds,
+      );
+      frame.cpuProfileReady.complete();
     }
   }
 

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -363,6 +363,8 @@ class TimeRange {
 
   Duration _end;
 
+  bool contains(Duration target) => target >= start && target <= end;
+
   set end(Duration value) {
     if (singleAssignment) {
       assert(_end == null);

--- a/packages/devtools/test/cpu_profile_model_test.dart
+++ b/packages/devtools/test/cpu_profile_model_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'package:devtools/src/timeline/cpu_profile_model.dart';
+import 'package:devtools/src/utils.dart';
 import 'package:test/test.dart';
 
 import 'support/timeline_test_data.dart';
@@ -23,6 +24,25 @@ void main() {
       expect(cpuProfileData.samplePeriod, equals(50));
       expect(cpuProfileData.time.start.inMicroseconds, equals(47377796685));
       expect(cpuProfileData.time.end.inMicroseconds, equals(47377799685));
+    });
+
+    test('subProfile', () {
+      final subProfile = CpuProfileData.subProfile(
+          cpuProfileData,
+          TimeRange()
+            ..start = const Duration(microseconds: 47377796685)
+            ..end = const Duration(microseconds: 47377799063));
+
+      expect(
+        subProfile.stackFramesJson,
+        equals(subProfileStackFrames),
+      );
+      expect(
+        subProfile.stackTraceEvents,
+        equals(subProfileTraceEvents),
+      );
+      expect(subProfile.sampleCount, equals(3));
+      expect(subProfile.samplePeriod, equals(cpuProfileData.samplePeriod));
     });
 
     test('to json', () {

--- a/packages/devtools/test/support/timeline_test_data.dart
+++ b/packages/devtools/test/support/timeline_test_data.dart
@@ -419,8 +419,54 @@ final Map<String, dynamic> cpuProfileResponseJson = {
   'traceEvents': goldenCpuProfileTraceEvents,
 };
 
-const Map<String, dynamic> goldenCpuProfileStackFrames = {
-// Root of new sample.
+final Map<String, dynamic> goldenCpuProfileStackFrames =
+    Map.from(subProfileStackFrames)
+      ..addAll({
+        '140357727781376-12': {
+          'category': 'Dart',
+          'name': 'RenderPhysicalModel.paint',
+          'parent': '140357727781376-9',
+          'resolvedUrl':
+              'path/to/flutter/packages/flutter/lib/src/rendering/proxy_box.dart',
+        },
+        '140357727781376-13': {
+          'category': 'Dart',
+          'name': 'RenderCustomMultiChildLayoutBox.paint',
+          'parent': '140357727781376-12',
+          'resolvedUrl':
+              'path/to/flutter/packages/flutter/lib/src/rendering/custom_layout.dart',
+        },
+        '140357727781376-14': {
+          'category': 'Dart',
+          'name': '_RenderCustomMultiChildLayoutBox.defaultPaint',
+          'parent': '140357727781376-13',
+          'resolvedUrl':
+              'path/to/flutter/packages/flutter/lib/src/rendering/box.dart',
+        },
+        '140357727781376-15': {
+          'category': 'Dart',
+          'name': 'RenderObject._paintWithContext',
+          'parent': '140357727781376-14',
+          'resolvedUrl':
+              'path/to/flutter/packages/flutter/lib/src/rendering/object.dart',
+        },
+        '140357727781376-16': {
+          'category': 'Dart',
+          'name': 'RenderStack.paintStack',
+          'parent': '140357727781376-14',
+          'resolvedUrl':
+              'path/to/flutter/packages/flutter/lib/src/rendering/stack.dart',
+        },
+        '140357727781376-17': {
+          'category': '[Stub] OneArgCheckInlineCache',
+          'name':
+              '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
+          'parent': '140357727781376-16',
+          'resolvedUrl': '',
+        }
+      });
+
+final subProfileStackFrames = {
   '140357727781376-1': {
     'category': 'Dart',
     'name': 'thread_start',
@@ -452,7 +498,6 @@ const Map<String, dynamic> goldenCpuProfileStackFrames = {
     'resolvedUrl':
         'path/to/flutter/packages/flutter/lib/src/widgets/binding.dart',
   },
-// Branches off to different sample.
   '140357727781376-6': {
     'category': 'Dart',
     'name': '_RenderProxyBox.paint',
@@ -473,7 +518,6 @@ const Map<String, dynamic> goldenCpuProfileStackFrames = {
     'parent': '140357727781376-7',
     'resolvedUrl': '',
   },
-// Root of new sample.
   '140357727781376-9': {
     'category': 'Dart',
     'name': '[Truncated]',
@@ -493,51 +537,64 @@ const Map<String, dynamic> goldenCpuProfileStackFrames = {
     'resolvedUrl':
         'file:///path/to/flutter/packages/flutter/lib/src/rendering/object.dart',
   },
-// Branches off to different sample.
-  '140357727781376-12': {
-    'category': 'Dart',
-    'name': 'RenderPhysicalModel.paint',
-    'parent': '140357727781376-9',
-    'resolvedUrl':
-        'path/to/flutter/packages/flutter/lib/src/rendering/proxy_box.dart',
-  },
-  '140357727781376-13': {
-    'category': 'Dart',
-    'name': 'RenderCustomMultiChildLayoutBox.paint',
-    'parent': '140357727781376-12',
-    'resolvedUrl':
-        'path/to/flutter/packages/flutter/lib/src/rendering/custom_layout.dart',
-  },
-  '140357727781376-14': {
-    'category': 'Dart',
-    'name': '_RenderCustomMultiChildLayoutBox.defaultPaint',
-    'parent': '140357727781376-13',
-    'resolvedUrl':
-        'path/to/flutter/packages/flutter/lib/src/rendering/box.dart',
-  },
-  '140357727781376-15': {
-    'category': 'Dart',
-    'name': 'RenderObject._paintWithContext',
-    'parent': '140357727781376-14',
-    'resolvedUrl':
-        'path/to/flutter/packages/flutter/lib/src/rendering/object.dart',
-  },
-  '140357727781376-16': {
-    'category': 'Dart',
-    'name': 'RenderStack.paintStack',
-    'parent': '140357727781376-14',
-    'resolvedUrl':
-        'path/to/flutter/packages/flutter/lib/src/rendering/stack.dart',
-  },
-  '140357727781376-17': {
-    'category': '[Stub] OneArgCheckInlineCache',
-    'name': '_WidgetsFlutterBinding&BindingBase&Gesture._invokeFrameCallback',
-    'parent': '140357727781376-16',
-    'resolvedUrl': '',
-  }
 };
 
-const List<Map<String, dynamic>> goldenCpuProfileTraceEvents = [
+final List<Map<String, dynamic>> goldenCpuProfileTraceEvents =
+    List.from(subProfileTraceEvents)
+      ..addAll([
+        {
+          'ph': 'P',
+          'name': '',
+          'pid': 77616,
+          'tid': 42247,
+          'ts': 47377800363,
+          'cat': 'Dart',
+          'args': {'mode': 'basic'},
+          'sf': '140357727781376-14'
+        },
+        {
+          'ph': 'P',
+          'name': '',
+          'pid': 77616,
+          'tid': 42247,
+          'ts': 47377800463,
+          'cat': 'Dart',
+          'args': {'mode': 'basic'},
+          'sf': '140357727781376-14'
+        },
+        {
+          'ph': 'P',
+          'name': '',
+          'pid': 77616,
+          'tid': 42247,
+          'ts': 47377800563,
+          'cat': 'Dart',
+          'args': {'mode': 'basic'},
+          'sf': '140357727781376-14'
+        },
+        {
+          'ph': 'P',
+          'name': '',
+          'pid': 77616,
+          'tid': 42247,
+          'ts': 47377800663,
+          'cat': 'Dart',
+          'args': {'mode': 'basic'},
+          'sf': '140357727781376-15'
+        },
+        {
+          'ph': 'P',
+          'name': '',
+          'pid': 77616,
+          'tid': 42247,
+          'ts': 47377800763,
+          'cat': 'Dart',
+          'args': {'mode': 'basic'},
+          'sf': '140357727781376-17'
+        }
+      ]);
+
+final subProfileTraceEvents = [
   {
     'ph': 'P',
     'name': '',
@@ -568,56 +625,6 @@ const List<Map<String, dynamic>> goldenCpuProfileTraceEvents = [
     'args': {'mode': 'basic'},
     'sf': '140357727781376-11'
   },
-  {
-    'ph': 'P',
-    'name': '',
-    'pid': 77616,
-    'tid': 42247,
-    'ts': 47377800363,
-    'cat': 'Dart',
-    'args': {'mode': 'basic'},
-    'sf': '140357727781376-14'
-  },
-  {
-    'ph': 'P',
-    'name': '',
-    'pid': 77616,
-    'tid': 42247,
-    'ts': 47377800463,
-    'cat': 'Dart',
-    'args': {'mode': 'basic'},
-    'sf': '140357727781376-14'
-  },
-  {
-    'ph': 'P',
-    'name': '',
-    'pid': 77616,
-    'tid': 42247,
-    'ts': 47377800563,
-    'cat': 'Dart',
-    'args': {'mode': 'basic'},
-    'sf': '140357727781376-14'
-  },
-  {
-    'ph': 'P',
-    'name': '',
-    'pid': 77616,
-    'tid': 42247,
-    'ts': 47377800663,
-    'cat': 'Dart',
-    'args': {'mode': 'basic'},
-    'sf': '140357727781376-15'
-  },
-  {
-    'ph': 'P',
-    'name': '',
-    'pid': 77616,
-    'tid': 42247,
-    'ts': 47377800763,
-    'cat': 'Dart',
-    'args': {'mode': 'basic'},
-    'sf': '140357727781376-17'
-  }
 ];
 
 // Mark: OfflineTimelineData.

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -4,6 +4,7 @@
 import 'package:devtools/src/timeline/timeline_controller.dart';
 import 'package:devtools/src/timeline/timeline_model.dart';
 import 'package:devtools/src/timeline/timeline_protocol.dart';
+import 'package:devtools/src/timeline/timeline_service.dart';
 import 'package:devtools/src/utils.dart';
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
@@ -37,10 +38,14 @@ void main() {
     TimelineProtocol timelineProtocol;
 
     setUp(() {
+      final timelineController = MockTimelineController();
+      when(timelineController.timelineService)
+          .thenReturn(MockTimelineService());
+
       timelineProtocol = TimelineProtocol(
         uiThreadId: testUiThreadId,
         gpuThreadId: testGpuThreadId,
-        timelineController: MockTimelineController(),
+        timelineController: timelineController,
       );
     });
 
@@ -212,6 +217,7 @@ void main() {
       expect(frame.uiEventFlow.toString(), equals(goldenUiString()));
       expect(frame.gpuEventFlow.toString(), equals(goldenGpuString()));
       expect(frame.addedToTimeline, isTrue);
+      expect(frame.cpuProfileReady.isCompleted, isTrue);
     });
 
     test('handles out of order timestamps', () async {
@@ -311,3 +317,5 @@ Future<void> delayForEventProcessing() async {
 }
 
 class MockTimelineController extends Mock implements TimelineController {}
+
+class MockTimelineService extends Mock implements TimelineService {}


### PR DESCRIPTION
After adding a frame to the timeline, we fetch the CPU profile for the frame. Upon selecting an event for a frame, we derive the sub-profile for that event from the CPU profile for the frame.

For safety, in a race condition where the user clicks on a timeline frame and selects an event before we are done fetching the CPU profile (unlikely), we await the completer `frame.cpuProfileReady`.

This allows us to keep CPU profile data for all frames in the timeline rather than having data for as many recent frames as the VM's buffer size allows.