### PR TITLE
Move travis helper functions for Windows before they're needed

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -7,29 +7,6 @@
 # Fast fail the script on failures.
 set -ex
 
-# Some integration tests assume the devtools package is up to date and located
-# adjacent to the devtools_app package.
-pushd packages/devtools
-    pub get
-popd
-
-pushd packages/devtools_app
-echo `pwd`
-
-# Add globally activated packages to the path.
-if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-    export PATH=$PATH:$APPDATA/Roaming/Pub/Cache/bin
-else
-    export PATH=$PATH:~/.pub-cache/bin
-fi
-
-if [[ $TRAVIS_OS_NAME == "windows" ]]; then
-    echo Installing Google Chrome Stable...
-    # Install Chrome via Chocolatey while `addons: chrome` doesn't seem to work on Windows yet
-    # https://travis-ci.community/t/installing-google-chrome-stable-but-i-cant-find-it-anywhere/2118
-    choco install googlechrome --acceptlicense --yes --no-progress --ignore-checksums
-fi
-
 # In GitBash on Windows, we have to call pub.bat so we alias `pub` in this script to call the
 # correct one based on the OS.
 function pub {
@@ -53,6 +30,29 @@ function flutter {
         command flutter "$@"
     fi
 }
+
+# Some integration tests assume the devtools package is up to date and located
+# adjacent to the devtools_app package.
+pushd packages/devtools
+    pub get
+popd
+
+pushd packages/devtools_app
+echo `pwd`
+
+# Add globally activated packages to the path.
+if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+    export PATH=$PATH:$APPDATA/Roaming/Pub/Cache/bin
+else
+    export PATH=$PATH:~/.pub-cache/bin
+fi
+
+if [[ $TRAVIS_OS_NAME == "windows" ]]; then
+    echo Installing Google Chrome Stable...
+    # Install Chrome via Chocolatey while `addons: chrome` doesn't seem to work on Windows yet
+    # https://travis-ci.community/t/installing-google-chrome-stable-but-i-cant-find-it-anywhere/2118
+    choco install googlechrome --acceptlicense --yes --no-progress --ignore-checksums
+fi
 
 # Print out the versions and ensure we can call both Dart and Pub.
 dart --version


### PR DESCRIPTION
The windows bots currently fail because the `pub get` at the top of this script doesn't work on Windows+GitBash (needs to be `pub.bat`). We have helper functions to handle this, but they were declared below it, so this should resolve that (it won't solve all the flaky Windows issues, but it should at least get further!).