### PR TITLE
Unskip server tests

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -180,11 +180,8 @@ void main() {
       expect(serverResponse['clients'][0]['vmServiceUri'],
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
-    // TODO(dantup): This test will fail until the devtools pubspec.yaml
-    // references a version of devtools_server that has this support!
-    // Usually we should only skip when not in release mode, since the API only
-    // works in release mode.
-  }, skip: true /*!testInReleaseMode*/);
+    // The API only works in release mode, so skip if not running release tests.
+  }, !testInReleaseMode);
 }
 
 Future<Map<String, dynamic>> launchDevTools({bool reuseWindows = false}) async {

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -181,7 +181,7 @@ void main() {
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
     // The API only works in release mode, so skip if not running release tests.
-  }, !testInReleaseMode);
+  }, skip: !testInReleaseMode);
 }
 
 Future<Map<String, dynamic>> launchDevTools({bool reuseWindows = false}) async {

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -235,7 +235,7 @@ Future<Map<String, dynamic>> _waitForClients(
               clients
                   .any((c) => c['hasConnection'] == requiredConnectionState));
     },
-    timeout: const Duration(seconds: 10),
+    timeout: const Duration(seconds: 30),
     timeoutMessage: 'Server did not return any known clients',
     delay: const Duration(seconds: 1),
   );


### PR DESCRIPTION
Now that the repo is pulling a version of the server that supports the API, these tests should all pass on CI too 🤞

Fixes #590.