### PR TITLE
Stop prefetching cpu profiles and lower the sampling rate.

### DIFF
--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -137,7 +137,14 @@ class TimelineController {
     if (!timelineData.selectedEvent.isUiEvent) return;
 
     assert(timelineData.selectedEvent.frameId == timelineData.selectedFrame.id);
-    await timelineData.selectedFrame.cpuProfileReady.future;
+
+    timelineData.selectedFrame.cpuProfileData ??=
+        await cpuProfilerService.getCpuProfile(
+      startMicros:
+          timelineData.selectedFrame.uiEventFlow.time.start.inMicroseconds,
+      extentMicros:
+          timelineData.selectedFrame.uiEventFlow.time.duration.inMicroseconds,
+    );
 
     timelineData.cpuProfileData = CpuProfileData.subProfile(
       timelineData.selectedFrame.cpuProfileData,

--- a/packages/devtools/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools/lib/src/timeline/timeline_model.dart
@@ -1,8 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:async';
-
 import 'package:meta/meta.dart';
 
 import '../profiler/cpu_profile_model.dart';
@@ -198,8 +196,6 @@ class TimelineFrame {
 
   // Stores frame start time, end time, and duration.
   final time = TimeRange();
-
-  final Completer cpuProfileReady = Completer();
 
   /// Pipeline item time range in micros.
   ///

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -502,6 +502,8 @@ class TimelineProtocol {
       timelineController.addFrame(frame);
       pendingFrames.remove(frame.id);
       frame.addedToTimeline = true;
+
+      // TODO(kenzie): add cpu profile pre-fetching here when the app is idle.
     }
   }
 

--- a/packages/devtools/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools/lib/src/timeline/timeline_protocol.dart
@@ -487,7 +487,7 @@ class TimelineProtocol {
     return true;
   }
 
-  void _maybeAddCompletedFrame(TimelineFrame frame) async {
+  void _maybeAddCompletedFrame(TimelineFrame frame) {
     if (frame.isReadyForTimeline && frame.addedToTimeline == null) {
       if (debugTimeline) {
         debugFrameTracking.writeln('Completing ${frame.id}');
@@ -502,14 +502,6 @@ class TimelineProtocol {
       timelineController.addFrame(frame);
       pendingFrames.remove(frame.id);
       frame.addedToTimeline = true;
-
-      // Pre-fetch the cpu profile for this frame.
-      frame.cpuProfileData =
-          await timelineController.cpuProfilerService.getCpuProfile(
-        startMicros: frame.uiEventFlow.time.start.inMicroseconds,
-        extentMicros: frame.uiEventFlow.time.duration.inMicroseconds,
-      );
-      frame.cpuProfileReady.complete();
     }
   }
 

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -28,7 +28,7 @@ class TimelineService {
   }
 
   void _handleConnectionStart(VmServiceWrapper service) {
-    serviceManager.service.setFlag('profile_period', '50');
+    serviceManager.service.setFlag('profile_period', '250');
     serviceManager.service.onEvent('Timeline').listen((Event event) {
       final List<dynamic> list = event.json['timelineEvents'];
       final List<Map<String, dynamic>> events =

--- a/packages/devtools/test/timeline_protocol_test.dart
+++ b/packages/devtools/test/timeline_protocol_test.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'package:devtools/src/profiler/cpu_profile_service.dart';
 import 'package:devtools/src/timeline/timeline_controller.dart';
 import 'package:devtools/src/timeline/timeline_model.dart';
 import 'package:devtools/src/timeline/timeline_protocol.dart';
@@ -38,14 +37,10 @@ void main() {
     TimelineProtocol timelineProtocol;
 
     setUp(() {
-      final timelineController = MockTimelineController();
-      when(timelineController.cpuProfilerService)
-          .thenReturn(MockCpuProfilerService());
-
       timelineProtocol = TimelineProtocol(
         uiThreadId: testUiThreadId,
         gpuThreadId: testGpuThreadId,
-        timelineController: timelineController,
+        timelineController: MockTimelineController(),
       );
     });
 
@@ -217,7 +212,6 @@ void main() {
       expect(frame.uiEventFlow.toString(), equals(goldenUiString()));
       expect(frame.gpuEventFlow.toString(), equals(goldenGpuString()));
       expect(frame.addedToTimeline, isTrue);
-      expect(frame.cpuProfileReady.isCompleted, isTrue);
     });
 
     test('handles out of order timestamps', () async {
@@ -317,5 +311,3 @@ Future<void> delayForEventProcessing() async {
 }
 
 class MockTimelineController extends Mock implements TimelineController {}
-
-class MockCpuProfilerService extends Mock implements CpuProfilerService {}


### PR DESCRIPTION
Pre-fetching cpu profiles after each frame is drawn stalls the UI and hinders app performance.

Stop pre-fetching to prevent this. Lower the default sampling rate to compensate (this will keep the buffer from overflowing so quickly). Eventually, we will add a selector so the user can increase / decrease their sampling rate and we will document the tradeoffs.