### PR TITLE
Don't try to complete multiple times if there are multiple [SEVERE] lines

### DIFF
--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -354,10 +354,12 @@ class WebdevFixture {
         print('pub run build_runner build • ${line.trim()}');
       }
 
-      if (line.contains('[INFO] Succeeded')) {
-        buildFinished.complete();
-      } else if (line.contains('[SEVERE]')) {
-        buildFinished.completeError(line);
+      if (!buildFinished.isCompleted) {
+        if (line.contains('[INFO] Succeeded')) {
+          buildFinished.complete();
+        } else if (line.contains('[SEVERE]')) {
+          buildFinished.completeError(line);
+        }
       }
     });
 


### PR DESCRIPTION
Build failures sometimes include multiple `[SEVERE]` error lines, and this was previously trying to complete for each, which led to a misleading error message in the logs.