### PR TITLE
Fix warning logging

### DIFF
--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -164,7 +164,7 @@ class GtagExceptionDevTools extends GtagException {
 void _logWarning(HttpRequest response, String apiType, [String respText]) {
   log(
     'HttpRequest $apiType failed status = ${response.status}'
-    '${respText ??= ', responseText = $respText}'}',
+    '${respText != null ? ', responseText = $respText' : ''}',
     LogLevel.warning,
   );
 }


### PR DESCRIPTION
@terrylucas I think there were two minor issues here:

1. A stray `}` (this isn't a problem, but led me to discover a VS Code syntax highlighting bug! https://github.com/Dart-Code/Dart-Code/issues/2056)

2. It was adding the `, respText =` only when `respText` was null, which I think was the opposite of what was intended.

I think this is what was intended?