### PR TITLE
ui changes; NPE; logging statements

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -222,6 +222,7 @@ class Framework {
     window.onKeyDown.listen((KeyboardEvent e) {
       if (current != null &&
           e.key.isNotEmpty &&
+          current.shortcutCallback != null &&
           current.shortcutCallback(e.ctrlKey, e.shiftKey, e.altKey, e.key)) {
         e.preventDefault();
       }

--- a/packages/devtools/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profiler.dart
@@ -28,7 +28,6 @@ abstract class CpuProfiler extends CoreElement {
 
     // Hide views that are not the default view.
     for (CpuProfilerView v in views.where((view) => view.type != defaultView)) {
-      print(v.type);
       v.hide();
     }
     _selectedViewType = defaultView;

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -8,6 +8,7 @@ import 'package:split/split.dart' as split;
 
 import '../framework/framework.dart';
 import '../globals.dart';
+import '../service_extensions.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
@@ -89,7 +90,7 @@ class TimelineScreen extends Screen {
           ..disabled = true
           ..click(_resumeRecording);
 
-    exportButton = PButton.icon('', exportIcon)
+    exportButton = PButton.icon('Export', exportIcon)
       ..small()
       ..clazz('margin-left')
       ..setAttribute('title', 'Export timeline')
@@ -121,7 +122,10 @@ class TimelineScreen extends Screen {
         clearButton,
         exitOfflineModeButton,
         div()..flex(),
-        debugButtonSection = div(c: 'btn-group'),
+        debugButtonSection = div(c: 'btn-group')
+          ..add([
+            ServiceExtensionButton(performanceOverlay).button,
+          ]),
         exportButton,
       ]);
 

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -122,7 +122,8 @@ class TimelineScreen extends Screen {
         clearButton,
         exitOfflineModeButton,
         div()..flex(),
-        debugButtonSection = div(c: 'btn-group')
+        debugButtonSection = div(c: 'btn-group'),
+        div(c: 'btn-group')
           ..add([
             ServiceExtensionButton(performanceOverlay).button,
           ]),

--- a/packages/devtools/lib/src/ui/material_icons.dart
+++ b/packages/devtools/lib/src/ui/material_icons.dart
@@ -12,22 +12,12 @@ const Icon clearIcon = MaterialIcon('block', defaultButtonIconColor);
 
 const Icon exitIcon = MaterialIcon('clear', defaultButtonIconColor);
 
-const Icon exportIcon = MaterialIcon(
-  'file_download',
-  defaultButtonIconColor,
-  fontSize: 32,
-  iconWidth: 18,
-);
+const Icon exportIcon = MaterialIcon('file_download', defaultButtonIconColor);
 
-const Icon recordPrimary = MaterialIcon(
-  'fiber_manual_record',
-  defaultPrimaryButtonIconColor,
-);
+const Icon recordPrimary =
+    MaterialIcon('fiber_manual_record', defaultPrimaryButtonIconColor);
 
-const Icon record = MaterialIcon(
-  'fiber_manual_record',
-  defaultButtonIconColor,
-);
+const Icon record = MaterialIcon('fiber_manual_record', defaultButtonIconColor);
 
 const Icon stop = MaterialIcon('stop', defaultButtonIconColor);
 
@@ -52,6 +42,7 @@ class MaterialIcon extends Icon {
 
 class FlutterMaterialIcons {
   FlutterMaterialIcons._();
+
   static final Map<String, MaterialIcon> _iconCache = {};
 
   static Icon getIconForCodePoint(int charCode) {


### PR DESCRIPTION
- fix an NPE on some ketpresses (not all screens have a non-null `shortcutCallback` function)
- remove a print to stdout
- add a label to the `Export` button on the timeline page (and adjust the size of the associated icon on the button)
- also add a toggle performance overlay button to the timeline page

Happy to split out the UI changes from the NPE if desired.

<img width="465" alt="Screen Shot 2019-07-12 at 10 07 12 AM" src="https://user-images.githubusercontent.com/1269969/61185764-d7ff5300-a611-11e9-9ee8-d6a3864b8258.png">
