### PR TITLE
Change "dart.bat" to "dart" for running VM on Windows

### DIFF
--- a/packages/devtools_app/test/support/cli_test_driver.dart
+++ b/packages/devtools_app/test/support/cli_test_driver.dart
@@ -76,7 +76,7 @@ class CliAppFixture extends AppFixture {
 
   static Future<CliAppFixture> create(String appScriptPath) async {
     final Process process = await Process.start(
-      Platform.isWindows ? 'dart.bat' : 'dart',
+      'dart',
       <String>['--observe=0', '--pause-isolates-on-start', appScriptPath],
     );
 

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -57,8 +57,7 @@ class DevToolsServerDriver {
     // if (useChromeHeadless && headlessModeIsSupported) {
     //   args.add('--headless');
     // }
-    final Process process =
-        await Process.start(Platform.resolvedExecutable, args);
+    final Process process = await Process.start('dart', args);
 
     return DevToolsServerDriver._(
         process,

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -58,7 +58,7 @@ class DevToolsServerDriver {
     //   args.add('--headless');
     // }
     final Process process =
-        await Process.start(Platform.isWindows ? 'dart.bat' : 'dart', args);
+        await Process.start(Platform.resolvedExecutable, args);
 
     return DevToolsServerDriver._(
         process,


### PR DESCRIPTION
@DaveShuckerow I'm not sure what the intention was here, but Dart is an exe on Windows (only `pub` and `flutter` are batch files). The bots fail running this, so this restores it.

~If there was a deliberate reason not to use `Platform.resolvedExecutable` and instead `dart` from `PATH` then this may need tweaking to just be `dart` (and if so we should probably add some comments about why).~

Apparently this is required - though I'm not sure why. Any ideas? It'd be good to comment it (or if it's a bug, try and get it fixed).