### PR TITLE
Add tests for server's vm.register method + fix it to use new vm_service_lib with conditions

### DIFF
--- a/packages/devtools/test/fixtures/empty_app.dart
+++ b/packages/devtools/test/fixtures/empty_app.dart
@@ -1,0 +1,12 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+void main() {
+  print('starting empty app');
+
+  // Don't exit until it's indicated we should by the controller.
+  Timer(const Duration(days: 1), () {});
+}

--- a/packages/devtools/test/integration_tests/integration_test.dart
+++ b/packages/devtools/test/integration_tests/integration_test.dart
@@ -19,7 +19,7 @@ void main() {
           Platform.environment['WEBDEV_RELEASE'] == 'true';
 
       webdevFixture =
-          await WebdevFixture.create(release: testInReleaseMode, verbose: true);
+          await WebdevFixture.serve(release: testInReleaseMode, verbose: true);
       browserManager = await BrowserManager.create();
     });
 

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:vm_service_lib/vm_service_lib.dart';
+
+import '../support/cli_test_driver.dart';
+import '../support/devtools_server_driver.dart';
+import 'integration.dart';
+
+void main() {
+  CliAppFixture appFixture;
+  DevToolsServerDriver server;
+
+  setUp(() async {
+    // Build the app, as the server can't start without the build output.
+    await WebdevFixture.build(verbose: true);
+
+    // The packages folder needs to be renamed to `pack` for the server to work.
+    if (await Directory('build/pack').exists()) {
+      await Directory('build/pack').delete(recursive: true);
+    }
+    await Directory('build/packages').rename('build/pack');
+
+    // Start the command-line server.
+    server = await DevToolsServerDriver.create();
+
+    // Start a test app we can use to connect to.
+    appFixture = await CliAppFixture.create('test/fixtures/empty_app.dart');
+  });
+
+  tearDown(() async {
+    server.kill();
+    await appFixture?.teardown();
+    await webdevFixture?.teardown();
+  });
+
+  test('registers service', () async {
+    // Track services as they're registered.
+    final registeredServices = <String>{};
+    // TODO(dantup): Remove this loop and just use
+    // appFixture.serviceConnection.onServiceEvent
+    // directly once the VM Service makes it to stable.
+    for (final serviceId in ['Service', '_Service']) {
+      appFixture.serviceConnection
+          .onEvent(serviceId)
+          .where((e) => e.kind == EventKind.kServiceRegistered)
+          .listen((e) => registeredServices.add(e.service));
+      await appFixture.serviceConnection
+          .streamListen(serviceId)
+          .catchError((e, stack) {
+        // TODO(dantup): Remove this empty catch when removing the loop, as it
+        // will no longer be required. We currently need it because one of the
+        // streams will fail.
+      });
+    }
+
+    server.stderr.listen((text) => throw 'STDERR: $text');
+
+    server.write({
+      'id': '10',
+      'method': 'vm.register',
+      'params': {'uri': appFixture.serviceUri.toString()}
+    });
+
+    // Expect to get a successful response from the server.
+    final serverResponse =
+        await server.output.firstWhere((e) => e['id'] == '10');
+    expect(serverResponse['result']['success'], isTrue);
+
+    // Expect the VM service to see the launchDevTools service registered.
+    expect(registeredServices, contains('launchDevTools'));
+  }, timeout: const Timeout.factor(10));
+}

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -34,7 +34,7 @@ void main() {
   });
 
   tearDown(() async {
-    server.kill();
+    server?.kill();
     await appFixture?.teardown();
     await webdevFixture?.teardown();
   });

--- a/packages/devtools/test/support/devtools_server_driver.dart
+++ b/packages/devtools/test/support/devtools_server_driver.dart
@@ -1,0 +1,50 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+const verbose = true;
+
+class DevToolsServerDriver {
+  DevToolsServerDriver._(
+      this._process, this._stdin, Stream<String> _stdout, this.stderr)
+      : output = _stdout.map((line) {
+          _trace(line);
+          return line;
+        }).map((line) => jsonDecode(line) as Map<String, dynamic>);
+
+  final Process _process;
+  final Stream<Map<String, dynamic>> output;
+  final Stream<String> stderr;
+  final StringSink _stdin;
+
+  void write(Map<String, dynamic> request) {
+    final line = jsonEncode(request);
+    _trace('==> $line');
+    _stdin.writeln(line);
+  }
+
+  static void _trace(String message) {
+    if (verbose) {
+      print(message);
+    }
+  }
+
+  bool kill() => _process.kill();
+
+  static Future<DevToolsServerDriver> create() async {
+    final Process process = await Process.start(
+      Platform.resolvedExecutable,
+      <String>['bin/devtools.dart', '--machine', '--port', '0'],
+    );
+
+    return new DevToolsServerDriver._(
+        process,
+        process.stdin,
+        process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+        process.stderr.transform(utf8.decoder).transform(const LineSplitter()));
+  }
+}

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+- vm_service_lib dependency has been pinned to 3.22.0
+- The `launchDevTools` service will now register with VMs using public APIs when available, falling back to private APIs otherwise.
+
 ## 0.1.3
 - vm_service_lib dependency has been pinned to 3.21.0
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -254,7 +254,12 @@ Future<void> registerLaunchDevToolsService(
       }
     });
 
-    await service.registerService(launchDevToolsService, 'DevTools Server');
+    if (isVersionLessThan(await service.getVersion(), major: 3, minor: 22)) {
+      await service.callMethod('_registerService',
+          args: {'service': launchDevToolsService, 'alias': 'DevTools Server'});
+    } else {
+      await service.registerService(launchDevToolsService, 'DevTools Server');
+    }
 
     printOutput(
       'Successfully registered launchDevTools service',
@@ -274,6 +279,16 @@ Future<void> registerLaunchDevToolsService(
       machineMode: machineMode,
     );
   }
+}
+
+bool isVersionLessThan(
+  Version version, {
+  @required int major,
+  @required int minor,
+}) {
+  assert(version != null);
+  return version.major < major ||
+      (version.major == major && version.minor < minor);
 }
 
 final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -254,12 +254,13 @@ Future<void> registerLaunchDevToolsService(
       }
     });
 
-    if (isVersionLessThan(await service.getVersion(), major: 3, minor: 22)) {
-      await service.callMethod('_registerService',
-          args: {'service': launchDevToolsService, 'alias': 'DevTools Server'});
-    } else {
-      await service.registerService(launchDevToolsService, 'DevTools Server');
-    }
+    // Handle registerService method name change based on protocol version.
+    final registerServiceMethodName =
+        isVersionLessThan(await service.getVersion(), major: 3, minor: 22)
+            ? '_registerService'
+            : 'registerService';
+    await service.callMethod(registerServiceMethodName,
+        args: {'service': launchDevToolsService, 'alias': 'DevTools Server'});
 
     printOutput(
       'Successfully registered launchDevTools service',

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.3
+version: 0.1.4
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
@@ -17,5 +17,5 @@ dependencies:
   pedantic: ^1.7.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  vm_service_lib: 3.21.0
+  vm_service_lib: 3.22.0
   webkit_inspection_protocol: ^0.4.0


### PR DESCRIPTION
This adds tests for the vm.register method in the servers API and updates the *server* (but not devtools) to use the new vm_service_lib.

The builds are green now because the Dart SDK dev build doesn't have the changes yet, but the dev bots will go red once it updates until we land both this fix and also a fix to devtools (which I can't land until we've shipped the new server).