### PR TITLE
Tree Table memory UX to display Inbound References.

### DIFF
--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -14,7 +14,6 @@ import '../globals.dart';
 import '../popup.dart';
 import '../table_data.dart';
 import '../tables.dart';
-import '../trees.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/analytics_platform.dart' as ga_platform;
 import '../ui/custom.dart';

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -310,15 +310,12 @@ class MemoryScreen extends Screen with SetStateMixin {
     }
   }
 
-  ClassHeapDetailStats findCLassDetails(String classRefId) {
+  ClassHeapDetailStats findClassDetails(String classRefId) {
     final List<ClassHeapDetailStats> classesData = tableStack.first.model.data;
-    for (ClassHeapDetailStats stat in classesData) {
-      if (stat.classRef.id == classRefId) {
-        return stat;
-      }
-    }
-
-    return null;
+    return classesData.firstWhere(
+      (stat) => stat.classRef.id == classRefId,
+      orElse: () => null,
+    );
   }
 
   void _selectClass(String className, [record = true]) {
@@ -787,7 +784,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     String classRef,
     int instanceHashCode,
   ) async {
-    final classDetails = findCLassDetails(classRef);
+    final classDetails = findClassDetails(classRef);
     if (classDetails != null) {
       final List<InstanceSummary> instances =
           await memoryController.getInstances(

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -288,7 +288,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   ClassHeapDetailStats findClass(String className) {
     final List<ClassHeapDetailStats> classesData = tableStack.first.model.data;
     return classesData.firstWhere(
-      (ClassHeapDetailStats stat) => stat.classRef.name == className,
+      (stat) => stat.classRef.name == className,
       orElse: () => null,
     );
   }
@@ -341,7 +341,7 @@ class MemoryScreen extends Screen with SetStateMixin {
   Future<int> _selectInstanceInFieldHashCode(
       String fieldName, int instanceHashCode) async {
     final Table<Object> instanceTable = tableStack.elementAt(1);
-    final Spinner spinner = Spinner.centered();
+    final spinner = Spinner.centered();
     instanceTable.element.add(spinner);
 
     // There's an instances table up.
@@ -730,8 +730,7 @@ class MemoryScreen extends Screen with SetStateMixin {
 
   Future<InboundsTree> displayInboundReferences(
       ClassHeapDetailStats row) async {
-    final InboundsTreeData treeData = InboundsTreeData();
-    treeData.data = InboundsTreeNode.root();
+    final treeData = InboundsTreeData()..data = InboundsTreeNode.root();
 
     final List<InstanceSummary> instanceRows =
         await memoryController.getInstances(
@@ -741,23 +740,22 @@ class MemoryScreen extends Screen with SetStateMixin {
     );
 
     for (var instance in instanceRows) {
-      // Add the instance.
-      final InboundsTreeNode instanceNode = InboundsTreeNode.instance(instance);
+      final instanceNode = InboundsTreeNode.instance(instance);
       treeData.data.addChild(instanceNode);
+      // Place holder to lazily compute next child when parent node is expanded.
+      // Place holder to lazily compute next child when parent node is expanded.
       instanceNode.addChild(InboundsTreeNode.empty());
     }
 
     final inboundsTreeTable = InboundsTree(this, treeData, row.classRef.name);
-    inboundsTreeTable.update();
-
-    return inboundsTreeTable;
+    return inboundsTreeTable..update();
   }
 
   Future<String> computeInboundReference(
     String objectRef,
     InboundsTreeNode instanceNode,
   ) async {
-    final InboundReferences refs = await getInboundReferences(objectRef, 1000);
+    final refs = await getInboundReferences(objectRef, 1000);
 
     String instanceHashCode;
     if (isMemoryExperiment) {
@@ -960,8 +958,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     if (hoverPopup.element.children.isNotEmpty) return;
 
     final CoreElement ulElem = ul();
-    final InboundReferences refs =
-        await getInboundReferences(hover.data.objectRef, 1000);
+    final refs = await getInboundReferences(hover.data.objectRef, 1000);
 
     if (refs == null) {
       framework.toast(

--- a/packages/devtools/lib/src/memory/memory_controller.dart
+++ b/packages/devtools/lib/src/memory/memory_controller.dart
@@ -130,6 +130,9 @@ class MemoryController {
       for (var field in fields) {
         if (field.decl.name == fieldName) {
           final InstanceRef ref = field.value;
+
+          if (ref == null) continue;
+
           final evalResult = await evaluate(ref.id, 'hashCode');
           final int objHashCode = int.parse(evalResult?.valueAsString);
           if (objHashCode == instanceHashCode) {

--- a/packages/devtools/lib/src/memory/memory_inbounds.dart
+++ b/packages/devtools/lib/src/memory/memory_inbounds.dart
@@ -1,0 +1,344 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import '../tables.dart';
+import '../trees.dart';
+import '../ui/custom.dart';
+import '../ui/elements.dart';
+
+import 'memory.dart';
+import 'memory_protocol.dart';
+import 'memory_service.dart';
+
+class InboundsTree extends InstanceRefsView {
+  InboundsTree(this._memoryScreen, InboundsTreeData theData, String className)
+      : super(theData) {
+    flex();
+    layoutVertical();
+
+    _init(className);
+  }
+
+  final MemoryScreen _memoryScreen;
+  TreeTable<InboundsTreeNode> referencesTable;
+
+  void _init(String className) {
+    final title =
+        '${inboundsTree.data.children.length} Instances of $className';
+
+    final classNameColumn = ClassNameColumn(title)
+      ..onNodeExpanded.listen((inboundNode) async {
+        if (inboundNode.children.length == 1 &&
+            inboundNode.children[0].isEmpty) {
+          inboundNode.children.removeLast();
+          // Make sure it's a known class (not abstract).
+          if (!inboundNode.isEmpty) {
+            final Spinner spinner = Spinner.centered();
+            referencesTable.element.add(spinner);
+
+            if (inboundNode.instanceHashCode == null &&
+                inboundNode.instance != null) {
+              // Need the hashCode.  It's slow - do it when needed.
+              // TODO(terry): Needs to be used with real snapshot.
+              final String instanceHashCode =
+                  await _memoryScreen.computeInboundReference(
+                inboundNode.instance.objectRef,
+                inboundNode,
+              );
+              inboundNode.instanceHashCode = instanceHashCode;
+            }
+
+            final int instanceHashCode = _memoryScreen.isMemoryExperiment
+                ? int.parse(inboundNode.instanceHashCode)
+                : -1;
+
+            final ClassHeapDetailStats classStats =
+                _memoryScreen.findClass(inboundNode.name);
+
+            // All instances of a class.
+            List<InstanceSummary> instances =
+                await _memoryScreen.findInstances(classStats);
+            for (InstanceSummary instance in instances) {
+              // Found the instance.
+              final InboundReferences refs =
+                  await getInboundReferences(instance.objectRef, 1000);
+
+              if (_memoryScreen.isMemoryExperiment) {
+                // TODO(terry): Temporary workaround since evaluate fails on expressions
+                // TODO(terry): accessing a private field e.g., _extra.hashcode.
+                if (await _memoryScreen.memoryController.matchObject(
+                    instance.objectRef,
+                    inboundNode.fieldName,
+                    instanceHashCode)) {
+                  // TODO(terry): Expensive need better VMService identity for objectRef.
+                  // Get hashCode identity object id changes but hashCode is our identity.
+                  var hashCodeResult;
+
+                  hashCodeResult =
+                      await evaluate(instance.objectRef, 'hashCode');
+
+                  // Record we have a real instance too.
+                  inboundNode.setInstance(
+                      instance, hashCodeResult?.valueAsString);
+
+                  final List<ClassHeapDetailStats> allClasses =
+                      _memoryScreen.tableStack.first.data;
+
+                  computeInboundRefs(allClasses, refs, (
+                    String referenceName,
+                    String owningAllocator,
+                    bool owningAllocatorIsAbstract,
+                  ) async {
+                    if (!owningAllocatorIsAbstract &&
+                        owningAllocator.isNotEmpty) {
+                      var newRefNode = InboundsTreeNode(owningAllocator,
+                          referenceName, hashCodeResult?.valueAsString);
+                      inboundNode.addChild(newRefNode);
+                      newRefNode.addChild(InboundsTreeNode.empty());
+                    }
+                  });
+                }
+              }
+            }
+            spinner.remove();
+          }
+        }
+
+        referencesTable.expandNode(inboundNode);
+      })
+      ..onNodeCollapsed
+          .listen((inboundNode) => referencesTable.collapseNode(inboundNode));
+
+    referencesTable = TreeTable<InboundsTreeNode>.virtual()
+      ..addColumn(classNameColumn)
+      ..addColumn(FieldNameColumn())
+      ..element.clazz('memory-table');
+
+    referencesTable..setRows(<InboundsTreeNode>[]);
+
+    referencesTable.onSelect.listen(_memoryScreen.select);
+
+    add(referencesTable.element);
+  }
+
+  @override
+  void rebuildView() {
+    final InboundsTreeData providerData = this.inboundsTree;
+
+// TODO(terry): Need root deepCopy?
+//    final CpuStackFrame root = data.cpuProfileRoot.deepCopy();
+
+    final List<InboundsTreeNode> rows = providerData.data.root.children.cast();
+    // TODO(terry): Work around bug if children have a parent (which they do
+    // TODO(terry): the TreeTable won't render.
+    for (InboundsTreeNode row in rows) row.parent = null;
+
+    referencesTable.setRows(rows);
+  }
+
+  @override
+  void reset() => referencesTable.setRows(<InboundsTreeNode>[]);
+}
+
+class InboundsTreeData {
+  InboundsTreeData();
+
+  InboundsTreeData.test() {
+    final treeNode00 = InboundsTreeNode('class_0_0', 'field_0');
+    final treeNode01 = InboundsTreeNode('class_0_1', 'field_1');
+    final treeNode02 = InboundsTreeNode('class_0_2', 'field_2');
+    final treeNode03 = InboundsTreeNode('class_0_3', 'field_3');
+    final treeNode04 = InboundsTreeNode('class_0_4', 'field_4');
+    final treeNode05 = InboundsTreeNode('class_0_5', 'field_5');
+
+    final treeNode10 = InboundsTreeNode('class_1', 'field_a');
+    final treeNode11 = InboundsTreeNode('class_1_1', 'field_b');
+    final treeNode12 = InboundsTreeNode('class_1_2', 'field_c');
+    final treeNode13 = InboundsTreeNode('class_1_3', 'field_d');
+    final treeNode14 = InboundsTreeNode('class_4_4', 'field_e');
+    final treeNode15 = InboundsTreeNode('class_1_5', 'field_f');
+
+    final terryStuff = InboundsTreeNode(
+        'TerryStuff allocated TerryExtra', 'extra [object/14752]');
+    final shrineAppState1 = InboundsTreeNode('_ShrineAppState', '_stuff');
+    final shrineAppState2 = InboundsTreeNode('_ShrineAppState', '_stuff2');
+    final statefulElement1 = InboundsTreeNode('StatefulElement', 'state');
+    final hashmapEntry1 = InboundsTreeNode('_HashMapEntry', '_key');
+    final singleChildrenObjectElement1 =
+        InboundsTreeNode('SingleChildrenObjectElement', '_child');
+    final statefulElement2 = InboundsTreeNode('StatefulElement', 'state');
+    final hashmapEntry2 = InboundsTreeNode('_HashMapEntry', '_key');
+    final singleChildrenObjectElement2 =
+        InboundsTreeNode('SingleChildrenObjectElement', '_child');
+
+    data = InboundsTreeNode.root()
+      ..addChild(treeNode00
+        ..addChild(treeNode01)
+        ..addChild(treeNode02
+          ..addChild(treeNode03)
+          ..addChild(treeNode04)
+          ..addChild(treeNode05)))
+      ..addChild(treeNode10
+        ..addChild(treeNode11)
+        ..addChild(treeNode12)
+        ..addChild(treeNode13)
+        ..addChild(treeNode14)
+        ..addChild(treeNode15))
+      ..addChild(terryStuff
+        ..addChild(shrineAppState1
+          ..addChild(statefulElement1
+            ..addChild(hashmapEntry1..addChild(singleChildrenObjectElement1))))
+        ..addChild(shrineAppState2
+          ..addChild(statefulElement2
+            ..addChild(
+                hashmapEntry2..addChild(singleChildrenObjectElement2)))));
+  }
+
+  InboundsTreeNode data;
+}
+
+class InboundsTreeNode extends TreeNode<InboundsTreeNode> {
+  InboundsTreeNode(this._name, this._fieldName, [this.instanceHashCode]);
+  InboundsTreeNode.instance(this._instance, [this.instanceHashCode])
+      : _name = _instance.objectRef,
+        _fieldName = '';
+  InboundsTreeNode.root()
+      : _name = 'Instances',
+        _fieldName = '',
+        instanceHashCode = null;
+  InboundsTreeNode.empty()
+      : _name = null,
+        _fieldName = null,
+        instanceHashCode = null;
+
+  String _name;
+
+  InstanceSummary _instance;
+
+  InstanceSummary get instance => _instance;
+
+  String get name => _name;
+
+  /// isNew signals objectRef (object/###) has changed.
+  void setInstance(InstanceSummary theInstance, String hashCode,
+      [bool isNew = false]) {
+    _instance = theInstance;
+    instanceHashCode = hashCode;
+    _name = _name.split(' ')[0]; // Throw away instance objectRef name.
+    _name = (isNew && !isInboundEntry)
+        ? _instance.objectRef
+        : '$name (${instance.objectRef})';
+  }
+
+  final String _fieldName;
+
+  String get fieldName => _fieldName;
+
+  bool get isInboundEntry => _fieldName?.isNotEmpty;
+
+  String instanceHashCode;
+
+  bool get isEmpty =>
+      _name == null && _fieldName == null && instanceHashCode == null;
+}
+
+abstract class InstanceRefsView extends CoreElement {
+  InstanceRefsView(this.inboundsTree) : super('div', classes: 'memory-table');
+
+  final InboundsTreeData inboundsTree;
+
+  bool viewNeedsRebuild = false;
+
+  void rebuildView();
+
+  void reset();
+
+  void update({bool showLoadingSpinner = false}) async {
+    if (inboundsTree == null) return;
+
+    // Update the view if it is visible. Otherwise, mark the view as needing a
+    // rebuild.
+    if (!isHidden) {
+      if (showLoadingSpinner) {
+        final Spinner spinner = Spinner.centered();
+        add(spinner);
+
+        // Awaiting this future ensures the spinner pops up in between switching
+        // profiler views. Without this, the UI is laggy and the spinner never
+        // appears.
+        await Future.delayed(const Duration(microseconds: 1));
+
+        rebuildView();
+        spinner.remove();
+      } else {
+        rebuildView();
+      }
+    } else {
+      viewNeedsRebuild = true;
+    }
+  }
+
+  void show() {
+    hidden(false);
+    if (viewNeedsRebuild) {
+      viewNeedsRebuild = false;
+      update(showLoadingSpinner: true);
+    }
+  }
+
+  void hide() => hidden(true);
+}
+
+class ClassNameColumn extends TreeColumn<InboundsTreeNode> {
+  ClassNameColumn(String title) : super(title);
+
+  static const maxClassNameLength = 75;
+
+  @override
+  dynamic getValue(InboundsTreeNode dataObject) => dataObject.name;
+
+  @override
+  String getDisplayValue(InboundsTreeNode dataObject) {
+    String name = dataObject.name;
+    if (name.length > maxClassNameLength) {
+      return name.substring(0, maxClassNameLength) + '...';
+    }
+    return name;
+  }
+
+  @override
+  bool get supportsSorting => true;
+
+  @override
+  String getTooltip(InboundsTreeNode dataObject) =>
+      '${dataObject.name} . ${dataObject.fieldName}';
+}
+
+//class FieldNameColumn extends TreeColumn<InboundsTreeNode> {
+class FieldNameColumn extends Column<InboundsTreeNode> {
+  FieldNameColumn() : super('Field Reference');
+
+  static const maxFieldNameLength = 25;
+
+  @override
+  dynamic getValue(InboundsTreeNode dataObject) => dataObject.fieldName;
+
+  @override
+  String getDisplayValue(InboundsTreeNode dataObject) {
+    String fieldName = dataObject.fieldName;
+    if (fieldName.length > maxFieldNameLength) {
+      return fieldName.substring(0, maxFieldNameLength) + '...';
+    }
+    return fieldName;
+  }
+
+  @override
+  bool get supportsSorting => false;
+
+  @override
+  String getTooltip(InboundsTreeNode dataObject) =>
+      '${dataObject.fieldName} OF ${dataObject.name}';
+}

--- a/packages/devtools/lib/src/memory/memory_inbounds.dart
+++ b/packages/devtools/lib/src/memory/memory_inbounds.dart
@@ -23,6 +23,7 @@ class InboundsTree extends InstanceRefsView {
   }
 
   final MemoryScreen _memoryScreen;
+
   TreeTable<InboundsTreeNode> referencesTable;
 
   void _init(String className) {

--- a/packages/devtools/lib/src/memory/memory_inbounds.dart
+++ b/packages/devtools/lib/src/memory/memory_inbounds.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import '../table_data.dart';
 import '../tables.dart';
 import '../trees.dart';
 import '../ui/custom.dart';
@@ -86,7 +87,7 @@ class InboundsTree extends InstanceRefsView {
                       instance, hashCodeResult?.valueAsString);
 
                   final List<ClassHeapDetailStats> allClasses =
-                      _memoryScreen.tableStack.first.data;
+                      _memoryScreen.tableStack.first.model.data;
 
                   computeInboundRefs(allClasses, refs, (
                     String referenceName,
@@ -108,19 +109,20 @@ class InboundsTree extends InstanceRefsView {
           }
         }
 
-        referencesTable.expandNode(inboundNode);
+        referencesTable.model.expandNode(inboundNode);
       })
-      ..onNodeCollapsed
-          .listen((inboundNode) => referencesTable.collapseNode(inboundNode));
+      ..onNodeCollapsed.listen(
+          (inboundNode) => referencesTable.model.collapseNode(inboundNode));
 
     referencesTable = TreeTable<InboundsTreeNode>.virtual()
-      ..addColumn(classNameColumn)
-      ..addColumn(FieldNameColumn())
       ..element.clazz('memory-table');
 
-    referencesTable..setRows(<InboundsTreeNode>[]);
+    referencesTable.model
+      ..addColumn(classNameColumn)
+      ..addColumn(FieldNameColumn())
+      ..setRows(<InboundsTreeNode>[]);
 
-    referencesTable.onSelect.listen(_memoryScreen.select);
+    referencesTable.model.onSelect.listen(_memoryScreen.select);
 
     add(referencesTable.element);
   }
@@ -137,11 +139,11 @@ class InboundsTree extends InstanceRefsView {
     // TODO(terry): the TreeTable won't render.
     for (InboundsTreeNode row in rows) row.parent = null;
 
-    referencesTable.setRows(rows);
+    referencesTable.model.setRows(rows);
   }
 
   @override
-  void reset() => referencesTable.setRows(<InboundsTreeNode>[]);
+  void reset() => referencesTable.model.setRows(<InboundsTreeNode>[]);
 }
 
 class InboundsTreeData {
@@ -293,7 +295,7 @@ abstract class InstanceRefsView extends CoreElement {
   void hide() => hidden(true);
 }
 
-class ClassNameColumn extends TreeColumn<InboundsTreeNode> {
+class ClassNameColumn extends TreeColumnData<InboundsTreeNode> {
   ClassNameColumn(String title) : super(title);
 
   static const maxClassNameLength = 75;
@@ -319,7 +321,7 @@ class ClassNameColumn extends TreeColumn<InboundsTreeNode> {
 }
 
 //class FieldNameColumn extends TreeColumn<InboundsTreeNode> {
-class FieldNameColumn extends Column<InboundsTreeNode> {
+class FieldNameColumn extends ColumnData<InboundsTreeNode> {
   FieldNameColumn() : super('Field Reference');
 
   static const maxFieldNameLength = 25;

--- a/packages/devtools/lib/src/memory/memory_inbounds.dart
+++ b/packages/devtools/lib/src/memory/memory_inbounds.dart
@@ -43,7 +43,7 @@ class InboundsTree extends InstanceRefsView {
           inboundNode.children.removeLast();
           // Make sure it's a known class (not abstract).
           if (!inboundNode.isEmpty) {
-            final Spinner spinner = Spinner.centered();
+            final spinner = Spinner.centered();
             referencesTable.element.add(spinner);
 
             if (inboundNode.instanceHashCode == null &&
@@ -58,7 +58,7 @@ class InboundsTree extends InstanceRefsView {
               inboundNode.instanceHashCode = instanceHashCode;
             }
 
-            final int instanceHashCode = _memoryScreen.isMemoryExperiment
+            final instanceHashCode = _memoryScreen.isMemoryExperiment
                 ? int.parse(inboundNode.instanceHashCode)
                 : -1;
 
@@ -70,8 +70,7 @@ class InboundsTree extends InstanceRefsView {
                 await _memoryScreen.findInstances(classStats);
             for (InstanceSummary instance in instances) {
               // Found the instance.
-              final InboundReferences refs =
-                  await getInboundReferences(instance.objectRef, 1000);
+              final refs = await getInboundReferences(instance.objectRef, 1000);
 
               if (_memoryScreen.isMemoryExperiment) {
                 // TODO(terry): Temporary workaround since evaluate fails on expressions
@@ -218,20 +217,20 @@ class InboundsTreeData {
 }
 
 class InboundsTreeNode extends TreeNode<InboundsTreeNode> {
-  InboundsTreeNode(this._name, this._fieldName, [this.instanceHashCode]);
+  InboundsTreeNode(this._name, this.fieldName, [this.instanceHashCode]);
 
   InboundsTreeNode.instance(this._instance, [this.instanceHashCode])
       : _name = _instance.objectRef,
-        _fieldName = '';
+        fieldName = '';
 
   InboundsTreeNode.root()
       : _name = 'Instances',
-        _fieldName = '',
+        fieldName = '',
         instanceHashCode = null;
 
   InboundsTreeNode.empty()
       : _name = null,
-        _fieldName = null,
+        fieldName = null,
         instanceHashCode = null;
 
   String get name => _name;
@@ -240,9 +239,17 @@ class InboundsTreeNode extends TreeNode<InboundsTreeNode> {
 
   InstanceSummary get instance => _instance;
 
-  /// isNew signals objectRef (object/###) has changed.
-  void setInstance(InstanceSummary theInstance, String hashCode,
-      [bool isNew = false]) {
+  /// Replaces the node's [instance], [instanceHashCode] and [name].  This is
+  /// can happen as a result of the objectRef id changing (as known by the VM).
+  /// It's matched to the propery objectRef (instance) by comparing hashCodes.
+  ///
+  /// [isNew] signals the objectRef (e.g., objects/123) changed to something
+  /// different (e.g., objects/245).
+  void setInstance(
+    InstanceSummary theInstance,
+    String hashCode, [
+    bool isNew = false,
+  ]) {
     _instance = theInstance;
     instanceHashCode = hashCode;
     _name = _name.split(' ')[0]; // Throw away instance objectRef name.
@@ -253,16 +260,14 @@ class InboundsTreeNode extends TreeNode<InboundsTreeNode> {
 
   InstanceSummary _instance;
 
-  String get fieldName => _fieldName;
+  final String fieldName;
 
-  final String _fieldName;
-
-  bool get isInboundEntry => _fieldName?.isNotEmpty;
+  bool get isInboundEntry => fieldName?.isNotEmpty;
 
   String instanceHashCode;
 
   bool get isEmpty =>
-      _name == null && _fieldName == null && instanceHashCode == null;
+      _name == null && fieldName == null && instanceHashCode == null;
 }
 
 abstract class InstanceRefsView extends CoreElement {
@@ -283,7 +288,7 @@ abstract class InstanceRefsView extends CoreElement {
     // rebuild.
     if (!isHidden) {
       if (showLoadingSpinner) {
-        final Spinner spinner = Spinner.centered();
+        final spinner = Spinner.centered();
         add(spinner);
 
         // Awaiting this future ensures the spinner pops up in between switching

--- a/packages/devtools/lib/src/memory/memory_service.dart
+++ b/packages/devtools/lib/src/memory/memory_service.dart
@@ -107,7 +107,7 @@ class InboundReference extends Response {
   bool get isSentinel => parentField.runtimeType == Sentinel;
 }
 
-typedef BuildHoverCard = void Function(
+typedef BuildInboundEntry = void Function(
   String referenceName,
   /* Field that owns reference to allocated memory */
   String owningAllocator,
@@ -127,7 +127,7 @@ ClassHeapDetailStats _searchClass(
 void computeInboundRefs(
   List<ClassHeapDetailStats> allClasses,
   InboundReferences refs,
-  BuildHoverCard buildCallback,
+  BuildInboundEntry buildCallback,
 ) {
   for (InboundReference element in refs.elements) {
     // Could be a reference to an evaluate so this isn't known.

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -698,6 +698,10 @@ div.tabnav {
     min-width: 500px;
 }
 
+.memory-table table:focus {
+    outline: none;
+}
+
 .memory-inspector {
     padding: 3px;
     box-sizing: border-box;


### PR DESCRIPTION
Press the snapshot button
![image](https://user-images.githubusercontent.com/2055873/62548518-c7f71f80-b81b-11e9-893e-58b298fd84de.png)

to collect and display the state of memory allocations and find the class TerryStuff
![image](https://user-images.githubusercontent.com/2055873/62548414-9a11db00-b81b-11e9-9183-e1e909f0462f.png)

Three instances of TerryStuff exists

![image](https://user-images.githubusercontent.com/2055873/62551866-91bc9e80-b821-11e9-84bc-b9d23a777477.png)

The Shrine app (in examples/flutter_gallery) has been modified to create a TerryStuff class and assign it to two fields _stuff and _stuff2 in the _ShrinkAppState.

```
class _ShrineAppState extends State<ShrineApp> with SingleTickerProviderStateMixin {
  AnimationController _controller;

  TerryStuff _stuff = TerryStuff('ROOT');    // ***** Allocation *****
  TerryStuff _stuff2;                        // ***** Allocation *****

  @override
  void initState() {
    super.initState();
    _controller = AnimationController(
      vsync: this,
      duration: const Duration(milliseconds: 450),
      value: 1.0,
    );
  }

  @override
  Widget build(BuildContext context) {
    _stuff2 = _stuff;                       // ***** Allocation *****


    return MaterialApp(
      title: 'Shrine',
      home: HomePage(
        backdrop: Backdrop(
          frontLayer: const ProductPage(),
...
        ),
        expandingBottomSheet: ExpandingBottomSheet(hideController: _controller),
      ),
      initialRoute: '/login',
      onGenerateRoute: _getRoute,
      theme: _kShrineTheme.copyWith(platform: Theme.of(context).platform),
    );
  }
}

```

Expanding all the instances of TerryStuff

![image](https://user-images.githubusercontent.com/2055873/62551944-b44eb780-b821-11e9-8e7e-49b0da8e0bc6.png)

Looking at objects/39 is the instance created in the above code.  The lines:

```
  TerryStuff _stuff = TerryStuff('ROOT');    // ***** Allocation *****
  TerryStuff _stuff2;                        // ***** Allocation *****
```

Allocated TerryStuff and stored a reference in class _ShrineAppState's field _stuff.

Additionally, _stuff2 is assigned to _stuff e.g.,
```
  Widget build(BuildContext context) {
    _stuff2 = _stuff;                       // ***** Allocation *****
```

Expanding objects/39 shows inbound references (which class and fields are holding onto a TerryStuff instance).  In our case, objects/39 is referenced in fields _stuff and _stuff2 in class _ShrineAppState.

**Memory Experiment**
_Warning this will shake memory (cause memory to change). Only available in debug mode._

This experiment can help to understand memory usage memory within an application.

To enable this experiment click the SnapShot button while pressing the SHIFT key.

Notice the status line (centered in the bottom line of the memory profile) displays the name _Experiment_ e.g.,

![image](https://user-images.githubusercontent.com/2055873/62554733-8029c580-b826-11e9-8e96-c3ae00fb738b.png)

When the experiment is enabled expanding an inbound reference will display the inbound instance that is holding on to our particular instance.  For example,

![image](https://user-images.githubusercontent.com/2055873/62553764-c8e07f00-b824-11e9-8e99-a3997df42d48.png)

Now displays the inbound references with (objects/111) which is the instance of _ShrineAppState for field _stuff_.  Clicking on this instance will display:

![image](https://user-images.githubusercontent.com/2055873/62553970-2d034300-b825-11e9-8363-2b822b7cf8f1.png)

Warning live navigation of memory causes memory to be created, referenced and unreferenced - fairly quickly (causing memory to grow/shrink).

![image](https://user-images.githubusercontent.com/2055873/62554324-c6325980-b825-11e9-9dc8-17c9ba27327a.png)


