### PR TITLE
Pin build_web_compilers to latest and use dart/raw/latest on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ os:
 
 language: dart
 dart:
-  - "dev/release/2.6.0-dev.0.0"
+  - "dev/raw/latest"
   - stable
 addons:
   chrome: stable

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -54,7 +54,7 @@ dependencies:
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ^0.10.0
-  build_web_compilers: '>=1.2.0 <3.0.0'
+  build_web_compilers: '>=2.6.2 <3.0.0'
   matcher: ^0.12.3
   mockito: ^4.0.0
   test: ^1.0.0


### PR DESCRIPTION
the latest build_web_compilers 2.6.2 fixed this [issue](https://github.com/flutter/devtools/issues/1095). Pin version to 2.6.2 and test latest dart on travis again.