### PR TITLE
Add missing package:meta dependency

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -9,7 +9,6 @@ import 'dart:isolate';
 
 import 'package:args/args.dart';
 import 'package:browser_launcher/browser_launcher.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf;


### PR DESCRIPTION
Due to 
https://github.com/dart-lang/sdk/issues/38255
we don't catch this warning with our travis tests/.