### PR TITLE
Handle Dream (g3) thread name formats for UI and GPU thread.

### DIFF
--- a/packages/devtools/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools/lib/src/timeline/timeline_controller.dart
@@ -58,6 +58,10 @@ class TimelineController {
   final StreamController<OfflineTimelineData> _loadOfflineDataController =
       StreamController<OfflineTimelineData>.broadcast();
 
+  /// Stream controller that notifies the timeline screen when a non-fatal error
+  /// should be logged for the timeline.
+  final _nonFatalErrorController = StreamController<String>.broadcast();
+
   Stream<TimelineFrame> get onFrameAdded => frameAddedController.stream;
 
   Stream<TimelineFrame> get onSelectedFrame => _selectedFrameController.stream;
@@ -67,6 +71,8 @@ class TimelineController {
 
   Stream<OfflineTimelineData> get onLoadOfflineData =>
       _loadOfflineDataController.stream;
+
+  Stream<String> get onNonFatalError => _nonFatalErrorController.stream;
 
   TimelineData timelineData;
 
@@ -227,6 +233,10 @@ class TimelineController {
   void exitOfflineMode() {
     timelineData.clear();
     offlineTimelineData = null;
+  }
+
+  void logNonFatalError(String message) {
+    _nonFatalErrorController.add(message);
   }
 }
 

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -265,6 +265,10 @@ class TimelineScreen extends Screen {
       _destroySplitter();
     });
 
+    timelineController.onNonFatalError.listen((message) {
+      ga.error(message, false);
+    });
+
     // The size of [flameChartContainer] will change as the splitter moved.
     // Observe resizing so that we can rebuild the flame chart canvas as
     // necessary.

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -96,7 +96,9 @@ class TimelineService {
     }
 
     if (uiThreadId == null || gpuThreadId == null) {
-      print('Possible threads: $threadNames');
+      timelineController.logNonFatalError(
+          'Could not find UI thread and / or GPU thread from names: '
+          '$threadNames');
     }
 
     timelineController.timelineProtocol = TimelineProtocol(

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -75,15 +75,28 @@ class TimelineService {
     // available in the engine.
     int uiThreadId;
     int gpuThreadId;
+
+    // Store the thread names for debugging purposes. If [uiThreadId] or
+    // [gpuThreadId] are null, we will print all the thread names we received
+    // to console.
+    final threadNames = [];
+
     for (TraceEvent event in events) {
-      // iOS - 'io.flutter.1.ui', Android - '1.ui'.
-      if (event.args['name'].contains('1.ui')) {
+      final name = event.args['name'];
+      threadNames.add(name);
+
+      // iOS - 'io.flutter.1.ui', Android - '1.ui', Other - io.flutter.ui
+      if (name.contains('1.ui') || name.contains('flutter.ui')) {
         uiThreadId = event.threadId;
       }
-      // iOS - 'io.flutter.1.gpu', Android - '1.gpu'.
-      if (event.args['name'].contains('1.gpu')) {
+      // iOS - 'io.flutter.1.gpu', Android - '1.gpu', Other - io.flutter.gpu
+      if (name.contains('1.gpu') || name.contains('flutter.gpu')) {
         gpuThreadId = event.threadId;
       }
+    }
+
+    if (uiThreadId == null || gpuThreadId == null) {
+      print('Possible threads: $threadNames');
     }
 
     timelineController.timelineProtocol = TimelineProtocol(

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -85,11 +85,11 @@ class TimelineService {
       final name = event.args['name'];
       threadNames.add(name);
 
-      // iOS - 'io.flutter.1.ui', Android - '1.ui', Other - io.flutter.ui
+      // iOS - io.flutter.1.ui, Android - 1.ui, Dream (g3) - io.flutter.ui
       if (name.contains('1.ui') || name.contains('flutter.ui')) {
         uiThreadId = event.threadId;
       }
-      // iOS - 'io.flutter.1.gpu', Android - '1.gpu', Other - io.flutter.gpu
+      // iOS - io.flutter.1.gpu, Android - 1.gpu, Dream (g3) - io.flutter.gpu
       if (name.contains('1.gpu') || name.contains('flutter.gpu')) {
         gpuThreadId = event.threadId;
       }

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -86,11 +86,11 @@ class TimelineService {
       threadNames.add(name);
 
       // iOS - io.flutter.1.ui, Android - 1.ui, Dream (g3) - io.flutter.ui
-      if (name.contains('1.ui') || name.contains('flutter.ui')) {
+      if (name.endsWith('.ui')) {
         uiThreadId = event.threadId;
       }
       // iOS - io.flutter.1.gpu, Android - 1.gpu, Dream (g3) - io.flutter.gpu
-      if (name.contains('1.gpu') || name.contains('flutter.gpu')) {
+      if (name.endsWith('.gpu')) {
         gpuThreadId = event.threadId;
       }
     }


### PR DESCRIPTION
On Dream (g3) devices, the UI and GPU threads are formated as "io.flutter.ui" and "io.flutter.gpu". This PR adds detection for threads named as such, and now the timeline works for devices with this naming pattern.

The PR also adds a debug print that will print the thread names to console in the event that we do not find a ui or gpu thread id. This will make it easier to detect unrecognized thread names in the future if we get reports that the timeline is "not working".