### PR TITLE
Move timeline / cpu profiler colors to separate file for sharing.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -6,6 +6,7 @@ import 'dart:html' as html;
 import 'package:js/js.dart';
 
 import '../globals.dart';
+import '../ui/colors.dart';
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
@@ -18,7 +19,6 @@ import 'cpu_profile_tables.dart';
 import 'cpu_profiler_view.dart';
 import 'frame_events_chart.dart';
 import 'timeline_controller.dart';
-import 'timeline_screen.dart';
 
 class EventDetails extends CoreElement {
   EventDetails(this.timelineController) : super('div') {

--- a/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
+++ b/packages/devtools/lib/src/timeline/flame_chart_canvas.dart
@@ -9,6 +9,7 @@ import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
 
+import '../ui/colors.dart';
 import '../ui/drag_scroll.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/fake_flutter.dart';
@@ -17,8 +18,6 @@ import '../ui/theme.dart';
 import '../ui/viewport_canvas.dart';
 import '../utils.dart';
 import 'cpu_profile_model.dart';
-import 'frame_events_chart.dart';
-import 'timeline_screen.dart';
 
 // TODO(kenzie): add tooltips to stack frames on hover.
 

--- a/packages/devtools/lib/src/timeline/frame_events_chart.dart
+++ b/packages/devtools/lib/src/timeline/frame_events_chart.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'package:meta/meta.dart';
 
 import '../ui/analytics.dart' as ga;
+import '../ui/colors.dart';
 import '../ui/drag_scroll.dart';
 import '../ui/elements.dart';
 import '../ui/fake_flutter/dart_ui/dart_ui.dart';
@@ -16,28 +17,8 @@ import '../ui/theme.dart';
 import '../utils.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
-import 'timeline_screen.dart';
 
 // TODO(kenzie): port all of this code to use flame_chart_canvas.dart.
-
-// Light Blue 50: 200-400 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-// Blue Material Dark: 200-400 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
-final uiColorPalette = [
-  const ThemedColor(mainUiColorLight, mainUiColorDark),
-  const ThemedColor(Color(0xFF4FC3F7), Color(0xFF8AB4F7)),
-  const ThemedColor(Color(0xFF29B6F6), Color(0xFF669CF6)),
-];
-
-// Light Blue 50: 700-900 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-// Blue Material Dark: 500-700 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
-final gpuColorPalette = [
-  const ThemedColor(mainGpuColorLight, mainGpuColorDark),
-  const ThemedColor(Color(0xFF0277BD), Color(0xFF1966D2)),
-  const ThemedColor(Color(0xFF01579B), Color(0xFF1859BD)),
-];
-
-const selectedFlameChartItemColor =
-    ThemedColor(mainUiColorSelectedLight, mainUiColorSelectedLight);
 
 final StreamController<FrameFlameChartItem>
     _selectedFrameFlameChartItemController =

--- a/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_plotly.dart
@@ -4,7 +4,7 @@
 
 import 'package:js/js_util.dart';
 
-import '../timeline/timeline_screen.dart';
+import '../ui/colors.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/plotly.dart';
 import '../ui/theme.dart';

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -11,7 +11,6 @@ import '../globals.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
-import '../ui/fake_flutter/dart_ui/dart_ui.dart';
 import '../ui/icons.dart';
 import '../ui/material_icons.dart';
 import '../ui/primer.dart';
@@ -23,39 +22,6 @@ import 'frames_bar_chart.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
 import 'timeline_protocol.dart';
-
-// Light mode is Light Blue 50 palette and Dark mode is Blue 50 palette.
-// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
-const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
-const mainUiColorSelectedLight = Color(0xFFD4D7DA); // Lighter grey.
-
-const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
-const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
-
-const mainUiColorDark = Color(0xFF9EBEF9); // Blue 200 Material Dark
-const mainUiColorSelectedDark = Colors.white;
-
-const mainGpuColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
-const mainGpuColorSelectedDark = Color(0xFFC9C9C9); // Grey.
-
-const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);
-const mainGpuColor = ThemedColor(mainGpuColorLight, mainGpuColorDark);
-
-const Color selectedUiColor =
-    ThemedColor(mainUiColorSelectedLight, mainUiColorSelectedDark);
-const Color selectedGpuColor =
-    ThemedColor(mainGpuColorSelectedLight, mainGpuColorSelectedDark);
-
-// Light is Red @ .2 opacity, Dark is Red 200 Material Dark @ .2 opacity.
-const Color jankGlowInside = ThemedColor(Color(0x66FF0000), Color(0x66F29C99));
-// Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
-const Color jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C));
-
-// Red 50 - 400 is light at 1/2 opacity, Dark Red 500 Material Dark.
-const Color highwater16msColor = mainUiColorSelectedLight;
-
-const Color hoverTextHighContrastColor = Colors.white;
-const Color hoverTextColor = Colors.black;
 
 // TODO(devoncarew): show the Skia picture (gpu drawing commands) for a frame
 

--- a/packages/devtools/lib/src/ui/colors.dart
+++ b/packages/devtools/lib/src/ui/colors.dart
@@ -1,4 +1,4 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
+// Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools/lib/src/ui/colors.dart
+++ b/packages/devtools/lib/src/ui/colors.dart
@@ -1,0 +1,71 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'fake_flutter/dart_ui/dart_ui.dart';
+import 'theme.dart';
+
+/// This file holds color constants that are used throughout DevTools.
+// TODO(kenzie): move colors from other pages to this file for consistency.
+
+/// Mark: Timeline / CPU profiler.
+///
+/// Light mode is Light Blue 50 palette and Dark mode is Blue 50 palette.
+/// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);
+const mainGpuColor = ThemedColor(mainGpuColorLight, mainGpuColorDark);
+
+const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
+const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
+
+const mainUiColorSelectedLight = Color(0xFFD4D7DA); // Lighter grey.
+const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
+
+const mainUiColorDark = Color(0xFF9EBEF9); // Blue 200 Material Dark
+const mainGpuColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
+
+const mainUiColorSelectedDark = Colors.white;
+const mainGpuColorSelectedDark = Color(0xFFC9C9C9); // Grey.
+
+const Color selectedUiColor = ThemedColor(
+  mainUiColorSelectedLight,
+  mainUiColorSelectedDark,
+);
+const Color selectedGpuColor = ThemedColor(
+  mainGpuColorSelectedLight,
+  mainGpuColorSelectedDark,
+);
+
+// Light Blue 50: 200-400 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Blue Material Dark: 200-400 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
+final uiColorPalette = [
+  const ThemedColor(mainUiColorLight, mainUiColorDark),
+  const ThemedColor(Color(0xFF4FC3F7), Color(0xFF8AB4F7)),
+  const ThemedColor(Color(0xFF29B6F6), Color(0xFF669CF6)),
+];
+
+// Light Blue 50: 700-900 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
+// Blue Material Dark: 500-700 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
+final gpuColorPalette = [
+  const ThemedColor(mainGpuColorLight, mainGpuColorDark),
+  const ThemedColor(Color(0xFF0277BD), Color(0xFF1966D2)),
+  const ThemedColor(Color(0xFF01579B), Color(0xFF1859BD)),
+];
+
+const selectedFlameChartItemColor = ThemedColor(
+  mainUiColorSelectedLight,
+  mainUiColorSelectedLight,
+);
+
+// Light is Red @ .2 opacity, Dark is Red 200 Material Dark @ .2 opacity.
+const Color jankGlowInside = ThemedColor(Color(0x66FF0000), Color(0x66F29C99),);
+
+// Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
+const Color jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C),);
+
+// Red 50 - 400 is light at 1/2 opacity, Dark Red 500 Material Dark.
+const Color highwater16msColor = mainUiColorSelectedLight;
+
+const Color hoverTextHighContrastColor = Colors.white;
+
+const Color hoverTextColor = Colors.black;

--- a/packages/devtools/lib/src/ui/colors.dart
+++ b/packages/devtools/lib/src/ui/colors.dart
@@ -58,10 +58,16 @@ const selectedFlameChartItemColor = ThemedColor(
 );
 
 // Light is Red @ .2 opacity, Dark is Red 200 Material Dark @ .2 opacity.
-const Color jankGlowInside = ThemedColor(Color(0x66FF0000), Color(0x66F29C99),);
+const Color jankGlowInside = ThemedColor(
+  Color(0x66FF0000),
+  Color(0x66F29C99),
+);
 
 // Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
-const Color jankGlowEdge = ThemedColor(Color(0x80FF0000), Color(0x99CE191C),);
+const Color jankGlowEdge = ThemedColor(
+  Color(0x80FF0000),
+  Color(0x99CE191C),
+);
 
 // Red 50 - 400 is light at 1/2 opacity, Dark Red 500 Material Dark.
 const Color highwater16msColor = mainUiColorSelectedLight;


### PR DESCRIPTION
Move timeline and cpu profiler colors to a separate file. This is in preparation to share cpu profiler UI (and the respective colors) between the timeline page and the performance page.

A nice cleanup for the future would be to move colors from other pages to this file so that we eliminate any repetition and make sharing easier.