### PR TITLE
Fix message manager bug.

### DIFF
--- a/packages/devtools_app/lib/src/html_message_manager.dart
+++ b/packages/devtools_app/lib/src/html_message_manager.dart
@@ -46,7 +46,7 @@ class HtmlMessageManager {
       _messages[screenId]?.remove(_message);
     });
 
-    _messages.putIfAbsent(screenId, () => {message});
+    _messages.putIfAbsent(screenId, () => {}).add(message);
     _showMessage(message);
   }
 }


### PR DESCRIPTION
Fixes a recent bug introduced by https://github.com/flutter/devtools/pull/1220. Thanks @natebosch for catching!

Originally was:
`_messages.putIfAbsent(screenId, () => Set()).add(message);`
Changed to:
`_messages.putIfAbsent(screenId, () => {message});` --> BUG
Now fixed:
`_messages.putIfAbsent(screenId, () => {}).add(message);`