### PR TITLE
tweak a toast message

### DIFF
--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -893,7 +893,6 @@ class MemoryScreen extends Screen with SetStateMixin {
     if (refs == null) {
       framework.toast(
         'Instance ${hover.data.objectRef} - Sentinel/Expired.',
-        title: 'Warning',
       );
       return;
     }


### PR DESCRIPTION
- tweak a toast message to not use the title 'Warning'; I don't think it's an error condition so much as just VM state that we want the user to be aware of

@terrylucas 