### PR TITLE
Fix misuses of Null

### DIFF
--- a/packages/devtools/lib/src/framework/framework_core.dart
+++ b/packages/devtools/lib/src/framework/framework_core.dart
@@ -41,7 +41,7 @@ class FrameworkCore {
     var uri = explicitUri ?? _getUriFromQuerystring();
 
     if (uri != null) {
-      final Completer<Null> finishedCompleter = Completer<Null>();
+      final finishedCompleter = Completer<void>();
 
       // Map the URI (which may be Observatory web app) to a WebSocket URI for
       // the VM service.

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -645,7 +645,7 @@ class MemoryScreen extends Screen with SetStateMixin {
     }
   }
 
-  Future<Null> _gcNow() async {
+  Future<void> _gcNow() async {
     ga.select(ga.memory, ga.gC);
 
     gcNowButton.disabled = true;

--- a/packages/devtools/lib/src/memory/memory_controller.dart
+++ b/packages/devtools/lib/src/memory/memory_controller.dart
@@ -25,10 +25,8 @@ class MemoryController {
 
   Stream<MemoryTracker> get onMemory => _memoryTrackerController.stream;
 
-  final StreamController<void> _disconnectController =
-      StreamController<void>.broadcast();
-
   Stream<void> get onDisconnect => _disconnectController.stream;
+  final _disconnectController = StreamController<void>.broadcast();
 
   MemoryTracker _memoryTracker;
 
@@ -46,7 +44,7 @@ class MemoryController {
     _memoryTracker = MemoryTracker(service);
     _memoryTracker.start();
 
-    _memoryTracker.onChange.listen((Null _) {
+    _memoryTracker.onChange.listen((_) {
       _memoryTrackerController.add(_memoryTracker);
     });
   }
@@ -55,7 +53,7 @@ class MemoryController {
     _memoryTracker?.stop();
     _memoryTrackerController.add(_memoryTracker);
 
-    _disconnectController.add(Null);
+    _disconnectController.add(null);
     hasStopped = true;
   }
 

--- a/packages/devtools/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools/lib/src/memory/memory_protocol.dart
@@ -18,8 +18,6 @@ class MemoryTracker {
 
   VmServiceWrapper service;
   Timer _pollingTimer;
-  final StreamController<Null> _changeController =
-      StreamController<Null>.broadcast();
 
   final List<HeapSample> samples = <HeapSample>[];
   final Map<String, List<HeapSpace>> isolateHeaps = <String, List<HeapSpace>>{};
@@ -28,7 +26,8 @@ class MemoryTracker {
 
   bool get hasConnection => service != null;
 
-  Stream<Null> get onChange => _changeController.stream;
+  Stream<void> get onChange => _changeController.stream;
+  final _changeController = StreamController<void>.broadcast();
 
   int get currentCapacity => samples.last.capacity;
 
@@ -58,7 +57,7 @@ class MemoryTracker {
   }
 
   // TODO(terry): Discuss need a record/stop record for memory?  Unless expensive probably not.
-  Future<Null> _pollMemory() async {
+  Future<void> _pollMemory() async {
     if (!hasConnection) {
       return;
     }

--- a/packages/devtools/lib/src/service.dart
+++ b/packages/devtools/lib/src/service.dart
@@ -8,7 +8,7 @@ import 'dart:typed_data';
 
 import 'vm_service_wrapper.dart';
 
-Future<VmServiceWrapper> connect(Uri uri, Completer<Null> finishedCompleter) {
+Future<VmServiceWrapper> connect(Uri uri, Completer<void> finishedCompleter) {
   final WebSocket ws = WebSocket(uri.toString());
 
   final Completer<VmServiceWrapper> connectedCompleter =

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -26,14 +26,10 @@ class ServiceConnectionManager {
     _serviceExtensionManager = serviceExtensionManager;
   }
 
-  final StreamController<Null> _stateController =
-      StreamController<Null>.broadcast();
   final StreamController<VmServiceWrapper> _connectionAvailableController =
       StreamController<VmServiceWrapper>.broadcast();
-  final StreamController<Null> _connectionClosedController =
-      StreamController<Null>.broadcast();
 
-  final Completer<Null> serviceAvailable = Completer();
+  final serviceAvailable = Completer<void>();
 
   VmServiceCapabilities _serviceCapabilities;
 
@@ -69,12 +65,14 @@ class ServiceConnectionManager {
 
   bool get hasConnection => service != null;
 
-  Stream<Null> get onStateChange => _stateController.stream;
+  Stream<void> get onStateChange => _stateController.stream;
+  final _stateController = StreamController<void>.broadcast();
 
   Stream<VmServiceWrapper> get onConnectionAvailable =>
       _connectionAvailableController.stream;
 
-  Stream<Null> get onConnectionClosed => _connectionClosedController.stream;
+  Stream<void> get onConnectionClosed => _connectionClosedController.stream;
+  final _connectionClosedController = StreamController<void>.broadcast();
 
   /// Call a service that is registered by exactly one client.
   Future<Response> callService(
@@ -235,7 +233,7 @@ class IsolateManager {
   final StreamController<IsolateRef> _selectedIsolateController =
       StreamController<IsolateRef>.broadcast();
 
-  Completer<Null> selectedIsolateAvailable = Completer();
+  void selectedIsolateAvailable = Completer<void>();
 
   List<LibraryRef> selectedIsolateLibraries;
 
@@ -384,7 +382,7 @@ class ServiceExtensionManager {
   // ignore: prefer_collection_literals
   final Set<String> _pendingServiceExtensions = Set<String>();
 
-  Completer<Null> extensionStatesUpdated = Completer();
+  var extensionStatesUpdated = Completer<void>();
 
   Future<void> _handleExtensionEvent(Event event) async {
     switch (event.extensionKind) {

--- a/packages/devtools/lib/src/service_manager.dart
+++ b/packages/devtools/lib/src/service_manager.dart
@@ -233,7 +233,7 @@ class IsolateManager {
   final StreamController<IsolateRef> _selectedIsolateController =
       StreamController<IsolateRef>.broadcast();
 
-  void selectedIsolateAvailable = Completer<void>();
+  var selectedIsolateAvailable = Completer<void>();
 
   List<LibraryRef> selectedIsolateLibraries;
 

--- a/packages/devtools/lib/src/table_data.dart
+++ b/packages/devtools/lib/src/table_data.dart
@@ -76,9 +76,6 @@ class TableData<T> extends Object {
   @protected
   final StreamController<T> selectController = StreamController<T>.broadcast();
 
-  final StreamController<Null> _rowsChangedController =
-      StreamController.broadcast();
-
   final StreamController<HoverCellData<T>> selectElementController =
       StreamController<HoverCellData<T>>.broadcast();
 
@@ -89,7 +86,8 @@ class TableData<T> extends Object {
 
   Stream<T> get onSelect => selectController.stream;
 
-  Stream<Null> get onRowsChanged => _rowsChangedController.stream;
+  Stream<void> get onRowsChanged => _rowsChangedController.stream;
+  final _rowsChangedController = StreamController<void>.broadcast();
 
   Stream<HoverCellData<T>> get onCellHover => selectElementController.stream;
 

--- a/packages/devtools/test/support/chrome.dart
+++ b/packages/devtools/test/support/chrome.dart
@@ -172,8 +172,6 @@ class ChromeTab {
   final wip.ChromeTab wipTab;
   WipConnection _wip;
 
-  final StreamController<Null> _disconnectStream =
-      StreamController<Null>.broadcast();
   final StreamController<LogEntry> _entryAddedController =
       StreamController<LogEntry>.broadcast();
   final StreamController<ConsoleAPIEvent> _consoleAPICalledController =
@@ -241,7 +239,8 @@ class ChromeTab {
 
   bool get isConnected => _wip != null;
 
-  Stream<Null> get onDisconnect => _disconnectStream.stream;
+  Stream<void> get onDisconnect => _disconnectStream.stream;
+  final _disconnectStream = StreamController<void>.broadcast();
 
   Stream<LogEntry> get onLogEntryAdded => _entryAddedController.stream;
 


### PR DESCRIPTION
Before Dart 2 it was common use use `Stream<Null>` or `Future<Null>` to
indicated unusable values. The modern approach is `void`.

- Replace all `<Null>` with `<void>`.
- Move some `StreamController` fields next to their related `Stream`
  getters.
- Remove unnecessary argument type on a function literal consuming a
  `Stream<void>`.
- Fix a `sink.add(Null)` with `sink.add(null)` - the `Type` had be used
  when a null value was intended.
- For the fields or variables being touched anyway, clean up to the
  current style of avoiding redundant types.