### PR TITLE
Introduce a safe division utility and tests to prevent nan errors

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -179,8 +179,8 @@ class CpuStackFrame extends TreeNode<CpuStackFrame> {
   int _inclusiveSampleCount;
   set inclusiveSampleCount(int count) => _inclusiveSampleCount = count;
 
-  double get totalTimeRatio =>
-      _totalTimeRatio ??= inclusiveSampleCount / profileMetaData.sampleCount;
+  double get totalTimeRatio => _totalTimeRatio ??=
+      safeDivide(inclusiveSampleCount, profileMetaData.sampleCount);
 
   double _totalTimeRatio;
 
@@ -191,8 +191,8 @@ class CpuStackFrame extends TreeNode<CpuStackFrame> {
 
   Duration _totalTime;
 
-  double get selfTimeRatio =>
-      _selfTimeRatio ??= exclusiveSampleCount / profileMetaData.sampleCount;
+  double get selfTimeRatio => _selfTimeRatio ??=
+      safeDivide(exclusiveSampleCount, profileMetaData.sampleCount);
 
   double _selfTimeRatio;
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -420,3 +420,21 @@ bool isDebugBuild() {
   })());
   return debugBuild;
 }
+
+/// Divides [numerator] by [denominator], not returning infinite, NaN, or null
+/// quotients.
+///
+/// Returns [ifNotFinite] as a return value when the result of dividing
+/// [numerator] by [denominator] would be a non-finite value: either
+/// NaN, null, or infinite.
+///
+/// [ifNotFinite] defaults to 0.0.
+double safeDivide(num numerator, num denominator, [double ifNotFinite = 0.0]) {
+  if (numerator != null && denominator != null) {
+    final quotient = numerator / denominator;
+    if (quotient.isFinite) {
+      return quotient;
+    }
+  }
+  return ifNotFinite;
+}

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -429,7 +429,7 @@ bool isDebugBuild() {
 /// NaN, null, or infinite.
 ///
 /// [ifNotFinite] defaults to 0.0.
-double safeDivide(num numerator, num denominator, [double ifNotFinite = 0.0]) {
+double safeDivide(num numerator, num denominator, {double ifNotFinite = 0.0}) {
   if (numerator != null && denominator != null) {
     final quotient = numerator / denominator;
     if (quotient.isFinite) {

--- a/packages/devtools_app/test/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profile_model_test.dart
@@ -149,6 +149,13 @@ void main() {
       expect(copyFromMidTree.parent, isNull);
       expect(copyFromMidTree.level, equals(0));
     });
+
+    test('handles zero values', () {
+      expect(zeroStackFrame.totalTime, const Duration(milliseconds: 0));
+      expect(zeroStackFrame.totalTimeRatio, 0.0);
+      expect(zeroStackFrame.selfTime, const Duration(milliseconds: 0));
+      expect(zeroStackFrame.selfTimeRatio, 0.0);
+    });
   });
 
   test('matches', () {

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -271,6 +271,34 @@ void main() {
       name = '_CustomZone.run';
       expect(getSimpleStackFrameName(name), equals(name));
     });
+
+    group('safeDivide', () {
+      test('divides a finite result correctly', () {
+        expect(safeDivide(2.0, 1.0), 2.0);
+        expect(safeDivide(2, -4), -0.5);
+      });
+
+      test('produces the safe value on nan division', () {
+        expect(safeDivide(double.nan, 1.0), 0.0);
+        expect(safeDivide(double.nan, 1.0, 50.0), 50.0);
+        expect(safeDivide(0.0, double.nan, -5.0), -5.0);
+      });
+
+      test('produces the safe value on infinite division', () {
+        expect(safeDivide(double.infinity, 1.0), 0.0);
+        expect(safeDivide(double.nan, double.negativeInfinity, 50.0), 50.0);
+      });
+
+      test('produces the safe value on null division', () {
+        expect(safeDivide(null, 1.0), 0.0);
+        expect(safeDivide(1.0, null, 50.0), 50.0);
+      });
+
+      test('produces the safe value on division by zero', () {
+        expect(safeDivide(1.0, 0.0), 0.0);
+        expect(safeDivide(-50.0, 0.0, 10.0), 10.0);
+      });
+    });
   });
 }
 

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -280,23 +280,29 @@ void main() {
 
       test('produces the safe value on nan division', () {
         expect(safeDivide(double.nan, 1.0), 0.0);
-        expect(safeDivide(double.nan, 1.0, 50.0), 50.0);
-        expect(safeDivide(0.0, double.nan, -5.0), -5.0);
+        expect(safeDivide(double.nan, 1.0, ifNotFinite: 50.0), 50.0);
+        expect(safeDivide(0.0, double.nan, ifNotFinite: -5.0), -5.0);
       });
 
       test('produces the safe value on infinite division', () {
         expect(safeDivide(double.infinity, 1.0), 0.0);
-        expect(safeDivide(double.nan, double.negativeInfinity, 50.0), 50.0);
+        expect(
+            safeDivide(
+              double.nan,
+              double.negativeInfinity,
+              ifNotFinite: 50.0,
+            ),
+            50.0);
       });
 
       test('produces the safe value on null division', () {
         expect(safeDivide(null, 1.0), 0.0);
-        expect(safeDivide(1.0, null, 50.0), 50.0);
+        expect(safeDivide(1.0, null, ifNotFinite: 50.0), 50.0);
       });
 
       test('produces the safe value on division by zero', () {
         expect(safeDivide(1.0, 0.0), 0.0);
-        expect(safeDivide(-50.0, 0.0, 10.0), 10.0);
+        expect(safeDivide(-50.0, 0.0, ifNotFinite: 10.0), 10.0);
       });
     });
   });

--- a/packages/devtools_testing/lib/support/cpu_profile_test_data.dart
+++ b/packages/devtools_testing/lib/support/cpu_profile_test_data.dart
@@ -496,3 +496,20 @@ const String bottomUpGolden = '''
         A - children: 0 - excl: 3 - incl: 3
 
 ''';
+
+final CpuProfileMetaData zeroProfileMetaData = CpuProfileMetaData(
+  sampleCount: 0,
+  samplePeriod: 50,
+  stackDepth: 128,
+  time: TimeRange()
+    ..start = const Duration(microseconds: 0)
+    ..end = const Duration(microseconds: 100),
+);
+
+final CpuStackFrame zeroStackFrame = CpuStackFrame(
+  id: 'id_0',
+  name: 'A',
+  category: 'Dart',
+  url: '',
+  profileMetaData: zeroProfileMetaData,
+)..exclusiveSampleCount = 0;


### PR DESCRIPTION
This fixes an issue where some stack traces were reporting NaN or Infinite time values on flutter desktop:

![image](https://user-images.githubusercontent.com/14947366/67135373-ce1b5c00-f1cd-11e9-84cd-765ae661ee48.png)

```
flutter: The following UnsupportedError was thrown building _TreeNodeWidget<CpuStackFrame>-[String
flutter: <'cpuProfile'>](dirty, state: _TreeNodeState<CpuStackFrame>#df9c4(tickers: tracking 2 tickers)):
flutter: Unsupported operation: Infinity or NaN toInt
flutter: 
flutter: User-created ancestor of the error-causing widget was:
flutter:   ListView
flutter:   file:///Users/djshuckerow/Code/github.com/DaveShuckerow/devtools/packages/devtools_app/lib/src/flutter/table.dart:199:35
flutter: 
flutter: When the exception was thrown, this was the stack:
flutter: #0      double.toInt (dart:core-patch/double.dart:192:36)
flutter: #1      double.round (dart:core-patch/double.dart:160:34)
flutter: #2      CpuStackFrame.totalTime (package:devtools_app/src/profiler/cpu_profile_model.dart:190:16)
flutter: #3      TotalTimeColumn.getDisplayValue (package:devtools_app/src/profiler/cpu_profile_columns.dart:55:33)
flutter: #4      _TreeNodeState.tableRowFor.columnFor (package:devtools_app/src/flutter/table.dart:374:18)
```

This type of error only happens when you're using a real int type, which naturally we've never had to deal with as a web-only app.