### PR TITLE
Update split library.

### DIFF
--- a/third_party/packages/split/lib/split.dart
+++ b/third_party/packages/split/lib/split.dart
@@ -79,8 +79,6 @@ class Splitter {
 /// for the size of the two split regions.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
 ///
-/// [parts] must be a list of [CoreElement], [Element], or query selectors.
-///
 /// The underlying split.js library supports splitting elements that use layout
 /// schemes other than flexbox but we don't need that flexibility.
 Splitter flexSplit(
@@ -120,8 +118,6 @@ Splitter flexSplit(
 /// may have arbitrary size resulting in flex-shrink causing problems for the
 /// flex calculations.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
-///
-/// [parts] must be a list of [CoreElement], [Element], or query selectors.
 ///
 /// The underlying split.js library supports splitting elements that use layout
 /// schemes other than flexbox but we don't need that flexibility.
@@ -210,8 +206,6 @@ StreamSubscription<Object> _splitBidirectional(
 /// for the size of the two split regions.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
 ///
-/// [parts] must be a list of [CoreElement], [Element], or query selectors.
-///
 /// To avoid memory leaks, cancel the stream subscription when the splitter is
 /// no longer being used.
 StreamSubscription<Object> flexSplitBidirectional(
@@ -239,8 +233,6 @@ StreamSubscription<Object> flexSplitBidirectional(
 /// may have arbitrary size resulting in flex-shrink causing problems for the
 /// flex calculations.
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/flex-shrink
-///
-/// [parts] must be a list of [CoreElement], [Element], or query selectors.
 ///
 /// To avoid memory leaks, cancel the stream subscription when the splitter is
 /// no longer being used.

--- a/third_party/packages/split/lib/split.dart
+++ b/third_party/packages/split/lib/split.dart
@@ -43,7 +43,7 @@ class _SplitOptions {
 
   external List<num> get minSize;
 
-  /// minSize is ignored unless this property is set.
+  /// Whether to use the [minSize] property.
   external bool get expandToMin;
 }
 
@@ -72,7 +72,7 @@ class Splitter {
 
 /// Splitter that splits multiple elements using flex layout.
 ///
-/// You should used this fixed splitter instead of the fixed splitter if the
+/// You should used this flex splitter instead of the fixed splitter if the
 /// size of the parent element of the element being split isn't fixed. Keep in
 /// mind that the children being split must be sized such that flex-shrink does
 /// not apply as otherwise flex-shrink will interact badly with the calculation
@@ -107,13 +107,13 @@ Splitter flexSplit(
       gutterSize: gutterSize,
       sizes: sizes,
       minSize: minSize,
-      expandToMin: minSize?.isNotEmpty == true,
+      expandToMin: minSize?.isNotEmpty ?? false,
     ),
   );
 }
 
 /// Splitter that splits multiple elements that must have a parent of fixed
-/// width.
+/// size.
 ///
 /// You should used this fixed splitter instead of flex splitter when the parent
 /// of the elements being split has a fixed size but one or more of the children
@@ -131,16 +131,22 @@ Splitter fixedSplit(
   gutterSize = 5,
   List<num> sizes,
   List<num> minSize,
-  expandToMin: true,
 }) {
   return _split(
     parts,
     _SplitOptions(
       elementStyle: allowInterop((dimension, size, gutterSize, index) {
         Object o = js_util.newObject();
-        js_util.setProperty(o, horizontal ? 'width' : 'height',
-            'calc($size% - ${gutterSize}px)');
-        js_util.setProperty(o, horizontal ? 'height' : 'width', '100%');
+        js_util.setProperty(
+          o,
+          horizontal ? 'width' : 'height',
+          'calc($size% - ${gutterSize}px)',
+        );
+        js_util.setProperty(
+          o,
+          horizontal ? 'height' : 'width',
+          '100%',
+        );
         return o;
       }),
       gutterStyle: allowInterop((dimension, gutterSize, index) {
@@ -161,7 +167,7 @@ Splitter fixedSplit(
       gutterSize: gutterSize,
       sizes: sizes,
       minSize: minSize,
-      expandToMin: minSize?.isNotEmpty == true,
+      expandToMin: minSize?.isNotEmpty ?? false,
     ),
   );
 }
@@ -197,7 +203,7 @@ StreamSubscription<Object> _splitBidirectional(
 /// Creates a flex splitter that changes from horizontal to vertical depending
 /// on the window aspect ratio.
 ///
-/// You should used this fixed splitter instead of the fixed splitter if the
+/// You should used this flex splitter instead of the fixed splitter if the
 /// size of the parent element of the element being split isn't fixed. Keep in
 /// mind that the children being split must be sized such that flex-shrink does
 /// not apply as otherwise flex-shrink will interact badly with the calculation
@@ -225,7 +231,7 @@ StreamSubscription<Object> flexSplitBidirectional(
   );
 }
 
-/// Creates a flex splitter that changes from horizontal to vertical depending
+/// Creates a fixed splitter that changes from horizontal to vertical depending
 /// on the window aspect ratio.
 ///
 /// You should used this fixed splitter instead of flex splitter when the parent

--- a/third_party/packages/split/pubspec.yaml
+++ b/third_party/packages/split/pubspec.yaml
@@ -2,10 +2,11 @@ name: split
 description: Minimal package containing 'split' third_party dependency used by package:devtools.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/split
-version: 0.0.3
+version: 0.0.4
 
 dependencies:
   js: ^0.6.1+1
+  meta: ^1.1.0
 
 environment:
   sdk: '>=2.1.0-dev <3.0.0'


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/864

Fix the issue by providing support for splitting based on specifying width/height as a fixed percentage rather than depending on flex layout which doesn't appear to have the right primitives to support this for cases where the items being flexed need to be shrunk to fit.

Also fixed bug where were passing in minSize but missing the parameter to make them actually be used.