### PR TITLE
Add tests for server and its vm.register method + call correct registerService variant based on protocol version

### DIFF
--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -120,8 +120,7 @@ class ServiceConnectionManager {
     VmServiceWrapper service, {
     @required Future<void> onClosed,
   }) async {
-    const kServiceStreamOld = '_Service';
-    const kServiceStreamNew = 'Service';
+    final serviceStreamName = await service.serviceStreamName;
 
     final vm = await service.getVM();
     this.vm = vm;
@@ -148,8 +147,7 @@ class ServiceConnectionManager {
       }
     }
 
-    service.onEvent(kServiceStreamOld).listen(handleServiceEvent);
-    service.onEvent(kServiceStreamNew).listen(handleServiceEvent);
+    service.onEvent(serviceStreamName).listen(handleServiceEvent);
 
     _isolateManager._service = service;
     _serviceExtensionManager._service = service;
@@ -173,8 +171,7 @@ class ServiceConnectionManager {
       EventStreams.kGC,
       EventStreams.kTimeline,
       EventStreams.kExtension,
-      kServiceStreamNew,
-      kServiceStreamOld,
+      serviceStreamName
     ];
 
     // The following streams are not yet supported by Flutter Web.
@@ -187,10 +184,9 @@ class ServiceConnectionManager {
         await service.streamListen(id);
       } catch (e) {
         // TODO(devoncarew): Remove this check on or after approx. Oct 1 2019.
-        if (id.endsWith('Logging') || id.endsWith('Service')) {
-          // Don't complain about '_Logging', 'Logging', '_Service', or 'Service'
-          // events (newer VMs don't the private names, and older ones don't
-          // support the public ones).
+        if (id.endsWith('Logging')) {
+          // Don't complain about '_Logging' or 'Logging' events (new VMs don't
+          // have the private names, and older ones don't have the public ones).
         } else {
           print("Service client stream not supported: '$id'\n  $e");
         }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -403,8 +403,10 @@ class VmServiceWrapper implements VmService {
 
     return response as Success;
 
-    // TODO(dantup): Revert to this when we no longer need to support clients
-    // on old VMs that don't support public registerService.
+    // TODO(dantup): When we no longer need to support clients on older VMs
+    // that don't support public registerService (added in July 2019, VM service
+    // v3.22) we can replace the above with a direct call to vm_service_lib's
+    // registerService (as long as we're pinned to version >= 3.22.0).
     // return _trackFuture(
     //     'registerService $service', _vmService.registerService(service, alias));
   }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -556,6 +556,14 @@ class VmServiceWrapper implements VmService {
         (_protocolVersion.major == major && _protocolVersion.minor < minor);
   }
 
+  /// Gets the name of the service stream for the connected VM service. Pre-v3.22
+  /// this was a private API and named _Service and in v3.22 (July 2019) it was
+  /// made public ("Service").
+  Future<String> get serviceStreamName async =>
+      (await isProtocolVersionLessThan(major: 3, minor: 22))
+          ? '_Service'
+          : 'Service';
+
   Future<T> _trackFuture<T>(String name, Future<T> future) {
     if (!trackFutures) {
       return future;

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -388,9 +388,25 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Success> registerService(String service, String alias) {
-    return _trackFuture(
-        'registerService $service', _vmService.registerService(service, alias));
+  Future<Success> registerService(String service, String alias) async {
+    // Handle registerService method name change based on protocol version.
+    final registerServiceMethodName =
+        await isProtocolVersionLessThan(major: 3, minor: 22)
+            ? '_registerService'
+            : 'registerService';
+
+    final response = await _trackFuture(
+      '$registerServiceMethodName $service',
+      callMethod(registerServiceMethodName,
+          args: {'service': service, 'alias': alias}),
+    );
+
+    return response as Success;
+
+    // TODO(dantup): Revert to this when we no longer need to support clients
+    // on old VMs that don't support public registerService.
+    // return _trackFuture(
+    //     'registerService $service', _vmService.registerService(service, alias));
   }
 
   @override

--- a/packages/devtools/test/fixtures/empty_app.dart
+++ b/packages/devtools/test/fixtures/empty_app.dart
@@ -1,0 +1,12 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+void main() {
+  print('starting empty app');
+
+  // Don't exit until it's indicated we should by the controller.
+  Timer(const Duration(days: 1), () {});
+}

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -344,6 +344,8 @@ class WebdevFixture {
 
       if (line.contains('[INFO] Succeeded')) {
         buildFinished.complete();
+      } else if (line.contains('[SEVERE]')) {
+        buildFinished.completeError(line);
       }
     });
 

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -324,7 +324,7 @@ class WebdevFixture {
   }) async {
     final List<String> cliArgs = ['build'];
 
-    final process = await _runWebdev(cliArgs);
+    final process = await _runWebdev(cliArgs, verbose: verbose);
 
     final Completer<void> buildFinished = Completer<void>();
 
@@ -348,6 +348,8 @@ class WebdevFixture {
     });
 
     await buildFinished.future;
+
+    await process.exitCode;
   }
 
   final Process process;
@@ -360,7 +362,10 @@ class WebdevFixture {
     await process.exitCode;
   }
 
-  static Future<Process> _runWebdev(List<String> buildArgs) async {
+  static Future<Process> _runWebdev(
+    List<String> buildArgs, {
+    bool verbose = false,
+  }) async {
     // Remove the DART_VM_OPTIONS env variable from the child process, so the
     // Dart VM doesn't try and open a service protocol port if
     // 'DART_VM_OPTIONS: --enable-vm-service:63990' was passed in.
@@ -373,8 +378,14 @@ class WebdevFixture {
     final List<String> cliArgs =
         ['global', 'run', 'webdev'].followedBy(buildArgs).toList();
 
+    final executable = Platform.isWindows ? 'pub.bat' : 'pub';
+
+    if (verbose) {
+      print('Running "$executable" with args: ${cliArgs.join(' ')}');
+    }
+
     return Process.start(
-      Platform.isWindows ? 'pub.bat' : 'pub',
+      executable,
       cliArgs,
       environment: environment,
     );

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -276,7 +276,7 @@ class AppError {
 }
 
 class WebdevFixture {
-  WebdevFixture._(this.process, this.url);
+  WebdevFixture._(this.process, this.url, this.verbose);
 
   static Future<WebdevFixture> serve({
     bool release = false,
@@ -316,7 +316,7 @@ class WebdevFixture {
 
     await delay();
 
-    return WebdevFixture._(process, url);
+    return WebdevFixture._(process, url, verbose);
   }
 
   static Future<void> build({
@@ -356,12 +356,16 @@ class WebdevFixture {
 
   final Process process;
   final String url;
+  final bool verbose;
 
   Uri get baseUri => Uri.parse(url);
 
   Future<void> teardown() async {
     process.kill();
-    await process.exitCode;
+    final exitCode = await process.exitCode;
+    if (verbose) {
+      print('webdev exited with code $exitCode');
+    }
   }
 
   static Future<Process> _runWebdev(

--- a/packages/devtools/test/integration_tests/integration_test.dart
+++ b/packages/devtools/test/integration_tests/integration_test.dart
@@ -19,7 +19,7 @@ void main() {
           Platform.environment['WEBDEV_RELEASE'] == 'true';
 
       webdevFixture =
-          await WebdevFixture.create(release: testInReleaseMode, verbose: true);
+          await WebdevFixture.serve(release: testInReleaseMode, verbose: true);
       browserManager = await BrowserManager.create();
     });
 

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -1,0 +1,78 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:vm_service_lib/vm_service_lib.dart';
+
+import '../support/cli_test_driver.dart';
+import '../support/devtools_server_driver.dart';
+import 'integration.dart';
+
+void main() {
+  CliAppFixture appFixture;
+  DevToolsServerDriver server;
+
+  setUp(() async {
+    // Build the app, as the server can't start without the build output.
+    await WebdevFixture.build(verbose: true);
+
+    // The packages folder needs to be renamed to `pack` for the server to work.
+    if (await Directory('build/pack').exists()) {
+      await Directory('build/pack').delete(recursive: true);
+    }
+    await Directory('build/packages').rename('build/pack');
+
+    // Start the command-line server.
+    server = await DevToolsServerDriver.create();
+
+    // Start a test app we can use to connect to.
+    appFixture = await CliAppFixture.create('test/fixtures/empty_app.dart');
+  });
+
+  tearDown(() async {
+    server?.kill();
+    await appFixture?.teardown();
+    await webdevFixture?.teardown();
+  });
+
+  test('registers service', () async {
+    // Track services as they're registered.
+    final registeredServices = <String>{};
+    // TODO(dantup): Remove this loop and just use
+    // appFixture.serviceConnection.onServiceEvent
+    // directly once the VM Service makes it to stable.
+    for (final serviceId in ['Service', '_Service']) {
+      appFixture.serviceConnection
+          .onEvent(serviceId)
+          .where((e) => e.kind == EventKind.kServiceRegistered)
+          .listen((e) => registeredServices.add(e.service));
+      await appFixture.serviceConnection
+          .streamListen(serviceId)
+          .catchError((e, stack) {
+        // TODO(dantup): Remove this empty catch when removing the loop, as it
+        // will no longer be required. We currently need it because one of the
+        // streams will fail.
+      });
+    }
+
+    server.stderr.listen((text) => throw 'STDERR: $text');
+
+    server.write({
+      'id': '10',
+      'method': 'vm.register',
+      'params': {'uri': appFixture.serviceUri.toString()}
+    });
+
+    // Expect to get a successful response from the server.
+    final serverResponse =
+        await server.output.firstWhere((e) => e['id'] == '10');
+    expect(serverResponse['result']['success'], isTrue);
+
+    // Expect the VM service to see the launchDevTools service registered.
+    expect(registeredServices, contains('launchDevTools'));
+  }, timeout: const Timeout.factor(10));
+}

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -41,22 +41,17 @@ void main() {
   test('registers service', () async {
     // Track services as they're registered.
     final registeredServices = <String>{};
-    // TODO(dantup): Remove this loop and just use
-    // appFixture.serviceConnection.onServiceEvent
-    // directly once the VM Service makes it to stable.
-    for (final serviceId in ['Service', '_Service']) {
-      appFixture.serviceConnection
-          .onEvent(serviceId)
-          .where((e) => e.kind == EventKind.kServiceRegistered)
-          .listen((e) => registeredServices.add(e.service));
-      await appFixture.serviceConnection
-          .streamListen(serviceId)
-          .catchError((e, stack) {
-        // TODO(dantup): Remove this empty catch when removing the loop, as it
-        // will no longer be required. We currently need it because one of the
-        // streams will fail.
-      });
-    }
+
+    // TODO(dantup): When the stable versions of Dart + Flutter are >= v3.22
+    // of the VM Service (July 2019), the _Service option here can be removed.
+    final serviceName = await appFixture.serviceConnection.serviceStreamName;
+
+    appFixture.serviceConnection
+        .onEvent(serviceName)
+        .where((e) => e.kind == EventKind.kServiceRegistered)
+        .listen((e) => registeredServices.add(e.service));
+
+    await appFixture.serviceConnection.streamListen(serviceName);
 
     server.stderr.listen((text) => throw 'STDERR: $text');
 

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -36,7 +36,6 @@ void main() {
   tearDown(() async {
     server?.kill();
     await appFixture?.teardown();
-    await webdevFixture?.teardown();
   });
 
   test('registers service', () async {

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -68,5 +68,8 @@ void main() {
 
     // Expect the VM service to see the launchDevTools service registered.
     expect(registeredServices, contains('launchDevTools'));
-  }, timeout: const Timeout.factor(10));
+    // Skipped on Windows due to webdev failing to start immediately after
+    // other tests fail.
+    // https://github.com/flutter/devtools/pull/802#issuecomment-512722437
+  }, timeout: const Timeout.factor(10), skip: Platform.isWindows);
 }

--- a/packages/devtools/test/support/devtools_server_driver.dart
+++ b/packages/devtools/test/support/devtools_server_driver.dart
@@ -1,0 +1,50 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+const verbose = true;
+
+class DevToolsServerDriver {
+  DevToolsServerDriver._(
+      this._process, this._stdin, Stream<String> _stdout, this.stderr)
+      : output = _stdout.map((line) {
+          _trace(line);
+          return line;
+        }).map((line) => jsonDecode(line) as Map<String, dynamic>);
+
+  final Process _process;
+  final Stream<Map<String, dynamic>> output;
+  final Stream<String> stderr;
+  final StringSink _stdin;
+
+  void write(Map<String, dynamic> request) {
+    final line = jsonEncode(request);
+    _trace('==> $line');
+    _stdin.writeln(line);
+  }
+
+  static void _trace(String message) {
+    if (verbose) {
+      print(message);
+    }
+  }
+
+  bool kill() => _process.kill();
+
+  static Future<DevToolsServerDriver> create() async {
+    final Process process = await Process.start(
+      Platform.resolvedExecutable,
+      <String>['bin/devtools.dart', '--machine', '--port', '0'],
+    );
+
+    return new DevToolsServerDriver._(
+        process,
+        process.stdin,
+        process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+        process.stderr.transform(utf8.decoder).transform(const LineSplitter()));
+  }
+}

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4
+- The `launchDevTools` service will now register with VMs using public APIs when available, falling back to private APIs otherwise.
+
 ## 0.1.3
 - vm_service_lib dependency has been pinned to 3.21.0
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -254,7 +254,13 @@ Future<void> registerLaunchDevToolsService(
       }
     });
 
-    await service.registerService(launchDevToolsService, 'DevTools Server');
+    // Handle registerService method name change based on protocol version.
+    final registerServiceMethodName =
+        isVersionLessThan(await service.getVersion(), major: 3, minor: 22)
+            ? '_registerService'
+            : 'registerService';
+    await service.callMethod(registerServiceMethodName,
+        args: {'service': launchDevToolsService, 'alias': 'DevTools Server'});
 
     printOutput(
       'Successfully registered launchDevTools service',
@@ -274,6 +280,16 @@ Future<void> registerLaunchDevToolsService(
       machineMode: machineMode,
     );
   }
+}
+
+bool isVersionLessThan(
+  Version version, {
+  @required int major,
+  @required int minor,
+}) {
+  assert(version != null);
+  return version.major < major ||
+      (version.major == major && version.minor < minor);
 }
 
 final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -282,6 +282,8 @@ Future<void> registerLaunchDevToolsService(
   }
 }
 
+// TODO(dantup): This method was adapted from devtools and should be upstreamed
+// in some form into vm_service_lib.
 bool isVersionLessThan(
   Version version, {
   @required int major,

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.3
+version: 0.1.4
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
This is an alternative PR to #797 which doesn't require increasing vm_service_lib for either package yet.