### PR TITLE
Bump devtools_server to 0.1.7 with matching vm_service dependency

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 #   path: ../../third_party/packages/ansi_up
   codemirror: ^0.5.10
   collection: ^1.14.11
-  devtools_server: 0.1.6
+  devtools_server: 0.1.7
 #    path: ../devtools_server
   http: ^0.12.0+1
   intl: ^0.16.0


### PR DESCRIPTION
This is required to fix the build:

```
Because devtools_server >=0.1.6 <0.1.7 depends on vm_service 1.1.1 and
  devtools depends on vm_service ^1.2.0, devtools_server >=0.1.6 <0.1.7 is
  forbidden.
```

In https://github.com/flutter/devtools/pull/983 the vm_service dependencies were updated, but devtools still referenced the older version of server without this dependency.