### PR TITLE
Wait for app to be fully ready at test startup

### DIFF
--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -127,7 +127,8 @@ class PerfToolFramework extends Framework {
   }
 
   void initTestingModel() {
-    App.register(this);
+    final app = App.register(this);
+    screensReady.future.then(app.devToolsReady);
   }
 
   void disableAppWithError(String title, [dynamic error]) {

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -22,6 +22,7 @@ import '../main.dart';
 
 class App {
   App(this.framework) {
+    _register<void>('devToolsReady', devToolsReady);
     _register<void>('echo', echo);
     _register<void>('switchPage', switchPage);
     _register<String>('currentPageId', currentPageId);
@@ -54,9 +55,8 @@ class App {
         'debugger.getConsoleContents', debuggerGetConsoleContents);
   }
 
-  static void register(PerfToolFramework framework) {
-    final App app = App(framework);
-    app._bind();
+  static App register(PerfToolFramework framework) {
+    return App(framework).._bind();
   }
 
   final PerfToolFramework framework;
@@ -77,6 +77,10 @@ class App {
     };
 
     js.context['devtools'] = binding;
+  }
+
+  Future<void> devToolsReady(dynamic message) async {
+    _sendNotification('app.devToolsReady', message);
   }
 
   Future<void> echo(dynamic message) async {

--- a/packages/devtools/test/integration_tests/app.dart
+++ b/packages/devtools/test/integration_tests/app.dart
@@ -36,7 +36,8 @@ void appTests() {
     final Uri baseAppUri = webdevFixture.baseUri.resolve('index.html');
     final DevtoolsManager tools =
         DevtoolsManager(tabInstance, webdevFixture.baseUri);
-    await tools.start(appFixture, overrideUri: baseAppUri);
+    await tools.start(appFixture,
+        overrideUri: baseAppUri, waitForConnection: false);
 
     final ConnectDialogManager connectDialog = ConnectDialogManager(tools);
 

--- a/packages/devtools/test/integration_tests/app.dart
+++ b/packages/devtools/test/integration_tests/app.dart
@@ -36,8 +36,11 @@ void appTests() {
     final Uri baseAppUri = webdevFixture.baseUri.resolve('index.html');
     final DevtoolsManager tools =
         DevtoolsManager(tabInstance, webdevFixture.baseUri);
-    await tools.start(appFixture,
-        overrideUri: baseAppUri, waitForConnection: false);
+    await tools.start(
+      appFixture,
+      overrideUri: baseAppUri,
+      waitForConnection: false,
+    );
 
     final ConnectDialogManager connectDialog = ConnectDialogManager(tools);
 


### PR DESCRIPTION
We seem to have some race conditions (eg. ex "page logging cannot be found") that I believe are related to this code:

https://github.com/flutter/devtools/blob/00a363b9699b07dd52c34e394b42a73341d512d9/packages/devtools/test/integration_tests/integration.dart#L52-L62

The first line doesn't wait for the app to initialise, but only load (eg. bind the `devtools` object in the JS). However some tests require the app to be loaded and connected (for ex. we need to switch screens, which means we need to have a connection since screens loaded conditionally based on the connected app type).

The `delay()` was a simple fix, but apparently Travis Windows is too slow.

This change causes us to send an event after we've connected and added screens (`app.devToolsReady`) and now we wait for that.

There's on test that checks the connection dialog (so can't wait for the connection) so there's a flag to opt-out. I did consider a separate method to wait on, but it's important we start listening for the event before waiting for the browser channel, so it would be more verbose in each test than the flag (you'd have to get the future first, then await it after).