### PR TITLE
Remove extraneous calls to allowInterop

### DIFF
--- a/packages/devtools/lib/src/timeline/event_details.dart
+++ b/packages/devtools/lib/src/timeline/event_details.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 import 'dart:html' as html;
 
-import 'package:js/js.dart';
-
 import '../globals.dart';
 import '../profiler/cpu_profile_flame_chart.dart';
 import '../profiler/cpu_profile_tables.dart';
@@ -31,9 +29,9 @@ class EventDetails extends CoreElement {
     // TODO(kenzie): clean this code up when
     // https://github.com/dart-lang/html/issues/104 is fixed.
     final observer =
-        html.ResizeObserver(allowInterop((List<dynamic> entries, _) {
+        html.ResizeObserver((List<dynamic> entries, _) {
       cpuProfiler.flameChart.updateForContainerResize();
-    }));
+    });
     observer.observe(element);
 
     assert(tabNav != null);

--- a/packages/devtools/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools/lib/src/timeline/timeline_screen.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:html' as html;
 import 'dart:math' as math;
 
-import 'package:js/js.dart';
 import 'package:meta/meta.dart';
 import 'package:split/split.dart' as split;
 
@@ -277,8 +276,7 @@ class TimelineScreen extends Screen {
     // necessary.
     // TODO(kenzie): clean this code up when
     // https://github.com/dart-lang/html/issues/104 is fixed.
-    final observer =
-        html.ResizeObserver(allowInterop((List<dynamic> entries, _) {
+    final observer = html.ResizeObserver((List<dynamic> entries, _) {
       // TODO(kenzie): observe resizing for recordedTimeline as well. Recorded
       // timeline will not have a selected frame.
       if (flameChartCanvas == null ||
@@ -301,7 +299,7 @@ class TimelineScreen extends Screen {
               TimelineFlameChartCanvas.sectionSpacing,
         ),
       );
-    }));
+    });
     observer.observe(flameChartContainer.element);
   }
 

--- a/packages/devtools/lib/src/ui/viewport_canvas.dart
+++ b/packages/devtools/lib/src/ui/viewport_canvas.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:html' hide VoidCallback;
-import 'dart:js';
 
 import 'package:meta/meta.dart';
 
@@ -171,9 +170,9 @@ class ViewportCanvas extends Object with SetStateMixin {
 
     // TODO(jacobr): clean this code up when
     // https://github.com/dart-lang/html/issues/104 is fixed.
-    _resizeObserver = ResizeObserver(allowInterop((List<dynamic> entries, _) {
+    _resizeObserver = ResizeObserver((List<dynamic> entries, _) {
       _scheduleRebuild();
-    }));
+    });
     _resizeObserver.observe(_element.element);
 
     element.onScroll.listen((_) {


### PR DESCRIPTION
`allowInterop` is intended for use with `package:js` style callback
arguments to `@JS()` annotated APIs, it is unnecessary when using APIs
from `dart:html`.