### PR TITLE
Hook up general CPU profiler.

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -486,7 +486,11 @@ abstract class Screen {
           span()
             ..add(span(text: '$name', c: 'optional-700'))
             ..add(span(text: ' Docs')),
-          href: 'https://flutter.dev/docs/development/tools/devtools/$id',
+          // TODO(kenzie): remove this special case once performance docs are
+          // published on flutter.dev.
+          href: id == 'performance'
+              ? 'https://flutter.dev/docs/development/tools/devtools/timeline#cpu-flame-chart'
+              : 'https://flutter.dev/docs/development/tools/devtools/$id',
           title: 'Documentation on using the $name page',
         ),
         disabled = allTabsEnabledByQuery ? false : disabled;

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -29,8 +29,6 @@ import 'utils.dart';
 
 // TODO(devoncarew): make the screens more robust through restarts
 
-const bool showPerformancePage = false;
-
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const flutterWebLibraryUri = 'package:flutter_web/src/widgets/binding.dart';
 
@@ -185,9 +183,7 @@ class PerfToolFramework extends Framework {
           'This screen is disabled because it is not yet ready for Flutter'
           ' Web',
     ));
-    if (showPerformancePage) {
-      addScreen(PerformanceScreen());
-    }
+    addScreen(PerformanceScreen());
     addScreen(DebuggerScreen(
       disabled: _isFlutterWebApp ||
           _isProfileBuild ||

--- a/packages/devtools/lib/src/performance/performance.css
+++ b/packages/devtools/lib/src/performance/performance.css
@@ -6,11 +6,11 @@
     justify-content: center;
 }
 
-.recording-message {
+.profiler-status-message {
     margin-top: -34px; /* Full height of the text field plus padding for the spinner. */
 }
 
-.recording-spinner {
+.profiler-spinner {
     margin-top: 0 !important;
 }
 

--- a/packages/devtools/lib/src/performance/performance_controller.dart
+++ b/packages/devtools/lib/src/performance/performance_controller.dart
@@ -3,16 +3,16 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math';
 
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_processor.dart';
+import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/cpu_profile_service.dart';
+import '../utils.dart';
 
 class PerformanceController {
   final CpuProfilerService cpuProfilerService = CpuProfilerService();
 
-  final CpuProfileProcessor cpuProfileProcessor = CpuProfileProcessor();
+  final CpuProfileTransformer cpuProfileTransformer = CpuProfileTransformer();
 
   /// Processed cpu profile data from the recorded performance profile.
   CpuProfileData cpuProfileData;
@@ -39,12 +39,10 @@ class PerformanceController {
   Future<void> stopRecording() async {
     _recording = false;
 
-    // 2^52 is the max int for dart2js. Using this as [extentMicros] for the
-    // getCpuProfile requests will give us all cpu samples we have available.
-    final maxJsInt = pow(2, 52);
-
     cpuProfileData = await cpuProfilerService.getCpuProfile(
       startMicros: _profileStartMicros,
+      // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
+      // give us all cpu samples we have available
       extentMicros: maxJsInt,
     );
   }

--- a/packages/devtools/lib/src/performance/performance_controller.dart
+++ b/packages/devtools/lib/src/performance/performance_controller.dart
@@ -5,8 +5,8 @@
 import 'dart:async';
 
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/cpu_profile_service.dart';
+import '../profiler/cpu_profile_transformer.dart';
 import '../utils.dart';
 
 class PerformanceController {

--- a/packages/devtools/lib/src/performance/performance_controller.dart
+++ b/packages/devtools/lib/src/performance/performance_controller.dart
@@ -3,19 +3,19 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math';
 
 import '../profiler/cpu_profile_model.dart';
+import '../profiler/cpu_profile_processor.dart';
 import '../profiler/cpu_profile_service.dart';
 
 class PerformanceController {
   final CpuProfilerService cpuProfilerService = CpuProfilerService();
 
-  /// Final cpu profile data after merging the recorded profiles.
-  CpuProfileData cpuProfileData;
+  final CpuProfileProcessor cpuProfileProcessor = CpuProfileProcessor();
 
-  /// Cpu profiles recorded on an interval during the time between starting and
-  /// stopping the recording.
-  List<CpuProfileData> recordedProfiles = [];
+  /// Processed cpu profile data from the recorded performance profile.
+  CpuProfileData cpuProfileData;
 
   Timer timer;
 
@@ -23,47 +23,34 @@ class PerformanceController {
 
   bool _recording = false;
 
-  void startRecording() async {
-    reset();
+  final int _profileStartMicros = 0;
+
+  Future<void> startRecording() async {
+    await reset();
     _recording = true;
 
-    // TODO(kenzie): ensure this code is backwards compatible. The first request
-    // will start at 0 and end at int max (2^52).
-    // TODO(kenzie): uncomment this code once getVMTimelineMicros is available.
-//    const int timerDuration = 100;
-//    int startMicros =
-//      (await serviceManager.service.getVMTimelineMicros()).timestamp;
-//    timer = Timer.periodic(
-//      const Duration(microseconds: timerDuration),
-//      (_) async {
-//        recordedProfiles.add(await cpuProfilerService.getCpuProfile(
-//          startMicros: startMicros,
-//          extentMicros: timerDuration,
-//        ));
-//        // Set [startMicros] to the end of the current profile. This will be the
-//        // start time in the request for the next sample.
-//        startMicros = cpuProfileData.time.end.inMicroseconds;
-//      },
-//    );
+    // TODO(kenzie): once [getVMTimelineMicros] is available, we can get the
+    // current timestamp here and set [_profileStartMicros] equal to it. We will
+    // use [_profileStartMicros] for [startMicros] in the [getCpuProfile]
+    // request. For backwards compatibility, we will let start micros default to
+    // 0.
   }
 
-  void stopRecording() {
-    // TODO(kenzie): uncomment this once getVMTimelineMicros is available.
-//    timer.cancel();
+  Future<void> stopRecording() async {
     _recording = false;
+
+    // 2^52 is the max int for dart2js. Using this as [extentMicros] for the
+    // getCpuProfile requests will give us all cpu samples we have available.
+    final maxJsInt = pow(2, 52);
+
+    cpuProfileData = await cpuProfilerService.getCpuProfile(
+      startMicros: _profileStartMicros,
+      extentMicros: maxJsInt,
+    );
   }
 
-  void reset() {
+  Future<void> reset() async {
     cpuProfileData = null;
-    recordedProfiles.clear();
-  }
-
-  void mergeRecordedProfiles() {
-    // TODO(kenzie): merge profiles from [recordedProfiles] and set
-    // cpuProfileData. We could do something smart here where we merge in the
-    // down time between `getCpuProfile` requests.
-
-    // Temporarily set equal to stub data.
-    cpuProfileData = debugStubCpuProfile;
+    await cpuProfilerService.clearCpuProfile();
   }
 }

--- a/packages/devtools/lib/src/performance/performance_screen.dart
+++ b/packages/devtools/lib/src/performance/performance_screen.dart
@@ -1,7 +1,6 @@
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 import 'package:meta/meta.dart';
 
 import '../framework/framework.dart';
@@ -13,7 +12,10 @@ import '../ui/elements.dart';
 import '../ui/html_icon_renderer.dart';
 import '../ui/material_icons.dart';
 import '../ui/primer.dart';
+import '../ui/ui_utils.dart';
 import 'performance_controller.dart';
+
+const performanceScreenId = 'performance';
 
 class PerformanceScreen extends Screen {
   PerformanceScreen()
@@ -30,9 +32,11 @@ class PerformanceScreen extends Screen {
 
   PButton _clearButton;
 
-  CoreElement _profilingInstructions;
+  CoreElement _profilerInstructions;
 
-  CoreElement _recordingMessage;
+  CoreElement _profilerStatus;
+
+  CoreElement _profilerStatusMessage;
 
   CpuProfilerTabNav _tabNav;
 
@@ -64,11 +68,13 @@ class PerformanceScreen extends Screen {
           div(c: 'profiler-container section-border')
             ..add([
               _cpuProfiler..hidden(true),
-              _profilingInstructions,
-              _recordingMessage..hidden(true)
+              _profilerInstructions,
+              _profilerStatus..hidden(true)
             ]),
         ]),
     ]);
+
+    maybeAddDebugMessage(framework, performanceScreenId);
 
     return screenDiv;
   }
@@ -77,13 +83,13 @@ class PerformanceScreen extends Screen {
     _startRecordingButton = PButton.icon('Record', recordPrimary)
       ..small()
       ..primary()
-      ..click(_startRecording);
+      ..click(() async => await _startRecording());
 
     _stopRecordingButton = PButton.icon('Stop', stop)
       ..small()
       ..clazz('margin-left')
       ..disabled = true
-      ..click(_stopRecording);
+      ..click(() async => await _stopRecording());
 
     _clearButton = PButton.icon('Clear', clearIcon)
       ..small()
@@ -91,7 +97,7 @@ class PerformanceScreen extends Screen {
       ..setAttribute('title', 'Clear timeline')
       ..click(_clear);
 
-    _profilingInstructions = div(c: 'center-in-parent instruction-container')
+    _profilerInstructions = div(c: 'center-in-parent instruction-container')
       ..layoutVertical()
       ..flex()
       ..add([
@@ -113,12 +119,12 @@ class PerformanceScreen extends Screen {
           ]),
       ]);
 
-    _recordingMessage = div(c: 'center-in-parent')
+    _profilerStatus = div(c: 'center-in-parent')
       ..layoutVertical()
       ..flex()
       ..add([
-        div(text: 'Recording', c: 'recording-message'),
-        Spinner.centered(classes: ['recording-spinner']),
+        _profilerStatusMessage = div(c: 'profiler-status-message'),
+        Spinner.centered(classes: ['profiler-spinner']),
       ]);
 
     _cpuProfiler = _CpuProfiler(
@@ -136,17 +142,19 @@ class PerformanceScreen extends Screen {
     );
   }
 
-  void _startRecording() {
-    _performanceController.startRecording();
+  Future<void> _startRecording() async {
+    await _performanceController.startRecording();
     _updateCpuProfilerVisibility(hidden: true);
     _updateButtonStates();
-    _profilingInstructions.hidden(true);
-    _recordingMessage.hidden(false);
+    _profilerInstructions.hidden(true);
+    _profilerStatusMessage.text = 'Recording profile';
+    _profilerStatus.hidden(false);
   }
 
-  void _stopRecording() async {
-    _performanceController.stopRecording();
-    _recordingMessage.hidden(true);
+  Future<void> _stopRecording() async {
+    _profilerStatusMessage.text = 'Processing profile';
+    await _performanceController.stopRecording();
+    _profilerStatus.hidden(true);
     _updateCpuProfilerVisibility(hidden: false);
     _updateButtonStates();
     await _cpuProfiler.update();
@@ -155,7 +163,7 @@ class PerformanceScreen extends Screen {
   void _clear() {
     _performanceController.reset();
     _updateCpuProfilerVisibility(hidden: true);
-    _profilingInstructions.hidden(false);
+    _profilerInstructions.hidden(false);
   }
 
   void _updateButtonStates() {
@@ -185,7 +193,8 @@ class _CpuProfiler extends CpuProfiler {
 
   @override
   Future<void> prepareCpuProfile() async {
-    _performanceController.mergeRecordedProfiles();
+    _performanceController.cpuProfileProcessor
+        .processData(_performanceController.cpuProfileData);
   }
 
   @override

--- a/packages/devtools/lib/src/performance/performance_screen.dart
+++ b/packages/devtools/lib/src/performance/performance_screen.dart
@@ -193,7 +193,7 @@ class _CpuProfiler extends CpuProfiler {
 
   @override
   Future<void> prepareCpuProfile() async {
-    _performanceController.cpuProfileProcessor
+    _performanceController.cpuProfileTransformer
         .processData(_performanceController.cpuProfileData);
   }
 

--- a/packages/devtools/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -65,9 +65,9 @@ class CpuFlameChart extends CpuProfilerView {
   }
 
   @override
-  void update() {
+  void update({bool showLoadingSpinner = false}) {
     reset();
-    super.update();
+    super.update(showLoadingSpinner: showLoadingSpinner);
   }
 
   void updateForContainerResize() {
@@ -99,6 +99,7 @@ class CpuFlameChart extends CpuProfilerView {
     }
   }
 
+  @override
   void reset() {
     if (canvas?.element?.element != null) {
       canvas.element.element.remove();

--- a/packages/devtools/lib/src/profiler/cpu_profile_processor.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_processor.dart
@@ -6,9 +6,9 @@ import 'package:meta/meta.dart';
 import '../utils.dart';
 import 'cpu_profile_model.dart';
 
-/// Protocol for processing [CpuProfileData] and composing it into a structured
-/// tree of [CpuStackFrame]'s.
-class CpuProfileProtocol {
+/// Process for composing [CpuProfileData] into a structured tree of
+/// [CpuStackFrame]'s.
+class CpuProfileProcessor {
   void processData(CpuProfileData cpuProfileData) {
     // Do not process this data if it has already been processed.
     if (cpuProfileData.processed) return;
@@ -86,7 +86,7 @@ class BottomUpProfileProcessor {
 
     // Merge samples when possible starting at the root (the leaf node of the
     // original CPU sample).
-    mergeRoots(bottomUpRoots);
+    mergeProfileRoots(bottomUpRoots);
 
     return bottomUpRoots;
   }
@@ -128,7 +128,7 @@ class BottomUpProfileProcessor {
   ///
   /// This is necessary for the transformation of a [CpuStackFrame] to its
   /// bottom-up representation. This is an intermediate step between
-  /// [getRoots] and [mergeRoots].
+  /// [getRoots] and [mergeProfileRoots].
   @visibleForTesting
   void cascadeSampleCounts(CpuStackFrame stackFrame) {
     stackFrame.inclusiveSampleCount = stackFrame.exclusiveSampleCount;
@@ -137,42 +137,45 @@ class BottomUpProfileProcessor {
       cascadeSampleCounts(child);
     }
   }
+}
 
-  /// Merges bottom up roots that share a common call stack (starting at the
-  /// root).
-  ///
-  /// Ex. C               C                     C
-  ///      -> B             -> B        -->      -> B
-  ///          -> A             -> D                 -> A
-  ///                                                -> D
-  ///
-  /// At the time this method is called, we assume we have a list of roots with
-  /// accurate bottom up sample counts.
-  @visibleForTesting
-  void mergeRoots(List<CpuStackFrame> roots) {
-    // Loop through a copy of [roots] so that we can remove nodes from [roots]
-    // once we have merged them.
-    final List<CpuStackFrame> rootsCopy = List.from(roots);
-    for (CpuStackFrame root in rootsCopy) {
-      if (!roots.contains(root)) {
-        // We have already merged [root] and removed it from [roots]. Do not
-        // attempt to merge again.
-        continue;
-      }
-
-      final matchingRoots =
-          roots.where((other) => other.matches(root) && other != root).toList();
-      if (matchingRoots.isEmpty) {
-        continue;
-      }
-
-      for (CpuStackFrame match in matchingRoots) {
-        match.children.forEach(root.addChild);
-        root.exclusiveSampleCount += match.exclusiveSampleCount;
-        root.inclusiveSampleCount += match.inclusiveSampleCount;
-        roots.remove(match);
-        mergeRoots(root.children);
-      }
+/// Merges CPU profile roots that share a common call stack (starting at the
+/// root).
+///
+/// Ex. C               C                     C
+///      -> B             -> B        -->      -> B
+///          -> A             -> D                 -> A
+///                                                -> D
+///
+/// At the time this method is called, we assume we have a list of roots with
+/// accurate inclusive/exclusive sample counts.
+void mergeProfileRoots(List<CpuStackFrame> roots) {
+  // Loop through a copy of [roots] so that we can remove nodes from [roots]
+  // once we have merged them.
+  final List<CpuStackFrame> rootsCopy = List.from(roots);
+  for (CpuStackFrame root in rootsCopy) {
+    if (!roots.contains(root)) {
+      // We have already merged [root] and removed it from [roots]. Do not
+      // attempt to merge again.
+      continue;
     }
+
+    final matchingRoots =
+        roots.where((other) => other.matches(root) && other != root).toList();
+    if (matchingRoots.isEmpty) {
+      continue;
+    }
+
+    for (CpuStackFrame match in matchingRoots) {
+      match.children.forEach(root.addChild);
+      root.exclusiveSampleCount += match.exclusiveSampleCount;
+      root.inclusiveSampleCount += match.inclusiveSampleCount;
+      roots.remove(match);
+      mergeProfileRoots(root.children);
+    }
+  }
+
+  for (CpuStackFrame root in roots) {
+    root.index = roots.indexOf(root);
   }
 }

--- a/packages/devtools/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_service.dart
@@ -7,16 +7,6 @@ import 'package:vm_service_lib/vm_service_lib.dart';
 
 import '../globals.dart';
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_protocol.dart';
-
-// TODO(kenzie): remove once we no longer need stub data to build the
-// performance UI.
-/// When true, we will store the first cpu profile response we see as
-/// [debugStubCpuProfile].
-///
-/// This is a hack to aid in developing the performance page.
-bool debugStoreCpuProfile = false;
-CpuProfileData debugStubCpuProfile;
 
 /// Manages interactions between the Cpu Profiler and the VmService.
 class CpuProfilerService {
@@ -30,13 +20,11 @@ class CpuProfilerService {
       startMicros,
       extentMicros,
     );
-    // TODO(kenzie): remove this once we no longer need stub data to build the
-    // performance UI.
-    if (debugStoreCpuProfile && debugStubCpuProfile == null) {
-      debugStubCpuProfile = CpuProfileData.parse(response.json);
-      CpuProfileProtocol().processData(debugStubCpuProfile);
-    }
-
     return CpuProfileData.parse(response.json);
+  }
+
+  Future<Success> clearCpuProfile() async {
+    return serviceManager.service
+        .clearCpuProfile(serviceManager.isolateManager.selectedIsolate.id);
   }
 }

--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -5,7 +5,7 @@ import '../tables.dart';
 import '../url_utils.dart';
 import '../utils.dart';
 import 'cpu_profile_model.dart';
-import 'cpu_profile_protocol.dart';
+import 'cpu_profile_processor.dart';
 import 'cpu_profiler.dart';
 
 const _timeColumnWidthPx = 145;
@@ -49,6 +49,9 @@ class CpuCallTree extends CpuProfilerView {
       ..addAll(root.children.cast());
     callTreeTable.setRows(rows);
   }
+
+  @override
+  void reset() => callTreeTable.setRows(<CpuStackFrame>[]);
 }
 
 class CpuBottomUp extends CpuProfilerView {
@@ -87,6 +90,9 @@ class CpuBottomUp extends CpuProfilerView {
         BottomUpProfileProcessor().processData(data.cpuProfileRoot);
     bottomUpTable.setRows(bottomUpRoots);
   }
+
+  @override
+  void reset() => bottomUpTable.setRows(<CpuStackFrame>[]);
 }
 
 class SelfTimeColumn extends Column<CpuStackFrame> {

--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -5,7 +5,7 @@ import '../tables.dart';
 import '../url_utils.dart';
 import '../utils.dart';
 import 'cpu_profile_model.dart';
-import 'cpu_profile_processor.dart';
+import 'cpu_profile_transformer.dart';
 import 'cpu_profiler.dart';
 
 const _timeColumnWidthPx = 145;
@@ -87,7 +87,7 @@ class CpuBottomUp extends CpuProfilerView {
   void rebuildView() {
     final CpuProfileData data = profileDataProvider();
     final List<CpuStackFrame> bottomUpRoots =
-        BottomUpProfileProcessor().processData(data.cpuProfileRoot);
+        BottomUpProfileTransformer().processData(data.cpuProfileRoot);
     bottomUpTable.setRows(bottomUpRoots);
   }
 

--- a/packages/devtools/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_transformer.dart
@@ -8,7 +8,7 @@ import 'cpu_profile_model.dart';
 
 /// Process for composing [CpuProfileData] into a structured tree of
 /// [CpuStackFrame]'s.
-class CpuProfileProcessor {
+class CpuProfileTransformer {
   void processData(CpuProfileData cpuProfileData) {
     // Do not process this data if it has already been processed.
     if (cpuProfileData.processed) return;
@@ -77,7 +77,7 @@ class CpuProfileProcessor {
 
 /// Process for converting a [CpuStackFrame] into a bottom-up representation of
 /// the CPU profile.
-class BottomUpProfileProcessor {
+class BottomUpProfileTransformer {
   List<CpuStackFrame> processData(CpuStackFrame stackFrame) {
     final List<CpuStackFrame> bottomUpRoots = getRoots(stackFrame, null, []);
 

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -4,7 +4,7 @@
 import 'dart:async';
 
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_processor.dart';
+import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/cpu_profile_service.dart';
 import 'timeline_model.dart';
 import 'timeline_protocol.dart';
@@ -16,7 +16,7 @@ const String timelineScreenId = 'timeline';
 ///
 /// The controller manages the timeline data model and communicates with the
 /// view to give and receive data updates. It also manages data processing via
-/// protocols [TimelineProtocol] and [CpuProfileProcessor], and it communicates
+/// protocols [TimelineProtocol] and [CpuProfileTransformer], and it communicates
 /// with [TimelineService].
 ///
 /// This class must not have direct dependencies on dart:html. This allows tests
@@ -76,7 +76,7 @@ class TimelineController {
 
   TimelineProtocol timelineProtocol;
 
-  CpuProfileProcessor cpuProfileProtocol = CpuProfileProcessor();
+  CpuProfileTransformer cpuProfileTransformer = CpuProfileTransformer();
 
   CpuProfilerService cpuProfilerService = CpuProfilerService();
 
@@ -143,7 +143,7 @@ class TimelineController {
       timelineData.selectedFrame.cpuProfileData,
       timelineData.selectedEvent.time,
     );
-    cpuProfileProtocol.processData(timelineData.cpuProfileData);
+    cpuProfileTransformer.processData(timelineData.cpuProfileData);
   }
 
   void restoreCpuProfileFromOfflineData() {
@@ -193,7 +193,7 @@ class TimelineController {
     timelineProtocol.maybeAddPendingEvents();
 
     if (timelineData.cpuProfileData != null) {
-      cpuProfileProtocol.processData(timelineData.cpuProfileData);
+      cpuProfileTransformer.processData(timelineData.cpuProfileData);
     }
 
     _loadOfflineDataController.add(offlineData);

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -4,8 +4,8 @@
 import 'dart:async';
 
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/cpu_profile_service.dart';
+import '../profiler/cpu_profile_transformer.dart';
 import 'timeline_model.dart';
 import 'timeline_protocol.dart';
 import 'timeline_service.dart';

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -4,7 +4,7 @@
 import 'dart:async';
 
 import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_protocol.dart';
+import '../profiler/cpu_profile_processor.dart';
 import '../profiler/cpu_profile_service.dart';
 import 'timeline_model.dart';
 import 'timeline_protocol.dart';
@@ -16,7 +16,7 @@ const String timelineScreenId = 'timeline';
 ///
 /// The controller manages the timeline data model and communicates with the
 /// view to give and receive data updates. It also manages data processing via
-/// protocols [TimelineProtocol] and [CpuProfileProtocol], and it communicates
+/// protocols [TimelineProtocol] and [CpuProfileProcessor], and it communicates
 /// with [TimelineService].
 ///
 /// This class must not have direct dependencies on dart:html. This allows tests
@@ -76,7 +76,7 @@ class TimelineController {
 
   TimelineProtocol timelineProtocol;
 
-  CpuProfileProtocol cpuProfileProtocol = CpuProfileProtocol();
+  CpuProfileProcessor cpuProfileProtocol = CpuProfileProcessor();
 
   CpuProfilerService cpuProfilerService = CpuProfilerService();
 

--- a/packages/devtools/lib/src/trees.dart
+++ b/packages/devtools/lib/src/trees.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:collection';
 import 'dart:math';
 
 /// Non-UI specific tree code should live in this file.
@@ -72,14 +73,14 @@ class TreeNode<T extends TreeNode<T>> {
     child.index = children.length - 1;
   }
 
-  bool containsChildWithCondition(bool condition(T node), {T root}) {
-    root ??= this;
-
-    if (condition(root)) {
-      return true;
-    }
-    for (T newRoot in root.children) {
-      return containsChildWithCondition(condition, root: newRoot);
+  bool containsChildWithCondition(bool condition(T node)) {
+    final Queue<T> queue = Queue.from([this]);
+    while (queue.isNotEmpty) {
+      final T node = queue.removeFirst();
+      if (condition(node)) {
+        return true;
+      }
+      node.children.forEach(queue.add);
     }
     return false;
   }

--- a/packages/devtools/lib/src/utils.dart
+++ b/packages/devtools/lib/src/utils.dart
@@ -20,6 +20,9 @@ ultrices, tincidunt quam sit amet, cursus lectus. Integer justo turpis, vestibul
 sodales suscipit risus. Nullam consequat sit amet turpis vitae facilisis. Integer sit amet tempus arcu.
 ''';
 
+// 2^52 is the max int for dart2js.
+final int maxJsInt = pow(2, 52);
+
 String getLoremText([int paragraphCount = 1]) {
   String str = '';
   for (int i = 0; i < paragraphCount; i++) {

--- a/packages/devtools/test/cpu_profile_processor_test.dart
+++ b/packages/devtools/test/cpu_profile_processor_test.dart
@@ -2,20 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'package:devtools/src/profiler/cpu_profile_model.dart';
-import 'package:devtools/src/profiler/cpu_profile_processor.dart';
+import 'package:devtools/src/profiler/cpu_profile_transformer.dart';
 import 'package:test/test.dart';
 
 import 'support/cpu_profile_test_data.dart';
 
 void main() {
-  group('CpuProfileProcessor', () {
-    final cpuProfileProcessor = CpuProfileProcessor();
+  group('CpuProfileTransformer', () {
+    final cpuProfileTransformer = CpuProfileTransformer();
     final CpuProfileData cpuProfileData =
         CpuProfileData.parse(cpuProfileResponseJson);
 
     test('processCpuProfile', () {
       expect(cpuProfileData.processed, isFalse);
-      cpuProfileProcessor.processData(cpuProfileData);
+      cpuProfileTransformer.processData(cpuProfileData);
       expect(cpuProfileData.processed, isTrue);
       expect(
         cpuProfileData.cpuProfileRoot.toStringDeep(),
@@ -29,7 +29,7 @@ void main() {
             CpuProfileData.parse(responseWithMissingLeafFrame);
         expect(
           () {
-            cpuProfileProcessor.processData(cpuProfileDataWithMissingLeaf);
+            cpuProfileTransformer.processData(cpuProfileDataWithMissingLeaf);
           },
           throwsA(const TypeMatcher<AssertionError>()),
         );
@@ -41,8 +41,8 @@ void main() {
     });
   });
 
-  group('BottomUpProfileProcessor', () {
-    final bottomUpProcessor = BottomUpProfileProcessor();
+  group('BottomUpProfileTransformer', () {
+    final bottomUpTransformer = BottomUpProfileTransformer();
 
     test('setBottomUpSampleCounts', () {
       void verifySampleCount(CpuStackFrame stackFrame, int targetCount) {
@@ -54,7 +54,7 @@ void main() {
       }
 
       final stackFrame = testStackFrame.deepCopy();
-      bottomUpProcessor.cascadeSampleCounts(stackFrame);
+      bottomUpTransformer.cascadeSampleCounts(stackFrame);
 
       verifySampleCount(stackFrame, 0);
     });
@@ -62,7 +62,7 @@ void main() {
     test('processData step by step', () {
       expect(testStackFrame.toStringDeep(), equals(testStackFrameStringGolden));
       final List<CpuStackFrame> bottomUpRoots =
-          bottomUpProcessor.getRoots(testStackFrame, null, []);
+          bottomUpTransformer.getRoots(testStackFrame, null, []);
 
       // Verify the original stack frame was not modified.
       expect(testStackFrame.toStringDeep(), equals(testStackFrameStringGolden));
@@ -70,7 +70,7 @@ void main() {
       expect(bottomUpRoots.length, equals(6));
 
       // Set the bottom up sample counts for the roots.
-      bottomUpRoots.forEach(bottomUpProcessor.cascadeSampleCounts);
+      bottomUpRoots.forEach(bottomUpTransformer.cascadeSampleCounts);
 
       final buf = StringBuffer();
       for (CpuStackFrame stackFrame in bottomUpRoots) {
@@ -93,7 +93,7 @@ void main() {
     test('processData', () {
       expect(testStackFrame.toStringDeep(), equals(testStackFrameStringGolden));
       final List<CpuStackFrame> bottomUpRoots =
-          bottomUpProcessor.processData(testStackFrame);
+          bottomUpTransformer.processData(testStackFrame);
 
       // Verify the original stack frame was not modified.
       expect(testStackFrame.toStringDeep(), equals(testStackFrameStringGolden));

--- a/packages/devtools/test/trees_test.dart
+++ b/packages/devtools/test/trees_test.dart
@@ -9,8 +9,8 @@ void main() {
   group('TreeNode', () {
     test('depth', () {
       expect(testTreeNode.depth, equals(4));
-      expect(treeNode2.depth, equals(1));
-      expect(treeNode3.depth, equals(2));
+      expect(treeNode2.depth, equals(3));
+      expect(treeNode3.depth, equals(1));
     });
 
     test('root', () {
@@ -19,7 +19,7 @@ void main() {
 
     test('level', () {
       expect(testTreeNode.level, equals(0));
-      expect(treeNode2.level, equals(2));
+      expect(treeNode2.level, equals(1));
       expect(treeNode5.level, equals(3));
     });
 
@@ -64,8 +64,8 @@ final treeNode3 = TestTreeNode();
 final treeNode4 = TestTreeNode();
 final treeNode5 = TestTreeNode();
 final TreeNode testTreeNode = treeNode0
-  ..addChild(treeNode1
-    ..addChild(treeNode2)
-    ..addChild(treeNode3..addChild(treeNode4)..addChild(treeNode5)));
+  ..addChild(treeNode1)
+  ..addChild(
+      treeNode2..addChild(treeNode3)..addChild(treeNode4..addChild(treeNode5)));
 
 class TestTreeNode extends TreeNode<TestTreeNode> {}

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -90,7 +90,7 @@
         <!-- add the known pages -->
         <a disabled><span class="octicon octicon-device-mobile"></span><span> <span class="optional-950">Flutter Inspector</span></span></a>
         <a disabled><span class="octicon octicon-pulse"></span><span> <span class="optional-950">Timeline</span></span></a>
-<!--        <a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-950">Performance</span></span></a>-->
+        <a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-950">Performance</span></span></a>
         <a disabled><span class="octicon octicon-package"></span><span> <span class="optional-950">Memory</span></span></a>
         <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-950">Debugger</span></span></a>
         <a disabled><span class="octicon octicon-clippy"></span><span> <span class="optional-950">Logging</span></span></a>


### PR DESCRIPTION
Clicking "Start recording" will clear the VM's cpu profile buffer. 
Clicking "Stop recording" will pull everything in the buffer and display it in the available profiling views (Call Tree, Bottom Up, Flame Chart).

Confirmed this works with Flutter apps and CLI apps.

Adding documentation for this page here: https://github.com/flutter/website/pull/2835.