### PR TITLE
rev to 0.1.6 in preparation for publishing

### DIFF
--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.6
+
+- Rev to using the latest version of `package:vm_service` (1.1.1).
+
 ## 0.1.4
 - The `launchDevTools` service will now register with VMs using public APIs when available, falling back to private APIs otherwise.
 

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.5
+version: 0.1.6
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
`package:devtools_server`:

- rev to 0.1.6 in preparation for publishing (the last published version was `0.1.5`)
