### PR TITLE
keep the order of screens stable

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -226,7 +226,8 @@ class Framework {
         id = id.substring(1);
       }
       Screen screen = getScreen(id, onlyEnabled: true);
-      screen ??= screens.first;
+      screen ??= screens.firstWhere((screen) => !screen.disabled,
+          orElse: () => screens.first);
       if (screen != null) {
         ga_platform.setupAndGaScreen(id);
         load(screen);

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -71,7 +71,6 @@ class PerfToolFramework extends Framework {
 
     await serviceManager.serviceAvailable.future;
     await addScreens();
-    sortScreens();
     screensReady.complete();
 
     final CoreElement mainNav = CoreElement.from(queryId('main-nav'));
@@ -195,16 +194,6 @@ class PerfToolFramework extends Framework {
       disabledTooltip: getDebuggerDisabledTooltip(),
     ));
     addScreen(LoggingScreen());
-  }
-
-  void sortScreens() {
-    // Move disabled screens to the end, but otherwise preserve order.
-    final sortedScreens = screens
-        .where((screen) => !screen.disabled)
-        .followedBy(screens.where((screen) => screen.disabled))
-        .toList();
-    screens.clear();
-    screens.addAll(sortedScreens);
   }
 
   IsolateRef get currentIsolate =>

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -90,8 +90,8 @@
         <a disabled><span class="octicon octicon-device-mobile"></span><span> <span class="optional-950">Flutter Inspector</span></span></a>
         <a disabled><span class="octicon octicon-pulse"></span><span> <span class="optional-950">Timeline</span></span></a>
         <a disabled><span class="octicon octicon-package"></span><span> <span class="optional-950">Memory</span></span></a>
-        <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-950">Debugger</span></span></a>
         <!-- a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-950">Performance</span></span></a -->
+        <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-950">Debugger</span></span></a>
         <a disabled><span class="octicon octicon-clippy"></span><span> <span class="optional-950">Logging</span></span></a>
     </nav>
 


### PR DESCRIPTION
- keep the order of screens stable

I noticed that as an app loads, the order of the screens would change (in the app's header). This PR preserves the screen order before and after app load. It does ensure that the first, non-disabled, screen is selected after load.

In the future, we may want to allow users to select disabled screens, but have the screen content be just a text area that explains why it's not enabled for that app.
