### PR TITLE
Hide Dart VM flags section if connected app is not running on Dart VM.

### DIFF
--- a/packages/devtools/lib/src/info/info_screen.dart
+++ b/packages/devtools/lib/src/info/info_screen.dart
@@ -100,7 +100,8 @@ class InfoScreen extends Screen {
             div(c: 'flag-list-container')
               ..flex()
               ..add(_flagList = div(c: 'flag-list')..layoutVertical()),
-          ]),
+          ])
+          ..hidden(!serviceManager.connectedApp.isRunningOnDartVM)
       ]);
 
     _controller.entering();


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1007