### PR TITLE
Avoid test failures due to changes in flag order.

### DIFF
--- a/packages/devtools_testing/lib/info_controller_test.dart
+++ b/packages/devtools_testing/lib/info_controller_test.dart
@@ -56,7 +56,9 @@ Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
 
       final flagList = await env.service.getFlagList();
       expect(flags.length, flagList.flags.length);
-      final expectedFlags = [
+      final expectedFlags = <String>{};
+
+      for (var flag in [
         Flag.parse({
           'name': 'causal_async_stacks',
           'comment': 'Improved async stacks',
@@ -69,13 +71,13 @@ Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
           'modified': false,
           'valueAsString': 'true'
         }),
-      ];
+      ]) {
+        expectedFlags.add(flag.toString());
+      }
+
       for (var i = 0; i < flags.length; i++) {
         expect(flags[i].toString(), flagList.flags[i].toString());
-        if (expectedFlags.isNotEmpty &&
-            expectedFlags.last.toString() == flags[i].toString()) {
-          expectedFlags.removeLast();
-        }
+        expectedFlags.remove(flags[i].toString());
       }
       expect(
         expectedFlags.length,


### PR DESCRIPTION
This may fix https://github.com/flutter/devtools/issues/1234
If it doesn't we should comment out the test as it is flaking a lot but not critical.