### PR TITLE
Fix stack frame id bug on Android.

### DIFF
--- a/packages/devtools/lib/src/timeline/cpu_profile_model.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_model.dart
@@ -58,7 +58,7 @@ class CpuProfileData {
 
     // Use a SplayTreeMap so that map iteration will be in sorted key order.
     final SplayTreeMap<String, Map<String, dynamic>> subStackFramesJson =
-        SplayTreeMap(_stackFrameIdCompare);
+        SplayTreeMap(stackFrameIdCompare);
     for (Map<String, dynamic> traceEvent in subTraceEvents) {
       // Add leaf frame.
       final String leafId = traceEvent[stackFrameIdKey];
@@ -265,7 +265,8 @@ class CpuStackFrame extends TreeNode<CpuStackFrame> {
   }
 }
 
-int _stackFrameIdCompare(String a, String b) {
+@visibleForTesting
+int stackFrameIdCompare(String a, String b) {
   // Stack frame ids are structured as 140225212960768-24 (iOS) or -784070656-24
   // (Android). We need to compare the number after the last dash to maintain
   // the correct order.

--- a/packages/devtools/lib/src/timeline/cpu_profile_model.dart
+++ b/packages/devtools/lib/src/timeline/cpu_profile_model.dart
@@ -266,11 +266,12 @@ class CpuStackFrame extends TreeNode<CpuStackFrame> {
 }
 
 int _stackFrameIdCompare(String a, String b) {
-  // Stack frame ids are structured as "140225212960768-24". We need to compare
-  // the number after the dash to maintain the correct order.
+  // Stack frame ids are structured as 140225212960768-24 (iOS) or -784070656-24
+  // (Android). We need to compare the number after the last dash to maintain
+  // the correct order.
   const dash = '-';
-  final aDashIndex = a.indexOf(dash);
-  final bDashIndex = b.indexOf(dash);
+  final aDashIndex = a.lastIndexOf(dash);
+  final bDashIndex = b.lastIndexOf(dash);
   try {
     final int aId = int.parse(a.substring(aDashIndex + 1));
     final int bId = int.parse(b.substring(bDashIndex + 1));

--- a/packages/devtools/test/cpu_profile_model_test.dart
+++ b/packages/devtools/test/cpu_profile_model_test.dart
@@ -48,6 +48,20 @@ void main() {
     test('to json', () {
       expect(cpuProfileData.json, equals(goldenCpuProfileDataJson));
     });
+
+    test('stackFrameIdCompare', () {
+      // iOS
+      String idA = '140225212960768-2';
+      String idB = '140225212960768-10';
+      expect(idA.compareTo(idB), equals(1));
+      expect(stackFrameIdCompare(idA, idB), equals(-1));
+
+      // Android
+      idA = '-784070656-2';
+      idB = '-784070656-10';
+      expect(idA.compareTo(idB), equals(1));
+      expect(stackFrameIdCompare(idA, idB), equals(-1));
+    });
   });
 
   group('CpuStackFrame', () {


### PR DESCRIPTION
Android stack frame ids are structured slightly different than iOS stack frame ids (they have a leading dash). Look for last dash index instead of first in stack frame id comparator.