### PR TITLE
Don't pass explicit null as args to Chrome launcher

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -421,7 +421,7 @@ Future<void> registerLaunchDevToolsService(
                   '--disable-gpu',
                   '--no-sandbox',
                 ]
-              : [];
+              : <String>[];
           await Chrome.start([uriToLaunch.toString()], args: args);
         }
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -421,7 +421,7 @@ Future<void> registerLaunchDevToolsService(
                   '--disable-gpu',
                   '--no-sandbox',
                 ]
-              : null;
+              : [];
           await Chrome.start([uriToLaunch.toString()], args: args);
         }
 


### PR DESCRIPTION
This crashes because `Chrome.start` has a default of empty list and calls `toList()` on this.

The server tests did catch this, but are disabled on CI until the next release (https://github.com/flutter/devtools/pull/1120). I hit this locally after merging the unskip-server-tests and headless-mode work.