### PR TITLE
Update goldens paths in gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,4 +25,4 @@
 *.zip    binary
 
 # Preserve \n line endings in Golden files.
-**/test/goldens*/* eol=lf
+**/*test*/goldens*/* eol=lf

--- a/packages/devtools_testing/lib/matchers/matchers.dart
+++ b/packages/devtools_testing/lib/matchers/matchers.dart
@@ -87,7 +87,9 @@ class _EqualsGoldenIgnoringHashCodes extends Matcher {
   static bool get updateGoldens => autoUpdateGoldenFiles;
 
   static String _normalize(String s) {
-    return s.replaceAll(RegExp(r'#[0-9a-f]{5}'), '#00000');
+    return s
+        .replaceAll(RegExp(r'#[0-9a-f]{5}'), '#00000')
+        .replaceAll('\r\n', '\n');
   }
 
   @override

--- a/packages/devtools_testing/lib/matchers/matchers.dart
+++ b/packages/devtools_testing/lib/matchers/matchers.dart
@@ -87,9 +87,7 @@ class _EqualsGoldenIgnoringHashCodes extends Matcher {
   static bool get updateGoldens => autoUpdateGoldenFiles;
 
   static String _normalize(String s) {
-    return s
-        .replaceAll(RegExp(r'#[0-9a-f]{5}'), '#00000')
-        .replaceAll('\r\n', '\n');
+    return s.replaceAll(RegExp(r'#[0-9a-f]{5}'), '#00000');
   }
 
   @override


### PR DESCRIPTION
~~On the Windows bots, these files are read from disk with `\r\n` but the actual output is just `\n`. I don't believe these tests care about those differences, so this will normalise them all to `\n` before comparing.~~

~~Example failure:~~

~~https://travis-ci.org/flutter/devtools/jobs/598111233#L444~~

We actually had gitattributes to ensure the golden files are always checked out the same, but this broke when the files where moved. I've changed this PR to just handle those paths and undone the normalisation change.