### PR TITLE
Add full timeline view.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -243,11 +243,11 @@ abstract class FlameChartCanvas<T> extends FlameChart {
   // canvas settings.
   void _paintCallback(CanvasRenderingContext2D canvas, Rect rect) {
     final int startRow = math.max(rowIndexForY(rect.top), 0);
-    final int endRow = math.min(
-      rowIndexForY(rect.bottom) + 1,
+    final int endRowInclusive = math.min(
+      rowIndexForY(rect.bottom),
       rows.length - 1,
     );
-    for (int i = startRow; i <= endRow; i++) {
+    for (int i = startRow; i <= endRowInclusive; i++) {
       paintRow(canvas, i, rect);
     }
 

--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -243,11 +243,11 @@ abstract class FlameChartCanvas<T> extends FlameChart {
   // canvas settings.
   void _paintCallback(CanvasRenderingContext2D canvas, Rect rect) {
     final int startRow = math.max(rowIndexForY(rect.top), 0);
-    final int endRowInclusive = math.min(
-      rowIndexForY(rect.bottom),
-      rows.length - 1,
+    final int endRow = math.min(
+      rowIndexForY(rect.bottom) + 1,
+      rows.length,
     );
-    for (int i = startRow; i <= endRowInclusive; i++) {
+    for (int i = startRow; i < endRow; i++) {
       paintRow(canvas, i, rect);
     }
 

--- a/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
@@ -84,7 +84,7 @@ class HtmlCpuFlameChart extends HtmlCpuProfilerView {
       // ensures that the grid lines in the chart will extend all the way to the
       // bottom of the container.
       canvas.forceRebuildForSize(
-        canvas.widthWithInsets,
+        canvas.calculatedWidthWithInsets,
         math.max(
           // Subtract [rowHeightWithPadding] to account for the size of
           // [stackFrameDetails] section at the bottom of the chart.
@@ -178,6 +178,7 @@ class CpuFlameChartCanvas extends FlameChartCanvas<CpuProfileData> {
         Colors.black,
         stackFrame,
         (_) => stackFrame.name,
+        sideInset,
       );
 
       rows[row].nodes.add(node);

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -229,6 +229,10 @@ class ServiceConnectionManager {
   }
 
   Future<double> getDisplayRefreshRate() async {
+    if (connectedApp == null || !await connectedApp.isAnyFlutterApp) {
+      return null;
+    }
+
     const unknownRefreshRate = 0.0;
 
     final flutterViewListResponse = await service.callServiceExtension(

--- a/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
@@ -8,6 +8,7 @@ import 'package:plotly_js/plotly.dart' hide Title, RangeSlider;
 
 import '../config_specific/logger.dart';
 import '../framework/html_framework.dart';
+import '../service_manager.dart';
 import '../ui/analytics.dart' as ga;
 import '../ui/html_elements.dart';
 import 'frames_bar_plotly.dart';
@@ -37,7 +38,8 @@ class FramesBarChart extends CoreElement with HtmlSetStateMixin {
       }
     });
 
-    timelineController.onFrameAdded.listen((TimelineFrame frame) {
+    timelineController.frameBasedTimeline.onFrameAdded
+        .listen((TimelineFrame frame) {
       frameUIgraph.process(frame);
     });
   }
@@ -86,7 +88,11 @@ class PlotlyDivGraph extends CoreElement {
     final int dataLength = dataIndexes.length;
     if (dataLength > 0) {
       plotlyChart.plotFPSDataList(
-          dataIndexes, uiDurations, gpuDurations, timelineController.paused);
+        dataIndexes,
+        uiDurations,
+        gpuDurations,
+        timelineController.frameBasedTimeline.paused,
+      );
 
       dataIndexes.removeRange(0, dataLength);
       uiDurations.removeRange(0, dataLength);
@@ -127,7 +133,7 @@ class PlotlyDivGraph extends CoreElement {
 
       if (_frames.containsKey(xPosition)) {
         final TimelineFrame timelineFrame = _frames[xPosition];
-        timelineController.selectFrame(timelineFrame);
+        timelineController.frameBasedTimeline.selectFrame(timelineFrame);
         ga.selectFrame(
           ga.timeline,
           ga.timelineFrame,
@@ -161,7 +167,9 @@ class PlotlyDivGraph extends CoreElement {
       element,
       useLogScale: false,
       showRangeSlider: false,
-      displayRefreshRate: await timelineController.displayRefreshRate,
+      displayRefreshRate:
+          await timelineController.frameBasedTimeline.displayRefreshRate ??
+              defaultRefreshRate,
     );
     plotlyChart.plotFPS();
 

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -40,7 +40,7 @@ import 'timeline_protocol.dart';
 
 // TODO(kenz): connect a frame's UI and GPU code in the full_timeline.
 
-const enableMultiModeTimeline = true;
+const enableMultiModeTimeline = false;
 
 class HtmlTimelineScreen extends HtmlScreen {
   HtmlTimelineScreen({bool enabled, String disabledTooltip})

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -38,8 +38,7 @@ import 'timeline_protocol.dart';
 
 // TODO(devoncarew): Have a timeline view thumbnail overview.
 
-// TODO(devoncarew): Switch to showing all timeline events, but highlighting the
-// area associated with the selected frame.
+// TODO(kenz): connect a frame's UI and GPU code in the full_timeline.
 
 const enableMultiModeTimeline = true;
 

--- a/packages/devtools_app/lib/src/timeline/simple_trace_example.dart
+++ b/packages/devtools_app/lib/src/timeline/simple_trace_example.dart
@@ -1,0 +1,681 @@
+final simpleTraceEvents = {
+  'traceEvents': [
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 4875,
+      'args': {'name': 'Dart ThreadPool Worker (4875)', 'mode': 'basic'}
+    },
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 4363,
+      'args': {'name': 'Dart ThreadPool Worker (4363)', 'mode': 'basic'}
+    },
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 4103,
+      'args': {'name': 'Dart ThreadPool Worker (4103)', 'mode': 'basic'}
+    },
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 4611,
+      'args': {'name': 'Dart ThreadPool Worker (4611)', 'mode': 'basic'}
+    },
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 3843,
+      'args': {
+        'name': 'Dart Profiler ThreadInterrupter (3843)',
+        'mode': 'basic'
+      }
+    },
+    {
+      'name': 'thread_name',
+      'ph': 'M',
+      'pid': 51385,
+      'tid': 775,
+      'args': {'name': 'Dart_Initialize (775)', 'mode': 'basic'}
+    },
+    {
+      'name': 'A',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937056864,
+      'ph': 'b',
+      'id': '1',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Aa',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937061035,
+      'ph': 'b',
+      'id': '7',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937113560,
+      'ph': 'b',
+      'id': '2',
+      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937117450,
+      'ph': 'b',
+      'id': '8',
+      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937141769,
+      'ph': 'b',
+      'id': 'd',
+      'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937141961,
+      'ph': 'b',
+      'id': 'f',
+      'args': {'parentId': 8, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937168961,
+      'ph': 'b',
+      'id': '3',
+      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937169662,
+      'ph': 'b',
+      'id': '9',
+      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937173019,
+      'ph': 'b',
+      'id': 'e',
+      'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937173132,
+      'ph': 'b',
+      'id': '10',
+      'args': {'parentId': 8, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937220903,
+      'ph': 'b',
+      'id': '11',
+      'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937221087,
+      'ph': 'b',
+      'id': '13',
+      'args': {'parentId': 9, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937225475,
+      'ph': 'e',
+      'id': 'd',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937225615,
+      'ph': 'e',
+      'id': 'f',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937281185,
+      'ph': 'e',
+      'id': 'e',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937281309,
+      'ph': 'e',
+      'id': '10',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937326225,
+      'ph': 'e',
+      'id': '11',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937326380,
+      'ph': 'e',
+      'id': '13',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937378812,
+      'ph': 'b',
+      'id': '12',
+      'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937378989,
+      'ph': 'b',
+      'id': '14',
+      'args': {'parentId': 9, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'B',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937382819,
+      'ph': 'e',
+      'id': '2',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Bb',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937382931,
+      'ph': 'e',
+      'id': '8',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937432875,
+      'ph': 'e',
+      'id': '12',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937432991,
+      'ph': 'e',
+      'id': '14',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'C',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937485018,
+      'ph': 'e',
+      'id': '3',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Cc',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937485110,
+      'ph': 'e',
+      'id': '9',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'D',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937574832,
+      'ph': 'b',
+      'id': '4',
+      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Dd',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937575344,
+      'ph': 'b',
+      'id': 'a',
+      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937630473,
+      'ph': 'b',
+      'id': '5',
+      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937631341,
+      'ph': 'b',
+      'id': 'b',
+      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'D',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937679798,
+      'ph': 'e',
+      'id': '4',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Dd',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937679953,
+      'ph': 'e',
+      'id': 'a',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937681385,
+      'ph': 'b',
+      'id': '15',
+      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937682955,
+      'ph': 'b',
+      'id': '19',
+      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'F',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937735555,
+      'ph': 'b',
+      'id': '6',
+      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ff',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937736205,
+      'ph': 'b',
+      'id': 'c',
+      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937736389,
+      'ph': 'b',
+      'id': '16',
+      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937736537,
+      'ph': 'b',
+      'id': '1a',
+      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'W',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937575692,
+      'tts': 28634,
+      'ph': 'X',
+      'dur': 206139,
+      'tdur': 5960,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E3',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937788218,
+      'ph': 'b',
+      'id': '17',
+      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee3',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937788380,
+      'ph': 'b',
+      'id': '1b',
+      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937893341,
+      'ph': 'e',
+      'id': '15',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee1',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937893466,
+      'ph': 'e',
+      'id': '19',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'F',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937940107,
+      'ph': 'e',
+      'id': '6',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ff',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937940216,
+      'ph': 'e',
+      'id': 'c',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'V',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937371774,
+      'tts': 25658,
+      'ph': 'X',
+      'dur': 615393,
+      'tdur': 10615,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937994780,
+      'ph': 'e',
+      'id': '16',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee2',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937994900,
+      'ph': 'e',
+      'id': '1a',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E3',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938050919,
+      'ph': 'e',
+      'id': '17',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee3',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938051050,
+      'ph': 'e',
+      'id': '1b',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E4',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938105406,
+      'ph': 'b',
+      'id': '18',
+      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee4',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938105579,
+      'ph': 'b',
+      'id': '1c',
+      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E4',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938160387,
+      'ph': 'e',
+      'id': '18',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee4',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938160492,
+      'ph': 'e',
+      'id': '1c',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'U',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937167696,
+      'tts': 20888,
+      'ph': 'X',
+      'dur': 1024347,
+      'tdur': 17484,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'E',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938264425,
+      'ph': 'e',
+      'id': '5',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Ee',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938264519,
+      'ph': 'e',
+      'id': 'b',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'T',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193937064411,
+      'tts': 12287,
+      'ph': 'X',
+      'dur': 1332000,
+      'tdur': 26683,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'A',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938740982,
+      'ph': 'e',
+      'id': '1',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Aa',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938741076,
+      'ph': 'e',
+      'id': '7',
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'Y',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938601826,
+      'tts': 39935,
+      'ph': 'X',
+      'dur': 203898,
+      'tdur': 866,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+    {
+      'name': 'X',
+      'cat': 'Dart',
+      'tid': 4875,
+      'pid': 51385,
+      'ts': 193938396852,
+      'tts': 39411,
+      'ph': 'X',
+      'dur': 614409,
+      'tdur': 1891,
+      'args': {'isolateId': 'isolates/2139247553966975'}
+    },
+  ]
+};

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -98,14 +98,8 @@ class TimelineController {
           : fullTimeline.data?.cpuProfileData;
 
   void selectTimelineEvent(TimelineEvent event) {
-    if (event == null) return;
-    if (timelineMode == TimelineMode.frameBased) {
-      if (frameBasedTimeline.data.selectedEvent == event) return;
-      frameBasedTimeline.data.selectedEvent = event;
-    } else {
-      if (fullTimeline.data.selectedEvent == event) return;
-      fullTimeline.data.selectedEvent = event;
-    }
+    if (event == null || timelineData.selectedEvent == event) return;
+    timelineData.selectedEvent = event;
     _selectedTimelineEventController.add(event);
   }
 
@@ -118,11 +112,7 @@ class TimelineController {
       extentMicros: selectedEvent.time.duration.inMicroseconds,
     );
 
-    if (timelineMode == TimelineMode.frameBased) {
-      frameBasedTimeline.data.cpuProfileData = cpuProfileData;
-    } else {
-      fullTimeline.data.cpuProfileData = cpuProfileData;
-    }
+    timelineData.cpuProfileData = cpuProfileData;
     _cpuProfileTransformer.processData(cpuProfileData);
   }
 
@@ -194,9 +184,7 @@ class TimelineController {
   }
 
   void exitOfflineMode({bool clearTimeline = true}) {
-    if (clearTimeline) {
-      frameBasedTimeline.data.clear();
-    }
+    clearData();
     offlineTimelineData = null;
   }
 
@@ -210,10 +198,7 @@ class TimelineController {
   }
 
   void recordTrace(Map<String, dynamic> trace) {
-    final traceEvents = timelineMode == TimelineMode.frameBased
-        ? frameBasedTimeline.data.traceEvents
-        : fullTimeline.data.traceEvents;
-    traceEvents.add(trace);
+    timelineData.traceEvents.add(trace);
   }
 
   void recordTraceForTimelineEvent(TimelineEvent event) {

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -3,16 +3,19 @@
 // found in the LICENSE file.
 import 'dart:math' as math;
 
+import 'package:html_shim/html.dart';
 import 'package:meta/meta.dart';
 
 import '../charts/flame_chart_canvas.dart';
 import '../ui/colors.dart';
 import '../ui/fake_flutter/fake_flutter.dart';
+import '../ui/flutter_html_shim.dart';
 import '../ui/theme.dart';
 import 'timeline_model.dart';
 
-class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
-  TimelineFlameChartCanvas({
+class FrameBasedTimelineFlameChartCanvas
+    extends FlameChartCanvas<TimelineFrame> {
+  FrameBasedTimelineFlameChartCanvas({
     @required TimelineFrame data,
     @required double width,
     @required double height,
@@ -33,9 +36,6 @@ class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
       data.uiEventFlow.depth + data.gpuEventFlow.depth,
       (i) => FlameChartRow(nodes: [], index: i),
     );
-
-    final totalWidth = width - 2 * sideInset;
-
     final int frameStartOffset = data.time.start.inMicroseconds;
 
     double getTopForRow(int row) {
@@ -48,46 +48,37 @@ class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
     }
 
     // Add UI section label.
-    const uiLabelWidth = 22.0 + rowPadding;
-    final uiLabelTop = getTopForRow(0);
-    final uiLabelBottom = uiLabelTop + rowHeight;
-    final uiSectionLabel = FlameChartNode<TimelineEvent>(
-      Rect.fromLTRB(rowPadding, uiLabelTop, uiLabelWidth, uiLabelBottom),
+    final uiSectionLabel = sectionLabel(
+      'UI',
       mainUiColor,
-      Colors.black,
-      Colors.black,
-      null,
-      (_) => 'UI',
+      top: getTopForRow(0),
+      width: 24.0,
     );
     rows[0].nodes.add(uiSectionLabel);
 
     // Add GPU section label.
-    const gpuLabelWidth = 40.0 + rowPadding;
-    final gpuLabelTop = getTopForRow(gpuSectionStartRow);
-    final gpuLabelBottom = gpuLabelTop + rowHeight;
-    final gpuSectionLabel = FlameChartNode<TimelineEvent>(
-      Rect.fromLTRB(rowPadding, gpuLabelTop, gpuLabelWidth, gpuLabelBottom),
+    final gpuSectionLabel = sectionLabel(
+      'GPU',
       mainGpuColor,
-      Colors.white,
-      Colors.white,
-      null,
-      (_) => 'GPU',
+      top: getTopForRow(gpuSectionStartRow),
+      width: 42.0,
     );
     rows[gpuSectionStartRow].nodes.add(gpuSectionLabel);
 
     void createChartNodes(TimelineEvent event, int row) {
       // Pixels per microsecond in order to fit the entire frame in view.
-      final double pxPerMicro = totalWidth / data.time.duration.inMicroseconds;
+      final double pxPerMicro =
+          totalStartingWidth / data.time.duration.inMicroseconds;
 
       // Do not round these values. Rounding the left could cause us to have
       // inaccurately placed events on the chart. Rounding the width could cause
       // us to lose very small events if the width rounds to zero.
       final double left =
           (event.time.start.inMicroseconds - frameStartOffset) * pxPerMicro +
-              sideInset;
+              startInset;
       final double right =
           (event.time.end.inMicroseconds - frameStartOffset) * pxPerMicro +
-              sideInset;
+              startInset;
       final top = getTopForRow(row);
       final backgroundColor =
           event.isUiEvent ? _nextUiColor() : _nextGpuColor();
@@ -101,6 +92,7 @@ class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
         Colors.black,
         event,
         (_) => event.name,
+        startInset,
       );
 
       rows[row].nodes.add(node);
@@ -123,7 +115,7 @@ class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
     // the root GPU event.
     return math.max(rows[gpuSectionStartRow].nodes.last.rect.right,
             rows[gpuSectionStartRow].nodes.last.rect.right) -
-        sideInset;
+        startInset;
   }
 
   @override
@@ -134,20 +126,262 @@ class TimelineFlameChartCanvas extends FlameChartCanvas<TimelineFrame> {
     }
     return absoluteY - topOffset;
   }
+}
 
-  int _uiColorOffset = 0;
+// TODO(kenz): color section backgrounds and alternate.
+// TODO(kenz): draw tree hierarchy lines between async events=
+// TODO(kenz): give top level children a secondary highlight color when a node
+// is selected.
+// TODO(kenz): make section label column resizeable.
+// TODO(kenz): make sections collapsible
 
-  int _gpuColorOffset = 0;
+class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
+  FullTimelineFlameChartCanvas({
+    @required FullTimelineData data,
+    @required double width,
+    @required double height,
+  }) : super(
+          data: data,
+          duration: data.time.duration,
+          width: width,
+          height: height,
+          startInset: _calculateStartInset(data),
+          // TODO(kenz): investigate if we need to be smarter here to avoid
+          // overflow in zooming calculations?
+          maxZoomLevel: 40000,
+        );
 
-  Color _nextUiColor() {
-    final color = uiColorPalette[_uiColorOffset % uiColorPalette.length];
-    _uiColorOffset++;
-    return color;
+  static Map<String, double> sectionLabelWidths = {};
+
+  static double maxSectionLabelWidth = 0.0;
+
+  static double _calculateStartInset(FullTimelineData data) {
+    final measurementCanvas = CanvasElement().context2D
+      ..font = fontStyleToCss(const TextStyle(fontSize: fontSize));
+    for (String bucketName in data.eventBuckets.keys) {
+      final measuredWidth =
+          measurementCanvas.measureText(bucketName).width.toDouble();
+      maxSectionLabelWidth = measuredWidth > maxSectionLabelWidth
+          ? measuredWidth
+          : maxSectionLabelWidth;
+      sectionLabelWidths[bucketName] = measuredWidth;
+    }
+    return maxSectionLabelWidth + 18.0;
   }
 
-  Color _nextGpuColor() {
-    final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
-    _gpuColorOffset++;
-    return color;
+  static const double sectionSpacing = 15.0;
+
+  int widestRow = -1;
+
+  final List<FlameChartSection> sections = [];
+
+  @override
+  void initRows() {
+    final int startTimeOffset = data.time.start.inMicroseconds;
+
+    double getTopForRow(int row, int section) {
+      // This accounts for section spacing between different threads of events.
+      final additionalPadding = section * sectionSpacing;
+      return (row * rowHeightWithPadding + topOffset + additionalPadding)
+          .toDouble();
+    }
+
+    double maxRight = -1;
+
+    void expandRowsToFitCurrentRow(int row) {
+      if (row >= rows.length) {
+        rows.addAll(List.generate(
+          row - rows.length + 1,
+          (i) => FlameChartRow(nodes: [], index: i),
+        ));
+      }
+    }
+
+    void createChartNodes(TimelineEvent event, int row, int section) {
+      // TODO(kenz): we should do something more clever here by inferring the
+      // missing start/end time based on ancestors/children. Skip for now.
+      if (!event.isWellFormed) return;
+
+      expandRowsToFitCurrentRow(row);
+
+      // Pixels per microsecond in order to fit the entire frame in view.
+      final double pxPerMicro =
+          totalStartingWidth / data.time.duration.inMicroseconds;
+
+      // Do not round these values. Rounding the left could cause us to have
+      // inaccurately placed events on the chart. Rounding the width could cause
+      // us to lose very small events if the width rounds to zero.
+      final top = getTopForRow(row, section);
+      final double left =
+          (event.time.start.inMicroseconds - startTimeOffset) * pxPerMicro +
+              startInset;
+      final double right =
+          (event.time.end.inMicroseconds - startTimeOffset) * pxPerMicro +
+              startInset;
+      if (right > maxRight) {
+        maxRight = right;
+        widestRow = row;
+      }
+
+      Color backgroundColor;
+      if (event.isAsyncEvent) {
+        backgroundColor = _nextAsyncColor();
+      } else if (event.isUiEvent) {
+        backgroundColor = _nextUiColor();
+      } else if (event.isGpuEvent) {
+        backgroundColor = _nextGpuColor();
+      } else {
+        backgroundColor = _nextUnknownColor();
+      }
+
+      Color textColor;
+      if (event.isGpuEvent) {
+        textColor = ThemedColor.fromSingleColor(contrastForegroundWhite);
+      } else {
+        textColor = ThemedColor.fromSingleColor(Colors.black);
+      }
+
+      final node = FlameChartNode<TimelineEvent>(
+        Rect.fromLTRB(left, top, right, top + rowHeight),
+        backgroundColor,
+        textColor,
+        Colors.black,
+        event,
+        (_) => event.name,
+        startInset,
+      );
+
+      rows[row].nodes.add(node);
+
+      var nextRow = row + 1;
+      for (var child in event.children) {
+        createChartNodes(child, nextRow, section);
+        if (event.hasOverlappingChildren) {
+          nextRow += child.displayDepth;
+        }
+      }
+    }
+
+    int currentRow = 0;
+    int currentSection = 0;
+
+    for (String bucketName in data.eventBuckets.keys) {
+      final section = FlameChartSection(
+        currentSection,
+        absStartY: getTopForRow(currentRow, currentSection),
+      );
+      sections.add(section);
+
+      Color backgroundColor;
+      switch (bucketName) {
+        case FullTimelineData.uiKey:
+          backgroundColor = mainUiColor;
+          break;
+        case FullTimelineData.gpuKey:
+          backgroundColor = mainGpuColor;
+          break;
+        case FullTimelineData.unknownKey:
+          backgroundColor = mainUnknownColor;
+          break;
+        default:
+          backgroundColor = mainAsyncColor;
+      }
+
+      // Padding necessary to ensure section labels fit in their respective
+      // [FlameChartNode]s.
+      const sectionLabelPadding = 13.0;
+
+      // Add section label.
+      final currentSectionLabel = sectionLabel(
+        bucketName,
+        backgroundColor,
+        top: getTopForRow(currentRow, currentSection),
+        width: math.max(
+          FlameChartNode.minWidthForText,
+          sectionLabelWidths[bucketName] + sectionLabelPadding,
+        ),
+      );
+      expandRowsToFitCurrentRow(currentRow);
+      rows[currentRow].nodes.add(currentSectionLabel);
+
+      final List<TimelineEvent> bucket = data.eventBuckets[bucketName];
+
+      int maxBucketDepth = 0;
+      for (TimelineEvent event in bucket) {
+        _resetColorOffsets();
+        maxBucketDepth = math.max(maxBucketDepth, event.displayDepth);
+        createChartNodes(event, currentRow, currentSection);
+      }
+      currentRow += maxBucketDepth;
+
+      currentSection++;
+    }
   }
+
+  @override
+  double get calculatedWidth =>
+      rows[widestRow].nodes.last.rect.right - startInset;
+
+  @override
+  num get zoomMultiplier => zoomLevel * 0.008;
+
+  @override
+  double relativeYPosition(double absoluteY) {
+    final section = sections
+            .lastWhere(
+              (s) => absoluteY >= s.absStartY,
+              orElse: () => null,
+            )
+            ?.index ??
+        0;
+    return absoluteY - topOffset - (section * sectionSpacing);
+  }
+}
+
+class FlameChartSection {
+  FlameChartSection(this.index, {this.absStartY});
+
+  final int index;
+
+  double absStartY;
+}
+
+int _uiColorOffset = 0;
+
+Color _nextUiColor() {
+  final color = uiColorPalette[_uiColorOffset % uiColorPalette.length];
+  _uiColorOffset++;
+  return color;
+}
+
+int _gpuColorOffset = 0;
+
+Color _nextGpuColor() {
+  final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
+  _gpuColorOffset++;
+  return color;
+}
+
+int _asyncColorOffset = 0;
+
+Color _nextAsyncColor() {
+  final color = asyncColorPalette[_asyncColorOffset % asyncColorPalette.length];
+  _asyncColorOffset++;
+  return color;
+}
+
+int _unknownColorOffset = 0;
+
+Color _nextUnknownColor() {
+  final color =
+      unknownColorPalette[_unknownColorOffset % unknownColorPalette.length];
+  _unknownColorOffset++;
+  return color;
+}
+
+void _resetColorOffsets() {
+  _asyncColorOffset = 0;
+  _uiColorOffset = 0;
+  _gpuColorOffset = 0;
+  _unknownColorOffset = 0;
 }

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -1,6 +1,10 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:async';
+import 'dart:collection';
+import 'dart:math';
+
 import 'package:meta/meta.dart';
 
 import '../globals.dart';
@@ -11,26 +15,161 @@ import '../utils.dart';
 import 'timeline_controller.dart';
 
 /// Data model for DevTools Timeline.
-class TimelineData {
-  TimelineData({
+class FrameBasedTimelineData extends TimelineData {
+  FrameBasedTimelineData({
     List<Map<String, dynamic>> traceEvents,
     List<TimelineFrame> frames,
     this.selectedFrame,
+    TimelineEvent selectedEvent,
+    CpuProfileData cpuProfileData,
+    double displayRefreshRate,
+  })  : frames = frames ?? [],
+        _displayRefreshRate = displayRefreshRate,
+        super(
+          traceEvents: traceEvents ?? [],
+          selectedEvent: selectedEvent,
+          cpuProfileData: cpuProfileData,
+        );
+
+  static const displayRefreshRateKey = 'displayRefreshRate';
+
+  static const selectedFrameIdKey = 'selectedFrameId';
+
+  FutureOr<double> get displayRefreshRate async =>
+      _displayRefreshRate ??= await serviceManager.getDisplayRefreshRate();
+
+  double _displayRefreshRate;
+
+  /// All frames currently visible in the timeline.
+  List<TimelineFrame> frames = [];
+
+  TimelineFrame selectedFrame;
+
+  String get selectedFrameId => selectedFrame?.id;
+
+  @override
+  Map<String, dynamic> get json => {
+        selectedFrameIdKey: selectedFrame?.id,
+        displayRefreshRateKey: _displayRefreshRate ?? defaultRefreshRate,
+      }..addAll(super.json);
+
+  @override
+  int get displayDepth =>
+      selectedFrame.uiEventFlow.depth + selectedFrame.gpuEventFlow.depth;
+
+  @override
+  void clear() {
+    super.clear();
+    frames.clear();
+    selectedFrame = null;
+    _displayRefreshRate = null;
+  }
+}
+
+class FullTimelineData extends TimelineData {
+  FullTimelineData({
+    List<Map<String, dynamic>> traceEvents,
+    TimelineEvent selectedEvent,
+    CpuProfileData cpuProfileData,
+    List<TimelineEvent> timelineEvents,
+  })  : timelineEvents = timelineEvents ?? [],
+        super(
+          traceEvents: traceEvents ?? [],
+          selectedEvent: selectedEvent,
+          cpuProfileData: cpuProfileData,
+        );
+
+  static const uiKey = 'UI';
+
+  static const gpuKey = 'GPU';
+
+  static const unknownKey = 'Unknown';
+
+  final List<TimelineEvent> timelineEvents;
+
+  final SplayTreeMap<String, List<TimelineEvent>> eventBuckets =
+      SplayTreeMap(eventBucketComparator);
+
+  TimeRange time = TimeRange();
+
+  @override
+  int get displayDepth {
+    if (_displayDepth != null) return _displayDepth;
+
+    if (eventBuckets.isEmpty) {
+      initializeEventBuckets();
+    }
+
+    int depth = 0;
+    for (List<TimelineEvent> bucket in eventBuckets.values) {
+      int bucketDisplayDepth = 0;
+      for (TimelineEvent event in bucket) {
+        bucketDisplayDepth = max(bucketDisplayDepth, event.displayDepth);
+      }
+      depth += bucketDisplayDepth;
+    }
+    return depth;
+  }
+
+  int _displayDepth;
+
+  void initializeEventBuckets() {
+    for (TimelineEvent event in timelineEvents) {
+      if (event.isAsyncEvent) {
+        eventBuckets.putIfAbsent(event.name, () => [])..add(event);
+      } else if (event.isUiEvent) {
+        eventBuckets.putIfAbsent(uiKey, () => [])..add(event);
+      } else if (event.isGpuEvent) {
+        eventBuckets.putIfAbsent(gpuKey, () => [])..add(event);
+      } else {
+        eventBuckets.putIfAbsent(unknownKey, () => [])..add(event);
+      }
+    }
+  }
+
+  @override
+  void clear() {
+    super.clear();
+    timelineEvents.clear();
+    eventBuckets.clear();
+    time = TimeRange();
+    _displayDepth = null;
+  }
+
+  @visibleForTesting
+  static int eventBucketComparator(String a, String b) {
+    if (a == b) return 0;
+
+    // Order Unknown buckets last.
+    if (a == unknownKey && b != unknownKey) return 1;
+    if (a != unknownKey && b == unknownKey) return -1;
+
+    // Order the GPU event bucket after the UI event bucket.
+    if ((a == uiKey && b == gpuKey) || (a == gpuKey && b == uiKey)) {
+      return -1 * a.compareTo(b);
+    }
+
+    // Order non-UI and non-GPU buckets before the UI / GPU buckets.
+    if (a == uiKey || a == gpuKey) return 1;
+    if (b == uiKey || b == gpuKey) return -1;
+
+    // Alphabetize all other buckets.
+    return a.compareTo(b);
+  }
+}
+
+abstract class TimelineData {
+  TimelineData({
+    List<Map<String, dynamic>> traceEvents,
     this.selectedEvent,
     this.cpuProfileData,
-    this.displayRefreshRate,
-  })  : traceEvents = traceEvents ?? [],
-        frames = frames ?? [];
+  }) : traceEvents = traceEvents ?? [];
 
   static const traceEventsKey = 'traceEvents';
 
   static const cpuProfileKey = 'cpuProfile';
 
-  static const selectedFrameIdKey = 'selectedFrameId';
-
   static const selectedEventKey = 'selectedEvent';
-
-  static const displayRefreshRateKey = 'displayRefreshRate';
 
   static const devToolsScreenKey = 'dartDevToolsScreen';
 
@@ -41,36 +180,22 @@ class TimelineData {
   /// clicked, this will be part of the output.
   List<Map<String, dynamic>> traceEvents = [];
 
-  /// All frames currently visible in the timeline.
-  List<TimelineFrame> frames = [];
-
-  TimelineFrame selectedFrame;
-
   TimelineEvent selectedEvent;
 
   CpuProfileData cpuProfileData;
 
-  double displayRefreshRate;
-
-  String get selectedFrameId => selectedFrame?.id;
-
   Map<String, dynamic> get json => {
         traceEventsKey: traceEvents,
         cpuProfileKey: cpuProfileData?.json ?? {},
-        selectedFrameIdKey: selectedFrame?.id,
         selectedEventKey: selectedEvent?.json ?? {},
-        displayRefreshRateKey: displayRefreshRate ?? defaultRefreshRate,
         devToolsScreenKey: timelineScreenId,
       };
 
-  Future<void> clear() async {
+  int get displayDepth;
+
+  void clear() {
     traceEvents.clear();
-    frames.clear();
-    selectedFrame = null;
     selectedEvent = null;
-    displayRefreshRate = serviceManager?.connectedApp == null
-        ? null
-        : await serviceManager.getDisplayRefreshRate();
     cpuProfileData = null;
   }
 
@@ -79,7 +204,7 @@ class TimelineData {
   }
 }
 
-class OfflineTimelineData extends TimelineData {
+class OfflineTimelineData extends FrameBasedTimelineData {
   OfflineTimelineData._({
     List<Map<String, dynamic>> traceEvents,
     List<TimelineFrame> frames,
@@ -107,7 +232,8 @@ class OfflineTimelineData extends TimelineData {
     final CpuProfileData cpuProfileData =
         cpuProfileJson.isNotEmpty ? CpuProfileData.parse(cpuProfileJson) : null;
 
-    final String selectedFrameId = json[TimelineData.selectedFrameIdKey];
+    final String selectedFrameId =
+        json[FrameBasedTimelineData.selectedFrameIdKey];
 
     final Map<String, dynamic> selectedEventJson =
         json[TimelineData.selectedEventKey] ?? {};
@@ -120,7 +246,9 @@ class OfflineTimelineData extends TimelineData {
           )
         : null;
 
-    final double displayRefreshRate = json[TimelineData.displayRefreshRateKey];
+    final double displayRefreshRate =
+        json[FrameBasedTimelineData.displayRefreshRateKey] ??
+            defaultRefreshRate;
 
     return OfflineTimelineData._(
       traceEvents: traceEvents,
@@ -137,6 +265,10 @@ class OfflineTimelineData extends TimelineData {
   String get selectedFrameId => _selectedFrameId;
   final String _selectedFrameId;
 
+  @override
+  FutureOr<double> get displayRefreshRate =>
+      _displayRefreshRate ?? defaultRefreshRate;
+
   /// Creates a new instance of [OfflineTimelineData] with references to the
   /// same objects contained in this instance.
   ///
@@ -151,7 +283,7 @@ class OfflineTimelineData extends TimelineData {
       selectedFrame: selectedFrame,
       selectedFrameId: selectedFrameId,
       selectedEvent: selectedEvent,
-      displayRefreshRate: displayRefreshRate,
+      displayRefreshRate: _displayRefreshRate,
       cpuProfileData: cpuProfileData,
     );
   }
@@ -166,7 +298,7 @@ class OfflineTimelineData extends TimelineData {
 ///
 /// We extend TimelineEvent so that our CPU profiler code requiring a selected
 /// timeline event will work as it does when we are not loading from offline.
-class OfflineTimelineEvent extends TimelineEvent {
+class OfflineTimelineEvent extends SyncTimelineEvent {
   OfflineTimelineEvent(
       String name, String eventType, int startMicros, int durationMicros)
       : super(TraceEventWrapper(
@@ -288,10 +420,11 @@ class TimelineFrame {
 enum TimelineEventType {
   ui,
   gpu,
+  async,
   unknown,
 }
 
-class TimelineEvent extends TreeNode<TimelineEvent> {
+abstract class TimelineEvent extends TreeNode<TimelineEvent> {
   TimelineEvent(TraceEventWrapper firstTraceEvent)
       : traceEvents = [firstTraceEvent],
         type = firstTraceEvent.event.type {
@@ -331,11 +464,20 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
 
   bool get isGpuEvent => type == TimelineEventType.gpu;
 
-  bool get isUiEventFlow => containsChildWithCondition(
-      (TimelineEvent event) => event.name.contains('Engine::BeginFrame'));
+  bool get isAsyncEvent => type == TimelineEventType.async;
 
-  bool get isGpuEventFlow => containsChildWithCondition(
-      (TimelineEvent event) => event.name.contains('PipelineConsume'));
+  bool get isWellFormed => time.start != null && time.end != null;
+
+  int get displayDepth;
+
+  bool get hasOverlappingChildren;
+
+  bool couldBeParentOf(TimelineEvent e);
+
+  void addEndEvent(TraceEventWrapper eventWrapper) {
+    time.end = Duration(microseconds: eventWrapper.event.timestampMicros);
+    traceEvents.add(eventWrapper);
+  }
 
   void maybeRemoveDuplicate() {
     void _maybeRemoveDuplicate({@required TimelineEvent parent}) {
@@ -350,7 +492,7 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
             parent.endTraceEventJson,
             parent.children.first.endTraceEventJson,
           )) {
-        parent.removeChild(children.first);
+        parent.removeChild(parent.children.first);
       }
     }
 
@@ -373,7 +515,6 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
 
   @override
   void addChild(TimelineEvent child) {
-    // Places the child in it's correct position amongst the other children.
     void _putChildInTree(TimelineEvent root) {
       // [root] is a leaf. Add child here.
       if (root.children.isEmpty) {
@@ -431,31 +572,6 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
     child.parent = this;
   }
 
-  bool couldBeParentOf(TimelineEvent e) {
-    final startTime = time.start.inMicroseconds;
-    final endTime = time.end?.inMicroseconds;
-    final eStartTime = e.time.start.inMicroseconds;
-    final eEndTime = e.time.end?.inMicroseconds;
-
-    if (endTime != null && eEndTime != null) {
-      if (startTime == eStartTime && endTime == eEndTime) {
-        return traceEvents.first.id < e.traceEvents.first.id;
-      }
-      return startTime <= eStartTime && endTime >= eEndTime;
-    } else if (endTime != null) {
-      // We don't use >= to compare [endTime] and [e.startTime] here because we
-      // don't want to falsely make [this] the parent of [e]. We do not know
-      // [e.endTime], meaning [e] could start at [endTime] and end later than
-      // [endTime] (unless e has a duration of 0). In this case, [this] would
-      // not be the parent of [e].
-      return startTime <= eStartTime && endTime > eStartTime;
-    } else if (startTime == eStartTime) {
-      return traceEvents.first.id < e.traceEvents.first.id;
-    } else {
-      return startTime < eStartTime;
-    }
-  }
-
   void format(StringBuffer buf, String indent) {
     buf.writeln('$indent$name $time');
     for (TimelineEvent child in children) {
@@ -488,7 +604,9 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
 
   @visibleForTesting
   TimelineEvent deepCopy() {
-    final copy = TimelineEvent(traceEvents.first);
+    final copy = isAsyncEvent
+        ? AsyncTimelineEvent(traceEvents.first)
+        : SyncTimelineEvent(traceEvents.first);
     copy.time.end = time.end;
     copy.parent = parent;
     for (TimelineEvent child in children) {
@@ -503,6 +621,196 @@ class TimelineEvent extends TreeNode<TimelineEvent> {
     final buf = StringBuffer();
     format(buf, '  ');
     return buf.toString();
+  }
+}
+
+class SyncTimelineEvent extends TimelineEvent {
+  SyncTimelineEvent(TraceEventWrapper firstTraceEvent) : super(firstTraceEvent);
+
+  bool get isUiEventFlow => containsChildWithCondition(
+      (TimelineEvent event) => event.name.contains('Engine::BeginFrame'));
+
+  bool get isGpuEventFlow => containsChildWithCondition(
+      (TimelineEvent event) => event.name.contains('PipelineConsume'));
+
+  @override
+  int get displayDepth => depth;
+
+  @override
+  bool get hasOverlappingChildren => false;
+
+  @override
+  bool couldBeParentOf(TimelineEvent e) {
+    final startTime = time.start.inMicroseconds;
+    final endTime = time.end?.inMicroseconds;
+    final eStartTime = e.time.start.inMicroseconds;
+    final eEndTime = e.time.end?.inMicroseconds;
+
+    if (endTime != null && eEndTime != null) {
+      if (startTime == eStartTime && endTime == eEndTime) {
+        return traceEvents.first.id < e.traceEvents.first.id;
+      }
+      return startTime <= eStartTime && endTime >= eEndTime;
+    } else if (endTime != null) {
+      // We don't use >= to compare [endTime] and [e.startTime] here because we
+      // don't want to falsely make [this] the parent of [e]. We do not know
+      // [e.endTime], meaning [e] could start at [endTime] and end later than
+      // [endTime] (unless e has a duration of 0). In this case, [this] would
+      // not be the parent of [e].
+      return startTime <= eStartTime && endTime > eStartTime;
+    } else if (startTime == eStartTime) {
+      return traceEvents.first.id < e.traceEvents.first.id;
+    } else {
+      return startTime < eStartTime;
+    }
+  }
+}
+
+class AsyncTimelineEvent extends TimelineEvent {
+  AsyncTimelineEvent(TraceEventWrapper firstTraceEvent)
+      : asyncId = firstTraceEvent.event.id,
+        parentId = firstTraceEvent.event.args[parentIdKey] != null
+            ? (firstTraceEvent.event.args[parentIdKey] as int).toRadixString(16)
+            : null,
+        super(firstTraceEvent) {
+    type = TimelineEventType.async;
+  }
+
+  static const parentIdKey = 'parentId';
+
+  final String asyncId;
+
+  /// Unique id for this async event's parent event.
+  ///
+  /// This field is not guaranteed to be non-null.
+  final String parentId;
+
+  bool get isWellFormedDeep => _isWellFormedDeep(this);
+
+  bool _isWellFormedDeep(AsyncTimelineEvent event) {
+    if (!event.isWellFormed) {
+      return false;
+    }
+    for (var child in event.children) {
+      return _isWellFormedDeep(child);
+    }
+    return true;
+  }
+
+  @override
+  int get displayDepth => _displayDepth ?? _calculateDisplayDepth();
+
+  int _displayDepth;
+
+  int _calculateDisplayDepth() {
+    // Base case.
+    if (children.isEmpty) {
+      return _displayDepth = 1;
+    }
+
+    var displayDepth = 1;
+    if (hasOverlappingChildren) {
+      // If any children have overlapping timestamps, display each child on its
+      // own row.
+      // TODO(kenz): save graph space by calculating when children can share a
+      // row in the flame chart.
+      for (var child in children) {
+        displayDepth += (child as AsyncTimelineEvent)._calculateDisplayDepth();
+      }
+    } else {
+      int maxChildDepth = -1;
+      for (var child in children) {
+        maxChildDepth = max(maxChildDepth,
+            (child as AsyncTimelineEvent)._calculateDisplayDepth());
+      }
+      displayDepth += maxChildDepth;
+    }
+    return _displayDepth = displayDepth;
+  }
+
+  @override
+  bool get hasOverlappingChildren {
+    if (_hasOverlappingChildren != null) return _hasOverlappingChildren;
+    for (int i = 0; i < children.length; i++) {
+      final currentChild = children[i];
+      // We do not have to look back because children will be ordered by their
+      // start times.
+      for (int j = i + 1; j < children.length; j++) {
+        final sibling = children[j];
+        // TODO(kenz): Check for deep timestamp overlap - since these events are
+        // async, children can extend the time bound of their parents, meaning
+        // we may still have display collisions even if parents do not overlap.
+        if (currentChild.time.overlaps(sibling.time)) {
+          return _hasOverlappingChildren = true;
+        }
+      }
+    }
+    return _hasOverlappingChildren = false;
+  }
+
+  bool _hasOverlappingChildren;
+
+  @override
+  void addChild(TimelineEvent child) {
+    final _child = child as AsyncTimelineEvent;
+    // Short circuit if we are using an explicit parentId.
+    if (_child.parentId != null &&
+        _child.parentId == traceEvents.first.event.id) {
+      _addChild(child);
+    } else {
+      super.addChild(child);
+    }
+  }
+
+  @override
+  bool couldBeParentOf(TimelineEvent e) {
+    final asyncEvent = e as AsyncTimelineEvent;
+
+    // If [asyncEvent] has an explicit parentId, use that as the truth.
+    if (asyncEvent.parentId != null) return asyncId == asyncEvent.parentId;
+
+    // Without an explicit parentId, two events must share an asyncId to be
+    // part of the same event tree.
+    if (asyncId != asyncEvent.asyncId) return false;
+
+    // When two events share an asyncId, determine parent / child relationships
+    // based on timestamps.
+    final startTime = time.start.inMicroseconds;
+    final endTime = time.end?.inMicroseconds;
+    final eStartTime = e.time.start.inMicroseconds;
+    final eEndTime = e.time.end?.inMicroseconds;
+
+    if (endTime != null && eEndTime != null) {
+      if (startTime == eStartTime && endTime == eEndTime) {
+        return int.parse(asyncId, radix: 16) <
+            int.parse(asyncEvent.asyncId, radix: 16);
+      }
+      return startTime <= eStartTime && endTime >= eEndTime;
+    } else if (endTime != null) {
+      // We don't use >= to compare [endTime] and [eStartTime] here because we
+      // don't want to falsely make [this] the parent of [e]. We do not know
+      // [eEndTime], meaning [e] could start at [endTime] and end later than
+      // [endTime] (unless e has a duration of 0). In this case, [this] would
+      // not be the parent of [e].
+      return startTime <= eStartTime && endTime > eStartTime;
+    } else if (startTime == eStartTime) {
+      return int.parse(asyncId, radix: 16) <
+          int.parse(asyncEvent.asyncId, radix: 16);
+    } else {
+      return startTime < eStartTime;
+    }
+  }
+
+  void endAsyncEvent(TraceEventWrapper eventWrapper) {
+    assert(asyncId == eventWrapper.event.id);
+    if (name == eventWrapper.event.name && endTraceEventJson == null) {
+      addEndEvent(eventWrapper);
+      return;
+    }
+
+    for (AsyncTimelineEvent child in children) {
+      child.endAsyncEvent(eventWrapper);
+    }
   }
 }
 
@@ -532,6 +840,15 @@ class TraceEvent {
   static const typeKey = 'type';
   static const idKey = 'id';
   static const scopeKey = 'scope';
+
+  static const asyncBeginPhase = 'b';
+  static const asyncEndPhase = 'e';
+  static const asyncInstantPhase = 'n';
+  static const durationBeginPhase = 'B';
+  static const durationEndPhase = 'E';
+  static const durationCompletePhase = 'X';
+  static const flowStartPhase = 's';
+  static const flowEndPhase = 'f';
 
   /// The original event JSON.
   final Map<String, dynamic> json;

--- a/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
@@ -577,6 +577,15 @@ class FrameBasedTimelineProcessor extends TimelineProcessor {
         // Only process events from the UI or GPU thread.
         (event.isGpuEvent || event.isUiEvent);
   }
+
+  @override
+  void reset() {
+    pendingFrames.clear();
+    pendingEvents.clear();
+    currentEventNodes.clear();
+    _previousDurationEndEvents.clear();
+    heaps.clear();
+  }
 }
 
 /// Processor for composing a recorded list of trace events into a timeline of
@@ -906,6 +915,7 @@ class FullTimelineProcessor extends TimelineProcessor {
     }
   }
 
+  @override
   void reset() {
     asyncEventsById.clear();
     currentDurationEventNodes.clear();
@@ -928,6 +938,8 @@ abstract class TimelineProcessor {
   final int gpuThreadId;
 
   final TimelineController timelineController;
+
+  void reset();
 
   @visibleForTesting
   TimelineEventType inferEventType(TraceEvent event) {

--- a/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
@@ -8,6 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import '../utils.dart';
+//import 'simple_trace_example.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
 
@@ -47,25 +48,17 @@ const Duration traceEventEpsilon = Duration(microseconds: 1000);
 const Duration traceEventDelay = Duration(milliseconds: 1000);
 
 /// Protocol for processing trace events and composing them into
-/// [TimelineEvents] and [TimelineFrames].
-class TimelineProtocol {
-  TimelineProtocol({
-    @required this.uiThreadId,
-    @required this.gpuThreadId,
-    @required this.timelineController,
-  });
-
-  static const durationBeginPhase = 'B';
-  static const durationEndPhase = 'E';
-  static const durationCompletePhase = 'X';
-  static const flowStartPhase = 's';
-  static const flowEndPhase = 'f';
-
-  // TODO(kenz): Remove the following members once ui/gpu distinction changes
-  //  and frame ids are available in the engine.
-  final int uiThreadId;
-  final int gpuThreadId;
-  final TimelineController timelineController;
+/// [SyncTimelineEvents] and [TimelineFrames].
+class FrameBasedTimelineProcessor extends TimelineProcessor {
+  FrameBasedTimelineProcessor({
+    @required int uiThreadId,
+    @required int gpuThreadId,
+    @required TimelineController timelineController,
+  }) : super(
+          uiThreadId: uiThreadId,
+          gpuThreadId: gpuThreadId,
+          timelineController: timelineController,
+        );
 
   /// Frames we are in the process of assembling.
   ///
@@ -75,27 +68,31 @@ class TimelineProtocol {
 
   /// Events we have collected and are waiting to add to their respective
   /// frames.
-  final List<TimelineEvent> pendingEvents = [];
+  final List<SyncTimelineEvent> pendingEvents = [];
 
   /// The current nodes in the tree structures of UI and GPU duration events.
-  final List<TimelineEvent> currentEventNodes = [null, null];
+  final List<SyncTimelineEvent> currentEventNodes = [null, null];
 
   /// The previously handled DurationEnd events for both UI and GPU.
   ///
   /// We need this information to balance the tree structures of our event nodes
   /// if they fall out of balance due to duplicate trace events.
-  List<TraceEvent> previousDurationEndEvents = [null, null];
+  final List<TraceEvent> _previousDurationEndEvents = [null, null];
 
   /// Heaps that order and store trace events as we receive them.
-  final List<HeapPriorityQueue<TraceEventWrapper>> heaps = List.generate(
+  final heaps = List.generate(
     2,
-    (_) => HeapPriorityQueue(),
+    (_) => HeapPriorityQueue<TraceEventWrapper>(),
   );
 
-  void processTraceEvent(TraceEvent event, {bool immediate = false}) {
+  void processTraceEvent(
+    TraceEventWrapper eventWrapper, {
+    bool immediate = false,
+  }) {
+    final event = eventWrapper.event;
     // TODO(kenz): stop manually setting the type once we have that data from
     // the engine.
-    event.type = _inferEventType(event);
+    event.type = inferEventType(event);
 
     if (!_shouldProcessTraceEvent(event)) return;
 
@@ -105,25 +102,24 @@ class TimelineProtocol {
     // lead to us creating Timeline frames where we shouldn't and therefore
     // showing bad data to the user.
     switch (event.phase) {
-      case flowStartPhase:
+      case TraceEvent.flowStartPhase:
         if (event.name.contains('PipelineItem')) {
           _handleFrameStartEvent(event);
         }
         break;
-      case flowEndPhase:
+      case TraceEvent.flowEndPhase:
         if (event.name.contains('PipelineItem')) {
           _handleFrameEndEvent(event);
         }
         break;
       default:
         if (immediate) {
-          _processDurationEvent(TraceEventWrapper(
-            event,
-            DateTime.now().millisecondsSinceEpoch,
-          ));
+          _processDurationEvent(eventWrapper);
         } else {
           // Add trace event to respective heap.
           final heap = heaps[event.type.index];
+
+          // Create a new [TraceEventWrapper] so that the delay starts now.
           heap.add(TraceEventWrapper(
             event,
             DateTime.now().millisecondsSinceEpoch,
@@ -132,20 +128,20 @@ class TimelineProtocol {
           executeWithDelay(
             Duration(milliseconds: traceEventDelay.inMilliseconds),
             () => _processDurationEvents(heap),
-            executeNow: shouldProcessTopEvent(heap),
+            executeNow: _shouldProcessTopEvent(heap),
           );
         }
     }
   }
 
-  bool shouldProcessTopEvent(HeapPriorityQueue<TraceEventWrapper> heap) {
+  bool _shouldProcessTopEvent(HeapPriorityQueue<TraceEventWrapper> heap) {
     return heap.isNotEmpty &&
         DateTime.now().millisecondsSinceEpoch - heap.first.timeReceived >=
             traceEventDelay.inMilliseconds;
   }
 
   void _processDurationEvents(HeapPriorityQueue<TraceEventWrapper> heap) {
-    while (heap.isNotEmpty && shouldProcessTopEvent(heap)) {
+    while (heap.isNotEmpty && _shouldProcessTopEvent(heap)) {
       _processDurationEvent(heap.removeFirst());
     }
   }
@@ -171,13 +167,13 @@ class TimelineProtocol {
     }
 
     switch (event.phase) {
-      case durationBeginPhase:
+      case TraceEvent.durationBeginPhase:
         _handleDurationBeginEvent(eventWrapper);
         break;
-      case durationEndPhase:
+      case TraceEvent.durationEndPhase:
         _handleDurationEndEvent(eventWrapper);
         break;
-      case durationCompletePhase:
+      case TraceEvent.durationCompletePhase:
         _handleDurationCompleteEvent(eventWrapper);
         break;
       // We do not need to handle other event types (phases 'b', 'n', 'e', etc.)
@@ -258,7 +254,7 @@ class TimelineProtocol {
       return;
     }
 
-    final timelineEvent = TimelineEvent(eventWrapper);
+    final timelineEvent = SyncTimelineEvent(eventWrapper);
 
     if (current != null) {
       current.addChild(timelineEvent);
@@ -268,7 +264,7 @@ class TimelineProtocol {
 
   void _handleDurationEndEvent(TraceEventWrapper eventWrapper) {
     final TraceEvent event = eventWrapper.event;
-    TimelineEvent current = currentEventNodes[event.type.index];
+    SyncTimelineEvent current = currentEventNodes[event.type.index];
 
     if (current == null) return;
 
@@ -278,7 +274,7 @@ class TimelineProtocol {
     if (event.name != current.name) {
       if (collectionEquals(
         event.json,
-        previousDurationEndEvents[event.type.index]?.json,
+        _previousDurationEndEvents[event.type.index]?.json,
       )) {
         // This is a duplicate of the previous DurationEnd event we received.
         //
@@ -296,7 +292,7 @@ class TimelineProtocol {
         }
         return;
       } else if (current.name ==
-              previousDurationEndEvents[event.type.index]?.name &&
+              _previousDurationEndEvents[event.type.index]?.name &&
           current.parent?.name == event.name &&
           current.children.length == 1 &&
           collectionEquals(
@@ -346,10 +342,9 @@ class TimelineProtocol {
       }
     }
 
-    previousDurationEndEvents[event.type.index] = event;
+    _previousDurationEndEvents[event.type.index] = event;
 
-    current.time.end = Duration(microseconds: event.timestampMicros);
-    current.traceEvents.add(eventWrapper);
+    current.addEndEvent(eventWrapper);
 
     // Even if the event is well nested, we could still have a duplicate in the
     // tree that needs to be removed. Ex:
@@ -379,7 +374,7 @@ class TimelineProtocol {
 
   void _handleDurationCompleteEvent(TraceEventWrapper eventWrapper) {
     final TraceEvent event = eventWrapper.event;
-    final TimelineEvent timelineEvent = TimelineEvent(eventWrapper);
+    final timelineEvent = SyncTimelineEvent(eventWrapper);
 
     timelineEvent.time.end =
         Duration(microseconds: event.timestampMicros + event.duration);
@@ -407,15 +402,15 @@ class TimelineProtocol {
 
     // Sort _pendingEvents by their startTime. This ensures we will add the
     // first matching event within the time boundary to the frame.
-    pendingEvents.sort((TimelineEvent a, TimelineEvent b) {
+    pendingEvents.sort((SyncTimelineEvent a, SyncTimelineEvent b) {
       return a.time.start.inMicroseconds.compareTo(b.time.start.inMicroseconds);
     });
 
     final List<TimelineFrame> frames = _getAndSortWellFormedFrames();
     for (TimelineFrame frame in frames) {
-      final List<TimelineEvent> eventsToRemove = [];
+      final eventsToRemove = [];
 
-      for (TimelineEvent event in pendingEvents) {
+      for (var event in pendingEvents) {
         final bool eventAdded = _maybeAddEventToFrame(event, frame);
         if (eventAdded) {
           eventsToRemove.add(event);
@@ -424,17 +419,14 @@ class TimelineProtocol {
       }
 
       if (eventsToRemove.isNotEmpty) {
-        // ignore: prefer_foreach
-        for (TimelineEvent event in eventsToRemove) {
-          pendingEvents.remove(event);
-        }
+        eventsToRemove.forEach(pendingEvents.remove);
       }
     }
   }
 
   /// Add event to an available frame in [pendingFrames] if we can, or
   /// otherwise add it to [pendingEvents].
-  void _maybeAddEvent(TimelineEvent event) {
+  void _maybeAddEvent(SyncTimelineEvent event) {
     if (!event.isUiEventFlow && !event.isGpuEventFlow) {
       // We do not care about events that are neither the main flow of UI
       // events nor the main flow of GPU events.
@@ -464,7 +456,7 @@ class TimelineProtocol {
 
   /// Attempts to add [event] to [frame], and returns a bool indicating whether
   /// the attempt was successful.
-  bool _maybeAddEventToFrame(TimelineEvent event, TimelineFrame frame) {
+  bool _maybeAddEventToFrame(SyncTimelineEvent event, TimelineFrame frame) {
     // Ensure the frame does not already have an event of this type and that
     // the event fits within the frame's time boundaries.
     if (frame.eventFlows[event.type.index] != null ||
@@ -499,7 +491,7 @@ class TimelineProtocol {
       timelineController.recordTraceForTimelineEvent(frame.gpuEventFlow);
       timelineController.recordTrace(frame.pipelineItemEndTrace.json);
 
-      timelineController.addFrame(frame);
+      timelineController.frameBasedTimeline.addFrame(frame);
       pendingFrames.remove(frame.id);
       frame.addedToTimeline = true;
 
@@ -507,7 +499,8 @@ class TimelineProtocol {
     }
   }
 
-  bool eventOccursWithinFrameBounds(TimelineEvent e, TimelineFrame f) {
+  @visibleForTesting
+  bool eventOccursWithinFrameBounds(SyncTimelineEvent e, TimelineFrame f) {
     // TODO(kenz): talk to the engine team about why we need the epsilon. Why
     // do event times extend slightly beyond the times we get from frame start
     // and end flow events.
@@ -566,23 +559,13 @@ class TimelineProtocol {
     return frames;
   }
 
-  TimelineEventType _inferEventType(TraceEvent event) {
-    if (event.threadId == uiThreadId) {
-      return TimelineEventType.ui;
-    } else if (event.threadId == gpuThreadId) {
-      return TimelineEventType.gpu;
-    } else {
-      return TimelineEventType.unknown;
-    }
-  }
-
   bool _shouldProcessTraceEvent(TraceEvent event) {
     final phaseWhitelist = {
-      flowStartPhase,
-      flowEndPhase,
-      durationBeginPhase,
-      durationEndPhase,
-      durationCompletePhase,
+      TraceEvent.flowStartPhase,
+      TraceEvent.flowEndPhase,
+      TraceEvent.durationBeginPhase,
+      TraceEvent.durationEndPhase,
+      TraceEvent.durationCompletePhase,
     };
     return phaseWhitelist.contains(event.phase) &&
         // Do not process Garbage Collection events.
@@ -593,5 +576,371 @@ class TimelineProtocol {
         event.name != 'MessageLoop::RunExpiredTasks' &&
         // Only process events from the UI or GPU thread.
         (event.isGpuEvent || event.isUiEvent);
+  }
+}
+
+/// Processor for composing a recorded list of trace events into a timeline of
+/// [AsyncTimelineEvent]s and [SyncTimelineEvent]s.
+class FullTimelineProcessor extends TimelineProcessor {
+  FullTimelineProcessor({
+    @required int uiThreadId,
+    @required int gpuThreadId,
+    @required TimelineController timelineController,
+  }) : super(
+          uiThreadId: uiThreadId,
+          gpuThreadId: gpuThreadId,
+          timelineController: timelineController,
+        );
+
+  /// Async timeline events we have processed, mapped to their respective async
+  /// ids.
+  Map<String, AsyncTimelineEvent> asyncEventsById = {};
+
+  /// The current timeline event nodes for duration events.
+  ///
+  /// The events are mapped to their thread id. As we process duration events,
+  /// a timeline event on a single thread will be formed and completed before
+  /// another timeline event on the same thread begins.
+  final Map<int, SyncTimelineEvent> currentDurationEventNodes = {};
+
+  /// The previously handled DurationEnd events for each thread.
+  ///
+  /// We need this information to balance the tree structures of our event nodes
+  /// if they fall out of balance due to duplicate trace events.
+  final Map<int, TraceEvent> previousDurationEndEvents = {};
+
+  /// Pending root duration complete event that has not yet been added to the
+  /// timeline.
+  ///
+  /// A DC event is a root if we do not have a current duration event tracked
+  /// for the given thread.
+  ///
+  /// We keep this event around to avoid prematurely adding a root DC event to
+  /// the timeline. Once we have processed events beyond a DC event's end
+  /// timestamp, we know that the DC event has no more unprocessed children.
+  /// This is guaranteed because we process the events in timestamp order.
+  SyncTimelineEvent pendingRootCompleteEvent;
+
+  void processTimeline(List<TraceEventWrapper> traceEvents) async {
+// Uncomment this code for testing the timeline.
+//    traceEvents = simpleTraceEvents['traceEvents']
+//        .where((json) =>
+//            json.containsKey(TraceEvent.timestampKey)) // thread_name events
+//        .map((e) => TraceEventWrapper(
+//            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
+//        .toList();
+    final _traceEvents = (traceEvents
+        // Throw out timeline events that do not have a timestamp
+        // (e.g. thread_name events).
+        .where((event) => event.event.timestampMicros != null)
+        .toList())
+      // Events need to be in increasing timestamp order.
+      ..sort()
+      ..map((event) => event.event.json)
+          .toList()
+          .forEach(timelineController.recordTrace);
+
+    for (var eventWrapper in _traceEvents) {
+      // TODO(kenz): stop manually setting the type once we have that data
+      // from the engine.
+      eventWrapper.event.type = inferEventType(eventWrapper.event);
+
+      // Add [pendingRootCompleteEvent] to the timeline if it is ready.
+      _addPendingCompleteRootToTimeline(
+          currentProcessingTime: eventWrapper.event.timestampMicros);
+
+      switch (eventWrapper.event.phase) {
+        case TraceEvent.asyncBeginPhase:
+        case TraceEvent.asyncInstantPhase:
+          _addAsyncEvent(eventWrapper);
+          break;
+        case TraceEvent.asyncEndPhase:
+          _endAsyncEvent(eventWrapper);
+          break;
+        case TraceEvent.durationBeginPhase:
+          _handleDurationBeginEvent(eventWrapper);
+          break;
+        case TraceEvent.durationEndPhase:
+          _handleDurationEndEvent(eventWrapper);
+          break;
+        case TraceEvent.durationCompletePhase:
+          _handleDurationCompleteEvent(eventWrapper);
+          break;
+        case TraceEvent.flowStartPhase:
+        case TraceEvent.flowEndPhase:
+        // TODO(kenz): add support for flows.
+        default:
+          break;
+      }
+    }
+
+    for (var rootEvent in asyncEventsById.values.where((e) => e.isRoot)) {
+      // Do not add incomplete async trees to the timeline.
+      // TODO(kenz): infer missing end times based on other end times in the
+      // async event tree. Add these "repaired" events to the timeline.
+      if (!rootEvent.isWellFormedDeep) continue;
+
+      timelineController.fullTimeline.addTimelineEvent(rootEvent);
+    }
+
+    _addPendingCompleteRootToTimeline(force: true);
+
+    // TODO(kenz): we should do something smarter using the processed data
+    // [timelineController.fullTimeline.data] to set start and end times.
+    timelineController.fullTimeline.data.time
+      ..start = Duration(microseconds: _traceEvents.first.event.timestampMicros)
+      ..end = Duration(microseconds: _traceEvents.last.event.timestampMicros);
+  }
+
+  void _addPendingCompleteRootToTimeline({
+    int currentProcessingTime,
+    bool force = false,
+  }) {
+    assert(currentProcessingTime != null || force);
+    if (pendingRootCompleteEvent != null &&
+        (force ||
+            currentProcessingTime >
+                pendingRootCompleteEvent.time.end.inMicroseconds)) {
+      timelineController.fullTimeline
+          .addTimelineEvent(pendingRootCompleteEvent);
+      pendingRootCompleteEvent = null;
+    }
+  }
+
+  void _addAsyncEvent(TraceEventWrapper eventWrapper) {
+    final timelineEvent = AsyncTimelineEvent(eventWrapper);
+    if (eventWrapper.event.phase == TraceEvent.asyncInstantPhase) {
+      timelineEvent.time.end = timelineEvent.time.start;
+    }
+
+    // If parentId is specified, use it to define the async tree structure.
+    final parentId = timelineEvent.parentId;
+    if (parentId != null) {
+      final parent = asyncEventsById[parentId];
+      if (parent != null) {
+        parent.addChild(timelineEvent);
+      }
+      asyncEventsById[eventWrapper.event.id] = timelineEvent;
+      return;
+    }
+
+    final currentEventWithId = asyncEventsById[eventWrapper.event.id];
+
+    // If we already have a timeline event with the same async id as
+    // [timelineEvent] (e.g. [currentEventWithId]), then [timelineEvent] is
+    // either a child of [currentEventWithId] or a new root event with this id.
+    if (currentEventWithId != null) {
+      if (currentEventWithId.isWellFormedDeep) {
+        // [timelineEvent] is a new root with the same id as
+        // [currentEventWithId]. Since [currentEventWithId] is well formed, add
+        // it to the timeline.
+        timelineController.fullTimeline.addTimelineEvent(currentEventWithId);
+        asyncEventsById[eventWrapper.event.id] = timelineEvent;
+      } else {
+        assert(!currentEventWithId.isWellFormed);
+        // We know it must be a child because we process events in timestamp
+        // order.
+        currentEventWithId.addChild(timelineEvent);
+      }
+    } else {
+      asyncEventsById[eventWrapper.event.id] = timelineEvent;
+    }
+  }
+
+  void _endAsyncEvent(TraceEventWrapper eventWrapper) {
+    final root = asyncEventsById[eventWrapper.event.id];
+    if (root == null) {
+      // Since we process trace events in timestamp order, we can guarantee that
+      // we have not already processed the matching begin event. Discard the end
+      // event in this case.
+      return;
+    }
+    root.endAsyncEvent(eventWrapper);
+  }
+
+  void _handleDurationBeginEvent(TraceEventWrapper eventWrapper) {
+    final current = currentDurationEventNodes[eventWrapper.event.threadId];
+    final timelineEvent = SyncTimelineEvent(eventWrapper);
+    if (current != null) {
+      current.addChild(timelineEvent);
+    }
+    currentDurationEventNodes[eventWrapper.event.threadId] = timelineEvent;
+  }
+
+  void _handleDurationEndEvent(TraceEventWrapper eventWrapper) {
+    final TraceEvent event = eventWrapper.event;
+    SyncTimelineEvent current = currentDurationEventNodes[event.threadId];
+
+    if (current == null) return;
+
+    // If the names of [event] and [current] do not match, our event nesting is
+    // off balance due to duplicate events from the engine. Balance the tree so
+    // we can continue processing trace events for [current].
+    if (event.name != current.name) {
+      if (collectionEquals(
+        event.json,
+        previousDurationEndEvents[event.threadId]?.json,
+      )) {
+        // This is a duplicate of the previous DurationEnd event we received.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        // Animator::BeginFrame - DurationBegin
+        // ...
+        // Animator::BeginFrame - DurationEnd [previousDurationEndEvent]
+        // Animator::BeginFrame - DurationEnd ([event] - duplicate)
+        // VSYNC - DurationEnd
+        //
+        if (debugTimeline) {
+          debugFrameTracking
+              .writeln('Duplicate duration end event: ${event.json}');
+        }
+        return;
+      } else if (current.name ==
+              previousDurationEndEvents[event.threadId]?.name &&
+          current.parent?.name == event.name &&
+          current.children.length == 1 &&
+          collectionEquals(
+            current.beginTraceEventJson,
+            current.children.first.beginTraceEventJson,
+          )) {
+        // There was a duplicate DurationBegin event associated with
+        // [previousDurationEndEvent]. [event] is actually the DurationEnd event
+        // for [current.parent]. Trim the extra layer created by the duplicate.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        // Animator::BeginFrame - DurationBegin (duplicate - remove this node)
+        // Animator::BeginFrame - DurationBegin
+        // ...
+        // Animator::BeginFrame - DurationEnd [previousDurationEndEvent]
+        // VSYNC - DurationEnd [event]
+        //
+        if (debugTimeline) {
+          debugFrameTracking.writeln(
+              'Duplicate duration begin event: ${current.beginTraceEventJson}');
+        }
+
+        current.parent.removeChild(current);
+        current = current.parent;
+        currentDurationEventNodes[event.threadId] = current;
+      } else {
+        // The current event node has fallen into an unrecoverable state. Reset
+        // the tracking node.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        //  Animator::BeginFrame - DurationBegin
+        //   VSYNC - DurationBegin (duplicate)
+        //    Animator::BeginFrame - DurationBegin (duplicate)
+        //     ...
+        //  Animator::BeginFrame - DurationEnd
+        // VSYNC - DurationEnd
+        if (debugTimeline) {
+          debugFrameTracking.writeln('Cannot recover unbalanced event tree.');
+          debugFrameTracking.writeln('Event: ${event.json}');
+          debugFrameTracking
+              .writeln('Current: ${currentDurationEventNodes[event.threadId]}');
+        }
+        currentDurationEventNodes[event.threadId] = null;
+        return;
+      }
+    }
+
+    previousDurationEndEvents[event.threadId] = event;
+
+    current.addEndEvent(eventWrapper);
+
+    // Even if the event is well nested, we could still have a duplicate in the
+    // tree that needs to be removed. Ex:
+    //   VSYNC - StartTime 123
+    //      VSYNC - StartTime 123 (duplicate)
+    //      VSYNC - EndTime 234 (duplicate)
+    //   VSYNC - EndTime 234
+    current.maybeRemoveDuplicate();
+
+    // Since this event is complete, move back up the tree to the nearest
+    // incomplete event.
+    while (current.parent != null &&
+        current.parent.time.end?.inMicroseconds != null) {
+      current = current.parent;
+    }
+    currentDurationEventNodes[event.threadId] = current.parent;
+
+    // If we have reached a null parent, this event is fully formed.
+    if (current.parent == null) {
+      if (debugTimeline) {
+        debugFrameTracking.writeln('Trying to add event after DurationEnd:');
+        current.format(debugFrameTracking, '   ');
+      }
+      timelineController.fullTimeline.addTimelineEvent(current);
+    }
+  }
+
+  void _handleDurationCompleteEvent(TraceEventWrapper eventWrapper) {
+    final event = eventWrapper.event;
+    final timelineEvent = SyncTimelineEvent(eventWrapper)
+      ..time.end =
+          Duration(microseconds: event.timestampMicros + event.duration);
+
+    final current = currentDurationEventNodes[event.threadId];
+    if (current != null) {
+      if (current
+          .containsChildWithCondition((TimelineEvent event) => collectionEquals(
+                event.beginTraceEventJson,
+                timelineEvent.beginTraceEventJson,
+              ))) {
+        // This is a duplicate DurationComplete event. Return early.
+        return;
+      }
+      current.addChild(timelineEvent);
+    } else {
+      // Since we do not have a current duration event for this thread, this DC
+      // event is either a timeline root event or a child of
+      // [pendingRootCompleteEvent].
+      if (pendingRootCompleteEvent == null) {
+        pendingRootCompleteEvent = timelineEvent;
+      } else {
+        pendingRootCompleteEvent.addChild(timelineEvent);
+      }
+    }
+  }
+
+  void reset() {
+    asyncEventsById.clear();
+    currentDurationEventNodes.clear();
+    previousDurationEndEvents.clear();
+    pendingRootCompleteEvent = null;
+  }
+}
+
+abstract class TimelineProcessor {
+  TimelineProcessor({
+    @required this.uiThreadId,
+    @required this.gpuThreadId,
+    @required this.timelineController,
+  });
+
+  // TODO(kenz): Remove the [uiThreadId] and [gpuThreadId] once ui/gpu
+  //  distinction changes and frame ids are available in the engine.
+  final int uiThreadId;
+
+  final int gpuThreadId;
+
+  final TimelineController timelineController;
+
+  @visibleForTesting
+  TimelineEventType inferEventType(TraceEvent event) {
+    if (event.phase == TraceEvent.asyncBeginPhase ||
+        event.phase == TraceEvent.asyncInstantPhase ||
+        event.phase == TraceEvent.asyncEndPhase) {
+      return TimelineEventType.async;
+    } else if (event.threadId == uiThreadId) {
+      return TimelineEventType.ui;
+    } else if (event.threadId == gpuThreadId) {
+      return TimelineEventType.gpu;
+    } else {
+      return TimelineEventType.unknown;
+    }
   }
 }

--- a/packages/devtools_app/lib/src/trees.dart
+++ b/packages/devtools_app/lib/src/trees.dart
@@ -38,6 +38,8 @@ class TreeNode<T extends TreeNode<T>> {
 
   int _depth = 0;
 
+  bool get isRoot => parent == null;
+
   T get root {
     if (_root != null) {
       return _root;

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -14,6 +14,8 @@ import 'theme.dart';
 /// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
 const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);
 const mainGpuColor = ThemedColor(mainGpuColorLight, mainGpuColorDark);
+final mainUnknownColor = ThemedColor.fromSingleColor(const Color(0xFFCAB8E9));
+final mainAsyncColor = ThemedColor.fromSingleColor(const Color(0xFF80CBC4));
 
 const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
 const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
@@ -50,6 +52,20 @@ final gpuColorPalette = [
   const ThemedColor(mainGpuColorLight, mainGpuColorDark),
   const ThemedColor(Color(0xFF0277BD), Color(0xFF1966D2)),
   const ThemedColor(Color(0xFF01579B), Color(0xFF1859BD)),
+];
+
+// Teal 200-400 - see https://material.io/design/color/#tools-for-picking-colors.
+final asyncColorPalette = [
+  mainAsyncColor,
+  ThemedColor.fromSingleColor(const Color(0xFF4DB6AC)),
+  ThemedColor.fromSingleColor(const Color(0xFF26A69A)),
+];
+
+// Slight variation on Deep purple 100-300 - see https://material.io/design/color/#tools-for-picking-colors.
+final unknownColorPalette = [
+  mainUnknownColor,
+  ThemedColor.fromSingleColor(const Color(0xFFB39DDB)),
+  ThemedColor.fromSingleColor(const Color(0xFF9D84CA)),
 ];
 
 const selectedFlameChartItemColor = ThemedColor(

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -391,6 +391,11 @@ class TimeRange {
 
   Duration get duration => end - start;
 
+  bool overlaps(TimeRange t) {
+    return (t.start >= start && t.start <= end) ||
+        (t.end >= start && t.end <= end);
+  }
+
   @override
   String toString({TimeUnit unit}) {
     unit ??= TimeUnit.microseconds;

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -393,8 +393,17 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Timestamp> getVMTimelineMicros() =>
-      _trackFuture('getVMTimelineMicros', _vmService.getVMTimelineMicros());
+  Future<Timestamp> getVMTimelineMicros() async {
+    if (await isProtocolVersionSupported(
+        supportedVersion: SemanticVersion(major: 3, minor: 21))) {
+      return _trackFuture(
+        'getVMTimelineMicros',
+        _vmService.getVMTimelineMicros(),
+      );
+    } else {
+      return null;
+    }
+  }
 
   @override
   Future<Version> getVersion() =>

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -13,20 +13,20 @@ import 'package:devtools_testing/support/timeline_test_data.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('TimelineData', () {
-    TimelineData timelineData;
+  group('FrameBasedTimelineData', () {
+    FrameBasedTimelineData timelineData;
 
     setUp(() {
-      timelineData = TimelineData();
+      timelineData = FrameBasedTimelineData(displayRefreshRate: 60.0);
     });
 
-    test('init', () {
+    test('init', () async {
       expect(timelineData.traceEvents, isEmpty);
       expect(timelineData.frames, isEmpty);
       expect(timelineData.selectedFrame, isNull);
       expect(timelineData.selectedFrameId, isNull);
       expect(timelineData.selectedEvent, isNull);
-      expect(timelineData.displayRefreshRate, isNull);
+      expect(await timelineData.displayRefreshRate, 60.0);
       expect(timelineData.cpuProfileData, isNull);
     });
 
@@ -36,47 +36,51 @@ void main() {
           equals({
             TimelineData.traceEventsKey: [],
             TimelineData.cpuProfileKey: {},
-            TimelineData.selectedFrameIdKey: null,
+            FrameBasedTimelineData.selectedFrameIdKey: null,
             TimelineData.selectedEventKey: {},
-            TimelineData.displayRefreshRateKey: 60,
+            FrameBasedTimelineData.displayRefreshRateKey: 60,
             TimelineData.devToolsScreenKey: timelineScreenId,
           }));
 
-      timelineData
+      timelineData = FrameBasedTimelineData(displayRefreshRate: 60)
         ..traceEvents.add({'name': 'FakeTraceEvent'})
         ..cpuProfileData = CpuProfileData.parse(goldenCpuProfileDataJson)
-        ..selectedEvent = vsyncEvent
-        ..displayRefreshRate = 60;
-
+        ..selectedEvent = vsyncEvent;
       expect(
-          timelineData.json,
-          equals({
-            TimelineData.traceEventsKey: [
-              {'name': 'FakeTraceEvent'}
-            ],
-            TimelineData.cpuProfileKey: goldenCpuProfileDataJson,
-            TimelineData.selectedFrameIdKey: null,
-            TimelineData.selectedEventKey: vsyncEvent.json,
-            TimelineData.displayRefreshRateKey: 60,
-            TimelineData.devToolsScreenKey: timelineScreenId,
-          }));
+        timelineData.json,
+        equals({
+          TimelineData.traceEventsKey: [
+            {'name': 'FakeTraceEvent'}
+          ],
+          TimelineData.cpuProfileKey: goldenCpuProfileDataJson,
+          FrameBasedTimelineData.selectedFrameIdKey: null,
+          TimelineData.selectedEventKey: vsyncEvent.json,
+          FrameBasedTimelineData.displayRefreshRateKey: 60,
+          TimelineData.devToolsScreenKey: timelineScreenId,
+        }),
+      );
     });
 
-    test('clear', () {
-      final frame = TimelineFrame('id_0');
-      timelineData
+    test('displayDepth', () {
+      timelineData.selectedFrame = testFrame;
+      expect(timelineData.selectedFrame.uiEventFlow.depth, equals(7));
+      expect(timelineData.selectedFrame.gpuEventFlow.depth, equals(2));
+      expect(timelineData.displayDepth, equals(9));
+    });
+
+    test('clear', () async {
+      timelineData = FrameBasedTimelineData(displayRefreshRate: 120)
         ..traceEvents.add({'test': 'trace event'})
-        ..frames.add(frame)
+        ..frames.add(testFrame)
         ..selectedEvent = vsyncEvent
-        ..selectedFrame = frame
-        ..displayRefreshRate = 120
+        ..selectedFrame = testFrame
         ..cpuProfileData = CpuProfileData.parse(jsonDecode(jsonEncode({})));
       expect(timelineData.traceEvents, isNotEmpty);
       expect(timelineData.frames, isNotEmpty);
       expect(timelineData.selectedFrame, isNotNull);
       expect(timelineData.selectedFrameId, 'id_0');
       expect(timelineData.selectedEvent, isNotNull);
-      expect(timelineData.displayRefreshRate, isNotNull);
+      expect(await timelineData.displayRefreshRate, equals(120));
       expect(timelineData.cpuProfileData, isNotNull);
 
       timelineData.clear();
@@ -85,8 +89,57 @@ void main() {
       expect(timelineData.selectedFrame, isNull);
       expect(timelineData.selectedFrameId, isNull);
       expect(timelineData.selectedEvent, isNull);
-      expect(timelineData.displayRefreshRate, isNull);
       expect(timelineData.cpuProfileData, isNull);
+    });
+  });
+
+  group('FullTimelineData', () {
+    FullTimelineData timelineData;
+    setUp(() {
+      timelineData = FullTimelineData(timelineEvents: [
+        goldenAsyncTimelineEvent,
+        goldenUiTimelineEvent,
+        goldenGpuTimelineEvent,
+        unknownEvent,
+      ]);
+    });
+
+    test('displayDepth', () {
+      expect(goldenAsyncTimelineEvent.displayDepth, equals(7));
+      expect(goldenUiTimelineEvent.displayDepth, equals(7));
+      expect(goldenGpuTimelineEvent.displayDepth, equals(2));
+      expect(unknownEvent.displayDepth, equals(1));
+      expect(timelineData.displayDepth, equals(17));
+    });
+
+    test('initializeEventBuckets', () {
+      expect(timelineData.eventBuckets, isEmpty);
+      timelineData.initializeEventBuckets();
+      expect(
+        timelineData.eventBuckets[FullTimelineData.uiKey].length,
+        equals(1),
+      );
+      expect(
+        timelineData.eventBuckets[FullTimelineData.gpuKey].length,
+        equals(1),
+      );
+      expect(
+        timelineData.eventBuckets[FullTimelineData.unknownKey].length,
+        equals(1),
+      );
+      expect(timelineData.eventBuckets['A'].length, equals(1));
+    });
+
+    test('event bucket compare', () {
+      expect(FullTimelineData.eventBucketComparator('UI', 'GPU'), equals(-1));
+      expect(FullTimelineData.eventBucketComparator('GPU', 'UI'), equals(1));
+      expect(FullTimelineData.eventBucketComparator('UI', 'UI'), equals(0));
+      expect(FullTimelineData.eventBucketComparator('UI', 'Async'), equals(1));
+      expect(FullTimelineData.eventBucketComparator('A', 'B'), equals(-1));
+      expect(
+        FullTimelineData.eventBucketComparator('Z', 'Unknown'),
+        equals(-1),
+      );
     });
   });
 
@@ -98,7 +151,7 @@ void main() {
       expect(offlineData.selectedFrame, isNull);
       expect(offlineData.selectedFrameId, isNull);
       expect(offlineData.selectedEvent, isNull);
-      expect(offlineData.displayRefreshRate, isNull);
+      expect(offlineData.displayRefreshRate, equals(60.0));
       expect(offlineData.cpuProfileData, isNull);
 
       offlineData = OfflineTimelineData.parse(offlineTimelineDataJson);
@@ -138,13 +191,13 @@ void main() {
     });
   });
 
-  group('TimelineEvent', () {
+  group('SyncTimelineEvent', () {
     test('maybeRemoveDuplicate', () {
       final goldenCopy = goldenUiTimelineEvent.deepCopy();
 
       // Event with no duplicates should be unchanged.
       goldenCopy.maybeRemoveDuplicate();
-      expect(goldenCopy.toString(), equals(goldenUiString()));
+      expect(goldenCopy.toString(), equals(goldenUiString));
 
       // Add a duplicate event in [goldenCopy]'s event tree.
       final duplicateEvent = goldenCopy.deepCopy();
@@ -155,10 +208,10 @@ void main() {
       goldenCopy.children
         ..clear()
         ..add(duplicateEvent);
-      expect(goldenCopy.toString(), isNot(equals(goldenUiString())));
+      expect(goldenCopy.toString(), isNot(equals(goldenUiString)));
 
       goldenCopy.maybeRemoveDuplicate();
-      expect(goldenCopy.toString(), equals(goldenUiString()));
+      expect(goldenCopy.toString(), equals(goldenUiString));
     });
 
     test('removeChild', () {
@@ -191,11 +244,11 @@ void main() {
 
     test('addChild', () {
       final TimelineEvent engineBeginFrame =
-          testTimelineEvent(engineBeginFrameJson);
+          testSyncTimelineEvent(engineBeginFrameTrace);
       expect(engineBeginFrame.children.isEmpty, isTrue);
 
       // Add child [animate] to a leaf [engineBeginFrame].
-      final TimelineEvent animate = testTimelineEvent(animateJson)
+      final TimelineEvent animate = testSyncTimelineEvent(animateTrace)
         ..time.end = const Duration(microseconds: 118039650871);
       engineBeginFrame.addChild(animate);
       expect(engineBeginFrame.children.length, equals(1));
@@ -203,14 +256,14 @@ void main() {
 
       // Add child [layout] where child is sibling of existing children
       // [animate].
-      final TimelineEvent layout = testTimelineEvent(layoutJson)
+      final TimelineEvent layout = testSyncTimelineEvent(layoutTrace)
         ..time.end = const Duration(microseconds: 118039651087);
       engineBeginFrame.addChild(layout);
       expect(engineBeginFrame.children.length, equals(2));
       expect(engineBeginFrame.children.last.name, equals(layoutEvent.name));
 
       // Add child [build] where existing child [layout] is parent of child.
-      final TimelineEvent build = testTimelineEvent(buildJson)
+      final TimelineEvent build = testSyncTimelineEvent(buildTrace)
         ..time.end = const Duration(microseconds: 118039651017);
       engineBeginFrame.addChild(build);
       expect(engineBeginFrame.children.length, equals(2));
@@ -219,7 +272,7 @@ void main() {
 
       // Add child [frame] child is parent of existing children [animate] and
       // [layout].
-      final TimelineEvent frame = testTimelineEvent(frameJson)
+      final TimelineEvent frame = testSyncTimelineEvent(frameTrace)
         ..time.end = const Duration(microseconds: 118039652334);
       engineBeginFrame.addChild(frame);
       expect(engineBeginFrame.children.length, equals(1));
@@ -227,6 +280,47 @@ void main() {
       expect(frame.children.length, equals(2));
       expect(frame.children.first.name, equals(animateEvent.name));
       expect(frame.children.last.name, equals(layoutEvent.name));
+    });
+  });
+
+  group('AsyncTimelineEvent', () {
+    test('isWellFormedDeep', () {
+      expect(goldenAsyncTimelineEvent.isWellFormedDeep, isTrue);
+    });
+
+    test('displayDepth', () {
+      expect(goldenAsyncTimelineEvent.displayDepth, equals(7));
+      expect(asyncEventB.displayDepth, equals(3));
+      expect(asyncEventC.displayDepth, equals(2));
+      expect(asyncEventD.displayDepth, equals(1));
+    });
+
+    test('hasOverlappingChildren', () {
+      expect(asyncEventA.hasOverlappingChildren, isTrue);
+      expect(asyncEventB.hasOverlappingChildren, isTrue);
+      expect(asyncEventC.hasOverlappingChildren, isFalse);
+      expect(asyncEventD.hasOverlappingChildren, isFalse);
+    });
+
+    test('couldBeParentOf', () {
+      expect(asyncEventA.couldBeParentOf(asyncEventB1), isFalse);
+      expect(asyncEventB.couldBeParentOf(asyncEventB1), isTrue);
+      expect(asyncEventB.couldBeParentOf(asyncEventC1), isFalse);
+      expect(asyncEventC.couldBeParentOf(asyncEventC1), isTrue);
+      expect(asyncParentId1.couldBeParentOf(asyncChildId1), isTrue);
+      expect(asyncParentId1.couldBeParentOf(asyncChildId2), isFalse);
+    });
+
+    test('addEndEvent', () {
+      final event = AsyncTimelineEvent(asyncStartATrace);
+      expect(event.endTraceEventJson, isNull);
+      expect(event.time.end, isNull);
+      event.addEndEvent(asyncEndATrace);
+      expect(event.endTraceEventJson, equals(asyncEndATrace.event.json));
+      expect(
+        event.time.end.inMicroseconds,
+        asyncEndATrace.event.timestampMicros,
+      );
     });
   });
 }

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -105,11 +105,11 @@ void main() {
     });
 
     test('displayDepth', () {
-      expect(goldenAsyncTimelineEvent.displayDepth, equals(7));
+      expect(goldenAsyncTimelineEvent.displayDepth, equals(6));
       expect(goldenUiTimelineEvent.displayDepth, equals(7));
       expect(goldenGpuTimelineEvent.displayDepth, equals(2));
       expect(unknownEvent.displayDepth, equals(1));
-      expect(timelineData.displayDepth, equals(17));
+      expect(timelineData.displayDepth, equals(16));
     });
 
     test('initializeEventBuckets', () {
@@ -289,7 +289,7 @@ void main() {
     });
 
     test('displayDepth', () {
-      expect(goldenAsyncTimelineEvent.displayDepth, equals(7));
+      expect(goldenAsyncTimelineEvent.displayDepth, equals(6));
       expect(asyncEventB.displayDepth, equals(3));
       expect(asyncEventC.displayDepth, equals(2));
       expect(asyncEventD.displayDepth, equals(1));

--- a/packages/devtools_app/test/trees_test.dart
+++ b/packages/devtools_app/test/trees_test.dart
@@ -13,6 +13,12 @@ void main() {
       expect(treeNode3.depth, equals(1));
     });
 
+    test('isRoot', () {
+      expect(treeNode0.isRoot, isTrue);
+      expect(treeNode1.isRoot, isFalse);
+      expect(treeNode5.isRoot, isFalse);
+    });
+
     test('root', () {
       expect(treeNode2.root, equals(treeNode0));
     });

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -130,6 +130,28 @@ void main() {
         timeRange.toString(unit: TimeUnit.milliseconds),
         equals('[1 ms - 8 ms]'),
       );
+
+      final t = TimeRange()
+        ..start = const Duration(milliseconds: 100)
+        ..end = const Duration(milliseconds: 200);
+      final overlapBeginning = TimeRange()
+        ..start = const Duration(milliseconds: 50)
+        ..end = const Duration(milliseconds: 150);
+      final overlapMiddle = TimeRange()
+        ..start = const Duration(milliseconds: 125)
+        ..end = const Duration(milliseconds: 175);
+      final overlapEnd = TimeRange()
+        ..start = const Duration(milliseconds: 150)
+        ..end = const Duration(milliseconds: 250);
+      final noOverlap = TimeRange()
+        ..start = const Duration(milliseconds: 300)
+        ..end = const Duration(milliseconds: 400);
+
+      expect(t.overlaps(t), isTrue);
+      expect(t.overlaps(overlapBeginning), isTrue);
+      expect(t.overlaps(overlapMiddle), isTrue);
+      expect(t.overlaps(overlapEnd), isTrue);
+      expect(t.overlaps(noOverlap), isFalse);
     });
 
     test('longestFittingSubstring', () {

--- a/packages/devtools_testing/lib/support/test_utils.dart
+++ b/packages/devtools_testing/lib/support/test_utils.dart
@@ -8,8 +8,8 @@ import 'dart:convert';
 
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 
-TimelineEvent testTimelineEvent(Map<String, dynamic> json) =>
-    TimelineEvent(testTraceEventWrapper(json));
+SyncTimelineEvent testSyncTimelineEvent(TraceEventWrapper eventWrapper) =>
+    SyncTimelineEvent(eventWrapper);
 
 TraceEvent testTraceEvent(Map<String, dynamic> json) =>
     TraceEvent(jsonDecode(jsonEncode(json)));

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -15,7 +15,7 @@ const testUiThreadId = 1;
 const testGpuThreadId = 2;
 const testUnknownThreadId = 3;
 
-final frameStartEvent = testTraceEvent({
+final frameStartEvent = testTraceEventWrapper({
   'name': 'PipelineItem',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -26,7 +26,7 @@ final frameStartEvent = testTraceEvent({
   'args': {}
 });
 
-final frameEndEvent = testTraceEvent({
+final frameEndEvent = testTraceEventWrapper({
   'name': 'PipelineItem',
   'cat': 'Embedder',
   'tid': testGpuThreadId,
@@ -38,62 +38,62 @@ final frameEndEvent = testTraceEvent({
   'args': {}
 });
 
+final testFrame = TimelineFrame('id_0')
+  ..setEventFlow(goldenUiTimelineEvent)
+  ..setEventFlow(goldenGpuTimelineEvent);
+
 // Mark: UI golden data.
 // None of the following data should be modified. If you have a need to modify
 // any of the below events for a test, make a copy and modify the copy.
-final TimelineEvent vsyncEvent = testTimelineEvent(vsyncJson)
-  ..time.end = const Duration(microseconds: 118039652422)
-  ..type = TimelineEventType.ui;
+final vsyncEvent = testSyncTimelineEvent(vsyncTrace)
+  ..type = TimelineEventType.ui
+  ..addEndEvent(endVsyncTrace);
 
-final TimelineEvent animatorBeginFrameEvent =
-    testTimelineEvent(animatorBeginFrameJson)
-      ..time.end = const Duration(microseconds: 118039652421)
-      ..type = TimelineEventType.ui;
+final animatorBeginFrameEvent = testSyncTimelineEvent(animatorBeginFrameTrace)
+  ..type = TimelineEventType.ui
+  ..addEndEvent(endAnimatorBeginFrameTrace);
 
-final TimelineEvent frameworkWorkloadEvent =
-    testTimelineEvent(frameworkWorkloadJson)
-      ..time.end = const Duration(microseconds: 118039652412)
-      ..type = TimelineEventType.ui;
+final frameworkWorkloadEvent = testSyncTimelineEvent(frameworkWorkloadTrace)
+  ..type = TimelineEventType.ui
+  ..addEndEvent(endFrameworkWorkloadTrace);
 
-final TimelineEvent engineBeginFrameEvent =
-    testTimelineEvent(engineBeginFrameJson)
-      ..time.end = const Duration(microseconds: 118039652411)
-      ..type = TimelineEventType.ui;
+final engineBeginFrameEvent = testSyncTimelineEvent(engineBeginFrameTrace)
+  ..type = TimelineEventType.ui
+  ..addEndEvent(endEngineBeginFrameTrace);
 
-final TimelineEvent frameEvent = testTimelineEvent(frameJson)
+final frameEvent = testSyncTimelineEvent(frameTrace)
   ..time.end = const Duration(microseconds: 118039652334)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent animateEvent = testTimelineEvent(animateJson)
+final animateEvent = testSyncTimelineEvent(animateTrace)
   ..time.end = const Duration(microseconds: 118039650871)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent layoutEvent = testTimelineEvent(layoutJson)
+final layoutEvent = testSyncTimelineEvent(layoutTrace)
   ..time.end = const Duration(microseconds: 118039651087)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent buildEvent = testTimelineEvent(buildJson)
+final buildEvent = testSyncTimelineEvent(buildTrace)
   ..time.end = const Duration(microseconds: 118039651017)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent compositingBitsEvent =
-    testTimelineEvent(compositingBitsJson)
-      ..time.end = const Duration(microseconds: 118039651090)
-      ..type = TimelineEventType.ui;
+final compositingBitsEvent = testSyncTimelineEvent(compositingBitsTrace)
+  ..time.end = const Duration(microseconds: 118039651090)
+  ..type = TimelineEventType.ui;
 
-final TimelineEvent paintEvent = testTimelineEvent(paintJson)
+final paintEvent = testSyncTimelineEvent(paintTrace)
   ..time.end = const Duration(microseconds: 118039651165)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent compositingEvent = testTimelineEvent(compositingJson)
+final compositingEvent = testSyncTimelineEvent(compositingTrace)
   ..time.end = const Duration(microseconds: 118039651460)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent semanticsEvent = testTimelineEvent(semanticsJson)
+final semanticsEvent = testSyncTimelineEvent(semanticsTrace)
   ..time.end = const Duration(microseconds: 118039652210)
   ..type = TimelineEventType.ui;
 
-final TimelineEvent finalizeTreeEvent = testTimelineEvent(finalizeTreeJson)
+final finalizeTreeEvent = testSyncTimelineEvent(finalizeTreeTrace)
   ..time.end = const Duration(microseconds: 118039652308)
   ..type = TimelineEventType.ui;
 
@@ -121,38 +121,88 @@ final goldenUiTimelineEvent = vsyncEvent
                     semanticsEvent..parent = frameEvent,
                     finalizeTreeEvent..parent = frameEvent,
                   ])
-              ])
-              ..traceEvents.add(testTraceEventWrapper(endEngineBeginFrameJson)),
-          ])
-          ..traceEvents.add(testTraceEventWrapper(endFrameworkWorkloadJson)),
-      ])
-      ..traceEvents.add(testTraceEventWrapper(endAnimatorBeginFrameJson)),
-  ])
-  ..traceEvents.add(testTraceEventWrapper(endVsyncJson));
+              ]),
+          ]),
+      ]),
+  ]);
 
-String goldenUiString() => goldenUiTimelineEvent.toString();
+const goldenUiString = '  VSYNC [118039650802 μs - 118039652422 μs]\n'
+    '    Animator::BeginFrame [118039650803 μs - 118039652421 μs]\n'
+    '      Framework Workload [118039650807 μs - 118039652412 μs]\n'
+    '        Engine::BeginFrame [118039650809 μs - 118039652411 μs]\n'
+    '          Frame [118039650834 μs - 118039652334 μs]\n'
+    '            Animate [118039650838 μs - 118039650871 μs]\n'
+    '            Layout [118039650876 μs - 118039651087 μs]\n'
+    '              Build [118039650984 μs - 118039651017 μs]\n'
+    '            Compositing bits [118039651088 μs - 118039651090 μs]\n'
+    '            Paint [118039651091 μs - 118039651165 μs]\n'
+    '            Compositing [118039651166 μs - 118039651460 μs]\n'
+    '            Semantics [118039651462 μs - 118039652210 μs]\n'
+    '            Finalize tree [118039652219 μs - 118039652308 μs]\n';
 
-final List<TraceEvent> goldenUiTraceEvents = [
-  testTraceEvent(vsyncJson),
-  testTraceEvent(animatorBeginFrameJson),
-  testTraceEvent(frameworkWorkloadJson),
-  testTraceEvent(engineBeginFrameJson),
-  testTraceEvent(animateJson),
-  testTraceEvent(buildJson),
-  testTraceEvent(layoutJson),
-  testTraceEvent(compositingBitsJson),
-  testTraceEvent(paintJson),
-  testTraceEvent(compositingJson),
-  testTraceEvent(semanticsJson),
-  testTraceEvent(finalizeTreeJson),
-  testTraceEvent(frameJson),
-  testTraceEvent(endEngineBeginFrameJson),
-  testTraceEvent(endFrameworkWorkloadJson),
-  testTraceEvent(endAnimatorBeginFrameJson),
-  testTraceEvent(endVsyncJson),
+final goldenUiTraceEvents = [
+  vsyncTrace,
+  animatorBeginFrameTrace,
+  frameworkWorkloadTrace,
+  engineBeginFrameTrace,
+  animateTrace,
+  buildTrace,
+  layoutTrace,
+  compositingBitsTrace,
+  paintTrace,
+  compositingTrace,
+  semanticsTrace,
+  finalizeTreeTrace,
+  frameTrace,
+  endEngineBeginFrameTrace,
+  endFrameworkWorkloadTrace,
+  endAnimatorBeginFrameTrace,
+  endVsyncTrace,
 ];
 
-const Map<String, dynamic> vsyncJson = {
+final outOfOrderUiTraceEvents = [
+  endVsyncTrace,
+  endAnimatorBeginFrameTrace,
+  endFrameworkWorkloadTrace,
+  endEngineBeginFrameTrace,
+  frameTrace,
+  finalizeTreeTrace,
+  semanticsTrace,
+  compositingTrace,
+  paintTrace,
+  compositingBitsTrace,
+  layoutTrace,
+  buildTrace,
+  animateTrace,
+  engineBeginFrameTrace,
+  frameworkWorkloadTrace,
+  animatorBeginFrameTrace,
+  vsyncTrace,
+];
+
+final uiTraceEventsWithDuplicates = [
+  vsyncTrace,
+  vsyncTrace,
+  animatorBeginFrameTrace,
+  frameworkWorkloadTrace,
+  engineBeginFrameTrace,
+  animateTrace,
+  buildTrace,
+  layoutTrace,
+  compositingBitsTrace,
+  paintTrace,
+  compositingTrace,
+  semanticsTrace,
+  finalizeTreeTrace,
+  frameTrace,
+  endEngineBeginFrameTrace,
+  endFrameworkWorkloadTrace,
+  endAnimatorBeginFrameTrace,
+  endVsyncTrace,
+  endVsyncTrace,
+];
+
+final vsyncTrace = testTraceEventWrapper({
   'name': 'VSYNC',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -160,9 +210,8 @@ const Map<String, dynamic> vsyncJson = {
   'ts': 118039650802,
   'ph': 'B',
   'args': {}
-};
-
-const Map<String, dynamic> animatorBeginFrameJson = {
+});
+final animatorBeginFrameTrace = testTraceEventWrapper({
   'name': 'Animator::BeginFrame',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -170,9 +219,8 @@ const Map<String, dynamic> animatorBeginFrameJson = {
   'ts': 118039650803,
   'ph': 'B',
   'args': {}
-};
-
-const Map<String, dynamic> frameworkWorkloadJson = {
+});
+final frameworkWorkloadTrace = testTraceEventWrapper({
   'name': 'Framework Workload',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -180,9 +228,8 @@ const Map<String, dynamic> frameworkWorkloadJson = {
   'ts': 118039650807,
   'ph': 'B',
   'args': {'mode': 'basic', 'frame': 'odd'}
-};
-
-const Map<String, dynamic> engineBeginFrameJson = {
+});
+final engineBeginFrameTrace = testTraceEventWrapper({
   'name': 'Engine::BeginFrame',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -190,9 +237,8 @@ const Map<String, dynamic> engineBeginFrameJson = {
   'ts': 118039650809,
   'ph': 'B',
   'args': {}
-};
-
-const Map<String, dynamic> animateJson = {
+});
+final animateTrace = testTraceEventWrapper({
   'name': 'Animate',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -201,9 +247,8 @@ const Map<String, dynamic> animateJson = {
   'ph': 'X',
   'dur': 33,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> buildJson = {
+});
+final buildTrace = testTraceEventWrapper({
   'name': 'Build',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -212,9 +257,8 @@ const Map<String, dynamic> buildJson = {
   'ph': 'X',
   'dur': 33,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> layoutJson = {
+});
+final layoutTrace = testTraceEventWrapper({
   'name': 'Layout',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -223,9 +267,8 @@ const Map<String, dynamic> layoutJson = {
   'ph': 'X',
   'dur': 211,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> compositingBitsJson = {
+});
+final compositingBitsTrace = testTraceEventWrapper({
   'name': 'Compositing bits',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -234,9 +277,8 @@ const Map<String, dynamic> compositingBitsJson = {
   'ph': 'X',
   'dur': 2,
   'args': {'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> paintJson = {
+});
+final paintTrace = testTraceEventWrapper({
   'name': 'Paint',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -245,9 +287,8 @@ const Map<String, dynamic> paintJson = {
   'ph': 'X',
   'dur': 74,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> compositingJson = {
+});
+final compositingTrace = testTraceEventWrapper({
   'name': 'Compositing',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -256,9 +297,8 @@ const Map<String, dynamic> compositingJson = {
   'ph': 'X',
   'dur': 294,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> semanticsJson = {
+});
+final semanticsTrace = testTraceEventWrapper({
   'name': 'Semantics',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -267,9 +307,8 @@ const Map<String, dynamic> semanticsJson = {
   'ph': 'X',
   'dur': 748,
   'args': {'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> finalizeTreeJson = {
+});
+final finalizeTreeTrace = testTraceEventWrapper({
   'name': 'Finalize tree',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -278,9 +317,9 @@ const Map<String, dynamic> finalizeTreeJson = {
   'ph': 'X',
   'dur': 89,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
+});
 
-const Map<String, dynamic> frameJson = {
+final frameTrace = testTraceEventWrapper({
   'name': 'Frame',
   'cat': 'Dart',
   'tid': testUiThreadId,
@@ -289,9 +328,8 @@ const Map<String, dynamic> frameJson = {
   'ph': 'X',
   'dur': 1500,
   'args': {'mode': 'basic', 'isolateNumber': '993728060'}
-};
-
-const Map<String, dynamic> endVsyncJson = {
+});
+final endVsyncTrace = testTraceEventWrapper({
   'name': 'VSYNC',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -299,9 +337,8 @@ const Map<String, dynamic> endVsyncJson = {
   'ts': 118039652422,
   'ph': 'E',
   'args': {}
-};
-
-const Map<String, dynamic> endAnimatorBeginFrameJson = {
+});
+final endAnimatorBeginFrameTrace = testTraceEventWrapper({
   'name': 'Animator::BeginFrame',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -309,9 +346,8 @@ const Map<String, dynamic> endAnimatorBeginFrameJson = {
   'ts': 118039652421,
   'ph': 'E',
   'args': {}
-};
-
-const Map<String, dynamic> endFrameworkWorkloadJson = {
+});
+final endFrameworkWorkloadTrace = testTraceEventWrapper({
   'name': 'Framework Workload',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -319,9 +355,8 @@ const Map<String, dynamic> endFrameworkWorkloadJson = {
   'ts': 118039652412,
   'ph': 'E',
   'args': {}
-};
-
-const Map<String, dynamic> endEngineBeginFrameJson = {
+});
+final endEngineBeginFrameTrace = testTraceEventWrapper({
   'name': 'Engine::BeginFrame',
   'cat': 'Embedder',
   'tid': testUiThreadId,
@@ -329,39 +364,35 @@ const Map<String, dynamic> endEngineBeginFrameJson = {
   'ts': 118039652411,
   'ph': 'E',
   'args': {}
-};
+});
 
 // Mark: GPU golden data. This data is abbreviated in comparison to the UI
 // golden data. We do not need both data sets to be complete for testing.
 // None of the following data should be modified. If you have a need to modify
 // any of the below events for a test, make a copy and modify the copy.
-final TimelineEvent gpuRasterizerDrawEvent =
-    testTimelineEvent(gpuRasterizerDrawJson)
-      ..time.end = const Duration(microseconds: 118039679873)
-      ..type = TimelineEventType.gpu;
+final gpuRasterizerDrawEvent = testSyncTimelineEvent(gpuRasterizerDrawTrace)
+  ..type = TimelineEventType.gpu
+  ..addEndEvent(endGpuRasterizerDrawTrace);
 
-final TimelineEvent pipelineConsumeEvent =
-    testTimelineEvent(pipelineConsumeJson)
-      ..time.end = const Duration(microseconds: 118039679870)
-      ..type = TimelineEventType.gpu;
+final pipelineConsumeEvent = testSyncTimelineEvent(pipelineConsumeTrace)
+  ..type = TimelineEventType.gpu
+  ..addEndEvent(endPipelineConsumeTrace);
 
 final goldenGpuTimelineEvent = gpuRasterizerDrawEvent
-  ..children.addAll([
-    pipelineConsumeEvent
-      ..traceEvents.add(testTraceEventWrapper(endPipelineConsumeJson))
-  ])
-  ..traceEvents.add(testTraceEventWrapper(endGpuRasterizerDrawJson));
+  ..children.add(pipelineConsumeEvent);
 
-String goldenGpuString() => goldenGpuTimelineEvent.toString();
+const goldenGpuString =
+    '  GPURasterizer::Draw [118039651469 μs - 118039679873 μs]\n'
+    '    PipelineConsume [118039651470 μs - 118039679870 μs]\n';
 
-final List<TraceEvent> goldenGpuTraceEvents = [
-  testTraceEvent(gpuRasterizerDrawJson),
-  testTraceEvent(pipelineConsumeJson),
-  testTraceEvent(endPipelineConsumeJson),
-  testTraceEvent(endGpuRasterizerDrawJson),
+final goldenGpuTraceEvents = [
+  gpuRasterizerDrawTrace,
+  pipelineConsumeTrace,
+  endPipelineConsumeTrace,
+  endGpuRasterizerDrawTrace,
 ];
 
-const Map<String, dynamic> gpuRasterizerDrawJson = {
+final gpuRasterizerDrawTrace = testTraceEventWrapper({
   'name': 'GPURasterizer::Draw',
   'cat': 'Embedder',
   'tid': testGpuThreadId,
@@ -369,9 +400,8 @@ const Map<String, dynamic> gpuRasterizerDrawJson = {
   'ts': 118039651469,
   'ph': 'B',
   'args': {}
-};
-
-const Map<String, dynamic> pipelineConsumeJson = {
+});
+final pipelineConsumeTrace = testTraceEventWrapper({
   'name': 'PipelineConsume',
   'cat': 'Embedder',
   'tid': testGpuThreadId,
@@ -379,8 +409,8 @@ const Map<String, dynamic> pipelineConsumeJson = {
   'ts': 118039651470,
   'ph': 'B',
   'args': {}
-};
-const Map<String, dynamic> endPipelineConsumeJson = {
+});
+final endPipelineConsumeTrace = testTraceEventWrapper({
   'name': 'PipelineConsume',
   'cat': 'Embedder',
   'tid': testGpuThreadId,
@@ -388,9 +418,8 @@ const Map<String, dynamic> endPipelineConsumeJson = {
   'ts': 118039679870,
   'ph': 'E',
   'args': {}
-};
-
-const Map<String, dynamic> endGpuRasterizerDrawJson = {
+});
+final endGpuRasterizerDrawTrace = testTraceEventWrapper({
   'name': 'GPURasterizer::Draw',
   'cat': 'Embedder',
   'tid': testGpuThreadId,
@@ -398,7 +427,298 @@ const Map<String, dynamic> endGpuRasterizerDrawJson = {
   'ts': 118039679873,
   'ph': 'E',
   'args': {}
-};
+});
+
+// Mark: AsyncTimelineData
+final goldenAsyncTimelineEvent = asyncEventA
+  ..children.addAll([
+    asyncEventB..children.addAll([asyncEventB1, asyncEventB2]),
+    asyncEventC..children.addAll([asyncEventC1, asyncEventC2]),
+  ]);
+
+const goldenAsyncString = '  A [193937056864 μs - 193938740982 μs]\n'
+    '    B [193937113560 μs - 193937382819 μs]\n'
+    '      B1 [193937141769 μs - 193937225475 μs]\n'
+    '      B2 [193937173019 μs - 193937281185 μs]\n'
+    '    C [193937168961 μs - 193937485018 μs]\n'
+    '      C1 [193937220903 μs - 193937326225 μs]\n'
+    '      C2 [193937378812 μs - 193937432875 μs]\n';
+
+final asyncEventA = AsyncTimelineEvent(asyncStartATrace)
+  ..addEndEvent(asyncEndATrace);
+final asyncEventB = AsyncTimelineEvent(asyncStartBTrace)
+  ..addEndEvent(asyncEndBTrace);
+final asyncEventB1 = AsyncTimelineEvent(asyncStartB1Trace)
+  ..addEndEvent(asyncEndB1Trace);
+final asyncEventB2 = AsyncTimelineEvent(asyncStartB2Trace)
+  ..addEndEvent(asyncEndB2Trace);
+final asyncEventC = AsyncTimelineEvent(asyncStartCTrace)
+  ..addEndEvent(asyncEndCTrace);
+final asyncEventC1 = AsyncTimelineEvent(asyncStartC1Trace)
+  ..addEndEvent(asyncEndC1Trace);
+final asyncEventC2 = AsyncTimelineEvent(asyncStartC2Trace)
+  ..addEndEvent(asyncEndC2Trace);
+final asyncEventD = AsyncTimelineEvent(asyncStartDTrace)
+  ..addEndEvent(asyncEndDTrace);
+
+final asyncParentId1 = AsyncTimelineEvent(asyncParentStartId1)
+  ..addEndEvent(asyncParentEndId1);
+final asyncChildId1 = AsyncTimelineEvent(asyncChildStartId1)
+  ..addEndEvent(asyncChildEndId1);
+final asyncChildId2 = AsyncTimelineEvent(asyncChildStartId2)
+  ..addEndEvent(asyncChildEndId2);
+
+final asyncTraceEvents = [
+  asyncStartATrace,
+  asyncStartDTrace,
+  asyncStartBTrace,
+  asyncStartB1Trace,
+  asyncStartCTrace,
+  asyncStartC1Trace,
+  asyncEndC1Trace,
+  asyncStartC2Trace,
+  asyncEndC2Trace,
+  asyncStartB2Trace,
+  asyncEndB1Trace,
+  asyncEndB2Trace,
+  asyncEndBTrace,
+  asyncEndCTrace,
+  asyncEndATrace,
+  asyncEndDTrace,
+];
+final asyncStartATrace = testTraceEventWrapper({
+  'name': 'A',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937056864,
+  'ph': 'b',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndATrace = testTraceEventWrapper({
+  'name': 'A',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193938740982,
+  'ph': 'e',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncStartBTrace = testTraceEventWrapper({
+  'name': 'B',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937113560,
+  'ph': 'b',
+  'id': '2',
+  'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndBTrace = testTraceEventWrapper({
+  'name': 'B',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937382819,
+  'ph': 'e',
+  'id': '2',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncStartB1Trace = testTraceEventWrapper({
+  'name': 'B1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937141769,
+  'ph': 'b',
+  'id': 'd',
+  'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndB1Trace = testTraceEventWrapper({
+  'name': 'B1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937225475,
+  'ph': 'e',
+  'id': 'd',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncStartB2Trace = testTraceEventWrapper({
+  'name': 'B2',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937173019,
+  'ph': 'b',
+  'id': 'e',
+  'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndB2Trace = testTraceEventWrapper({
+  'name': 'B2',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937281185,
+  'ph': 'e',
+  'id': 'e',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncStartCTrace = testTraceEventWrapper({
+  'name': 'C',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937168961,
+  'ph': 'b',
+  'id': '3',
+  'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndCTrace = testTraceEventWrapper({
+  'name': 'C',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937485018,
+  'ph': 'e',
+  'id': '3',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncStartC1Trace = testTraceEventWrapper({
+  'name': 'C1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937220903,
+  'ph': 'b',
+  'id': '11',
+  'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+});
+final asyncEndC1Trace = testTraceEventWrapper({
+  'name': 'C1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937326225,
+  'ph': 'e',
+  'id': '11',
+  'args': {'isolateId': 'isolates/2139247553966975'}
+});
+final asyncStartC2Trace = testTraceEventWrapper({
+  'name': 'C2',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937378812,
+  'ph': 'b',
+  'id': '12',
+  'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+});
+final asyncEndC2Trace = testTraceEventWrapper({
+  'name': 'C2',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937432875,
+  'ph': 'e',
+  'id': '12',
+  'args': {'isolateId': 'isolates/2139247553966975'}
+});
+final asyncStartDTrace = testTraceEventWrapper({
+  'name': 'D',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193937061035,
+  'ph': 'b',
+  'id': '7',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncEndDTrace = testTraceEventWrapper({
+  'name': 'D',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 193938741076,
+  'ph': 'e',
+  'id': '7',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncParentStartId1 = testTraceEventWrapper({
+  'name': 'asyncParentId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 1000,
+  'ph': 'b',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncParentEndId1 = testTraceEventWrapper({
+  'name': 'asyncParentId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 2000,
+  'ph': 'e',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncChildStartId1 = testTraceEventWrapper({
+  'name': 'asyncChildId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 1100,
+  'ph': 'b',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncChildEndId1 = testTraceEventWrapper({
+  'name': 'asyncChildId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 1900,
+  'ph': 'e',
+  'id': '1',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncChildStartId2 = testTraceEventWrapper({
+  'name': 'asyncChildId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 1200,
+  'ph': 'b',
+  'id': '2',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final asyncChildEndId2 = testTraceEventWrapper({
+  'name': 'asyncChildId1',
+  'cat': 'Dart',
+  'tid': 4875,
+  'pid': 51385,
+  'ts': 1800,
+  'ph': 'e',
+  'id': '2',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+
+// Mark: unknown event
+final unknownEvent = SyncTimelineEvent(unknownEventTrace);
+final unknownEventTrace = testTraceEventWrapper({
+  'name': 'Unknown trace event',
+  'cat': 'Dart',
+  'tid': testUnknownThreadId,
+  'pid': 51385,
+  'ts': 193938741076,
+  'ph': 'B',
+  'id': '7',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
 
 // Mark: OfflineTimelineData.
 final goldenTraceEventsJson = List.from(
@@ -408,8 +728,8 @@ final goldenTraceEventsJson = List.from(
 final offlineTimelineDataJson = {
   TimelineData.traceEventsKey: goldenTraceEventsJson,
   TimelineData.cpuProfileKey: goldenCpuProfileDataJson,
-  TimelineData.selectedFrameIdKey: 'PipelineItem-1',
+  FrameBasedTimelineData.selectedFrameIdKey: 'PipelineItem-1',
   TimelineData.selectedEventKey: vsyncEvent.json,
-  TimelineData.displayRefreshRateKey: 120.0,
+  FrameBasedTimelineData.displayRefreshRateKey: 120.0,
   TimelineData.devToolsScreenKey: timelineScreenId,
 };


### PR DESCRIPTION
Adds a full timeline to devtools. This timeline shows events from multiple frames as well as async and non-flutter-frame-related events. There are still several polish todos (like showing parent-child guidelines for async events, coloring backgrounds for different sections, etc.), but this CL provides the timeline processing logic and the brunt of the UI.
 ![Screen Shot 2019-10-16 at 9 04 13 AM](https://user-images.githubusercontent.com/43759233/67249063-23987880-f41b-11e9-9089-4c8299176f66.png)
![Screen Shot 2019-10-16 at 9 42 23 AM](https://user-images.githubusercontent.com/43759233/67249139-6e19f500-f41b-11e9-8811-e9f7febc8dde.png)

