### PR TITLE
Updated CLI about needing to update webdev.

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,6 +23,7 @@ Next, run the local web server, which serves the DevTools application itself.
 To do that, run one of the following two commands:
 
 - `pub global run devtools` (if you have `pub` on your path)
+- `pub global activate webdev` (webdev may need to be updated too)
 
 - `flutter pub global run devtools` (if you have `flutter` on your path)
 


### PR DESCRIPTION
Update doc, command line running of webdev serve for DevTools may require webdev to be globally activated.