### PR TITLE
Re-enable Windows builds for all except Flutter stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,17 @@ matrix:
     #     we can build on an older SDK.
     - dart: stable
       env: BOT=main
+    # TODO(dantup): Temporarily skip stable Flutter builds on Windows because the
+    # Dart SDK download can take too long due to Invoke-WebRequest performance.
+    # This block can be removed when https://github.com/flutter/flutter/pull/37792
+    # rolls to the Flutter stable channel.
+    - os: windows
+      dart:  stable
+      env: BOT=flutter_sdk_tests
+    # TODO(dantup): Skip Flutter builds until we understand/fix Flutter crashing
+    # with "failed to delete build/assets: file is locked by another process".
+    - os: windows
+      env: BOT=flutter_sdk_tests
   include:
     - dart: "dev/raw/latest"
       env: BOT=packages

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
   - osx
+  - windows
 
 language: dart
 dart:

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -384,7 +384,7 @@ class WebdevFixture {
       environment['DART_VM_OPTIONS'] = '';
     }
 
-    // Run the snapshot directly instead of going bia pub.bat so that on Windows
+    // Run the snapshot directly instead of going via pub.bat so that on Windows
     // when we send kill() it gets passed to Dart and doesn't sometimes terminate
     // the shell and leave the Dart process behind.
     final executable = Platform.executable;

--- a/packages/devtools/test/integration_tests/integration.dart
+++ b/packages/devtools/test/integration_tests/integration.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
+import 'package:path/path.dart' as path;
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     show ConsoleAPIEvent, RemoteObject;
 
@@ -383,10 +384,19 @@ class WebdevFixture {
       environment['DART_VM_OPTIONS'] = '';
     }
 
-    final List<String> cliArgs =
-        ['global', 'run', 'webdev'].followedBy(buildArgs).toList();
+    // Run the snapshot directly instead of going bia pub.bat so that on Windows
+    // when we send kill() it gets passed to Dart and doesn't sometimes terminate
+    // the shell and leave the Dart process behind.
+    final executable = Platform.executable;
+    final pubSnapshotPath = path.join(
+      File(executable).parent.path,
+      'snapshots',
+      'pub.dart.snapshot',
+    );
 
-    final executable = Platform.isWindows ? 'pub.bat' : 'pub';
+    final List<String> cliArgs = [pubSnapshotPath, 'global', 'run', 'webdev']
+        .followedBy(buildArgs)
+        .toList();
 
     if (verbose) {
       print('Running "$executable" with args: ${cliArgs.join(' ')}');


### PR DESCRIPTION
I disabled Windows builds because we had a lot of failures lately, as a result of several different issues that coincidentally started cropping up around the same time.

1. [Travis has having network issues](https://www.traviscistatus.com/incidents/hl4vqb7hvv5n)
2. [Flutter's Dart SDK downloads are super-slow without BITS](https://github.com/flutter/flutter/issues/37789)
3. The Chocolate package for Google-Chrome was failing due to a new installer and outdated hash
4. Flutter was sometimes failing to clear its build folder as part of a build

Most of these are fixed:

1. Travis has rolled back the change that caused the network issue.
2. I've [fixed the Flutter download issue](https://github.com/flutter/flutter/pull/37792) on `master` (so as a result, this PR temporarily excludes Flutter tests on stable)
3. The updated chocolatey package has been approved

The last one I can't repro locally, and I haven't seen it a lot - so I'm opening this PR to see how it goes. If we continue to see (4) we can drop the Flutter tests for Windows too until we can track it down.