### PR TITLE
 Add Call Tree to CPU profiler.

### DIFF
--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -551,10 +551,10 @@ class LogKindColumn extends Column<LogData> {
   String get cssClass => 'log-label-column';
 
   @override
-  dynamic getValue(LogData item) {
-    final String cssClass = getCssClassForEventKind(item);
+  dynamic getValue(LogData dataObject) {
+    final String cssClass = getCssClassForEventKind(dataObject);
 
-    return '<span class="label $cssClass">${item.kind}</span>';
+    return '<span class="label $cssClass">${dataObject.kind}</span>';
   }
 
   @override
@@ -571,7 +571,7 @@ class LogWhenColumn extends Column<LogData> {
   bool get supportsSorting => false;
 
   @override
-  dynamic getValue(LogData item) => item.timestamp;
+  dynamic getValue(LogData dataObject) => dataObject.timestamp;
 
   @override
   String render(dynamic value) {
@@ -582,7 +582,7 @@ class LogWhenColumn extends Column<LogData> {
 }
 
 class LogMessageColumn extends Column<LogData> {
-  LogMessageColumn() : super('Message', wide: true);
+  LogMessageColumn() : super('Message', percentWidth: 1.0);
 
   @override
   String get cssClass => 'pre-wrap monospace';
@@ -594,7 +594,7 @@ class LogMessageColumn extends Column<LogData> {
   bool get supportsSorting => false;
 
   @override
-  dynamic getValue(LogData item) => item;
+  dynamic getValue(LogData dataObject) => dataObject;
 
   @override
   String render(dynamic value) {

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -350,8 +350,9 @@ class MemoryScreen extends Screen with SetStateMixin {
       );
 
       table.addColumn(new MemoryColumnSimple<InstanceSummary>(
-          '${instanceRows.length} Instances of ${row.classRef.name}',
-          (InstanceSummary row) => row.objectRef));
+        '${instanceRows.length} Instances of ${row.classRef.name}',
+        (InstanceSummary row) => row.objectRef,
+      ));
 
       table.setRows(instanceRows);
     } catch (e) {

--- a/packages/devtools/lib/src/memory/memory_detail.dart
+++ b/packages/devtools/lib/src/memory/memory_detail.dart
@@ -17,10 +17,10 @@ class MemoryRow {
 }
 
 class MemoryColumnClassName extends Column<ClassHeapDetailStats> {
-  MemoryColumnClassName() : super('Class', wide: true);
+  MemoryColumnClassName() : super('Class', percentWidth: 0.8);
 
   @override
-  dynamic getValue(ClassHeapDetailStats item) => item.classRef.name;
+  dynamic getValue(ClassHeapDetailStats dataObject) => dataObject.classRef.name;
 }
 
 class MemoryColumnSize extends Column<ClassHeapDetailStats> {
@@ -32,7 +32,7 @@ class MemoryColumnSize extends Column<ClassHeapDetailStats> {
   //String get cssClass => 'monospace';
 
   @override
-  dynamic getValue(ClassHeapDetailStats item) => item.bytesCurrent;
+  dynamic getValue(ClassHeapDetailStats dataObject) => dataObject.bytesCurrent;
 
   @override
   String render(dynamic value) {
@@ -51,7 +51,8 @@ class MemoryColumnInstanceCount extends Column<ClassHeapDetailStats> {
   bool get numeric => true;
 
   @override
-  dynamic getValue(ClassHeapDetailStats item) => item.instancesCurrent;
+  dynamic getValue(ClassHeapDetailStats dataObject) =>
+      dataObject.instancesCurrent;
 
   @override
   String render(dynamic value) => Column.fastIntl(value);
@@ -65,20 +66,20 @@ class MemoryColumnInstanceAccumulatedCount
   bool get numeric => true;
 
   @override
-  dynamic getValue(ClassHeapDetailStats item) => item.instancesAccumulated;
+  dynamic getValue(ClassHeapDetailStats dataObject) =>
+      dataObject.instancesAccumulated;
 
   @override
   String render(dynamic value) => Column.fastIntl(value);
 }
 
 class MemoryColumnSimple<T> extends Column<T> {
-  MemoryColumnSimple(String name, this.getter, {bool wide = false})
-      : super(name, wide: wide);
+  MemoryColumnSimple(String name, this.getter) : super(name);
 
   String Function(T) getter;
 
   @override
-  String getValue(T item) => getter(item);
+  String getValue(T dataObject) => getter(dataObject);
 }
 
 //  void _loadHeapSnapshot() {

--- a/packages/devtools/lib/src/performance/performance.dart
+++ b/packages/devtools/lib/src/performance/performance.dart
@@ -312,7 +312,7 @@ class PerfColumnInclusive extends Column<PerfData> {
   bool get numeric => true;
 
   @override
-  dynamic getValue(PerfData item) => item.inclusive;
+  dynamic getValue(PerfData dataObject) => dataObject.inclusive;
 
   @override
   String render(dynamic value) => percent2(value);
@@ -325,24 +325,24 @@ class PerfColumnSelf extends Column<PerfData> {
   bool get numeric => true;
 
   @override
-  dynamic getValue(PerfData item) => item.self;
+  dynamic getValue(PerfData dataObject) => dataObject.self;
 
   @override
   String render(dynamic value) => percent2(value);
 }
 
 class PerfColumnMethodName extends Column<PerfData> {
-  PerfColumnMethodName() : super('Method', wide: true);
+  PerfColumnMethodName() : super('Method', percentWidth: 0.8);
 
   @override
   bool get usesHtml => true;
 
   @override
-  dynamic getValue(PerfData item) {
-    if (item.kind == 'Dart') {
-      return item.name;
+  dynamic getValue(PerfData dataObject) {
+    if (dataObject.kind == 'Dart') {
+      return dataObject.name;
     }
-    return '${item.name} <span class="function-kind ${item.kind}">${item.kind}</span>';
+    return '${dataObject.name} <span class="function-kind ${dataObject.kind}">${dataObject.kind}</span>';
   }
 }
 

--- a/packages/devtools/lib/src/timeline/cpu_bottom_up.dart
+++ b/packages/devtools/lib/src/timeline/cpu_bottom_up.dart
@@ -11,4 +11,12 @@ class CpuBottomUp extends CoreElement {
 
     add(div(text: 'Bottom up view coming soon', c: 'message'));
   }
+
+  void show() {
+    attribute('hidden', false);
+  }
+
+  void hide() {
+    attribute('hidden', true);
+  }
 }

--- a/packages/devtools/lib/src/timeline/cpu_call_tree.dart
+++ b/packages/devtools/lib/src/timeline/cpu_call_tree.dart
@@ -1,14 +1,143 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
+import '../tables.dart';
 import '../ui/elements.dart';
+import '../utils.dart';
+import 'cpu_profile_model.dart';
+import 'timeline_controller.dart';
+
+const _timeColumnWidth = 145;
 
 class CpuCallTree extends CoreElement {
-  CpuCallTree() : super('div', classes: 'ui-details-section') {
+  CpuCallTree(this.timelineController)
+      : super('div', classes: 'ui-details-section') {
     flex();
     layoutVertical();
 
-    add(div(text: 'Call tree view coming soon', c: 'message'));
+    _init();
   }
+
+  final TimelineController timelineController;
+
+  TreeTable<CpuStackFrame> callTreeTable;
+
+  bool tableNeedsRebuild = false;
+
+  void _init() {
+    final methodNameColumn = MethodNameColumn()
+      ..onNodeExpanded
+          .listen((stackFrame) => callTreeTable.expandNode(stackFrame))
+      ..onNodeCollapsed
+          .listen((stackFrame) => callTreeTable.collapseNode(stackFrame));
+
+    callTreeTable = TreeTable<CpuStackFrame>.virtual()
+      ..addColumn(TotalTimeColumn())
+      ..addColumn(SelfTimeColumn())
+      ..addColumn(methodNameColumn)
+      ..addColumn(SourceColumn());
+    callTreeTable
+      ..setSortColumn(callTreeTable.columns.first)
+      ..setRows(<CpuStackFrame>[]);
+    add(callTreeTable.element);
+  }
+
+  void update() {
+    // Update the table if the call tree is visible. Otherwise, mark the table
+    // as needing a rebuild.
+    if (!isHidden) {
+      final CpuStackFrame root =
+          timelineController.timelineData.cpuProfileData.cpuProfileRoot;
+
+      // Expand the root stack frame to start.
+      final List<CpuStackFrame> rows = [root..isExpanded = true]
+        ..addAll(root.children.cast());
+      callTreeTable.setRows(rows);
+    } else {
+      tableNeedsRebuild = true;
+    }
+  }
+
+  void show() async {
+    attribute('hidden', false);
+
+    if (tableNeedsRebuild) {
+      tableNeedsRebuild = false;
+      update();
+    }
+  }
+
+  void hide() {
+    attribute('hidden', true);
+  }
+}
+
+class SelfTimeColumn extends Column<CpuStackFrame> {
+  SelfTimeColumn() : super('Self Time', fixedWidthPx: _timeColumnWidth);
+
+  @override
+  bool get numeric => true;
+
+  @override
+  dynamic getValue(CpuStackFrame dataObject) => dataObject.selfTimeRatio;
+
+  @override
+  String getDisplayValue(CpuStackFrame dataObject) =>
+      '${msText(dataObject.selfTime, fractionDigits: 2)} '
+      '(${percent2(dataObject.selfTimeRatio)})';
+}
+
+class TotalTimeColumn extends Column<CpuStackFrame> {
+  TotalTimeColumn() : super('Total Time', fixedWidthPx: _timeColumnWidth);
+
+  @override
+  bool get numeric => true;
+
+  @override
+  dynamic getValue(CpuStackFrame dataObject) => dataObject.totalTimeRatio;
+
+  @override
+  String getDisplayValue(CpuStackFrame dataObject) =>
+      '${msText(dataObject.totalTime, fractionDigits: 2)} '
+      '(${percent2(dataObject.totalTimeRatio)})';
+}
+
+class MethodNameColumn extends TreeColumn<CpuStackFrame> {
+  MethodNameColumn() : super('Method');
+
+  static const maxMethodNameLength = 75;
+
+  @override
+  dynamic getValue(CpuStackFrame dataObject) => dataObject.name;
+
+  @override
+  String getDisplayValue(CpuStackFrame dataObject) {
+    if (dataObject.name.length > maxMethodNameLength) {
+      return dataObject.name.substring(0, maxMethodNameLength) + '...';
+    }
+    return dataObject.name;
+  }
+
+  @override
+  bool get supportsSorting => true;
+
+  @override
+  String getTooltip(CpuStackFrame dataObject) => dataObject.name;
+}
+
+// TODO(kenzie): make these urls clickable once we can jump to source.
+class SourceColumn extends Column<CpuStackFrame> {
+  SourceColumn() : super('Source', alignment: ColumnAlignment.right);
+
+  @override
+  dynamic getValue(CpuStackFrame dataObject) => dataObject.url;
+
+  @override
+  dynamic getDisplayValue(CpuStackFrame dataObject) => dataObject.simplifiedUrl;
+
+  @override
+  String getTooltip(CpuStackFrame dataObject) => dataObject.url;
+
+  @override
+  bool get supportsSorting => true;
 }

--- a/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
+++ b/packages/devtools/lib/src/timeline/cpu_flame_chart.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 import 'dart:math' as math;
 
-import '../globals.dart';
-import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/flutter_html_shim.dart';
@@ -38,41 +36,7 @@ class CpuFlameChart extends CoreElement {
 
   bool canvasNeedsRebuild = false;
 
-  bool showingMessage = false;
-
   void _drawFlameChart() {
-    if (offlineMode &&
-        timelineController.timelineData.selectedEvent !=
-            timelineController.offlineTimelineData?.selectedEvent) {
-      final offlineModeMessage = div()
-        ..add(span(
-            text:
-                'CPU profiling is not yet available for snapshots. You can only'
-                ' view '));
-      if (timelineController.offlineTimelineData?.cpuProfileData != null) {
-        offlineModeMessage
-          ..add(span(text: 'the '))
-          ..add(span(text: 'CPU profile', c: 'message-action')
-            ..click(
-                () => timelineController.restoreCpuProfileFromOfflineData()))
-          ..add(span(text: ' included in the snapshot.'));
-      } else {
-        offlineModeMessage.add(span(
-            text:
-                'a CPU profile if it is included in the imported snapshot file.'));
-      }
-      _updateChartWithMessage(offlineModeMessage);
-      return;
-    }
-
-    if (timelineController.timelineData.cpuProfileData.stackFrames.isEmpty) {
-      _updateChartWithMessage(div(
-          text: 'CPU profile unavailable for time range'
-              ' [${timelineController.timelineData.selectedEvent.time.start.inMicroseconds} -'
-              ' ${timelineController.timelineData.selectedEvent.time.end.inMicroseconds}]'));
-      return;
-    }
-
     canvas = FlameChartCanvas(
       data: timelineController.timelineData.cpuProfileData,
       flameChartWidth: element.clientWidth,
@@ -88,56 +52,23 @@ class CpuFlameChart extends CoreElement {
     );
 
     canvas.onStackFrameSelected.listen((stackFrame) {
-      final frameDuration = Duration(
-          microseconds: (stackFrame.cpuConsumptionRatio *
-                  timelineController
-                      .timelineData.selectedEvent.time.duration.inMicroseconds)
-              .round());
-      stackFrameDetails.text = stackFrame.toString(duration: frameDuration);
+      stackFrameDetails.text = stackFrame.toString();
     });
 
     add(canvas.element);
 
-    if (!showingMessage) {
-      stackFrameDetails
-        ..text = stackFrameDetailsDefaultText
-        ..attribute('hidden', false);
-    }
+    stackFrameDetails
+      ..text = stackFrameDetailsDefaultText
+      ..attribute('hidden', false);
   }
 
-  void _updateChartWithMessage(CoreElement message) {
-    showingMessage = true;
-    add(message
-      ..id = 'flame-chart-message'
-      ..clazz('message'));
-    stackFrameDetails.attribute('hidden', true);
-  }
-
-  Future<void> update() async {
+  void update() {
     reset();
-
-    // If we are loading offline data, draw the flame chart without attempting
-    // to fetch a profile.
-    if (offlineMode && timelineController.offlineTimelineData != null) {
-      _drawFlameChart();
-      return;
-    }
 
     // Update the canvas if the flame chart is visible. Otherwise, mark the
     // canvas as needing a rebuild.
     if (!isHidden) {
-      final Spinner spinner = Spinner.centered();
-      add(spinner);
-
-      try {
-        await timelineController.getCpuProfileForSelectedEvent();
-        _drawFlameChart();
-      } catch (e) {
-        _updateChartWithMessage(
-            div(text: 'Error retrieving CPU profile: ${e.toString()}'));
-      }
-
-      spinner.remove();
+      _drawFlameChart();
     } else {
       canvasNeedsRebuild = true;
     }
@@ -172,13 +103,17 @@ class CpuFlameChart extends CoreElement {
     }
   }
 
-  Future<void> show() async {
+  void show() async {
     attribute('hidden', false);
 
     if (canvasNeedsRebuild) {
       canvasNeedsRebuild = false;
-      await update();
+      update();
     }
+  }
+
+  void hide() {
+    attribute('hidden', true);
   }
 
   void reset() {
@@ -189,12 +124,5 @@ class CpuFlameChart extends CoreElement {
 
     stackFrameDetails.text = stackFrameDetailsDefaultText;
     stackFrameDetails.attribute('hidden', true);
-
-    _removeMessage();
-  }
-
-  void _removeMessage() {
-    element.children.removeWhere((e) => e.id == 'flame-chart-message');
-    showingMessage = false;
   }
 }

--- a/packages/devtools/lib/src/timeline/cpu_profile_model.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_model.dart
@@ -3,10 +3,10 @@
 // found in the LICENSE file.
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:math';
 
 import 'package:meta/meta.dart';
 
+import '../trees.dart';
 import '../utils.dart';
 import 'timeline_model.dart';
 
@@ -18,7 +18,15 @@ class CpuProfileData {
     @required this.sampleCount,
     @required this.samplePeriod,
     @required this.time,
-  });
+  }) {
+    _cpuProfileRoot = CpuStackFrame(
+      id: 'cpuProfile',
+      name: 'all',
+      category: 'Dart',
+      url: '',
+      profileTime: time,
+    );
+  }
 
   static CpuProfileData parse(Map<String, dynamic> json) {
     return CpuProfileData._(
@@ -106,12 +114,9 @@ class CpuProfileData {
 
   final TimeRange time;
 
-  final cpuProfileRoot = CpuStackFrame(
-    id: 'cpuProfile',
-    name: 'all',
-    category: 'Dart',
-    url: 'root',
-  );
+  CpuStackFrame get cpuProfileRoot => _cpuProfileRoot;
+
+  CpuStackFrame _cpuProfileRoot;
 
   Map<String, CpuStackFrame> stackFrames = {};
 
@@ -126,12 +131,13 @@ class CpuProfileData {
       };
 }
 
-class CpuStackFrame {
+class CpuStackFrame extends TreeTableNode {
   CpuStackFrame({
     @required this.id,
     @required this.name,
     @required this.category,
     @required this.url,
+    @required this.profileTime,
   });
 
   final String id;
@@ -142,32 +148,11 @@ class CpuStackFrame {
 
   final String url;
 
-  final List<CpuStackFrame> children = [];
-
-  CpuStackFrame parent;
-
-  /// Index in [parent.children].
-  int index = -1;
+  // Time data for stack frame's enclosing CPU profile.
+  final TimeRange profileTime;
 
   /// How many cpu samples for which this frame is a leaf.
   int exclusiveSampleCount = 0;
-
-  /// Depth of this CpuStackFrame tree, including [this].
-  ///
-  /// We assume that CpuStackFrame nodes are not modified after the first time
-  /// [depth] is accessed. We would need to clear the cache if this was
-  /// supported.
-  int get depth {
-    if (_depth != 0) {
-      return _depth;
-    }
-    for (CpuStackFrame child in children) {
-      _depth = max(_depth, child.depth);
-    }
-    return _depth = _depth + 1;
-  }
-
-  int _depth = 0;
 
   int get inclusiveSampleCount =>
       _inclusiveSampleCount ?? _calculateInclusiveSampleCount();
@@ -175,23 +160,37 @@ class CpuStackFrame {
   /// How many cpu samples this frame is included in.
   int _inclusiveSampleCount;
 
-  double get cpuConsumptionRatio => _cpuConsumptionRatio ??=
-      inclusiveSampleCount / getRoot().inclusiveSampleCount;
+  double get totalTimeRatio => _totalTimeRatio ??=
+      inclusiveSampleCount / (root as CpuStackFrame).inclusiveSampleCount;
 
-  double _cpuConsumptionRatio;
+  double _totalTimeRatio;
 
-  void addChild(CpuStackFrame child) {
-    children.add(child);
-    child.parent = this;
-    child.index = children.length - 1;
-  }
+  Duration get totalTime => _totalTime ??= Duration(
+      microseconds:
+          (totalTimeRatio * profileTime.duration.inMicroseconds).round());
 
-  CpuStackFrame getRoot() {
-    CpuStackFrame root = this;
-    while (root.parent != null) {
-      root = root.parent;
+  Duration _totalTime;
+
+  double get selfTimeRatio => _selfTimeRatio ??=
+      exclusiveSampleCount / (root as CpuStackFrame).inclusiveSampleCount;
+
+  double _selfTimeRatio;
+
+  Duration get selfTime => _selfTime ??= Duration(
+      microseconds:
+          (selfTimeRatio * profileTime.duration.inMicroseconds).round());
+
+  Duration _selfTime;
+
+  /// Returns a simplified version of the url with [path/to/flutter] removed.
+  String get simplifiedUrl {
+    const flutterPrefix = 'flutter/packages/';
+    final flutterPrefixIndex = url.indexOf(flutterPrefix);
+    if (flutterPrefixIndex != -1) {
+      return 'package:' +
+          url.substring(flutterPrefixIndex + flutterPrefix.length);
     }
-    return root;
+    return url;
   }
 
   /// Returns the number of cpu samples this stack frame is a part of.
@@ -223,17 +222,17 @@ class CpuStackFrame {
   }
 
   @override
-  String toString({Duration duration}) {
+  String toString() {
     final buf = StringBuffer();
     buf.write('$name ');
-    if (duration != null) {
+    if (totalTime != null) {
       // TODO(kenzie): use a number of fractionDigits that better matches the
       // resolution of the stack frame.
-      buf.write('- ${msText(duration, fractionDigits: 2)} ');
+      buf.write('- ${msText(totalTime, fractionDigits: 2)} ');
     }
     buf.write('($inclusiveSampleCount ');
     buf.write(inclusiveSampleCount == 1 ? 'sample' : 'samples');
-    buf.write(', ${percent2(cpuConsumptionRatio)})');
+    buf.write(', ${percent2(totalTimeRatio)})');
     return buf.toString();
   }
 }

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -22,6 +22,7 @@ class CpuProfileProtocol {
         // included in the response, this will be null. If the frame is a native
         // frame, the this will be the empty string.
         url: v[CpuProfileData.resolvedUrlKey],
+        profileTime: cpuProfileData.time,
       );
       _processStackFrame(
         stackFrame,

--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -108,22 +108,23 @@ abstract class FlameChart {
     final Map<String, double> stackFrameLefts = {};
 
     double calculateLeftForStackFrame(CpuStackFrame stackFrame) {
+      final CpuStackFrame parent = stackFrame.parent;
       double left;
-      if (stackFrame.parent == null) {
+      if (parent == null) {
         left = _flameChartInset.toDouble();
       } else {
         final stackFrameIndex = stackFrame.index;
         if (stackFrameIndex == 0) {
           // This is the first child of parent. [left] should equal the left
           // value of [stackFrame]'s parent.
-          left = stackFrameLefts[stackFrame.parent.id];
+          left = stackFrameLefts[parent.id];
         } else {
           assert(stackFrameIndex != -1);
           // [stackFrame] is not the first child of its parent. [left] should
           // equal the right value of its previous sibling.
-          final previous = stackFrame.parent.children[stackFrameIndex - 1];
+          final CpuStackFrame previous = parent.children[stackFrameIndex - 1];
           left = stackFrameLefts[previous.id] +
-              (totalWidth * previous.cpuConsumptionRatio);
+              (totalWidth * previous.totalTimeRatio);
         }
       }
       stackFrameLefts[stackFrame.id] = left;
@@ -132,7 +133,7 @@ abstract class FlameChart {
 
     void createChartNodes(CpuStackFrame stackFrame, int row) {
       final double width =
-          totalWidth * stackFrame.cpuConsumptionRatio - stackFramePadding;
+          totalWidth * stackFrame.totalTimeRatio - stackFramePadding;
       final left = calculateLeftForStackFrame(stackFrame);
       final top = (row * rowHeightWithPadding + _flameChartTop).toDouble();
 

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -218,7 +218,7 @@
     left: 0;
 }
 
-#flame-chart-message .message-action {
+#cpu-profiler-message .message-action {
     color: var(--link-color) !important;
     text-decoration: underline;
     cursor: pointer;

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -125,6 +125,11 @@ class TimelineController {
     _selectedTimelineEventController.add(event);
   }
 
+  void addFrame(TimelineFrame frame) {
+    timelineData.frames.add(frame);
+    frameAddedController.add(frame);
+  }
+
   Future<void> getCpuProfileForSelectedEvent() async {
     if (!timelineData.selectedEvent.isUiEvent) return;
 
@@ -136,11 +141,6 @@ class TimelineController {
       timelineData.selectedEvent.time,
     );
     cpuProfileProtocol.processData(timelineData.cpuProfileData);
-  }
-
-  void addFrame(TimelineFrame frame) {
-    timelineData.frames.add(frame);
-    frameAddedController.add(frame);
   }
 
   void restoreCpuProfileFromOfflineData() {
@@ -189,7 +189,9 @@ class TimelineController {
     // processing for every frame in the snapshot.
     timelineProtocol.maybeAddPendingEvents();
 
-    cpuProfileProtocol.processData(timelineData.cpuProfileData);
+    if (timelineData.cpuProfileData != null) {
+      cpuProfileProtocol.processData(timelineData.cpuProfileData);
+    }
 
     _loadOfflineDataController.add(offlineData);
   }

--- a/packages/devtools/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools/lib/src/timeline/timeline_model.dart
@@ -253,6 +253,7 @@ enum TimelineEventType {
   unknown,
 }
 
+// TODO(kenzie): extend [TreeNode] class to take advantage of shared tree logic.
 class TimelineEvent {
   TimelineEvent(TraceEventWrapper firstTraceEvent)
       : traceEvents = [firstTraceEvent],

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -289,7 +289,7 @@ class TimelineScreen extends Screen {
   void clearTimeline() {
     debugHandledTraceEvents.clear();
     debugFrameTracking.clear();
-    timelineController.timelineData.clear();
+    timelineController.timelineData?.clear();
     framesBarChart.frameUIgraph.reset();
     frameEventsChart.attribute('hidden', true);
     eventDetails.reset(hide: true);

--- a/packages/devtools/lib/src/trees.dart
+++ b/packages/devtools/lib/src/trees.dart
@@ -1,0 +1,83 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+/// Non-UI specific tree code should live in this file.
+///
+/// This file does not have direct dependencies on dart:html and therefore
+/// allows for testing to be done on the VM.
+
+// TODO(kenzie): look into consolidating logic between this file and
+// ui/trees.dart, which houses generic tree types vs the base classes in this
+// file.
+
+class TreeNode {
+  TreeNode parent;
+
+  final List<TreeNode> children = [];
+
+  /// Index in [parent.children].
+  int index = -1;
+
+  /// Depth of this tree, including [this].
+  ///
+  /// We assume that TreeNodes are not modified after the first time [depth] is
+  /// accessed. We would need to clear the cache before accessing, otherwise.
+  int get depth {
+    if (_depth != 0) {
+      return _depth;
+    }
+    for (TreeNode child in children) {
+      _depth = max(_depth, child.depth);
+    }
+    return _depth = _depth + 1;
+  }
+
+  int _depth = 0;
+
+  TreeNode get root {
+    if (_root != null) {
+      return _root;
+    }
+    TreeNode root = this;
+    while (root.parent != null) {
+      root = root.parent;
+    }
+    return _root = root;
+  }
+
+  TreeNode _root;
+
+  int get level {
+    if (_level != null) {
+      return _level;
+    }
+    int level = 0;
+    TreeNode current = this;
+    while (current.parent != null) {
+      current = current.parent;
+      level++;
+    }
+    return _level = level;
+  }
+
+  /// The level (0-based) of this tree node in the tree.
+  int _level;
+
+  void addChild(TreeNode child) {
+    children.add(child);
+    child.parent = this;
+    child.index = children.length - 1;
+  }
+}
+
+/// TreeNode with methods specific to displaying the tree in a tree UI.
+class TreeTableNode extends TreeNode {
+  /// Whether the tree table node is expandable.
+  bool get isExpandable => children.isNotEmpty;
+
+  /// Whether the node is currently expanded in the tree table.
+  bool isExpanded = false;
+}

--- a/packages/devtools/lib/src/ui/custom.dart
+++ b/packages/devtools/lib/src/ui/custom.dart
@@ -331,14 +331,18 @@ class SelectableTree<T> extends CoreElement
   }
 }
 
+// TODO(kenzie): wrap this element in a larger div to increase tap target.
 class TreeToggle extends CoreElement {
-  TreeToggle({bool empty = false})
+  TreeToggle({bool empty = false, bool forceOpen = false})
       : super('div', classes: 'tree-toggle octicon') {
     if (!empty) {
       click(toggle);
-    }
-    if (!empty) {
-      clazz('octicon-triangle-right');
+      if (forceOpen) {
+        _isOpen = true;
+        clazz('octicon-triangle-down');
+      } else {
+        clazz('octicon-triangle-right');
+      }
     }
   }
 

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -50,7 +50,9 @@ String escape(String text) => text == null ? '' : htmlEscape.convert(text);
 
 final NumberFormat nf = NumberFormat.decimalPattern();
 
-String percent(double d) => '${(d * 100).toStringAsFixed(1)}%';
+String percent0(double d) => '${(d * 100).toStringAsFixed(0)}%';
+
+String percent1(double d) => '${(d * 100).toStringAsFixed(1)}%';
 
 String percent2(double d) => '${(d * 100).toStringAsFixed(2)}%';
 

--- a/packages/devtools/test/cpu_profile_model_test.dart
+++ b/packages/devtools/test/cpu_profile_model_test.dart
@@ -51,85 +51,88 @@ void main() {
   });
 
   group('CpuStackFrame', () {
-    test('depth', () {
-      expect(testStackFrame.depth, equals(4));
-    });
-
     test('sampleCount', () {
-      expect(testStackFrame.inclusiveSampleCount, equals(3));
+      expect(testStackFrame.inclusiveSampleCount, equals(10));
     });
 
-    test('cpuConsumptionRatio', () {
-      expect(stackFrame_3.cpuConsumptionRatio, equals(0.6666666666666666));
-      expect(stackFrame_5.cpuConsumptionRatio, equals(0.3333333333333333));
+    test('totalTime and selfTime', () {
+      expect(testStackFrame.totalTimeRatio, equals(1.0));
+      expect(testStackFrame.totalTime.inMicroseconds, equals(100));
+      expect(testStackFrame.selfTimeRatio, equals(0.0));
+      expect(testStackFrame.selfTime.inMicroseconds, equals(0));
+
+      expect(stackFrame_2.totalTimeRatio, equals(0.3));
+      expect(stackFrame_2.totalTime.inMicroseconds, equals(30));
+      expect(stackFrame_2.selfTimeRatio, equals(0.3));
+      expect(stackFrame_2.selfTime.inMicroseconds, equals(30));
+
+      expect(stackFrame_3.totalTimeRatio, equals(0.7));
+      expect(stackFrame_3.totalTime.inMicroseconds, equals(70));
+      expect(stackFrame_3.selfTimeRatio, equals(0.2));
+      expect(stackFrame_3.selfTime.inMicroseconds, equals(20));
+
+      expect(stackFrame_5.totalTimeRatio, equals(0.4));
+      expect(stackFrame_5.totalTime.inMicroseconds, equals(40));
+      expect(stackFrame_5.selfTimeRatio, equals(0.4));
+      expect(stackFrame_5.selfTime.inMicroseconds, equals(40));
     });
 
-    test('add child', () {
-      final parent = CpuStackFrame(
-        id: 'id_0',
-        name: 'parent',
-        category: 'Dart',
-        url: 'url',
-      );
-      final child = CpuStackFrame(
-        id: 'id_1',
-        name: 'child',
-        category: 'Dart',
-        url: 'url',
-      );
-      expect(parent.children, isEmpty);
-      expect(child.parent, isNull);
-      parent.addChild(child);
-      expect(parent.children, isNotEmpty);
-      expect(parent.children.first, equals(child));
-      expect(child.parent, equals(parent));
-    });
-
-    test('getRoot', () {
+    test('simplifiedUrl', () {
+      expect(stackFrame_0.simplifiedUrl, equals(''));
+      expect(stackFrame_1.simplifiedUrl, equals(stackFrame_1.url));
       expect(
-        stackFrame_2.getRoot().toStringDeep(),
-        equals(testStackFrame.toStringDeep()),
+        stackFrame_2.simplifiedUrl,
+        equals('package:flutter/lib/src/widgets/binding.dart'),
       );
     });
   });
 }
 
+final TimeRange profileTime = TimeRange()
+  ..start = const Duration(microseconds: 0)
+  ..end = const Duration(microseconds: 100);
 final CpuStackFrame stackFrame_0 = CpuStackFrame(
   id: 'id_0',
   name: '0',
   category: 'Dart',
-  url: 'url',
+  url: '',
+  profileTime: profileTime,
 )..exclusiveSampleCount = 0;
 final CpuStackFrame stackFrame_1 = CpuStackFrame(
   id: 'id_1',
   name: '1',
   category: 'Dart',
-  url: 'url',
+  url: 'org-dartlang-sdk:///third_party/dart/sdk/lib/async/zone.dart',
+  profileTime: profileTime,
 )..exclusiveSampleCount = 0;
 final CpuStackFrame stackFrame_2 = CpuStackFrame(
   id: 'id_2',
   name: '2',
   category: 'Dart',
-  url: 'url',
-)..exclusiveSampleCount = 1;
+  url: 'file:///path/to/flutter/packages/flutter/lib/src/widgets/binding.dart',
+  profileTime: profileTime,
+)..exclusiveSampleCount = 3;
 final CpuStackFrame stackFrame_3 = CpuStackFrame(
   id: 'id_3',
   name: '3',
   category: 'Dart',
   url: 'url',
-)..exclusiveSampleCount = 0;
+  profileTime: profileTime,
+)..exclusiveSampleCount = 2;
 final CpuStackFrame stackFrame_4 = CpuStackFrame(
   id: 'id_4',
   name: '4',
   category: 'Dart',
   url: 'url',
+  profileTime: profileTime,
 )..exclusiveSampleCount = 1;
 final CpuStackFrame stackFrame_5 = CpuStackFrame(
   id: 'id_5',
   name: '5',
   category: 'Dart',
   url: 'url',
-)..exclusiveSampleCount = 1;
+  profileTime: profileTime,
+)..exclusiveSampleCount = 4;
 
 final CpuStackFrame testStackFrame = stackFrame_0
   ..addChild(stackFrame_1

--- a/packages/devtools/test/trees_test.dart
+++ b/packages/devtools/test/trees_test.dart
@@ -1,0 +1,48 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools/src/trees.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('TreeNode', () {
+    test('depth', () {
+      expect(testTreeNode.depth, equals(4));
+      expect(treeNode_2.depth, equals(1));
+      expect(treeNode_3.depth, equals(2));
+    });
+
+    test('root', () {
+      expect(treeNode_2.root, equals(treeNode_0));
+    });
+
+    test('level', () {
+      expect(testTreeNode.level, equals(0));
+      expect(treeNode_2.level, equals(2));
+      expect(treeNode_5.level, equals(3));
+    });
+
+    test('addChild', () {
+      final parent = TreeNode();
+      final child = TreeNode();
+      expect(parent.children, isEmpty);
+      expect(child.parent, isNull);
+      parent.addChild(child);
+      expect(parent.children, isNotEmpty);
+      expect(parent.children.first, equals(child));
+      expect(child.parent, equals(parent));
+    });
+  });
+}
+
+final treeNode_0 = TreeNode();
+final treeNode_1 = TreeNode();
+final treeNode_2 = TreeNode();
+final treeNode_3 = TreeNode();
+final treeNode_4 = TreeNode();
+final treeNode_5 = TreeNode();
+final TreeNode testTreeNode = treeNode_0
+  ..addChild(treeNode_1
+    ..addChild(treeNode_2)
+    ..addChild(treeNode_3..addChild(treeNode_4)..addChild(treeNode_5)));

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -204,11 +204,14 @@ span.label.gc {
 }
 
 .table-virtual td {
-    max-width: 500px; /* required for text-overflow to work? */
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
     cursor: pointer;
+}
+
+.table-virtual.overflow-y td {
+    max-width: 500px; /* required for text-overflow to work? */
 }
 
 table thead {
@@ -229,10 +232,6 @@ table th {
   color: var(--header-color);
   background-color: var(--header-background);
   white-space: nowrap;
-}
-
-table th.wide {
-    width: 80%;
 }
 
 table td,
@@ -699,6 +698,10 @@ nav.menu li {
     list-style: none;
 }
 
+tr.selected .tree-toggle {
+    color: var(--header-background);
+}
+
 .tree-toggle {
     width: 14px;
     font-size: 14px;
@@ -706,6 +709,7 @@ nav.menu li {
     padding-bottom: 1px;
     color: var(--subtle);
     user-select: none;
+    align-self: center;
 }
 
 .tree-toggle.octicon-triangle-right {


### PR DESCRIPTION
Supported features:
- Hierarchical sorting. Sort tree elements without disrupting the structure of the tree.
- Arrow key tree traversal with node expansion and collapse.
- Preserved expansion state of subtrees. When collapsing and expanding a node, the previous expansion state will be restored.
- Vertical and horizontal scrolling to support very deep (and thus wide) trees.

![Screen Shot 2019-06-12 at 10 54 51 AM](https://user-images.githubusercontent.com/43759233/59374361-8efd6b80-8d00-11e9-9e90-95b07065c3e8.png)

TODO:
- Filtering
- Expand all / collapse all 