### PR TITLE
analyze the case_study/ projects

### DIFF
--- a/case_study/memory_leak/lib/logging.dart
+++ b/case_study/memory_leak/lib/logging.dart
@@ -54,13 +54,13 @@ class TimeStamp {
 class TimeModel {
   TimeModel(this._logging);
 
-  Logging _logging;
+  final Logging _logging;
 
   List<TimeStamp> log = <TimeStamp>[];
 
-  String _time = '';
-  String _date = '';
-  String _meridiem = '';
+  final String _time = '';
+  final String _date = '';
+  final String _meridiem = '';
   Timer _clockUpdateTimer;
   DateTime now = DateTime.now();
 

--- a/case_study/memory_leak/lib/tabs/logger.dart
+++ b/case_study/memory_leak/lib/tabs/logger.dart
@@ -101,14 +101,17 @@ class LoggerState extends State<Logger> {
           // This calculates the actual number of word pairings in the ListView,
           // minus the divider widgets.
           final index = i ~/ 2;
-          if (index < _logging.logs.length)
+
+          if (index < _logging.logs.length) {
             return _buildRow(_logging.logs[index]);
-/*
-          // Emits Idle... lots of them every 100ms.
-          // TOOD(terry): UI needs to appear sluggish clue to look for leaks, etc.
-          else
-            return _buildRow('Idle...');
-*/
+          } else {
+            return null;
+          }
+
+          // // Emits Idle... lots of them every 100ms.
+          // // TOOD(terry): UI needs to appear sluggish clue to look for leaks, etc.
+          // else
+          //   return _buildRow('Idle...');
         });
   }
 }

--- a/case_study/memory_leak/lib/tabs/logger.dart
+++ b/case_study/memory_leak/lib/tabs/logger.dart
@@ -18,7 +18,7 @@ class Logger extends StatefulWidget {
 class LoggerState extends State<Logger> {
   LoggerState(this._logging);
 
-  Logging _logging;
+  final Logging _logging;
   final List<String> _saved = [];
   final _biggerFont = const TextStyle(fontSize: 18.0);
 
@@ -32,6 +32,7 @@ class LoggerState extends State<Logger> {
     );
   }
 
+  // ignore: unused_element
   void _pushSaved() {
     Navigator.of(context).push(
       MaterialPageRoute(

--- a/tool/get_flutter.sh
+++ b/tool/get_flutter.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# Copyright 2019 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Fast fail the script on failures.
+set -ex
+
+if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
+    echo "Cloning stable Flutter branch"
+    git clone https://github.com/flutter/flutter.git --branch stable ../flutter
+
+    # Set the suffix so we use stable goldens.
+    export DART_VM_OPTIONS="-DGOLDENS_SUFFIX=_stable"
+else
+    echo "Cloning master Flutter branch"
+    git clone https://github.com/flutter/flutter.git ../flutter
+fi
+
+pushd ..
+export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
+popd
+
+flutter config --no-analytics

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -13,8 +13,10 @@ pushd packages/devtools
     pub get
 popd
 
-pushd packages/devtools_app
-echo `pwd`
+# Get Flutter.
+if [[ $TRAVIS_OS_NAME != "windows" ]]; then
+    ./tool/get_flutter.sh
+fi
 
 # Add globally activated packages to the path.
 if [[ $TRAVIS_OS_NAME == "windows" ]]; then
@@ -22,6 +24,9 @@ if [[ $TRAVIS_OS_NAME == "windows" ]]; then
 else
     export PATH=$PATH:~/.pub-cache/bin
 fi
+
+pushd packages/devtools_app
+echo `pwd`
 
 if [[ $TRAVIS_OS_NAME == "windows" ]]; then
     echo Installing Google Chrome Stable...
@@ -102,9 +107,6 @@ elif [ "$BOT" = "test_dart2js" ]; then
 
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
-    # Get Flutter.
-    ./tool/get_flutter.sh
-
     flutter doctor
 
     # Put the Flutter version into a variable.
@@ -138,9 +140,6 @@ elif [ "$BOT" = "packages" ]; then
     (cd packages/devtools_testing; pub get)
     (cd packages/html_shim; pub get)
     (cd packages; pub global run tuneup check)
-
-    # Get Flutter.
-    ./tool/get_flutter.sh
 
     # Analyze case_study/
     (cd case_study/memory_leak; flutter pub get)

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -153,6 +153,11 @@ elif [ "$BOT" = "packages" ]; then
     (cd packages/html_shim; pub get)
     (cd packages; pub global run tuneup check)
 
+    # Analyze case_study/
+    (cd case_study/memory_leak; flutter pub get)
+    (cd case_study/platform_channel; flutter pub get)
+    (cd case_study; pub global run tuneup check)
+
     # Analyze third_party/
     (cd third_party/packages/ansi_up; pub get)
     (cd third_party/packages/plotly_js; pub get)

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -103,7 +103,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
     # Get Flutter.
-    ./get_flutter.sh
+    ./tool/get_flutter.sh
 
     flutter doctor
 
@@ -140,7 +140,7 @@ elif [ "$BOT" = "packages" ]; then
     (cd packages; pub global run tuneup check)
 
     # Get Flutter.
-    ./get_flutter.sh
+    ./tool/get_flutter.sh
 
     # Analyze case_study/
     (cd case_study/memory_leak; flutter pub get)

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -103,19 +103,8 @@ elif [ "$BOT" = "test_dart2js" ]; then
 elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
     # Get Flutter.
-    if [ "$TRAVIS_DART_VERSION" = "stable" ]; then
-        echo "Cloning stable Flutter branch"
-        git clone https://github.com/flutter/flutter.git --branch stable ../flutter
+    ./get_flutter.sh
 
-        # Set the suffix so we use stable goldens.
-        export DART_VM_OPTIONS="-DGOLDENS_SUFFIX=_stable"
-    else
-        echo "Cloning master Flutter branch"
-        git clone https://github.com/flutter/flutter.git ../flutter
-    fi
-    cd ..
-    export PATH=`pwd`/flutter/bin:`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
-    flutter config --no-analytics
     flutter doctor
 
     # Put the Flutter version into a variable.
@@ -129,9 +118,6 @@ elif [ "$BOT" = "flutter_sdk_tests" ]; then
 
     # We should be using dart from ../flutter/bin/cache/dart-sdk/bin/dart.
     echo "which dart: " `which dart`
-
-    # Return to the devtools_app directory.
-    cd devtools_app
 
     # Provision our packages using Flutter's version of Dart.
     pub get
@@ -152,6 +138,9 @@ elif [ "$BOT" = "packages" ]; then
     (cd packages/devtools_testing; pub get)
     (cd packages/html_shim; pub get)
     (cd packages; pub global run tuneup check)
+
+    # Get Flutter.
+    ./get_flutter.sh
 
     # Analyze case_study/
     (cd case_study/memory_leak; flutter pub get)


### PR DESCRIPTION
- analyze the `case_study/` projects on the CI

@terrylucas, there's one failure here:

```
  warning • This function has a return type of 'Widget', but doesn't end with a return statement at case_study/memory_leak/lib/tabs/logger.dart:95:22 • (missing_return)
```

I'm not sure if we should address the issue, or if it's important to the case study, and we should ignore it in-line.