### PR TITLE
Use custom comparator to fix stack frame processing order.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_model.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_model.dart
@@ -244,8 +244,19 @@ int _stackFrameIdCompare(String a, String b) {
   const dash = '-';
   final aDashIndex = a.indexOf(dash);
   final bDashIndex = b.indexOf(dash);
-  assert(aDashIndex != -1 && bDashIndex != -1);
-  final int aId = int.parse(a.substring(aDashIndex + 1));
-  final int bId = int.parse(b.substring(bDashIndex + 1));
-  return aId.compareTo(bId);
+  try {
+    final int aId = int.parse(a.substring(aDashIndex + 1));
+    final int bId = int.parse(b.substring(bDashIndex + 1));
+    return aId.compareTo(bId);
+  } catch (e) {
+    String error = 'invalid stack frame ';
+    if (aDashIndex == -1 && bDashIndex != -1) {
+      error += 'id [$a]';
+    } else if (aDashIndex != -1 && bDashIndex == -1) {
+      error += 'id [$b]';
+    } else {
+      error += 'ids [$a, $b]';
+    }
+    throw error;
+  }
 }

--- a/packages/devtools/lib/src/timeline/cpu_profile_model.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_model.dart
@@ -49,7 +49,7 @@ class CpuProfileData {
 
     // Use a SplayTreeMap so that map iteration will be in sorted key order.
     final SplayTreeMap<String, Map<String, dynamic>> subStackFramesJson =
-        SplayTreeMap();
+        SplayTreeMap(_stackFrameIdCompare);
     for (Map<String, dynamic> traceEvent in subTraceEvents) {
       // Add leaf frame.
       final String leafId = traceEvent[stackFrameIdKey];
@@ -236,4 +236,16 @@ class CpuStackFrame {
     buf.write(', ${percent2(cpuConsumptionRatio)})');
     return buf.toString();
   }
+}
+
+int _stackFrameIdCompare(String a, String b) {
+  // Stack frame ids are structured as "140225212960768-24". We need to compare
+  // the number after the dash to maintain the correct order.
+  const dash = '-';
+  final aDashIndex = a.indexOf(dash);
+  final bDashIndex = b.indexOf(dash);
+  assert(aDashIndex != -1 && bDashIndex != -1);
+  final int aId = int.parse(a.substring(aDashIndex + 1));
+  final int bId = int.parse(b.substring(bDashIndex + 1));
+  return aId.compareTo(bId);
 }


### PR DESCRIPTION
The default comparator was comparing stackFrame ids as strings.

`140225212960768-10` compared to `140225212960768-9` would order the frames as 
1. 140225212960768-10
2. 140225212960768-9

We only need to compare the counter part of the id (following the dash) which will give us the proper order
1. 140225212960768-9
2. 140225212960768-10