### PR TITLE
Use frame time in CPU profile unavailable message.

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -189,10 +189,17 @@ class _CpuProfiler extends CpuProfiler {
     }
 
     if (_timelineController.timelineData.cpuProfileData.stackFrames.isEmpty) {
+      final frameOffset =
+          _timelineController.timelineData.selectedFrame.time.start;
+      final startTime =
+          _timelineController.timelineData.selectedEvent.time.start -
+              frameOffset;
+      final endTime =
+          _timelineController.timelineData.selectedEvent.time.end - frameOffset;
       showMessage(div(
           text: 'CPU profile unavailable for time range'
-              ' [${_timelineController.timelineData.selectedEvent.time.start.inMicroseconds} -'
-              ' ${_timelineController.timelineData.selectedEvent.time.end.inMicroseconds}]'));
+              ' [${msText(startTime, fractionDigits: 2)} -'
+              ' ${msText(endTime, fractionDigits: 2)}]'));
       return true;
     }
     return false;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/866. In the "CPU profile unavailable..." message, we now reference the time showed in the frame timeline, rather than the time in microseconds sent by the VM.

Before:
![image](https://user-images.githubusercontent.com/43759233/63381047-be59d580-c34c-11e9-9ae0-fe09ccce8faa.png)
After:
![Screen Shot 2019-08-20 at 1 05 47 PM](https://user-images.githubusercontent.com/43759233/63381058-c44fb680-c34c-11e9-86b3-7335d4f8b158.png)
