### PR TITLE
Replace usage of last private VM service protocol RPCs

### DIFF
--- a/packages/devtools/lib/src/performance/performance_controller.dart
+++ b/packages/devtools/lib/src/performance/performance_controller.dart
@@ -49,6 +49,6 @@ class PerformanceController {
 
   Future<void> reset() async {
     cpuProfileData = null;
-    await cpuProfilerService.clearCpuProfile();
+    await cpuProfilerService.clearCpuSamples();
   }
 }

--- a/packages/devtools/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools/lib/src/profiler/cpu_profile_service.dart
@@ -19,17 +19,15 @@ class CpuProfilerService {
     @required int startMicros,
     @required int extentMicros,
   }) async {
-    final Response response =
-        await serviceManager.service.getCpuProfileTimeline(
+    return await serviceManager.service.getCpuProfileTimeline(
       serviceManager.isolateManager.selectedIsolate.id,
       startMicros,
       extentMicros,
     );
-    return CpuProfileData.parse(response.json);
   }
 
-  Future<Success> clearCpuProfile() async {
+  Future<Success> clearCpuSamples() async {
     return serviceManager.service
-        .clearCpuProfile(serviceManager.isolateManager.selectedIsolate.id);
+        .clearCpuSamples(serviceManager.isolateManager.selectedIsolate.id);
   }
 }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -215,7 +215,7 @@ class VmServiceWrapper implements VmService {
     final traceObject = <String, dynamic>{
       CpuProfileData.sampleCountKey: cpuSamples.sampleCount,
       CpuProfileData.samplePeriodKey: cpuSamples.samplePeriod,
-      CpuProfileData.stackDepthKey: cpuSamples.stackDepth,
+      CpuProfileData.stackDepthKey: cpuSamples.maxStackDepth,
       CpuProfileData.timeOriginKey: cpuSamples.timeOriginMicros,
       CpuProfileData.timeExtentKey: cpuSamples.timeExtentMicros,
       CpuProfileData.stackFramesKey: {},
@@ -256,10 +256,6 @@ class VmServiceWrapper implements VmService {
         'tid': sample.tid,
         'ts': sample.timestamp,
         'cat': 'Dart',
-        'args': {
-          // TODO(bkonyi): !IsVMInteralIsolate only
-          'mode': 'basic',
-        },
         CpuProfileData.stackFrameIdKey: '$isolateId-${tree.frameId}',
       });
     }
@@ -682,18 +678,6 @@ class TrackedFuture<T> {
 }
 
 class _CpuProfileTimelineTree {
-  static final _timelineTreeExpando = Expando<_CpuProfileTimelineTree>();
-  static const kRootIndex = -1;
-  static const kNoFrameId = -1;
-  final CpuSamples samples;
-  final int index;
-  int frameId = kNoFrameId;
-
-  String get name => samples.functions[index].function.name;
-  String get resolvedUrl => samples.functions[index].resolvedUrl;
-
-  final children = <_CpuProfileTimelineTree>[];
-
   factory _CpuProfileTimelineTree.fromCpuSamples(CpuSamples cpuSamples) {
     final root = _CpuProfileTimelineTree._fromIndex(cpuSamples, kRootIndex);
     _CpuProfileTimelineTree current;
@@ -710,6 +694,18 @@ class _CpuProfileTimelineTree {
   }
 
   _CpuProfileTimelineTree._fromIndex(this.samples, this.index);
+
+  static final _timelineTreeExpando = Expando<_CpuProfileTimelineTree>();
+  static const kRootIndex = -1;
+  static const kNoFrameId = -1;
+  final CpuSamples samples;
+  final int index;
+  int frameId = kNoFrameId;
+
+  String get name => samples.functions[index].function.name;
+  String get resolvedUrl => samples.functions[index].resolvedUrl;
+
+  final children = <_CpuProfileTimelineTree>[];
 
   static _CpuProfileTimelineTree getTreeFromSample(CpuSample sample) =>
       _timelineTreeExpando[sample];

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:devtools/src/profiler/cpu_profile_model.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -93,10 +94,15 @@ class VmServiceWrapper implements VmService {
         ));
   }
 
-  Future<Success> clearCpuProfile(String isolateId) async {
-    final response = await _trackFuture('clearCpuProfile',
-        callMethod('_clearCpuProfile', isolateId: isolateId));
-    return response as Success;
+  @override
+  Future<Success> clearCpuSamples(String isolateId) async {
+    if (await isProtocolVersionLessThan(major: 3, minor: 27)) {
+      final response = await _trackFuture('clearCpuProfile',
+          callMethod('_clearCpuProfile', isolateId: isolateId));
+      return response as Success;
+    }
+    return _trackFuture(
+        'clearCpuSamples', _vmService.clearCpuSamples(isolateId));
   }
 
   @override
@@ -176,21 +182,88 @@ class VmServiceWrapper implements VmService {
     );
   }
 
-  // TODO(kenzie): keep track of all private methods we are currently using to
-  // share with the VM team and request that they be made public.
-  Future<Response> getCpuProfileTimeline(
-      String isolateId, int origin, int extent) async {
+  @override
+  Future<CpuSamples> getCpuSamples(
+      String isolateId, int timeOriginMicros, int timeExtentMicros) async {
     return _trackFuture(
-        'getCpuProfileTimeline',
-        callMethod(
-          '_getCpuProfileTimeline',
-          isolateId: isolateId,
-          args: {
-            'tags': 'None',
-            'timeOriginMicros': origin,
-            'timeExtentMicros': extent,
-          },
-        ));
+        'getCpuSamples',
+        _vmService.getCpuSamples(
+            isolateId, timeOriginMicros, timeExtentMicros));
+  }
+
+  Future<CpuProfileData> getCpuProfileTimeline(
+      String isolateId, int origin, int extent) async {
+    if (await isProtocolVersionLessThan(major: 3, minor: 27)) {
+      return _trackFuture(
+          'getCpuProfileTimeline',
+          callMethod(
+            '_getCpuProfileTimeline',
+            isolateId: isolateId,
+            args: {
+              'tags': 'None',
+              'timeOriginMicros': origin,
+              'timeExtentMicros': extent,
+            },
+          )).then((Response response) => CpuProfileData.parse(response.json));
+    }
+    // As of service protocol version 3.27 _getCpuProfileTimeline does not exist
+    // and has been replaced by getCpuSamples. We need to do some processing to
+    // get back to the format we expect.
+    final cpuSamples = await getCpuSamples(isolateId, origin, extent);
+    const int kRootId = 0;
+    int nextId = kRootId;
+    final traceObject = <String, dynamic>{
+      CpuProfileData.sampleCountKey: cpuSamples.sampleCount,
+      CpuProfileData.samplePeriodKey: cpuSamples.samplePeriod,
+      CpuProfileData.stackDepthKey: cpuSamples.stackDepth,
+      CpuProfileData.timeOriginKey: cpuSamples.timeOriginMicros,
+      CpuProfileData.timeExtentKey: cpuSamples.timeExtentMicros,
+      CpuProfileData.stackFramesKey: {},
+      CpuProfileData.traceEventsKey: [],
+    };
+
+    void processStackFrame(
+        _CpuProfileTimelineTree current, _CpuProfileTimelineTree parent) {
+      final id = nextId;
+      ++nextId;
+      current.frameId = id;
+
+      // Skip the root
+      if (id != kRootId) {
+        final key = '$isolateId-$id';
+        traceObject[CpuProfileData.stackFramesKey][key] = {
+          CpuProfileData.nameKey: current.name,
+          CpuProfileData.resolvedUrlKey: current.resolvedUrl,
+          if (parent != null && parent.frameId != 0)
+            CpuProfileData.parentIdKey: '$isolateId-${parent.frameId}',
+        };
+      }
+      for (final child in current.children) {
+        processStackFrame(child, current);
+      }
+    }
+
+    final root = _CpuProfileTimelineTree.fromCpuSamples(cpuSamples);
+    processStackFrame(root, /* parent */ null);
+
+    // Build the trace events.
+    for (final sample in cpuSamples.samples) {
+      final tree = _CpuProfileTimelineTree.getTreeFromSample(sample);
+      traceObject[CpuProfileData.traceEventsKey].add({
+        'ph': 'P', // kind = sample event
+        'name': '', // Blank to keep about:tracing happy
+        'pid': cpuSamples.pid,
+        'tid': sample.tid,
+        'ts': sample.timestamp,
+        'cat': 'Dart',
+        'args': {
+          // TODO(bkonyi): !IsVMInteralIsolate only
+          'mode': 'basic',
+        },
+        CpuProfileData.stackFrameIdKey: '$isolateId-${tree.frameId}',
+      });
+    }
+    return CpuProfileData.parse(traceObject);
   }
 
   @override
@@ -606,4 +679,61 @@ class TrackedFuture<T> {
 
   final String name;
   final Future<T> future;
+}
+
+class _CpuProfileTimelineTree {
+  static final _timelineTreeExpando = Expando<_CpuProfileTimelineTree>();
+  static const kRootIndex = -1;
+  static const kNoFrameId = -1;
+  final CpuSamples samples;
+  final int index;
+  int frameId = kNoFrameId;
+
+  String get name => samples.functions[index].function.name;
+  String get resolvedUrl => samples.functions[index].resolvedUrl;
+
+  final children = <_CpuProfileTimelineTree>[];
+
+  factory _CpuProfileTimelineTree.fromCpuSamples(CpuSamples cpuSamples) {
+    final root = _CpuProfileTimelineTree._fromIndex(cpuSamples, kRootIndex);
+    _CpuProfileTimelineTree current;
+    // TODO handle truncated?
+    for (final sample in cpuSamples.samples) {
+      current = root;
+      // Build an inclusive trie.
+      for (final index in sample.stack.reversed) {
+        current = current._getChild(index);
+      }
+      _timelineTreeExpando[sample] = current;
+    }
+    return root;
+  }
+
+  _CpuProfileTimelineTree._fromIndex(this.samples, this.index);
+
+  static _CpuProfileTimelineTree getTreeFromSample(CpuSample sample) =>
+      _timelineTreeExpando[sample];
+
+  _CpuProfileTimelineTree _getChild(int index) {
+    final length = children.length;
+    int i = 0;
+    while (i < length) {
+      final child = children[i];
+      final childIndex = child.index;
+      if (childIndex == index) {
+        return child;
+      }
+      if (childIndex > index) {
+        break;
+      }
+      ++i;
+    }
+    final child = _CpuProfileTimelineTree._fromIndex(samples, index);
+    if (i < length) {
+      children.insert(i, child);
+    } else {
+      children.add(child);
+    }
+    return child;
+  }
 }

--- a/packages/devtools/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools/lib/src/vm_service_wrapper.dart
@@ -244,6 +244,7 @@ class VmServiceWrapper implements VmService {
       if (id != kRootId) {
         final key = '$isolateId-$id';
         traceObject[CpuProfileData.stackFramesKey][key] = {
+          CpuProfileData.categoryKey: 'Dart',
           CpuProfileData.nameKey: current.name,
           CpuProfileData.resolvedUrlKey: current.resolvedUrl,
           if (parent != null && parent.frameId != 0)

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
-  vm_service: ^1.1.1
+  vm_service: ^1.2.0
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:
     ^0.0.1

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -15,4 +15,4 @@ dependencies:
   path: ^1.6.0
   shelf: ^0.7.4
   shelf_static: ^0.2.8
-  vm_service: ^1.1.1
+  vm_service: ^1.2.0


### PR DESCRIPTION
The timeline page was using the private `_getCpuProfileTimeline` RPC which
is being removed from the VM and replaced with `getCpuSamples`. This new
RPC provides a minimally processed sample buffer which needs to be
further processed by clients.

This change updates`'getCpuProfileTimeline` in vm_service_wrapper.dart to
process the `CpuSamples` response from `getCpuSamples` into the format previously
returned by the `_getCpuProfileTimeline RPC`. In addition,
`_clearCpuProfile` was renamed to `clearCpuSamples` and made public.

This depends on [this CL](https://dart-review.googlesource.com/c/sdk/+/112265) landing in the Dart SDK and `package:vm_service` being updated to support version 3.27 of the service protocol.