### PR TITLE
Structured logging improvements.

### DIFF
--- a/packages/devtools/lib/src/framework/framework.dart
+++ b/packages/devtools/lib/src/framework/framework.dart
@@ -201,16 +201,21 @@ class Framework {
     screens.add(screen);
   }
 
-  void navigateTo(String id) {
-    ga.screen(id);
+  /// Returns false if the screen is disabled.
+  bool navigateTo(String id) {
     final Screen screen = getScreen(id);
     assert(screen != null);
+    if (screen.disabled) {
+      return false;
+    }
+    ga.screen(id);
 
     final String search = window.location.search;
     final String ref = search == null ? screen.ref : '$search${screen.ref}';
     window.history.pushState(null, screen.name, ref);
 
     load(screen);
+    return true;
   }
 
   void showAnalyticsDialog() {

--- a/packages/devtools/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools/lib/src/inspector/diagnostics_node.dart
@@ -24,9 +24,7 @@ const Map<String, DiagnosticLevel> nameToDiagnosticLevel = {
   'info': DiagnosticLevel.info,
   'warning': DiagnosticLevel.warning,
   'hint': DiagnosticLevel.hint,
-  'fix': DiagnosticLevel.fix,
-  'contract': DiagnosticLevel.contract,
-  'violation': DiagnosticLevel.violation,
+  'summary': DiagnosticLevel.summary,
   'error': DiagnosticLevel.error,
   'off': DiagnosticLevel.off,
 };
@@ -43,8 +41,7 @@ const Map<String, DiagnosticsTreeStyle> nameToTreeStyle = {
   'error': DiagnosticsTreeStyle.error,
   'flat': DiagnosticsTreeStyle.flat,
   'singleLine': DiagnosticsTreeStyle.singleLine,
-  'headerLine': DiagnosticsTreeStyle.headerLine,
-  'indentedSingleLine': DiagnosticsTreeStyle.indentedSingleLine,
+  'errorProperty': DiagnosticsTreeStyle.errorProperty,
   'shallow': DiagnosticsTreeStyle.shallow,
   'truncateChildren': DiagnosticsTreeStyle.truncateChildren,
 };
@@ -152,7 +149,13 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
 
   /// Hint for how the node should be displayed.
   DiagnosticsTreeStyle get style {
-    return getStyleMember('style', DiagnosticsTreeStyle.sparse);
+    return _styleOverride ??
+        getStyleMember('style', DiagnosticsTreeStyle.sparse);
+  }
+
+  DiagnosticsTreeStyle _styleOverride;
+  set style(DiagnosticsTreeStyle style) {
+    _styleOverride = style;
   }
 
   /// Dart class defining the diagnostic node.

--- a/packages/devtools/lib/src/inspector/inspector.css
+++ b/packages/devtools/lib/src/inspector/inspector.css
@@ -24,7 +24,6 @@
 
 .inspector-no-wrap {
     white-space: nowrap;
-    overflow: hidden;
 }
 
 .inspector-tree-row-content {
@@ -70,8 +69,12 @@ messages beautiful.
 
 .inspector-style-error {
     background-color: var(--error-background);
-    padding: 12px;
-    margin: 5px 0;
+    margin: 0px -5px;
+    padding: 5px;
+    color: var(--inspector-hint-color);
+    background-color: var(--error-background);
+    text-align: center;
+    font-weight: 700;
 }
 
 .inspector-style-flat {
@@ -109,28 +112,24 @@ messages beautiful.
 
 }
 .inspector-level-info {
-
+    color: var(--inspector-info-color);
 }
 .inspector-level-warning {
 
 }
 .inspector-level-hint {
     background-color: var(--hint-background);
+    color: var(--inspector-hint-color);
     padding: 8px;
     margin: 5px 0;
 }
-.inspector-level-fix {
 
+.inspector-level-summary {
+  font-weight: 700;
+  color: var(--error-summary-color);
+  font-size: 16px;
 }
-.inspector-level-contract {
 
-}
-.inspector-level-violation {
-
-}
-.inspector-level-error {
-
-}
 .inspector-level-off {
 
 }

--- a/packages/devtools/lib/src/inspector/inspector_text_styles.dart
+++ b/packages/devtools/lib/src/inspector/inspector_text_styles.dart
@@ -2,7 +2,7 @@ import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/theme.dart';
 
 final TextStyle unimportant = TextStyle(
-  color: ThemedColor(Colors.grey.shade500, Colors.grey.shade400),
+  color: ThemedColor(Colors.grey.shade500, Colors.grey.shade600),
 );
 const TextStyle regular = TextStyle(color: defaultForeground);
 final TextStyle warning = TextStyle(

--- a/packages/devtools/lib/src/inspector/inspector_tree_html.dart
+++ b/packages/devtools/lib/src/inspector/inspector_tree_html.dart
@@ -20,6 +20,7 @@ import '../ui/html_icon_renderer.dart';
 import '../ui/icons.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service.dart';
+import 'inspector_text_styles.dart';
 import 'inspector_tree.dart';
 import 'inspector_tree_web.dart';
 
@@ -100,9 +101,17 @@ class InspectorTreeNodeRenderHtmlBuilder
     }
     if (textStyle != lastStyle) {
       if (textStyle.color != lastStyle?.color) {
-        color = colorToCss(textStyle.color);
+        if (textStyle.color == regular.color) {
+          color = null;
+        } else {
+          color = colorToCss(textStyle.color);
+        }
       }
-      font = fontStyleToCss(textStyle);
+      if (textStyle == regular) {
+        font = null;
+      } else {
+        font = fontStyleToCss(textStyle);
+      }
       lastStyle = textStyle;
     }
     _entries.add(HtmlTextPaintEntry(text: text, color: color, font: font));
@@ -286,6 +295,11 @@ class InspectorTreeHtml extends InspectorTree implements InspectorTreeWeb {
   @override
   InspectorTreeNode createNode() => InspectorTreeNodeHtml();
 
+  // Horizontal padding is specified by CSS so including it here would throw
+  // off calculations.
+  @override
+  double get horizontalPadding => 0.0;
+
   Element paintRow(
     int index, {
     @required InspectorTreeNode selection,
@@ -368,7 +382,7 @@ class InspectorTreeHtml extends InspectorTree implements InspectorTreeWeb {
       if (renderObject == null) {
         return container;
       }
-      currentX = getDepthIndent(row.depth) - columnWidth;
+      currentX = getDepthIndent(row.depth - 1) - columnWidth;
       if (!row.node.showExpandCollapse) {
         currentX += columnWidth;
       }

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -59,6 +59,8 @@ class LoggingScreen extends Screen {
 
     logDetailsUI = LogDetailsUI();
 
+    final CoreElement structuredErrorsButton =
+        ServiceExtensionButton(structuredErrors).button;
     screenDiv.add(<CoreElement>[
       div(c: 'section')
         ..add(<CoreElement>[
@@ -73,7 +75,7 @@ class LoggingScreen extends Screen {
                   controller.clear();
                 }),
               div()..flex(),
-              ServiceExtensionButton(structuredErrors).button,
+              structuredErrorsButton,
             ])
         ]),
       div(c: 'section log-area bidirectional')

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -42,6 +42,21 @@ class LoggingScreen extends Screen {
     logCountStatus.element.text = '';
     addStatusItem(logCountStatus);
 
+    const String structuredErrorsExtension =
+        'ext.flutter.inspector.structuredErrors';
+    serviceManager.serviceExtensionManager.hasServiceExtension(
+      structuredErrorsExtension,
+      (available) {
+        if (available) {
+          serviceManager.serviceExtensionManager.setServiceExtensionState(
+            structuredErrorsExtension,
+            true,
+            true,
+          );
+        }
+      },
+    );
+
     serviceManager.onConnectionAvailable.listen(_handleConnectionStart);
     if (serviceManager.hasConnection) {
       _handleConnectionStart(serviceManager.service);

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools/src/inspector/inspector_tree_web.dart';
-import 'package:devtools/src/service_extensions.dart';
-import 'package:devtools/src/ui/service_extension_elements.dart';
 import 'package:split/split.dart' as split;
 
 import '../framework/framework.dart';
@@ -12,12 +9,15 @@ import '../inspector/inspector.dart';
 import '../inspector/inspector_service.dart';
 import '../inspector/inspector_tree.dart';
 import '../inspector/inspector_tree_html.dart';
+import '../inspector/inspector_tree_web.dart';
+import '../service_extensions.dart';
 import '../tables.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
 import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/primer.dart';
+import '../ui/service_extension_elements.dart';
 import '../ui/ui_utils.dart';
 import 'logging_controller.dart';
 
@@ -59,8 +59,6 @@ class LoggingScreen extends Screen {
 
     logDetailsUI = LogDetailsUI();
 
-    final CoreElement structuredErrorsButton =
-        ServiceExtensionButton(structuredErrors).button;
     screenDiv.add(<CoreElement>[
       div(c: 'section')
         ..add(<CoreElement>[
@@ -75,7 +73,7 @@ class LoggingScreen extends Screen {
                   controller.clear();
                 }),
               div()..flex(),
-              structuredErrorsButton,
+              ServiceExtensionCheckbox(structuredErrors).element,
             ])
         ]),
       div(c: 'section log-area bidirectional')

--- a/packages/devtools/lib/src/logging/logging.dart
+++ b/packages/devtools/lib/src/logging/logging.dart
@@ -2,38 +2,24 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-import 'dart:convert';
-import 'dart:math' as math;
-
-import 'package:intl/intl.dart';
+import 'package:devtools/src/inspector/inspector_tree_web.dart';
+import 'package:devtools/src/service_extensions.dart';
+import 'package:devtools/src/ui/service_extension_elements.dart';
 import 'package:split/split.dart' as split;
-import 'package:vm_service/vm_service.dart';
 
-import '../core/message_bus.dart';
 import '../framework/framework.dart';
-import '../globals.dart';
-import '../inspector/diagnostics_node.dart';
+import '../inspector/inspector.dart';
 import '../inspector/inspector_service.dart';
 import '../inspector/inspector_tree.dart';
 import '../inspector/inspector_tree_html.dart';
-import '../memory/heap_space.dart';
 import '../tables.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/elements.dart';
+import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/primer.dart';
 import '../ui/ui_utils.dart';
-import '../utils.dart';
-import '../vm_service_wrapper.dart';
-
-// For performance reasons, we drop old logs in batches, so the log will grow
-// to kMaxLogItemsUpperBound then truncate to kMaxLogItemsLowerBound.
-const int kMaxLogItemsLowerBound = 5000;
-const int kMaxLogItemsUpperBound = 5500;
-final DateFormat timeFormat = DateFormat('HH:mm:ss.SSS');
-
-bool _verboseDebugging = false;
+import 'logging_controller.dart';
 
 class LoggingScreen extends Screen {
   LoggingScreen()
@@ -41,41 +27,19 @@ class LoggingScreen extends Screen {
     logCountStatus = StatusItem();
     logCountStatus.element.text = '';
     addStatusItem(logCountStatus);
-
-    const String structuredErrorsExtension =
-        'ext.flutter.inspector.structuredErrors';
-    serviceManager.serviceExtensionManager.hasServiceExtension(
-      structuredErrorsExtension,
-      (available) {
-        if (available) {
-          serviceManager.serviceExtensionManager.setServiceExtensionState(
-            structuredErrorsExtension,
-            true,
-            true,
-          );
-        }
+    controller = LoggingController(
+      isVisible: () => visible,
+      onLogCountStatusChanged: (status) {
+        logCountStatus.element.text = status;
       },
     );
-
-    serviceManager.onConnectionAvailable.listen(_handleConnectionStart);
-    if (serviceManager.hasConnection) {
-      _handleConnectionStart(serviceManager.service);
-    }
-    serviceManager.onConnectionClosed.listen(_handleConnectionStop);
   }
 
-  Table<LogData> loggingTable;
+  Table<LogData> _loggingTable;
 
+  LoggingController controller;
   LogDetailsUI logDetailsUI;
-
   StatusItem logCountStatus;
-
-  SetStateMixin loggingStateMixin = SetStateMixin();
-
-  bool hasPendingDomUpdates = false;
-
-  /// ObjectGroup for Flutter (completes with null for non-Flutter apps).
-  Future<ObjectGroup> objectGroup;
 
   @override
   CoreElement createContent(Framework framework) {
@@ -85,7 +49,15 @@ class LoggingScreen extends Screen {
 
     this.framework = framework;
 
+    _loggingTable = _createTableView();
+    _loggingTable.element
+      ..layoutHorizontal()
+      ..clazz('section')
+      ..clazz('full-size')
+      ..clazz('log-summary');
     // TODO(devoncarew): Add checkbox toggles to enable specific logging channels.
+
+    logDetailsUI = LogDetailsUI();
 
     screenDiv.add(<CoreElement>[
       div(c: 'section')
@@ -96,592 +68,68 @@ class LoggingScreen extends Screen {
             ..add(<CoreElement>[
               PButton('Clear logs')
                 ..small()
-                ..click(_clear),
+                ..click(() {
+                  ga.select(ga.logging, ga.clearLogs);
+                  controller.clear();
+                }),
+              div()..flex(),
+              ServiceExtensionButton(structuredErrors).button,
             ])
         ]),
       div(c: 'section log-area bidirectional')
         ..flex()
         ..add(<CoreElement>[
-          _createTableView()
-            ..layoutHorizontal()
-            ..clazz('section')
-            ..clazz('full-size')
-            ..flex(),
-          logDetailsUI = LogDetailsUI(),
+          _loggingTable.element,
+          logDetailsUI,
         ]),
     ]);
 
-    // configure the table / details splitter
-    split.flexSplitBidirectional(
-      [loggingTable.element.element, logDetailsUI.element],
-      gutterSize: defaultSplitterWidth,
-      horizontalSizes: [60, 40],
-      verticalSizes: [70, 30],
+    controller.loggingTableModel = _loggingTable.model;
+    controller.detailsController = LoggingDetailsController(
+      onShowInspector: () {
+        framework.navigateTo(inspectorScreenId);
+      },
+      onShowDetails: logDetailsUI.onShowDetails,
+      createLoggingTree: logDetailsUI.createLoggingTree,
     );
-
-    loggingTable.onSelect.listen((LogData selection) {
-      logDetailsUI.setData(selection);
-    });
-
-    _updateStatus();
-    loggingTable.onRowsChanged.listen((_) {
-      _updateStatus();
-    });
-
-    messageBus.onEvent(type: 'reload.end').listen((BusEvent event) {
-      _log(LogData(
-        'hot.reload',
-        event.data,
-        DateTime.now().millisecondsSinceEpoch,
-      ));
-    });
-    messageBus.onEvent(type: 'restart.end').listen((BusEvent event) {
-      _log(LogData(
-        'hot.restart',
-        event.data,
-        DateTime.now().millisecondsSinceEpoch,
-      ));
-    });
-
     return screenDiv;
   }
 
+  bool _firstEnter = true;
+
   @override
   void entering() {
-    if (hasPendingDomUpdates) {
-      loggingTable.setRows(data);
-
-      hasPendingDomUpdates = false;
+    if (_firstEnter) {
+      // configure the table / details splitter. Setting up this splitter works
+      // better once the UI is active in the DOM so we have to delay it until
+      // we get the entering event.
+      split.fixedSplitBidirectional(
+        [_loggingTable.element.element, logDetailsUI.element],
+        gutterSize: defaultSplitterWidth,
+        horizontalSizes: [60, 40],
+        verticalSizes: [70, 30],
+        minSize: [200, 200],
+      );
+      _firstEnter = false;
     }
+    controller.entering();
   }
 
-  CoreElement _createTableView() {
-    loggingTable = Table<LogData>.virtual();
-
-    loggingTable.addColumn(LogWhenColumn());
-    loggingTable.addColumn(LogKindColumn());
-    loggingTable.addColumn(LogMessageColumn());
-
-    loggingTable.setRows(data);
-
-    return loggingTable.element;
-  }
-
-  void _updateStatus() {
-    final int count = loggingTable.rowCount;
-    final String label = count >= kMaxLogItemsLowerBound
-        ? '${nf.format(kMaxLogItemsLowerBound)}+'
-        : nf.format(count);
-    logCountStatus.element.text = '$label events';
-  }
-
-  void _clear() {
-    ga.select(ga.logging, ga.clearLogs);
-    data.clear();
-    logDetailsUI?.setData(null);
-    loggingTable.setRows(data);
-  }
-
-  void _handleConnectionStart(VmServiceWrapper service) async {
-    // Log stdout events.
-    final _StdoutEventHandler stdoutHandler =
-        _StdoutEventHandler(this, 'stdout');
-    service.onStdoutEvent.listen(stdoutHandler.handle);
-
-    // Log stderr events.
-    final _StdoutEventHandler stderrHandler =
-        _StdoutEventHandler(this, 'stderr', isError: true);
-    service.onStderrEvent.listen(stderrHandler.handle);
-
-    // Log GC events.
-    service.onGCEvent.listen(_handleGCEvent);
-
-    // Log `dart:developer` `log` events.
-    // TODO(devoncarew): Remove `_Logging` support on or after approx. Oct 1 2019.
-    service.onEvent('_Logging').listen(_handleDeveloperLogEvent);
-    service.onLoggingEvent.listen(_handleDeveloperLogEvent);
-
-    // Log Flutter extension events.
-    service.onExtensionEvent.listen(_handleExtensionEvent);
-
-    await ensureInspectorServiceDependencies();
-
-    objectGroup = InspectorService.createGroup(service, 'console-group')
-        .catchError((e) => null,
-            test: (e) => e is FlutterInspectorLibraryNotFound);
-  }
-
-  void _handleExtensionEvent(Event e) async {
-    // Events to show without a summary in the table.
-    final Set<String> untitledEvents = {
-      'Flutter.FirstFrame',
-      'Flutter.FrameworkInitialization',
-    };
-
-    if (e.extensionKind == FrameInfo.eventName) {
-      final FrameInfo frame = FrameInfo.from(e.extensionData.data);
-
-      final String frameId = '#${frame.number}';
-      final String frameInfo =
-          '<span class="pre">$frameId ${frame.elapsedMs.toStringAsFixed(1).padLeft(4)}ms </span>';
-      final String div = createFrameDivHtml(frame);
-
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.extensionData.data),
-        e.timestamp,
-        summaryHtml: '$frameInfo$div',
-      ));
-    } else if (e.extensionKind == NavigationInfo.eventName) {
-      final NavigationInfo navInfo = NavigationInfo.from(e.extensionData.data);
-
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.json),
-        e.timestamp,
-        summary: navInfo.routeDescription,
-      ));
-    } else if (untitledEvents.contains(e.extensionKind)) {
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.json),
-        e.timestamp,
-        summary: '',
-      ));
-    } else if (e.extensionKind == ServiceExtensionStateChangedInfo.eventName) {
-      final ServiceExtensionStateChangedInfo changedInfo =
-          ServiceExtensionStateChangedInfo.from(e.extensionData.data);
-
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.json),
-        e.timestamp,
-        summary: '${changedInfo.extension}: ${changedInfo.value}',
-      ));
-    } else if (e.extensionKind == 'Flutter.Error') {
-      // TODO(pq): add tests for error extension handling once framework changes
-      // are landed.
-      final RemoteDiagnosticsNode node =
-          RemoteDiagnosticsNode(e.extensionData.data, objectGroup, false, null);
-      if (_verboseDebugging) {
-        print('node toStringDeep:######\n${node.toStringDeep()}\n###');
-      }
-
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.json),
-        e.timestamp,
-        summary: node.toDiagnosticsNode().toString(),
-        node: node,
-      ));
-    } else {
-      _log(LogData(
-        e.extensionKind.toLowerCase(),
-        jsonEncode(e.json),
-        e.timestamp,
-        summary: e.json.toString(),
-      ));
-    }
-  }
-
-  void _handleGCEvent(Event e) {
-    final HeapSpace newSpace = HeapSpace.parse(e.json['new']);
-    final HeapSpace oldSpace = HeapSpace.parse(e.json['old']);
-    final Map<dynamic, dynamic> isolateRef = e.json['isolate'];
-
-    final int usedBytes = newSpace.used + oldSpace.used;
-    final int capacityBytes = newSpace.capacity + oldSpace.capacity;
-
-    final int time = ((newSpace.time + oldSpace.time) * 1000).round();
-
-    final String summary = '${isolateRef['name']} • '
-        '${e.json['reason']} collection in $time ms • '
-        '${printMb(usedBytes)} MB used of ${printMb(capacityBytes)} MB';
-
-    final Map<String, dynamic> event = <String, dynamic>{
-      'reason': e.json['reason'],
-      'new': newSpace.json,
-      'old': oldSpace.json,
-      'isolate': isolateRef,
-    };
-
-    final String message = jsonEncode(event);
-    _log(LogData('gc', message, e.timestamp, summary: summary));
-  }
-
-  void _handleDeveloperLogEvent(Event e) {
-    final VmServiceWrapper service = serviceManager.service;
-
-    final dynamic logRecord = e.json['logRecord'];
-
-    String loggerName =
-        _valueAsString(InstanceRef.parse(logRecord['loggerName']));
-    if (loggerName == null || loggerName.isEmpty) {
-      loggerName = 'log';
-    }
-    final int level = logRecord['level'];
-    final InstanceRef messageRef = InstanceRef.parse(logRecord['message']);
-    String summary = _valueAsString(messageRef);
-    if (messageRef.valueAsStringIsTruncated == true) {
-      summary += '...';
-    }
-    final InstanceRef error = InstanceRef.parse(logRecord['error']);
-    final InstanceRef stackTrace = InstanceRef.parse(logRecord['stackTrace']);
-
-    final String details = summary;
-    Future<String> detailsComputer;
-
-    // If the message string was truncated by the VM, or the error object or
-    // stackTrace objects were non-null, we need to ask the VM for more
-    // information in order to render the log entry. We do this asynchronously
-    // on-demand using the `detailsComputer` Future.
-    if (messageRef.valueAsStringIsTruncated == true ||
-        _isNotNull(error) ||
-        _isNotNull(stackTrace)) {
-      detailsComputer = Future<String>(() async {
-        // Get the full string value of the message.
-        String result =
-            await _retrieveFullStringValue(service, e.isolate, messageRef);
-
-        // Get information about the error object. Some users of the
-        // dart:developer log call may pass a data payload in the `error`
-        // field, encoded as a json encoded string, so handle that case.
-        if (_isNotNull(error)) {
-          if (error.valueAsString != null) {
-            final String errorString =
-                await _retrieveFullStringValue(service, e.isolate, error);
-            result += '\n\n$errorString';
-          } else {
-            // Call `toString()` on the error object and display that.
-            final dynamic toStringResult = await service.invoke(
-              e.isolate.id,
-              error.id,
-              'toString',
-              <String>[],
-              disableBreakpoints: true,
-            );
-
-            if (toStringResult is ErrorRef) {
-              final String errorString = _valueAsString(error);
-              result += '\n\n$errorString';
-            } else if (toStringResult is InstanceRef) {
-              final String str = await _retrieveFullStringValue(
-                  service, e.isolate, toStringResult);
-              result += '\n\n$str';
-            }
-          }
-        }
-
-        // Get info about the stackTrace object.
-        if (_isNotNull(stackTrace)) {
-          result += '\n\n${_valueAsString(stackTrace)}';
-        }
-
-        return result;
-      });
-    }
-
-    const int severeIssue = 1000;
-    final bool isError = level != null && level >= severeIssue ? true : false;
-
-    _log(LogData(
-      loggerName,
-      details,
-      e.timestamp,
-      isError: isError,
-      summary: summary,
-      detailsComputer: detailsComputer,
-    ));
-  }
-
-  Future<String> _retrieveFullStringValue(
-    VmServiceWrapper service,
-    IsolateRef isolateRef,
-    InstanceRef stringRef,
-  ) async {
-    if (stringRef.valueAsStringIsTruncated != true) {
-      return stringRef.valueAsString;
-    }
-
-    final dynamic result = await service.getObject(isolateRef.id, stringRef.id,
-        offset: 0, count: stringRef.length);
-    if (result is Instance) {
-      final Instance obj = result;
-      return obj.valueAsString;
-    } else {
-      return '${stringRef.valueAsString}...';
-    }
-  }
-
-  void _handleConnectionStop(dynamic event) {}
-
-  List<LogData> data = <LogData>[];
-
-  DateTime _lastScrollTime;
-
-  void _log(LogData log) {
-    // Insert the new item and clamped the list to kMaxLogItemsLength. The table
-    // is rendered reversed so new items are at the top but we can use .add()
-    // here which is much faster than inserting at the start of the list.
-    data.add(log);
-    // Note: We need to drop rows from the start because we want to drop old
-    // rows but because that's expensive, we only do it periodically (eg. when
-    // the list is 500 rows more).
-    if (data.length > kMaxLogItemsUpperBound) {
-      int itemsToRemove = data.length - kMaxLogItemsLowerBound;
-      // Ensure we remove an even number of rows to keep the alternating
-      // background in-sync.
-      if (itemsToRemove % 2 == 1) {
-        itemsToRemove--;
-      }
-      data = data.sublist(itemsToRemove);
-    }
-
-    if (visible && loggingTable != null) {
-      // TODO(jacobr): adding data should be more incremental than this.
-      // We are blowing away state for all already added rows.
-      loggingTable.setRows(data);
-      // Smooth scroll if we havent scrolled in a while, otherwise use an
-      // immediate scroll because repeatedly smooth scrolling on the web means
-      // you never reach your destination.
-      final DateTime now = DateTime.now();
-      final bool smoothScroll = _lastScrollTime == null ||
-          _lastScrollTime.difference(now).inSeconds > 1;
-      _lastScrollTime = now;
-      loggingTable.scrollTo(data.last,
-          scrollBehavior: smoothScroll ? 'smooth' : 'auto');
-    } else {
-      hasPendingDomUpdates = true;
-    }
-  }
-
-  String createFrameDivHtml(FrameInfo frame) {
-    const double maxFrameEventBarMs = 100.0;
-    final String classes = (frame.elapsedMs >= FrameInfo.kTargetMaxFrameTimeMs)
-        ? 'frame-bar over-budget'
-        : 'frame-bar';
-
-    final int pixelWidth =
-        (math.min(frame.elapsedMs, maxFrameEventBarMs) * 3).round();
-    return '<div class="$classes" style="width: ${pixelWidth}px"/>';
+  Table<LogData> _createTableView() {
+    final table = Table<LogData>.virtual();
+    table.model
+      ..addColumn(LogWhenColumn())
+      ..addColumn(LogKindColumn())
+      ..addColumn(LogMessageColumn());
+    return table;
   }
 }
 
-/// Receive and log stdout / stderr events from the VM.
-///
-/// This class buffers the events for up to 1ms. This is in order to combine a
-/// stdout message and its newline. Currently, `foo\n` is sent as two VM events;
-/// we wait for up to 1ms when we get the `foo` event, to see if the next event
-/// is a single newline. If so, we add the newline to the previous log message.
-class _StdoutEventHandler {
-  _StdoutEventHandler(this.loggingScreen, this.name, {this.isError = false});
-
-  final LoggingScreen loggingScreen;
-  final String name;
-  final bool isError;
-
-  LogData buffer;
-  Timer timer;
-
-  void handle(Event e) {
-    final String message = decodeBase64(e.bytes);
-
-    if (buffer != null) {
-      timer?.cancel();
-
-      if (message == '\n') {
-        loggingScreen._log(LogData(
-          buffer.kind,
-          buffer.details + message,
-          buffer.timestamp,
-          summary: buffer.summary + message,
-          isError: buffer.isError,
-        ));
-        buffer = null;
-        return;
-      }
-
-      loggingScreen._log(buffer);
-      buffer = null;
-    }
-
-    String summary = message;
-    if (message.length > 200) {
-      summary = message.substring(0, 200) + '…';
-    }
-
-    final LogData data = LogData(
-      name,
-      message,
-      e.timestamp,
-      summary: summary,
-      isError: isError,
-    );
-
-    if (message == '\n') {
-      loggingScreen._log(data);
-    } else {
-      buffer = data;
-      timer = Timer(const Duration(milliseconds: 1), () {
-        loggingScreen._log(buffer);
-        buffer = null;
-      });
-    }
-  }
-}
-
-bool _isNotNull(InstanceRef serviceRef) {
-  return serviceRef != null && serviceRef.kind != 'Null';
-}
-
-String _valueAsString(InstanceRef ref) {
-  if (ref == null) {
-    return null;
-  }
-
-  if (ref.valueAsString == null) {
-    return ref.valueAsString;
-  }
-
-  if (ref.valueAsStringIsTruncated == true) {
-    return '${ref.valueAsString}...';
-  } else {
-    return ref.valueAsString;
-  }
-}
-
-/// A log data object that includes an optional summary (in either text or html
-/// form), information about whether the log entry represents an error entry,
-/// the log entry kind, and more detailed data for the entry.
-///
-/// The details can optionally be loaded lazily on first use. If this is the
-/// case, this log entry will have a non-null `detailsComputer` field. After the
-/// data is calculated, the log entry will be modified to contain the calculated
-/// `details` data.
-class LogData {
-  LogData(
-    this.kind,
-    this._details,
-    this.timestamp, {
-    this.summary,
-    this.summaryHtml,
-    this.isError = false,
-    this.detailsComputer,
-    this.node,
-  });
-
-  final String kind;
-  final int timestamp;
-  final bool isError;
-  final String summary;
-  final String summaryHtml;
-
-  final RemoteDiagnosticsNode node;
-  String _details;
-  Future<String> detailsComputer;
-
-  String get details => _details;
-
-  bool get needsComputing => detailsComputer != null;
-
-  Future<void> compute() async {
-    _details = await detailsComputer;
-    detailsComputer = null;
-  }
-}
-
-class LogKindColumn extends Column<LogData> {
-  LogKindColumn() : super('Kind');
-
-  @override
-  bool get supportsSorting => false;
-
-  @override
-  bool get usesHtml => true;
-
-  @override
-  String get cssClass => 'log-label-column';
-
-  @override
-  dynamic getValue(LogData dataObject) {
-    final String cssClass = getCssClassForEventKind(dataObject);
-
-    return '<span class="label $cssClass">${dataObject.kind}</span>';
-  }
-
-  @override
-  String render(dynamic value) => value;
-}
-
-class LogWhenColumn extends Column<LogData> {
-  LogWhenColumn() : super('When');
-
-  @override
-  String get cssClass => 'pre monospace';
-
-  @override
-  bool get supportsSorting => false;
-
-  @override
-  dynamic getValue(LogData dataObject) => dataObject.timestamp;
-
-  @override
-  String render(dynamic value) {
-    return value == null
-        ? ''
-        : timeFormat.format(DateTime.fromMillisecondsSinceEpoch(value));
-  }
-}
-
-class LogMessageColumn extends Column<LogData> {
-  LogMessageColumn() : super.wide('Message');
-
-  @override
-  String get cssClass => 'pre-wrap monospace';
-
-  @override
-  bool get usesHtml => true;
-
-  @override
-  bool get supportsSorting => false;
-
-  @override
-  dynamic getValue(LogData dataObject) => dataObject;
-
-  @override
-  String render(dynamic value) {
-    final LogData log = value;
-
-    if (log.summaryHtml != null) {
-      return log.summaryHtml;
-    } else {
-      return escape(log.summary ?? log.details);
-    }
-  }
-}
-
-String getCssClassForEventKind(LogData item) {
-  String cssClass = '';
-
-  if (item.kind == 'stderr' || item.isError) {
-    cssClass = 'stderr';
-  } else if (item.kind == 'stdout') {
-    cssClass = 'stdout';
-  } else if (item.kind == 'flutter.error') {
-    cssClass = 'stderr';
-  } else if (item.kind.startsWith('flutter')) {
-    cssClass = 'flutter';
-  } else if (item.kind == 'gc') {
-    cssClass = 'gc';
-  }
-
-  return cssClass;
-}
-
+// TODO(jacobr): refactor this code to have a cleaner view-controller
+// separation.
 class LogDetailsUI extends CoreElement {
   LogDetailsUI() : super('div', classes: 'full-size') {
     layoutVertical();
-    flex();
 
     add(<CoreElement>[
       content = div(c: 'log-details table-border')
@@ -690,132 +138,31 @@ class LogDetailsUI extends CoreElement {
     ]);
   }
 
-  static const JsonEncoder jsonEncoder = JsonEncoder.withIndent('  ');
-
-  LogData data;
-
   CoreElement content;
   CoreElement message;
 
-  InspectorTreeHtml tree;
-
-  void setData(LogData data) {
+  void onShowDetails({String text, InspectorTree tree}) {
     // Reset the vertical scroll value if any.
     content.element.scrollTop = 0;
-
-    this.data = data;
-
-    tree = null;
-
-    if (data == null) {
-      message.text = '';
-      return;
+    message.clear();
+    if (text != null) {
+      message.text = text;
     }
-
-    if (data.node != null) {
-      message.clear();
-      tree = InspectorTreeHtml(
-        summaryTree: false,
-        treeType: FlutterTreeType.widget,
-        onSelectionChange: () {
-          final InspectorTreeNode node = tree.selection;
-          if (node != null) {
-            tree.maybePopulateChildren(node);
-          }
-          node.diagnostic.setSelectionInspector(false);
-          // TODO(jacobr): warn if the selection can't be set as the node is
-          // stale which is likely if this is an old log entry.
-        },
-      );
-
-      final InspectorTreeNode root = tree.setupInspectorTreeNode(
-        tree.createNode(),
-        data.node,
-        expandChildren: true,
-        expandProperties: true,
-      );
-      // No sense in collapsing the root node.
-      root.allowExpandCollapse = false;
-      tree.root = root;
-      message.add(tree.element);
-
-      return;
-    }
-
-    // See if we need to asynchronously compute the log entry details.
-    if (data.needsComputing) {
-      message.text = '';
-
-      data.compute().then((_) {
-        // If we're still displaying the same log entry, then update the UI with
-        // the calculated value.
-        if (this.data == data) {
-          _updateUIFromData();
-        }
-      });
-    } else {
-      _updateUIFromData();
+    if (tree != null) {
+      message.add((tree as InspectorTreeWeb).element);
     }
   }
 
-  void _updateUIFromData() {
-    if (data.details.startsWith('{') && data.details.endsWith('}')) {
-      try {
-        // If the string decodes properly, then format the json.
-        final dynamic result = jsonDecode(data.details);
-        message.text = jsonEncoder.convert(result);
-      } catch (e) {
-        message.text = data.details;
-      }
-    } else {
-      message.text = data.details;
-    }
+  InspectorTreeWeb createLoggingTree({VoidCallback onSelectionChange}) {
+    return InspectorTreeHtml(
+      summaryTree: false,
+      treeType: FlutterTreeType.widget,
+      onHover: (node, icon) {
+        element.style.cursor = (node?.diagnostic?.isDiagnosticableValue == true)
+            ? 'pointer'
+            : 'auto';
+      },
+      onSelectionChange: onSelectionChange,
+    );
   }
-}
-
-class FrameInfo {
-  FrameInfo(this.number, this.elapsedMs, this.startTimeMs);
-
-  static const String eventName = 'Flutter.Frame';
-
-  static const double kTargetMaxFrameTimeMs = 1000.0 / 60;
-
-  static FrameInfo from(Map<String, dynamic> data) {
-    return FrameInfo(
-        data['number'], data['elapsed'] / 1000, data['startTime'] / 1000);
-  }
-
-  final int number;
-  final num elapsedMs;
-  final num startTimeMs;
-
-  @override
-  String toString() => 'frame $number ${elapsedMs.toStringAsFixed(1)}ms';
-}
-
-class NavigationInfo {
-  NavigationInfo(this._route);
-
-  static const String eventName = 'Flutter.Navigation';
-
-  static NavigationInfo from(Map<String, dynamic> data) {
-    return NavigationInfo(data['route']);
-  }
-
-  final Map<String, dynamic> _route;
-
-  String get routeDescription => _route == null ? null : _route['description'];
-}
-
-class ServiceExtensionStateChangedInfo {
-  ServiceExtensionStateChangedInfo(this.extension, this.value);
-
-  static const String eventName = 'Flutter.ServiceExtensionStateChanged';
-
-  static ServiceExtensionStateChangedInfo from(Map<String, dynamic> data) {
-    return ServiceExtensionStateChangedInfo(data['extension'], data['value']);
-  }
-
-  final String extension;
-  final dynamic value;
 }

--- a/packages/devtools/lib/src/logging/logging_controller.dart
+++ b/packages/devtools/lib/src/logging/logging_controller.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math' as math;
 
-import 'package:devtools/src/inspector/inspector_tree.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
@@ -15,6 +14,7 @@ import '../core/message_bus.dart';
 import '../globals.dart';
 import '../inspector/diagnostics_node.dart';
 import '../inspector/inspector_service.dart';
+import '../inspector/inspector_tree.dart';
 import '../memory/heap_space.dart';
 import '../table_data.dart';
 import '../ui/fake_flutter/fake_flutter.dart';
@@ -32,6 +32,7 @@ bool _verboseDebugging = false;
 typedef OnLogCountStatusChanged = void Function(String status);
 
 typedef OnShowDetails = void Function({String text, InspectorTree tree});
+
 typedef CreateLoggingTree = InspectorTree Function(
     {VoidCallback onSelectionChange});
 
@@ -189,11 +190,14 @@ class LoggingController {
     }
   }
 
-  // Callbacks to apply changes in the controller to other views.
+  /// Callbacks to apply changes in the controller to other views.
   final OnLogCountStatusChanged onLogCountStatusChanged;
+
+  /// Callback returning whether the logging screen is visible.
   final bool Function() isVisible;
 
   List<LogData> data = <LogData>[];
+
   final List<StreamSubscription> _subscriptions = [];
 
   DateTime _lastScrollTime;

--- a/packages/devtools/lib/src/logging/logging_controller.dart
+++ b/packages/devtools/lib/src/logging/logging_controller.dart
@@ -1,0 +1,804 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:math' as math;
+
+import 'package:devtools/src/inspector/inspector_tree.dart';
+import 'package:intl/intl.dart';
+import 'package:meta/meta.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../core/message_bus.dart';
+import '../globals.dart';
+import '../inspector/diagnostics_node.dart';
+import '../inspector/inspector_service.dart';
+import '../memory/heap_space.dart';
+import '../table_data.dart';
+import '../ui/fake_flutter/fake_flutter.dart';
+import '../utils.dart';
+import '../vm_service_wrapper.dart';
+
+// For performance reasons, we drop old logs in batches, so the log will grow
+// to kMaxLogItemsUpperBound then truncate to kMaxLogItemsLowerBound.
+const int kMaxLogItemsLowerBound = 5000;
+const int kMaxLogItemsUpperBound = 5500;
+final DateFormat timeFormat = DateFormat('HH:mm:ss.SSS');
+
+bool _verboseDebugging = false;
+
+typedef OnLogCountStatusChanged = void Function(String status);
+
+typedef OnShowDetails = void Function({String text, InspectorTree tree});
+typedef CreateLoggingTree = InspectorTree Function(
+    {VoidCallback onSelectionChange});
+
+class LoggingDetailsController {
+  LoggingDetailsController({
+    @required this.onShowInspector,
+    @required this.onShowDetails,
+    @required this.createLoggingTree,
+  });
+
+  static const JsonEncoder jsonEncoder = JsonEncoder.withIndent('  ');
+
+  LogData data;
+
+  /// Callback to execute to show the inspector.
+  final VoidCallback onShowInspector;
+
+  /// Callback to executue to show the data from the details tree in the view.
+  final OnShowDetails onShowDetails;
+
+  /// Callback to create an inspectorTree for the logging view of the correct
+  /// type.
+  final CreateLoggingTree createLoggingTree;
+
+  InspectorTree tree;
+
+  void setData(LogData data) {
+    this.data = data;
+
+    tree = null;
+
+    if (data == null) {
+      onShowDetails(text: '');
+      return;
+    }
+
+    if (data.node != null) {
+      tree = createLoggingTree(
+        onSelectionChange: () {
+          final InspectorTreeNode node = tree.selection;
+          if (node != null) {
+            tree.maybePopulateChildren(node);
+          }
+          // TODO(jacobr): node.diagnostic.isDiagnosticableValue isn't quite
+          // right.
+          if (node.diagnostic.isDiagnosticableValue) {
+            // TODO(jacobr): warn if the selection can't be set as the node is
+            // stale which is likely if this is an old log entry.
+            if (onShowInspector != null) {
+              onShowInspector();
+            }
+            node.diagnostic.setSelectionInspector(false);
+          }
+        },
+      );
+
+      final InspectorTreeNode root = tree.setupInspectorTreeNode(
+        tree.createNode(),
+        data.node,
+        expandChildren: true,
+        expandProperties: true,
+      );
+      // No sense in collapsing the root node.
+      root.allowExpandCollapse = false;
+      tree.root = root;
+      onShowDetails(tree: tree);
+
+      return;
+    }
+
+    // See if we need to asynchronously compute the log entry details.
+    if (data.needsComputing) {
+      assert(data.node == null);
+      onShowDetails(text: '');
+
+      data.compute().then((_) {
+        // If we're still displaying the same log entry, then update the UI with
+        // the calculated value.
+        if (this.data == data) {
+          _updateUIFromData();
+        }
+      });
+    } else {
+      _updateUIFromData();
+    }
+  }
+
+  void _updateUIFromData() {
+    assert(data.node == null);
+    if (data.details.startsWith('{') && data.details.endsWith('}')) {
+      try {
+        // If the string decodes properly, then format the json.
+        final dynamic result = jsonDecode(data.details);
+        onShowDetails(text: jsonEncoder.convert(result));
+      } catch (e) {
+        onShowDetails(text: data.details);
+      }
+    } else {
+      onShowDetails(text: data.details);
+    }
+  }
+}
+
+class LoggingController {
+  LoggingController({
+    @required this.onLogCountStatusChanged,
+    @required this.isVisible,
+  }) {
+    _listen(serviceManager.onConnectionAvailable, _handleConnectionStart);
+    if (serviceManager.hasConnection) {
+      _handleConnectionStart(serviceManager.service);
+    }
+    _listen(serviceManager.onConnectionClosed, _handleConnectionStop);
+  }
+
+  LoggingDetailsController detailsController;
+
+  /// Listen on a stream and track the stream subscription for automatic
+  /// disposal if the dispose method is called.
+  StreamSubscription<T> _listen<T>(Stream<T> stream, void onData(T event)) {
+    final subscription = stream.listen(onData);
+    _subscriptions.add(subscription);
+    return subscription;
+  }
+
+  TableData<LogData> get loggingTableModel => _loggingTableModel;
+  TableData<LogData> _loggingTableModel;
+  set loggingTableModel(TableData<LogData> model) {
+    _loggingTableModel = model;
+    _listen(_loggingTableModel.onSelect, (LogData selection) {
+      detailsController?.setData(selection);
+    });
+
+    _updateStatus();
+    _listen(_loggingTableModel.onRowsChanged, (_) {
+      _updateStatus();
+    });
+
+    // TODO(jacobr): expose the messageBus for use by vm tests.
+    if (messageBus != null) {
+      _listen(messageBus.onEvent(type: 'reload.end'), (BusEvent event) {
+        _log(LogData(
+          'hot.reload',
+          event.data,
+          DateTime.now().millisecondsSinceEpoch,
+        ));
+      });
+      _listen(messageBus.onEvent(type: 'restart.end'), (BusEvent event) {
+        _log(LogData(
+          'hot.restart',
+          event.data,
+          DateTime.now().millisecondsSinceEpoch,
+        ));
+      });
+    }
+  }
+
+  // Callbacks to apply changes in the controller to other views.
+  final OnLogCountStatusChanged onLogCountStatusChanged;
+  final bool Function() isVisible;
+
+  List<LogData> data = <LogData>[];
+  final List<StreamSubscription> _subscriptions = [];
+
+  DateTime _lastScrollTime;
+
+  bool _hasPendingUiUpdates = false;
+
+  /// ObjectGroup for Flutter (completes with null for non-Flutter apps).
+  Future<ObjectGroup> objectGroup;
+
+  void _updateStatus() {
+    final int count = _loggingTableModel.rowCount;
+    final String label = count >= kMaxLogItemsLowerBound
+        ? '${nf.format(kMaxLogItemsLowerBound)}+'
+        : nf.format(count);
+    onLogCountStatusChanged('$label events');
+  }
+
+  void clear() {
+    data.clear();
+    detailsController?.setData(null);
+    _loggingTableModel.setRows(data);
+  }
+
+  void _handleConnectionStart(VmServiceWrapper service) async {
+    // Log stdout events.
+    final _StdoutEventHandler stdoutHandler =
+        _StdoutEventHandler(this, 'stdout');
+    _listen(service.onStdoutEvent, stdoutHandler.handle);
+
+    // Log stderr events.
+    final _StdoutEventHandler stderrHandler =
+        _StdoutEventHandler(this, 'stderr', isError: true);
+    _listen(service.onStderrEvent, stderrHandler.handle);
+
+    // Log GC events.
+    _listen(service.onGCEvent, _handleGCEvent);
+
+    // Log `dart:developer` `log` events.
+    // TODO(devoncarew): Remove `_Logging` support on or after approx. Oct 1 2019.
+    _listen(service.onEvent('_Logging'), _handleDeveloperLogEvent);
+    _listen(service.onLoggingEvent, _handleDeveloperLogEvent);
+
+    // Log Flutter extension events.
+    _listen(service.onExtensionEvent, _handleExtensionEvent);
+
+    await ensureInspectorServiceDependencies();
+
+    objectGroup = InspectorService.createGroup(service, 'console-group')
+        .catchError((e) => null,
+            test: (e) => e is FlutterInspectorLibraryNotFound);
+  }
+
+  void _handleExtensionEvent(Event e) async {
+    // Events to show without a summary in the table.
+    const Set<String> untitledEvents = {
+      'Flutter.FirstFrame',
+      'Flutter.FrameworkInitialization',
+    };
+
+    // TODO(jacobr): make the list of filtered events configurable.
+    const Set<String> filteredEvents = {
+      // Suppress these events by default as they just add noise to the log
+      ServiceExtensionStateChangedInfo.eventName,
+    };
+
+    if (filteredEvents.contains(e.extensionKind)) {
+      return;
+    }
+    if (e.extensionKind == FrameInfo.eventName) {
+      final FrameInfo frame = FrameInfo.from(e.extensionData.data);
+
+      final String frameId = '#${frame.number}';
+      final String frameInfo =
+          '<span class="pre">$frameId ${frame.elapsedMs.toStringAsFixed(1).padLeft(4)}ms </span>';
+      final String div = _createFrameDivHtml(frame);
+
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.extensionData.data),
+        e.timestamp,
+        summaryHtml: '$frameInfo$div',
+      ));
+    } else if (e.extensionKind == NavigationInfo.eventName) {
+      final NavigationInfo navInfo = NavigationInfo.from(e.extensionData.data);
+
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: navInfo.routeDescription,
+      ));
+    } else if (untitledEvents.contains(e.extensionKind)) {
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: '',
+      ));
+    } else if (e.extensionKind == ServiceExtensionStateChangedInfo.eventName) {
+      final ServiceExtensionStateChangedInfo changedInfo =
+          ServiceExtensionStateChangedInfo.from(e.extensionData.data);
+
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: '${changedInfo.extension}: ${changedInfo.value}',
+      ));
+    } else if (e.extensionKind == 'Flutter.Error') {
+      // TODO(pq): add tests for error extension handling once framework changes
+      // are landed.
+      final RemoteDiagnosticsNode node =
+          RemoteDiagnosticsNode(e.extensionData.data, objectGroup, false, null);
+      // Workaround the fact that the error objects from the server don't have
+      // style error.
+      node.style = DiagnosticsTreeStyle.error;
+      if (_verboseDebugging) {
+        print('node toStringDeep:######\n${node.toStringDeep()}\n###');
+      }
+
+      final RemoteDiagnosticsNode summary = _findFirstSummary(node) ?? node;
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: summary.toDiagnosticsNode().toString(),
+        node: node,
+      ));
+    } else {
+      _log(LogData(
+        e.extensionKind.toLowerCase(),
+        jsonEncode(e.json),
+        e.timestamp,
+        summary: e.json.toString(),
+      ));
+    }
+  }
+
+  void _handleGCEvent(Event e) {
+    final HeapSpace newSpace = HeapSpace.parse(e.json['new']);
+    final HeapSpace oldSpace = HeapSpace.parse(e.json['old']);
+    final Map<dynamic, dynamic> isolateRef = e.json['isolate'];
+
+    final int usedBytes = newSpace.used + oldSpace.used;
+    final int capacityBytes = newSpace.capacity + oldSpace.capacity;
+
+    final int time = ((newSpace.time + oldSpace.time) * 1000).round();
+
+    final String summary = '${isolateRef['name']} • '
+        '${e.json['reason']} collection in $time ms • '
+        '${printMb(usedBytes)} MB used of ${printMb(capacityBytes)} MB';
+
+    final Map<String, dynamic> event = <String, dynamic>{
+      'reason': e.json['reason'],
+      'new': newSpace.json,
+      'old': oldSpace.json,
+      'isolate': isolateRef,
+    };
+
+    final String message = jsonEncode(event);
+    _log(LogData('gc', message, e.timestamp, summary: summary));
+  }
+
+  void _handleDeveloperLogEvent(Event e) {
+    final VmServiceWrapper service = serviceManager.service;
+
+    final dynamic logRecord = e.json['logRecord'];
+
+    String loggerName =
+        _valueAsString(InstanceRef.parse(logRecord['loggerName']));
+    if (loggerName == null || loggerName.isEmpty) {
+      loggerName = 'log';
+    }
+    final int level = logRecord['level'];
+    final InstanceRef messageRef = InstanceRef.parse(logRecord['message']);
+    String summary = _valueAsString(messageRef);
+    if (messageRef.valueAsStringIsTruncated == true) {
+      summary += '...';
+    }
+    final InstanceRef error = InstanceRef.parse(logRecord['error']);
+    final InstanceRef stackTrace = InstanceRef.parse(logRecord['stackTrace']);
+
+    final String details = summary;
+    Future<String> detailsComputer;
+
+    // If the message string was truncated by the VM, or the error object or
+    // stackTrace objects were non-null, we need to ask the VM for more
+    // information in order to render the log entry. We do this asynchronously
+    // on-demand using the `detailsComputer` Future.
+    if (messageRef.valueAsStringIsTruncated == true ||
+        _isNotNull(error) ||
+        _isNotNull(stackTrace)) {
+      detailsComputer = Future<String>(() async {
+        // Get the full string value of the message.
+        String result =
+            await _retrieveFullStringValue(service, e.isolate, messageRef);
+
+        // Get information about the error object. Some users of the
+        // dart:developer log call may pass a data payload in the `error`
+        // field, encoded as a json encoded string, so handle that case.
+        if (_isNotNull(error)) {
+          if (error.valueAsString != null) {
+            final String errorString =
+                await _retrieveFullStringValue(service, e.isolate, error);
+            result += '\n\n$errorString';
+          } else {
+            // Call `toString()` on the error object and display that.
+            final dynamic toStringResult = await service.invoke(
+              e.isolate.id,
+              error.id,
+              'toString',
+              <String>[],
+              disableBreakpoints: true,
+            );
+
+            if (toStringResult is ErrorRef) {
+              final String errorString = _valueAsString(error);
+              result += '\n\n$errorString';
+            } else if (toStringResult is InstanceRef) {
+              final String str = await _retrieveFullStringValue(
+                  service, e.isolate, toStringResult);
+              result += '\n\n$str';
+            }
+          }
+        }
+
+        // Get info about the stackTrace object.
+        if (_isNotNull(stackTrace)) {
+          result += '\n\n${_valueAsString(stackTrace)}';
+        }
+
+        return result;
+      });
+    }
+
+    const int severeIssue = 1000;
+    final bool isError = level != null && level >= severeIssue ? true : false;
+
+    _log(LogData(
+      loggerName,
+      details,
+      e.timestamp,
+      isError: isError,
+      summary: summary,
+      detailsComputer: detailsComputer,
+    ));
+  }
+
+  Future<String> _retrieveFullStringValue(
+    VmServiceWrapper service,
+    IsolateRef isolateRef,
+    InstanceRef stringRef,
+  ) async {
+    if (stringRef.valueAsStringIsTruncated != true) {
+      return stringRef.valueAsString;
+    }
+
+    final dynamic result = await service.getObject(isolateRef.id, stringRef.id,
+        offset: 0, count: stringRef.length);
+    if (result is Instance) {
+      final Instance obj = result;
+      return obj.valueAsString;
+    } else {
+      return '${stringRef.valueAsString}...';
+    }
+  }
+
+  void _handleConnectionStop(dynamic event) {}
+
+  void _log(LogData log) {
+    // Insert the new item and clamped the list to kMaxLogItemsLength.
+    data.add(log);
+    // Note: We need to drop rows from the start because we want to drop old
+    // rows but because that's expensive, we only do it periodically (eg. when
+    // the list is 500 rows more).
+    if (data.length > kMaxLogItemsUpperBound) {
+      int itemsToRemove = data.length - kMaxLogItemsLowerBound;
+      // Ensure we remove an even number of rows to keep the alternating
+      // background in-sync.
+      if (itemsToRemove % 2 == 1) {
+        itemsToRemove--;
+      }
+      data = data.sublist(itemsToRemove);
+    }
+
+    if (isVisible() && _loggingTableModel != null) {
+      // TODO(jacobr): adding data should be more incremental than this.
+      // We are blowing away state for all already added rows.
+      _loggingTableModel.setRows(data);
+      // Smooth scroll if we haven't scrolled in a while, otherwise use an
+      // immediate scroll because repeatedly smooth scrolling on the web means
+      // you never reach your destination.
+      final DateTime now = DateTime.now();
+      final bool smoothScroll = _lastScrollTime == null ||
+          _lastScrollTime.difference(now).inSeconds > 1;
+      _lastScrollTime = now;
+      _loggingTableModel.scrollTo(data.last,
+          scrollBehavior: smoothScroll ? 'smooth' : 'auto');
+    } else {
+      _hasPendingUiUpdates = true;
+    }
+  }
+
+  void entering() {
+    if (_hasPendingUiUpdates) {
+      _loggingTableModel.setRows(data);
+      _loggingTableModel.scrollTo(data.last, scrollBehavior: 'auto');
+      _hasPendingUiUpdates = false;
+    }
+  }
+
+  RemoteDiagnosticsNode _findFirstSummary(RemoteDiagnosticsNode node) {
+    if (node.level == DiagnosticLevel.summary) {
+      return node;
+    }
+    RemoteDiagnosticsNode summary;
+    if (node.inlineProperties != null) {
+      for (RemoteDiagnosticsNode property in node.inlineProperties) {
+        summary = _findFirstSummary(property);
+        if (summary != null) return summary;
+      }
+    }
+    if (node.childrenNow != null) {
+      for (RemoteDiagnosticsNode child in node.childrenNow) {
+        summary = _findFirstSummary(child);
+        if (summary != null) return summary;
+      }
+    }
+    return null;
+  }
+
+  void dispose() {
+    for (var subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
+  }
+}
+
+/// Receive and log stdout / stderr events from the VM.
+///
+/// This class buffers the events for up to 1ms. This is in order to combine a
+/// stdout message and its newline. Currently, `foo\n` is sent as two VM events;
+/// we wait for up to 1ms when we get the `foo` event, to see if the next event
+/// is a single newline. If so, we add the newline to the previous log message.
+class _StdoutEventHandler {
+  _StdoutEventHandler(this.loggingController, this.name,
+      {this.isError = false});
+
+  final LoggingController loggingController;
+  final String name;
+  final bool isError;
+
+  LogData buffer;
+  Timer timer;
+
+  void handle(Event e) {
+    final String message = decodeBase64(e.bytes);
+
+    if (buffer != null) {
+      timer?.cancel();
+
+      if (message == '\n') {
+        loggingController._log(LogData(
+          buffer.kind,
+          buffer.details + message,
+          buffer.timestamp,
+          summary: buffer.summary + message,
+          isError: buffer.isError,
+        ));
+        buffer = null;
+        return;
+      }
+
+      loggingController._log(buffer);
+      buffer = null;
+    }
+
+    String summary = message;
+    if (message.length > 200) {
+      summary = message.substring(0, 200) + '…';
+    }
+
+    final LogData data = LogData(
+      name,
+      message,
+      e.timestamp,
+      summary: summary,
+      isError: isError,
+    );
+
+    if (message == '\n') {
+      loggingController._log(data);
+    } else {
+      buffer = data;
+      timer = Timer(const Duration(milliseconds: 1), () {
+        loggingController._log(buffer);
+        buffer = null;
+      });
+    }
+  }
+}
+
+bool _isNotNull(InstanceRef serviceRef) {
+  return serviceRef != null && serviceRef.kind != 'Null';
+}
+
+String _valueAsString(InstanceRef ref) {
+  if (ref == null) {
+    return null;
+  }
+
+  if (ref.valueAsString == null) {
+    return ref.valueAsString;
+  }
+
+  if (ref.valueAsStringIsTruncated == true) {
+    return '${ref.valueAsString}...';
+  } else {
+    return ref.valueAsString;
+  }
+}
+
+/// A log data object that includes an optional summary (in either text or html
+/// form), information about whether the log entry represents an error entry,
+/// the log entry kind, and more detailed data for the entry.
+///
+/// The details can optionally be loaded lazily on first use. If this is the
+/// case, this log entry will have a non-null `detailsComputer` field. After the
+/// data is calculated, the log entry will be modified to contain the calculated
+/// `details` data.
+class LogData {
+  LogData(
+    this.kind,
+    this._details,
+    this.timestamp, {
+    this.summary,
+    this.summaryHtml,
+    this.isError = false,
+    this.detailsComputer,
+    this.node,
+  });
+
+  final String kind;
+  final int timestamp;
+  final bool isError;
+  final String summary;
+  final String summaryHtml;
+
+  final RemoteDiagnosticsNode node;
+  String _details;
+  Future<String> detailsComputer;
+
+  String get details => _details;
+
+  bool get needsComputing => detailsComputer != null;
+
+  Future<void> compute() async {
+    _details = await detailsComputer;
+    detailsComputer = null;
+  }
+}
+
+class LogKindColumn extends ColumnData<LogData> {
+  LogKindColumn() : super('Kind');
+
+  @override
+  bool get supportsSorting => false;
+
+  @override
+  bool get usesHtml => true;
+
+  @override
+  String get cssClass => 'log-label-column';
+
+  @override
+  dynamic getValue(LogData dataObject) {
+    final String cssClass = getCssClassForEventKind(dataObject);
+
+    return '<span class="label $cssClass">${dataObject.kind}</span>';
+  }
+
+  @override
+  String render(dynamic value) => value;
+}
+
+class LogWhenColumn extends ColumnData<LogData> {
+  LogWhenColumn() : super('When');
+
+  @override
+  String get cssClass => 'pre monospace';
+
+  @override
+  bool get supportsSorting => false;
+
+  @override
+  dynamic getValue(LogData dataObject) => dataObject.timestamp;
+
+  @override
+  String render(dynamic value) {
+    return value == null
+        ? ''
+        : timeFormat.format(DateTime.fromMillisecondsSinceEpoch(value));
+  }
+}
+
+class LogMessageColumn extends ColumnData<LogData> {
+  LogMessageColumn() : super.wide('Message');
+
+  @override
+  String get cssClass => 'pre-wrap monospace';
+
+  @override
+  bool get usesHtml => true;
+
+  @override
+  bool get supportsSorting => false;
+
+  @override
+  dynamic getValue(LogData dataObject) => dataObject;
+
+  @override
+  String render(dynamic value) {
+    final LogData log = value;
+
+    if (log.summaryHtml != null) {
+      return log.summaryHtml;
+    } else {
+      return escape(log.summary ?? log.details);
+    }
+  }
+}
+
+class FrameInfo {
+  FrameInfo(this.number, this.elapsedMs, this.startTimeMs);
+
+  static const String eventName = 'Flutter.Frame';
+
+  static const double kTargetMaxFrameTimeMs = 1000.0 / 60;
+
+  static FrameInfo from(Map<String, dynamic> data) {
+    return FrameInfo(
+        data['number'], data['elapsed'] / 1000, data['startTime'] / 1000);
+  }
+
+  final int number;
+  final num elapsedMs;
+  final num startTimeMs;
+
+  @override
+  String toString() => 'frame $number ${elapsedMs.toStringAsFixed(1)}ms';
+}
+
+class NavigationInfo {
+  NavigationInfo(this._route);
+
+  static const String eventName = 'Flutter.Navigation';
+
+  static NavigationInfo from(Map<String, dynamic> data) {
+    return NavigationInfo(data['route']);
+  }
+
+  final Map<String, dynamic> _route;
+
+  String get routeDescription => _route == null ? null : _route['description'];
+}
+
+class ServiceExtensionStateChangedInfo {
+  ServiceExtensionStateChangedInfo(this.extension, this.value);
+
+  static const String eventName = 'Flutter.ServiceExtensionStateChanged';
+
+  static ServiceExtensionStateChangedInfo from(Map<String, dynamic> data) {
+    return ServiceExtensionStateChangedInfo(data['extension'], data['value']);
+  }
+
+  final String extension;
+  final dynamic value;
+}
+
+String getCssClassForEventKind(LogData item) {
+  String cssClass = '';
+
+  if (item.kind == 'stderr' || item.isError) {
+    cssClass = 'stderr';
+  } else if (item.kind == 'stdout') {
+    cssClass = 'stdout';
+  } else if (item.kind == 'flutter.error') {
+    cssClass = 'stderr';
+  } else if (item.kind.startsWith('flutter')) {
+    cssClass = 'flutter';
+  } else if (item.kind == 'gc') {
+    cssClass = 'gc';
+  }
+
+  return cssClass;
+}
+
+String _createFrameDivHtml(FrameInfo frame) {
+  const double maxFrameEventBarMs = 100.0;
+  final String classes = (frame.elapsedMs >= FrameInfo.kTargetMaxFrameTimeMs)
+      ? 'frame-bar over-budget'
+      : 'frame-bar';
+
+  final int pixelWidth =
+      (math.min(frame.elapsedMs, maxFrameEventBarMs) * 3).round();
+  return '<div class="$classes" style="width: ${pixelWidth}px"/>';
+}

--- a/packages/devtools/lib/src/memory/memory_detail.dart
+++ b/packages/devtools/lib/src/memory/memory_detail.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../tables.dart';
+import '../table_data.dart';
 import 'memory_protocol.dart';
 
 class MemoryRow {
@@ -16,14 +16,14 @@ class MemoryRow {
   String toString() => name;
 }
 
-class MemoryColumnClassName extends Column<ClassHeapDetailStats> {
+class MemoryColumnClassName extends ColumnData<ClassHeapDetailStats> {
   MemoryColumnClassName() : super.wide('Class');
 
   @override
   dynamic getValue(ClassHeapDetailStats dataObject) => dataObject.classRef.name;
 }
 
-class MemoryColumnSize extends Column<ClassHeapDetailStats> {
+class MemoryColumnSize extends ColumnData<ClassHeapDetailStats> {
   MemoryColumnSize() : super('Size');
 
   @override
@@ -37,14 +37,14 @@ class MemoryColumnSize extends Column<ClassHeapDetailStats> {
   @override
   String render(dynamic value) {
     if (value < 1024) {
-      return ' ${Column.fastIntl(value)}';
+      return ' ${ColumnData.fastIntl(value)}';
     } else {
-      return ' ${Column.fastIntl(value ~/ 1024)}k';
+      return ' ${ColumnData.fastIntl(value ~/ 1024)}k';
     }
   }
 }
 
-class MemoryColumnInstanceCount extends Column<ClassHeapDetailStats> {
+class MemoryColumnInstanceCount extends ColumnData<ClassHeapDetailStats> {
   MemoryColumnInstanceCount() : super('Count');
 
   @override
@@ -55,11 +55,11 @@ class MemoryColumnInstanceCount extends Column<ClassHeapDetailStats> {
       dataObject.instancesCurrent;
 
   @override
-  String render(dynamic value) => Column.fastIntl(value);
+  String render(dynamic value) => ColumnData.fastIntl(value);
 }
 
 class MemoryColumnInstanceAccumulatedCount
-    extends Column<ClassHeapDetailStats> {
+    extends ColumnData<ClassHeapDetailStats> {
   MemoryColumnInstanceAccumulatedCount() : super('Accumulator');
 
   @override
@@ -70,10 +70,10 @@ class MemoryColumnInstanceAccumulatedCount
       dataObject.instancesAccumulated;
 
   @override
-  String render(dynamic value) => Column.fastIntl(value);
+  String render(dynamic value) => ColumnData.fastIntl(value);
 }
 
-class MemoryColumnSimple<T> extends Column<T> {
+class MemoryColumnSimple<T> extends ColumnData<T> {
   MemoryColumnSimple(String name, this.getter,
       {bool wide = false,
       bool usesHtml = false,

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -12,13 +12,13 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js' as js;
 
-import 'package:devtools/src/logging/logging_controller.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../debugger/debugger.dart';
 import '../framework/framework.dart';
 import '../globals.dart';
 import '../logging/logging.dart';
+import '../logging/logging_controller.dart';
 import '../main.dart';
 
 class App {

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -12,6 +12,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:js' as js;
 
+import 'package:devtools/src/logging/logging_controller.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../debugger/debugger.dart';
@@ -110,12 +111,12 @@ class App {
 
   Future<void> logsClearLogs([dynamic _]) async {
     final LoggingScreen screen = framework.getScreen('logging');
-    screen.loggingTable.setRows(<LogData>[]);
+    screen.controller.loggingTableModel.setRows(<LogData>[]);
   }
 
   Future<int> logsLogCount([dynamic _]) async {
     final LoggingScreen screen = framework.getScreen('logging');
-    return screen.loggingTable.rowCount;
+    return screen.controller.loggingTableModel.rowCount;
   }
 
   Future<String> debuggerGetState([dynamic _]) async {

--- a/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_tables.dart
@@ -1,6 +1,7 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import '../table_data.dart';
 import '../tables.dart';
 import '../url_utils.dart';
 import '../utils.dart';
@@ -24,17 +25,18 @@ class CpuCallTree extends CpuProfilerView {
   void _init() {
     final methodNameColumn = MethodNameColumn()
       ..onNodeExpanded
-          .listen((stackFrame) => callTreeTable.expandNode(stackFrame))
+          .listen((stackFrame) => callTreeTable.model.expandNode(stackFrame))
       ..onNodeCollapsed
-          .listen((stackFrame) => callTreeTable.collapseNode(stackFrame));
+          .listen((stackFrame) => callTreeTable.model.collapseNode(stackFrame));
 
-    callTreeTable = TreeTable<CpuStackFrame>.virtual()
+    callTreeTable = TreeTable<CpuStackFrame>.virtual();
+    callTreeTable.model
       ..addColumn(TotalTimeColumn())
       ..addColumn(SelfTimeColumn())
       ..addColumn(methodNameColumn)
       ..addColumn(SourceColumn());
-    callTreeTable
-      ..sortColumn = callTreeTable.columns.first
+    callTreeTable.model
+      ..sortColumn = callTreeTable.model.columns.first
       ..setRows(<CpuStackFrame>[]);
     add(callTreeTable.element);
   }
@@ -49,11 +51,11 @@ class CpuCallTree extends CpuProfilerView {
       root..expand(),
       ...root.children.cast(),
     ];
-    callTreeTable.setRows(rows);
+    callTreeTable.model.setRows(rows);
   }
 
   @override
-  void reset() => callTreeTable.setRows(<CpuStackFrame>[]);
+  void reset() => callTreeTable.model.setRows(<CpuStackFrame>[]);
 }
 
 class CpuBottomUp extends CpuProfilerView {
@@ -69,17 +71,17 @@ class CpuBottomUp extends CpuProfilerView {
   void _init() {
     final methodNameColumn = MethodNameColumn()
       ..onNodeExpanded
-          .listen((stackFrame) => bottomUpTable.expandNode(stackFrame))
+          .listen((stackFrame) => bottomUpTable.model.expandNode(stackFrame))
       ..onNodeCollapsed
-          .listen((stackFrame) => bottomUpTable.collapseNode(stackFrame));
+          .listen((stackFrame) => bottomUpTable.model.collapseNode(stackFrame));
     final selfTimeColumn = SelfTimeColumn();
 
-    bottomUpTable = TreeTable<CpuStackFrame>.virtual()
+    bottomUpTable = TreeTable<CpuStackFrame>.virtual();
+    bottomUpTable.model
       ..addColumn(TotalTimeColumn())
       ..addColumn(selfTimeColumn)
       ..addColumn(methodNameColumn)
-      ..addColumn(SourceColumn());
-    bottomUpTable
+      ..addColumn(SourceColumn())
       ..sortColumn = selfTimeColumn
       ..setRows(<CpuStackFrame>[]);
     add(bottomUpTable.element);
@@ -90,14 +92,14 @@ class CpuBottomUp extends CpuProfilerView {
     final CpuProfileData data = profileDataProvider();
     final List<CpuStackFrame> bottomUpRoots =
         BottomUpProfileTransformer().processData(data.cpuProfileRoot);
-    bottomUpTable.setRows(bottomUpRoots);
+    bottomUpTable.model.setRows(bottomUpRoots);
   }
 
   @override
-  void reset() => bottomUpTable.setRows(<CpuStackFrame>[]);
+  void reset() => bottomUpTable.model.setRows(<CpuStackFrame>[]);
 }
 
-class SelfTimeColumn extends Column<CpuStackFrame> {
+class SelfTimeColumn extends ColumnData<CpuStackFrame> {
   SelfTimeColumn() : super('Self Time', fixedWidthPx: _timeColumnWidthPx);
 
   @override
@@ -123,7 +125,7 @@ class SelfTimeColumn extends Column<CpuStackFrame> {
   }
 }
 
-class TotalTimeColumn extends Column<CpuStackFrame> {
+class TotalTimeColumn extends ColumnData<CpuStackFrame> {
   TotalTimeColumn() : super('Total Time', fixedWidthPx: _timeColumnWidthPx);
 
   @override
@@ -149,7 +151,7 @@ class TotalTimeColumn extends Column<CpuStackFrame> {
   }
 }
 
-class MethodNameColumn extends TreeColumn<CpuStackFrame> {
+class MethodNameColumn extends TreeColumnData<CpuStackFrame> {
   MethodNameColumn() : super('Method');
 
   static const maxMethodNameLength = 75;
@@ -173,7 +175,7 @@ class MethodNameColumn extends TreeColumn<CpuStackFrame> {
 }
 
 // TODO(kenzie): make these urls clickable once we can jump to source.
-class SourceColumn extends Column<CpuStackFrame> {
+class SourceColumn extends ColumnData<CpuStackFrame> {
   SourceColumn() : super('Source', alignment: ColumnAlignment.right);
 
   @override

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -190,7 +190,7 @@ final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Disable structured errors for Flutter framework issues',
   disabledTooltip: 'Show structured errors for Flutter framework issues',
-  gaScreenName: ga.inspector,
+  gaScreenName: ga.logging,
   gaItem: ga.structuredErrors,
 );
 
@@ -208,6 +208,7 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   toggleSelectWidgetMode,
   togglePlatformMode,
   slowAnimations,
+  structuredErrors,
 ];
 
 final Map<String, ServiceExtensionDescription> serviceExtensionsWhitelist =

--- a/packages/devtools/lib/src/service_extensions.dart
+++ b/packages/devtools/lib/src/service_extensions.dart
@@ -182,6 +182,18 @@ final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.selectWidgetMode,
 );
 
+final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.flutter.inspector.structuredErrors',
+  description: 'Show structured errors',
+  icon: FlutterIcons.redError,
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'Disable structured errors for Flutter framework issues',
+  disabledTooltip: 'Show structured errors for Flutter framework issues',
+  gaScreenName: ga.inspector,
+  gaItem: ga.structuredErrors,
+);
+
 // This extension should never be displayed as a button so does not need a
 // ServiceExtensionDescription object.
 const String didSendFirstFrameEvent = 'ext.flutter.didSendFirstFrameEvent';

--- a/packages/devtools/lib/src/table_data.dart
+++ b/packages/devtools/lib/src/table_data.dart
@@ -56,7 +56,9 @@ class TableData<T> extends Object {
   bool _hasPendingRebuild = false;
 
   List<ColumnData<T>> get columns => _columns;
+
   final List<ColumnData<T>> _columns = <ColumnData<T>>[];
+
   List<T> data = [];
 
   int get rowCount => data?.length ?? 0;
@@ -73,6 +75,7 @@ class TableData<T> extends Object {
 
   @protected
   final StreamController<T> selectController = StreamController<T>.broadcast();
+
   final StreamController<Null> _rowsChangedController =
       StreamController.broadcast();
 
@@ -354,24 +357,27 @@ class TreeTableData<T extends TreeNode<T>> extends TableData<T> {
 }
 
 abstract class ColumnData<T> {
-  ColumnData(this.title,
-      {this.alignment = ColumnAlignment.left,
-      this.fixedWidthPx,
-      this.percentWidth,
-      this.usesHtml = false,
-      this.hover = false,
-      this.cssClass}) {
+  ColumnData(
+    this.title, {
+    this.alignment = ColumnAlignment.left,
+    this.fixedWidthPx,
+    this.percentWidth,
+    this.usesHtml = false,
+    this.hover = false,
+    this.cssClass,
+  }) {
     if (percentWidth != null) {
       percentWidth.clamp(0, 100);
     }
   }
 
-  ColumnData.wide(this.title,
-      {this.alignment = ColumnAlignment.left,
-      this.usesHtml = false,
-      this.hover = false,
-      this.cssClass})
-      : percentWidth = defaultWideColumnPercentWidth;
+  ColumnData.wide(
+    this.title, {
+    this.alignment = ColumnAlignment.left,
+    this.usesHtml = false,
+    this.hover = false,
+    this.cssClass,
+  }) : percentWidth = defaultWideColumnPercentWidth;
 
   static const defaultWideColumnPercentWidth = 100;
 
@@ -394,6 +400,7 @@ abstract class ColumnData<T> {
   final ColumnAlignment alignment;
 
   final bool usesHtml;
+
   final bool hover;
 
   bool get numeric => false;

--- a/packages/devtools/lib/src/table_data.dart
+++ b/packages/devtools/lib/src/table_data.dart
@@ -1,0 +1,477 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import 'trees.dart';
+import 'ui/fake_flutter/fake_flutter.dart';
+import 'utils.dart';
+
+class HoverCellData<T> {
+  HoverCellData(this.data);
+
+  final T data;
+}
+
+abstract class TableDataClient<T> {
+  void rebuildTable();
+
+  /// Override to update data after setting rows.
+  void onSetRows();
+
+  void setState(VoidCallback modifyState);
+
+  /// The way the columns are sorted have changed.
+  ///
+  /// Update the UI to reflect the new state.
+  void onColumnSortChanged(ColumnData<T> column, SortOrder sortDirection);
+
+  /// Selects by index. Note: This is index of the row as it's rendered
+  /// and not necessarily for rows[] since it may be being rendered in reverse.
+  /// This way, +1 will always move down the visible table.
+  /// scrollBehaviour is a string as defined for the HTML scrollTo() method
+  /// https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollTo (eg.
+  /// `smooth`, `instance`, `auto`).
+  void selectByIndex(
+    int newIndex, {
+    bool keepVisible = true,
+    String scrollBehavior = 'smooth',
+  });
+
+  void scrollToIndex(int rowIndex, {String scrollBehavior = 'smooth'});
+
+  void clearSelection();
+}
+
+class TableData<T> extends Object {
+  void setState(VoidCallback modifyState) {
+    client?.setState(modifyState);
+  }
+
+  TableDataClient<T> client;
+
+  bool _hasPendingRebuild = false;
+
+  List<ColumnData<T>> get columns => _columns;
+  final List<ColumnData<T>> _columns = <ColumnData<T>>[];
+  List<T> data = [];
+
+  int get rowCount => data?.length ?? 0;
+
+  ColumnData<T> _sortColumn;
+
+  SortOrder _sortDirection;
+
+  set sortColumn(ColumnData<T> column) {
+    _sortColumn = column;
+    _sortDirection =
+        column.numeric ? SortOrder.descending : SortOrder.ascending;
+  }
+
+  @protected
+  final StreamController<T> selectController = StreamController<T>.broadcast();
+  final StreamController<Null> _rowsChangedController =
+      StreamController.broadcast();
+
+  final StreamController<HoverCellData<T>> selectElementController =
+      StreamController<HoverCellData<T>>.broadcast();
+
+  @mustCallSuper
+  void dispose() {
+    client = null;
+  }
+
+  Stream<T> get onSelect => selectController.stream;
+
+  Stream<Null> get onRowsChanged => _rowsChangedController.stream;
+
+  Stream<HoverCellData<T>> get onCellHover => selectElementController.stream;
+
+  void addColumn(ColumnData<T> column) {
+    _columns.add(column);
+  }
+
+  void setRows(List<T> data) {
+    // If the selected object is no longer valid, clear the selection and
+    // scroll to the top.
+    if (!data.contains(_selectedObject)) {
+      if (rowCount > 0) {
+        client?.scrollToIndex(0, scrollBehavior: 'auto');
+      }
+      client?.clearSelection();
+    }
+
+    // Copy the list, so that changes to it don't affect us.
+    this.data = data.toList();
+
+    _rowsChangedController.add(null);
+
+    client?.onSetRows();
+
+    if (_sortColumn == null) {
+      final ColumnData<T> column = _columns.firstWhere(
+          (ColumnData<T> c) => c.supportsSorting,
+          orElse: () => null);
+      if (column != null) {
+        sortColumn = column;
+      }
+    }
+
+    if (_sortColumn != null) {
+      _doSort();
+    }
+
+    scheduleRebuild();
+  }
+
+  void scrollTo(T row, {String scrollBehavior = 'smooth'}) {
+    final index = data.indexOf(row);
+    if (index == -1) {
+      return;
+    }
+    if (_hasPendingRebuild) {
+      // Wait for the content to be rendered before we scroll otherwise we may
+      // not be able to scroll far enough.
+      setState(() {
+        // We assume the index is still valid. Alternately we search for the
+        // index again. The one thing we should absolutely not do is call the
+        // scrollTo helper method again as there is a significant risk scrollTo
+        // would never be called if items are added to the table every frame.
+        client?.scrollToIndex(index, scrollBehavior: scrollBehavior);
+      });
+      return;
+    }
+    client?.scrollToIndex(index, scrollBehavior: scrollBehavior);
+  }
+
+  void scheduleRebuild() {
+    if (!_hasPendingRebuild) {
+      // Set a flag to ensure we don't schedule rebuilds if there's already one
+      // in the queue.
+      _hasPendingRebuild = true;
+
+      setState(() {
+        _hasPendingRebuild = false;
+        client?.rebuildTable();
+      });
+    }
+  }
+
+  void _doSort() {
+    final ColumnData<T> column = _sortColumn;
+    final int direction = _sortDirection == SortOrder.ascending ? 1 : -1;
+
+    client?.onColumnSortChanged(column, _sortDirection);
+
+    _sortData(column, direction);
+  }
+
+  void _sortData(ColumnData column, int direction) {
+    data.sort((T a, T b) => _compareData(a, b, column, direction));
+  }
+
+  int _compareData(T a, T b, ColumnData column, int direction) {
+    return column.compare(a, b) * direction;
+  }
+
+  T get selectedObject => _selectedObject;
+  T _selectedObject;
+
+  int get selectedObjectIndex => _selectedObjectIndex;
+  int _selectedObjectIndex;
+
+  void setSelection(T object, int index) {
+    assert(index == null || data[index] == object);
+    _selectedObjectIndex = index;
+    if (selectedObject != object) {
+      _selectedObject = object;
+      selectController.add(object);
+    }
+  }
+
+  bool get hasSelection => _selectedObject != null;
+
+  void onColumnClicked(ColumnData<T> column) {
+    if (!column.supportsSorting) {
+      return;
+    }
+
+    if (_sortColumn == column) {
+      _sortDirection = _sortDirection == SortOrder.ascending
+          ? SortOrder.descending
+          : SortOrder.ascending;
+    } else {
+      sortColumn = column;
+    }
+
+    _doSort();
+    scheduleRebuild();
+  }
+
+  /// Override this method if the table should handle left key strokes.
+  void handleLeftKey() {}
+
+  /// Override this method if the table should handle right key strokes.
+  void handleRightKey() {}
+}
+
+/// Data for a tree table where nodes in the tree can be expanded and
+/// collapsed.
+///
+/// A TreeTableData must have exactly one column that is a [TreeColumnData].
+class TreeTableData<T extends TreeNode<T>> extends TableData<T> {
+  @override
+  void addColumn(ColumnData<T> column) {
+    // Avoid adding multiple TreeColumnData columns.
+    assert(column is! TreeColumnData<T> ||
+        _columns.where((c) => c is TreeColumnData).isEmpty);
+    super.addColumn(column);
+  }
+
+  @override
+  void handleLeftKey() {
+    if (_selectedObject != null) {
+      if (_selectedObject.isExpanded) {
+        // Collapse node and preserve selection.
+        collapseNode(_selectedObject);
+      } else {
+        // Select the node's parent.
+        final parentIndex = data.indexOf(_selectedObject.parent);
+        if (parentIndex != null && parentIndex != -1) {
+          client?.selectByIndex(parentIndex);
+        }
+      }
+    }
+  }
+
+  @override
+  void handleRightKey() {
+    if (_selectedObject != null) {
+      if (_selectedObject.isExpanded) {
+        // Select the node's first child.
+        final firstChildIndex = data.indexOf(_selectedObject.children.first);
+        client?.selectByIndex(firstChildIndex);
+      } else if (_selectedObject.isExpandable) {
+        // Expand node and preserve selection.
+        expandNode(_selectedObject);
+      } else {
+        // The node is not expandable. Select the next node in range.
+        final nextIndex = data.indexOf(_selectedObject) + 1;
+        if (nextIndex != data.length) {
+          client?.selectByIndex(nextIndex);
+        }
+      }
+    }
+  }
+
+  @override
+  void _sortData(ColumnData column, int direction) {
+    final List<T> sortedData = [];
+
+    void _addToSortedData(T dataObject) {
+      sortedData.add(dataObject);
+      if (dataObject.isExpanded) {
+        dataObject.children
+          ..sort((T a, T b) => _compareData(a, b, column, direction))
+          ..forEach(_addToSortedData);
+      }
+    }
+
+    data.where((dataObject) => dataObject.level == 0).toList()
+      ..sort((T a, T b) => _compareData(a, b, column, direction))
+      ..forEach(_addToSortedData);
+
+    data = sortedData;
+  }
+
+  void collapseNode(T dataObject) {
+    void cascadingRemove(T _dataObject) {
+      if (!data.contains(_dataObject)) return;
+      data.remove(_dataObject);
+      (_dataObject.children).forEach(cascadingRemove);
+    }
+
+    assert(data.contains(dataObject));
+    dataObject.children.forEach(cascadingRemove);
+    dataObject.collapse();
+
+    _selectedObject ??= dataObject;
+    setRows(data);
+  }
+
+  void expandNode(T dataObject) {
+    void expand(T node) {
+      assert(data.contains(node));
+      int insertIndex = data.indexOf(node) + 1;
+      for (T child in node.children) {
+        data.insert(insertIndex, child);
+        if (child.isExpanded) {
+          expand(child);
+        }
+        insertIndex++;
+      }
+      node.expand();
+    }
+
+    expand(dataObject);
+
+    _selectedObject ??= dataObject;
+    setRows(data);
+  }
+
+  void expandAll() {
+    // Store visited nodes so that we do not expand the same root multiple
+    // times.
+    final visited = <T>{};
+    for (T dataObject in data) {
+      final root = dataObject.root;
+      if (!visited.contains(root)) {
+        root.expandCascading();
+        visited.add(root);
+      }
+    }
+
+    setRows(data);
+  }
+
+  void collapseAll() {
+    // Store visited nodes so that we do not expand the same root multiple
+    // times.
+    final visited = <T>{};
+    for (T dataObject in data) {
+      final root = dataObject.root;
+      if (!visited.contains(root)) {
+        root.collapseCascading();
+        visited.add(root);
+      }
+    }
+
+    setRows(data);
+  }
+}
+
+abstract class ColumnData<T> {
+  ColumnData(this.title,
+      {this.alignment = ColumnAlignment.left,
+      this.fixedWidthPx,
+      this.percentWidth,
+      this.usesHtml = false,
+      this.hover = false,
+      this.cssClass}) {
+    if (percentWidth != null) {
+      percentWidth.clamp(0, 100);
+    }
+  }
+
+  ColumnData.wide(this.title,
+      {this.alignment = ColumnAlignment.left,
+      this.usesHtml = false,
+      this.hover = false,
+      this.cssClass})
+      : percentWidth = defaultWideColumnPercentWidth;
+
+  static const defaultWideColumnPercentWidth = 100;
+
+  final String title;
+
+  // TODO(jacobr): remove this field from the data before porting to FlutterWeb.
+  final String cssClass;
+
+  /// Width of the column expressed as a fixed number of pixels.
+  ///
+  /// If both [fixedWidthPx] and [percentWidth] are specified, [fixedWidthPx]
+  /// will be used.
+  int fixedWidthPx;
+
+  /// Width of the column expressed as a percent value between 0 and 100.
+  ///
+  /// TODO(jacobr): make this a double.
+  int percentWidth;
+
+  final ColumnAlignment alignment;
+
+  final bool usesHtml;
+  final bool hover;
+
+  bool get numeric => false;
+
+  bool get supportsSorting => numeric;
+
+  int compare(T a, T b) {
+    final Comparable valueA = getValue(a);
+    final Comparable valueB = getValue(b);
+    return valueA.compareTo(valueB);
+  }
+
+  /// Get the cell's value from the given [dataObject].
+  dynamic getValue(T dataObject);
+
+  /// Get the cell's display value from the given [dataObject].
+  dynamic getDisplayValue(T dataObject) => getValue(dataObject);
+
+  /// Get the cell's tooltip value from the given [dataObject].
+  String getTooltip(T dataObject) => '';
+
+  /// Given a value from [getValue], render it to a String.
+  String render(dynamic value) {
+    if (value is num) {
+      return fastIntl(value);
+    }
+    return value.toString();
+  }
+
+  static String fastIntl(num value) {
+    if (value is int && value < 1000) {
+      return value.toString();
+    } else {
+      return nf.format(value);
+    }
+  }
+
+  @override
+  String toString() => title;
+}
+
+abstract class TreeColumnData<T extends TreeNode<T>> extends ColumnData<T> {
+  TreeColumnData(
+    title, {
+    int fixedWidthPx,
+    int percentWidth,
+  }) : super(title, fixedWidthPx: fixedWidthPx, percentWidth: percentWidth);
+
+  static const treeToggleWidth = 14;
+
+  final StreamController<T> nodeExpandedController =
+      StreamController<T>.broadcast();
+
+  Stream<T> get onNodeExpanded => nodeExpandedController.stream;
+
+  final StreamController<T> nodeCollapsedController =
+      StreamController<T>.broadcast();
+
+  Stream<T> get onNodeCollapsed => nodeCollapsedController.stream;
+
+  int getNodeIndentPx(T dataObject) {
+    int indentWidth = dataObject.level * treeToggleWidth;
+    if (!dataObject.isExpandable) {
+      // If the object is not expandable, we need to increase the width of our
+      // spacer to account for the missing tree toggle.
+      indentWidth += TreeColumnData.treeToggleWidth;
+    }
+    return indentWidth;
+  }
+}
+
+enum ColumnAlignment {
+  left,
+  right,
+  center,
+}
+
+enum SortOrder {
+  ascending,
+  descending,
+}

--- a/packages/devtools/lib/src/ui/analytics_constants.dart
+++ b/packages/devtools/lib/src/ui/analytics_constants.dart
@@ -70,3 +70,4 @@ const String allExceptions = 'allExceptions';
 
 // Logging UX actions:
 const String clearLogs = 'clearLogs';
+const String structuredErrors = 'structuredErrors';

--- a/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
@@ -15,6 +15,7 @@ library fake_flutter;
 
 import 'dart:async';
 import 'dart:collection';
+import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
 

--- a/packages/devtools/lib/src/ui/fake_flutter/foundation.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/foundation.dart
@@ -8,3 +8,23 @@ typedef VoidCallback = void Function();
 
 /// The signature of [State.setState] functions.
 typedef StateSetter = void Function(VoidCallback fn);
+
+const kReleaseMode = false;
+
+/// Configure [debugFormatDouble] using [num.toStringAsPrecision].
+///
+/// Defaults to null, which uses the default logic of [debugFormatDouble].
+int debugDoublePrecision;
+
+/// Formats a double to have standard formatting.
+///
+/// This behavior can be overriden by [debugDoublePrecision].
+String debugFormatDouble(double value) {
+  if (value == null) {
+    return 'null';
+  }
+  if (debugDoublePrecision != null) {
+    return value.toStringAsPrecision(debugDoublePrecision);
+  }
+  return value.toStringAsFixed(1);
+}

--- a/packages/devtools/lib/src/ui/fake_flutter/print.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/print.dart
@@ -96,7 +96,6 @@ Future<void> get debugPrintDone =>
     _debugPrintCompleter?.future ?? Future<void>.value();
 
 final RegExp _indentPattern = RegExp('^ *(?:[-+*] |[0-9]+[.):] )?');
-enum _WordWrapParseMode { inSpace, inWord, atBreak }
 
 /// Wraps the given string at the given width.
 ///

--- a/packages/devtools/lib/src/ui/icons.dart
+++ b/packages/devtools/lib/src/ui/icons.dart
@@ -126,6 +126,8 @@ class FlutterIcons {
   static const Icon redProgress = UrlIcon('/icons/perf/red_progress.gif');
   static const Icon yellowProgress = UrlIcon('/icons/perf/yellow_progress.gif');
 
+  static const Icon redError = UrlIcon('/icons/perf/RedExcl.png');
+
   // Icons matching IntelliJ core icons.
   static const Icon locate = UrlIcon('/icons/general/locate.png');
   static const Icon forceRefresh = UrlIcon('/icons/actions/forceRefresh.svg');

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -34,10 +34,10 @@ dependencies:
     ^0.0.1
 #    path: ../../third_party/packages/polymer_css
   primer_css:
-     ^0.0.2
+    ^0.0.2
 #    path: ../../third_party/packages/primer_css
   split:
-    ^0.0.2
+    ^0.0.4
 #    path: ../../third_party/packages/split
   plotly_js:
     ^0.0.1

--- a/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold.txt
+++ b/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold.txt
@@ -1,15 +1,15 @@
-▼[S] Scaffold <-- selected
-│   dependencies: [MediaQuery, _LocalizationsScope-[GlobalKey#00000], Directionality, _InheritedTheme]
-│   ▶state: ScaffoldState#00000(tickers: tracking 2 tickers)
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
+▼[S]Scaffold <-- selected
+│ dependencies: [MediaQuery, _LocalizationsScope-[GlobalKey#00000], Directionality, _InheritedTheme]
+│ ▶state: ScaffoldState#00000(tickers: tracking 2 tickers)
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
     │   ScrollController#00000(no clients)
-    └─▼[M] Material
+    └─▼[M]Material
       │   type: canvas
       │   color: [#00000aff]#00000a
       │   dependencies: [_LocalizationsScope-[GlobalKey#00000], _InheritedTheme]
       │   state: _MaterialState#00000
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
         │   duration: 200ms
         │   shape: rectangle
         │   borderRadius: BorderRadius.zero
@@ -19,17 +19,17 @@
         │   shadowColor: [#000000ff]#000000
         │   animateShadowColor: true
         │   ▶state: _AnimatedPhysicalModelState#00000(ticker inactive)
-        └─▼[P] PhysicalModel
+        └─▼[P]PhysicalModel
           │   shape: rectangle
           │   borderRadius: BorderRadius.zero
           │   elevation: 0.0
           │   color: [#00000aff]#00000a
           │   shadowColor: [#000000ff]#000000
           │   ▶renderObject: RenderPhysicalModel#00000
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
               │   ▶renderObject: _RenderInkFeatures#00000
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
                 │   duration: 200ms
                 │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
                 │   inherit: false
@@ -42,7 +42,7 @@
                 │   softWrap: wrapping at box width
                 │   overflow: clip
                 │   ▶state: _AnimatedDefaultTextStyleState#00000(ticker inactive)
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
                   │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
                   │   inherit: false
                   │   color: [#000000dd]#00000000
@@ -53,46 +53,46 @@
                   │   decoration: TextDecoration.none
                   │   softWrap: wrapping at box width
                   │   overflow: clip
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
                     │   animation: AnimationController#00000(⏭ 1.000; paused)
                     │   state: _AnimatedState#00000
-                    └─▼[C] CustomMultiChildLayout
+                    └─▼[C]CustomMultiChildLayout
                       │   ▶renderObject: RenderCustomMultiChildLayoutBox#00000
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
                       │   │   id: _ScaffoldSlot.body
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
                       │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                      │     └─▶[C] Center
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
+                      │     └─▶[C]Center
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
                       │   │   id: _ScaffoldSlot.appBar
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
                       │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                      │     └─▼[C] ConstrainedBox
+                      │     └─▼[C]ConstrainedBox
                       │       │   BoxConstraints(0.0<=w<=Infinity, 0.0<=h<=56.0)
                       │       │   ▶renderObject: RenderConstrainedBox#00000 relayoutBoundary=up1
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
                         │   id: _ScaffoldSlot.floatingActionButton
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
                           │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                          └─▼[F] _FloatingActionButtonTransition
+                          └─▼[F]_FloatingActionButtonTransition
                             │   ▶state: _FloatingActionButtonTransitionState#00000(tickers: tracking 1 ticker)
-                            └─▼[/icons/inspector/value.png] Stack
+                            └─▼[/icons/inspector/value.png]Stack
                               │   alignment: centerRight
                               │   fit: loose
                               │   overflow: clip
                               │   dependencies: [Directionality]
                               │   ▶renderObject: RenderStack#00000 relayoutBoundary=up1
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
                                 │   animation: AnimationMin<double>(_AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: FlippedCurve(Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00)))➩1.0➪ReverseAnimation, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00))➩1.0), AnimationController#00000(⏮ 0.000; paused)➩Cubic(0.42, 0.00, 1.00, 1.00))
                                 │   state: _AnimatedState#00000
-                                └─▼[/icons/inspector/colors.png] Transform
+                                └─▼[/icons/inspector/colors.png]Transform
                                   │   dependencies: [Directionality]
                                   │   ▶renderObject: RenderTransform#00000 relayoutBoundary=up2
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
                                     │   animation: AnimationController#00000(⏮ 0.000; paused)➩CurveTween(curve: Cubic(0.42, 0.00, 1.00, 1.00))➩Tween<double>(0.875 → 1.0)➩0.875➩TrainHoppingAnimation(next: _AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩Tween<double>(0.75 → 1.0)➩1.0, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Threshold)➩1.0➪ReverseAnimation))
                                     │   state: _AnimatedState#00000
-                                    └─▼[/icons/inspector/colors.png] Transform
+                                    └─▼[/icons/inspector/colors.png]Transform
                                         dependencies: [Directionality]
                                         ▶renderObject: RenderTransform#00000 relayoutBoundary=up3

--- a/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold_expanded.txt
+++ b/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold_expanded.txt
@@ -1,29 +1,29 @@
-▼[S] Scaffold <-- selected
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
-    └─▼[M] Material
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
-        └─▼[P] PhysicalModel
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
-                    └─▼[C] CustomMultiChildLayout
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] Center
-                      │       └─▶[/icons/inspector/textArea.png] Text
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] ConstrainedBox
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
-                          └─▼[F] _FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png] Stack
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
-                                └─▼[/icons/inspector/colors.png] Transform
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
-                                    └─▼[/icons/inspector/colors.png] Transform
+▼[S]Scaffold <-- selected
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]Center
+                      │       └─▶[/icons/inspector/textArea.png]Text
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_details_tree_scaffold_with_styles.txt
@@ -1,29 +1,29 @@
-▼[S]<grayed> </grayed><bold>Scaffold</bold> <-- selected
-└─▼[S]<grayed> </grayed>_ScaffoldScope
-    ▼[P]<grayed> </grayed>PrimaryScrollController
-    └─▼[M]<grayed> </grayed>Material
-      └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedPhysicalModel
-        └─▼[P]<grayed> </grayed>PhysicalModel
-          └─▼[N]<grayed> </grayed>NotificationListener <grayed><LayoutChangedNotification></grayed>
-              ▼[I]<grayed> </grayed>_InkFeatures <grayed>[GlobalKey#00000 ink renderer]</grayed>
-              └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png]<grayed> </grayed>DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedBuilder
-                    └─▼[C]<grayed> </grayed>CustomMultiChildLayout
-                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.body>]</grayed>
-                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                      │     └─▼[C]<grayed> </grayed><bold>Center</bold>
-                      │       └─▶[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold>
-                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.appBar>]</grayed>
-                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                      │     └─▼[C]<grayed> </grayed>ConstrainedBox
-                      │       └─▼[F]<grayed> </grayed>FlexibleSpaceBarSettings
-                      │           ▶[A]<grayed> </grayed><bold>AppBar</bold>
-                      └─▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.floatingActionButton>]</grayed>
-                        └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                          └─▼[F]<grayed> </grayed>_FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png]<grayed> </grayed>Stack
-                              └─▼[/icons/inspector/resume.png]<grayed> </grayed>ScaleTransition
-                                └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform
-                                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>RotationTransition
-                                    └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform
+▼[S]<bold>Scaffold</bold> <-- selected
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]<bold>Center</bold>
+                      │       └─▶[/icons/inspector/textArea.png]<bold>Text</bold>
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]<bold>AppBar</bold>
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens/inspector_controller_details_tree_scrolled_to_center.txt
+++ b/packages/devtools/test/goldens/inspector_controller_details_tree_scrolled_to_center.txt
@@ -1,29 +1,29 @@
-▼[S] Scaffold
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
-    └─▼[M] Material
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
-        └─▼[P] PhysicalModel
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
-                    └─▼[C] CustomMultiChildLayout
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] Center <-- selected
-                      │       └─▶[/icons/inspector/textArea.png] Text
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] ConstrainedBox
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
-                          └─▼[F] _FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png] Stack
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
-                                └─▼[/icons/inspector/colors.png] Transform
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
-                                    └─▼[/icons/inspector/colors.png] Transform
+▼[S]Scaffold
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]Center <-- selected
+                      │       └─▶[/icons/inspector/textArea.png]Text
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_initial_tree_with_styles.txt
@@ -1,8 +1,8 @@
-▼[R]<grayed> </grayed>root <grayed>]</grayed>
-  ▼[M]<grayed> </grayed>MyApp
-    ▼[M]<grayed> </grayed>MaterialApp
-      ▼[S]<grayed> </grayed>Scaffold
-      ├───▼[C]<grayed> </grayed>Center
-      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text
-      └─▼[A]<grayed> </grayed>AppBar
-          [/icons/inspector/textArea.png]<grayed> </grayed>Text
+▼[R][root]
+  ▼[M]MyApp
+    ▼[M]MaterialApp
+      ▼[S]Scaffold
+      ├───▼[C]Center
+      │     [/icons/inspector/textArea.png]Text
+      └─▼[A]AppBar
+          [/icons/inspector/textArea.png]Text

--- a/packages/devtools/test/goldens/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_selection_with_styles.txt
@@ -1,8 +1,8 @@
-▼[R]<grayed> </grayed>root <grayed>]</grayed>
-  ▼[M]<grayed> </grayed>MyApp
-    ▼[M]<grayed> </grayed>MaterialApp
-      ▼[S]<grayed> </grayed>Scaffold
-      ├───▼[C]<grayed> </grayed>Center
-      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
-      └─▼[A]<grayed> </grayed>AppBar
-          [/icons/inspector/textArea.png]<grayed> </grayed>Text
+▼[R][root]
+  ▼[M]MyApp
+    ▼[M]MaterialApp
+      ▼[S]Scaffold
+      ├───▼[C]Center
+      │     [/icons/inspector/textArea.png]Text <-- selected
+      └─▼[A]AppBar
+          [/icons/inspector/textArea.png]Text

--- a/packages/devtools/test/goldens/inspector_controller_text_details_tree.txt
+++ b/packages/devtools/test/goldens/inspector_controller_text_details_tree.txt
@@ -1,14 +1,14 @@
-▼[/icons/inspector/textArea.png] Text <-- selected
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png] RichText
+▼[/icons/inspector/textArea.png]Text <-- selected
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"

--- a/packages/devtools/test/goldens/inspector_controller_text_details_tree_richtext_selected.txt
+++ b/packages/devtools/test/goldens/inspector_controller_text_details_tree_richtext_selected.txt
@@ -1,14 +1,14 @@
-▼[/icons/inspector/textArea.png] Text
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png] RichText <-- selected
+▼[/icons/inspector/textArea.png]Text
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText <-- selected
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"

--- a/packages/devtools/test/goldens/inspector_controller_text_details_tree_with_styles.txt
+++ b/packages/devtools/test/goldens/inspector_controller_text_details_tree_with_styles.txt
@@ -1,16 +1,16 @@
-▼[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold> <-- selected
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png]<grayed> </grayed>RichText
+▼[/icons/inspector/textArea.png]<bold>Text</bold> <-- selected
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"
     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
-    ▶renderObject: RenderParagraph#00000 relayoutBoundary=up2
+    ▶renderObject: RenderParagraph<grayed>#00000 relayoutBoundary=up2</grayed>

--- a/packages/devtools/test/goldens/inspector_service_text_details_tree.txt
+++ b/packages/devtools/test/goldens/inspector_service_text_details_tree.txt
@@ -13,5 +13,6 @@ Text
      softWrap: wrapping at box width
      maxLines: unlimited
      text: "Hello, World!"
-     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+     dependencies: [_LocalizationsScope-[GlobalKey#00000],
+       Directionality]
      renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/goldens/logging_controller_material_error.txt
+++ b/packages/devtools/test/goldens/logging_controller_material_error.txt
@@ -1,0 +1,126 @@
+Exception caught by widgets library
+The following assertion was thrown building TextField:
+No Material widget found.
+TextField widgets require a Material widget ancestor.
+In material design, most widgets are conceptually "printed" on a sheet of material. In Flutter's material library, that material is represented by the Material widget. It is the Material widget that renders ink splashes, for instance. Because of this, many material library widgets require that there be a Material widget in the tree above them.
+To introduce a Material widget, you can either directly include one, or use a widget that contains Material itself, such as a Card, Dialog, Drawer, or Scaffold.
+The specific widget that could not find a Material ancestor was:
+  TextField(controller: TextEditingController#<NUMBER>(TextEditingValue(text: ┤├, selection: TextSelection(baseOffset: -<NUMBER>, extentOffset: -<NUMBER>, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: -<NUMBER>, end: -<NUMBER>))), decoration: InputDecoration(hintText: "Type something"))
+The ancestors of this widget were:
+  Column(direction: vertical, mainAxisAlignment: center, crossAxisAlignment: center)
+  ExampleWidget
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  Builder
+  RepaintBoundary-[GlobalKey#<NUMBER>]
+  IgnorePointer(ignoring: false)
+  FadeTransition(opacity: AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩<NUMBER>)
+  FractionalTranslation
+  SlideTransition(animation: AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩Tween<Offset>(Offset(<NUMBER>, <NUMBER>) → Offset(<NUMBER>, <NUMBER>))➩Offset(<NUMBER>, <NUMBER>))
+  _FadeUpwardsPageTransition
+  AnimatedBuilder(animation: Listenable.merge([AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation, kAlwaysDismissedAnimation➩ProxyAnimation➩ProxyAnimation]))
+  RepaintBoundary
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(node: FocusScopeNode#<NUMBER>)
+  PageStorage
+  Offstage(offstage: false)
+  _ModalScopeStatus(active)
+  _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#<NUMBER>]
+  _OverlayEntry-[LabeledGlobalKey<_OverlayEntryState>#<NUMBER>]
+  Stack(alignment: AlignmentDirectional.topStart, fit: expand, overflow: clip)
+  _Theatre
+  Overlay-[LabeledGlobalKey<OverlayState>#<NUMBER>]
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(AUTOFOCUS, node: FocusScopeNode#<NUMBER>)
+  AbsorbPointer(absorbing: false)
+  _PointerListener(listeners: [down, up, cancel], behavior: deferToChild)
+  Listener
+  Navigator-[GlobalObjectKey<NavigatorState> _WidgetsAppState#<NUMBER>]
+  IconTheme(IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)))
+  IconTheme(IconThemeData#<NUMBER>(color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>))))
+  _InheritedCupertinoTheme
+  CupertinoTheme
+  _InheritedTheme
+  Theme(ThemeData#<NUMBER>(buttonTheme: ButtonThemeData#<NUMBER>(buttonColor: Color(<NUMBER>xffe<NUMBER>e<NUMBER>e<NUMBER>), focusColor: Color(<NUMBER>x<NUMBER>f<NUMBER>), hoverColor: Color(<NUMBER>x<NUMBER>a<NUMBER>), colorScheme: ColorScheme#<NUMBER>(primary: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)), primaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), secondary: Color(<NUMBER>xff<NUMBER>f<NUMBER>), secondaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), background: Color(<NUMBER>xff<NUMBER>caf<NUMBER>), error: Color(<NUMBER>xffd<NUMBER>f<NUMBER>f), onSecondary: Color(<NUMBER>xffffffff), onBackground: Color(<NUMBER>xffffffff)), materialTapTargetSize: MaterialTapTargetSize.padded), toggleButtonsTheme: ToggleButtonsThemeData#<NUMBER>, textTheme: TextTheme#<NUMBER>, primaryTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), accentTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), inputDecorationTheme: InputDecorationTheme#<NUMBER>, iconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)), primaryIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), accentIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), sliderTheme: SliderThemeData#<NUMBER>, tabBarTheme: TabBarTheme#<NUMBER>, tooltipTheme: TooltipThemeData#<NUMBER>, cardTheme: CardTheme#<NUMBER>, chipTheme: ChipThemeData#<NUMBER>, materialTapTargetSize: MaterialTapTargetSize.padded, applyElevationOverlayColor: false, pageTransitionsTheme: PageTransitionsTheme#<NUMBER>))
+  AnimatedTheme(duration: <NUMBER>ms)
+  Builder
+  DefaultTextStyle(debugLabel: fallback style; consider putting your text in a Material, inherit: true, color: Color(<NUMBER>xd<NUMBER>ff<NUMBER>), family: monospace, size: <NUMBER>, weight: <NUMBER>, decoration: double Color(<NUMBER>xffffff<NUMBER>) TextDecoration.underline, softWrap: wrapping at box width, overflow: clip)
+  CustomPaint
+  Banner("DEBUG", textDirection: ltr, location: topEnd, Color(<NUMBER>xa<NUMBER>b<NUMBER>c<NUMBER>c), text inherit: true, text color: Color(<NUMBER>xffffffff), text size: <NUMBER>, text weight: <NUMBER>, text height: <NUMBER>x)
+  CheckedModeBanner("DEBUG")
+  Title(title: "Missing Material", color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)))
+  Directionality(textDirection: ltr)
+  _LocalizationsScope-[GlobalKey#<NUMBER>]
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, textDirection: ltr, hintOverrides: null)
+  Localizations(locale: en_US, delegates: [DefaultMaterialLocalizations.delegate(en_US), DefaultCupertinoLocalizations.delegate(en_US), DefaultWidgetsLocalizations.delegate(en_US)])
+  MediaQuery(MediaQueryData(size: Size(<NUMBER>, <NUMBER>), devicePixelRatio: <NUMBER>, textScaleFactor: <NUMBER>, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse<NUMBER>HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false))
+  DefaultFocusTraversal
+  WidgetsApp-[GlobalObjectKey _MaterialAppState#<NUMBER>]
+  ScrollConfiguration(behavior: _MaterialScrollBehavior)
+  MaterialApp
+  MissingMaterialError
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  Builder
+  RepaintBoundary-[GlobalKey#<NUMBER>]
+  IgnorePointer(ignoring: false)
+  FadeTransition(opacity: kAlwaysCompleteAnimation➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩<NUMBER>)
+  FractionalTranslation
+  SlideTransition(animation: kAlwaysCompleteAnimation➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩Tween<Offset>(Offset(<NUMBER>, <NUMBER>) → Offset(<NUMBER>, <NUMBER>))➩Offset(<NUMBER>, <NUMBER>))
+  _FadeUpwardsPageTransition
+  AnimatedBuilder(animation: Listenable.merge([kAlwaysCompleteAnimation➩ProxyAnimation, kAlwaysDismissedAnimation➩ProxyAnimation]))
+  RepaintBoundary
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(node: FocusScopeNode#<NUMBER>)
+  PageStorage
+  Offstage(offstage: true)
+  _ModalScopeStatus(active, can pop)
+  _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#<NUMBER>]
+  _OverlayEntry-[LabeledGlobalKey<_OverlayEntryState>#<NUMBER>]
+  Stack(alignment: AlignmentDirectional.topStart, fit: expand, overflow: clip)
+  _Theatre
+  Overlay-[LabeledGlobalKey<OverlayState>#<NUMBER>]
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(AUTOFOCUS, node: FocusScopeNode#<NUMBER>)
+  AbsorbPointer(absorbing: false)
+  _PointerListener(listeners: [down, up, cancel], behavior: deferToChild)
+  Listener
+  Navigator-[GlobalObjectKey<NavigatorState> _WidgetsAppState#<NUMBER>]
+  IconTheme(IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)))
+  IconTheme(IconThemeData#<NUMBER>(color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>))))
+  _InheritedCupertinoTheme
+  CupertinoTheme
+  _InheritedTheme
+  Theme(ThemeData#<NUMBER>(buttonTheme: ButtonThemeData#<NUMBER>(buttonColor: Color(<NUMBER>xffe<NUMBER>e<NUMBER>e<NUMBER>), focusColor: Color(<NUMBER>x<NUMBER>f<NUMBER>), hoverColor: Color(<NUMBER>x<NUMBER>a<NUMBER>), colorScheme: ColorScheme#<NUMBER>(primary: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)), primaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), secondary: Color(<NUMBER>xff<NUMBER>f<NUMBER>), secondaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), background: Color(<NUMBER>xff<NUMBER>caf<NUMBER>), error: Color(<NUMBER>xffd<NUMBER>f<NUMBER>f), onSecondary: Color(<NUMBER>xffffffff), onBackground: Color(<NUMBER>xffffffff)), materialTapTargetSize: MaterialTapTargetSize.padded), toggleButtonsTheme: ToggleButtonsThemeData#<NUMBER>, textTheme: TextTheme#<NUMBER>, primaryTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), accentTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), inputDecorationTheme: InputDecorationTheme#<NUMBER>, iconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)), primaryIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), accentIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), sliderTheme: SliderThemeData#<NUMBER>, tabBarTheme: TabBarTheme#<NUMBER>, tooltipTheme: TooltipThemeData#<NUMBER>, cardTheme: CardTheme#<NUMBER>, chipTheme: ChipThemeData#<NUMBER>, materialTapTargetSize: MaterialTapTargetSize.padded, applyElevationOverlayColor: false, pageTransitionsTheme: PageTransitionsTheme#<NUMBER>))
+  AnimatedTheme(duration: <NUMBER>ms)
+  Builder
+  DefaultTextStyle(debugLabel: fallback style; consider putting your text in a Material, inherit: true, color: Color(<NUMBER>xd<NUMBER>ff<NUMBER>), family: monospace, size: <NUMBER>, weight: <NUMBER>, decoration: double Color(<NUMBER>xffffff<NUMBER>) TextDecoration.underline, softWrap: wrapping at box width, overflow: clip)
+  CustomPaint
+  Banner("DEBUG", textDirection: ltr, location: topEnd, Color(<NUMBER>xa<NUMBER>b<NUMBER>c<NUMBER>c), text inherit: true, text color: Color(<NUMBER>xffffffff), text size: <NUMBER>, text weight: <NUMBER>, text height: <NUMBER>x)
+  CheckedModeBanner("DEBUG")
+  Title(title: "Flutter Demo", color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)))
+  Directionality(textDirection: ltr)
+  _LocalizationsScope-[GlobalKey#<NUMBER>]
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, textDirection: ltr, hintOverrides: null)
+  Localizations(locale: en_US, delegates: [DefaultMaterialLocalizations.delegate(en_US), DefaultCupertinoLocalizations.delegate(en_US), DefaultWidgetsLocalizations.delegate(en_US)])
+  MediaQuery(MediaQueryData(size: Size(<NUMBER>, <NUMBER>), devicePixelRatio: <NUMBER>, textScaleFactor: <NUMBER>, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse<NUMBER>HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false))
+  DefaultFocusTraversal
+  WidgetsApp-[GlobalObjectKey _MaterialAppState#<NUMBER>]
+  ScrollConfiguration(behavior: _MaterialScrollBehavior)
+  MaterialApp
+  MyApp
+  [root]
+
+▼User-created ancestor of the error-causing widget was: 
+<STACK_TRACE_LINE>
+
+▼When the exception was thrown, this was the stack: 
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+...
+

--- a/packages/devtools/test/goldens/logging_controller_navigation.txt
+++ b/packages/devtools/test/goldens/logging_controller_navigation.txt
@@ -1,0 +1,21 @@
+{
+  "type": "Event",
+  "kind": "Extension",
+  "extensionKind": "Flutter.Navigation",
+  "isolate": {
+    "type": "@Isolate",
+    "id": "isolates/<NUMBER>",
+    "name": "main",
+    "number": "<NUMBER>"
+  },
+  "timestamp": <NUMBER>,
+  "extensionData": {
+    "route": {
+      "description": "MaterialPageRoute<dynamic>(/)",
+      "settings": {
+        "name": "/",
+        "isInitialRoute": true
+      }
+    }
+  }
+}

--- a/packages/devtools/test/goldens/logging_controller_overflow_error.txt
+++ b/packages/devtools/test/goldens/logging_controller_overflow_error.txt
@@ -1,0 +1,44 @@
+Exception caught by rendering library
+The following assertion was thrown during layout:
+A RenderFlex overflowed by <NUMBER> pixels on the bottom.
+
+▼User-created ancestor of the error-causing widget was: 
+<STACK_TRACE_LINE>
+
+The overflowing RenderFlex has an orientation of Axis.vertical.
+The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
+Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the RenderFlex to fit within the available space instead of being sized to their natural size.
+This is considered an error condition because it indicates that there is content that cannot be seen. If the content is legitimately bigger than the available space, consider clipping it with a ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex, like a ListView.
+▼The specific RenderFlex in question is: RenderFlex#<NUMBER> OVERFLOWING
+│ needs compositing
+│ parentData: <none> (can use size)
+│ constraints: BoxConstraints(w=<NUMBER>, h=<NUMBER>)
+│ size: Size(<NUMBER>, <NUMBER>)
+│ direction: vertical
+│ mainAxisAlignment: center
+│ mainAxisSize: max
+│ crossAxisAlignment: center
+│ verticalDirection: down
+├─▼child <NUMBER>: RenderErrorBox#<NUMBER>
+│   parentData: offset=Offset(<NUMBER>, <NUMBER>); flex=null; fit=null (can use size)
+│   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+│   size: Size(<NUMBER>, <NUMBER>)
+└─▼child <NUMBER>: RenderSemanticsAnnotations#<NUMBER> relayoutBoundary=up<NUMBER>
+  │   needs compositing
+  │   parentData: offset=Offset(<NUMBER>, <NUMBER>); flex=null; fit=null (can use size)
+  │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+  │   semantic boundary
+  │   size: Size(<NUMBER>, <NUMBER>)
+  └─▼_RenderInputPadding#<NUMBER> relayoutBoundary=up<NUMBER>
+    │   needs compositing
+    │   parentData: <none> (can use size)
+    │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+    │   size: Size(<NUMBER>, <NUMBER>)
+    └─▼RenderConstrainedBox#<NUMBER> relayoutBoundary=up<NUMBER>
+      │   needs compositing
+      │   parentData: offset=Offset(<NUMBER>, <NUMBER>) (can use size)
+      │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+      │   size: Size(<NUMBER>, <NUMBER>)
+      │   additionalConstraints: BoxConstraints(<NUMBER><=w<=Infinity, <NUMBER><=h<=Infinity)
+      └─▶RenderPhysicalShape#<NUMBER> relayoutBoundary=up<NUMBER>
+◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold.txt
@@ -1,15 +1,15 @@
-▼[S] Scaffold <-- selected
-│   dependencies: [MediaQuery, _LocalizationsScope-[GlobalKey#00000], Directionality, _InheritedTheme]
-│   ▶state: ScaffoldState#00000(tickers: tracking 2 tickers)
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
+▼[S]Scaffold <-- selected
+│ dependencies: [MediaQuery, _LocalizationsScope-[GlobalKey#00000], Directionality, _InheritedTheme]
+│ ▶state: ScaffoldState#00000(tickers: tracking 2 tickers)
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
     │   ScrollController#00000(no clients)
-    └─▼[M] Material
+    └─▼[M]Material
       │   type: canvas
       │   color: [#00000aff]#00000a
       │   dependencies: [_LocalizationsScope-[GlobalKey#00000], _InheritedTheme]
       │   state: _MaterialState#00000
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
         │   duration: 200ms
         │   shape: rectangle
         │   borderRadius: BorderRadius.zero
@@ -19,17 +19,17 @@
         │   shadowColor: [#000000ff]#000000
         │   animateShadowColor: true
         │   ▶state: _AnimatedPhysicalModelState#00000(ticker inactive)
-        └─▼[P] PhysicalModel
+        └─▼[P]PhysicalModel
           │   shape: rectangle
           │   borderRadius: BorderRadius.zero
           │   elevation: 0.0
           │   color: [#00000aff]#00000a
           │   shadowColor: [#000000ff]#000000
           │   ▶renderObject: RenderPhysicalModel#00000
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
               │   ▶renderObject: _RenderInkFeatures#00000
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
                 │   duration: 200ms
                 │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
                 │   inherit: false
@@ -42,7 +42,7 @@
                 │   softWrap: wrapping at box width
                 │   overflow: clip
                 │   ▶state: _AnimatedDefaultTextStyleState#00000(ticker inactive)
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
                   │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
                   │   inherit: false
                   │   color: [#000000dd]#00000000
@@ -53,46 +53,46 @@
                   │   decoration: TextDecoration.none
                   │   softWrap: wrapping at box width
                   │   overflow: clip
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
                     │   animation: AnimationController#00000(⏭ 1.000; paused)
                     │   state: _AnimatedState#00000
-                    └─▼[C] CustomMultiChildLayout
+                    └─▼[C]CustomMultiChildLayout
                       │   ▶renderObject: RenderCustomMultiChildLayoutBox#00000
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
                       │   │   id: _ScaffoldSlot.body
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
                       │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                      │     └─▶[C] Center
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
+                      │     └─▶[C]Center
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
                       │   │   id: _ScaffoldSlot.appBar
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
                       │     │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                      │     └─▼[C] ConstrainedBox
+                      │     └─▼[C]ConstrainedBox
                       │       │   BoxConstraints(0.0<=w<=Infinity, 0.0<=h<=56.0)
                       │       │   ▶renderObject: RenderConstrainedBox#00000 relayoutBoundary=up1
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
                         │   id: _ScaffoldSlot.floatingActionButton
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
                           │   MediaQueryData(size: Size(800.0, 600.0), devicePixelRatio: 3.0, textScaleFactor: 1.0, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse24HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false)
-                          └─▼[F] _FloatingActionButtonTransition
+                          └─▼[F]_FloatingActionButtonTransition
                             │   ▶state: _FloatingActionButtonTransitionState#00000(tickers: tracking 1 ticker)
-                            └─▼[/icons/inspector/value.png] Stack
+                            └─▼[/icons/inspector/value.png]Stack
                               │   alignment: centerRight
                               │   fit: loose
                               │   overflow: clip
                               │   dependencies: [Directionality]
                               │   ▶renderObject: RenderStack#00000 relayoutBoundary=up1
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
                                 │   animation: AnimationMin<double>(_AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: FlippedCurve(Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00)))➩1.0➪ReverseAnimation, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Interval(0.5⋯1.0)➩Cubic(0.25, 0.10, 0.25, 1.00))➩1.0), AnimationController#00000(⏮ 0.000; paused)➩Cubic(0.42, 0.00, 1.00, 1.00))
                                 │   state: _AnimatedState#00000
-                                └─▼[/icons/inspector/colors.png] Transform
+                                └─▼[/icons/inspector/colors.png]Transform
                                   │   dependencies: [Directionality]
                                   │   ▶renderObject: RenderTransform#00000 relayoutBoundary=up2
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
                                     │   animation: AnimationController#00000(⏮ 0.000; paused)➩CurveTween(curve: Cubic(0.42, 0.00, 1.00, 1.00))➩Tween<double>(0.875 → 1.0)➩0.875➩TrainHoppingAnimation(next: _AnimationSwap<double>(AnimationController#00000(⏭ 1.000; paused)➩Tween<double>(0.75 → 1.0)➩1.0, AnimationController#00000(⏭ 1.000; paused)➩CurveTween(curve: Threshold)➩1.0➪ReverseAnimation))
                                     │   state: _AnimatedState#00000
-                                    └─▼[/icons/inspector/colors.png] Transform
+                                    └─▼[/icons/inspector/colors.png]Transform
                                         dependencies: [Directionality]
                                         ▶renderObject: RenderTransform#00000 relayoutBoundary=up3

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_expanded.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_expanded.txt
@@ -1,29 +1,29 @@
-▼[S] Scaffold <-- selected
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
-    └─▼[M] Material
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
-        └─▼[P] PhysicalModel
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
-                    └─▼[C] CustomMultiChildLayout
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] Center
-                      │       └─▶[/icons/inspector/textArea.png] Text
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] ConstrainedBox
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
-                          └─▼[F] _FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png] Stack
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
-                                └─▼[/icons/inspector/colors.png] Transform
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
-                                    └─▼[/icons/inspector/colors.png] Transform
+▼[S]Scaffold <-- selected
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]Center
+                      │       └─▶[/icons/inspector/textArea.png]Text
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scaffold_with_styles.txt
@@ -1,29 +1,29 @@
-▼[S]<grayed> </grayed><bold>Scaffold</bold> <-- selected
-└─▼[S]<grayed> </grayed>_ScaffoldScope
-    ▼[P]<grayed> </grayed>PrimaryScrollController
-    └─▼[M]<grayed> </grayed>Material
-      └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedPhysicalModel
-        └─▼[P]<grayed> </grayed>PhysicalModel
-          └─▼[N]<grayed> </grayed>NotificationListener <grayed><LayoutChangedNotification></grayed>
-              ▼[I]<grayed> </grayed>_InkFeatures <grayed>[GlobalKey#00000 ink renderer]</grayed>
-              └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png]<grayed> </grayed>DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>AnimatedBuilder
-                    └─▼[C]<grayed> </grayed>CustomMultiChildLayout
-                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.body>]</grayed>
-                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                      │     └─▼[C]<grayed> </grayed><bold>Center</bold>
-                      │       └─▶[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold>
-                      ├───▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.appBar>]</grayed>
-                      │   └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                      │     └─▼[C]<grayed> </grayed>ConstrainedBox
-                      │       └─▼[F]<grayed> </grayed>FlexibleSpaceBarSettings
-                      │           ▶[A]<grayed> </grayed><bold>AppBar</bold>
-                      └─▼[L]<grayed> </grayed>LayoutId <grayed>[<_ScaffoldSlot.floatingActionButton>]</grayed>
-                        └─▼[/icons/inspector/atrule.png]<grayed> </grayed>MediaQuery
-                          └─▼[F]<grayed> </grayed>_FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png]<grayed> </grayed>Stack
-                              └─▼[/icons/inspector/resume.png]<grayed> </grayed>ScaleTransition
-                                └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform
-                                  └─▼[/icons/inspector/resume.png]<grayed> </grayed>RotationTransition
-                                    └─▼[/icons/inspector/colors.png]<grayed> </grayed>Transform
+▼[S]<bold>Scaffold</bold> <-- selected
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]<bold>Center</bold>
+                      │       └─▶[/icons/inspector/textArea.png]<bold>Text</bold>
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]<bold>AppBar</bold>
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scrolled_to_center.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_details_tree_scrolled_to_center.txt
@@ -1,29 +1,29 @@
-▼[S] Scaffold
-└─▼[S] _ScaffoldScope
-    ▼[P] PrimaryScrollController
-    └─▼[M] Material
-      └─▼[/icons/inspector/resume.png] AnimatedPhysicalModel
-        └─▼[P] PhysicalModel
-          └─▼[N] NotificationListener <LayoutChangedNotification>
-              ▼[I] _InkFeatures [GlobalKey#00000 ink renderer]
-              └─▼[/icons/inspector/resume.png] AnimatedDefaultTextStyle
-                └─▼[/icons/inspector/textArea.png] DefaultTextStyle
-                  └─▼[/icons/inspector/resume.png] AnimatedBuilder
-                    └─▼[C] CustomMultiChildLayout
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.body>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] Center <-- selected
-                      │       └─▶[/icons/inspector/textArea.png] Text
-                      ├───▼[L] LayoutId [<_ScaffoldSlot.appBar>]
-                      │   └─▼[/icons/inspector/atrule.png] MediaQuery
-                      │     └─▼[C] ConstrainedBox
-                      │       └─▼[F] FlexibleSpaceBarSettings
-                      │           ▶[A] AppBar
-                      └─▼[L] LayoutId [<_ScaffoldSlot.floatingActionButton>]
-                        └─▼[/icons/inspector/atrule.png] MediaQuery
-                          └─▼[F] _FloatingActionButtonTransition
-                            └─▼[/icons/inspector/value.png] Stack
-                              └─▼[/icons/inspector/resume.png] ScaleTransition
-                                └─▼[/icons/inspector/colors.png] Transform
-                                  └─▼[/icons/inspector/resume.png] RotationTransition
-                                    └─▼[/icons/inspector/colors.png] Transform
+▼[S]Scaffold
+└─▼[S]_ScaffoldScope
+    ▼[P]PrimaryScrollController
+    └─▼[M]Material
+      └─▼[/icons/inspector/resume.png]AnimatedPhysicalModel
+        └─▼[P]PhysicalModel
+          └─▼[N]NotificationListener<LayoutChangedNotification>
+              ▼[I]_InkFeatures-[GlobalKey#00000 ink renderer]
+              └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
+                └─▼[/icons/inspector/textArea.png]DefaultTextStyle
+                  └─▼[/icons/inspector/resume.png]AnimatedBuilder
+                    └─▼[C]CustomMultiChildLayout
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.body>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]Center <-- selected
+                      │       └─▶[/icons/inspector/textArea.png]Text
+                      ├───▼[L]LayoutId-[<_ScaffoldSlot.appBar>]
+                      │   └─▼[/icons/inspector/atrule.png]MediaQuery
+                      │     └─▼[C]ConstrainedBox
+                      │       └─▼[F]FlexibleSpaceBarSettings
+                      │           ▶[A]AppBar
+                      └─▼[L]LayoutId-[<_ScaffoldSlot.floatingActionButton>]
+                        └─▼[/icons/inspector/atrule.png]MediaQuery
+                          └─▼[F]_FloatingActionButtonTransition
+                            └─▼[/icons/inspector/value.png]Stack
+                              └─▼[/icons/inspector/resume.png]ScaleTransition
+                                └─▼[/icons/inspector/colors.png]Transform
+                                  └─▼[/icons/inspector/resume.png]RotationTransition
+                                    └─▼[/icons/inspector/colors.png]Transform

--- a/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_initial_tree_with_styles.txt
@@ -1,8 +1,8 @@
-▼[R]<grayed> </grayed>root <grayed>]</grayed>
-  ▼[M]<grayed> </grayed>MyApp
-    ▼[M]<grayed> </grayed>MaterialApp
-      ▼[S]<grayed> </grayed>Scaffold
-      ├───▼[C]<grayed> </grayed>Center
-      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text
-      └─▼[A]<grayed> </grayed>AppBar
-          [/icons/inspector/textArea.png]<grayed> </grayed>Text
+▼[R][root]
+  ▼[M]MyApp
+    ▼[M]MaterialApp
+      ▼[S]Scaffold
+      ├───▼[C]Center
+      │     [/icons/inspector/textArea.png]Text
+      └─▼[A]AppBar
+          [/icons/inspector/textArea.png]Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_selection_with_styles.txt
@@ -1,8 +1,8 @@
-▼[R]<grayed> </grayed>root <grayed>]</grayed>
-  ▼[M]<grayed> </grayed>MyApp
-    ▼[M]<grayed> </grayed>MaterialApp
-      ▼[S]<grayed> </grayed>Scaffold
-      ├───▼[C]<grayed> </grayed>Center
-      │     [/icons/inspector/textArea.png]<grayed> </grayed>Text <-- selected
-      └─▼[A]<grayed> </grayed>AppBar
-          [/icons/inspector/textArea.png]<grayed> </grayed>Text
+▼[R][root]
+  ▼[M]MyApp
+    ▼[M]MaterialApp
+      ▼[S]Scaffold
+      ├───▼[C]Center
+      │     [/icons/inspector/textArea.png]Text <-- selected
+      └─▼[A]AppBar
+          [/icons/inspector/textArea.png]Text

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree.txt
@@ -1,14 +1,14 @@
-▼[/icons/inspector/textArea.png] Text <-- selected
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png] RichText
+▼[/icons/inspector/textArea.png]Text <-- selected
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_richtext_selected.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_richtext_selected.txt
@@ -1,14 +1,14 @@
-▼[/icons/inspector/textArea.png] Text
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png] RichText <-- selected
+▼[/icons/inspector/textArea.png]Text
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText <-- selected
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"

--- a/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_with_styles.txt
+++ b/packages/devtools/test/goldens_stable/inspector_controller_text_details_tree_with_styles.txt
@@ -1,16 +1,16 @@
-▼[/icons/inspector/textArea.png]<grayed> </grayed><bold>Text</bold> <-- selected
-│   "Hello, World!"
-│   textAlign: null [D]
-│   textDirection: null [D]
-│   locale: null [D]
-│   softWrap: null [D]
-│   overflow: null [D]
-│   textScaleFactor: null [D]
-│   maxLines: null [D]
-│   dependencies: [DefaultTextStyle, MediaQuery]
-└─▼[/icons/inspector/textArea.png]<grayed> </grayed>RichText
+▼[/icons/inspector/textArea.png]<bold>Text</bold> <-- selected
+│ "Hello, World!"
+│ textAlign: null [D]
+│ textDirection: null [D]
+│ locale: null [D]
+│ softWrap: null [D]
+│ overflow: null [D]
+│ textScaleFactor: null [D]
+│ maxLines: null [D]
+│ dependencies: [DefaultTextStyle, MediaQuery]
+└─▼[/icons/inspector/textArea.png]RichText
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"
     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
-    ▶renderObject: RenderParagraph#00000 relayoutBoundary=up2
+    ▶renderObject: RenderParagraph<grayed>#00000 relayoutBoundary=up2</grayed>

--- a/packages/devtools/test/goldens_stable/inspector_service_text_details_tree.txt
+++ b/packages/devtools/test/goldens_stable/inspector_service_text_details_tree.txt
@@ -13,5 +13,6 @@ Text
      softWrap: wrapping at box width
      maxLines: unlimited
      text: "Hello, World!"
-     dependencies: [_LocalizationsScope-[GlobalKey#00000], Directionality]
+     dependencies: [_LocalizationsScope-[GlobalKey#00000],
+       Directionality]
      renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools/test/goldens_stable/logging_controller_material_error.txt
+++ b/packages/devtools/test/goldens_stable/logging_controller_material_error.txt
@@ -1,0 +1,120 @@
+Exception Caught By widgets library
+The following assertion was thrown building TextField:
+No Material widget found.
+TextField widgets require a Material widget ancestor.
+In material design, most widgets are conceptually "printed" on a sheet of material. In Flutter's material library, that material is represented by the Material widget. It is the Material widget that renders ink splashes, for instance. Because of this, many material library widgets require that there be a Material widget in the tree above them.
+To introduce a Material widget, you can either directly include one, or use a widget that contains Material itself, such as a Card, Dialog, Drawer, or Scaffold.
+The specific widget that could not find a Material ancestor was:
+  TextField(controller: TextEditingController#<NUMBER>(TextEditingValue(text: ┤├, selection: TextSelection(baseOffset: -<NUMBER>, extentOffset: -<NUMBER>, affinity: TextAffinity.downstream, isDirectional: false), composing: TextRange(start: -<NUMBER>, end: -<NUMBER>))), decoration: InputDecoration(hintText: "Type something"))
+The ancestors of this widget were:
+  Column(direction: vertical, mainAxisAlignment: center, crossAxisAlignment: center)
+  ExampleWidget
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  Builder
+  RepaintBoundary-[GlobalKey#<NUMBER>]
+  IgnorePointer(ignoring: false)
+  FadeTransition(opacity: AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩<NUMBER>)
+  FractionalTranslation
+  SlideTransition(animation: AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩Tween<Offset>(Offset(<NUMBER>, <NUMBER>) → Offset(<NUMBER>, <NUMBER>))➩Offset(<NUMBER>, <NUMBER>))
+  _FadeUpwardsPageTransition
+  AnimatedBuilder(animation: Listenable.merge([AnimationController#<NUMBER>(⏭ <NUMBER>; paused; for MaterialPageRoute<dynamic>(/))➩ProxyAnimation, kAlwaysDismissedAnimation➩ProxyAnimation➩ProxyAnimation]))
+  RepaintBoundary
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(node: FocusScopeNode#<NUMBER>)
+  PageStorage
+  Offstage(offstage: false)
+  _ModalScopeStatus(active)
+  _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#<NUMBER>]
+  _OverlayEntry-[LabeledGlobalKey<_OverlayEntryState>#<NUMBER>]
+  Stack(alignment: AlignmentDirectional.topStart, fit: expand, overflow: clip)
+  _Theatre
+  Overlay-[LabeledGlobalKey<OverlayState>#<NUMBER>]
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(AUTOFOCUS, node: FocusScopeNode#<NUMBER>)
+  AbsorbPointer(absorbing: false)
+  Listener(listeners: [down, up, cancel], behavior: deferToChild)
+  Navigator-[GlobalObjectKey<NavigatorState> _WidgetsAppState#<NUMBER>]
+  IconTheme(IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)))
+  IconTheme(IconThemeData#<NUMBER>(color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>))))
+  _InheritedCupertinoTheme
+  CupertinoTheme
+  _InheritedTheme
+  Theme(ThemeData#<NUMBER>(buttonTheme: ButtonThemeData#<NUMBER>(buttonColor: Color(<NUMBER>xffe<NUMBER>e<NUMBER>e<NUMBER>), focusColor: Color(<NUMBER>x<NUMBER>f<NUMBER>), hoverColor: Color(<NUMBER>x<NUMBER>a<NUMBER>), colorScheme: ColorScheme#<NUMBER>(primary: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)), primaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), secondary: Color(<NUMBER>xff<NUMBER>f<NUMBER>), secondaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), background: Color(<NUMBER>xff<NUMBER>caf<NUMBER>), error: Color(<NUMBER>xffd<NUMBER>f<NUMBER>f), onSecondary: Color(<NUMBER>xffffffff), onBackground: Color(<NUMBER>xffffffff)), materialTapTargetSize: MaterialTapTargetSize.padded), textTheme: TextTheme#<NUMBER>, primaryTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), accentTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), inputDecorationTheme: InputDecorationTheme#<NUMBER>, iconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)), primaryIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), accentIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), sliderTheme: SliderThemeData#<NUMBER>, tabBarTheme: TabBarTheme#<NUMBER>, cardTheme: CardTheme#<NUMBER>, chipTheme: ChipThemeData#<NUMBER>, materialTapTargetSize: MaterialTapTargetSize.padded, pageTransitionsTheme: PageTransitionsTheme#<NUMBER>))
+  AnimatedTheme(duration: <NUMBER>ms)
+  Builder
+  DefaultTextStyle(debugLabel: fallback style; consider putting your text in a Material, inherit: true, color: Color(<NUMBER>xd<NUMBER>ff<NUMBER>), family: monospace, size: <NUMBER>, weight: <NUMBER>, decoration: double Color(<NUMBER>xffffff<NUMBER>) TextDecoration.underline, softWrap: wrapping at box width, overflow: clip)
+  CustomPaint
+  Banner("DEBUG", textDirection: ltr, location: topEnd, Color(<NUMBER>xa<NUMBER>b<NUMBER>c<NUMBER>c), text inherit: true, text color: Color(<NUMBER>xffffffff), text size: <NUMBER>, text weight: <NUMBER>, text height: <NUMBER>x)
+  CheckedModeBanner("DEBUG")
+  Title(title: "Missing Material", color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)))
+  Directionality(textDirection: ltr)
+  _LocalizationsScope-[GlobalKey#<NUMBER>]
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, textDirection: ltr, hintOverrides: null)
+  Localizations(locale: en_US, delegates: [DefaultMaterialLocalizations.delegate(en_US), DefaultCupertinoLocalizations.delegate(en_US), DefaultWidgetsLocalizations.delegate(en_US)])
+  MediaQuery(MediaQueryData(size: Size(<NUMBER>, <NUMBER>), devicePixelRatio: <NUMBER>, textScaleFactor: <NUMBER>, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse<NUMBER>HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false))
+  DefaultFocusTraversal
+  WidgetsApp-[GlobalObjectKey _MaterialAppState#<NUMBER>]
+  ScrollConfiguration(behavior: _MaterialScrollBehavior)
+  MaterialApp
+  MissingMaterialError
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  Builder
+  RepaintBoundary-[GlobalKey#<NUMBER>]
+  IgnorePointer(ignoring: false)
+  FadeTransition(opacity: kAlwaysCompleteAnimation➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩<NUMBER>)
+  FractionalTranslation
+  SlideTransition(animation: kAlwaysCompleteAnimation➩ProxyAnimation➩CurveTween(curve: Cubic(<NUMBER>, <NUMBER>, <NUMBER>, <NUMBER>))➩Tween<Offset>(Offset(<NUMBER>, <NUMBER>) → Offset(<NUMBER>, <NUMBER>))➩Offset(<NUMBER>, <NUMBER>))
+  _FadeUpwardsPageTransition
+  AnimatedBuilder(animation: Listenable.merge([kAlwaysCompleteAnimation➩ProxyAnimation, kAlwaysDismissedAnimation➩ProxyAnimation]))
+  RepaintBoundary
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(node: FocusScopeNode#<NUMBER>)
+  PageStorage
+  Offstage(offstage: true)
+  _ModalScopeStatus(active, can pop)
+  _ModalScope<dynamic>-[LabeledGlobalKey<_ModalScopeState<dynamic>>#<NUMBER>]
+  _OverlayEntry-[LabeledGlobalKey<_OverlayEntryState>#<NUMBER>]
+  Stack(alignment: AlignmentDirectional.topStart, fit: expand, overflow: clip)
+  _Theatre
+  Overlay-[LabeledGlobalKey<OverlayState>#<NUMBER>]
+  _FocusMarker
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, hintOverrides: null)
+  FocusScope(AUTOFOCUS, node: FocusScopeNode#<NUMBER>)
+  AbsorbPointer(absorbing: false)
+  Listener(listeners: [down, up, cancel], behavior: deferToChild)
+  Navigator-[GlobalObjectKey<NavigatorState> _WidgetsAppState#<NUMBER>]
+  IconTheme(IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)))
+  IconTheme(IconThemeData#<NUMBER>(color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>))))
+  _InheritedCupertinoTheme
+  CupertinoTheme
+  _InheritedTheme
+  Theme(ThemeData#<NUMBER>(buttonTheme: ButtonThemeData#<NUMBER>(buttonColor: Color(<NUMBER>xffe<NUMBER>e<NUMBER>e<NUMBER>), focusColor: Color(<NUMBER>x<NUMBER>f<NUMBER>), hoverColor: Color(<NUMBER>x<NUMBER>a<NUMBER>), colorScheme: ColorScheme#<NUMBER>(primary: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)), primaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), secondary: Color(<NUMBER>xff<NUMBER>f<NUMBER>), secondaryVariant: Color(<NUMBER>xff<NUMBER>d<NUMBER>), background: Color(<NUMBER>xff<NUMBER>caf<NUMBER>), error: Color(<NUMBER>xffd<NUMBER>f<NUMBER>f), onSecondary: Color(<NUMBER>xffffffff), onBackground: Color(<NUMBER>xffffffff)), materialTapTargetSize: MaterialTapTargetSize.padded), textTheme: TextTheme#<NUMBER>, primaryTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), accentTextTheme: TextTheme#<NUMBER>(display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), display<NUMBER>: TextStyle(debugLabel: whiteMountainView display<NUMBER>, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), headline: TextStyle(debugLabel: whiteMountainView headline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), title: TextStyle(debugLabel: whiteMountainView title, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subhead: TextStyle(debugLabel: whiteMountainView subhead, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), body<NUMBER>: TextStyle(debugLabel: whiteMountainView body<NUMBER>, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), caption: TextStyle(debugLabel: whiteMountainView caption, inherit: true, color: Color(<NUMBER>xb<NUMBER>ffffff), family: Roboto, decoration: TextDecoration.none), button: TextStyle(debugLabel: whiteMountainView button, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), subtitle): TextStyle(debugLabel: whiteMountainView subtitle, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none), overline: TextStyle(debugLabel: whiteMountainView overline, inherit: true, color: Color(<NUMBER>xffffffff), family: Roboto, decoration: TextDecoration.none)), inputDecorationTheme: InputDecorationTheme#<NUMBER>, iconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xdd<NUMBER>)), primaryIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), accentIconTheme: IconThemeData#<NUMBER>(color: Color(<NUMBER>xffffffff)), sliderTheme: SliderThemeData#<NUMBER>, tabBarTheme: TabBarTheme#<NUMBER>, cardTheme: CardTheme#<NUMBER>, chipTheme: ChipThemeData#<NUMBER>, materialTapTargetSize: MaterialTapTargetSize.padded, pageTransitionsTheme: PageTransitionsTheme#<NUMBER>))
+  AnimatedTheme(duration: <NUMBER>ms)
+  Builder
+  DefaultTextStyle(debugLabel: fallback style; consider putting your text in a Material, inherit: true, color: Color(<NUMBER>xd<NUMBER>ff<NUMBER>), family: monospace, size: <NUMBER>, weight: <NUMBER>, decoration: double Color(<NUMBER>xffffff<NUMBER>) TextDecoration.underline, softWrap: wrapping at box width, overflow: clip)
+  CustomPaint
+  Banner("DEBUG", textDirection: ltr, location: topEnd, Color(<NUMBER>xa<NUMBER>b<NUMBER>c<NUMBER>c), text inherit: true, text color: Color(<NUMBER>xffffffff), text size: <NUMBER>, text weight: <NUMBER>, text height: <NUMBER>x)
+  CheckedModeBanner("DEBUG")
+  Title(title: "Flutter Demo", color: MaterialColor(primary value: Color(<NUMBER>xff<NUMBER>f<NUMBER>)))
+  Directionality(textDirection: ltr)
+  _LocalizationsScope-[GlobalKey#<NUMBER>]
+  Semantics(container: false, properties: SemanticsProperties, label: null, value: null, hint: null, textDirection: ltr, hintOverrides: null)
+  Localizations(locale: en_US, delegates: [DefaultMaterialLocalizations.delegate(en_US), DefaultCupertinoLocalizations.delegate(en_US), DefaultWidgetsLocalizations.delegate(en_US)])
+  MediaQuery(MediaQueryData(size: Size(<NUMBER>, <NUMBER>), devicePixelRatio: <NUMBER>, textScaleFactor: <NUMBER>, platformBrightness: Brightness.light, padding: EdgeInsets.zero, viewPadding: EdgeInsets.zero, viewInsets: EdgeInsets.zero, alwaysUse<NUMBER>HourFormat: false, accessibleNavigation: false, disableAnimations: false, invertColors: false, boldText: false))
+  DefaultFocusTraversal
+  WidgetsApp-[GlobalObjectKey _MaterialAppState#<NUMBER>]
+  ScrollConfiguration(behavior: _MaterialScrollBehavior)
+  MaterialApp
+  MyApp
+  [root]
+
+▼When the exception was thrown, this was the stack: 
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+<STACK_TRACE_LINE>
+...

--- a/packages/devtools/test/goldens_stable/logging_controller_navigation.txt
+++ b/packages/devtools/test/goldens_stable/logging_controller_navigation.txt
@@ -1,0 +1,21 @@
+{
+  "type": "Event",
+  "kind": "Extension",
+  "extensionKind": "Flutter.Navigation",
+  "isolate": {
+    "type": "@Isolate",
+    "id": "isolates/<NUMBER>",
+    "name": "main",
+    "number": "<NUMBER>"
+  },
+  "timestamp": <NUMBER>,
+  "extensionData": {
+    "route": {
+      "description": "MaterialPageRoute<dynamic>(/)",
+      "settings": {
+        "name": "/",
+        "isInitialRoute": true
+      }
+    }
+  }
+}

--- a/packages/devtools/test/goldens_stable/logging_controller_overflow_error.txt
+++ b/packages/devtools/test/goldens_stable/logging_controller_overflow_error.txt
@@ -1,0 +1,41 @@
+Exception Caught By rendering library
+The following assertion was thrown during layout:
+A RenderFlex overflowed by <NUMBER> pixels on the bottom.
+
+The overflowing RenderFlex has an orientation of Axis.vertical.
+The edge of the RenderFlex that is overflowing has been marked in the rendering with a yellow and black striped pattern. This is usually caused by the contents being too big for the RenderFlex.
+Consider applying a flex factor (e.g. using an Expanded widget) to force the children of the RenderFlex to fit within the available space instead of being sized to their natural size.
+This is considered an error condition because it indicates that there is content that cannot be seen. If the content is legitimately bigger than the available space, consider clipping it with a ClipRect widget before putting it in the flex, or using a scrollable container rather than a Flex, like a ListView.
+▼The specific RenderFlex in question is: RenderFlex#<NUMBER> OVERFLOWING
+│ needs compositing
+│ parentData: <none> (can use size)
+│ constraints: BoxConstraints(w=<NUMBER>, h=<NUMBER>)
+│ size: Size(<NUMBER>, <NUMBER>)
+│ direction: vertical
+│ mainAxisAlignment: center
+│ mainAxisSize: max
+│ crossAxisAlignment: center
+│ verticalDirection: down
+├─▼child <NUMBER>: RenderErrorBox#<NUMBER>
+│   parentData: offset=Offset(<NUMBER>, <NUMBER>); flex=null; fit=null (can use size)
+│   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+│   size: Size(<NUMBER>, <NUMBER>)
+└─▼child <NUMBER>: RenderSemanticsAnnotations#<NUMBER> relayoutBoundary=up<NUMBER>
+  │   needs compositing
+  │   parentData: offset=Offset(<NUMBER>, <NUMBER>); flex=null; fit=null (can use size)
+  │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+  │   semantic boundary
+  │   size: Size(<NUMBER>, <NUMBER>)
+  └─▼_RenderInputPadding#<NUMBER> relayoutBoundary=up<NUMBER>
+    │   needs compositing
+    │   parentData: <none> (can use size)
+    │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+    │   size: Size(<NUMBER>, <NUMBER>)
+    └─▼RenderConstrainedBox#<NUMBER> relayoutBoundary=up<NUMBER>
+      │   needs compositing
+      │   parentData: offset=Offset(<NUMBER>, <NUMBER>) (can use size)
+      │   constraints: BoxConstraints(<NUMBER><=w<=<NUMBER>, <NUMBER><=h<=Infinity)
+      │   size: Size(<NUMBER>, <NUMBER>)
+      │   additionalConstraints: BoxConstraints(<NUMBER><=w<=Infinity, <NUMBER><=h<=Infinity)
+      └─▶RenderPhysicalShape#<NUMBER> relayoutBoundary=up<NUMBER>
+◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤◢◤

--- a/packages/devtools/test/inspector_controller_test.dart
+++ b/packages/devtools/test/inspector_controller_test.dart
@@ -3,260 +3,21 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:async';
 import 'dart:io';
 
 import 'package:devtools/src/inspector/flutter_widget.dart';
 import 'package:devtools/src/inspector/inspector_controller.dart';
 import 'package:devtools/src/inspector/inspector_service.dart';
-import 'package:devtools/src/inspector/inspector_text_styles.dart' as styles;
 import 'package:devtools/src/inspector/inspector_tree.dart';
 import 'package:devtools/src/ui/fake_flutter/fake_flutter.dart';
-import 'package:devtools/src/ui/flutter_html_shim.dart' as shim;
-import 'package:devtools/src/ui/icons.dart';
-import 'package:devtools/src/ui/material_icons.dart';
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 
 import 'matchers/fake_flutter_matchers.dart';
 import 'matchers/matchers.dart';
+import 'support/fake_inspector_tree.dart';
 import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
 import 'support/flutter_test_environment.dart';
-
-class FakePaintEntry extends PaintEntry {
-  FakePaintEntry({this.icon, this.text, this.textStyle, @required this.x});
-
-  @override
-  final Icon icon;
-  final String text;
-  final TextStyle textStyle;
-  final double x;
-
-  double get right {
-    double right = x;
-    if (icon != null) {
-      right += icon.iconWidth;
-    }
-    if (text != null) {
-      right += text.length * 10;
-    }
-    return right;
-  }
-}
-
-class FakeInspectorTreeNodeRender
-    extends InspectorTreeNodeRender<FakePaintEntry> {
-  FakeInspectorTreeNodeRender(List<FakePaintEntry> entries, Size size)
-      : super(entries, size);
-
-  @override
-  PaintEntry hitTest(Offset location) {
-    location = location - offset;
-    if (location.dy < 0 || location.dy >= size.height) {
-      return null;
-    }
-    // There is no need to optimize this but we could perform a binary search.
-    for (var entry in entries) {
-      if (entry.x <= location.dx && entry.right > location.dx) {
-        return entry;
-      }
-    }
-    return null;
-  }
-}
-
-class FakeInspectorTreeNodeRenderBuilder
-    extends InspectorTreeNodeRenderBuilder {
-  final List<FakePaintEntry> entries = [];
-  double x = 0;
-
-  @override
-  void addIcon(Icon icon) {
-    x += 20;
-    entries.add(FakePaintEntry(icon: icon, x: x));
-  }
-
-  @override
-  void appendText(String text, TextStyle textStyle) {
-    x += text.length * 10;
-    entries.add(FakePaintEntry(text: text, textStyle: textStyle, x: x));
-  }
-
-  @override
-  InspectorTreeNodeRender build() {
-    final double rowWidth = entries.isEmpty ? 0 : entries.last.right;
-    return FakeInspectorTreeNodeRender(entries, Size(rowWidth, rowHeight));
-  }
-}
-
-class FakeInspectorTreeNode extends InspectorTreeNode {
-  @override
-  InspectorTreeNodeRenderBuilder createRenderBuilder() {
-    return FakeInspectorTreeNodeRenderBuilder();
-  }
-}
-
-const double fakeRowWidth = 200.0;
-
-class FakeInspectorTree extends InspectorTreeFixedRowHeight {
-  FakeInspectorTree({
-    @required bool summaryTree,
-    @required FlutterTreeType treeType,
-    @required NodeAddedCallback onNodeAdded,
-    VoidCallback onSelectionChange,
-    TreeEventCallback onExpand,
-    TreeHoverEventCallback onHover,
-  }) : super(
-          summaryTree: summaryTree,
-          treeType: treeType,
-          onNodeAdded: onNodeAdded,
-          onSelectionChange: onSelectionChange,
-          onExpand: onExpand,
-          onHover: onHover,
-        );
-
-  final List<Rect> scrollToRequests = [];
-
-  @override
-  InspectorTreeNode createNode() {
-    return FakeInspectorTreeNode();
-  }
-
-  @override
-  Rect getBoundingBox(InspectorTreeRow row) {
-    return Rect.fromLTWH(
-      getDepthIndent(row.depth),
-      getRowY(row.index),
-      fakeRowWidth,
-      rowHeight,
-    );
-  }
-
-  @override
-  void scrollToRect(Rect targetRect) {
-    scrollToRequests.add(targetRect);
-  }
-
-  Completer<void> setStateCalled;
-
-  /// Hack to allow tests to wait until the next time this UI is updated.
-  Future<void> get nextUiFrame {
-    setStateCalled ??= Completer();
-
-    return setStateCalled.future;
-  }
-
-  @override
-  void setState(VoidCallback modifyState) {
-    // Execute async calls synchronously for faster test execution.
-    modifyState();
-
-    setStateCalled?.complete(null);
-    setStateCalled = null;
-
-    for (int i = 0; i < numRows; i++) {
-      final row = root.getRow(i, selection: selection);
-      row?.node?.renderObject?.attach(
-        this,
-        Offset(row.depth * columnWidth, i * rowHeight),
-      );
-    }
-  }
-
-  // Debugging string to make it easy to write integration tests.
-  String toStringDeep(
-      {bool hidePropertyLines = false, bool includeTextStyles = false}) {
-    if (root == null) return '<empty>\n';
-    // Visualize the ticks computed for this node so that bugs in the tick
-    // computation code will result in rendering artifacts in the text output.
-    final StringBuffer sb = StringBuffer();
-    for (int i = 0; i < numRows; i++) {
-      final row = root.getRow(i, selection: selection);
-      if (hidePropertyLines && row?.node?.diagnostic?.isProperty == true) {
-        continue;
-      }
-      int last = 0;
-      for (int tick in row.ticks) {
-        // Visualize the line to parent if there is one.
-        if (tick - last > 0) {
-          sb.write('  ' * (tick - last));
-        }
-        if (tick == (row.depth - 1) && row.lineToParent) {
-          sb.write('├─');
-        } else {
-          sb.write('│ ');
-        }
-        last = tick;
-      }
-      final int delta = row.depth - last;
-      if (delta > 0) {
-        if (row.lineToParent) {
-          if (delta > 1 || last == 0) {
-            sb.write('  ' * (delta - 1));
-            sb.write('└─');
-          } else {
-            sb.write('──');
-          }
-        } else {
-          sb.write('  ' * delta);
-        }
-      }
-      final renderObject = row.node.renderObject;
-      if (renderObject == null) {
-        sb.write('<empty>\n');
-        continue;
-      }
-      final entries = renderObject.entries;
-      for (FakePaintEntry entry in entries) {
-        if (entry.icon != null) {
-          // Visualize icons
-          final Icon icon = entry.icon;
-          if (icon == collapseArrow) {
-            sb.write('▼');
-          } else if (icon == expandArrow) {
-            sb.write('▶');
-          } else if (icon is UrlIcon) {
-            sb.write('[${icon.src}]');
-          } else if (icon is ColorIcon) {
-            sb.write('[${shim.colorToCss(icon.color)}]');
-          } else if (icon is CustomIcon) {
-            sb.write('[${icon.text}]');
-          } else if (icon is MaterialIcon) {
-            sb.write('[${icon.text}]');
-          }
-        }
-        // TODO(jacobr): optionally visualize colors as well.
-        if (entry.text != null) {
-          if (entry.textStyle != null && includeTextStyles) {
-            final String shortStyle = styles.debugStyleNames[entry.textStyle];
-            if (shortStyle == null) {
-              // Display the style a little like an html style.
-              sb.write('<style ${entry.textStyle}>${entry.text}</style>');
-            } else {
-              if (shortStyle == '') {
-                // Omit the default text style completely for readability of
-                // the debug output.
-                sb.write(entry.text);
-              } else {
-                sb.write('<$shortStyle>${entry.text}</$shortStyle>');
-              }
-            }
-          } else {
-            sb.write(entry.text);
-          }
-        }
-      }
-      if (row.isSelected) {
-        sb.write(' <-- selected');
-      }
-      sb.write('\n');
-    }
-    return sb.toString();
-  }
-
-  @override
-  String tooltip = '';
-}
 
 void main() async {
   Catalog.setCatalog(
@@ -340,14 +101,14 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[R] root ]\n'
-            '  ▼[M] MyApp\n'
-            '    ▼[M] MaterialApp\n'
-            '      ▼[S] Scaffold\n'
-            '      ├───▼[C] Center\n'
-            '      │     [/icons/inspector/textArea.png] Text\n'
-            '      └─▼[A] AppBar\n'
-            '          [/icons/inspector/textArea.png] Text\n',
+            '▼[R][root]\n'
+            '  ▼[M]MyApp\n'
+            '    ▼[M]MaterialApp\n'
+            '      ▼[S]Scaffold\n'
+            '      ├───▼[C]Center\n'
+            '      │     [/icons/inspector/textArea.png]Text\n'
+            '      └─▼[A]AppBar\n'
+            '          [/icons/inspector/textArea.png]Text\n',
           ));
 
       expect(
@@ -366,14 +127,14 @@ void main() async {
       // select row index 5.
       simulateRowClick(tree, rowIndex: 5);
       const textSelected = // Comment to make dartfmt behave.
-          '▼[R] root ]\n'
-          '  ▼[M] MyApp\n'
-          '    ▼[M] MaterialApp\n'
-          '      ▼[S] Scaffold\n'
-          '      ├───▼[C] Center\n'
-          '      │     [/icons/inspector/textArea.png] Text <-- selected\n'
-          '      └─▼[A] AppBar\n'
-          '          [/icons/inspector/textArea.png] Text\n';
+          '▼[R][root]\n'
+          '  ▼[M]MyApp\n'
+          '    ▼[M]MaterialApp\n'
+          '      ▼[S]Scaffold\n'
+          '      ├───▼[C]Center\n'
+          '      │     [/icons/inspector/textArea.png]Text <-- selected\n'
+          '      └─▼[A]AppBar\n'
+          '          [/icons/inspector/textArea.png]Text\n';
 
       expect(tree.toStringDeep(), equalsIgnoringHashCodes(textSelected));
       expect(
@@ -432,14 +193,14 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[R] root ]\n'
-            '  ▼[M] MyApp\n'
-            '    ▼[M] MaterialApp\n'
-            '      ▼[S] Scaffold <-- selected\n'
-            '      ├───▼[C] Center\n'
-            '      │     [/icons/inspector/textArea.png] Text\n'
-            '      └─▼[A] AppBar\n'
-            '          [/icons/inspector/textArea.png] Text\n',
+            '▼[R][root]\n'
+            '  ▼[M]MyApp\n'
+            '    ▼[M]MaterialApp\n'
+            '      ▼[S]Scaffold <-- selected\n'
+            '      ├───▼[C]Center\n'
+            '      │     [/icons/inspector/textArea.png]Text\n'
+            '      └─▼[A]AppBar\n'
+            '          [/icons/inspector/textArea.png]Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -458,14 +219,14 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[R] root ]\n'
-            '  ▼[M] MyApp\n'
-            '    ▼[M] MaterialApp\n'
-            '      ▼[S] Scaffold\n'
-            '      ├───▼[C] Center <-- selected\n'
-            '      │     [/icons/inspector/textArea.png] Text\n'
-            '      └─▼[A] AppBar\n'
-            '          [/icons/inspector/textArea.png] Text\n',
+            '▼[R][root]\n'
+            '  ▼[M]MyApp\n'
+            '    ▼[M]MaterialApp\n'
+            '      ▼[S]Scaffold\n'
+            '      ├───▼[C]Center <-- selected\n'
+            '      │     [/icons/inspector/textArea.png]Text\n'
+            '      └─▼[A]AppBar\n'
+            '          [/icons/inspector/textArea.png]Text\n',
           ));
 
       await detailsTree.nextUiFrame;
@@ -481,14 +242,14 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[R] root ]\n'
-            '  ▼[M] MyApp\n'
-            '    ▼[M] MaterialApp\n'
-            '      ▼[S] Scaffold <-- selected\n'
-            '      ├───▼[C] Center\n'
-            '      │     [/icons/inspector/textArea.png] Text\n'
-            '      └─▼[A] AppBar\n'
-            '          [/icons/inspector/textArea.png] Text\n',
+            '▼[R][root]\n'
+            '  ▼[M]MyApp\n'
+            '    ▼[M]MaterialApp\n'
+            '      ▼[S]Scaffold <-- selected\n'
+            '      ├───▼[C]Center\n'
+            '      │     [/icons/inspector/textArea.png]Text\n'
+            '      └─▼[A]AppBar\n'
+            '          [/icons/inspector/textArea.png]Text\n',
           ));
 
       // Verify that the details tree scrolled back as well.
@@ -531,14 +292,14 @@ void main() async {
       expect(
           tree.toStringDeep(),
           equalsIgnoringHashCodes(
-            '▼[R] root ]\n'
-            '  ▼[M] MyApp\n'
-            '    ▼[M] MaterialApp\n'
-            '      ▼[S] Scaffold\n'
-            '      ├───▼[C] Center\n'
-            '      │     [/icons/inspector/textArea.png] Text <-- selected\n'
-            '      └─▼[A] AppBar\n'
-            '          [/icons/inspector/textArea.png] Text\n',
+            '▼[R][root]\n'
+            '  ▼[M]MyApp\n'
+            '    ▼[M]MaterialApp\n'
+            '      ▼[S]Scaffold\n'
+            '      ├───▼[C]Center\n'
+            '      │     [/icons/inspector/textArea.png]Text <-- selected\n'
+            '      └─▼[A]AppBar\n'
+            '          [/icons/inspector/textArea.png]Text\n',
           ));
 
       // TODO(jacobr): would be nice to have some tests that trigger a hot
@@ -560,14 +321,14 @@ void main() async {
       expect(
         tree.toStringDeep(),
         equalsIgnoringHashCodes(
-          '▼[R] root ]\n'
-              '  ▼[M] MyApp\n'
-              '    ▼[M] MaterialApp\n'
-              '      ▼[S] Scaffold\n'
-              '      ├───▼[C] Center <-- selected\n'
-              '      │     ▼[/icons/inspector/textArea.png] Text\n'
-              '      └─▼[A] AppBar\n'
-              '          ▼[/icons/inspector/textArea.png] Text\n',
+          '▼[R]root]\n'
+              '  ▼[M]MyApp\n'
+              '    ▼[M]MaterialApp\n'
+              '      ▼[S]Scaffold\n'
+              '      ├───▼[C]Center <-- selected\n'
+              '      │     ▼[/icons/inspector/textArea.png]Text\n'
+              '      └─▼[A]AppBar\n'
+              '          ▼[/icons/inspector/textArea.png]Text\n',
         ),
       );
 
@@ -591,14 +352,14 @@ void main() async {
       expect(
         tree.toStringDeep(),
         equalsIgnoringHashCodes(
-          '▼[R] root ]\n'
-              '  ▼[M] MyApp\n'
-              '    ▼[M] MaterialApp\n'
-              '      ▼[S] Scaffold\n'
-              '      ├───▼[C] Center\n'
-              '      │     ▼[/icons/inspector/textArea.png] Text\n'
-              '      └─▼[A] AppBar\n'
-              '          ▼[/icons/inspector/textArea.png] Text\n',
+          '▼[R][root]\n'
+              '  ▼[M]MyApp\n'
+              '    ▼[M]MaterialApp\n'
+              '      ▼[S]Scaffold\n'
+              '      ├───▼[C]Center\n'
+              '      │     ▼[/icons/inspector/textArea.png]Text\n'
+              '      └─▼[A]AppBar\n'
+              '          ▼[/icons/inspector/textArea.png]Text\n',
         ),
       );
 
@@ -607,14 +368,14 @@ void main() async {
       expect(
         tree.toStringDeep(),
         equalsIgnoringHashCodes(
-          '▼[R] root ]\n'
-              '  ▼[M] MyApp\n'
-              '    ▼[M] MaterialApp\n'
-              '      ▼[S] Scaffold\n'
-              '      ├───▼[C] Center <-- selected\n'
-              '      │     ▼[/icons/inspector/textArea.png] Text\n'
-              '      └─▼[A] AppBar\n'
-              '          ▼[/icons/inspector/textArea.png] Text\n',
+          '▼[R][root]\n'
+              '  ▼[M]MyApp\n'
+              '    ▼[M]MaterialApp\n'
+              '      ▼[S]Scaffold\n'
+              '      ├───▼[C]Center <-- selected\n'
+              '      │     ▼[/icons/inspector/textArea.png]Text\n'
+              '      └─▼[A]AppBar\n'
+              '          ▼[/icons/inspector/textArea.png]Text\n',
         ),
       );
       await env.tearDownEnvironment();

--- a/packages/devtools/test/logging_controller_test.dart
+++ b/packages/devtools/test/logging_controller_test.dart
@@ -1,0 +1,288 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:async';
+import 'dart:io';
+
+import 'package:devtools/src/eval_on_dart_library.dart';
+import 'package:devtools/src/globals.dart';
+import 'package:devtools/src/inspector/flutter_widget.dart';
+import 'package:devtools/src/logging/logging_controller.dart';
+import 'package:devtools/src/inspector/inspector_service.dart';
+import 'package:devtools/src/inspector/inspector_tree.dart';
+import 'package:devtools/src/service_extensions.dart';
+import 'package:devtools/src/table_data.dart';
+import 'package:devtools/src/ui/fake_flutter/fake_flutter.dart';
+import 'package:test/test.dart';
+
+import 'matchers/matchers.dart';
+import 'support/fake_inspector_tree.dart';
+import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
+import 'support/flutter_test_environment.dart';
+
+/// If this test starts timing out it probably means the number of log messages
+/// received has changed. Enable this flag to see what log messages are being
+/// sent to debug the issue.
+bool debugLogMessages = false;
+
+/// Broadcast stream of log status messages received.
+StreamController<String> logStatusController;
+
+/// Broadcast stream of log data with gc events filtered out to keep tests predictable.
+StreamController<LogData> logDataController;
+
+// Broadcast stream with an event each time the details selection changes.
+StreamController<void> detailsSelectionController;
+
+List<LogData> unhandledLogData = [];
+Stream<String> get logStatusStream => logStatusController.stream;
+Stream<LogData> get logDataStream => logDataController.stream;
+
+Stream<void> get detailsSelectionStream => detailsSelectionController.stream;
+
+// Current inspector tree displayed in the details view if any
+FakeInspectorTree currentDetailsTree;
+// Current details text shown in the details view if any.
+String currentDetailsText;
+
+/// Returns a future after length new log data entries that are not GC events
+/// have been added to the controller.
+Future<List<LogData>> waitForNextLogData(int length) async {
+  if (unhandledLogData.length < length) {
+    await for (LogData value in logDataStream) {
+      assert(value == unhandledLogData.last);
+      if (unhandledLogData.length >= length) break;
+    }
+  }
+  final ret = unhandledLogData;
+  unhandledLogData = [];
+  return ret;
+}
+
+void main() async {
+  // Required as the logging view depends on the inspector which needs a version
+  // of the widget catalog.
+  Catalog.setCatalog(
+      Catalog.decode(await File('web/widgets.json').readAsString()));
+
+  final detailsValuesSet = <LogData>[];
+  LoggingController loggingController;
+  // Whether the log view is currently visible.
+  bool visible;
+  InspectorService inspectorService;
+
+  final FlutterTestEnvironment env = FlutterTestEnvironment(
+    const FlutterRunConfiguration(withDebugger: true),
+    testAppDirectory: '../../fixtures/flutter_error_app',
+  );
+
+  env.afterNewSetup = () async {
+    await ensureInspectorServiceDependencies();
+  };
+
+  env.afterEverySetup = () async {
+    inspectorService = await InspectorService.create(env.service);
+    visible = false;
+    detailsValuesSet.clear();
+    logStatusController = StreamController.broadcast();
+    logDataController = StreamController.broadcast();
+    detailsSelectionController = StreamController.broadcast();
+    {
+      final logDataItemsSeen = <LogData>{};
+      loggingController = LoggingController(
+        onLogCountStatusChanged: (logStatus) {
+          logStatusController.add(logStatus);
+          // Brute force approach to find all new log data entries.
+          for (var row in loggingController.data) {
+            if (logDataItemsSeen.add(row) && row.kind != 'gc') {
+              if (debugLogMessages) {
+                print(
+                    'Received LogMessage(kind: ${row.kind}, summary: ${row.summary})');
+              }
+              logDataController.add(row);
+              unhandledLogData.add(row);
+            }
+          }
+        },
+        isVisible: () => visible,
+      );
+      loggingController.detailsController = LoggingDetailsController(
+        onShowInspector: () {},
+        onShowDetails: ({String text, InspectorTree tree}) {
+          currentDetailsTree = tree;
+          currentDetailsText = text;
+          detailsSelectionController.add(null);
+        },
+        createLoggingTree: ({VoidCallback onSelectionChange}) {
+          return FakeInspectorTree(
+            summaryTree: false,
+            treeType: FlutterTreeType.widget,
+            onNodeAdded: (_, __) {},
+            onSelectionChange: onSelectionChange,
+            onExpand: (_) {},
+            onHover: (_, __) {},
+          );
+        },
+      );
+    }
+    loggingController.loggingTableModel = TableData();
+    if (env.reuseTestEnvironment) {
+      // TODO(jacobr): should we reset the service extension settings?
+    }
+    visible = true;
+  };
+
+  env.beforeEveryTearDown = () async {
+    loggingController?.dispose();
+    loggingController = null;
+    inspectorService?.dispose();
+    inspectorService = null;
+  };
+
+  group('logging controller tests', () {
+    tearDownAll(() async {
+      await env.tearDownEnvironment(force: true);
+    });
+
+    test('initial state', () async {
+      await env.setupEnvironment();
+
+      expect(loggingController.isVisible(), true);
+      visible = false;
+      expect(loggingController.isVisible(), false);
+      visible = true;
+      expect(loggingController.isVisible(), true);
+      // Simulate that the logging screen is now active.
+      loggingController.entering();
+
+      final tableModel = loggingController.loggingTableModel;
+      expect(tableModel.rowCount, equals(0));
+    });
+
+    test('structured errors', () async {
+      // Enable structured errors.
+      await serviceManager.serviceExtensionManager.setServiceExtensionState(
+        structuredErrors.extension,
+        true,
+        true,
+      );
+
+      // Clear the logging messages to avoid unpredictability about what point
+      // the debugging tool was attached.
+      loggingController.clear();
+      unhandledLogData.clear();
+
+      final evalOnDartLibrary = EvalOnDartLibrary(
+          ['package:flutter_error_app/main.dart'], env.service);
+
+      await evalOnDartLibrary.eval('print("Example message A', isAlive: null);
+      await evalOnDartLibrary.eval('print("Example message B', isAlive: null);
+
+      var logEntries = await waitForNextLogData(2);
+      expect(logEntries[0].kind, equals('stdout'));
+      expect(logEntries[0].summary, equals('Example message A\n'));
+      expect(logEntries[1].kind, equals('stdout'));
+      expect(logEntries[1].summary, equals('Example message B\n'));
+
+      await evalOnDartLibrary
+          .eval('navigateToScreen("Missing Material Example")', isAlive: null);
+
+      logEntries = await waitForNextLogData(4);
+      // TODO(jacobr): why do we get two navigation events for this case?
+      expect(logEntries[0].kind, 'flutter.navigation');
+      expect(logEntries[0].summary, equals('MaterialPageRoute<dynamic>(null)'));
+      expect(logEntries[0].node, isNull);
+
+      expect(logEntries[1].kind, 'flutter.navigation');
+      expect(logEntries[1].summary, equals('MaterialPageRoute<dynamic>(/)'));
+      expect(logEntries[1].node, isNull);
+
+      {
+        final row = logEntries[2];
+        expect(row.kind, 'flutter.error');
+        // This error message will change when we apply further cleanup to the error messages.
+        expect(row.summary, 'No Material widget found.');
+        expect(row.node, isNotNull);
+        final index = loggingController.loggingTableModel.data.indexOf(row);
+        // The logging table may contain
+        // other rows related to GC that we aren't interested in.
+        expect(index, greaterThanOrEqualTo(2));
+        expect(currentDetailsTree, isNull);
+        final selectionChanged = detailsSelectionStream.first;
+        // Trigger the details selection change.
+        loggingController.loggingTableModel.setSelection(row, index);
+        await selectionChanged;
+        expect(currentDetailsText, isNull);
+        expect(currentDetailsTree, isNotNull);
+        expect(
+          normalizeErrorText(currentDetailsTree.toStringDeep()),
+          equalsGoldenIgnoringHashCodes(
+            'logging_controller_material_error.txt',
+          ),
+        );
+      }
+
+      {
+        final row = logEntries[3];
+        expect(row.kind, 'flutter.error');
+        expect(
+            row.summary,
+            matches(RegExp(
+                r'A RenderFlex overflowed by \d+ pixels on the bottom.')));
+        expect(row.node, isNotNull);
+        final index = loggingController.loggingTableModel.data.indexOf(row);
+        // The logging table may contain
+        // other rows related to GC that we aren't interested in.
+        expect(index, greaterThanOrEqualTo(4));
+        final selectionChanged = detailsSelectionStream.first;
+        // Trigger the details selection change.
+        loggingController.loggingTableModel.setSelection(row, index);
+        await selectionChanged;
+        expect(currentDetailsText, isNull);
+        expect(currentDetailsTree, isNotNull);
+        expect(
+          normalizeErrorText(currentDetailsTree.toStringDeep()),
+          equalsGoldenIgnoringHashCodes(
+            'logging_controller_overflow_error.txt',
+          ),
+        );
+      }
+
+      {
+        final row = logEntries[1];
+        expect(row.kind, 'flutter.navigation');
+        final index = loggingController.loggingTableModel.data.indexOf(row);
+        // The logging table may contain
+        // other rows related to GC that we aren't interested in.
+        expect(index, greaterThanOrEqualTo(1));
+        final selectionChanged = detailsSelectionStream.first;
+        // Trigger the details selection change.
+        loggingController.loggingTableModel.setSelection(row, index);
+        await selectionChanged;
+        expect(
+          normalizeErrorText(currentDetailsText),
+          equalsGoldenIgnoringHashCodes(
+            'logging_controller_navigation.txt',
+          ),
+        );
+
+        expect(currentDetailsTree, isNull);
+      }
+      await env.tearDownEnvironment();
+    });
+  }, tags: 'useFlutterSdk', timeout: const Timeout.factor(8));
+}
+
+/// Normalize text in error messages that is likely unstable.
+String normalizeErrorText(String message) {
+  final lines = message.split('\n');
+  return lines.map((line) {
+    if (line.contains('file:///') || line.contains('package:')) {
+      return '<STACK_TRACE_LINE>';
+    }
+    line = line.replaceAll(RegExp(r'#[0-9a-f]{5}'), '#00000');
+    return line.replaceAll(RegExp(r'\d+(\.\d+)?'), '<NUMBER>');
+  }).join('\n');
+}

--- a/packages/devtools/test/logging_controller_test.dart
+++ b/packages/devtools/test/logging_controller_test.dart
@@ -37,14 +37,17 @@ StreamController<LogData> logDataController;
 StreamController<void> detailsSelectionController;
 
 List<LogData> unhandledLogData = [];
+
 Stream<String> get logStatusStream => logStatusController.stream;
+
 Stream<LogData> get logDataStream => logDataController.stream;
 
 Stream<void> get detailsSelectionStream => detailsSelectionController.stream;
 
-// Current inspector tree displayed in the details view if any
+/// Current inspector tree displayed in the details view if any
 FakeInspectorTree currentDetailsTree;
-// Current details text shown in the details view if any.
+
+/// Current details text shown in the details view if any.
 String currentDetailsText;
 
 /// Returns a future after length new log data entries that are not GC events
@@ -175,10 +178,18 @@ void main() async {
       unhandledLogData.clear();
 
       final evalOnDartLibrary = EvalOnDartLibrary(
-          ['package:flutter_error_app/main.dart'], env.service);
+        ['package:flutter_error_app/main.dart'],
+        env.service,
+      );
 
-      await evalOnDartLibrary.eval('print("Example message A', isAlive: null);
-      await evalOnDartLibrary.eval('print("Example message B', isAlive: null);
+      await evalOnDartLibrary.eval(
+        'print("Example message A',
+        isAlive: null,
+      );
+      await evalOnDartLibrary.eval(
+        'print("Example message B',
+        isAlive: null,
+      );
 
       var logEntries = await waitForNextLogData(2);
       expect(logEntries[0].kind, equals('stdout'));
@@ -186,8 +197,10 @@ void main() async {
       expect(logEntries[1].kind, equals('stdout'));
       expect(logEntries[1].summary, equals('Example message B\n'));
 
-      await evalOnDartLibrary
-          .eval('navigateToScreen("Missing Material Example")', isAlive: null);
+      await evalOnDartLibrary.eval(
+        'navigateToScreen("Missing Material Example")',
+        isAlive: null,
+      );
 
       logEntries = await waitForNextLogData(4);
       // TODO(jacobr): why do we get two navigation events for this case?

--- a/packages/devtools/test/support/fake_inspector_tree.dart
+++ b/packages/devtools/test/support/fake_inspector_tree.dart
@@ -1,0 +1,250 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math';
+
+import 'package:devtools/src/inspector/inspector_service.dart';
+import 'package:devtools/src/inspector/inspector_text_styles.dart' as styles;
+import 'package:devtools/src/inspector/inspector_tree.dart';
+import 'package:devtools/src/ui/fake_flutter/fake_flutter.dart';
+import 'package:devtools/src/ui/flutter_html_shim.dart' as shim;
+import 'package:devtools/src/ui/icons.dart';
+import 'package:devtools/src/ui/material_icons.dart';
+import 'package:meta/meta.dart';
+
+class FakePaintEntry extends PaintEntry {
+  FakePaintEntry({this.icon, this.text, this.textStyle, @required this.x});
+
+  @override
+  final Icon icon;
+  final String text;
+  final TextStyle textStyle;
+  final double x;
+
+  double get right {
+    double right = x;
+    if (icon != null) {
+      right += icon.iconWidth;
+    }
+    if (text != null) {
+      right += text.length * 10;
+    }
+    return right;
+  }
+}
+
+class FakeInspectorTreeNodeRender
+    extends InspectorTreeNodeRender<FakePaintEntry> {
+  FakeInspectorTreeNodeRender(List<FakePaintEntry> entries, Size size)
+      : super(entries, size);
+
+  @override
+  PaintEntry hitTest(Offset location) {
+    location = location - offset;
+    if (location.dy < 0 || location.dy >= size.height) {
+      return null;
+    }
+    // There is no need to optimize this but we could perform a binary search.
+    for (var entry in entries) {
+      if (entry.x <= location.dx && entry.right > location.dx) {
+        return entry;
+      }
+    }
+    return null;
+  }
+}
+
+class FakeInspectorTreeNodeRenderBuilder
+    extends InspectorTreeNodeRenderBuilder {
+  final List<FakePaintEntry> entries = [];
+  double x = 0;
+
+  @override
+  void addIcon(Icon icon) {
+    x += 20;
+    entries.add(FakePaintEntry(icon: icon, x: x));
+  }
+
+  @override
+  void appendText(String text, TextStyle textStyle) {
+    x += text.length * 10;
+    entries.add(FakePaintEntry(text: text, textStyle: textStyle, x: x));
+  }
+
+  @override
+  InspectorTreeNodeRender build() {
+    final double rowWidth = entries.isEmpty ? 0 : entries.last.right;
+    return FakeInspectorTreeNodeRender(entries, Size(rowWidth, rowHeight));
+  }
+}
+
+class FakeInspectorTreeNode extends InspectorTreeNode {
+  @override
+  InspectorTreeNodeRenderBuilder createRenderBuilder() {
+    return FakeInspectorTreeNodeRenderBuilder();
+  }
+}
+
+const double fakeRowWidth = 200.0;
+
+class FakeInspectorTree extends InspectorTreeFixedRowHeight {
+  FakeInspectorTree({
+    @required bool summaryTree,
+    @required FlutterTreeType treeType,
+    @required NodeAddedCallback onNodeAdded,
+    VoidCallback onSelectionChange,
+    TreeEventCallback onExpand,
+    TreeHoverEventCallback onHover,
+  }) : super(
+          summaryTree: summaryTree,
+          treeType: treeType,
+          onNodeAdded: onNodeAdded,
+          onSelectionChange: onSelectionChange,
+          onExpand: onExpand,
+          onHover: onHover,
+        );
+
+  final List<Rect> scrollToRequests = [];
+
+  @override
+  InspectorTreeNode createNode() {
+    return FakeInspectorTreeNode();
+  }
+
+  @override
+  Rect getBoundingBox(InspectorTreeRow row) {
+    return Rect.fromLTWH(
+      getDepthIndent(row.depth),
+      getRowY(row.index),
+      fakeRowWidth,
+      rowHeight,
+    );
+  }
+
+  @override
+  void scrollToRect(Rect targetRect) {
+    scrollToRequests.add(targetRect);
+  }
+
+  Completer<void> setStateCalled;
+
+  /// Hack to allow tests to wait until the next time this UI is updated.
+  Future<void> get nextUiFrame {
+    setStateCalled ??= Completer();
+
+    return setStateCalled.future;
+  }
+
+  @override
+  void setState(VoidCallback modifyState) {
+    // Execute async calls synchronously for faster test execution.
+    modifyState();
+
+    setStateCalled?.complete(null);
+    setStateCalled = null;
+
+    for (int i = 0; i < numRows; i++) {
+      final row = root.getRow(i, selection: selection);
+      row?.node?.renderObject?.attach(
+        this,
+        Offset(row.depth * columnWidth, i * rowHeight),
+      );
+    }
+  }
+
+  // Debugging string to make it easy to write integration tests.
+  String toStringDeep(
+      {bool hidePropertyLines = false, bool includeTextStyles = false}) {
+    if (root == null) return '<empty>\n';
+    // Visualize the ticks computed for this node so that bugs in the tick
+    // computation code will result in rendering artifacts in the text output.
+    final StringBuffer sb = StringBuffer();
+    for (int i = 0; i < numRows; i++) {
+      final row = root.getRow(i, selection: selection);
+      if (hidePropertyLines && row?.node?.diagnostic?.isProperty == true) {
+        continue;
+      }
+      int last = 0;
+      for (int tick in row.ticks) {
+        // Visualize the line to parent if there is one.
+        if (tick - last > 0) {
+          sb.write('  ' * (tick - last));
+        }
+        if (tick == (row.depth - 1) && row.lineToParent) {
+          sb.write('├─');
+        } else {
+          sb.write('│ ');
+        }
+        last = max(tick, 1);
+      }
+      final int delta = row.depth - last;
+      if (delta > 0) {
+        if (row.lineToParent) {
+          if (delta > 1 || last == 0) {
+            sb.write('  ' * (delta - 1));
+            sb.write('└─');
+          } else {
+            sb.write('──');
+          }
+        } else {
+          sb.write('  ' * delta);
+        }
+      }
+      final renderObject = row.node.renderObject;
+      if (renderObject == null) {
+        sb.write('<empty>\n');
+        continue;
+      }
+      final entries = renderObject.entries;
+      for (FakePaintEntry entry in entries) {
+        if (entry.icon != null) {
+          // Visualize icons
+          final Icon icon = entry.icon;
+          if (icon == collapseArrow) {
+            sb.write('▼');
+          } else if (icon == expandArrow) {
+            sb.write('▶');
+          } else if (icon is UrlIcon) {
+            sb.write('[${icon.src}]');
+          } else if (icon is ColorIcon) {
+            sb.write('[${shim.colorToCss(icon.color)}]');
+          } else if (icon is CustomIcon) {
+            sb.write('[${icon.text}]');
+          } else if (icon is MaterialIcon) {
+            sb.write('[${icon.text}]');
+          }
+        }
+        // TODO(jacobr): optionally visualize colors as well.
+        if (entry.text != null) {
+          if (entry.textStyle != null && includeTextStyles) {
+            final String shortStyle = styles.debugStyleNames[entry.textStyle];
+            if (shortStyle == null) {
+              // Display the style a little like an html style.
+              sb.write('<style ${entry.textStyle}>${entry.text}</style>');
+            } else {
+              if (shortStyle == '') {
+                // Omit the default text style completely for readability of
+                // the debug output.
+                sb.write(entry.text);
+              } else {
+                sb.write('<$shortStyle>${entry.text}</$shortStyle>');
+              }
+            }
+          } else {
+            sb.write(entry.text);
+          }
+        }
+      }
+      if (row.isSelected) {
+        sb.write(' <-- selected');
+      }
+      sb.write('\n');
+    }
+    return sb.toString();
+  }
+
+  @override
+  String tooltip = '';
+}

--- a/packages/devtools/test/tables_test.dart
+++ b/packages/devtools/test/tables_test.dart
@@ -5,6 +5,7 @@
 @TestOn('browser')
 import 'dart:html';
 
+import 'package:devtools/src/table_data.dart';
 import 'package:devtools/src/tables.dart';
 import 'package:test/test.dart';
 
@@ -22,9 +23,10 @@ void main() {
         ..overflow = 'scroll';
       document.body.append(table.element.element);
 
-      table.addColumn(TestColumn('Col One'));
-      table.addColumn(TestColumn('Col Two'));
-      table.setRows(oneThousandRows);
+      table.model
+        ..addColumn(TestColumn('Col One'))
+        ..addColumn(TestColumn('Col Two'))
+        ..setRows(oneThousandRows);
 
       await window.animationFrame;
     });
@@ -46,9 +48,10 @@ void main() {
         ..overflow = 'scroll';
       document.body.append(table.element.element);
 
-      table.addColumn(TestColumn('Col One'));
-      table.addColumn(TestColumn('Col Two'));
-      table.setRows(oneThousandRows);
+      table.model
+        ..addColumn(TestColumn('Col One'))
+        ..addColumn(TestColumn('Col Two'))
+        ..setRows(oneThousandRows);
 
       await window.animationFrame;
     });
@@ -145,7 +148,7 @@ class TestData {
   final String message;
 }
 
-class TestColumn extends Column<TestData> {
+class TestColumn extends ColumnData<TestData> {
   TestColumn(String name) : super(name);
 
   @override

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -21,6 +21,8 @@
     --default-color: #000;
     --disabled-background: #ddd;
     --error-background: #f97c7c;
+    --error-summary-color: #F44336;
+    --inspector-info-color: #24292e;
     --even-row-background: #f7f7f7;
     --footer-color: #7a7a7a;
     --footer-link-hover: #0366d6;
@@ -30,7 +32,8 @@
     --header-color: #586069;
     --header-item-rgb: 255, 255, 255;
     --header-item: rgba(var(--header-item-rgb), 1);
-    --hint-background: lightgoldenrodyellow;
+    --hint-background: #fffbdd;
+    --inspector-hint-color: #000;
     --light-background: #ccc;
     --light-text-color: #f5f5dc;
     --list-background: #fff;
@@ -405,6 +408,7 @@ table tr.selected {
     background-position: 50%;
     margin-left: 0;
     margin-right: 0;
+    flex-shrink: 0;
 }
 
 .gutter.gutter-horizontal {
@@ -426,6 +430,7 @@ table tr.selected {
     background-repeat: no-repeat;
     background-position: center;
     display: inline-block;
+    vertical-align: text-bottom;
 }
 
 input:disabled+label {
@@ -1182,4 +1187,9 @@ span.strong {
 
 .checkbox-text {
     margin-bottom: 1px;
+}
+
+.inspector-tree-html {
+  font: 14px arial;
+  line-height: 22px;
 }

--- a/packages/devtools/web/styles_dark.css
+++ b/packages/devtools/web/styles_dark.css
@@ -16,17 +16,21 @@
     --default-color-thumb: #888;
     --default-color: #fff;
     --disabled-background: #555;
-    --error-background: #7c1c05;
+    --error-background: rgb(65, 33, 36);
+    --error-summary-color: #ff6b68;
+    --inspector-info-color: #909090;
+    --inspector-hint-color: #bbb;
+    --light-text-color: #aaaaaa;
     --even-row-background: #383636;
     --footer-color: #858585;
     --footer-link-hover: wheat;
     --footer-strong: #ccc;
     --form-select-background: #202225;
     --header-background: #282828;
-    --header-color: #ccc;
+    --header-color: #bbbbbb;
     --header-item-rgb: 255, 255, 255;
     --header-item: rgba(var(--header-item-rgb), 1);
-    --hint-background: #4b4b3f;
+    --hint-background: #383636;
     --light-background: #585858;
     --light-text-color: #fafbfc;
     --masthead-background: #394959;
@@ -132,4 +136,9 @@ nav.menu .menu-item {
 .flash-warn {
     background-color: #fffbdd;
     color: #735c0f;
+}
+
+/* The default body color for the primer dark theme is way too bright for a dark theme. */
+body {
+    color: #999999;
 }


### PR DESCRIPTION
Update the structured error support in devtools to reflect the latest changes in package:flutter and polished a bunch of rough edges in the html inspector tree display used to render the errors. As part of this, noticed a bug where we were adding one space of extra whitespace in a bunch of places we didn't intend to as part of the inspector tree code and fixed the bug which caused most of the golden text file diffs.

The change is broken up into two parts. The first is the tweaks to support the flutter logging changes along with some tweaks to the tree rendering code.
The second part refactors code so that the logging and table code is testable as part of command line tests.

The structured errors are disabled by default but can be opted into. Enabling structured errors will also opt vscode and intellij into them so I don't want it to be the default yet. I'm open to suggestions for different wording for the button to show structured errors.

<img width="1242" alt="Screen Shot 2019-08-01 at 4 53 38 PM" src="https://user-images.githubusercontent.com/1226812/62334608-35522b80-b47d-11e9-88a3-8ce59e8aa8ba.png">
