### PR TITLE
Pin vm_service_lib in server + prepare release

### DIFF
--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.3
+- vm_service_lib dependency has been pinned to 3.21.0
+
 ## 0.1.2
 - The `launchDevTools` service will now return well-formed errors if it fails to
   launch the browser for any reason.

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -17,5 +17,5 @@ dependencies:
   pedantic: ^1.7.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  vm_service_lib: ^3.15.1+2
+  vm_service_lib: 3.21.0
   webkit_inspection_protocol: ^0.4.0

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.2
+version: 0.1.3
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
Without this, DevTools will take newer versions which might contain breaking changes (see https://github.com/Dart-Code/Dart-Code/issues/1852).