### PR TITLE
Trim mixins from CPU stack frame names.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -1,6 +1,9 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:meta/meta.dart';
+
+import '../utils.dart';
 import 'cpu_profile_model.dart';
 
 /// Protocol for processing [CpuProfileData] and composing it into a structured
@@ -13,7 +16,7 @@ class CpuProfileProtocol {
     cpuProfileData.stackFramesJson.forEach((k, v) {
       final stackFrame = CpuStackFrame(
         id: k,
-        name: v[CpuProfileData.nameKey],
+        name: getSimpleStackFrameName(v[CpuProfileData.nameKey]),
         category: v[CpuProfileData.categoryKey],
         // If the user is on a version of Flutter where resolvedUrl is not
         // included in the response, this will be null. If the frame is a native
@@ -67,5 +70,30 @@ class CpuProfileProtocol {
       );
       cpuProfileData.stackFrames[leafId]?.exclusiveSampleCount++;
     }
+  }
+
+  /// Returns a simplified version of a StackFrame name.
+  ///
+  /// Given an input such as
+  /// "_WidgetsFlutterBinding&BindingBase&GestureBinding.handleBeginFrame", this
+  /// method will strip off all the Mixin names and return
+  /// "_WidgetsFlutterBinding.handleBeginFrame".
+  @visibleForTesting
+  String getSimpleStackFrameName(String name) {
+    final firstAmpersandIndex = name.indexOf('&');
+    final firstPeriodIndex = name.indexOf('.');
+
+    if (firstAmpersandIndex != -1 &&
+        firstPeriodIndex != -1 &&
+        firstAmpersandIndex < firstPeriodIndex &&
+        name.length > firstAmpersandIndex + 1) {
+      final nextCharCodeUnit = name[firstAmpersandIndex + 1].codeUnitAt(0);
+      if (isLetter(nextCharCodeUnit)) {
+        return name.substring(0, firstAmpersandIndex) +
+            name.substring(firstPeriodIndex);
+      }
+    }
+
+    return name;
   }
 }

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -145,6 +145,10 @@ String longestFittingSubstring(
   return originalText.substring(0, i);
 }
 
+/// Whether a given code unit is a letter (A-Z or a-z).
+bool isLetter(int codeUnit) =>
+    (codeUnit >= 65 && codeUnit <= 90) || (codeUnit >= 97 && codeUnit <= 122);
+
 /// Returns a trimmed vm service uri without any trailing characters.
 ///
 /// For example, given a [value] of http://127.0.0.1:60667/72K34Xmq0X0=/#/vm,

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -39,6 +39,35 @@ void main() {
       // Only run this test if asserts are enabled.
       assert(_runTest());
     });
+
+    test('getSimpleStackFrameName', () {
+      // Ampersand and period cases.
+      String name =
+          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
+          'SchedulerBinding.handleBeginFrame';
+      expect(
+        cpuProfileProtocol.getSimpleStackFrameName(name),
+        equals('_WidgetsFlutterBinding.handleBeginFrame'),
+      );
+
+      name =
+          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
+          'SchedulerBinding.handleBeginFrame.<anonymous closure>';
+      expect(
+        cpuProfileProtocol.getSimpleStackFrameName(name),
+        equals('_WidgetsFlutterBinding.handleBeginFrame.<anonymous closure>'),
+      );
+
+      // Ampersand and no period.
+      name =
+          'dart::DartEntry::InvokeFunction(dart::Function const&, dart::Array '
+          'const&, dart::Array const&, unsigned long)';
+      expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
+
+      // No ampersand and no period.
+      name = '_CustomZone.run';
+      expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
+    });
   });
 }
 

--- a/packages/devtools/test/utils_test.dart
+++ b/packages/devtools/test/utils_test.dart
@@ -220,6 +220,17 @@ void main() {
       );
     });
 
+    test('isLetter', () {
+      expect(isLetter('@'.codeUnitAt(0)), isFalse);
+      expect(isLetter('['.codeUnitAt(0)), isFalse);
+      expect(isLetter('`'.codeUnitAt(0)), isFalse);
+      expect(isLetter('{'.codeUnitAt(0)), isFalse);
+      expect(isLetter('A'.codeUnitAt(0)), isTrue);
+      expect(isLetter('Z'.codeUnitAt(0)), isTrue);
+      expect(isLetter('a'.codeUnitAt(0)), isTrue);
+      expect(isLetter('z'.codeUnitAt(0)), isTrue);
+    });
+
     test('getTrimmedUri', () {
       expect(
         getTrimmedUri('http://127.0.0.1:60667/72K34Xmq0X0=/#/vm').toString(),


### PR DESCRIPTION
Example: `_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding._handlePersistentFrameCallback`

The important information here would be `_WidgetsFlutterBinding._handlePersistentFrameCallback`, which is now what we will show in the profiler UI.

Original issue filed here: https://github.com/dart-lang/sdk/issues/36999. Handling the name processing locally.