### PR TITLE
Add generated environment files to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ pubspec.lock
 # .DS_Store is a file that stores custom attributes of its containing folder,
 # such as the position of icons or the choice of a background image.
 .DS_Store
+
+# A generated file not intended to be checked in to version control
+fixtures/*/ios/Flutter/flutter_export_environment.sh
+


### PR DESCRIPTION
I saw when running tests locally that these file were getting modified, so I thought it would be helpful to add to gitignore.  Let me know if this is a good change or if there's another way you'd like to hide this.