### PR TITLE
remove support for the older _Logging stream

### DIFF
--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -161,6 +161,7 @@ class LoggingController {
 
   TableData<LogData> get loggingTableModel => _loggingTableModel;
   TableData<LogData> _loggingTableModel;
+
   set loggingTableModel(TableData<LogData> model) {
     _loggingTableModel = model;
     _listen(_loggingTableModel.onSelect, (LogData selection) {
@@ -237,8 +238,6 @@ class LoggingController {
     _listen(service.onGCEvent, _handleGCEvent);
 
     // Log `dart:developer` `log` events.
-    // TODO(devoncarew): Remove `_Logging` support on or after approx. Oct 1 2019.
-    _listen(service.onEvent('_Logging'), _handleDeveloperLogEvent);
     _listen(service.onLoggingEvent, _handleDeveloperLogEvent);
 
     // Log Flutter extension events.

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -166,28 +166,22 @@ class ServiceConnectionManager {
     unawaited(onClosed.then((_) => vmServiceClosed()));
 
     final streamIds = [
-      EventStreams.kStdout,
-      EventStreams.kStderr,
-      EventStreams.kVM,
-      EventStreams.kIsolate,
       EventStreams.kDebug,
-      EventStreams.kGC,
-      EventStreams.kTimeline,
       EventStreams.kExtension,
-      serviceStreamName
+      EventStreams.kGC,
+      EventStreams.kIsolate,
+      EventStreams.kLogging,
+      EventStreams.kStderr,
+      EventStreams.kStdout,
+      EventStreams.kTimeline,
+      EventStreams.kVM,
+      serviceStreamName,
     ];
-
-    // The following streams are not yet supported by Flutter Web / Dart web
-    // apps.
-    if (!await connectedApp.isDartWebApp) {
-      streamIds.addAll(['_Logging', EventStreams.kLogging]);
-    }
 
     await Future.wait(streamIds.map((String id) async {
       try {
         await service.streamListen(id);
       } catch (e) {
-        // TODO(devoncarew): Remove this check on or after approx. Oct 1 2019.
         if (id.endsWith('Logging')) {
           // Don't complain about '_Logging' or 'Logging' events (new VMs don't
           // have the private names, and older ones don't have the public ones).


### PR DESCRIPTION
- remove support for the older `_Logging` stream
- potentially address https://github.com/flutter/devtools/issues/1207 (I'm not sure if there aren't other issues further down the bootstrap sequence)
