### PR TITLE
Drop dependency on RxDart

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -167,6 +167,7 @@ class DebuggerScreen extends Screen {
       _updatePauseButton(disabled: false);
     });
 
+    // TODO(#926): Is this necessary?
     _updatePauseButton(disabled: debuggerState.isPaused.value);
     _updateResumeButton(disabled: !debuggerState.isPaused.value);
     debuggerState.isPaused.addListener(() {
@@ -181,6 +182,7 @@ class DebuggerScreen extends Screen {
     breakOnExceptionControl.onPauseModeChanged.listen((String mode) {
       debuggerState.setExceptionPauseMode(mode);
     });
+    // TODO(#926): Is this necessary?
     breakOnExceptionControl.exceptionPauseMode =
         debuggerState.exceptionPauseMode.value;
     debuggerState.exceptionPauseMode.addListener(() {
@@ -304,7 +306,7 @@ class DebuggerScreen extends Screen {
       minSize: [200, 60],
     );
 
-    debuggerState.supportsSteppingListenable.addListener(() {
+    void updateStepCapabilities() {
       final value = debuggerState.supportsSteppingListenable.value;
       stepIn.enabled = value;
 
@@ -313,7 +315,12 @@ class DebuggerScreen extends Screen {
       // meaningful.
       stepOver.enabled = value && (debuggerState.lastEvent.topFrame != null);
       stepOut.enabled = value && (debuggerState.lastEvent.topFrame != null);
-    });
+    }
+
+    // TODO(#926): Is this necessary?
+    updateStepCapabilities();
+    debuggerState.supportsSteppingListenable
+        .addListener(updateStepCapabilities);
 
     stepOver.click(() => debuggerState.stepOver());
     stepIn.click(() => debuggerState.stepIn());
@@ -335,11 +342,13 @@ class DebuggerScreen extends Screen {
 
     sourceEditor = SourceEditor(codeMirror, debuggerState);
 
+    // TODO(#926): Is this necessary?
+    sourceEditor.setBreakpoints(debuggerState.breakpoints.value);
     debuggerState.breakpoints.addListener(() {
       sourceEditor.setBreakpoints(debuggerState.breakpoints.value);
     });
 
-    debuggerState.isPaused.addListener(() async {
+    void updateFrames() async {
       if (debuggerState.isPaused.value) {
         // Check for async causal frames; fall back to using regular sync frames.
         final Stack stack = await debuggerState.getStack();
@@ -373,10 +382,13 @@ class DebuggerScreen extends Screen {
         callStackView.clearFrames();
         sourceEditor.clearExecutionPoint();
       }
-    });
+    }
 
-    // Update the status line.
-    debuggerState.isPaused.addListener(() async {
+    // TODO(#926): Is this necessary?
+    updateFrames();
+    debuggerState.isPaused.addListener(updateFrames);
+
+    void updateStatusLine() async {
       if (debuggerState.isPaused.value &&
           debuggerState.lastEvent.topFrame != null) {
         final Frame topFrame = debuggerState.lastEvent.topFrame;
@@ -393,7 +405,11 @@ class DebuggerScreen extends Screen {
       } else {
         deviceStatus.element.text = '';
       }
-    });
+    }
+
+    // TODO(#926): Is this necessary?
+    updateStatusLine();
+    debuggerState.isPaused.addListener(updateStatusLine);
 
     callStackView.onSelectionChanged.listen((Frame frame) async {
       if (frame == null) {
@@ -618,6 +634,8 @@ class DebuggerScreen extends Screen {
       ..flex()
       ..layoutVertical();
 
+    // TODO(#926): Is this necessary?
+    breakpointsView.showBreakpoints(debuggerState.breakpoints.value);
     debuggerState.breakpoints.addListener(() {
       breakpointsView.showBreakpoints(debuggerState.breakpoints.value);
     });

--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -307,7 +307,7 @@ class DebuggerScreen extends Screen {
     );
 
     void updateStepCapabilities() {
-      final value = debuggerState.supportsSteppingListenable.value;
+      final value = debuggerState.supportsStepping.value;
       stepIn.enabled = value;
 
       // Only enable step over and step out if we're paused at a frame. When
@@ -319,8 +319,7 @@ class DebuggerScreen extends Screen {
 
     // TODO(#926): Is this necessary?
     updateStepCapabilities();
-    debuggerState.supportsSteppingListenable
-        .addListener(updateStepCapabilities);
+    debuggerState.supportsStepping.addListener(updateStepCapabilities);
 
     stepOver.click(() => debuggerState.stepOver());
     stepIn.click(() => debuggerState.stepIn());

--- a/packages/devtools/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools/lib/src/debugger/debugger_state.dart
@@ -26,18 +26,18 @@ class DebuggerState {
 
   final _hasFrames = ValueNotifier<bool>(false);
   ValueNotifier<bool> _supportsStepping;
-  ValueListenable<bool> get supportsSteppingListenable =>
-      _supportsStepping ??= () {
-        final notifier =
-            ValueNotifier<bool>(_isPaused.value && _hasFrames.value);
-        void update() {
-          notifier.value = _isPaused.value && _hasFrames.value;
-        }
+  ValueListenable<bool> get supportsSteppingListenable {
+    return _supportsStepping ??= () {
+      final notifier = ValueNotifier<bool>(_isPaused.value && _hasFrames.value);
+      void update() {
+        notifier.value = _isPaused.value && _hasFrames.value;
+      }
 
-        _isPaused.addListener(update);
-        _hasFrames.addListener(update);
-        return notifier;
-      }();
+      _isPaused.addListener(update);
+      _hasFrames.addListener(update);
+      return notifier;
+    }();
+  }
 
   Event lastEvent;
 

--- a/packages/devtools/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools/lib/src/debugger/debugger_state.dart
@@ -291,7 +291,7 @@ class DebuggerState {
   }
 }
 
-class _Property<T> implements StreamSink<T> {
+class _Property<T> {
   _Property([T initialValue]) : _value = initialValue;
 
   T _value;
@@ -300,24 +300,8 @@ class _Property<T> implements StreamSink<T> {
   final _controller = StreamController<T>.broadcast();
   Stream<T> get stream => _controller.stream;
 
-  @override
   void add(T value) {
     _value = value;
     _controller.add(value);
   }
-
-  @override
-  void addError(Object error, [StackTrace stackTrace]) {
-    _controller.addError(error, stackTrace);
-  }
-
-  @override
-  Future addStream(Stream<T> stream) =>
-      stream.listen(add).asFuture().catchError(addError);
-
-  @override
-  Future close() => _controller.close();
-
-  @override
-  Future get done => _controller.done;
 }

--- a/packages/devtools/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools/lib/src/debugger/debugger_state.dart
@@ -26,7 +26,7 @@ class DebuggerState {
 
   final _hasFrames = ValueNotifier<bool>(false);
   ValueNotifier<bool> _supportsStepping;
-  ValueListenable<bool> get supportsSteppingListenable {
+  ValueListenable<bool> get supportsStepping {
     return _supportsStepping ??= () {
       final notifier = ValueNotifier<bool>(_isPaused.value && _hasFrames.value);
       void update() {

--- a/packages/devtools/lib/src/model/model.dart
+++ b/packages/devtools/lib/src/model/model.dart
@@ -121,7 +121,7 @@ class App {
 
   Future<String> debuggerGetState([dynamic _]) async {
     final DebuggerScreen screen = framework.getScreen('debugger');
-    return screen.debuggerState.isPaused ? 'paused' : 'running';
+    return screen.debuggerState.isPaused.value ? 'paused' : 'running';
   }
 
   Future<String> debuggerGetConsoleContents([dynamic _]) async {
@@ -162,9 +162,9 @@ class App {
 
   Future<List<String>> debuggerGetBreakpoints([dynamic _]) async {
     final DebuggerScreen screen = framework.getScreen('debugger');
-    return screen.debuggerState.breakpoints.map((Breakpoint breakpoint) {
-      return breakpoint.id;
-    }).toList();
+    return screen.debuggerState.breakpoints.value
+        .map((breakpoint) => breakpoint.id)
+        .toList();
   }
 
   Future<bool> debuggerSupportsScripts([dynamic _]) async {

--- a/packages/devtools/lib/src/ui/fake_flutter/change_notifier.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/change_notifier.dart
@@ -1,0 +1,221 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of 'fake_flutter.dart';
+
+/// An object that maintains a list of listeners.
+///
+/// The listeners are typically used to notify clients that the object has been
+/// updated.
+///
+/// There are two variants of this interface:
+///
+///  * [ValueListenable], an interface that augments the [Listenable] interface
+///    with the concept of a _current value_.
+///
+///  * [Animation], an interface that augments the [ValueListenable] interface
+///    to add the concept of direction (forward or reverse).
+///
+/// Many classes in the Flutter API use or implement these interfaces. The
+/// following subclasses are especially relevant:
+///
+///  * [ChangeNotifier], which can be subclassed or mixed in to create objects
+///    that implement the [Listenable] interface.
+///
+///  * [ValueNotifier], which implements the [ValueListenable] interface with
+///    a mutable value that triggers the notifications when modified.
+///
+/// The terms "notify clients", "send notifications", "trigger notifications",
+/// and "fire notifications" are used interchangeably.
+///
+/// See also:
+///
+///  * [AnimatedBuilder], a widget that uses a builder callback to rebuild
+///    whenever a given [Listenable] triggers its notifications. This widget is
+///    commonly used with [Animation] subclasses, wherein its name. It is a
+///    subclass of [AnimatedWidget], which can be used to create widgets that
+///    are driven from a [Listenable].
+///  * [ValueListenableBuilder], a widget that uses a builder callback to
+///    rebuild whenever a [ValueListenable] object triggers its notifications,
+///    providing the builder with the value of the object.
+///  * [InheritedNotifier], an abstract superclass for widgets that use a
+///    [Listenable]'s notifications to trigger rebuilds in descendant widgets
+///    that declare a dependency on them, using the [InheritedWidget] mechanism.
+///  * [new Listenable.merge], which creates a [Listenable] that triggers
+///    notifications whenever any of a list of other [Listenable]s trigger their
+///    notifications.
+abstract class Listenable {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const Listenable();
+
+  /// Register a closure to be called when the object notifies its listeners.
+  void addListener(VoidCallback listener);
+
+  /// Remove a previously registered closure from the list of closures that the
+  /// object notifies.
+  void removeListener(VoidCallback listener);
+}
+
+/// An interface for subclasses of [Listenable] that expose a [value].
+///
+/// This interface is implemented by [ValueNotifier<T>] and [Animation<T>], and
+/// allows other APIs to accept either of those implementations interchangeably.
+abstract class ValueListenable<T> extends Listenable {
+  /// Abstract const constructor. This constructor enables subclasses to provide
+  /// const constructors so that they can be used in const expressions.
+  const ValueListenable();
+
+  /// The current value of the object. When the value changes, the callbacks
+  /// registered with [addListener] will be invoked.
+  T get value;
+}
+
+/// A class that can be extended or mixed in that provides a change notification
+/// API using [VoidCallback] for notifications.
+///
+/// [ChangeNotifier] is optimized for small numbers (one or two) of listeners.
+/// It is O(N) for adding and removing listeners and O(N²) for dispatching
+/// notifications (where N is the number of listeners).
+///
+/// See also:
+///
+///  * [ValueNotifier], which is a [ChangeNotifier] that wraps a single value.
+class ChangeNotifier implements Listenable {
+  var _listeners = <VoidCallback>[];
+
+  bool _debugAssertNotDisposed() {
+    assert(() {
+      if (_listeners == null) {
+        throw FlutterError('A $runtimeType was used after being disposed.\n'
+            'Once you have called dispose() on a $runtimeType, it can no longer be used.');
+      }
+      return true;
+    }());
+    return true;
+  }
+
+  /// Whether any listeners are currently registered.
+  ///
+  /// Clients should not depend on this value for their behavior, because having
+  /// one listener's logic change when another listener happens to start or stop
+  /// listening will lead to extremely hard-to-track bugs. Subclasses might use
+  /// this information to determine whether to do any work when there are no
+  /// listeners, however; for example, resuming a [Stream] when a listener is
+  /// added and pausing it when a listener is removed.
+  ///
+  /// Typically this is used by overriding [addListener], checking if
+  /// [hasListeners] is false before calling `super.addListener()`, and if so,
+  /// starting whatever work is needed to determine when to call
+  /// [notifyListeners]; and similarly, by overriding [removeListener], checking
+  /// if [hasListeners] is false after calling `super.removeListener()`, and if
+  /// so, stopping that same work.
+  @protected
+  bool get hasListeners {
+    assert(_debugAssertNotDisposed());
+    return _listeners.isNotEmpty;
+  }
+
+  /// Register a closure to be called when the object changes.
+  ///
+  /// This method must not be called after [dispose] has been called.
+  @override
+  void addListener(VoidCallback listener) {
+    assert(_debugAssertNotDisposed());
+    _listeners.add(listener);
+  }
+
+  /// Remove a previously registered closure from the list of closures that are
+  /// notified when the object changes.
+  ///
+  /// If the given listener is not registered, the call is ignored.
+  ///
+  /// This method must not be called after [dispose] has been called.
+  ///
+  /// If a listener had been added twice, and is removed once during an
+  /// iteration (i.e. in response to a notification), it will still be called
+  /// again. If, on the other hand, it is removed as many times as it was
+  /// registered, then it will no longer be called. This odd behavior is the
+  /// result of the [ChangeNotifier] not being able to determine which listener
+  /// is being removed, since they are identical, and therefore conservatively
+  /// still calling all the listeners when it knows that any are still
+  /// registered.
+  ///
+  /// This surprising behavior can be unexpectedly observed when registering a
+  /// listener on two separate objects which are both forwarding all
+  /// registrations to a common upstream object.
+  @override
+  void removeListener(VoidCallback listener) {
+    assert(_debugAssertNotDisposed());
+    _listeners.remove(listener);
+  }
+
+  /// Discards any resources used by the object. After this is called, the
+  /// object is not in a usable state and should be discarded (calls to
+  /// [addListener] and [removeListener] will throw after the object is
+  /// disposed).
+  ///
+  /// This method should only be called by the object's owner.
+  @mustCallSuper
+  void dispose() {
+    assert(_debugAssertNotDisposed());
+    _listeners = null;
+  }
+
+  /// Call all the registered listeners.
+  ///
+  /// Call this method whenever the object changes, to notify any clients the
+  /// object may have. Listeners that are added during this iteration will not
+  /// be visited. Listeners that are removed during this iteration will not be
+  /// visited after they are removed.
+  ///
+  /// Exceptions thrown by listeners will be caught and reported using
+  /// [FlutterError.reportError].
+  ///
+  /// This method must not be called after [dispose] has been called.
+  ///
+  /// Surprising behavior can result when reentrantly removing a listener (i.e.
+  /// in response to a notification) that has been registered multiple times.
+  /// See the discussion at [removeListener].
+  @protected
+  @visibleForTesting
+  void notifyListeners() {
+    assert(_debugAssertNotDisposed());
+    if (_listeners != null) {
+      final List<VoidCallback> localListeners =
+          List<VoidCallback>.from(_listeners);
+      for (VoidCallback listener in localListeners) {
+        try {
+          if (_listeners.contains(listener)) listener();
+        } catch (exception) {
+          debugPrint('Error while dispatching notifications for $runtimeType.'
+              ' $exception');
+        }
+      }
+    }
+  }
+}
+
+/// A [ChangeNotifier] that holds a single value.
+///
+/// When [value] is replaced, this class notifies its listeners.
+class ValueNotifier<T> extends ChangeNotifier implements ValueListenable<T> {
+  /// Creates a [ChangeNotifier] that wraps this value.
+  ValueNotifier(this._value);
+
+  /// The current value stored in this notifier.
+  ///
+  /// When the value is replaced, this class notifies its listeners.
+  @override
+  T get value => _value;
+  T _value;
+  set value(T newValue) {
+    if (_value == newValue) return;
+    _value = newValue;
+    notifyListeners();
+  }
+
+  @override
+  String toString() => '${describeIdentity(this)}($value)';
+}

--- a/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
+++ b/packages/devtools/lib/src/ui/fake_flutter/fake_flutter.dart
@@ -27,6 +27,7 @@ export 'collections.dart';
 export 'dart_ui/dart_ui.dart' hide TextStyle;
 
 part 'assertions.dart';
+part 'change_notifier.dart';
 part 'diagnosticable.dart';
 part 'foundation.dart';
 part 'print.dart';

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
+  async: ^2.0.0
   codemirror: ^0.5.3
   collection: ^1.14.11
   devtools_server: 0.1.5
@@ -24,7 +25,6 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
-  rxdart: ^0.22.0
   vm_service: 1.1.0
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -12,7 +12,6 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  async: ^2.0.0
   codemirror: ^0.5.3
   collection: ^1.14.11
   devtools_server: 0.1.5


### PR DESCRIPTION
Towards #926

The only usage was of `BehaviorSubject` and there only a small set of
functionality which is cheap to recreate locally. The usage of
`Observable.concat` was a likely bug.

- Copy `ValueNotifier` and related code from flutter into `fake_flutter`.
- Change the interface from exposing `Stream` to exposing `ValueListenable`. Merge the value and change fields into a single listenable getter and move the `.value` to call sites.
- Update the `.listen` calls to use `.addListener` and always eagerly act as if it had changed. Leave some TODO to explore whether this is necessary.