### PR TITLE
Do not show Flutter-specific warnings for non-Flutter apps.

### DIFF
--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -38,9 +38,9 @@ class ConnectedApp {
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
 
-    // Flutter web apps do not have profile and non-profile builds. If this
-    // changes in the future, we can remove this check.
-    if (await isFlutterWebApp) return false;
+    // Flutter web apps and CLI apps do not have profile and non-profile builds.
+    // If this changes in the future (flutter web), we can modify this check.
+    if (!await isFlutterApp) return false;
 
     try {
       final Isolate isolate = await serviceManager.service

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -104,6 +104,7 @@ StatusItem createLinkStatusItem(
 Future<void> maybeAddDebugMessage(Framework framework, String screenId) async {
   if (!offlineMode &&
       serviceManager.connectedApp != null &&
+      await serviceManager.connectedApp.isFlutterApp &&
       !await serviceManager.connectedApp.isProfileBuild) {
     framework.showMessage(message: debugWarning, screenId: screenId);
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/784.

We no longer show the debug warning for CLI apps.