### PR TITLE
Introduce API endpoints to the DevTools server for logging page views

### DIFF
--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -157,6 +157,8 @@ void screen(
   String screenName, [
   int value = 0,
 ]) {
+  // Let the server know that we're logging a screen view event,
+  // then let GA know about the event.
   HttpRequest.request(
     '/api/logScreenView',
     method: 'POST',

--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -7,6 +7,9 @@ library gtags;
 
 // ignore_for_file: non_constant_identifier_names
 
+import 'dart:convert';
+
+import 'package:html_shim/html.dart';
 import 'package:js/js.dart';
 
 import '../../devtools.dart' as devtools show version;
@@ -154,6 +157,11 @@ void screen(
   String screenName, [
   int value = 0,
 ]) {
+  HttpRequest.request(
+    '/api/logScreenView',
+    method: 'POST',
+    sendData: jsonEncode({'screen': screenName}),
+  );
   GTag.event(
     screenName,
     GtagEventDevTools(

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:convert';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
@@ -36,10 +37,49 @@ Future<shelf.Handler> defaultHandler() async {
 
   // Make a handler that delegates based on path.
   return (shelf.Request request) {
+    // The API handler takes all calls to api/.
+    if (Api.canHandle(request)) {
+      return Api.handle(request);
+    }
     return request.url.path.startsWith('packages/')
         // request.change here will strip the `packages` prefix from the path
         // so it's relative to packHandler's root.
         ? packHandler(request.change(path: 'packages'))
         : buildHandler(request);
   };
+}
+
+/// The DevTools server API.
+///
+/// This defines endpoints that serve all requests that come in over api/.
+class Api {
+  static bool canHandle(shelf.Request request) {
+    return request.url.path.startsWith('api/');
+  }
+
+  /// Handles all requests.
+  ///
+  /// To override an API call, pass in a subclass of [Api].
+  static FutureOr<shelf.Response> handle(shelf.Request request, [Api api]) {
+    api ??= Api();
+    switch (request.url.path) {
+      case 'api/logPageView':
+        return api.logPageView(request);
+      default:
+        return api.notImplemented;
+    }
+  }
+
+  /// Logs a page view in the DevTools server.
+  ///
+  /// In the open-source version of DevTools, Google Analytics handles this
+  /// without any need to involve the server.
+  FutureOr<shelf.Response> logPageView(shelf.Request request) async {
+    return notImplemented;
+  }
+
+  /// A [shelf.Response] for API calls that have not been implemented in this
+  /// server.
+  shelf.Response get notImplemented => shelf.Response.notFound(
+      'This API is not implemented in this version of the DevTools server.');
 }

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -37,8 +37,8 @@ Future<shelf.Handler> defaultHandler() async {
   // Make a handler that delegates based on path.
   return (shelf.Request request) {
     // The API handler takes all calls to api/.
-    if (Api.canHandle(request)) {
-      return Api.handle(request);
+    if (ServerApi.canHandle(request)) {
+      return ServerApi.handle(request);
     }
     return request.url.path.startsWith('packages/')
         // request.change here will strip the `packages` prefix from the path
@@ -51,7 +51,7 @@ Future<shelf.Handler> defaultHandler() async {
 /// The DevTools server API.
 ///
 /// This defines endpoints that serve all requests that come in over api/.
-class Api {
+class ServerApi {
   /// Determines whether or not [request] is an API call.
   static bool canHandle(shelf.Request request) {
     return request.url.path.startsWith('api/');
@@ -59,12 +59,12 @@ class Api {
 
   /// Handles all requests.
   ///
-  /// To override an API call, pass in a subclass of [Api].
-  static FutureOr<shelf.Response> handle(shelf.Request request, [Api api]) {
-    api ??= Api();
+  /// To override an API call, pass in a subclass of [ServerApi].
+  static FutureOr<shelf.Response> handle(shelf.Request request, [ServerApi api]) {
+    api ??= ServerApi();
     switch (request.url.path) {
-      case 'api/logPageView':
-        return api.logPageView(request);
+      case 'api/logScreenView':
+        return api.logScreenView(request);
       default:
         return api.notImplemented(request);
     }
@@ -74,7 +74,7 @@ class Api {
   ///
   /// In the open-source version of DevTools, Google Analytics handles this
   /// without any need to involve the server.
-  FutureOr<shelf.Response> logPageView(shelf.Request request) =>
+  FutureOr<shelf.Response> logScreenView(shelf.Request request) =>
       notImplemented(request);
 
   /// A [shelf.Response] for API calls that have not been implemented in this

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -66,7 +66,7 @@ class Api {
       case 'api/logPageView':
         return api.logPageView(request);
       default:
-        return api.notImplemented;
+        return api.notImplemented(request);
     }
   }
 
@@ -74,12 +74,12 @@ class Api {
   ///
   /// In the open-source version of DevTools, Google Analytics handles this
   /// without any need to involve the server.
-  FutureOr<shelf.Response> logPageView(shelf.Request request) async {
-    return notImplemented;
-  }
+  FutureOr<shelf.Response> logPageView(shelf.Request request) =>
+      notImplemented(request);
 
   /// A [shelf.Response] for API calls that have not been implemented in this
   /// server.
-  shelf.Response get notImplemented => shelf.Response.notFound(
-      'This API is not implemented in this version of the DevTools server.');
+  shelf.Response notImplemented(shelf.Request request) => shelf.Response.notFound(
+      '${request.url.path} is not implemented in this version of the DevTools '
+      'server.');
 }

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:convert';
 import 'dart:isolate';
 
 import 'package:path/path.dart' as path;
@@ -53,6 +52,7 @@ Future<shelf.Handler> defaultHandler() async {
 ///
 /// This defines endpoints that serve all requests that come in over api/.
 class Api {
+  /// Determines whether or not [request] is an API call.
   static bool canHandle(shelf.Request request) {
     return request.url.path.startsWith('api/');
   }

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.9
+version: 0.1.10
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
This introduces an abstraction called API that knows how to route from an `/api/foo` request to a specific method.  It should be fairly extensible, as well as overridable by the bazel version of the API.

Comments appreciated on the design (and, of course the implementation).

cc @kenzieschmoll 