### PR TITLE
Use custom scrollbar for debugger in dark mode.

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -130,7 +130,7 @@ class DebuggerScreen extends Screen {
   CoreElement createContent(Framework framework) {
     ga_platform.setupDimensions();
 
-    final CoreElement screenDiv = div()..layoutVertical();
+    final CoreElement screenDiv = div(c: 'custom-scrollbar')..layoutVertical();
 
     CoreElement sourceArea;
     CoreElement consoleDiv;


### PR DESCRIPTION
We were using the light theme scrollbar for dark mode. Debugger window scrollbars now look like this:
<img width="1466" alt="Screen Shot 2019-07-29 at 3 05 32 PM" src="https://user-images.githubusercontent.com/43759233/62086282-ac37bc00-b212-11e9-9955-0cceb445bf82.png">
