### PR TITLE
Add expandAll / collapseAll functionality to tree tables.

### DIFF
--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -45,7 +45,7 @@ class CpuCallTree extends CpuProfilerView {
     final CpuStackFrame root = data.cpuProfileRoot.deepCopy();
 
     // Expand the root stack frame to start.
-    final List<CpuStackFrame> rows = [
+    final rows = <CpuStackFrame>[
       root..expand(),
       ...root.children.cast(),
     ];

--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -45,8 +45,10 @@ class CpuCallTree extends CpuProfilerView {
     final CpuStackFrame root = data.cpuProfileRoot.deepCopy();
 
     // Expand the root stack frame to start.
-    final List<CpuStackFrame> rows = [root..expand()]
-      ..addAll(root.children.cast());
+    final List<CpuStackFrame> rows = [
+      root..expand(),
+      ...root.children.cast(),
+    ];
     callTreeTable.setRows(rows);
   }
 

--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -45,7 +45,7 @@ class CpuCallTree extends CpuProfilerView {
     final CpuStackFrame root = data.cpuProfileRoot.deepCopy();
 
     // Expand the root stack frame to start.
-    final List<CpuStackFrame> rows = [root..isExpanded = true]
+    final List<CpuStackFrame> rows = [root..expand()]
       ..addAll(root.children.cast());
     callTreeTable.setRows(rows);
   }

--- a/packages/devtools/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profiler.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 import 'package:meta/meta.dart';
 
+import '../tables.dart';
 import '../ui/custom.dart';
 import '../ui/elements.dart';
 import '../ui/primer.dart';
@@ -190,6 +191,8 @@ class CpuProfilerTabNav {
 
   final CpuProfilerTabOrder tabOrder;
 
+  final TreeTableToolbar treeTableToolbar = TreeTableToolbar<CpuStackFrame>();
+
   PTabNav get element => _tabNav;
 
   PTabNav _tabNav;
@@ -217,7 +220,14 @@ class CpuProfilerTabNav {
       tabs.firstWhere((tab) => tab.type == tabOrder.second),
       tabs.firstWhere((tab) => tab.type == tabOrder.third),
     ])
-      ..element.style.borderBottom = '0';
+      ..element.style.borderBottom = '0'
+      ..layoutHorizontal()
+      ..add([
+        div()..flex(),
+        treeTableToolbar,
+      ]);
+
+    _updateToolbarForSelection(selectedTab);
 
     _tabNav.onTabSelected.listen((PTabNavTab tab) {
       // Return early if this tab is already selected.
@@ -225,8 +235,25 @@ class CpuProfilerTabNav {
         return;
       }
       selectedTab = tab;
+      _updateToolbarForSelection(selectedTab);
       cpuProfiler.showView((tab as CpuProfilerTab).type);
     });
+  }
+
+  void _updateToolbarForSelection(PTabNavTab selectedTab) {
+    switch ((selectedTab as CpuProfilerTab).type) {
+      case CpuProfilerViewType.flameChart:
+        treeTableToolbar.hidden(true);
+        break;
+      case CpuProfilerViewType.callTree:
+        treeTableToolbar.hidden(false);
+        treeTableToolbar.treeTable = cpuProfiler.callTree.callTreeTable;
+        break;
+      case CpuProfilerViewType.bottomUp:
+        treeTableToolbar.hidden(false);
+        treeTableToolbar.treeTable = cpuProfiler.bottomUp.bottomUpTable;
+        break;
+    }
   }
 }
 

--- a/packages/devtools/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profiler.dart
@@ -191,7 +191,7 @@ class CpuProfilerTabNav {
 
   final CpuProfilerTabOrder tabOrder;
 
-  final TreeTableToolbar treeTableToolbar = TreeTableToolbar<CpuStackFrame>();
+  final TreeTableToolbar<CpuStackFrame> treeTableToolbar = TreeTableToolbar();
 
   PTabNav get element => _tabNav;
 
@@ -240,8 +240,8 @@ class CpuProfilerTabNav {
     });
   }
 
-  void _updateToolbarForSelection(PTabNavTab selectedTab) {
-    switch ((selectedTab as CpuProfilerTab).type) {
+  void _updateToolbarForSelection(CpuProfilerTab selectedTab) {
+    switch (selectedTab.type) {
       case CpuProfilerViewType.flameChart:
         treeTableToolbar.hidden(true);
         break;

--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -670,14 +670,10 @@ class TreeTable<T extends TreeNode<T>> extends Table<T> {
   }
 
   void expandAll() {
-    // Make a copy so that we are not concurrently modifying the tree data.
-    final List<T> dataCopy = data;
-
     // Store visited nodes so that we do not expand the same root multiple
     // times.
-    // ignore: prefer_collection_literals
-    final Set<T> visited = Set<T>();
-    for (T dataObject in dataCopy) {
+    final Set<T> visited = {};
+    for (T dataObject in data) {
       final root = dataObject.root;
       if (!visited.contains(root)) {
         root.expandCascading();
@@ -685,18 +681,14 @@ class TreeTable<T extends TreeNode<T>> extends Table<T> {
       }
     }
 
-    setRows(dataCopy);
+    setRows(data);
   }
 
   void collapseAll() {
-    // Make a copy so that we are not concurrently modifying the tree data.
-    final List<T> dataCopy = data;
-
     // Store visited nodes so that we do not expand the same root multiple
     // times.
-    // ignore: prefer_collection_literals
-    final Set<T> visited = Set<T>();
-    for (T dataObject in dataCopy) {
+    final Set<T> visited = {};
+    for (T dataObject in data) {
       final root = dataObject.root;
       if (!visited.contains(root)) {
         root.collapseCascading();
@@ -704,7 +696,7 @@ class TreeTable<T extends TreeNode<T>> extends Table<T> {
       }
     }
 
-    setRows(dataCopy);
+    setRows(data);
   }
 }
 
@@ -886,15 +878,14 @@ class TreeTableToolbar<T extends TreeNode<T>> extends CoreElement {
       ]));
   }
 
-  TreeTable<T> _treeTable;
-  set treeTable(TreeTable table) => _treeTable = table;
+  TreeTable<T> treeTable;
 
   void _expandAll() {
-    _treeTable.expandAll();
+    treeTable.expandAll();
   }
 
   void _collapseAll() {
-    _treeTable.collapseAll();
+    treeTable.collapseAll();
   }
 }
 

--- a/packages/devtools/lib/src/tables.dart
+++ b/packages/devtools/lib/src/tables.dart
@@ -672,7 +672,7 @@ class TreeTable<T extends TreeNode<T>> extends Table<T> {
   void expandAll() {
     // Store visited nodes so that we do not expand the same root multiple
     // times.
-    final Set<T> visited = {};
+    final visited = <T>{};
     for (T dataObject in data) {
       final root = dataObject.root;
       if (!visited.contains(root)) {
@@ -687,7 +687,7 @@ class TreeTable<T extends TreeNode<T>> extends Table<T> {
   void collapseAll() {
     // Store visited nodes so that we do not expand the same root multiple
     // times.
-    final Set<T> visited = {};
+    final visited = <T>{};
     for (T dataObject in data) {
       final root = dataObject.root;
       if (!visited.contains(root)) {

--- a/packages/devtools/lib/src/trees.dart
+++ b/packages/devtools/lib/src/trees.dart
@@ -45,8 +45,7 @@ class TreeNode<T extends TreeNode<T>> {
 
     // Store nodes we have visited so we can cache the root value for each one
     // once we find the root.
-    // ignore: prefer_collection_literals
-    final Set<T> visited = Set.from([this]);
+    final Set<T> visited = {this};
 
     T root = this;
     while (root.parent != null) {
@@ -134,7 +133,7 @@ class TreeNode<T extends TreeNode<T>> {
 /// every single node, we would do this through the [action] param.
 T breadthFirstTraversal<T extends TreeNode<T>>(T root,
     {bool returnCondition(T node), void action(T node)}) {
-  final Queue<T> queue = Queue.from([root]);
+  final Queue<T> queue = Queue.of([root]);
   while (queue.isNotEmpty) {
     final T node = queue.removeFirst();
     if (returnCondition != null && returnCondition(node)) {

--- a/packages/devtools/lib/src/trees.dart
+++ b/packages/devtools/lib/src/trees.dart
@@ -45,7 +45,7 @@ class TreeNode<T extends TreeNode<T>> {
 
     // Store nodes we have visited so we can cache the root value for each one
     // once we find the root.
-    final Set<T> visited = {this};
+    final visited = {this};
 
     T root = this;
     while (root.parent != null) {
@@ -133,9 +133,9 @@ class TreeNode<T extends TreeNode<T>> {
 /// every single node, we would do this through the [action] param.
 T breadthFirstTraversal<T extends TreeNode<T>>(T root,
     {bool returnCondition(T node), void action(T node)}) {
-  final Queue<T> queue = Queue.of([root]);
+  final queue = Queue.of([root]);
   while (queue.isNotEmpty) {
-    final T node = queue.removeFirst();
+    final node = queue.removeFirst();
     if (returnCondition != null && returnCondition(node)) {
       return node;
     }

--- a/packages/devtools/lib/src/trees.dart
+++ b/packages/devtools/lib/src/trees.dart
@@ -42,15 +42,29 @@ class TreeNode<T extends TreeNode<T>> {
     if (_root != null) {
       return _root;
     }
+
+    // Store nodes we have visited so we can cache the root value for each one
+    // once we find the root.
+    // ignore: prefer_collection_literals
+    final Set<T> visited = Set.from([this]);
+
     T root = this;
     while (root.parent != null) {
+      visited.add(root);
       root = root.parent;
     }
-    return _root = root;
+
+    // Set [_root] for all nodes we visited.
+    for (T node in visited) {
+      node._root = root;
+    }
+
+    return root;
   }
 
   T _root;
 
+  /// The level (0-based) of this tree node in the tree.
   int get level {
     if (_level != null) {
       return _level;
@@ -64,8 +78,22 @@ class TreeNode<T extends TreeNode<T>> {
     return _level = level;
   }
 
-  /// The level (0-based) of this tree node in the tree.
   int _level;
+
+  /// Whether the tree table node is expandable.
+  bool get isExpandable => children.isNotEmpty;
+
+  /// Whether the node is currently expanded in the tree table.
+  bool get isExpanded => _isExpanded;
+  bool _isExpanded = false;
+
+  void expand() {
+    _isExpanded = true;
+  }
+
+  void collapse() {
+    _isExpanded = false;
+  }
 
   void addChild(T child) {
     children.add(child);
@@ -73,21 +101,49 @@ class TreeNode<T extends TreeNode<T>> {
     child.index = children.length - 1;
   }
 
-  bool containsChildWithCondition(bool condition(T node)) {
-    final Queue<T> queue = Queue.from([this]);
-    while (queue.isNotEmpty) {
-      final T node = queue.removeFirst();
-      if (condition(node)) {
-        return true;
-      }
-      node.children.forEach(queue.add);
-    }
-    return false;
+  /// Expands this node and all of its children (cascading).
+  void expandCascading() {
+    breadthFirstTraversal<T>(this, action: (T node) {
+      node.expand();
+    });
   }
 
-  /// Whether the tree table node is expandable.
-  bool get isExpandable => children.isNotEmpty;
+  /// Collapses this node and all of its children (cascading).
+  void collapseCascading() {
+    breadthFirstTraversal<T>(this, action: (T node) {
+      node.collapse();
+    });
+  }
 
-  /// Whether the node is currently expanded in the tree table.
-  bool isExpanded = false;
+  bool containsChildWithCondition(bool condition(T node)) {
+    final T childWithCondition = breadthFirstTraversal<T>(
+      this,
+      returnCondition: condition,
+    );
+    return childWithCondition != null;
+  }
+}
+
+/// Traverses a tree in breadth-first order.
+///
+/// [returnCondition] specifies the condition for which we should stop
+/// traversing the tree. For example, if we are calling this method to perform
+/// BFS, [returnCondition] would specify when we have found the node we are
+/// searching for. [action] specifies an action that we will execute on each
+/// node. For example, if we need to traverse a tree and change a property on
+/// every single node, we would do this through the [action] param.
+T breadthFirstTraversal<T extends TreeNode<T>>(T root,
+    {bool returnCondition(T node), void action(T node)}) {
+  final Queue<T> queue = Queue.from([root]);
+  while (queue.isNotEmpty) {
+    final T node = queue.removeFirst();
+    if (returnCondition != null && returnCondition(node)) {
+      return node;
+    }
+    if (action != null) {
+      action(node);
+    }
+    node.children.forEach(queue.add);
+  }
+  return null;
 }

--- a/packages/devtools/test/cpu_profile_model_test.dart
+++ b/packages/devtools/test/cpu_profile_model_test.dart
@@ -130,7 +130,7 @@ void main() {
     test('deepCopy', () {
       expect(testStackFrame.isExpanded, isFalse);
       expect(testStackFrame.children.length, equals(1));
-      testStackFrame.isExpanded = true;
+      testStackFrame.expand();
       expect(testStackFrame.isExpanded, isTrue);
 
       final copy = testStackFrame.deepCopy();

--- a/packages/devtools/test/trees_test.dart
+++ b/packages/devtools/test/trees_test.dart
@@ -23,6 +23,31 @@ void main() {
       expect(treeNode5.level, equals(3));
     });
 
+    test('expand and collapse', () {
+      expect(testTreeNode.isExpanded, isFalse);
+      testTreeNode.expand();
+      expect(testTreeNode.isExpanded, isTrue);
+      testTreeNode.collapse();
+      expect(testTreeNode.isExpanded, isFalse);
+
+      breadthFirstTraversal<TestTreeNode>(testTreeNode,
+          action: (TreeNode node) {
+        expect(node.isExpanded, isFalse);
+      });
+
+      testTreeNode.expandCascading();
+      breadthFirstTraversal<TestTreeNode>(testTreeNode,
+          action: (TreeNode node) {
+        expect(node.isExpanded, isTrue);
+      });
+
+      testTreeNode.collapseCascading();
+      breadthFirstTraversal<TestTreeNode>(testTreeNode,
+          action: (TreeNode node) {
+        expect(node.isExpanded, isFalse);
+      });
+    });
+
     test('addChild', () {
       final parent = TestTreeNode();
       final child = TestTreeNode();


### PR DESCRIPTION
Exposes this functionality to the CpuProfiler via a table toolbar [TreeTableToolbar].
![Screen Shot 2019-07-24 at 3 01 32 PM](https://user-images.githubusercontent.com/43759233/61833094-1ffb5280-ae28-11e9-8b15-7a0842b2927d.png)
![Screen Shot 2019-07-24 at 3 02 00 PM](https://user-images.githubusercontent.com/43759233/61833097-21c51600-ae28-11e9-9d85-80b19992c419.png)
