### PR TITLE
reduce deps; de-constrain package:vm_service

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
     ^0.0.2
 #    path: ../../third_party/packages/primer_css
   split:
-    0.0.5
+    ^0.0.5
 #    path: ../../third_party/packages/split
   plotly_js:
     ^0.0.1

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
-  vm_service: 1.1.1
+  vm_service: ^1.1.1
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1
@@ -43,11 +43,11 @@ dependencies:
   sse: ^2.0.0
 
 dev_dependencies:
-  mockito: ^4.0.0
   build_runner: ^1.3.0
   build_test: ^0.10.0
   build_web_compilers: '>=1.2.0 <3.0.0'
   matcher: ^0.12.3
+  mockito: ^4.0.0
   test: ^1.0.0
   webkit_inspection_protocol: '>=0.4.0 <0.6.0'
 

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -12,9 +12,7 @@ environment:
 dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.2
-  meta: ^1.1.0
   path: ^1.6.0
-  pedantic: ^1.7.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  vm_service: 1.1.1
+  vm_service: ^1.1.1


### PR DESCRIPTION
- reduce deps (remove unused deps)
- de-constrain package:vm_service; we're relying on `package:vm_service` using semver going forward (which, it should generally do now)
- fix https://github.com/flutter/devtools/issues/959, https://github.com/flutter/devtools/issues/953
