### PR TITLE
Rename method in settings screen.

### DIFF
--- a/packages/devtools/lib/src/settings/settings_controller.dart
+++ b/packages/devtools/lib/src/settings/settings_controller.dart
@@ -33,10 +33,10 @@ class SettingsController {
 
   Future<void> entering() async {
     onFlagListChanged(await serviceManager.service.getFlagList());
-    await _onFlutterVersionChanged();
+    await _listenForFlutterVersionChanges();
   }
 
-  Future<void> _onFlutterVersionChanged() async {
+  Future<void> _listenForFlutterVersionChanges() async {
     if (await serviceManager.connectedApp.isAnyFlutterApp) {
       serviceManager.hasRegisteredService(
         registrations.flutterVersion.service,


### PR DESCRIPTION
side note: we don't await `settingsController.entering()` from `createContent` in `settings_screen.dart` because we can't override the `createContent` method and change the return type to `Future<CoreElement>`. It should still be safe without awaiting `entering`, because the UI is updated automatically via callbacks when the futures and listeners complete with data.