### PR TITLE
Use a selector for platform mode (iOS / Android) instead of a button.

### DIFF
--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -88,7 +88,7 @@ class InspectorScreen extends Screen {
           ..display = 'none',
         div()..flex(),
       ]);
-    getServiceExtensionButtons().forEach(buttonSection.add);
+    getServiceExtensionElements().forEach(buttonSection.add);
 
     screenDiv.add(<CoreElement>[
       buttonSection,

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -10,31 +10,72 @@ import 'ui/analytics_constants.dart' as ga;
 import 'ui/icons.dart';
 
 // Each service extension needs to be added to [_extensionDescriptions].
-class ToggleableServiceExtensionDescription<T> {
-  const ToggleableServiceExtensionDescription._({
-    this.extension,
-    this.description,
+class ToggleableServiceExtensionDescription<T>
+    extends ServiceExtensionDescription {
+  ToggleableServiceExtensionDescription._({
+    Icon icon,
+    @required String extension,
+    @required String description,
+    @required T enabledValue,
+    @required T disabledValue,
+    @required String enabledTooltip,
+    @required String disabledTooltip,
+    @required String gaScreenName,
+    @required String gaItem,
+  }) : super(
+          extension: extension,
+          description: description,
+          icon: icon,
+          values: [enabledValue, disabledValue],
+          tooltips: [enabledTooltip, disabledTooltip],
+          gaScreenName: gaScreenName,
+          gaItem: gaItem,
+        );
+
+  static const enabledValueIndex = 0;
+
+  static const disabledValueIndex = 1;
+
+  T get enabledValue => values[enabledValueIndex];
+
+  T get disabledValue => values[disabledValueIndex];
+
+  String get enabledTooltip => tooltips[enabledValueIndex];
+
+  String get disabledTooltip => tooltips[disabledValueIndex];
+}
+
+class ServiceExtensionDescription<T> {
+  ServiceExtensionDescription({
     this.icon,
-    this.enabledValue,
-    this.disabledValue,
-    this.enabledTooltip,
-    this.disabledTooltip,
+    List<String> displayValues,
+    @required this.extension,
+    @required this.description,
+    @required this.values,
+    @required this.tooltips,
     @required this.gaScreenName,
     @required this.gaItem,
-  });
+  }) : displayValues =
+            displayValues ?? values.map((v) => v.toString()).toList();
 
   final String extension;
+
   final String description;
+
   final Icon icon;
-  final T enabledValue;
-  final T disabledValue;
-  final String enabledTooltip;
-  final String disabledTooltip;
+
+  final List<T> values;
+
+  final List<String> displayValues;
+
+  final List<String> tooltips;
+
   final String gaScreenName; // Analytics screen (screen name where item lives).
+
   final String gaItem; // Analytics item name (toggleable item's name).
 }
 
-const debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
+final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugAllowBanner',
   description: 'Debug Banner',
   icon: FlutterIcons.debugBanner,
@@ -46,7 +87,7 @@ const debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.debugBanner,
 );
 
-const debugPaint = ToggleableServiceExtensionDescription<bool>._(
+final debugPaint = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaint',
   description: 'Debug Paint',
   icon: FlutterIcons.debugPaint,
@@ -58,7 +99,7 @@ const debugPaint = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.debugPaint,
 );
 
-const debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
+final debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaintBaselinesEnabled',
   description: 'Paint Baselines',
   icon: FlutterIcons.text,
@@ -70,7 +111,7 @@ const debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.paintBaseline,
 );
 
-const performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
+final performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.showPerformanceOverlay',
   description: 'Performance Overlay',
   icon: FlutterIcons.performanceOverlay,
@@ -82,7 +123,7 @@ const performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.performanceOverlay,
 );
 
-const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
+final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.profileWidgetBuilds',
   description: 'Track Widget Rebuilds',
   icon: FlutterIcons.greyProgr,
@@ -94,7 +135,7 @@ const profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.trackRebuilds,
 );
 
-const repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
+final repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.repaintRainbow',
   description: 'Repaint Rainbow',
   icon: FlutterIcons.repaintRainbow,
@@ -106,7 +147,7 @@ const repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.repaintRainbow,
 );
 
-const slowAnimations = ToggleableServiceExtensionDescription<num>._(
+final slowAnimations = ToggleableServiceExtensionDescription<num>._(
   extension: 'ext.flutter.timeDilation',
   description: 'Slow Animations',
   icon: FlutterIcons.history,
@@ -118,19 +159,18 @@ const slowAnimations = ToggleableServiceExtensionDescription<num>._(
   gaItem: ga.slowAnimation,
 );
 
-const togglePlatformMode = ToggleableServiceExtensionDescription<String>._(
+final togglePlatformMode = ServiceExtensionDescription<String>(
   extension: 'ext.flutter.platformOverride',
-  description: 'iOS',
+  description: 'Override target platform',
   icon: FlutterIcons.phone,
-  enabledValue: 'iOS',
-  disabledValue: 'android',
-  enabledTooltip: 'Toggle iOS Platform',
-  disabledTooltip: 'Toggle iOS Platform',
+  values: ['iOS', 'android', 'fuchsia'],
+  displayValues: ['Platform: iOS', 'Platform: Android', 'Platform: Fuchsia'],
+  tooltips: ['Override target platform'],
   gaScreenName: ga.inspector,
-  gaItem: ga.toggleIoS,
+  gaItem: ga.togglePlatform,
 );
 
-const toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
+final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.show',
   description: 'Select Widget Mode',
   icon: FlutterIcons.locate,
@@ -146,7 +186,7 @@ const toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
 // ServiceExtensionDescription object.
 const String didSendFirstFrameEvent = 'ext.flutter.didSendFirstFrameEvent';
 
-const List<ToggleableServiceExtensionDescription> _extensionDescriptions = [
+final List<ServiceExtensionDescription> _extensionDescriptions = [
   debugPaint,
   debugPaintBaselines,
   repaintRainbow,
@@ -158,8 +198,8 @@ const List<ToggleableServiceExtensionDescription> _extensionDescriptions = [
   slowAnimations,
 ];
 
-final Map<String, ToggleableServiceExtensionDescription>
-    toggleableExtensionsWhitelist = Map.fromIterable(
+final Map<String, ServiceExtensionDescription> serviceExtensionsWhitelist =
+    Map.fromIterable(
   _extensionDescriptions,
   key: (extension) => extension.extension,
   value: (extension) => extension,

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -165,7 +165,7 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
   icon: FlutterIcons.phone,
   values: ['iOS', 'android', 'fuchsia'],
   displayValues: ['Platform: iOS', 'Platform: Android', 'Platform: Fuchsia'],
-  tooltips: ['Override target platform'],
+  tooltips: ['Override Target Platform'],
   gaScreenName: ga.inspector,
   gaItem: ga.togglePlatform,
 );

--- a/packages/devtools/lib/src/ui/analytics_constants.dart
+++ b/packages/devtools/lib/src/ui/analytics_constants.dart
@@ -42,7 +42,7 @@ const String slowAnimation = 'slowAnimation';
 const String repaintRainbow = 'repaintRainbow';
 const String debugBanner = 'debugBanner';
 const String trackRebuilds = 'trackRebuilds';
-const String toggleIoS = 'iOS';
+const String togglePlatform = 'togglePlatform';
 const String selectWidgetMode = 'selectWidgetMode';
 
 // Timeline UX actions:

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -169,10 +169,10 @@ class ServiceExtensionSelector {
   ServiceExtensionSelector(this.extensionDescription) {
     selector = PSelect()
       ..small()
-      ..option(extensionDescription.enabledValue) // Index 0
-      ..option(extensionDescription.disabledValue) // Index 1
       ..clazz('toggle-platform')
       ..change(_handleSelect);
+
+    extensionDescription.displayValues.forEach(selector.option);
 
     final extensionName = extensionDescription.extension;
 
@@ -182,14 +182,10 @@ class ServiceExtensionSelector {
     serviceManager.serviceExtensionManager.hasServiceExtension(
         extensionName, (available) => selector.disabled = !available);
 
-    _selectedValue = selector.value;
+    _updateState();
   }
 
-  static const enabledValueIndex = 0;
-
-  static const disabledValueIndex = 1;
-
-  final ToggleableServiceExtensionDescription extensionDescription;
+  final ServiceExtensionDescription extensionDescription;
 
   PSelect selector;
 
@@ -200,13 +196,13 @@ class ServiceExtensionSelector {
 
     ga.select(extensionDescription.gaScreenName, extensionDescription.gaItem);
 
-    final isEnabled = selector.value == extensionDescription.enabledValue;
+    final extensionValue = extensionDescription
+        .values[extensionDescription.displayValues.indexOf(selector.value)];
+
     serviceManager.serviceExtensionManager.setServiceExtensionState(
       extensionDescription.extension,
-      isEnabled,
-      isEnabled
-          ? extensionDescription.enabledValue
-          : extensionDescription.disabledValue,
+      true,
+      extensionValue,
     );
 
     _selectedValue = selector.value;
@@ -216,9 +212,11 @@ class ServiceExtensionSelector {
     // Select option whose state is already enabled.
     serviceManager.serviceExtensionManager
         .getServiceExtensionState(extensionDescription.extension, (state) {
-      final extensionEnabled = state.value == extensionDescription.enabledValue;
-      selector.selectedIndex =
-          extensionEnabled ? enabledValueIndex : disabledValueIndex;
+      if (state.value != null) {
+        final selectedIndex = extensionDescription.values.indexOf(state.value);
+        selector.selectedIndex = selectedIndex;
+        _selectedValue = extensionDescription.displayValues[selectedIndex];
+      }
     });
   }
 }

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -170,7 +170,9 @@ class ServiceExtensionSelector {
     selector = PSelect()
       ..small()
       ..clazz('toggle-platform')
-      ..change(_handleSelect);
+      ..change(_handleSelect)
+      ..tooltip = extensionDescription.tooltips.first ??
+          extensionDescription.description;
 
     extensionDescription.displayValues.forEach(selector.option);
 

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   rxdart: ^0.22.0
-  vm_service_lib: ^3.21.0
+  vm_service_lib: 3.21.0
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -16,6 +16,7 @@
     --dark-shadow-color: #666;
     --default-background-rgb: 255, 255, 255;
     --default-background: rgba(var(--default-background-rgb), 1);
+    --default-button-text-color: #24292e;
     --default-color-thumb: #888;
     --default-color: #000;
     --disabled-background: #ddd;
@@ -24,6 +25,7 @@
     --footer-color: #7a7a7a;
     --footer-link-hover: #0366d6;
     --footer-strong: #333;
+    --form-select-background: #f9fbfc;
     --header-background: #f3f3f3;
     --header-color: #586069;
     --header-item-rgb: 255, 255, 255;
@@ -743,7 +745,8 @@ div.tabnav-tab {
 }
 
 .form-select.toggle-platform {
-    background-color: #f9fbfc;
+    background-color: var(--form-select-background);
+    color: var(--default-button-text-color);
     display: inline-flex;
     align-items: center;
     height: 30px;

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -742,6 +742,13 @@ div.tabnav-tab {
     border-bottom-left-radius: 0;
 }
 
+.form-select.toggle-platform {
+    background-color: #f9fbfc;
+    display: inline-flex;
+    align-items: center;
+    height: 30px;
+}
+
 /* To truly center an object in its parent, give the object a negative top margin of half its height.
  * See [centered-single-line-message] as an example (where the height of the single line is ~20px). */
 .center-in-parent, .centered-single-line-message {

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -12,6 +12,7 @@
     --dark-shadow-color: #999;
     --default-background-rgb: 32, 33, 36;
     --default-background: rgba(var(--default-background-rgb), 1);
+    --default-button-text-color: #89b5f8;
     --default-color-thumb: #888;
     --default-color: #fff;
     --disabled-background: #555;
@@ -20,6 +21,7 @@
     --footer-color: #858585;
     --footer-link-hover: wheat;
     --footer-strong: #ccc;
+    --form-select-background: #202225;
     --header-background: #282828;
     --header-color: #ccc;
     --header-item-rgb: 255, 255, 255;


### PR DESCRIPTION
Addresses https://github.com/flutter/devtools/issues/763 @sfshaza2

Also regrouped the buttons to put this selector at the far right.

![Screen Shot 2019-07-10 at 2 07 54 PM](https://user-images.githubusercontent.com/43759233/61005042-37144d80-a31c-11e9-88a5-b72541f4c05a.png)
![Screen Shot 2019-07-10 at 2 08 08 PM](https://user-images.githubusercontent.com/43759233/61005047-3976a780-a31c-11e9-8e7e-2dd3a72b934a.png)

@jacob314 