### PR TITLE
Fix bug where we displayed the Dart SDK version as a Flutter SDK version.

### DIFF
--- a/packages/devtools/lib/src/settings/settings_controller.dart
+++ b/packages/devtools/lib/src/settings/settings_controller.dart
@@ -13,8 +13,9 @@ class SettingsController {
   final Function(String) onSdkVersionChange;
 
   Future<String> _getSdkVersion() async {
-    final isAnyFlutterApp = await serviceManager.connectedApp.isAnyFlutterApp;
-    return '${isAnyFlutterApp ? 'Flutter' : 'Dart'} SDK Version: ${serviceManager.sdkVersion}';
+    // TODO(jacobr): fetch the Flutter version as well as the Dart version once
+    // https://github.com/flutter/devtools/issues/954 is fixed.
+    return 'Dart SDK Version: ${serviceManager.sdkVersion}';
   }
 
   Future<void> entering() async {

--- a/packages/devtools/test/settings_controller_test.dart
+++ b/packages/devtools/test/settings_controller_test.dart
@@ -32,7 +32,7 @@ void main() async {
       expect(flags, null);
 
       await settingsController.entering();
-      expect(sdkVersion, 'Flutter SDK Version: ${serviceManager.sdkVersion}');
+      expect(sdkVersion, 'Dart SDK Version: ${serviceManager.sdkVersion}');
 
       final flagList = await env.service.getFlagList();
       expect(flags.length, flagList.flags.length);


### PR DESCRIPTION
Workaround until https://github.com/flutter/devtools/issues/954
is fixed by adding an extra service to Flutter.