### PR TITLE
adjust some of the logging flutter.error presentation

### DIFF
--- a/packages/devtools/lib/src/inspector/inspector.css
+++ b/packages/devtools/lib/src/inspector/inspector.css
@@ -82,7 +82,7 @@ messages beautiful.
 }
 
 .inspector-style-singleLine {
-    
+    min-height: 1em;
 }
 
 .inspector-style-headerLine {
@@ -120,14 +120,14 @@ messages beautiful.
 .inspector-level-hint {
     background-color: var(--hint-background);
     color: var(--inspector-hint-color);
-    padding: 8px;
-    margin: 5px 0;
+    padding: 4px 0;
+    margin: 12px 0;
 }
 
 .inspector-level-summary {
   font-weight: 700;
   color: var(--error-summary-color);
-  font-size: 16px;
+  font-size: 14px;
 }
 
 .inspector-level-off {


### PR DESCRIPTION
- adjust some of the logging flutter.error presentation

This adds some whitespace after the summary line, and adjusts some other minor css.

<img width="547" alt="Screen Shot 2019-08-09 at 8 31 16 AM" src="https://user-images.githubusercontent.com/1269969/62796306-c5036580-ba8d-11e9-87ab-fc7ec701b922.png">
