### PR TITLE
Move mockito dependency to dev_dependencies

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.6 - 2019-08-14
+* Bug fix: dependency on mockito is removed.
+
 ## 0.1.6 - 2019-08-06
 * Support `sse` and `sses` schemes for connection with a running app.
 

--- a/packages/devtools/lib/devtools.dart
+++ b/packages/devtools/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.1.7';
+const String version = '0.1.6-dev.2';

--- a/packages/devtools/lib/devtools.dart
+++ b/packages/devtools/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.1.6-dev.2';
+const String version = '0.1.7';

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -3,7 +3,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 
 # Note: when updating this version, please update the corresponding entry in
 # lib/devtools.dart.
-version: 0.1.6-dev.2
+version: 0.1.7
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   intl: ^0.15.0
   js: ^0.6.1+1
   meta: ^1.1.0
-  mockito: 4.0.0
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
@@ -47,6 +46,7 @@ dependencies:
   sse: ^2.0.0
 
 dev_dependencies:
+  mockito: ^4.0.0
   build_runner: ^1.3.0
   build_test: ^0.10.0
   build_web_compilers: '>=1.2.0 <3.0.0'

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -3,7 +3,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 
 # Note: when updating this version, please update the corresponding entry in
 # lib/devtools.dart.
-version: 0.1.7
+version: 0.1.6-dev.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
devtools currently has a tight version constraint on mockito, but this is only used in testing. As a result, flutter_tools is too constrained to roll in an updated dwds. 

Move the dependency to dev_dependencies and update with a caret. This also bumps the version for publishing.

