### PR TITLE
Fix bug causing non-dart-web apps to always show up as debug builds.

### DIFF
--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -40,7 +40,7 @@ class ConnectedApp {
     assert(serviceManager.serviceAvailable.isCompleted);
     // Only flutter apps have profile and non-profile builds. If this changes in
     // the future (flutter web), we can modify this check.
-    if (!await isFlutterApp) return false;
+    if (!isRunningOnDartVM || !await isFlutterApp) return false;
 
     try {
       final Isolate isolate = await serviceManager.service

--- a/packages/devtools/lib/src/connected_app.dart
+++ b/packages/devtools/lib/src/connected_app.dart
@@ -38,10 +38,8 @@ class ConnectedApp {
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
-
-    // Flutter web apps and CLI apps do not have profile and non-profile builds.
-    // If this changes in the future (flutter web), we can modify this check.
-    if (!await isDartWebApp) return false;
+    // Only flutter apps have profile and non-profile builds. If this changes in
+    // the future (flutter web), we can modify this check.
     if (!await isFlutterApp) return false;
 
     try {


### PR DESCRIPTION
Any app that was not a dart web app (i.e. any flutter app) was showing up as a debug build. Remove the check against dart web and only check that an app is a flutter app when determining profile build vs debug build.

Fixes https://github.com/flutter/devtools/issues/999