### PR TITLE
Use the dark theme by default in flutter desktop (debugging environment)

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -4,21 +4,31 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';
-import 'package:html_shim/html.dart' show document;
+import 'package:html_shim/html.dart' show document, window;
 
 import 'src/flutter/app.dart';
+import 'src/framework/framework_core.dart';
 
 void main() {
+  String url;
   if (kIsWeb) {
     // Clear out the unneeded HTML from index.html.
     for (var element in document.body.querySelectorAll('.legacy-dart')) {
       element.remove();
     }
+    url = window.location.toString();
   } else {
     // When running in a desktop embedder, Flutter throws an error because the
     // platform is not officially supported. This is not needed for web.
     debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
+    // TODO(jacobr): we don't yet have a direct analog to the URL on flutter
+    // desktop.
+    // Hard code to the dark theme as the majority of users are on the dark
+    // theme.
+    url = '/?theme=dark';
   }
+  FrameworkCore.init(url);
+
   // Now run the app.
   runApp(
     DevToolsApp(),

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -10,6 +10,7 @@ import '../../src/framework/framework_core.dart';
 import '../../src/globals.dart';
 import '../info/flutter/info_screen.dart';
 import '../inspector/flutter/inspector_screen.dart';
+import '../ui/theme.dart' as devtools_theme;
 import 'connect_screen.dart';
 import 'scaffold.dart';
 import 'screen.dart';
@@ -31,7 +32,6 @@ class DevToolsAppState extends State<DevToolsApp> {
   @override
   void initState() {
     super.initState();
-    FrameworkCore.init(WidgetsBinding.instance.window.defaultRouteName);
   }
 
   /// Generates routes, separating the path from URL query parameters.
@@ -75,10 +75,17 @@ class DevToolsAppState extends State<DevToolsApp> {
         ),
     '/connect': (_) => DevToolsScaffold.withChild(child: ConnectScreenBody()),
   };
+
   @override
   Widget build(BuildContext context) {
+    final theme =
+        devtools_theme.isDarkTheme ? ThemeData.dark() : ThemeData.light();
+    // TODO(jacobr): determine whether to update the theme to match the
+    // devtools_theme or update devtools_theme to match the flutter theme.
+    // For example, to match the devtools_theme we would wrtie:
+    // theme.copyWith(backgroundColor: devtools_theme.defaultBackground);
     return MaterialApp(
-      theme: ThemeData.light(),
+      theme: theme,
       onGenerateRoute: _generateRoute,
     );
   }

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -102,6 +102,8 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
               isDense: true,
               border: OutlineInputBorder(),
               enabledBorder: OutlineInputBorder(
+                // TODO(jacobr): we need to use themed colors everywhere instead
+                // of hard coding material colors.
                 borderSide: BorderSide(width: 0.5, color: Colors.grey),
               ),
               hintText: 'URL',


### PR DESCRIPTION
Load the theme from a url query parameter.
Move where the theme is being initialized slightly.

I think calling `FrameworkCore.init(url);` from main is more consistent than in initState as it is triggering side effects on a bunch of global objects which is odd to do from initState. This also gives us a reasonable hook to read the URL in flutter web.