### PR TITLE
Bump vm_service_lib and use public methods.

### DIFF
--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -413,13 +413,13 @@ class MemoryScreen extends Screen with SetStateMixin {
         return value.name;
       }
 
-      final Instance ref = value;
+      final InstanceRef ref = value;
 
       if (ref.valueAsString != null && !ref.valueAsStringIsTruncated) {
         return ref.valueAsString;
       } else {
         final dynamic result = await serviceManager.service.invoke(
-          _debuggerState.isolateRef.id,
+          _debuggerState.isolateRef?.id,
           ref.id,
           'toString',
           <String>[],

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -60,7 +60,7 @@ class TimelineService {
     await serviceManager.service.clearVMTimeline();
 
     final Timeline timeline =
-        await serviceManager.service.getVMTimeline(null, null);
+        await serviceManager.service.getVMTimeline();
     final List<dynamic> list = timeline.json['traceEvents'];
     final List<Map<String, dynamic>> traceEvents =
         list.cast<Map<String, dynamic>>();

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -59,8 +59,7 @@ class TimelineService {
         .setVMTimelineFlags(<String>['GC', 'Dart', 'Embedder']);
     await serviceManager.service.clearVMTimeline();
 
-    final Timeline timeline =
-        await serviceManager.service.getVMTimeline();
+    final Timeline timeline = await serviceManager.service.getVMTimeline();
     final List<dynamic> list = timeline.json['traceEvents'];
     final List<Map<String, dynamic>> traceEvents =
         list.cast<Map<String, dynamic>>();

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -59,8 +59,9 @@ class TimelineService {
         .setVMTimelineFlags(<String>['GC', 'Dart', 'Embedder']);
     await serviceManager.service.clearVMTimeline();
 
-    final Response response = await serviceManager.service.getVMTimeline();
-    final List<dynamic> list = response.json['traceEvents'];
+    final Timeline timeline =
+        await serviceManager.service.getVMTimeline(null, null);
+    final List<dynamic> list = timeline.json['traceEvents'];
     final List<Map<String, dynamic>> traceEvents =
         list.cast<Map<String, dynamic>>();
 

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -517,7 +517,6 @@ class VmServiceWrapper implements VmService {
     @required int minor,
   }) async {
     _protocolVersion ??= await getVersion();
-    print(_protocolVersion);
     return protocolVersionLessThan(major: major, minor: minor);
   }
 

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -287,8 +287,10 @@ class VmServiceWrapper implements VmService {
   Future<VM> getVM() => _trackFuture('getVM', _vmService.getVM());
 
   @override
-  Future<Timeline> getVMTimeline(
-      int timeOriginMicros, int timeExtentMicros) async {
+  Future<Timeline> getVMTimeline({
+    int timeOriginMicros,
+    int timeExtentMicros,
+  }) async {
     if (await isProtocolVersionLessThan(major: 3, minor: 19)) {
       final Response response =
           await _trackFuture('getVMTimeline', callMethod('_getVMTimeline'));
@@ -296,7 +298,10 @@ class VmServiceWrapper implements VmService {
     }
     return _trackFuture(
       'getVMTimeline',
-      _vmService.getVMTimeline(timeOriginMicros, timeExtentMicros),
+      _vmService.getVMTimeline(
+        timeOriginMicros: timeOriginMicros,
+        timeExtentMicros: timeExtentMicros,
+      ),
     );
   }
 

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   rxdart: ^0.21.0
-  vm_service_lib: ^3.17.0+1
+  vm_service_lib: ^3.20.0+1
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   rxdart: ^0.21.0
-  vm_service_lib: ^3.20.0+1
+  vm_service_lib: ^3.20.0+2
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1


### PR DESCRIPTION
Consume public apis made available in 3.18, 3.19, 3.20 VM Service protocol versions. This will also fix the broken build for dart:latest.

cc @devoncarew 