### PR TITLE
Remove focus border for data inspector and add ide_launched dimension.

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.css
+++ b/packages/devtools/lib/src/debugger/debugger.css
@@ -51,6 +51,10 @@
     cursor: pointer;
 }
 
+.debugger-items-list:focus {
+    outline: none;
+}
+
 .open-popup {
     z-index: 1000;
     position: absolute;

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -913,10 +913,23 @@ class MemoryScreen extends Screen with SetStateMixin {
         bool owningAllocatorIsAbstract,
       ) async {
         // Callback function to build each item in the hover card.
+        final classAllocation = owningAllocatorIsAbstract
+            ? 'allocation-abstract allocated-by-class'
+            : 'allocated-by-class';
+
+        final fieldAllocation =
+            owningAllocatorIsAbstract ? 'allocation-abstract ref-by' : 'ref-by';
+
         final CoreElement liElem = li(c: 'allocation-li')
           ..add([
-            span(text: 'class $owningAllocator', c: 'allocated-by-class'),
-            span(text: 'field $referenceName', c: 'ref-by')
+            span(
+              text: 'class $owningAllocator',
+              c: classAllocation,
+            ),
+            span(
+              text: 'field $referenceName',
+              c: fieldAllocation,
+            ),
           ]);
         if (owningAllocatorIsAbstract) {
           // Mark as grayed/italic

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -79,9 +79,7 @@ class App {
     js.context['devtools'] = binding;
   }
 
-  Future<void> devToolsReady(dynamic message) async {
-    _sendNotification('app.devToolsReady', message);
-  }
+  Future<void> devToolsReady(dynamic message) async {}
 
   Future<void> echo(dynamic message) async {
     _sendNotification('app.echo', message);

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -245,7 +245,8 @@ class App {
     if (params != null) {
       map['params'] = params;
     }
-    print('[${jsonEncode(map)}]');
+    // TODO(terry): Shouldn't print to console by default.
+    // print('[${jsonEncode(map)}]');
   }
 
   void _sendResponseResult(int id, [dynamic result]) {
@@ -255,7 +256,8 @@ class App {
     if (result != null) {
       map['result'] = result;
     }
-    print('[${jsonEncode(map)}]');
+    // TODO(terry): Shouldn't print to console by default.
+    // print('[${jsonEncode(map)}]');
   }
 
   void _sendReponseError(int id, dynamic error, StackTrace stackTrace) {
@@ -266,6 +268,7 @@ class App {
         'stackTrace': stackTrace.toString(),
       },
     };
+    // TODO(terry): Better error message to user and log to GA too?
     print('[${jsonEncode(map)}]');
   }
 

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -246,7 +246,7 @@ class App {
       map['params'] = params;
     }
     // TODO(terry): Shouldn't print to console by default.
-    // print('[${jsonEncode(map)}]');
+    print('[${jsonEncode(map)}]');
   }
 
   void _sendResponseResult(int id, [dynamic result]) {
@@ -257,7 +257,7 @@ class App {
       map['result'] = result;
     }
     // TODO(terry): Shouldn't print to console by default.
-    // print('[${jsonEncode(map)}]');
+    print('[${jsonEncode(map)}]');
   }
 
   void _sendReponseError(int id, dynamic error, StackTrace stackTrace) {

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -79,7 +79,9 @@ class App {
     js.context['devtools'] = binding;
   }
 
-  Future<void> devToolsReady(dynamic message) async {}
+  Future<void> devToolsReady(dynamic message) async {
+    _sendNotification('app.devToolsReady', message);
+  }
 
   Future<void> echo(dynamic message) async {
     _sendNotification('app.echo', message);

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -145,15 +145,15 @@ void screen(
   GTag.event(
       screenName,
       GtagEventDevTools(
-          event_category: screenViewEvent,
-          value: value,
-          user_app: userAppType,
-          user_build: userBuildType,
-          user_platform: userPlatformType,
-          devtools_platform: devtoolsPlatformType,
-          devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion,
-          ide_launched: ideLaunched,
+        event_category: screenViewEvent,
+        value: value,
+        user_app: userAppType,
+        user_build: userBuildType,
+        user_platform: userPlatformType,
+        devtools_platform: devtoolsPlatformType,
+        devtools_chrome: devtoolsChrome,
+        devtools_version: devtoolsVersion,
+        ide_launched: ideLaunched,
       ));
 }
 
@@ -165,16 +165,16 @@ void select(
   GTag.event(
       screenName,
       GtagEventDevTools(
-          event_category: selectEvent,
-          event_label: selectedItem,
-          value: value,
-          user_app: userAppType,
-          user_build: userBuildType,
-          user_platform: userPlatformType,
-          devtools_platform: devtoolsPlatformType,
-          devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion,
-          ide_launched: ideLaunched,
+        event_category: selectEvent,
+        event_label: selectedItem,
+        value: value,
+        user_app: userAppType,
+        user_build: userBuildType,
+        user_platform: userPlatformType,
+        devtools_platform: devtoolsPlatformType,
+        devtools_chrome: devtoolsChrome,
+        devtools_version: devtoolsVersion,
+        ide_launched: ideLaunched,
       ));
 }
 
@@ -188,17 +188,17 @@ void selectFrame(
   GTag.event(
       screenName,
       GtagEventDevTools(
-          event_category: selectEvent,
-          event_label: selectedItem,
-          gpu_duration: gpuDuration,
-          ui_duration: uiDuration,
-          user_app: userAppType,
-          user_build: userBuildType,
-          user_platform: userPlatformType,
-          devtools_platform: devtoolsPlatformType,
-          devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion,
-          ide_launched: ideLaunched,
+        event_category: selectEvent,
+        event_label: selectedItem,
+        gpu_duration: gpuDuration,
+        ui_duration: uiDuration,
+        user_app: userAppType,
+        user_build: userBuildType,
+        user_platform: userPlatformType,
+        devtools_platform: devtoolsPlatformType,
+        devtools_chrome: devtoolsChrome,
+        devtools_version: devtoolsVersion,
+        ide_launched: ideLaunched,
       ));
 }
 
@@ -213,15 +213,15 @@ void error(
   _lastGaError = errorMessage;
 
   GTag.exception(GtagExceptionDevTools(
-      description: errorMessage,
-      fatal: fatal,
-      user_app: userAppType,
-      user_build: userBuildType,
-      user_platform: userPlatformType,
-      devtools_platform: devtoolsPlatformType,
-      devtools_chrome: devtoolsChrome,
-      devtools_version: devtoolsVersion,
-      ide_launched: ideLaunched,
+    description: errorMessage,
+    fatal: fatal,
+    user_app: userAppType,
+    user_build: userBuildType,
+    user_platform: userPlatformType,
+    devtools_platform: devtoolsPlatformType,
+    devtools_chrome: devtoolsChrome,
+    devtools_version: devtoolsVersion,
+    ide_launched: ideLaunched,
   ));
 }
 

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -143,18 +143,19 @@ void screen(
   int value = 0,
 ]) {
   GTag.event(
-      screenName,
-      GtagEventDevTools(
-        event_category: screenViewEvent,
-        value: value,
-        user_app: userAppType,
-        user_build: userBuildType,
-        user_platform: userPlatformType,
-        devtools_platform: devtoolsPlatformType,
-        devtools_chrome: devtoolsChrome,
-        devtools_version: devtoolsVersion,
-        ide_launched: ideLaunched,
-      ));
+    screenName,
+    GtagEventDevTools(
+      event_category: screenViewEvent,
+      value: value,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
+      devtools_version: devtoolsVersion,
+      ide_launched: ideLaunched,
+    ),
+  );
 }
 
 void select(
@@ -163,19 +164,20 @@ void select(
   int value = 0,
 ]) {
   GTag.event(
-      screenName,
-      GtagEventDevTools(
-        event_category: selectEvent,
-        event_label: selectedItem,
-        value: value,
-        user_app: userAppType,
-        user_build: userBuildType,
-        user_platform: userPlatformType,
-        devtools_platform: devtoolsPlatformType,
-        devtools_chrome: devtoolsChrome,
-        devtools_version: devtoolsVersion,
-        ide_launched: ideLaunched,
-      ));
+    screenName,
+    GtagEventDevTools(
+      event_category: selectEvent,
+      event_label: selectedItem,
+      value: value,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
+      devtools_version: devtoolsVersion,
+      ide_launched: ideLaunched,
+    ),
+  );
 }
 
 // Used only for Timeline Frame selection.
@@ -186,20 +188,21 @@ void selectFrame(
   int uiDuration, // Custom metric
 ]) {
   GTag.event(
-      screenName,
-      GtagEventDevTools(
-        event_category: selectEvent,
-        event_label: selectedItem,
-        gpu_duration: gpuDuration,
-        ui_duration: uiDuration,
-        user_app: userAppType,
-        user_build: userBuildType,
-        user_platform: userPlatformType,
-        devtools_platform: devtoolsPlatformType,
-        devtools_chrome: devtoolsChrome,
-        devtools_version: devtoolsVersion,
-        ide_launched: ideLaunched,
-      ));
+    screenName,
+    GtagEventDevTools(
+      event_category: selectEvent,
+      event_label: selectedItem,
+      gpu_duration: gpuDuration,
+      ui_duration: uiDuration,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
+      devtools_version: devtoolsVersion,
+      ide_launched: ideLaunched,
+    ),
+  );
 }
 
 String _lastGaError;
@@ -212,17 +215,19 @@ void error(
   if (_lastGaError == errorMessage) return;
   _lastGaError = errorMessage;
 
-  GTag.exception(GtagExceptionDevTools(
-    description: errorMessage,
-    fatal: fatal,
-    user_app: userAppType,
-    user_build: userBuildType,
-    user_platform: userPlatformType,
-    devtools_platform: devtoolsPlatformType,
-    devtools_chrome: devtoolsChrome,
-    devtools_version: devtoolsVersion,
-    ide_launched: ideLaunched,
-  ));
+  GTag.exception(
+    GtagExceptionDevTools(
+      description: errorMessage,
+      fatal: fatal,
+      user_app: userAppType,
+      user_build: userBuildType,
+      user_platform: userPlatformType,
+      devtools_platform: devtoolsPlatformType,
+      devtools_chrome: devtoolsChrome,
+      devtools_version: devtoolsVersion,
+      ide_launched: ideLaunched,
+    ),
+  );
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/devtools/lib/src/ui/analytics.dart
+++ b/packages/devtools/lib/src/ui/analytics.dart
@@ -43,6 +43,10 @@ const String devToolsChromeIos = 'Crios/'; // starts with and ends with n.n.n
 const String devToolsChromeOS = 'CrOS'; // Chrome OS
 // Dimension6 devToolsVersion
 
+// Dimension7 ideLaunched
+const String ideLaunchedQuery = 'ide'; // '&ide=' query parameter
+const String ideLaunchedCLI = 'CLI'; // Command Line Interface
+
 @JS('gtagsEnabled')
 external bool isGtagsEnabled();
 
@@ -66,6 +70,7 @@ class GtagEventDevTools extends GtagEvent {
     String devtools_platform, // dimension4 linux/android/mac/windows
     String devtools_chrome, // dimension5 Chrome version #
     String devtools_version, // dimension6 DevTools version #
+    String ide_launched, // dimension7 Devtools launched (CLI, VSCode, Android)
 
     int gpu_duration,
     int ui_duration,
@@ -96,6 +101,7 @@ class GtagEventDevTools extends GtagEvent {
   external String get devtools_platform;
   external String get devtools_chrome;
   external String get devtools_version;
+  external String get ide_launched;
 
   // Custom metrics:
   external int get gpu_duration;
@@ -114,6 +120,7 @@ class GtagExceptionDevTools extends GtagException {
     String devtools_platform, // dimension4 linux/android/mac/windows
     String devtools_chrome, // dimension5 Chrome version #
     String devtools_version, // dimension6 DevTools version #
+    String ide_launched, // dimension7 IDE launched DevTools
   });
 
   @override
@@ -128,6 +135,7 @@ class GtagExceptionDevTools extends GtagException {
   external String get devtools_platform;
   external String get devtools_chrome;
   external String get devtools_version;
+  external String get ide_launched;
 }
 
 void screen(
@@ -144,7 +152,9 @@ void screen(
           user_platform: userPlatformType,
           devtools_platform: devtoolsPlatformType,
           devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion));
+          devtools_version: devtoolsVersion,
+          ide_launched: ideLaunched,
+      ));
 }
 
 void select(
@@ -163,7 +173,9 @@ void select(
           user_platform: userPlatformType,
           devtools_platform: devtoolsPlatformType,
           devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion));
+          devtools_version: devtoolsVersion,
+          ide_launched: ideLaunched,
+      ));
 }
 
 // Used only for Timeline Frame selection.
@@ -185,7 +197,9 @@ void selectFrame(
           user_platform: userPlatformType,
           devtools_platform: devtoolsPlatformType,
           devtools_chrome: devtoolsChrome,
-          devtools_version: devtoolsVersion));
+          devtools_version: devtoolsVersion,
+          ide_launched: ideLaunched,
+      ));
 }
 
 String _lastGaError;
@@ -206,7 +220,9 @@ void error(
       user_platform: userPlatformType,
       devtools_platform: devtoolsPlatformType,
       devtools_chrome: devtoolsChrome,
-      devtools_version: devtoolsVersion));
+      devtools_version: devtoolsVersion,
+      ide_launched: ideLaunched,
+  ));
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -223,6 +239,8 @@ String _devtoolsPlatformType =
 String _devtoolsChrome = ''; // dimension5 Chrome/n.n.n  or Crios/n.n.n
 
 const String devtoolsVersion = devtools.version; //dimension6 n.n.n
+
+String _ideLaunched = ''; // dimension7 IDE launched DevTools (VSCode, CLI, ...)
 
 String get userAppType => _userAppType;
 set userAppType(String __userAppType) {
@@ -247,6 +265,11 @@ set devtoolsPlatformType(String __devtoolsPlatformType) {
 String get devtoolsChrome => _devtoolsChrome;
 set devtoolsChrome(String __devtoolsChrome) {
   _devtoolsChrome = __devtoolsChrome;
+}
+
+String get ideLaunched => _ideLaunched;
+set ideLaunched(String __ideLaunched) {
+  _ideLaunched = __ideLaunched;
 }
 
 bool _analyticsComputed = false;

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -69,7 +69,7 @@ void computeDevToolsQueryParams() {
   final ideValue = uri.queryParameters[ga.ideLaunchedQuery];
   if (ideValue != null) {
     ga.ideLaunched = ideValue;
-  };
+  }
 }
 
 bool _computing = false;

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -61,6 +61,16 @@ void computeDevToolsCustomGTagsData() {
   }
 }
 
+// Look at the query parameters '&ide=' and record in GA.
+void computeDevToolsQueryParams() {
+  ga.ideLaunched = ga.ideLaunchedCLI; // Default is Command Line launch.
+  final searchParams = html.UrlSearchParams(html.window.location.search);
+  if (searchParams.has(ga.ideLaunchedQuery)) {
+    // IDE specified use that value.
+    ga.ideLaunched = searchParams.get(ga.ideLaunchedQuery);
+  }
+}
+
 bool _computing = false;
 
 int _stillWaiting = 0;
@@ -101,6 +111,7 @@ void setupDimensions() async {
     // available before first GA event sent.
     await ga.computeUserApplicationCustomGTagData();
     computeDevToolsCustomGTagsData();
+    computeDevToolsQueryParams();
     ga.dimensionsComputed();
   }
 }

--- a/packages/devtools/lib/src/ui/analytics_platform.dart
+++ b/packages/devtools/lib/src/ui/analytics_platform.dart
@@ -64,11 +64,12 @@ void computeDevToolsCustomGTagsData() {
 // Look at the query parameters '&ide=' and record in GA.
 void computeDevToolsQueryParams() {
   ga.ideLaunched = ga.ideLaunchedCLI; // Default is Command Line launch.
-  final searchParams = html.UrlSearchParams(html.window.location.search);
-  if (searchParams.has(ga.ideLaunchedQuery)) {
-    // IDE specified use that value.
-    ga.ideLaunched = searchParams.get(ga.ideLaunchedQuery);
-  }
+
+  final Uri uri = Uri.parse(html.window.location.toString());
+  final ideValue = uri.queryParameters[ga.ideLaunchedQuery];
+  if (ideValue != null) {
+    ga.ideLaunched = ideValue;
+  };
 }
 
 bool _computing = false;

--- a/packages/devtools/web/devtools_analytics.js
+++ b/packages/devtools/web/devtools_analytics.js
@@ -64,6 +64,7 @@ function _initializeGA() {
              dimension4: 'devtools_platform',
              dimension5: 'devtools_chrome',
              dimension6: 'devtools_version',
+             dimension7: 'ide_launched',
 
              // Custom metrics:
              metric1: 'gpu_duration',

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -242,9 +242,13 @@ table th.wide {
     float: right;
 }
 
+.allocation-abstract {
+    text-decoration: line-through;
+    color: var(--dark-shadow-color);
+}
+
 .li-allocation-abstract {
     font-style: italic;
-    color: lightgray;
 }
 
 .alloc-image {
@@ -256,12 +260,12 @@ table th.wide {
 }
 
 .allocation:hover {
-    background-color: lightblue;
+    background-color: var(--selected-background);
     cursor: pointer;
 }
 
 .allocation-hover {
-    background-color: lightblue;;
+    background-color: var(--selected-background);
     cursor: pointer;
     float: right;
 }
@@ -270,9 +274,9 @@ table th.wide {
     display: none;
     height: 25%;
     position: absolute;
-    background-color: white;
+    background-color: var(--default-background);
     color: var(--title);
-    border: 4px solid #eee;
+    border: 4px solid var(--popup-border-color);
     overflow-y: scroll;
     width: 30em;
     z-index: 101; /* Keep hover top-most. */
@@ -289,7 +293,13 @@ table th.wide {
 }
 
 .allocation-li-title {
-    background-color: #eee;
+    background-color: var(--header-background);
+    color: var(--header-color);
+}
+
+.allocation-li {
+    background-color: var(--default-background);
+    color: var(--default-color)
 }
 
 .allocation-li:hover {
@@ -326,13 +336,13 @@ table th.wide {
 
 .history-link {
     text-decoration: underline;
-    color: blue;
+    color: var(--link-color);
     cursor: pointer;
 }
 
 .history-link-last {
     text-decoration: underline;
-    color: blue;
+    color: var(--link-color);
     font-weight: bold;
     cursor: pointer;
 }
@@ -641,6 +651,8 @@ div.tabnav {
     visibility: hidden;
     vertical-align: top;
     height: 2.1em;
+    background-color: var(--default-background);
+    color: var(--default-color);
     width: 20em; /* Matches width of popup-view, see below. */
 }
 


### PR DESCRIPTION
- Don't display border selection for the data inspector used by both debugger and memory views.
- Added `ide_launched` dimension for GA.
- Fixed dark mode theme for find memory popup, allocation/field hover card and memory navigation history links.
- Removed echoing of devToolsReady to console.