### PR TITLE
use the prefer_relative_imports lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -107,6 +107,7 @@ linter:
     # - prefer_iterable_whereType # https://github.com/dart-lang/sdk/issues/32463
     - prefer_is_empty
     - prefer_is_not_empty
+    - prefer_relative_imports
     - prefer_single_quotes
     - prefer_typing_uninitialized_variables
     - recursive_getters

--- a/case_study/memory_leak/lib/logging.dart
+++ b/case_study/memory_leak/lib/logging.dart
@@ -54,13 +54,13 @@ class TimeStamp {
 class TimeModel {
   TimeModel(this._logging);
 
-  Logging _logging;
+  final Logging _logging;
 
   List<TimeStamp> log = <TimeStamp>[];
 
-  String _time = '';
-  String _date = '';
-  String _meridiem = '';
+  final String _time = '';
+  final String _date = '';
+  final String _meridiem = '';
   Timer _clockUpdateTimer;
   DateTime now = DateTime.now();
 

--- a/case_study/memory_leak/lib/tabs/logger.dart
+++ b/case_study/memory_leak/lib/tabs/logger.dart
@@ -18,7 +18,7 @@ class Logger extends StatefulWidget {
 class LoggerState extends State<Logger> {
   LoggerState(this._logging);
 
-  Logging _logging;
+  final Logging _logging;
   final List<String> _saved = [];
   final _biggerFont = const TextStyle(fontSize: 18.0);
 

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'package:html_shim/html.dart';
 
-import 'package:devtools_app/src/framework/framework_core.dart';
-import 'package:devtools_app/src/main.dart';
-import 'package:devtools_app/src/ui/analytics.dart' as ga;
-import 'package:devtools_app/src/ui/analytics_platform.dart' as ga_platform;
+import 'package:html_shim/html.dart';
 import 'package:platform_detect/platform_detect.dart';
+
+import 'src/framework/framework_core.dart';
+import 'src/main.dart';
+import 'src/ui/analytics.dart' as ga;
+import 'src/ui/analytics_platform.dart' as ga_platform;
 
 void main() {
   // Run in a zone in order to catch all Dart exceptions.

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -5,12 +5,13 @@
 import 'dart:async';
 import 'dart:isolate';
 
-import 'package:devtools_server/src/client_manager.dart';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_static/shelf_static.dart';
 import 'package:sse/server/sse_handler.dart';
+
+import 'client_manager.dart';
 
 /// Default [shelf.Handler] for serving DevTools files.
 ///

--- a/packages/devtools_testing/lib/info_controller_test.dart
+++ b/packages/devtools_testing/lib/info_controller_test.dart
@@ -6,14 +6,13 @@
 // ignore_for_file: invalid_use_of_visible_for_testing_member
 
 @TestOn('vm')
-
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/info/info_controller.dart';
 import 'package:devtools_app/src/version.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
-import 'package:devtools_testing/support/flutter_test_environment.dart';
+import 'support/flutter_test_environment.dart';
 
 Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
   InfoController infoController;

--- a/packages/devtools_testing/lib/inspector_service_test.dart
+++ b/packages/devtools_testing/lib/inspector_service_test.dart
@@ -12,13 +12,13 @@ import 'dart:io';
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:devtools_app/src/inspector/flutter_widget.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
-import 'package:devtools_testing/matchers/fake_flutter_matchers.dart';
-import 'package:devtools_testing/matchers/matchers.dart';
-import 'package:devtools_testing/support/flutter_test_driver.dart'
-    show FlutterRunConfiguration;
-import 'package:devtools_testing/support/flutter_test_environment.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:test/test.dart';
+
+import 'matchers/fake_flutter_matchers.dart';
+import 'matchers/matchers.dart';
+import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
+import 'support/flutter_test_environment.dart';
 
 Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
   final devtoolsPackageRoot =

--- a/packages/devtools_testing/lib/logging_controller_test.dart
+++ b/packages/devtools_testing/lib/logging_controller_test.dart
@@ -12,17 +12,18 @@ import 'dart:io';
 import 'package:devtools_app/src/eval_on_dart_library.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/inspector/flutter_widget.dart';
-import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
 import 'package:devtools_app/src/inspector/inspector_tree.dart';
+import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/service_extensions.dart';
 import 'package:devtools_app/src/table_data.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
-import 'package:devtools_testing/matchers/matchers.dart';
-import 'package:devtools_testing/support/fake_inspector_tree.dart';
-import 'package:devtools_testing/support/flutter_test_environment.dart';
 import 'package:package_resolver/package_resolver.dart';
 import 'package:test/test.dart';
+
+import 'matchers/matchers.dart';
+import 'support/fake_inspector_tree.dart';
+import 'support/flutter_test_environment.dart';
 
 /// If this test starts timing out it probably means the number of log messages
 /// received has changed. Enable this flag to see what log messages are being

--- a/packages/devtools_testing/lib/memory_service_test.dart
+++ b/packages/devtools_testing/lib/memory_service_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/memory/memory_protocol.dart';
 import 'package:test/test.dart';
 
-import 'package:devtools_testing/support/flutter_test_environment.dart';
+import 'support/flutter_test_environment.dart';
 
 MemoryController memoryController;
 

--- a/packages/devtools_testing/lib/service_manager_test.dart
+++ b/packages/devtools_testing/lib/service_manager_test.dart
@@ -18,10 +18,9 @@ import 'package:devtools_app/src/vm_service_wrapper.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
-import 'package:devtools_testing/support/flutter_test_driver.dart';
-import 'package:devtools_testing/support/flutter_test_environment.dart';
-
 import 'support/constants.dart';
+import 'support/flutter_test_driver.dart';
+import 'support/flutter_test_environment.dart';
 
 // Error codes defined by
 // https://www.jsonrpc.org/specification#error_object

--- a/packages/devtools_testing/lib/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/timeline_controller_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:test/test.dart';
 
-import 'package:devtools_testing/support/flutter_test_environment.dart';
+import 'support/flutter_test_environment.dart';
 import 'support/timeline_test_data.dart';
 
 Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {


### PR DESCRIPTION
- use the new `prefer_relative_imports` lint

This is only available in the latest dev dart sdk; I'll see how this builds through, and if there are issues, will remove the use of the lint (but keep the results).
