### PR TITLE
Improve test error reporting

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -300,23 +300,34 @@ Future<Map<String, dynamic>> _waitForClients({
   String requiredPage,
 }) async {
   Map<String, dynamic> serverResponse;
+
+  String timeoutMessage = 'Server did not return any known clients';
+  if (requiredConnectionState != null) {
+    timeoutMessage += requiredConnectionState
+        ? ' that are connected'
+        : ' that are not connected';
+  }
+  if (requiredPage != null) {
+    timeoutMessage += ' that are on page $requiredPage';
+  }
+
+  final isOnPage = (Map<String, Object> c) => c['currentPage'] == requiredPage;
+  final hasConnectionState =
+      (Map<String, Object> c) => c['hasConnection'] == requiredConnectionState;
+
   await waitFor(
     () async {
       serverResponse = await _send('client.list');
       final clients = serverResponse['clients'];
       return clients is List &&
           clients.isNotEmpty &&
-          (requiredPage == null ||
-              clients.any((c) => c['currentPage'] == requiredPage)) &&
-          (requiredConnectionState == null ||
-              clients
-                  .any((c) => c['hasConnection'] == requiredConnectionState));
+          (requiredPage == null || clients.any(isOnPage)) &&
+          (requiredConnectionState == null || clients.any(hasConnectionState));
     },
     timeout: const Duration(seconds: 10),
-    timeoutMessage: 'Server did not return any known clients'
-        '${requiredConnectionState != null ? (requiredConnectionState ? ' that are connected' : ' that are not connected') : ''}'
-        '${requiredPage != null ? ' that are on page $requiredPage' : ''}',
+    timeoutMessage: timeoutMessage,
     delay: const Duration(seconds: 1),
   );
+
   return serverResponse;
 }

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -313,7 +313,9 @@ Future<Map<String, dynamic>> _waitForClients({
                   .any((c) => c['hasConnection'] == requiredConnectionState));
     },
     timeout: const Duration(seconds: 10),
-    timeoutMessage: 'Server did not return any known clients',
+    timeoutMessage: 'Server did not return any known clients'
+        '${requiredConnectionState != null ? (requiredConnectionState ? ' that are connected' : ' that are not connected') : ''}'
+        '${requiredPage != null ? ' that are on page $requiredPage' : ''}',
     delay: const Duration(seconds: 1),
   );
   return serverResponse;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -311,9 +311,9 @@ Future<Map<String, dynamic>> _waitForClients({
     timeoutMessage += ' that are on page $requiredPage';
   }
 
-  final isOnPage = (Map<String, Object> c) => c['currentPage'] == requiredPage;
+  final isOnPage = (client) => client['currentPage'] == requiredPage;
   final hasConnectionState =
-      (Map<String, Object> c) => c['hasConnection'] == requiredConnectionState;
+      (client) => client['hasConnection'] == requiredConnectionState;
 
   await waitFor(
     () async {


### PR DESCRIPTION
Trying to track down #1236. This improve the error message to make it clearer which stage of the test fails (in this case it's after the app is torn down, but it's easier to tell with this improved message) and also increases the timeout (on the off chance that the failure is due to slow CI machines).

Note: The timeout only triggers if it fails, so this won't make any *passing* test runs slower, though it may allow more runs to pass *if* they were taking too long. I don't think the issue is a timeout, but in the absence of other ideas, this might help confirm it. I've also added timestamps to the printed lines, so if it is taking > 10 seconds but then passing, we can identify that and investigate why.