### PR TITLE
Add support to try ascending ports when binding the server

### DIFF
--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -35,15 +35,22 @@ class DevToolsServerDriver {
 
   bool kill() => _process.kill();
 
-  static Future<DevToolsServerDriver> create() async {
+  static Future<DevToolsServerDriver> create({
+    int port = 0,
+    int tryPorts,
+  }) async {
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
     final args = [
       '../devtools/bin/devtools.dart',
       '--machine',
       '--port',
-      '0',
+      '$port',
     ];
+
+    if (tryPorts != null) {
+      args.addAll(['--try-ports', '$tryPorts']);
+    }
 
     // TODO: This needs enabling once the server version that supports headless
     // has been published.


### PR DESCRIPTION
Fixes #1037.

Note: Test is currently disabled because the tests run using the version of the server from pub. It can be enabled after a version of the server with this code is published, and then the repo updated (this is something that still feels weird but I don't have a good solution for).