### PR TITLE
Add UI for recorded timeline (non-frame-based).

### DIFF
--- a/packages/devtools/lib/src/performance/performance.css
+++ b/packages/devtools/lib/src/performance/performance.css
@@ -1,19 +1,3 @@
-.instruction-container {
-    margin-top: -22px; /* Negative top margin of half of the container height. */
-}
-
-.instruction-message {
-    justify-content: center;
-}
-
-.profiler-status-message {
-    margin-top: -34px; /* Full height of the text field plus padding for the spinner. */
-}
-
-.profiler-spinner {
-    margin-top: 0 !important;
-}
-
 .profiler-container {
     position: relative;
     height: 100%;

--- a/packages/devtools/lib/src/performance/performance_screen.dart
+++ b/packages/devtools/lib/src/performance/performance_screen.dart
@@ -9,7 +9,6 @@ import '../profiler/cpu_profile_tables.dart';
 import '../profiler/cpu_profiler.dart';
 import '../ui/custom.dart';
 import '../ui/elements.dart';
-import '../ui/html_icon_renderer.dart';
 import '../ui/material_icons.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
@@ -35,11 +34,11 @@ class PerformanceScreen extends Screen {
 
   ProfileGranularitySelector _profileGranularitySelector;
 
-  CoreElement _profilerInstructions;
+  CoreElement _recordingInstructions;
 
-  CoreElement _profilerStatus;
+  CoreElement _recordingStatus;
 
-  CoreElement _profilerStatusMessage;
+  CoreElement _recordingStatusMessage;
 
   CpuProfilerTabNav _tabNav;
 
@@ -73,8 +72,8 @@ class PerformanceScreen extends Screen {
           div(c: 'profiler-container section-border')
             ..add([
               _cpuProfiler..hidden(true),
-              _profilerInstructions,
-              _profilerStatus..hidden(true)
+              _recordingInstructions,
+              _recordingStatus..hidden(true)
             ]),
         ]),
     ]);
@@ -104,34 +103,15 @@ class PerformanceScreen extends Screen {
 
     _profileGranularitySelector = ProfileGranularitySelector(framework);
 
-    _profilerInstructions = div(c: 'center-in-parent instruction-container')
-      ..layoutVertical()
-      ..flex()
-      ..add([
-        div(c: 'instruction-message')
-          ..layoutHorizontal()
-          ..flex()
-          ..add([
-            div(text: 'Click the record button '),
-            createIconElement(record),
-            div(text: 'to start recording a CPU profile.')
-          ]),
-        div(c: 'instruction-message')
-          ..layoutHorizontal()
-          ..flex()
-          ..add([
-            div(text: 'Click the stop button '),
-            createIconElement(stop),
-            div(text: 'to end the recording.')
-          ]),
-      ]);
+    _recordingInstructions = createRecordingInstructions(
+        recordingGoal: 'to start recording a CPU profile.');
 
-    _profilerStatus = div(c: 'center-in-parent')
+    _recordingStatus = div(c: 'center-in-parent')
       ..layoutVertical()
       ..flex()
       ..add([
-        _profilerStatusMessage = div(c: 'profiler-status-message'),
-        Spinner.centered(classes: ['profiler-spinner']),
+        _recordingStatusMessage = div(c: 'recording-status-message'),
+        Spinner.centered(classes: ['recording-spinner']),
       ]);
 
     _cpuProfiler = _CpuProfiler(
@@ -158,15 +138,15 @@ class PerformanceScreen extends Screen {
     await _performanceController.startRecording();
     _updateCpuProfilerVisibility(hidden: true);
     _updateButtonStates();
-    _profilerInstructions.hidden(true);
-    _profilerStatusMessage.text = 'Recording profile';
-    _profilerStatus.hidden(false);
+    _recordingInstructions.hidden(true);
+    _recordingStatusMessage.text = 'Recording profile';
+    _recordingStatus.hidden(false);
   }
 
   Future<void> _stopRecording() async {
-    _profilerStatusMessage.text = 'Processing profile';
+    _recordingStatusMessage.text = 'Processing profile';
     await _performanceController.stopRecording();
-    _profilerStatus.hidden(true);
+    _recordingStatus.hidden(true);
     _updateCpuProfilerVisibility(hidden: false);
     _updateButtonStates();
     await _cpuProfiler.update();
@@ -175,7 +155,7 @@ class PerformanceScreen extends Screen {
   void _clear() {
     _performanceController.reset();
     _updateCpuProfilerVisibility(hidden: true);
-    _profilerInstructions.hidden(false);
+    _recordingInstructions.hidden(false);
   }
 
   void _updateButtonStates() {

--- a/packages/devtools/lib/src/timeline/frames_bar_chart.dart
+++ b/packages/devtools/lib/src/timeline/frames_bar_chart.dart
@@ -14,7 +14,7 @@ import 'timeline_model.dart';
 
 class FramesBarChart extends CoreElement with SetStateMixin {
   FramesBarChart(this.timelineController)
-      : super('div', classes: 'timeline-frames') {
+      : super('div', classes: 'timeline-frames section section-border') {
     // No frame around component, so data spikes can appear to go through the
     // roof (highest horizontal line is 100 ms).
     layoutHorizontal();

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -169,3 +169,18 @@
     /* 100% height minus the height of the event-details-heading */
     height: calc(100% - 27px);
 }
+
+.checkbox-container {
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: 6px;
+}
+
+.checkbox {
+    margin-left: 6px;
+    margin-right: 6px;
+}
+
+.checkbox-text {
+    margin-bottom: 1px;
+}

--- a/packages/devtools/lib/src/timeline/timeline.css
+++ b/packages/devtools/lib/src/timeline/timeline.css
@@ -169,18 +169,3 @@
     /* 100% height minus the height of the event-details-heading */
     height: calc(100% - 27px);
 }
-
-.checkbox-container {
-    justify-content: flex-end;
-    align-items: center;
-    margin-right: 6px;
-}
-
-.checkbox {
-    margin-left: 6px;
-    margin-right: 6px;
-}
-
-.checkbox-text {
-    margin-bottom: 1px;
-}

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -83,18 +83,34 @@ class TimelineController {
   /// Whether the timeline has been manually paused via the Pause button.
   bool manuallyPaused = false;
 
+  /// Whether the timeline is being recorded, which will only occur when the
+  /// timeline is not in display-by-frame mode.
+  bool recording = false;
+
   bool get hasStarted => timelineData != null;
 
   bool get paused => _paused;
 
   bool _paused = false;
 
-  void pause() {
+  void pause({bool manual = false}) {
+    manuallyPaused = manual;
     _paused = true;
   }
 
   void resume() {
+    manuallyPaused = false;
     _paused = false;
+  }
+
+  void startRecording() {
+    // TODO(kenzie): kick off timeline recording here.
+    recording = true;
+  }
+
+  void stopRecording() {
+    // TODO(kenzie): kick off trace event processing here.
+    recording = false;
   }
 
   void selectFrame(TimelineFrame frame) {

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -80,6 +80,8 @@ class TimelineController {
 
   CpuProfilerService cpuProfilerService = CpuProfilerService();
 
+  bool frameBasedTimelineMode = false;
+
   /// Whether the timeline has been manually paused via the Pause button.
   bool manuallyPaused = false;
 

--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -80,7 +80,7 @@ class TimelineController {
 
   CpuProfilerService cpuProfilerService = CpuProfilerService();
 
-  bool frameBasedTimelineMode = false;
+  TimelineMode timelineMode = TimelineMode.frameBased;
 
   /// Whether the timeline has been manually paused via the Pause button.
   bool manuallyPaused = false;
@@ -228,4 +228,9 @@ class TimelineController {
     timelineData.clear();
     offlineTimelineData = null;
   }
+}
+
+enum TimelineMode {
+  frameBased,
+  full,
 }

--- a/packages/devtools/lib/src/ui/ui_utils.dart
+++ b/packages/devtools/lib/src/ui/ui_utils.dart
@@ -112,3 +112,27 @@ void downloadFile(String src, String filename) {
   element.click();
   element.remove();
 }
+
+CoreElement createRecordingInstructions({@required String recordingGoal}) {
+  return div(c: 'center-in-parent recording-instruction-container')
+    ..layoutVertical()
+    ..flex()
+    ..add([
+      div(c: 'recording-instruction-message')
+        ..layoutHorizontal()
+        ..flex()
+        ..add([
+          div(text: 'Click the record button '),
+          createIconElement(record),
+          div(text: recordingGoal)
+        ]),
+      div(c: 'recording-instruction-message')
+        ..layoutHorizontal()
+        ..flex()
+        ..add([
+          div(text: 'Click the stop button '),
+          createIconElement(stop),
+          div(text: 'to end the recording.')
+        ]),
+    ]);
+}

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -1151,3 +1151,19 @@ span.strong {
         flex-direction: row;
     }
 }
+
+.recording-instruction-container {
+    margin-top: -22px; /* Negative top margin of half of the container height. */
+}
+
+.recording-instruction-message {
+    justify-content: center;
+}
+
+.recording-status-message {
+    margin-top: -34px; /* Full height of the text field plus padding for the spinner. */
+}
+
+.recording-spinner {
+    margin-top: 0 !important;
+}

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -1167,3 +1167,18 @@ span.strong {
 .recording-spinner {
     margin-top: 0 !important;
 }
+
+.checkbox-container {
+    justify-content: flex-end;
+    align-items: center;
+    margin-right: 6px;
+}
+
+.checkbox {
+    margin-left: 6px;
+    margin-right: 6px;
+}
+
+.checkbox-text {
+    margin-bottom: 1px;
+}


### PR DESCRIPTION
This CL is to add the UI for a non-frame-based mode of the timeline. Actual implementation to follow. This code is guarded behind a flag `enableMultiModeTimeline` so the UI will not be visible in DevTools by default.

<img width="974" alt="Screen Shot 2019-07-29 at 8 12 29 AM" src="https://user-images.githubusercontent.com/43759233/62059733-a1603580-b1d8-11e9-9d9e-0a32d5f5cf1d.png">
<img width="1173" alt="Screen Shot 2019-07-29 at 8 03 50 AM" src="https://user-images.githubusercontent.com/43759233/62059571-6958f280-b1d8-11e9-85d5-bb4b40fdc3b0.png">
