### PR TITLE
Update build_release script to use flutter

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -10,7 +10,7 @@ pushd packages/devtools_app
 
 rm -rf build
 rm -rf ../devtools/build
-pub run build_runner build -o web:build --release
+flutter pub run build_runner build -o web:build --release
 mv ./build/packages ./build/pack
 
 # move release to the devtools package from the devtools_app package for deployment


### PR DESCRIPTION
Now we're using Flutter, we get "The Flutter SDK is not available." when running this script. I believe this is the fix (seems to work locally for me).