### PR TITLE
Fix macos build entitlements and add flutter desktop paste workaround.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 
 import '../../src/framework/framework_core.dart';
 import 'screen.dart';
@@ -66,6 +68,21 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
         ),
         const Padding(padding: EdgeInsets.only(top: 20.0)),
         _buildTextInput(),
+        // Workaround the lack of copy/paste in macOS shell text input
+        // https://github.com/flutter/flutter/issues/30709
+        // by providing a manual paste button.
+        if (!kIsWeb)
+          RaisedButton(
+            child: const Text(
+              'Paste from clipboard (Flutter Desktop paste support workaround)',
+            ),
+            onPressed: () async {
+              final data = await Clipboard.getData('text/plain');
+              if (data?.text?.isNotEmpty == true) {
+                controller.text = data?.text;
+              }
+            },
+          ),
         const _SpacedDivider(),
         // TODO(https://github.com/flutter/devtools/issues/1111): support drag-and-drop of snapshot files here.
       ],

--- a/packages/devtools_app/macos/Runner-DebugProfile.entitlements
+++ b/packages/devtools_app/macos/Runner-DebugProfile.entitlements
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 	<key>com.apple.security.cs.allow-jit</key>
 	<true/>
 	<key>com.apple.security.network.server</key>

--- a/packages/devtools_app/macos/Runner-Release.entitlements
+++ b/packages/devtools_app/macos/Runner-Release.entitlements
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.app-sandbox</key>
-	<true/>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
The macos security restrictions were blocking using websockets.
Added a workaround for paste on flutter desktop to make testing with Flutter Desktop work well without standard copy and paste support.
I now strongly recommend that all iteration on the app is done with Flutter Desktop instead of Flutter Web for hot reload and a generally faster iteration cycle.

App performance is also noticeably faster on flutter desktop in debug mode even the Info Screen that Dave added. 
Manual paste button only displayed on flutter desktop:
<img width="683" alt="Screen Shot 2019-10-12 at 4 50 42 PM" src="https://user-images.githubusercontent.com/1226812/66709037-759d1800-ed10-11e9-87c6-24a4d5d3bad6.png">
The info page on Flutter Desktop (requires Dave's pending CL)
<img width="694" alt="Screen Shot 2019-10-12 at 4 05 15 PM" src="https://user-images.githubusercontent.com/1226812/66709022-31117c80-ed10-11e9-87bf-fa140aa822b6.png">
<img width="741" alt="Screen Shot 2019-10-12 at 4 40 46 PM" src="https://user-images.githubusercontent.com/1226812/66709020-3078e600-ed10-11e9-91ec-4593129765a9.png">
