### PR TITLE
Clear pending service extensions in `resetAvailableExtensions`

### DIFF
--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -607,6 +607,7 @@ class ServiceExtensionManager {
   void resetAvailableExtensions() {
     extensionStatesUpdated = Completer();
     _firstFrameEventReceived = false;
+    _pendingServiceExtensions.clear();
     _serviceExtensions.clear();
     _serviceExtensionController
         .forEach((String name, StreamController<bool> stream) {


### PR DESCRIPTION
Copying explanation from: https://github.com/flutter/devtools/issues/599

I'm not able to reproduce this error, but it seems like calling `_pendingServiceExtensions.clear();` where Devon suggested in `resetAvailableExtensions()` is the correct thing to do (we reset all the other service extension related vars here). This feels like a safe change.

Fixes https://github.com/flutter/devtools/issues/599