### PR TITLE
Add headless mode to server for testing

### DIFF
--- a/packages/devtools_app/test/support/chrome.dart
+++ b/packages/devtools_app/test/support/chrome.dart
@@ -15,7 +15,9 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 
 // Change this if you want to be able to see Chrome opening while tests run
 // to aid debugging.
-const _useChromeHeadless = true;
+const useChromeHeadless = true;
+
+final headlessModeIsSupported = !Platform.isWindows;
 
 class Chrome {
   factory Chrome.from(String executable) {
@@ -80,7 +82,7 @@ class Chrome {
     ];
     // TODO(dantup): Chrome headless currently hangs on Windows (both Travis and
     // locally), so use non-headless there until we have a fix.
-    if (_useChromeHeadless && !Platform.isWindows) {
+    if (useChromeHeadless && headlessModeIsSupported) {
       args.addAll(<String>[
         '--headless',
         '--disable-gpu',

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -6,6 +6,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'chrome.dart';
+
 const verbose = true;
 
 class DevToolsServerDriver {
@@ -38,10 +40,18 @@ class DevToolsServerDriver {
   static Future<DevToolsServerDriver> create() async {
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
-    final Process process = await Process.start(
-      Platform.resolvedExecutable,
-      <String>['../devtools/bin/devtools.dart', '--machine', '--port', '0'],
-    );
+    final args = <String>[
+      '../devtools/bin/devtools.dart',
+      '--machine',
+      '--port',
+      '0'
+    ];
+
+    if (useChromeHeadless && headlessModeIsSupported) {
+      args.add('--headless');
+    }
+    final Process process =
+        await Process.start(Platform.resolvedExecutable, args);
 
     return DevToolsServerDriver._(
         process,

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -6,8 +6,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'chrome.dart';
-
 const verbose = true;
 
 class DevToolsServerDriver {

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -47,9 +47,11 @@ class DevToolsServerDriver {
       '0'
     ];
 
-    if (useChromeHeadless && headlessModeIsSupported) {
-      args.add('--headless');
-    }
+    // TODO: This needs enabling once the server version that supports headless
+    // has been published.
+    // if (useChromeHeadless && headlessModeIsSupported) {
+    //   args.add('--headless');
+    // }
     final Process process =
         await Process.start(Platform.resolvedExecutable, args);
 

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -38,11 +38,11 @@ class DevToolsServerDriver {
   static Future<DevToolsServerDriver> create() async {
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
-    final args = <String>[
+    final args = [
       '../devtools/bin/devtools.dart',
       '--machine',
       '--port',
-      '0'
+      '0',
     ];
 
     // TODO: This needs enabling once the server version that supports headless


### PR DESCRIPTION
This adds a hidden `--headless` flag to the server, which will cause Chrome to be spawned in headless mode. This is required for it to work on non-Windows CI so we can test it.

(Some background info at https://github.com/flutter/devtools/pull/1120#issuecomment-537904248).

The tests are still disabled - we'll need to get this out in a live release before they can be enabled (they're all passing locally - though that doesn't mean a lot since they did before, because headless mode isn't required when testing locally!).