### PR TITLE
Fix thread name bug.

### DIFF
--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -85,11 +85,13 @@ class TimelineService {
       final name = event.args['name'];
       threadNames.add(name);
 
-      // iOS - io.flutter.1.ui, Android - 1.ui, Dream (g3) - io.flutter.ui
+      // iOS: "io.flutter.1.ui (12652)", Android: "1.ui (12652)",
+      // Dream (g3): "io.flutter.ui (12652)"
       if (name.contains('.ui')) {
         uiThreadId = event.threadId;
       }
-      // iOS - io.flutter.1.gpu, Android - 1.gpu, Dream (g3) - io.flutter.gpu
+      // iOS: "io.flutter.1.gpu (12651)", Android: "1.gpu (12651)",
+      // Dream (g3): "io.flutter.gpu (12651)"
       if (name.contains('.gpu')) {
         gpuThreadId = event.threadId;
       }

--- a/packages/devtools/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools/lib/src/timeline/timeline_service.dart
@@ -86,11 +86,11 @@ class TimelineService {
       threadNames.add(name);
 
       // iOS - io.flutter.1.ui, Android - 1.ui, Dream (g3) - io.flutter.ui
-      if (name.endsWith('.ui')) {
+      if (name.contains('.ui')) {
         uiThreadId = event.threadId;
       }
       // iOS - io.flutter.1.gpu, Android - 1.gpu, Dream (g3) - io.flutter.gpu
-      if (name.endsWith('.gpu')) {
+      if (name.contains('.gpu')) {
         gpuThreadId = event.threadId;
       }
     }


### PR DESCRIPTION
Check that a thread name contains the desired pattern (".ui" or ".gpu") instead of checking that it ends with the pattern.