### PR TITLE
Bump minSdk to 2.3.0

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.2.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   codemirror: ^0.5.3

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   codemirror: ^0.5.3

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -297,20 +297,8 @@ bool isVersionLessThan(
 final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();
 
 bool _isAccessibleToChromeOSNativeBrowser(Uri uri) {
-  // TODO(dantup): Change to Set literal when supported.
-  const tunneledPorts = {
-    8000: true,
-    8008: true,
-    8080: true,
-    8085: true,
-    8888: true,
-    9005: true,
-    3000: true,
-    4200: true,
-    5000: true,
-  };
-
-  return uri != null && uri.hasPort && tunneledPorts[uri.port] == true;
+  const tunneledPorts = {8000, 8008, 8080, 8085, 8888, 9005, 3000, 4200, 5000};
+  return uri != null && uri.hasPort && tunneledPorts.contains(uri.port) == true;
 }
 
 Future<VmService> _connectToVmService(Uri uri) async {

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -298,7 +298,7 @@ final bool _isChromeOS = new File('/dev/.cros_milestone').existsSync();
 
 bool _isAccessibleToChromeOSNativeBrowser(Uri uri) {
   const tunneledPorts = {8000, 8008, 8080, 8085, 8888, 9005, 3000, 4200, 5000};
-  return uri != null && uri.hasPort && tunneledPorts.contains(uri.port) == true;
+  return uri != null && uri.hasPort && tunneledPorts.contains(uri.port);
 }
 
 Future<VmService> _connectToVmService(Uri uri) async {

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.1.2-dev.0.0 <3.0.0'
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   args: ^1.5.1

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -7,7 +7,7 @@ author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.2.2 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   args: ^1.5.1


### PR DESCRIPTION
This will give us access to UI as code features like spread operators.
Flutter stable is on 2.4.0, so this should be safe.