### PR TITLE
Analytics error handling plus variable fix

### DIFF
--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -63,7 +63,7 @@ void main() {
   }, onError: (error, stack) {
     // Report exceptions with DevTools to GA, any user's Flutter app exceptions
     // are not collected.
-    ga.error('${error.toString()}\n$stack.toString()', true);
+    ga.error('${error.toString()}\n${stack.toString()}', true);
     // Also write them to the console to aid debugging (rather than silently
     // failing to load).
     window.console.error(error);

--- a/packages/devtools/web/main.dart
+++ b/packages/devtools/web/main.dart
@@ -20,10 +20,16 @@ void main() {
     final PerfToolFramework framework = PerfToolFramework();
 
     // Show the opt-in dialog for collection analytics?
-    if (ga.isGtagsEnabled() &
-        (!window.localStorage.containsKey(ga_platform.devToolsProperty()) ||
-            window.localStorage[ga_platform.devToolsProperty()].isEmpty)) {
-      framework.showAnalyticsDialog();
+    try {
+      if (ga.isGtagsEnabled() &
+          (!window.localStorage.containsKey(ga_platform.devToolsProperty()) ||
+              window.localStorage[ga_platform.devToolsProperty()].isEmpty)) {
+        framework.showAnalyticsDialog();
+      }
+    } catch (e) {
+      // If there are errors setting up analytics, write them to the console
+      // but do not prevent DevTools from loading.
+      window.console.error(e);
     }
 
     if (!browser.isChrome) {
@@ -58,5 +64,8 @@ void main() {
     // Report exceptions with DevTools to GA, any user's Flutter app exceptions
     // are not collected.
     ga.error('${error.toString()}\n$stack.toString()', true);
+    // Also write them to the console to aid debugging (rather than silently
+    // failing to load).
+    window.console.error(error);
   });
 }


### PR DESCRIPTION
Two changes:

1. Fix a bug in analytics error report (would have `.toString()` in the message)
2. If errors occur sending analytics (eg. you're offline), write them the console but don't let the error prevent the DevTools init code from running

These were previously in #666 but since landing that is trickier, makes sense to land these separately.

@devoncarew @terrylucas 