### PR TITLE
Enable service test on Windows

### DIFF
--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -320,9 +320,11 @@ class WebdevFixture {
   }
 
   static Future<void> build({
+    bool release = false,
     bool verbose = false,
   }) async {
     final List<String> cliArgs = ['build'];
+    cliArgs.add(release ? '--release' : '--no-release');
 
     final process = await _runWebdev(cliArgs, verbose: verbose);
 

--- a/packages/devtools/test/integration_tests/server_test.dart
+++ b/packages/devtools/test/integration_tests/server_test.dart
@@ -17,8 +17,11 @@ void main() {
   DevToolsServerDriver server;
 
   setUp(() async {
+    final bool testInReleaseMode =
+        Platform.environment['WEBDEV_RELEASE'] == 'true';
+
     // Build the app, as the server can't start without the build output.
-    await WebdevFixture.build(verbose: true);
+    await WebdevFixture.build(release: testInReleaseMode, verbose: true);
 
     // The packages folder needs to be renamed to `pack` for the server to work.
     if (await Directory('build/pack').exists()) {
@@ -68,8 +71,5 @@ void main() {
 
     // Expect the VM service to see the launchDevTools service registered.
     expect(registeredServices, contains('launchDevTools'));
-    // Skipped on Windows due to webdev failing to start immediately after
-    // other tests fail.
-    // https://github.com/flutter/devtools/pull/802#issuecomment-512722437
-  }, timeout: const Timeout.factor(10), skip: Platform.isWindows);
+  }, timeout: const Timeout.factor(10));
 }


### PR DESCRIPTION
Reverts flutter/devtools#827 which was a revert of #824 (so this re-lands that work). The failure that caused the revert was an unrelated build_runner update that coincidentally landed around the time I added tests that ran builds.