### PR TITLE
Make it easier to run local server version

### DIFF
--- a/packages/devtools/.vscode/launch.json
+++ b/packages/devtools/.vscode/launch.json
@@ -10,12 +10,14 @@
 			"preLaunchTask": "pub: build_runner serve"
 		},
 		{
-			"type": "chrome",
+			"type": "dart",
 			"request": "launch",
-			"name": "Build+Run Release dart2js app",
-			"url": "http://localhost:9100",
-			"webRoot": "${workspaceFolder}/build",
-			"preLaunchTask": "Build + Serve Release Build",
+			"name": "Run Server with Release Build",
+			"program": "bin/devtools.dart",
+			"args": [
+				"--launch-browser"
+			],
+			"preLaunchTask": "Build Release Package"
 		},
-	],
+	]
 }

--- a/packages/devtools/.vscode/tasks.json
+++ b/packages/devtools/.vscode/tasks.json
@@ -4,37 +4,12 @@
 		{
 			"label": "Build Release Package",
 			"type": "shell",
-			"command": "pub",
-			"args": [
-				"global",
-				"run",
-				"webdev",
-				"build"
-			],
+			"options": {
+				"cwd": "${workspaceFolder}/../../",
+			},
+			"command": "tool/build_release.sh",
 			"group": "build",
 			"problemMatcher": []
-		},
-		{
-			"label": "Build + Serve Release Build",
-			"type": "shell",
-			"command": "dart",
-			"args": [
-				"bin/devtools.dart"
-			],
-			"group": "build",
-			"problemMatcher": {
-				"owner": "custom",
-				"pattern": {
-					"regexp": "_________________"
-				},
-				"background": {
-					"activeOnStart": true,
-					"beginsPattern": "_________________",
-					"endsPattern": "^Serving DevTools"
-				}
-			},
-			"isBackground": true,
-			"dependsOn": "Build Release Package"
 		}
 	],
 }

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -18,6 +18,7 @@ import 'package:vm_service/utils.dart';
 import 'package:vm_service/vm_service.dart' hide Isolate;
 
 const argHelp = 'help';
+const argLaunchBrowser = 'launch-browser';
 const argMachine = 'machine';
 const argPort = 'port';
 const launchDevToolsService = 'launchDevTools';
@@ -43,6 +44,12 @@ final argParser = new ArgParser()
     negatable: false,
     abbr: 'm',
     help: 'Sets output format to JSON for consumption in tools.',
+  )
+  ..addFlag(
+    argLaunchBrowser,
+    negatable: false,
+    abbr: 'b',
+    help: 'Launches DevTools in a browser immediately at start.',
   );
 
 void serveDevToolsWithArgs(List<String> arguments) async {
@@ -50,14 +57,20 @@ void serveDevToolsWithArgs(List<String> arguments) async {
 
   final help = args[argHelp];
   final bool machineMode = args[argMachine];
+  final bool launchBrowser = args[argLaunchBrowser];
   final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
 
-  serveDevTools(help: help, machineMode: machineMode, port: port);
+  serveDevTools(
+      help: help,
+      machineMode: machineMode,
+      launchBrowser: launchBrowser,
+      port: port);
 }
 
 void serveDevTools({
   bool help = false,
   bool machineMode = false,
+  bool launchBrowser = false,
   int port = 0,
 }) async {
   if (help) {
@@ -113,6 +126,10 @@ void serveDevTools({
     },
     machineMode: machineMode,
   );
+
+  if (launchBrowser) {
+    await Chrome.start([devToolsUrl.toString()]);
+  }
 
   final Stream<Map<String, dynamic>> _stdinCommandStream = stdin
       .transform<String>(utf8.decoder)

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2019 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+set -x #echo on
+
+pushd packages/devtools
+
+rm -rf build
+pub run build_runner build -o web:build --release
+mv ./build/packages ./build/pack
+
+popd

--- a/tool/publish.sh
+++ b/tool/publish.sh
@@ -8,14 +8,14 @@ set -x #echo on
 echo "Editing .gitignore to comment out build directory"
 
 pushd packages/devtools
-
 pub get
+popd
 
-rm -rf build
-pub run build_runner build -o web:build --release
-mv ./build/packages ./build/pack
+tool/build_release.sh
 
+pushd packages/devtools
 perl -pi -e "s/^build\/\$/\# build\//g" .gitignore
+popd
 
 set +x
 echo "Ready to publish."
@@ -24,4 +24,3 @@ echo "Publish by:"
 echo "cd packages/devtools"
 echo "pub publish"
 echo "git checkout .gitignore"
-popd


### PR DESCRIPTION
These changes are to make it easier to dev on the server, including:

1. Extracts the code that builds and renames packages->pack from `publish.sh` into `build_release.sh` to make it reusable when developing locally (without it trashing ignore)
2. Changes the launch config for running the release version to call `build_release.sh` to avoid manually renaming `packages`->`pack` and then run the server in debug mode (instead of just shelling out to Dart) to allow debugging the server
3. Adds a flag `--launch-browser` to immediately launch Chrome at DevTools (this is mostly for dev convenience so the launch config opens up the browser - it may be generally useful though)

The remaining manual step is that you need to change `pubspec.yaml` to have a `path` for the `devtools_server` dependency, but I don't think that one is easily resolvable.