### PR TITLE
Revert "Enable service test on Windows"

### DIFF
--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -320,11 +320,9 @@ class WebdevFixture {
   }
 
   static Future<void> build({
-    bool release = false,
     bool verbose = false,
   }) async {
     final List<String> cliArgs = ['build'];
-    cliArgs.add(release ? '--release' : '--no-release');
 
     final process = await _runWebdev(cliArgs, verbose: verbose);
 

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -17,11 +17,8 @@ void main() {
   DevToolsServerDriver server;
 
   setUp(() async {
-    final bool testInReleaseMode =
-        Platform.environment['WEBDEV_RELEASE'] == 'true';
-
     // Build the app, as the server can't start without the build output.
-    await WebdevFixture.build(release: testInReleaseMode, verbose: true);
+    await WebdevFixture.build(verbose: true);
 
     // The packages folder needs to be renamed to `pack` for the server to work.
     if (await Directory('build/pack').exists()) {
@@ -71,5 +68,8 @@ void main() {
 
     // Expect the VM service to see the launchDevTools service registered.
     expect(registeredServices, contains('launchDevTools'));
-  }, timeout: const Timeout.factor(10));
+    // Skipped on Windows due to webdev failing to start immediately after
+    // other tests fail.
+    // https://github.com/flutter/devtools/pull/802#issuecomment-512722437
+  }, timeout: const Timeout.factor(10), skip: Platform.isWindows);
 }


### PR DESCRIPTION
Reverts flutter/devtools#824 since it seems to have had a bunch of failures (for ex. "Could not find an option named "build-mode".").