### PR TITLE
Disable proper devtools pages for dart web apps.

### DIFF
--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -10,7 +10,7 @@ import 'globals.dart';
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const flutterWebLibraryUri = 'package:flutter_web/src/widgets/binding.dart';
-const angularLibraryUri = 'package:angular';
+const dartHtmlLibraryUri = 'dart:html';
 
 class ConnectedApp {
   ConnectedApp();
@@ -36,10 +36,10 @@ class ConnectedApp {
   Future<bool> get isAnyFlutterApp async =>
       await isFlutterApp || await isFlutterWebApp;
 
-  Future<bool> get isAngularApp async =>
-      _isAngularApp ??= await _libraryUriAvailable(angularLibraryUri);
+  Future<bool> get isDartWebApp async =>
+      _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
 
-  bool _isAngularApp;
+  bool _isDartWebApp;
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
@@ -69,14 +69,9 @@ class ConnectedApp {
     assert(serviceManager.serviceAvailable.isCompleted);
     await serviceManager.isolateManager.selectedIsolateAvailable.future;
 
-    final uris = serviceManager.isolateManager.selectedIsolateLibraries
+    return serviceManager.isolateManager.selectedIsolateLibraries
         .map((ref) => ref.uri)
-        .toList();
-    for (String u in uris) {
-      if (u.startsWith(uri)) {
-        return true;
-      }
-    }
-    return false;
+        .toList()
+        .any((u) => u.startsWith(uri));
   }
 }

--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -10,12 +10,13 @@ import 'globals.dart';
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const flutterWebLibraryUri = 'package:flutter_web/src/widgets/binding.dart';
+const angularLibraryUri = 'package:angular';
 
 class ConnectedApp {
   ConnectedApp();
 
   Future<bool> get isFlutterApp async =>
-      _isFlutterApp ?? await _libraryUriAvailable(flutterLibraryUri);
+      _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
 
   bool _isFlutterApp;
 
@@ -23,17 +24,22 @@ class ConnectedApp {
   // flutter merges with flutter_web. See
   // https://github.com/flutter/devtools/issues/466.
   Future<bool> get isFlutterWebApp async =>
-      _isFlutterWebApp ?? await _libraryUriAvailable(flutterWebLibraryUri);
+      _isFlutterWebApp ??= await _libraryUriAvailable(flutterWebLibraryUri);
 
   bool _isFlutterWebApp;
 
   Future<bool> get isProfileBuild async =>
-      _isProfileBuild ?? await _connectedToProfileBuild();
+      _isProfileBuild ??= await _connectedToProfileBuild();
 
   bool _isProfileBuild;
 
   Future<bool> get isAnyFlutterApp async =>
       await isFlutterApp || await isFlutterWebApp;
+
+  Future<bool> get isAngularApp async =>
+      _isAngularApp ??= await _libraryUriAvailable(angularLibraryUri);
+
+  bool _isAngularApp;
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
@@ -63,9 +69,14 @@ class ConnectedApp {
     assert(serviceManager.serviceAvailable.isCompleted);
     await serviceManager.isolateManager.selectedIsolateAvailable.future;
 
-    return serviceManager.isolateManager.selectedIsolateLibraries
+    final uris = serviceManager.isolateManager.selectedIsolateLibraries
         .map((ref) => ref.uri)
-        .toList()
-        .contains(uri);
+        .toList();
+    for (String u in uris) {
+      if (u.startsWith(uri)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -143,7 +143,7 @@ class PerfToolFramework extends Framework {
     final _isFlutterWebApp = await serviceManager.connectedApp.isFlutterWebApp;
     final _isProfileBuild = await serviceManager.connectedApp.isProfileBuild;
     final _isAnyFlutterApp = await serviceManager.connectedApp.isAnyFlutterApp;
-    final _isAngularApp = await serviceManager.connectedApp.isAngularApp;
+    final _isDartWebApp = await serviceManager.connectedApp.isDartWebApp;
 
     const notRunningFlutterApp =
         'This screen is disabled because you are not running a Flutter '
@@ -156,8 +156,8 @@ class PerfToolFramework extends Framework {
     const duplicateDebuggerFunctionality =
         'This screen is disabled because it provides functionality already '
         'available in your code editor';
-    const runningAngular =
-        'This screen is disabled because you are running an Angular app';
+    const runningDartWeb =
+        'This screen is disabled because you are running a Dart web app';
 
     String getDebuggerDisabledTooltip() {
       if (_isFlutterWebApp) return runningFlutterWeb;
@@ -180,12 +180,12 @@ class PerfToolFramework extends Framework {
           _isFlutterWebApp ? runningFlutterWeb : notRunningFlutterApp,
     ));
     addScreen(MemoryScreen(
-      disabled: _isFlutterWebApp || _isAngularApp,
-      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningAngular,
+      disabled: _isFlutterWebApp || _isDartWebApp,
+      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningDartWeb,
     ));
     addScreen(PerformanceScreen(
-      disabled: _isFlutterWebApp || _isAngularApp,
-      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningAngular,
+      disabled: _isFlutterWebApp || _isDartWebApp,
+      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningDartWeb,
     ));
     addScreen(DebuggerScreen(
       disabled: _isFlutterWebApp ||

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -143,20 +143,26 @@ class PerfToolFramework extends Framework {
     final _isFlutterWebApp = await serviceManager.connectedApp.isFlutterWebApp;
     final _isProfileBuild = await serviceManager.connectedApp.isProfileBuild;
     final _isAnyFlutterApp = await serviceManager.connectedApp.isAnyFlutterApp;
+    final _isAngularApp = await serviceManager.connectedApp.isAngularApp;
 
-    const notReadyForFlutterWeb =
+    const notRunningFlutterApp =
+        'This screen is disabled because you are not running a Flutter '
+        'application';
+    const runningFlutterWeb =
         'This screen is disabled because it is not yet ready for Flutter Web';
+    const runningProfileBuild =
+        'This screen is disabled because you are running a profile build of '
+        'your application';
+    const duplicateDebuggerFunctionality =
+        'This screen is disabled because it provides functionality already '
+        'available in your code editor';
+    const runningAngular =
+        'This screen is disabled because you are running an Angular app';
 
     String getDebuggerDisabledTooltip() {
-      if (_isFlutterWebApp) {
-        return notReadyForFlutterWeb;
-      }
-      if (_isProfileBuild) {
-        return 'This screen is disabled because you are running a profile build'
-            ' of your application';
-      }
-      return 'This screen is disabled because it provides functionality already'
-          ' available in your code editor';
+      if (_isFlutterWebApp) return runningFlutterWeb;
+      if (_isProfileBuild) return runningProfileBuild;
+      return duplicateDebuggerFunctionality;
     }
 
     // Collect all platform information flutter, web, chrome, versions, etc. for
@@ -165,26 +171,21 @@ class PerfToolFramework extends Framework {
 
     addScreen(InspectorScreen(
       disabled: !_isAnyFlutterApp || _isProfileBuild,
-      disabledTooltip: !_isAnyFlutterApp
-          ? 'This screen is disabled because you are not running a Flutter '
-              'application'
-          : 'This screen is disabled because you are running a profile build '
-              'of your application',
+      disabledTooltip:
+          !_isAnyFlutterApp ? notRunningFlutterApp : runningProfileBuild,
     ));
     addScreen(TimelineScreen(
       disabled: !_isFlutterApp,
-      disabledTooltip: _isFlutterWebApp
-          ? notReadyForFlutterWeb
-          : 'This screen is disabled because you are not running a '
-              'Flutter application',
+      disabledTooltip:
+          _isFlutterWebApp ? runningFlutterWeb : notRunningFlutterApp,
     ));
     addScreen(MemoryScreen(
-      disabled: _isFlutterWebApp,
-      disabledTooltip: notReadyForFlutterWeb,
+      disabled: _isFlutterWebApp || _isAngularApp,
+      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningAngular,
     ));
     addScreen(PerformanceScreen(
-      disabled: _isFlutterWebApp,
-      disabledTooltip: notReadyForFlutterWeb,
+      disabled: _isFlutterWebApp || _isAngularApp,
+      disabledTooltip: _isFlutterWebApp ? runningFlutterWeb : runningAngular,
     ));
     addScreen(DebuggerScreen(
       disabled: _isFlutterWebApp ||

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -174,8 +174,9 @@ class ServiceConnectionManager {
       serviceStreamName
     ];
 
-    // The following streams are not yet supported by Flutter Web.
-    if (!await connectedApp.isFlutterWebApp) {
+    // The following streams are not yet supported by Flutter Web / Dart web
+    // apps.
+    if (!await connectedApp.isDartWebApp) {
       streamIds.addAll(['_Graph', '_Logging', EventStreams.kLogging]);
     }
 

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -20,9 +20,11 @@ class TimelineService {
 
   final TimelineController timelineController;
 
-  void _initListeners() {
+  void _initListeners() async {
     serviceManager.onConnectionAvailable.listen(_handleConnectionStart);
-    if (serviceManager.hasConnection) {
+    // Do not start the timeline for Dart web apps.
+    if (serviceManager.hasConnection &&
+        !await serviceManager.connectedApp.isDartWebApp) {
       _handleConnectionStart(serviceManager.service);
     }
     serviceManager.onConnectionClosed.listen(_handleConnectionStop);


### PR DESCRIPTION
All pages except debugger and logging should be disabled for dart web apps (that are also not flutter web). We are detecting this by looking for the "dart:html" package.

All checks for flutter web apps come first, so we will still handle the flutter web case independently.