### PR TITLE
Move server_test build to setUpAll to only run once instead of per-test

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -26,9 +26,7 @@ void main() {
   final bool testInReleaseMode =
       Platform.environment['WEBDEV_RELEASE'] == 'true';
 
-  setUp(() async {
-    compensateForFlutterTestDirectoryBug();
-
+  setUpAll(() async {
     // Clear the existing build directory.
     if (Directory('build').existsSync()) {
       Directory('build').deleteSync(recursive: true);
@@ -48,6 +46,10 @@ void main() {
     }
 
     Directory('build').renameSync('../devtools/build');
+  });
+
+  setUp(() async {
+    compensateForFlutterTestDirectoryBug();
 
     // Start the command-line server.
     server = await DevToolsServerDriver.create();


### PR DESCRIPTION
The server integration tests need to build the release version of the app and copy to the correct location. It was previously being done at the start of every test, even though nothing here changed.

This moves the build part from `setUp` to `setUpAll`.