### PR TITLE
prep for the next version of the vm_service_lib

### DIFF
--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -686,7 +686,7 @@ class MemoryScreen extends Screen with SetStateMixin {
         'Problem fetching instances of ${row.classRef.name}: $e',
         title: 'Error',
       );
-      print(st);
+      print('Problem fetching instances of ${row.classRef.name}: $e\n$st');
     }
 
     table.onCellHover.listen(hoverInstanceAllocations);

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -215,7 +215,7 @@ class MemoryScreen extends Screen with SetStateMixin {
       _mouseOutHover(evt);
     });
 
-    history = div(c: 'history-navigation hidden');
+    history = div(c: 'history-navigation section', a: 'hidden');
 
     screenDiv.add(<CoreElement>[
       div(c: 'section')
@@ -241,13 +241,13 @@ class MemoryScreen extends Screen with SetStateMixin {
                 ]),
             ]),
         ]),
-      heapAutoCompletePopup,
-      hoverPopup, // Hover card
       memoryChart = MemoryChart(memoryController)..disabled = true,
       tableContainer = div(c: 'section overflow-auto')
         ..layoutHorizontal()
         ..flex(),
       history,
+      heapAutoCompletePopup,
+      hoverPopup, // Hover card
     ]);
 
     memoryController.onDisconnect.listen((__) {
@@ -332,7 +332,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   void _resetHistory() {
-    history..clazz('history-navigation', removeOthers: true)..clazz('hidden');
+    history.attribute('hidden');
     history.clear();
     memoryPath = NavigationPath();
   }
@@ -513,6 +513,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   final List<String> _knownSnapshotClasses = [];
+
   List<String> getKnownSnapshotClasses() {
     if (_knownSnapshotClasses.isEmpty) {
       final List<ClassHeapDetailStats> classesData = tableStack.first.data;
@@ -680,11 +681,12 @@ class MemoryScreen extends Screen with SetStateMixin {
       ));
 
       table.setRows(instanceRows);
-    } catch (e) {
+    } catch (e, st) {
       framework.toast(
         'Problem fetching instances of ${row.classRef.name}: $e',
         title: 'Error',
       );
+      print(st);
     }
 
     table.onCellHover.listen(hoverInstanceAllocations);
@@ -751,7 +753,7 @@ class MemoryScreen extends Screen with SetStateMixin {
         history.clear();
         memoryPath.displayPathsAsLinks(history, _handleHistoryClicks);
 
-        history..clazz('history-navigation', removeOthers: true);
+        history.hidden(false);
       }
     }
   }
@@ -793,13 +795,13 @@ class MemoryScreen extends Screen with SetStateMixin {
       }
 
       history.clear();
+
       Timer(const Duration(milliseconds: 100), () {
         if (!memoryPath.isLastInBound) {
-          history
-            ..clazz('history-navigation', removeOthers: true)
-            ..clazz('hidden');
+          history.hidden(true);
         } else {
           memoryPath.displayPathsAsLinks(history, _handleHistoryClicks);
+          history.hidden(false);
         }
       });
     }
@@ -1071,7 +1073,9 @@ class MemoryScreen extends Screen with SetStateMixin {
 ///      field [field of parent class that has ref]
 class NavigationState {
   NavigationState._() : _className = '';
+
   NavigationState.classSelect(this._className);
+
   NavigationState.instanceSelect(this._className, this._hashCode);
 
   // data attribute names.
@@ -1090,8 +1094,10 @@ class NavigationState {
 
   bool get isClass =>
       _className.isNotEmpty && field.isEmpty && _hashCode == null;
+
   bool get isInstance =>
       _className.isNotEmpty && field.isEmpty && _hashCode != null;
+
   bool get isInbound =>
       _className.isNotEmpty && field.isNotEmpty && _hashCode != null;
 
@@ -1142,6 +1148,7 @@ class NavigationPath {
   set fieldReference(String field) => _inboundFieldName = field;
 
   bool get isEmpty => _path.isEmpty;
+
   bool get isNotEmpty => _path.isNotEmpty;
 
   void add(NavigationState state) {
@@ -1184,7 +1191,7 @@ class NavigationPath {
     }
   }
 
-  // Last item in path an inBound NavigationState.
+  /// Is the last item in the path an inBound NavigationState.
   bool get isLastInBound => _path.isNotEmpty ? _path.last.isInbound : false;
 
   bool get isLastInstance => _path.isNotEmpty ? _path.last.isInstance : false;

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -332,7 +332,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   }
 
   void _resetHistory() {
-    history.attribute('hidden');
+    history.hidden(true);
     history.clear();
     memoryPath = NavigationPath();
   }

--- a/packages/devtools/lib/src/memory/memory_controller.dart
+++ b/packages/devtools/lib/src/memory/memory_controller.dart
@@ -7,7 +7,6 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../globals.dart';
 import '../vm_service_wrapper.dart';
-
 import 'memory_protocol.dart';
 import 'memory_service.dart';
 
@@ -23,13 +22,16 @@ class MemoryController {
 
   final StreamController<MemoryTracker> _memoryTrackerController =
       StreamController<MemoryTracker>.broadcast();
+
   Stream<MemoryTracker> get onMemory => _memoryTrackerController.stream;
 
   final StreamController<void> _disconnectController =
       StreamController<void>.broadcast();
+
   Stream<void> get onDisconnect => _disconnectController.stream;
 
   MemoryTracker _memoryTracker;
+
   MemoryTracker get memoryTracker => _memoryTracker;
 
   bool get hasStarted => _memoryTracker != null;
@@ -118,7 +120,7 @@ class MemoryController {
 
   // Temporary hack to allow accessing private fields(e.g., _extra) using eval
   // of '_extra.hashCode' to fetch the hashCode of the object of that field.
-  // Used to find the object which allocated/references the object being viewd.
+  // Used to find the object which allocated/references the object being viewed.
   Future<bool> matchObject(
       String objectRef, String fieldName, int instanceHashCode) async {
     final dynamic object = await getObject(objectRef);

--- a/packages/devtools/lib/src/memory/memory_service.dart
+++ b/packages/devtools/lib/src/memory/memory_service.dart
@@ -60,7 +60,8 @@ class InboundReferences extends Response {
 
 class InboundReference extends Response {
   InboundReference._fromJson(Map<String, dynamic> json) {
-    //source = json['source'],
+    //source = json['source']
+    // For vm_service_lib 3.21.1, use ['ObjRef']?
     parentField = createServiceObject(json['parentField']);
     parentListIndex = json['parentListIndex'];
     parentWordOffset = json['_parentWordOffset'];

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   rxdart: ^0.22.0
-  vm_service_lib: ^3.21.0
+  vm_service_lib: 3.21.0
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -323,10 +323,6 @@ table th.wide {
     display: block;
 }
 
-.history-navigation .hidden {
-    display: none;
-}
-
 .history-separator {
     color: gray;
     padding-left: 1em;

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -320,7 +320,6 @@ table th.wide {
 .ref-by { float: right; }
 
 .history-navigation {
-    padding-top: 1.5em;
     display: block;
 }
 

--- a/packages/devtools_server/devtools_server.iml
+++ b/packages/devtools_server/devtools_server.iml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.dart_tool" />
+      <excludeFolder url="file://$MODULE_DIR$/.pub" />
+      <excludeFolder url="file://$MODULE_DIR$/build" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Dart SDK" level="project" />
+    <orderEntry type="library" name="Dart Packages" level="project" />
+  </component>
+</module>


### PR DESCRIPTION
- prep for the next version of the vm_service_lib
- update the memory page with some ws changes

This pegs us to the `3.21.0` version of the vm_service_lib - the next version will return `null`s where we're not expecting them currently, so will need some updating.

@terrylucas, I'm not sure if I got the logic correct wrt when the history panel should be visible or not; can you review this (previously, it wasn't hidden, as the css selectors key off a `hidden` attribute, not a `hidden` class)?

cc @bkonyi - this doesn't update for `3.21.1`, but we'll want to land this first.