### PR TITLE
use optional parameter in split.js callback

### DIFF
--- a/third_party/packages/split/lib/split.dart
+++ b/third_party/packages/split/lib/split.dart
@@ -13,8 +13,8 @@ import 'package:meta/meta.dart';
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as js_util;
 
-typedef _ElementStyleCallback = Function(
-    Object dimension, Object size, num gutterSize, int index);
+typedef _ElementStyleCallback
+    = Function(Object dimension, Object size, num gutterSize, [int index]);
 typedef _GutterStyleCallback = Function(
     Object dimension, num gutterSize, int index);
 
@@ -104,7 +104,7 @@ Splitter flexSplit(
   return _split(
     parts,
     _SplitOptions(
-      elementStyle: allowInterop((dimension, size, gutterSize, index) {
+      elementStyle: allowInterop((dimension, size, gutterSize, [index]) {
         return js_util.jsify({
           'flex-basis': 'calc($size% - ${gutterSize}px)',
         });
@@ -148,7 +148,7 @@ Splitter fixedSplit(
   return _split(
     parts,
     _SplitOptions(
-      elementStyle: allowInterop((dimension, size, gutterSize, index) {
+      elementStyle: allowInterop((dimension, size, gutterSize, [index]) {
         final Object o = js_util.newObject();
         js_util.setProperty(
           o,

--- a/third_party/packages/split/pubspec.yaml
+++ b/third_party/packages/split/pubspec.yaml
@@ -2,7 +2,7 @@ name: split
 description: Minimal package containing 'split' third_party dependency used by package:devtools.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/split
-version: 0.0.5
+version: 0.0.6
 
 dependencies:
   js: ^0.6.1+1


### PR DESCRIPTION
The fourth argument in the ElementStyle callback should be optional. Without it, destroy() can cause exceptions to occur in dart2js:

```
Uncaught NoSuchMethodError: method not found: 'call'
Receiver: Closure 'minified:qx'
Arguments: ["height", null, 3]
 ```

split.js calls `elementStyle` with either 3 or for arguments. In this case, `destroy()` will call it with 3:

```js
                if (preserveStyles !== true) {
                    var style = elementStyle(
                        dimension,
                        pair.a.size,
                        pair[aGutterSize]
                    );
```

The other call happens when the splitters are initialized

The splitters are working with the DevTools using `webdev serve --release`.

related to #193