### PR TITLE
Revert "Skip failing integration tests while they're being debugged"

### DIFF
--- a/packages/devtools/test/integration_tests/integration_test.dart
+++ b/packages/devtools/test/integration_tests/integration_test.dart
@@ -31,6 +31,5 @@ void main() {
     group('app', appTests);
     group('logging', loggingTests);
     group('debugging', debuggingTests);
-    // Temporarily skipped while tests are being debugged...
-  }, timeout: const Timeout.factor(4), skip: true);
+  }, timeout: const Timeout.factor(4));
 }


### PR DESCRIPTION
Reverts flutter/devtools#1018

For reasons I cannot explain, on my branch these tests appear to be passing today, so trying here too...