### PR TITLE
Documentation fixes.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -47,15 +47,7 @@ Keep note of this uri, as you will use it to connect your app to DevTools.
 
 ## Opening DevTools and connecting to the target app
 
-Using DevTools now is as simple as opening a Chrome browser window. You can either open
-`http://localhost:9100` in Chrome, or run:
-
-```
-open http://localhost:9100
-```
-
-from the command line.
-
+Using DevTools now is as simple as opening a Chrome browser window to `http://localhost:9100`.
 Once DevTools opens, you will see a connect dialog:
 
 <img src="images/connect_dialog.png" width="600" />

--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -84,7 +84,7 @@ should be viewed as a top-down stack trace, where the top-most stack frame calls
 stack frame represents the amount of time it consumed the CPU. Stack frames that consume a lot of CPU time may be a good
 place to look for possible performance improvements.
 
-<img src="images/cpu_profile_flame_chart.png" width="800" />
+<img src="images/cpu_profiler_flame_chart.png" width="800" />
 
 ### Call Tree
 
@@ -95,7 +95,7 @@ meaning a method can be expanded to show its _callees_.
 - **Method**: name of the called method
 - **Source**: file path for the method call site
 
-<img src="images/cpu_profile_call_tree.png" width="800" />
+<img src="images/cpu_profiler_call_tree.png" width="800" />
 
 ### Bottom Up
 
@@ -112,7 +112,7 @@ is the self time of the callee when being called by the caller. Using the exampl
 - **Method**: name of the called method
 - **Source**: file path for the method call site
 
-<img src="images/cpu_profile_bottom_up.png" width="800" />
+<img src="images/cpu_profiler_bottom_up.png" width="800" />
 
 ## Import and Export
 


### PR DESCRIPTION
- Fix broken images in timeline docs.
- Remove `open <url>` instructions that do not work on Windows and will open the default browser (which is an issue if the default is not Chrome).
@sfshaza2 