### PR TITLE
Use devtools store for survey logic.

### DIFF
--- a/packages/devtools_app/lib/src/framework/html_framework.dart
+++ b/packages/devtools_app/lib/src/framework/html_framework.dart
@@ -652,15 +652,11 @@ class HtmlSurveyToast extends CoreElement {
           label(text: 'Help improve DevTools! ', c: 'toast-title'),
           surveyLink =
               a(text: 'Take our Q3 survey', href: _url, target: '_blank')
-                ..click(() {
-                  toastAnimator.hide();
-                }),
+                ..click(_hideAndSetActionTaken),
           label(text: '.'),
           div()..flex(),
           span(c: 'octicon octicon-x flash-close js-flash-close')
-            ..click(() {
-              toastAnimator.hide();
-            }),
+            ..click(_hideAndSetActionTaken),
         ]),
       div(
           text:
@@ -682,6 +678,11 @@ class HtmlSurveyToast extends CoreElement {
 
   void show() async {
     toastAnimator.show(hideDelay: HtmlToastAnimator.infiniteHideDelay);
+  }
+
+  void _hideAndSetActionTaken() {
+    toastAnimator.hide();
+    ga.setSurveyActionTaken();
   }
 }
 

--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -310,15 +310,15 @@ Future<bool> get isSurveyActionTaken async {
 // TODO(terry): remove the query param logic for this request.
 // setSurveyActionTaken should only be called with the value of true, so
 // we can remove the extra complexity.
-void setSurveyActionTaken([bool value = true]) async {
+void setSurveyActionTaken() async {
   final resp = await HttpRequest.request(
     // Format of request is e.g. api/setSurveyActionTaken?surveyActionTaken=true
     '${server.apiSetSurveyActionTaken}'
-    '?${server.surveyActionTakenPropertyName}=$value',
+    '?${server.surveyActionTakenPropertyName}=true',
     method: 'POST',
   );
   if (resp.status == HttpStatus.ok) {
-    assert(json.decode(resp.responseText) == value);
+    assert(json.decode(resp.responseText) == true);
   } else {
     _logWarning(resp, server.apiSetSurveyActionTaken, resp.responseText);
   }

--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -307,9 +307,12 @@ Future<bool> get isSurveyActionTaken async {
 
 /// Set DevTools property value 'surveyActionTaken' stored in the file
 /// '~\.devtools'.
+// TODO(terry): remove the query param logic for this request.
+// setSurveyActionTaken should only be called with the value of true, so
+// we can remove the extra complexity.
 void setSurveyActionTaken([bool value = true]) async {
   final resp = await HttpRequest.request(
-    // Format of request is e.g., api/setDevToolsEnabled?surveyActionTaken=true
+    // Format of request is e.g. api/setSurveyActionTaken?surveyActionTaken=true
     '${server.apiSetSurveyActionTaken}'
     '?${server.surveyActionTakenPropertyName}=$value',
     method: 'POST',

--- a/packages/devtools_server/lib/src/handlers.dart
+++ b/packages/devtools_server/lib/src/handlers.dart
@@ -133,6 +133,9 @@ class ServerApi {
         // SurveyActionTaken has the survey been acted upon (taken or dismissed)
         return api.getCompleted(
             request, json.encode(_devToolsUsage.surveyActionTaken));
+      // TODO(terry): remove the query param logic for this request.
+      // setSurveyActionTaken should only be called with the value of true, so
+      // we can remove the extra complexity.
       case apiSetSurveyActionTaken:
         // Set the SurveyActionTaken.
         // Has the survey been taken or dismissed..


### PR DESCRIPTION
We will show the survey if 
- the date is before Nov 14th (4 weeks after survey launch - assuming a 0.1.9 release tomorrow)
- the user has not taken action on the toast (clicked the survey link or dismissed the toast)
- the user has seen the survey 5 times or less without taking action

Also added a todo to clean up some unnecessary complexity in the setSurveyActionTaken API.