### PR TITLE
Polish button collapsing for small screen widths.

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -243,7 +243,7 @@ class DebuggerScreen extends Screen {
               div(c: 'section flex-wrap')
                 ..layoutHorizontal()
                 ..add(<CoreElement>[
-                  div(c: 'btn-group collapsible-700 flex-no-wrap')
+                  div(c: 'btn-group collapsible-785 flex-no-wrap')
                     ..add(<CoreElement>[
                       pauseButton,
                       resumeButton,

--- a/packages/devtools/lib/src/inspector/inspector.dart
+++ b/packages/devtools/lib/src/inspector/inspector.dart
@@ -73,7 +73,7 @@ class InspectorScreen extends Screen {
     final CoreElement buttonSection = div(c: 'section')
       ..layoutHorizontal()
       ..add(<CoreElement>[
-        div(c: 'btn-group collapsible-700 nowrap')
+        div(c: 'btn-group collapsible-750 nowrap')
           ..add([
             ServiceExtensionButton(
               extensions.toggleSelectWidgetMode,

--- a/packages/devtools/lib/src/main.dart
+++ b/packages/devtools/lib/src/main.dart
@@ -78,7 +78,7 @@ class PerfToolFramework extends Framework {
       final CoreElement link = CoreElement('a')
         ..add(<CoreElement>[
           span(c: 'octicon ${screen.iconClass}'),
-          span(text: ' ${screen.name}', c: 'optional-950')
+          span(text: ' ${screen.name}', c: 'optional-1060')
         ]);
       if (screen.disabled) {
         link

--- a/packages/devtools/lib/src/memory/memory.dart
+++ b/packages/devtools/lib/src/memory/memory.dart
@@ -246,13 +246,14 @@ class MemoryScreen extends Screen with SetStateMixin {
             ..layoutHorizontal()
             ..clazz('align-items-center')
             ..add(<CoreElement>[
-              div(c: 'btn-group flex-no-wrap')
+              div(c: 'btn-group collapsible-885 flex-no-wrap')
                 ..add(<CoreElement>[
                   pauseButton,
                   resumeButton,
                 ]),
               div()..flex(),
-              div(c: 'btn-group collapsible-700 flex-no-wrap margin-left')
+              div(c: 'btn-group collapsible-785 nowrap margin-left')
+                ..flex()
                 ..add(<CoreElement>[
                   vmSearchField,
                   vmMemorySearchButton,

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -185,24 +185,27 @@ class TimelineScreen extends Screen {
         div(text: 'Show frames', c: 'checkbox-text')
       ]);
 
+    // TODO(kenzie): once [enableMultiModeTimeline] is enabled by default,
+    // adjust collapsible-xxx CSS classes to account for timeline mode checkbox.
     upperButtonSection = div(c: 'section')
       ..layoutHorizontal()
       ..add(<CoreElement>[
-        div(c: 'btn-group')
+        div(c: 'btn-group collapsible-885')
           ..add([
             pauseButton,
             resumeButton,
             _startRecordingButton,
             _stopRecordingButton,
           ]),
-        clearButton,
+        div(c: 'btn-group collapsible-685')..add(clearButton),
         exitOfflineModeButton,
         div()..flex(),
         debugButtonSection = div(c: 'btn-group'),
         if (enableMultiModeTimeline) _frameBasedTimelineSettingContainer,
         _profileGranularitySelector.selector..clazz('margin-left'),
-        performanceOverlayButton.button..clazz('margin-left'),
-        exportButton,
+        div(c: 'btn-group collapsible-685 margin-left')
+          ..add(performanceOverlayButton.button),
+        div(c: 'btn-group collapsible-685')..add(exportButton),
       ]);
 
     _maybeAddDebugButtons();

--- a/packages/devtools/web/index.html
+++ b/packages/devtools/web/index.html
@@ -88,12 +88,12 @@
 
     <nav class="masthead-nav" id="main-nav">
         <!-- add the known pages -->
-        <a disabled><span class="octicon octicon-device-mobile"></span><span> <span class="optional-950">Flutter Inspector</span></span></a>
-        <a disabled><span class="octicon octicon-pulse"></span><span> <span class="optional-950">Timeline</span></span></a>
-        <a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-950">Performance</span></span></a>
-        <a disabled><span class="octicon octicon-package"></span><span> <span class="optional-950">Memory</span></span></a>
-        <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-950">Debugger</span></span></a>
-        <a disabled><span class="octicon octicon-clippy"></span><span> <span class="optional-950">Logging</span></span></a>
+        <a disabled><span class="octicon octicon-device-mobile"></span><span> <span class="optional-1060">Flutter Inspector</span></span></a>
+        <a disabled><span class="octicon octicon-pulse"></span><span> <span class="optional-1060">Timeline</span></span></a>
+        <a disabled><span class="octicon octicon-dashboard"></span><span> <span class="optional-1060">Performance</span></span></a>
+        <a disabled><span class="octicon octicon-package"></span><span> <span class="optional-1060">Memory</span></span></a>
+        <a disabled><span class="octicon octicon-bug"></span><span> <span class="optional-1060">Debugger</span></span></a>
+        <a disabled><span class="octicon octicon-clippy"></span><span> <span class="optional-1060">Logging</span></span></a>
     </nav>
 
     <div id="global-actions" class="masthead-nav"></div>

--- a/packages/devtools/web/styles.css
+++ b/packages/devtools/web/styles.css
@@ -1093,24 +1093,64 @@ span.strong {
 
 @media all and (max-width: 550px) { .optional-550 { display: none; } }
 @media all and (max-width: 700px) { .optional-700 { display: none; } }
-@media all and (max-width: 850px) { .optional-850 { display: none; } }
-@media all and (max-width: 950px) { .optional-950 { display: none; } }
 @media all and (max-width: 1000px) { .optional-1000 { display: none; } }
-@media all and (max-width: 1200px) { .optional-1200 { display: none; } }
-@media all and (max-width: 1400px) { .optional-1400 { display: none; } }
-
+@media all and (max-width: 1060px) { .optional-1060 { display: none; } }
 
 /*
  * Support tagging btn-groups with collapsible that can have children tagged
  * with optional-text to be hidden when the page is below a certain threshold.
  */
 
-@media all and (max-width: 700px) {
-    .btn-group.collapsible-700 .optional-text span:not(.octicon) {
+@media all and (max-width: 685px) {
+    .btn-group.collapsible-685 .optional-text span:not(.octicon) {
         display: none;
     }
 
-    .btn-group.collapsible-700 .btn .flutter-icon {
+    .btn-group.collapsible-685 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 750px) {
+    .btn-group.collapsible-750 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-750 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 785px) {
+    .btn-group.collapsible-785 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-785 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 800px) {
+    .btn-group.collapsible-800 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-800 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 885px) {
+    .btn-group.collapsible-885 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-885 .btn .flutter-icon {
         margin-right: 0;
         box-sizing: content-box;
     }


### PR DESCRIPTION
With some added buttons to page toolbars, button collapse widths have fallen out of date. This CL polishes button collapsing on all devtools pages. Example:
![inspector_buttons](https://user-images.githubusercontent.com/43759233/62794661-7eac0780-ba89-11e9-9d8b-88c886e80e54.gif)

Fixes https://github.com/flutter/devtools/issues/900.
Fixes https://github.com/flutter/devtools/issues/901.