### PR TITLE
Switch to using flutter to build and deploy the application.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/html_event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/html_event_details.dart
@@ -8,7 +8,7 @@ import '../profiler/html_cpu_profile_flame_chart.dart';
 import '../profiler/html_cpu_profile_tables.dart';
 import '../profiler/html_cpu_profiler.dart';
 import '../ui/colors.dart';
-import '../ui/fake_flutter/dart_ui/dart_ui.dart';
+import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/flutter_html_shim.dart';
 import '../ui/html_elements.dart';
 import '../ui/theme.dart';

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 
 import '../charts/flame_chart_canvas.dart';
 import '../ui/colors.dart';
-import '../ui/fake_flutter/dart_ui/dart_ui.dart';
+import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/theme.dart';
 import 'timeline_model.dart';
 

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'fake_flutter/dart_ui/dart_ui.dart';
+import 'fake_flutter/fake_flutter.dart';
 import 'theme.dart';
 
 /// This file holds color constants that are used throughout DevTools.

--- a/packages/devtools_app/lib/src/ui/fake_flutter/_fake_flutter.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/_fake_flutter.dart
@@ -1,0 +1,35 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Collection of utility classes forked from package:flutter and dart:ui
+/// to make it easier to write UI code that can later be ported to flutter.
+///
+/// Once Hummingbird launches, this library should be removed completely.
+/// https://github.com/flutter/devtools/issues/69
+///
+/// Functionality such as I18N and shadows have been arbitrarily ripped out of
+/// these classes as it would be hard to implement writing directly to
+/// dart:html.
+library fake_flutter;
+
+import 'dart:async';
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:meta/meta.dart';
+
+import 'collections.dart';
+import 'dart_ui/dart_ui.dart' hide TextStyle;
+import 'dart_ui/dart_ui.dart' as ui;
+
+export 'collections.dart';
+export 'dart_ui/dart_ui.dart' hide TextStyle;
+
+part 'assertions.dart';
+part 'change_notifier.dart';
+part 'diagnosticable.dart';
+part 'foundation.dart';
+part 'print.dart';
+part 'text.dart';
+part 'text_span.dart';

--- a/packages/devtools_app/lib/src/ui/fake_flutter/_real_flutter.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/_real_flutter.dart
@@ -1,0 +1,4 @@
+export 'dart:ui' show Color;
+
+export 'package:flutter/material.dart';
+export 'package:flutter/foundation.dart';

--- a/packages/devtools_app/lib/src/ui/fake_flutter/assertions.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/assertions.dart
@@ -1,7 +1,7 @@
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 /// Error class used to report Flutter-specific assertion failures and
 /// contract violations.

--- a/packages/devtools_app/lib/src/ui/fake_flutter/change_notifier.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/change_notifier.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 /// An object that maintains a list of listeners.
 ///

--- a/packages/devtools_app/lib/src/ui/fake_flutter/diagnosticable.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/diagnosticable.dart
@@ -4,7 +4,7 @@
 
 // This is a direct copy of
 // /packages/flutter/lib/src/foundation/diagnostics.dart
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 // Examples can assume:
 // int rows, columns;

--- a/packages/devtools_app/lib/src/ui/fake_flutter/fake_flutter.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/fake_flutter.dart
@@ -1,35 +1,6 @@
-// Copyright 2018 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// TODO(jacobr): rename this library to flutter with a followup CL.
 
-/// Collection of utility classes forked from package:flutter and dart:ui
-/// to make it easier to write UI code that can later be ported to flutter.
-///
-/// Once Hummingbird launches, this library should be removed completely.
-/// https://github.com/flutter/devtools/issues/69
-///
-/// Functionality such as I18N and shadows have been arbitrarily ripped out of
-/// these classes as it would be hard to implement writing directly to
-/// dart:html.
-library fake_flutter;
-
-import 'dart:async';
-import 'dart:collection';
-import 'dart:math' as math;
-
-import 'package:meta/meta.dart';
-
-import 'collections.dart';
-import 'dart_ui/dart_ui.dart' hide TextStyle;
-import 'dart_ui/dart_ui.dart' as ui;
-
-export 'collections.dart';
-export 'dart_ui/dart_ui.dart' hide TextStyle;
-
-part 'assertions.dart';
-part 'change_notifier.dart';
-part 'diagnosticable.dart';
-part 'foundation.dart';
-part 'print.dart';
-part 'text.dart';
-part 'text_span.dart';
+export '_real_flutter.dart'
+    if (dart.library.ui) '_real_flutter.dart'
+    if (dart.library.html) '_fake_flutter.dart'
+    if (dart.library.io) '_fake_flutter.dart' hide Element;

--- a/packages/devtools_app/lib/src/ui/fake_flutter/foundation.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/foundation.dart
@@ -1,7 +1,7 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 /// Signature of callbacks that have no arguments and return no data.
 typedef VoidCallback = void Function();

--- a/packages/devtools_app/lib/src/ui/fake_flutter/print.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/print.dart
@@ -5,7 +5,7 @@
 // This file is a copy of packages/flutter/lib/src/foundation/print.dart
 // with functionality that can't run without a full flutter runtime stripped
 // out.
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 /// Signature for [debugPrint] implementations.
 typedef DebugPrintCallback = void Function(String message, {int wrapWidth});

--- a/packages/devtools_app/lib/src/ui/fake_flutter/text.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/text.dart
@@ -1,7 +1,7 @@
 // Copyright 2015 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 const String _kDefaultDebugLabel = 'unknown';
 

--- a/packages/devtools_app/lib/src/ui/fake_flutter/text_span.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/text_span.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of 'fake_flutter.dart';
+part of '_fake_flutter.dart';
 
 /// An immutable span of text.
 ///

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -98,4 +98,12 @@ class ThemedColor implements Color {
 
   @override
   Color withRed(int r) => _current.withRed(r);
+
+  // TODO(jacobr): remove these methods when they are removed from flutter_web.
+  // @override only on Flutter Web
+  String toCssString() => (_current as dynamic).toCssString();
+
+  // TODO(jacobr): remove these methods when they are removed from flutter_web.
+  // @override only on Flutter Web
+  String toCssStringRgbOnly() => (_current as dynamic).toCssStringRgbOnly();
 }

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -10,7 +10,7 @@ import 'package:collection/collection.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_service/vm_service.dart';
 
-import 'ui/fake_flutter/dart_ui/dart_ui.dart';
+import 'ui/fake_flutter/fake_flutter.dart';
 
 bool collectionEquals(e1, e2) => const DeepCollectionEquality().equals(e1, e2);
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -13,6 +13,10 @@ homepage: https://github.com/flutter/devtools
 
 environment:
   sdk: '>=2.3.0 <3.0.0'
+  # The flutter desktop support interacts with build scripts on the Flutter
+  # side that are not yet stable, so it requires a very recent version of
+  # Flutter. This version will increase regularly as the build scripts change.
+  # flutter: '>=1.9.8-pre.31'
 
 dependencies:
   ansicolor: ^1.0.2

--- a/packages/devtools_app/test/viewport_canvas_test.dart
+++ b/packages/devtools_app/test/viewport_canvas_test.dart
@@ -59,23 +59,26 @@ void main() {
 
     test('render only first rect', () async {
       expect(paintsRequested.length, equals(1));
-      expect(paintsRequested.first, equals(Rect.fromLTWH(0, 0, 512, 512)));
+      expect(
+          paintsRequested.first, equals(const Rect.fromLTWH(0, 0, 512, 512)));
     });
 
     test('visibility observer fired', () async {
       await settleUi();
       expect(paintsRequested.length, equals(1));
 
-      expect(viewportCanvas.viewport, equals(Rect.fromLTWH(0, 0, 500, 300)));
+      expect(
+          viewportCanvas.viewport, equals(const Rect.fromLTWH(0, 0, 500, 300)));
       viewportCanvas.element.element.style..height = '1000px';
 
       await window.animationFrame;
       await window.animationFrame;
-      expect(viewportCanvas.viewport, equals(Rect.fromLTWH(0, 0, 500, 1000)));
+      expect(viewportCanvas.viewport,
+          equals(const Rect.fromLTWH(0, 0, 500, 1000)));
 
       expect(paintsRequested.length, equals(2));
-      expect(paintsRequested[0], equals(Rect.fromLTWH(0, 0, 512, 512)));
-      expect(paintsRequested[1], equals(Rect.fromLTWH(0, 512, 512, 512)));
+      expect(paintsRequested[0], equals(const Rect.fromLTWH(0, 0, 512, 512)));
+      expect(paintsRequested[1], equals(const Rect.fromLTWH(0, 512, 512, 512)));
     });
 
     test('scroll to rect', () async {
@@ -84,7 +87,8 @@ void main() {
       expect(viewportCanvas.viewport.left, equals(0));
       expect(viewportCanvas.viewport.top, equals(0));
 
-      viewportCanvas.scrollToRect(Rect.fromLTWH(1000.0, 1500.0, 100.0, 100.0));
+      viewportCanvas
+          .scrollToRect(const Rect.fromLTWH(1000.0, 1500.0, 100.0, 100.0));
 
       await settleUi();
 
@@ -93,7 +97,8 @@ void main() {
 
       // Scroll down slightly. The top should not move all the way to match the
       // top of the target.
-      viewportCanvas.scrollToRect(Rect.fromLTWH(1000.0, 1700.0, 100.0, 200.0));
+      viewportCanvas
+          .scrollToRect(const Rect.fromLTWH(1000.0, 1700.0, 100.0, 200.0));
 
       await settleUi();
 
@@ -101,7 +106,8 @@ void main() {
       expect(viewportCanvas.viewport.top, equals(1600.0));
 
       // Doesn't cause a scroll
-      viewportCanvas.scrollToRect(Rect.fromLTWH(1000.0, 1600.0, 100.0, 200.0));
+      viewportCanvas
+          .scrollToRect(const Rect.fromLTWH(1000.0, 1600.0, 100.0, 200.0));
 
       await settleUi();
 
@@ -109,7 +115,7 @@ void main() {
       expect(viewportCanvas.viewport.top, equals(1600.0));
 
       // Scroll back to top.
-      viewportCanvas.scrollToRect(Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
+      viewportCanvas.scrollToRect(const Rect.fromLTWH(0.0, 0.0, 100.0, 100.0));
 
       await settleUi();
 
@@ -149,23 +155,25 @@ void main() {
       await settleUi();
       paintsRequested.clear();
       // Nothing to actually rebuild
-      viewportCanvas.markNeedsPaint(Rect.fromLTWH(0, 0, 50, 50));
+      viewportCanvas.markNeedsPaint(const Rect.fromLTWH(0, 0, 50, 50));
       await settleUi();
       expect(paintsRequested.length, 1);
-      expect(paintsRequested.first, equals(Rect.fromLTWH(0, 0, 512, 512)));
+      expect(
+          paintsRequested.first, equals(const Rect.fromLTWH(0, 0, 512, 512)));
       paintsRequested.clear();
       // Off the edge of the ui.
-      viewportCanvas.markNeedsPaint(Rect.fromLTWH(300000, 0, 50, 50));
+      viewportCanvas.markNeedsPaint(const Rect.fromLTWH(300000, 0, 50, 50));
       await settleUi();
       expect(paintsRequested, isEmpty);
 
       // Request triggering multiple chunks to paint
       paintsRequested.clear();
-      viewportCanvas.markNeedsPaint(Rect.fromLTWH(400, 600, 512, 40));
+      viewportCanvas.markNeedsPaint(const Rect.fromLTWH(400, 600, 512, 40));
       await settleUi();
       expect(paintsRequested.length, equals(2));
-      expect(paintsRequested[0], equals(Rect.fromLTWH(0, 512, 512, 512)));
-      expect(paintsRequested[1], equals(Rect.fromLTWH(512, 512, 512, 512)));
+      expect(paintsRequested[0], equals(const Rect.fromLTWH(0, 512, 512, 512)));
+      expect(
+          paintsRequested[1], equals(const Rect.fromLTWH(512, 512, 512, 512)));
     });
   });
 


### PR DESCRIPTION
fake_flutter.dart now is actually real flutter guarded by a conditional import so as to not break things with the bazel build.
As soon as we switch fully to flutter we will be able to remove fake_flutter completely.