### PR TITLE
Add a bot to run with local dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     # rolls to the Flutter stable channel.
     - os: windows
       dart:  stable
-      env: 
+      env:
         - BOT=flutter_sdk_tests
         - BOT=test_ddc
         - BOT=test_dart2js
@@ -45,7 +45,7 @@ matrix:
     # TODO(dantup): Skip Flutter builds until we understand/fix Flutter crashing
     # with "failed to delete build/assets: file is locked by another process".
     - os: windows
-      env: 
+      env:
         - BOT=flutter_sdk_tests
         - BOT=test_ddc
         - BOT=test_dart2js
@@ -64,12 +64,16 @@ env:
   - BOT=test_dart2js
   - BOT=integration_ddc
   - BOT=integration_dart2js
+  - BOT=integration_dart2js USE_LOCAL_DEPENDENCIES=true
 
 script: ./tool/travis.sh
 
-# Only building master means that we don't run two builds for each pull request.
-branches:
-  only: [master]
+# Specifying master here means that we don't run two builds for each pull request
+# made from within the DevTools repo, however it complicates running builds on
+# forks without opening PRs.
+# See https://github.com/flutter/devtools/pull/398
+# branches:
+#   only: [master]
 
 cache:
   directories:

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -19,8 +19,14 @@ environment:
 
 dependencies:
   devtools_server: 0.1.10
-#    path: ../devtools_server
   http: ^0.12.0+1
+
+dependency_overrides:
+# The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
+# tests can run using the in-repo version of these dependencies instead of
+# only the live Pub version.
+#OVERRIDE_FOR_TESTS   devtools_server:
+#OVERRIDE_FOR_TESTS     path: ../devtools_server
 
 executables:
   devtools:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,6 @@ dependencies:
   codemirror: ^0.5.10
   collection: ^1.14.11
   devtools_server: 0.1.10
-#    path: ../devtools_server
   flutter_icons: ^0.3.1
   http: ^0.12.0+1
   html_shim: ^0.0.2
@@ -60,6 +59,13 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_widgets: ^0.1.6
+
+dependency_overrides:
+# The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
+# tests can run using the in-repo version of these dependencies instead of
+# only the live Pub version.
+#OVERRIDE_FOR_TESTS   devtools_server:
+#OVERRIDE_FOR_TESTS     path: ../devtools_server
 
 dev_dependencies:
   build_runner: ^1.3.0

--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -300,7 +300,7 @@ class WebdevFixture {
     final Completer<String> hasUrl = Completer<String>();
 
     _toLines(process.stderr).listen((String line) {
-      if (verbose) {
+      if (verbose || hasUrl.isCompleted) {
         print('pub run build_runner serve • ${process.pid}'
             ' • STDERR • ${line.trim()}');
       }

--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -300,23 +300,32 @@ class WebdevFixture {
     final Completer<String> hasUrl = Completer<String>();
 
     _toLines(process.stderr).listen((String line) {
+      if (verbose) {
+        print('pub run build_runner serve • ${process.pid}'
+            ' • STDERR • ${line.trim()}');
+      }
+
       final err = 'error starting webdev: $line';
       if (!hasUrl.isCompleted) {
         hasUrl.completeError(err);
       } else {
-        print(err);
+        print('Ignoring stderr output because already completed');
       }
     });
 
     _toLines(process.stdout).listen((String line) {
       if (verbose) {
-        print('pub run build_runner serve • ${line.trim()}');
+        print('pub run build_runner serve • ${process.pid} • ${line.trim()}');
       }
 
       // Serving `web` on http://localhost:8080
       if (line.contains('Serving `web`')) {
-        final String url = line.substring(line.indexOf('http://'));
-        hasUrl.complete(url);
+        if (!hasUrl.isCompleted) {
+          final String url = line.substring(line.indexOf('http://'));
+          hasUrl.complete(url);
+        } else {
+          print('Ignoring "Serving..." notification because already completed');
+        }
       }
     });
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -142,7 +142,7 @@ Future<HttpServer> serveDevTools({
 
   handler ??= await defaultHandler(clients);
 
-  HttpMultiServer server;
+  HttpServer server;
   SocketException ex;
   while (server == null && numPortsToTry > 0) {
     try {

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -31,6 +31,14 @@ function flutter {
     fi
 }
 
+if [ -z "$USE_LOCAL_DEPENDENCIES" ]; then
+    echo "Using dependencies from Pub"
+else
+    echo "Updating pubspecs to use local dependencies"
+    perl -pi -e 's/#OVERRIDE_FOR_TESTS//' packages/devtools/pubspec.yaml
+    perl -pi -e 's/#OVERRIDE_FOR_TESTS//' packages/devtools_app/pubspec.yaml
+fi
+
 # Some integration tests assume the devtools package is up to date and located
 # adjacent to the devtools_app package.
 pushd packages/devtools


### PR DESCRIPTION
This adds a new bot that runs the integration tests using the local version of the server (though if we have other packages, it would work for them too).

It adds two temporary flags so that the tests are enabled only for the local server (`serverSupportsHeadless`, `serverSupportsTryPort`) which can be removed once we publish a new version of the server.

This supersedes https://github.com/flutter/devtools/pull/1120 since it enables the server tests where they'll work.

There are some other minor changes to logging of the webdev service to try and track down flakes and avoid the issue where webdev prints that it's serving multiple times and we tried to complete the future twice.

(@terrylucas FYI - if you had server tests that require changes, using a variable like `serverSupportsHeadless` temporarily may allow you to land the change and still have the tests run)
