### PR TITLE
fix an NPE in the debugger

### DIFF
--- a/packages/devtools/lib/src/debugger/debugger.dart
+++ b/packages/devtools/lib/src/debugger/debugger.dart
@@ -522,6 +522,9 @@ class DebuggerScreen extends Screen {
       }
 
       final InstanceRef ref = value;
+      if (ref == null) {
+        return null;
+      }
 
       if (ref.valueAsString != null && !ref.valueAsStringIsTruncated) {
         return ref.valueAsString;


### PR DESCRIPTION
- fix an NPE in the debugger when debugging a flutter web app

```
package:devtools/src/debugger/debugger.dart 526:14       <fn>
dart:sdk_internal 22649:7                                _async
package:devtools/src/debugger/debugger.dart 509:56       <fn>
package:devtools/src/debugger/variables_view.dart 71:37  <fn>
dart:sdk_internal 28373:34                               <fn>
```
