### PR TITLE
Trim private mixins from class names.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -89,7 +89,7 @@ class CpuProfileProtocol {
         firstAmpersandIndex < firstPeriodIndex &&
         name.length > firstAmpersandIndex + 1) {
       final nextCharCodeUnit = name[firstAmpersandIndex + 1].codeUnitAt(0);
-      if (isLetter(nextCharCodeUnit)) {
+      if (isLetter(nextCharCodeUnit) || nextCharCodeUnit == '_'.codeUnitAt(0)) {
         return name.substring(0, firstAmpersandIndex) +
             name.substring(firstPeriodIndex);
       }

--- a/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_protocol.dart
@@ -1,8 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'package:meta/meta.dart';
-
 import '../utils.dart';
 import 'cpu_profile_model.dart';
 
@@ -71,30 +69,5 @@ class CpuProfileProtocol {
       );
       cpuProfileData.stackFrames[leafId]?.exclusiveSampleCount++;
     }
-  }
-
-  /// Returns a simplified version of a StackFrame name.
-  ///
-  /// Given an input such as
-  /// "_WidgetsFlutterBinding&BindingBase&GestureBinding.handleBeginFrame", this
-  /// method will strip off all the Mixin names and return
-  /// "_WidgetsFlutterBinding.handleBeginFrame".
-  @visibleForTesting
-  String getSimpleStackFrameName(String name) {
-    final firstAmpersandIndex = name.indexOf('&');
-    final firstPeriodIndex = name.indexOf('.');
-
-    if (firstAmpersandIndex != -1 &&
-        firstPeriodIndex != -1 &&
-        firstAmpersandIndex < firstPeriodIndex &&
-        name.length > firstAmpersandIndex + 1) {
-      final nextCharCodeUnit = name[firstAmpersandIndex + 1].codeUnitAt(0);
-      if (isLetter(nextCharCodeUnit) || nextCharCodeUnit == '_'.codeUnitAt(0)) {
-        return name.substring(0, firstAmpersandIndex) +
-            name.substring(firstPeriodIndex);
-      }
-    }
-
-    return name;
   }
 }

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -147,6 +147,30 @@ String longestFittingSubstring(
 bool isLetter(int codeUnit) =>
     (codeUnit >= 65 && codeUnit <= 90) || (codeUnit >= 97 && codeUnit <= 122);
 
+/// Returns a simplified version of a StackFrame name.
+///
+/// Given an input such as
+/// "_WidgetsFlutterBinding&BindingBase&GestureBinding.handleBeginFrame", this
+/// method will strip off all the Mixin names and return
+/// "_WidgetsFlutterBinding.handleBeginFrame".
+String getSimpleStackFrameName(String name) {
+  final firstAmpersandIndex = name.indexOf('&');
+  final firstPeriodIndex = name.indexOf('.');
+
+  if (firstAmpersandIndex != -1 &&
+      firstPeriodIndex != -1 &&
+      firstAmpersandIndex < firstPeriodIndex &&
+      name.length > firstAmpersandIndex + 1) {
+    final nextCharCodeUnit = name[firstAmpersandIndex + 1].codeUnitAt(0);
+    if (isLetter(nextCharCodeUnit) || nextCharCodeUnit == '_'.codeUnitAt(0)) {
+      return name.substring(0, firstAmpersandIndex) +
+          name.substring(firstPeriodIndex);
+    }
+  }
+
+  return name;
+}
+
 /// Returns a trimmed vm service uri without any trailing characters.
 ///
 /// For example, given a [value] of http://127.0.0.1:60667/72K34Xmq0X0=/#/vm,

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -150,9 +150,9 @@ bool isLetter(int codeUnit) =>
 /// Returns a simplified version of a StackFrame name.
 ///
 /// Given an input such as
-/// "_WidgetsFlutterBinding&BindingBase&GestureBinding.handleBeginFrame", this
+/// `_WidgetsFlutterBinding&BindingBase&GestureBinding.handleBeginFrame`, this
 /// method will strip off all the Mixin names and return
-/// "_WidgetsFlutterBinding.handleBeginFrame".
+/// `_WidgetsFlutterBinding.handleBeginFrame`.
 String getSimpleStackFrameName(String name) {
   final firstAmpersandIndex = name.indexOf('&');
   final firstPeriodIndex = name.indexOf('.');

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -58,13 +58,20 @@ void main() {
         equals('_WidgetsFlutterBinding.handleBeginFrame.<anonymous closure>'),
       );
 
+      name = '__CompactLinkedHashSet&_HashFieldBase&_HashBase&_OperatorEquals'
+          'AndHashCode&SetMixin.toList';
+      expect(
+        cpuProfileProtocol.getSimpleStackFrameName(name),
+        equals('__CompactLinkedHashSet.toList'),
+      );
+
       // Ampersand and no period.
       name =
           'dart::DartEntry::InvokeFunction(dart::Function const&, dart::Array '
           'const&, dart::Array const&, unsigned long)';
       expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
 
-      // No ampersand and no period.
+      // Period and no ampersand.
       name = '_CustomZone.run';
       expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
     });

--- a/packages/devtools/test/cpu_profile_protocol_test.dart
+++ b/packages/devtools/test/cpu_profile_protocol_test.dart
@@ -39,42 +39,6 @@ void main() {
       // Only run this test if asserts are enabled.
       assert(_runTest());
     });
-
-    test('getSimpleStackFrameName', () {
-      // Ampersand and period cases.
-      String name =
-          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
-          'SchedulerBinding.handleBeginFrame';
-      expect(
-        cpuProfileProtocol.getSimpleStackFrameName(name),
-        equals('_WidgetsFlutterBinding.handleBeginFrame'),
-      );
-
-      name =
-          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
-          'SchedulerBinding.handleBeginFrame.<anonymous closure>';
-      expect(
-        cpuProfileProtocol.getSimpleStackFrameName(name),
-        equals('_WidgetsFlutterBinding.handleBeginFrame.<anonymous closure>'),
-      );
-
-      name = '__CompactLinkedHashSet&_HashFieldBase&_HashBase&_OperatorEquals'
-          'AndHashCode&SetMixin.toList';
-      expect(
-        cpuProfileProtocol.getSimpleStackFrameName(name),
-        equals('__CompactLinkedHashSet.toList'),
-      );
-
-      // Ampersand and no period.
-      name =
-          'dart::DartEntry::InvokeFunction(dart::Function const&, dart::Array '
-          'const&, dart::Array const&, unsigned long)';
-      expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
-
-      // Period and no ampersand.
-      name = '_CustomZone.run';
-      expect(cpuProfileProtocol.getSimpleStackFrameName(name), equals(name));
-    });
   });
 }
 

--- a/packages/devtools/test/utils_test.dart
+++ b/packages/devtools/test/utils_test.dart
@@ -231,6 +231,40 @@ void main() {
       expect(isLetter('z'.codeUnitAt(0)), isTrue);
     });
 
+    test('getSimpleStackFrameName', () {
+      // Ampersand and period cases.
+      String name =
+          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
+          'SchedulerBinding.handleBeginFrame';
+      expect(
+        getSimpleStackFrameName(name),
+        equals('_WidgetsFlutterBinding.handleBeginFrame'),
+      );
+
+      name =
+          '_WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&'
+          'SchedulerBinding.handleBeginFrame.<anonymous closure>';
+      expect(
+        getSimpleStackFrameName(name),
+        equals('_WidgetsFlutterBinding.handleBeginFrame.<anonymous closure>'),
+      );
+
+      name = '__CompactLinkedHashSet&_HashFieldBase&_HashBase&_OperatorEquals'
+          'AndHashCode&SetMixin.toList';
+      expect(getSimpleStackFrameName(name),
+          equals('__CompactLinkedHashSet.toList'));
+
+      // Ampersand and no period.
+      name =
+          'dart::DartEntry::InvokeFunction(dart::Function const&, dart::Array '
+          'const&, dart::Array const&, unsigned long)';
+      expect(getSimpleStackFrameName(name), equals(name));
+
+      // Period and no ampersand.
+      name = '_CustomZone.run';
+      expect(getSimpleStackFrameName(name), equals(name));
+    });
+
     test('getTrimmedUri', () {
       expect(
         getTrimmedUri('http://127.0.0.1:60667/72K34Xmq0X0=/#/vm').toString(),


### PR DESCRIPTION
Fixes a bug where we were not trimming mixins from the class names if they were private.

Before:
`__CompactLinkedHashSet&_HashFieldBase&_HashBase&_OperatorEqualsAndHashCode&SetMixin.toList` --> unchanged

After:
`__CompactLinkedHashSet&_HashFieldBase&_HashBase&_OperatorEqualsAndHashCode&SetMixin.toList` --> `__CompactLinkedHashSet.toList`