### PR TITLE
Fix documentation link.

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -487,11 +487,7 @@ abstract class Screen {
           span()
             ..add(span(text: '$name', c: 'optional-700'))
             ..add(span(text: ' Docs')),
-          // TODO(kenzie): remove this special case once performance docs are
-          // published on flutter.dev.
-          href: id == 'performance'
-              ? 'https://flutter.dev/docs/development/tools/devtools/timeline#cpu-flame-chart'
-              : 'https://flutter.dev/docs/development/tools/devtools/$id',
+          href: 'https://flutter.dev/docs/development/tools/devtools/$id',
           title: 'Documentation on using the $name page',
         ),
         disabled = allTabsEnabledByQuery ? false : disabled;


### PR DESCRIPTION
The performance docs link will go live as soon as https://github.com/flutter/website/pull/2835 lands, which I will do as soon as the next DevTools release goes out.