### PR TITLE
Skip server API tests

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -249,7 +249,9 @@ void main() {
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
     // The API only works in release mode.
-  }, skip: !testInReleaseMode);
+    // TODO(dantup): Remove '|| true' once tests are not flaky.
+    //   https://github.com/flutter/devtools/issues/1236
+  }, skip: !testInReleaseMode || true);
 }
 
 Future<Map<String, dynamic>> launchDevTools({


### PR DESCRIPTION
This skips the server API tests while they're flaky (see #1236). The issue seems to be that when we terminate the Flutter app, DevTools never sends a 'disconnected' event back to the server like it should.

I'm trying to track it down on a fork (doesn't happen locally), but in the meantime we shouldn't keep all the bots red.