### PR TITLE
Fix NPE on stackFrame.url for older versions of Flutter.

### DIFF
--- a/packages/devtools/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_transformer.dart
@@ -21,7 +21,7 @@ class CpuProfileTransformer {
         // If the user is on a version of Flutter where resolvedUrl is not
         // included in the response, this will be null. If the frame is a native
         // frame, the this will be the empty string.
-        url: v[CpuProfileData.resolvedUrlKey],
+        url: v[CpuProfileData.resolvedUrlKey] ?? '',
         profileMetaData: cpuProfileData.profileMetaData,
       );
       _processStackFrame(


### PR DESCRIPTION
On older versions of Flutter, the "resolvedUrl" key is not included in the json for stack frames. If `json["resolvedUrl"]` is null, set `stackFrame.url` equal to the empty string. 