### PR TITLE
Rebuild table rows on selection.

### DIFF
--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -411,6 +411,7 @@ class Table<T> extends Object with SetStateMixin {
           final rowElement = tableRow.element;
           final dataForRow = _dataForRow[rowElement];
           selectRow(rowElement, data.indexOf(dataForRow));
+          // TODO(kenzie): we should do less work on selection.
           _scheduleRebuild();
         });
       }

--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -411,6 +411,7 @@ class Table<T> extends Object with SetStateMixin {
           final rowElement = tableRow.element;
           final dataForRow = _dataForRow[rowElement];
           selectRow(rowElement, data.indexOf(dataForRow));
+          _scheduleRebuild();
         });
       }
 


### PR DESCRIPTION
One more bug fix for virtual tables. We need to rebuild the table upon selection so that the `dataForRow` map is properly updated before we try to navigate around the table via up/down keys.