### PR TITLE
Allow server to control which page loads, and navigate to page when reusing clients

### DIFF
--- a/packages/devtools_app/lib/src/framework/html_framework.dart
+++ b/packages/devtools_app/lib/src/framework/html_framework.dart
@@ -76,6 +76,9 @@ class HtmlFramework {
 
   HtmlSurveyToast devToolsSurvey;
 
+  Stream<String> get onPageChange => _pageChangeController.stream;
+  final _pageChangeController = StreamController<String>.broadcast();
+
   final HtmlStatusItem defaultAuxiliaryStatus = createLinkStatusItem(
     span()..add(span(text: 'DevTools Docs', c: 'optional-700')),
     href: 'https://flutter.dev/docs/development/tools/devtools/overview',
@@ -367,6 +370,7 @@ class HtmlFramework {
       final bool isCurrent = current.ref == element.attributes['href'];
       e.toggleClass('active', isCurrent);
     }
+    _pageChangeController.add(current.id);
   }
 
   void showMessage({

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -166,6 +166,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
         devToolsServer.notify();
       }
 
+      onPageChange.listen(devToolsServer.notifyCurrentPage);
       serviceManager.onStateChange.listen((connected) {
         try {
           if (connected) {

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -149,7 +149,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
     }
 
     try {
-      devToolsServer = DevToolsServerApiClient();
+      devToolsServer = DevToolsServerApiClient(this);
       // If we showed a notification for DevTools and the user manually clicked
       // into the window instead, we should hide the notification automatically.
       html.window.onFocus.listen((_) => devToolsServer.dismissNotifications());

--- a/packages/devtools_app/lib/src/server_api_client.dart
+++ b/packages/devtools_app/lib/src/server_api_client.dart
@@ -56,6 +56,10 @@ class DevToolsServerApiClient {
     _send('disconnected');
   }
 
+  void notifyCurrentPage(String pageId) {
+    _send('currentPage', {'id': pageId});
+  }
+
   void connectToVm(Map<String, dynamic> requestParams) {
     // Reload the page with the new VM service URI in the querystring.
     // TODO(dantup): Remove this code and replace with code that just reconnects

--- a/packages/devtools_server/lib/src/client_manager.dart
+++ b/packages/devtools_server/lib/src/client_manager.dart
@@ -60,6 +60,9 @@ class DevToolsClient {
           case 'connected':
             _vmServiceUri = Uri.parse(request['params']['uri']);
             return;
+          case 'currentPage':
+            _currentPage = request['params']['id'];
+            return;
           case 'disconnected':
             _vmServiceUri = null;
             return;
@@ -105,4 +108,6 @@ class DevToolsClient {
   Uri _vmServiceUri;
   Uri get vmServiceUri => _vmServiceUri;
   bool get hasConnection => _vmServiceUri != null;
+  String _currentPage;
+  String get currentPage => _currentPage;
 }

--- a/packages/devtools_server/lib/src/client_manager.dart
+++ b/packages/devtools_server/lib/src/client_manager.dart
@@ -94,6 +94,13 @@ class DevToolsClient {
     }));
   }
 
+  Future<void> showPage(String pageId) async {
+    _connection.sink.add(jsonEncode({
+      'method': 'showPage',
+      'params': {'page': pageId}
+    }));
+  }
+
   final SseConnection _connection;
   Uri _vmServiceUri;
   Uri get vmServiceUri => _vmServiceUri;

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -231,7 +231,7 @@ Future<void> _handleClientsList(
   printOutput(
     connectedClients
         .map((c) =>
-            '${c.hasConnection.toString().padRight(5, ' ')} ${c.vmServiceUri.toString()}')
+            '${c.hasConnection.toString().padRight(5, ' ')} ${c.currentPage?.padRight(12, ' ')} ${c.vmServiceUri.toString()}')
         .join('\n'),
     {
       'id': id,
@@ -239,6 +239,7 @@ Future<void> _handleClientsList(
         'clients': connectedClients
             .map((c) => {
                   'hasConnection': c.hasConnection,
+                  'currentPage': c.currentPage,
                   'vmServiceUri': c.vmServiceUri?.toString(),
                 })
             .toList()

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -249,12 +249,16 @@ Future<void> _handleClientsList(
 }
 
 Future<bool> _tryReuseExistingDevToolsInstance(
-    Uri vmServiceUri, bool notifyUser) async {
+  Uri vmServiceUri,
+  String page,
+  bool notifyUser,
+) async {
   // First try to find a client that's already connected to this VM service,
   // and just send the user a notification for that one.
   final existingClient = clients.findExistingConnectedClient(vmServiceUri);
   if (existingClient != null) {
     try {
+      await existingClient.showPage(page);
       if (notifyUser) {
         await existingClient.notify();
       }
@@ -312,9 +316,11 @@ Future<void> registerLaunchDevToolsService(
         final shouldNotify = params != null &&
             params.containsKey('notify') &&
             params['notify'] == true;
+        final page = params != null ? params['page'] : null;
         if (canReuse &&
             await _tryReuseExistingDevToolsInstance(
               vmServiceUri,
+              page,
               shouldNotify,
             )) {
           emitLaunchEvent(reused: true, notified: shouldNotify);
@@ -341,6 +347,7 @@ Future<void> registerLaunchDevToolsService(
           // to the containers loopback IP).
           path: devToolsUri.path.isEmpty ? '/' : devToolsUri.path,
           queryParameters: uriParams,
+          fragment: page,
         );
 
         // TODO(dantup): When ChromeOS has support for tunneling all ports we


### PR DESCRIPTION
Fixes #1053.

This currently doesn't have specific tests. I'm not sure of a good way to verify the page that's loaded in DevTools without building more API between server/DevTools for it to know which page you're on (it's trivial to do, though I'm concerned about making the API larger just for testing as we'll need to maintain compatibility going forwards). If anyone has suggestions, lmk!