### PR TITLE
Prep for devtools_server release 0.1.10.

### DIFF
--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.10
+- Add API for handling http requests.
+- Add API endpoints for `logScreenView` and `getUserId`.
+
 ## 0.1.9
 
 - Support configurable `hostname`.


### PR DESCRIPTION
The version number for devtools_server was already bumped to 0.1.10 in a previous CL, so it is not modified here.
