### PR TITLE
Cast _clearCpuProfile method response to Future<Success>.

### DIFF
--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -98,9 +98,10 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Success> clearCpuProfile(String isolateId) {
-    return _trackFuture('clearCpuProfile',
+  Future<Success> clearCpuProfile(String isolateId) async {
+    final response = await _trackFuture('clearCpuProfile',
         callMethod('_clearCpuProfile', isolateId: isolateId));
+    return response as Success;
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/835.