### PR TITLE
Refactor inspector implementation to prepare for flutter version.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
@@ -25,6 +25,7 @@ import '../ui/service_extension_elements.dart';
 import '../ui/ui_utils.dart';
 import 'inspector_controller.dart';
 import 'inspector_service.dart';
+import 'inspector_tree.dart';
 import 'inspector_tree_canvas.dart';
 import 'inspector_tree_html.dart';
 import 'inspector_tree_web.dart';
@@ -150,41 +151,21 @@ class HtmlInspectorScreen extends HtmlScreen {
     // TODO(jacobr): support the Render tree, Layer tree, and Semantic trees as
     // well as the widget tree.
 
+    InspectorTreeController createTree() {
+      return _useHtmlInspectorTreeRenderer
+          ? InspectorTreeHtml()
+          : InspectorTreeCanvas();
+    }
+
+    final InspectorTreeWeb inspectorTree = createTree();
+    final InspectorTreeWeb detailsInspectorTree = createTree();
     inspectorController = InspectorController(
-      inspectorTreeFactory: ({
-        summaryTree,
-        treeType,
-        onNodeAdded,
-        onSelectionChange,
-        onExpand,
-        onHover,
-      }) {
-        if (_useHtmlInspectorTreeRenderer) {
-          return InspectorTreeHtml(
-            summaryTree: summaryTree,
-            treeType: treeType,
-            onNodeAdded: onNodeAdded,
-            onSelectionChange: onSelectionChange,
-            onExpand: onExpand,
-            onHover: onHover,
-          );
-        }
-        return InspectorTreeCanvas(
-          summaryTree: summaryTree,
-          treeType: treeType,
-          onNodeAdded: onNodeAdded,
-          onSelectionChange: onSelectionChange,
-          onExpand: onExpand,
-          onHover: onHover,
-        );
-      },
+      inspectorTree: inspectorTree,
+      detailsTree: detailsInspectorTree,
       inspectorService: inspectorService,
       treeType: FlutterTreeType.widget,
       onExpandCollapseSupported: _onExpandCollapseSupported,
     );
-    final InspectorTreeWeb inspectorTree = inspectorController.inspectorTree;
-    final InspectorTreeWeb detailsInspectorTree =
-        inspectorController.details.inspectorTree;
 
     final elements = <Element>[
       inspectorTree.element.element,

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -54,7 +54,8 @@ TextStyle textStyleForLevel(DiagnosticLevel level) {
 class InspectorController implements InspectorServiceClient {
   InspectorController({
     @required this.inspectorService,
-    @required InspectorTreeFactory inspectorTreeFactory,
+    @required this.inspectorTree,
+    InspectorTreeController detailsTree,
     @required this.treeType,
     this.parent,
     this.isSummaryTree = true,
@@ -64,7 +65,8 @@ class InspectorController implements InspectorServiceClient {
             InspectorObjectGroupManager(inspectorService, 'selection') {
     _refreshRateLimiter = RateLimiter(refreshFramesPerSecond, refresh);
 
-    inspectorTree = inspectorTreeFactory(
+    assert(inspectorTree != null);
+    inspectorTree.config = InspectorTreeConfig(
       summaryTree: isSummaryTree,
       treeType: treeType,
       onNodeAdded: _onNodeAdded,
@@ -75,7 +77,7 @@ class InspectorController implements InspectorServiceClient {
     if (isSummaryTree) {
       details = InspectorController(
         inspectorService: inspectorService,
-        inspectorTreeFactory: inspectorTreeFactory,
+        inspectorTree: detailsTree,
         treeType: treeType,
         parent: this,
         isSummaryTree: false,
@@ -115,8 +117,7 @@ class InspectorController implements InspectorServiceClient {
 
   InspectorController details;
 
-  InspectorTree inspectorTree;
-
+  InspectorTreeController inspectorTree;
   final FlutterTreeType treeType;
 
   final InspectorService inspectorService;
@@ -764,9 +765,9 @@ class InspectorController implements InspectorServiceClient {
 
   Future<void> expandAllNodesInDetailsTree() async {
     await details.recomputeTreeRoot(
-      inspectorTree.selection.diagnostic,
+      inspectorTree.selection?.diagnostic,
       details.inspectorTree.selection?.diagnostic ??
-          details.inspectorTree.root.diagnostic,
+          details.inspectorTree.root?.diagnostic,
       false,
       subtreeDepth: maxJsInt,
     );

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -14,31 +14,22 @@ library inspector_tree;
 import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger.dart';
 import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/icons.dart';
 import '../ui/material_icons.dart';
 import '../ui/theme.dart';
-import '../utils.dart';
 import 'diagnostics_node.dart';
-import 'inspector_controller.dart';
 import 'inspector_service.dart';
-import 'inspector_text_styles.dart' as inspector_text_styles;
 
 /// Split text into two groups, word characters at the start of a string and all
 /// other characters.
-final RegExp _primaryDescriptionPattern = RegExp(r'^([\w ]+)(.*)$');
+final RegExp treeNodePrimaryDescriptionPattern = RegExp(r'^([\w ]+)(.*)$');
 // TODO(jacobr): temporary workaround for missing structure from assertion thrown building
 // widget errors.
-final RegExp _assertionThrownBuildingError = RegExp(
+final RegExp assertionThrownBuildingError = RegExp(
     r'^(The following assertion was thrown building [a-zA-Z]+)(\(.*\))(:)$');
-
-final ColorIconMaker _colorIconMaker = ColorIconMaker();
-final CustomIconMaker _customIconMaker = CustomIconMaker();
-
-const bool _showRenderObjectPropertiesAsLinks = false;
 
 typedef TreeEventCallback = void Function(InspectorTreeNode node);
 typedef TreeHoverEventCallback = void Function(
@@ -69,7 +60,6 @@ const double columnWidth = 16.0;
 const double verticalPadding = 10.0;
 const double rowHeight = 24.0;
 const Color arrowColor = Colors.grey;
-final DevToolsIcon defaultIcon = _customIconMaker.fromInfo('Default');
 
 // TODO(jacobr): these arrows are a bit ugly.
 // We should create pngs instead of trying to stretch the material icons into
@@ -94,7 +84,7 @@ abstract class PaintEntry {
 
   DevToolsIcon get icon;
 
-  void attach(InspectorTree owner) {}
+  void attach(InspectorTreeController owner) {}
 }
 
 abstract class InspectorTreeNodeRenderBuilder<
@@ -112,13 +102,21 @@ abstract class InspectorTreeNodeRenderBuilder<
   InspectorTreeNodeRender build();
 }
 
-abstract class InspectorTreeNodeRender<E extends PaintEntry> {
-  InspectorTreeNodeRender(this.entries, this.size);
+abstract class InspectorTreeNodeRender<E> {
+  InspectorTreeNodeRender(this.entries);
 
   final List<E> entries;
+
+  PaintEntry hitTest(Offset location);
+}
+
+abstract class InspectorTreeNodeRendererLegacy<E extends PaintEntry>
+    extends InspectorTreeNodeRender<E> {
+  InspectorTreeNodeRendererLegacy(List<E> entries, this.size) : super(entries);
+
   final Size size;
 
-  void attach(InspectorTree owner, Offset offset) {
+  void attach(InspectorTreeController owner, Offset offset) {
     if (_owner != owner) {
       _owner = owner;
     }
@@ -134,18 +132,16 @@ abstract class InspectorTreeNodeRender<E extends PaintEntry> {
   Offset get offset => _offset;
   Offset _offset;
 
-  InspectorTree _owner;
+  InspectorTreeController _owner;
 
   Rect get paintBounds => _offset & size;
-
-  PaintEntry hitTest(Offset location);
 }
 
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector
 /// specific as that is the only case we care about.
 // TODO(kenz): extend TreeNode class to share tree logic.
-abstract class InspectorTreeNode {
+class InspectorTreeNode {
   InspectorTreeNode({
     InspectorTreeNode parent,
     bool expandChildren = true,
@@ -161,8 +157,8 @@ abstract class InspectorTreeNode {
   bool _isDirty = true;
   set isDirty(bool dirty) {
     if (dirty) {
-      _renderObject = null;
       _isDirty = true;
+      _shouldShow = null;
       if (_childrenCount == null) {
         // Already dirty.
         return;
@@ -176,129 +172,24 @@ abstract class InspectorTreeNode {
     }
   }
 
-  bool selected = false;
-
-  /// Override this method to define a tree node to build render objects
-  /// appropriate for a specific platform.
-  InspectorTreeNodeRenderBuilder createRenderBuilder();
-
-  /// This method defines the logic of how a RenderObject is converted to
-  /// a list of styled text and icons. If you want to change how tree content
-  /// is styled modify this message as it is the robust way for style changes
-  /// to apply to all ways inspector trees are rendered (html, canvas, Flutter
-  /// in the future).
-  /// If you change this rendering also change the matching logic in
-  /// src/io/flutter/view/DiagnosticsTreeCellRenderer.java
-  InspectorTreeNodeRender get renderObject {
-    if (_renderObject != null || diagnostic == null) {
-      return _renderObject;
+  /// Returns whether the node is currently visible in the tree.
+  void updateShouldShow(bool value) {
+    if (value != _shouldShow) {
+      _shouldShow = value;
+      for (var child in children) {
+        child.updateShouldShow(value);
+      }
     }
-
-    final builder = createRenderBuilder();
-    final icon = diagnostic.icon;
-    if (showExpandCollapse) {
-      builder.addIcon(isExpanded ? collapseArrow : expandArrow);
-    }
-    if (icon != null) {
-      builder.addIcon(icon);
-    }
-    final String name = diagnostic.name;
-    TextStyle textStyle = textStyleForLevel(diagnostic.level);
-    if (diagnostic.isProperty) {
-      // Display of inline properties.
-      final String propertyType = diagnostic.propertyType;
-      final Map<String, Object> properties = diagnostic.valuePropertiesJson;
-
-      if (name?.isNotEmpty == true && diagnostic.showName) {
-        builder.appendText('$name${diagnostic.separator} ', textStyle);
-      }
-
-      if (isCreatedByLocalProject) {
-        textStyle = textStyle.merge(inspector_text_styles.regularBold);
-      }
-
-      String description = diagnostic.description;
-      if (propertyType != null && properties != null) {
-        switch (propertyType) {
-          case 'Color':
-            {
-              final int alpha = JsonUtils.getIntMember(properties, 'alpha');
-              final int red = JsonUtils.getIntMember(properties, 'red');
-              final int green = JsonUtils.getIntMember(properties, 'green');
-              final int blue = JsonUtils.getIntMember(properties, 'blue');
-              String radix(int chan) => chan.toRadixString(16).padLeft(2, '0');
-              if (alpha == 255) {
-                description = '#${radix(red)}${radix(green)}${radix(blue)}';
-              } else {
-                description =
-                    '#${radix(alpha)}${radix(red)}${radix(green)}${radix(blue)}';
-              }
-
-              final Color color = Color.fromARGB(alpha, red, green, blue);
-              builder.addIcon(_colorIconMaker.getCustomIcon(color));
-              break;
-            }
-
-          case 'IconData':
-            {
-              final int codePoint =
-                  JsonUtils.getIntMember(properties, 'codePoint');
-              if (codePoint > 0) {
-                final DevToolsIcon icon =
-                    FlutterMaterialIcons.getIconForCodePoint(codePoint);
-                if (icon != null) {
-                  builder.addIcon(icon);
-                }
-              }
-              break;
-            }
-        }
-      }
-
-      if (_showRenderObjectPropertiesAsLinks &&
-          propertyType == 'RenderObject') {
-        textStyle = textStyle..merge(inspector_text_styles.link);
-      }
-
-      // TODO(jacobr): custom display for units, iterables, and padding.
-      _renderDescription(builder, description, textStyle, isProperty: true);
-
-      if (diagnostic.level == DiagnosticLevel.fine &&
-          diagnostic.hasDefaultValue) {
-        builder.appendText(' ', textStyle);
-        builder.addIcon(defaultIcon);
-      }
-    } else {
-      // Non property, regular node case.
-      if (name?.isNotEmpty == true && diagnostic.showName && name != 'child') {
-        if (name.startsWith('child ')) {
-          builder.appendText(name, inspector_text_styles.unimportant);
-        } else {
-          builder.appendText(name, textStyle);
-        }
-
-        if (diagnostic.showSeparator) {
-          builder.appendText(
-              diagnostic.separator, inspector_text_styles.unimportant);
-          if (diagnostic.separator != ' ' &&
-              diagnostic.description.isNotEmpty) {
-            builder.appendText(' ', inspector_text_styles.unimportant);
-          }
-        }
-      }
-
-      if (!diagnostic.isSummaryTree && diagnostic.isCreatedByLocalProject) {
-        textStyle = textStyle.merge(inspector_text_styles.regularBold);
-      }
-
-      _renderDescription(builder, diagnostic.description, textStyle,
-          isProperty: false);
-    }
-    _renderObject = builder.build();
-    return _renderObject;
   }
 
-  InspectorTreeNodeRender _renderObject;
+  bool _shouldShow;
+  bool shouldShow() {
+    _shouldShow ??= parent == null || parent.isExpanded && parent.shouldShow();
+    return _shouldShow;
+  }
+
+  bool selected = false;
+
   RemoteDiagnosticsNode _diagnostic;
   final List<InspectorTreeNode> _children;
 
@@ -321,6 +212,11 @@ abstract class InspectorTreeNode {
     if (value != _isExpanded) {
       _isExpanded = value;
       isDirty = true;
+      if (_shouldShow ?? false) {
+        for (var child in children) {
+          child.updateShouldShow(value);
+        }
+      }
     }
   }
 
@@ -457,34 +353,6 @@ abstract class InspectorTreeNode {
     _children.clear();
     isDirty = true;
   }
-
-  void _renderDescription(
-    InspectorTreeNodeRenderBuilder<InspectorTreeNodeRender<PaintEntry>> builder,
-    String description,
-    TextStyle textStyle, {
-    bool isProperty,
-  }) {
-    if (diagnostic.isDiagnosticableValue) {
-      final match = _primaryDescriptionPattern.firstMatch(description);
-      if (match != null) {
-        builder.appendText(match.group(1), textStyle);
-        if (match.group(2).isNotEmpty) {
-          builder.appendText(match.group(2), inspector_text_styles.unimportant);
-        }
-        return;
-      }
-    } else if (diagnostic.type == 'ErrorDescription') {
-      final match = _assertionThrownBuildingError.firstMatch(description);
-      if (match != null) {
-        builder.appendText(match.group(1), textStyle);
-        builder.appendText(match.group(3), textStyle);
-        return;
-      }
-    }
-    if (description?.isNotEmpty == true) {
-      builder.appendText(description, textStyle);
-    }
-  }
 }
 
 /// A row in the tree with all information required to render it.
@@ -508,38 +376,32 @@ class InspectorTreeRow {
   bool get isSelected => node.selected;
 }
 
-typedef InspectorTreeFactory = InspectorTree Function({
-  @required bool summaryTree,
-  @required FlutterTreeType treeType,
-  @required NodeAddedCallback onNodeAdded,
-  VoidCallback onSelectionChange,
-  TreeEventCallback onExpand,
-  TreeHoverEventCallback onHover,
-});
-
 /// Callback issued every time a node is added to the tree.
 typedef NodeAddedCallback = void Function(
     InspectorTreeNode node, RemoteDiagnosticsNode diagnosticsNode);
 
-abstract class InspectorTree {
-  InspectorTree({
+class InspectorTreeConfig {
+  InspectorTreeConfig({
     @required this.summaryTree,
     @required this.treeType,
-    @required NodeAddedCallback onNodeAdded,
-    VoidCallback onSelectionChange,
+    @required this.onNodeAdded,
+    this.onSelectionChange,
     this.onExpand,
-    TreeHoverEventCallback onHover,
-  })  : _onHoverCallback = onHover,
-        _onSelectionChange = onSelectionChange,
-        _onNodeAdded = onNodeAdded;
+    this.onHover,
+  });
 
-  final TreeHoverEventCallback _onHoverCallback;
-
+  final bool summaryTree;
+  final FlutterTreeType treeType;
+  final NodeAddedCallback onNodeAdded;
+  final VoidCallback onSelectionChange;
   final TreeEventCallback onExpand;
+  final TreeHoverEventCallback onHover;
+}
 
-  final VoidCallback _onSelectionChange;
-
-  final NodeAddedCallback _onNodeAdded;
+abstract class InspectorTreeController {
+  // Abstract method defined to avoid a direct Flutter dependency.
+  @protected
+  void setState(VoidCallback fn);
 
   InspectorTreeNode get root => _root;
   InspectorTreeNode _root;
@@ -554,6 +416,14 @@ abstract class InspectorTree {
   InspectorTreeNode get selection => _selection;
   InspectorTreeNode _selection;
 
+  InspectorTreeConfig get config => _config;
+  InspectorTreeConfig _config;
+  set config(InspectorTreeConfig value) {
+    // Only allow setting config once.
+    assert(_config == null);
+    _config = value;
+  }
+
   set selection(InspectorTreeNode node) {
     if (node == _selection) return;
 
@@ -561,8 +431,8 @@ abstract class InspectorTree {
       _selection?.selected = false;
       _selection = node;
       _selection?.selected = true;
-      if (_onSelectionChange != null) {
-        _onSelectionChange();
+      if (config.onSelectionChange != null) {
+        config.onSelectionChange();
       }
     });
   }
@@ -570,13 +440,8 @@ abstract class InspectorTree {
   InspectorTreeNode get hover => _hover;
   InspectorTreeNode _hover;
 
-  final bool summaryTree;
-
-  final FlutterTreeType treeType;
-
   double lastContentWidth;
 
-  void setState(VoidCallback modifyState);
   InspectorTreeNode createNode();
 
   final List<InspectorTreeRow> cachedRows = [];
@@ -614,11 +479,7 @@ abstract class InspectorTree {
     });
   }
 
-  String get tooltip;
-  set tooltip(String value);
-
-  RemoteDiagnosticsNode _currentHoverDiagnostic;
-  bool _computingHover = false;
+  RemoteDiagnosticsNode currentHoverDiagnostic;
 
   void navigateUp() {
     _navigateHelper(-1);
@@ -673,68 +534,6 @@ abstract class InspectorTree {
         .getRow(
             (root.getRowIndex(selection) + indexOffset).clamp(0, numRows - 1))
         ?.node;
-  }
-
-  Future<void> onHover(InspectorTreeNode node, PaintEntry entry) async {
-    if (_onHoverCallback != null) {
-      _onHoverCallback(node, entry?.icon);
-    }
-
-    final diagnostic = node?.diagnostic;
-    final lastHover = _currentHoverDiagnostic;
-    _currentHoverDiagnostic = diagnostic;
-    // Only show tooltips when we are hovering over specific content in a row
-    // rather than over the entire row.
-    // TODO(jacobr): consider showing the tooltip any time we are on a row with
-    // a diagnostics node to make tooltips more discoverable.
-    // To make this work well we would need to add custom tooltip rendering that
-    // more clearly links tooltips to the exact content in a row they apply to.
-    if (diagnostic == null || entry == null) {
-      tooltip = '';
-      _computingHover = false;
-      return;
-    }
-
-    if (entry.icon == defaultIcon) {
-      tooltip = 'Default value';
-      _computingHover = false;
-      return;
-    }
-
-    if (diagnostic.isEnumProperty()) {
-      // We can display a better tooltip than the one provied with the
-      // RemoteDiagnosticsNode as we have access to introspection
-      // via the vm service.
-
-      if (lastHover == diagnostic && _computingHover) {
-        // No need to spam the VMService. We are already computing the hover
-        // for this node.
-        return;
-      }
-      _computingHover = true;
-      Map<String, InstanceRef> properties;
-      try {
-        properties = await diagnostic.valueProperties;
-      } finally {
-        _computingHover = false;
-      }
-      if (lastHover != diagnostic) {
-        // Skipping as the tooltip is no longer relevant for the currently
-        // hovered over node.
-        return;
-      }
-      if (properties == null) {
-        // Something went wrong getting the enum value.
-        // Fall back to the regular tooltip;
-        tooltip = diagnostic.tooltip;
-        return;
-      }
-      tooltip = 'Allowed values:\n${properties.keys.join('\n')}';
-      return;
-    }
-
-    tooltip = diagnostic.tooltip;
-    _computingHover = false;
   }
 
   double get horizontalPadding => 10.0;
@@ -810,32 +609,22 @@ abstract class InspectorTree {
 
   void animateToTargets(List<InspectorTreeNode> targets);
 
-  void onTap(Offset offset) {
-    final row = getRow(offset);
-    if (row == null) {
-      return;
-    }
-
-    onTapIcon(row, row.node.renderObject?.hitTest(offset)?.icon);
+  void onExpandRow(InspectorTreeRow row) {
+    setState(() {
+      row.node.isExpanded = true;
+      if (config.onExpand != null) {
+        config.onExpand(row.node);
+      }
+    });
   }
 
-  void onTapIcon(InspectorTreeRow row, DevToolsIcon icon) {
-    if (icon == expandArrow) {
-      setState(() {
-        row.node.isExpanded = true;
-        if (onExpand != null) {
-          onExpand(row.node);
-        }
-      });
-      return;
-    }
-    if (icon == collapseArrow) {
-      setState(() {
-        row.node.isExpanded = false;
-      });
-      return;
-    }
-    // TODO(jacobr): add other interactive elements here.
+  void onCollapseRow(InspectorTreeRow row) {
+    setState(() {
+      row.node.isExpanded = false;
+    });
+  }
+
+  void onSelectRow(InspectorTreeRow row) {
     selection = row.node;
     expandPath(row.node);
   }
@@ -872,8 +661,8 @@ abstract class InspectorTree {
     assert(expandChildren != null);
     assert(expandProperties != null);
     node.diagnostic = diagnosticsNode;
-    if (_onNodeAdded != null) {
-      _onNodeAdded(node, diagnosticsNode);
+    if (config.onNodeAdded != null) {
+      config.onNodeAdded(node, diagnosticsNode);
     }
 
     if (diagnosticsNode.hasChildren ||
@@ -970,40 +759,10 @@ abstract class InspectorTree {
   }
 }
 
-abstract class InspectorTreeFixedRowHeight extends InspectorTree {
-  InspectorTreeFixedRowHeight({
-    @required bool summaryTree,
-    @required FlutterTreeType treeType,
-    @required NodeAddedCallback onNodeAdded,
-    VoidCallback onSelectionChange,
-    TreeEventCallback onExpand,
-    TreeHoverEventCallback onHover,
-  }) : super(
-          summaryTree: summaryTree,
-          treeType: treeType,
-          onNodeAdded: onNodeAdded,
-          onSelectionChange: onSelectionChange,
-          onExpand: onExpand,
-          onHover: onHover,
-        );
-
+mixin InspectorTreeFixedRowHeightController on InspectorTreeController {
   Rect getBoundingBox(InspectorTreeRow row);
 
   void scrollToRect(Rect targetRect);
-
-  /// The future completes when the possible tooltip on hover is available.
-  ///
-  /// Generally only await this future for tests that check for the value shown
-  /// on hover matches the expected value.
-  Future<void> onMouseMove(Offset offset) async {
-    final row = getRow(offset);
-    if (row != null) {
-      final node = row.node;
-      await onHover(node, node?.renderObject?.hitTest(offset));
-    } else {
-      await onHover(null, null);
-    }
-  }
 
   @override
   void animateToTargets(List<InspectorTreeNode> targets) {

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -182,11 +182,11 @@ class InspectorTreeNode {
     }
   }
 
-  bool _shouldShow;
-  bool shouldShow() {
-    _shouldShow ??= parent == null || parent.isExpanded && parent.shouldShow();
+  bool get shouldShow {
+    _shouldShow ??= parent == null || parent.isExpanded && parent.shouldShow;
     return _shouldShow;
   }
+  bool _shouldShow;
 
   bool selected = false;
 

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -186,6 +186,7 @@ class InspectorTreeNode {
     _shouldShow ??= parent == null || parent.isExpanded && parent.shouldShow;
     return _shouldShow;
   }
+
   bool _shouldShow;
 
   bool selected = false;

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_canvas.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_canvas.dart
@@ -14,8 +14,8 @@ import '../ui/html_elements.dart';
 import '../ui/html_icon_renderer.dart';
 import '../ui/icons.dart';
 import '../ui/viewport_canvas.dart';
-import 'inspector_service.dart';
 import 'inspector_tree.dart';
+import 'inspector_tree_legacy.dart';
 import 'inspector_tree_web.dart';
 
 typedef CanvasPaintCallback = void Function(
@@ -63,11 +63,12 @@ class IconPaintEntry extends CanvasPaintEntry {
   double get right => x + icon.iconWidth;
 
   @override
-  void attach(InspectorTree owner) {
+  void attach(InspectorTreeController owner) {
     final image = iconRenderer.image;
     if (image == null) {
       iconRenderer.loadImage().then((_) {
         // TODO(jacobr): only repaint what is needed.
+        // ignore: invalid_use_of_protected_member
         owner.setState(() {});
       });
     }
@@ -155,7 +156,7 @@ class InspectorTreeNodeRenderCanvasBuilder
 }
 
 class InspectorTreeNodeCanvasRender
-    extends InspectorTreeNodeRender<CanvasPaintEntry> {
+    extends InspectorTreeNodeRendererLegacy<CanvasPaintEntry> {
   InspectorTreeNodeCanvasRender(List<CanvasPaintEntry> entries, Size size)
       : super(entries, size);
 
@@ -188,7 +189,7 @@ class InspectorTreeNodeCanvasRender
   }
 }
 
-class InspectorTreeNodeCanvas extends InspectorTreeNode {
+class InspectorTreeNodeCanvas extends InspectorTreeNodeLegacy {
   @override
   InspectorTreeNodeRenderBuilder createRenderBuilder() {
     return InspectorTreeNodeRenderCanvasBuilder(
@@ -198,23 +199,9 @@ class InspectorTreeNodeCanvas extends InspectorTreeNode {
   }
 }
 
-class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
-    with InspectorTreeWeb {
-  InspectorTreeCanvas({
-    @required bool summaryTree,
-    @required FlutterTreeType treeType,
-    @required NodeAddedCallback onNodeAdded,
-    VoidCallback onSelectionChange,
-    TreeEventCallback onExpand,
-    TreeHoverEventCallback onHover,
-  }) : super(
-          summaryTree: summaryTree,
-          treeType: treeType,
-          onNodeAdded: onNodeAdded,
-          onSelectionChange: onSelectionChange,
-          onExpand: onExpand,
-          onHover: onHover,
-        ) {
+class InspectorTreeCanvas extends InspectorTreeControllerLegacy
+    with InspectorTreeWeb, InspectorTreeFixedRowHeightController {
+  InspectorTreeCanvas() {
     _viewportCanvas = ViewportCanvas(
       paintCallback: _paintCallback,
       onTap: onTap,
@@ -226,6 +213,20 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
 
     _viewportCanvas.element.element.tabIndex = 0;
     addKeyboardListeners(_viewportCanvas.element);
+  }
+
+  /// The future completes when the possible tooltip on hover is available.
+  ///
+  /// Generally only await this future for tests that check for the value shown
+  /// on hover matches the expected value.
+  Future<void> onMouseMove(Offset offset) async {
+    final row = getRow(offset);
+    if (row != null) {
+      final InspectorTreeNodeCanvas node = row.node;
+      await onHover(node, node?.renderObject?.hitTest(offset));
+    } else {
+      await onHover(null, null);
+    }
   }
 
   void _updateForContainerResize(Size size) {
@@ -244,10 +245,10 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
   bool _recomputeRows = false;
 
   @override
-  void setState(VoidCallback modifyState) {
+  void setState(VoidCallback fn) {
     // More closely match Flutter semantics where state is set immediately
     // instead of after a frame.
-    modifyState();
+    fn();
     if (!_recomputeRows) {
       _recomputeRows = true;
       window.requestAnimationFrame((_) => _rebuildData());
@@ -322,7 +323,7 @@ class InspectorTreeCanvas extends InspectorTreeFixedRowHeight
     if (row == null) {
       return;
     }
-    final node = row.node;
+    final InspectorTreeNodeCanvas node = row.node;
     final showExpandCollapse = node.showExpandCollapse;
     final InspectorTreeNodeCanvasRender renderObject = node.renderObject;
 

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_legacy.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_legacy.dart
@@ -1,0 +1,279 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// Library with legacy inspector_tree functionality only required to keep the
+/// dart:html version of the app running.
+///
+/// If you update any functionality in this file be sure to update the
+/// corresponding code in the Flutter version of the application.
+library inspector_tree_legacy;
+
+import 'package:vm_service/vm_service.dart';
+
+import '../ui/fake_flutter/fake_flutter.dart';
+import '../ui/icons.dart';
+import '../ui/material_icons.dart';
+import '../utils.dart';
+import 'inspector_controller.dart';
+import 'inspector_text_styles.dart' as inspector_text_styles;
+import 'inspector_tree.dart';
+
+final ColorIconMaker _colorIconMaker = ColorIconMaker();
+final CustomIconMaker _customIconMaker = CustomIconMaker();
+
+final DevToolsIcon defaultIcon = _customIconMaker.fromInfo('Default');
+
+const bool _showRenderObjectPropertiesAsLinks = false;
+
+abstract class InspectorTreeControllerLegacy extends InspectorTreeController {
+  void onTapIcon(InspectorTreeRow row, DevToolsIcon icon) {
+    if (icon == expandArrow) {
+      onExpandRow(row);
+      return;
+    }
+    if (icon == collapseArrow) {
+      onCollapseRow(row);
+      return;
+    }
+    // TODO(jacobr): add other interactive elements here.
+    onSelectRow(row);
+  }
+
+  void onTap(Offset offset) {
+    final row = getRow(offset);
+    if (row == null) {
+      return;
+    }
+
+    final InspectorTreeNodeLegacy node = row.node;
+    onTapIcon(row, node.renderObject?.hitTest(offset)?.icon);
+  }
+
+  String get tooltip;
+  set tooltip(String value);
+  bool _computingHover = false;
+
+  Future<void> onHover(InspectorTreeNode node, PaintEntry entry) async {
+    if (config.onHover != null) {
+      config.onHover(node, entry?.icon);
+    }
+
+    final diagnostic = node?.diagnostic;
+    final lastHover = currentHoverDiagnostic;
+    currentHoverDiagnostic = diagnostic;
+    // Only show tooltips when we are hovering over specific content in a row
+    // rather than over the entire row.
+    // TODO(jacobr): consider showing the tooltip any time we are on a row with
+    // a diagnostics node to make tooltips more discoverable.
+    // To make this work well we would need to add custom tooltip rendering that
+    // more clearly links tooltips to the exact content in a row they apply to.
+    if (diagnostic == null || entry == null) {
+      tooltip = '';
+      _computingHover = false;
+      return;
+    }
+
+    if (entry.icon == defaultIcon) {
+      tooltip = 'Default value';
+      _computingHover = false;
+      return;
+    }
+
+    if (diagnostic.isEnumProperty()) {
+      // We can display a better tooltip than the one provied with the
+      // RemoteDiagnosticsNode as we have access to introspection
+      // via the vm service.
+
+      if (lastHover == diagnostic && _computingHover) {
+        // No need to spam the VMService. We are already computing the hover
+        // for this node.
+        return;
+      }
+      _computingHover = true;
+      Map<String, InstanceRef> properties;
+      try {
+        properties = await diagnostic.valueProperties;
+      } finally {
+        _computingHover = false;
+      }
+      if (lastHover != diagnostic) {
+        // Skipping as the tooltip is no longer relevant for the currently
+        // hovered over node.
+        return;
+      }
+      if (properties == null) {
+        // Something went wrong getting the enum value.
+        // Fall back to the regular tooltip;
+        tooltip = diagnostic.tooltip;
+        return;
+      }
+      tooltip = 'Allowed values:\n${properties.keys.join('\n')}';
+      return;
+    }
+
+    tooltip = diagnostic.tooltip;
+    _computingHover = false;
+  }
+}
+
+// Legacy tree node class for dart:html based app.
+abstract class InspectorTreeNodeLegacy extends InspectorTreeNode {
+  /// Override this method to define a tree node to build render objects
+  /// appropriate for a specific platform.
+  InspectorTreeNodeRenderBuilder createRenderBuilder();
+
+  /// This method defines the logic of how a RenderObject is converted to
+  /// a list of styled text and icons. If you want to change how tree content
+  /// is styled modify this message as it is the robust way for style changes
+  /// to apply to all ways inspector trees are rendered (html, canvas, Flutter
+  /// in the future).
+  /// If you change this rendering also change the matching logic in
+  /// src/io/flutter/view/DiagnosticsTreeCellRenderer.java
+  InspectorTreeNodeRender get renderObject {
+    if (_renderObject != null || diagnostic == null) {
+      return _renderObject;
+    }
+
+    final builder = createRenderBuilder();
+    final icon = diagnostic.icon;
+    if (showExpandCollapse) {
+      builder.addIcon(isExpanded ? collapseArrow : expandArrow);
+    }
+    if (icon != null) {
+      builder.addIcon(icon);
+    }
+    final String name = diagnostic.name;
+    TextStyle textStyle = textStyleForLevel(diagnostic.level);
+    if (diagnostic.isProperty) {
+      // Display of inline properties.
+      final String propertyType = diagnostic.propertyType;
+      final Map<String, Object> properties = diagnostic.valuePropertiesJson;
+
+      if (name?.isNotEmpty == true && diagnostic.showName) {
+        builder.appendText('$name${diagnostic.separator} ', textStyle);
+      }
+
+      if (isCreatedByLocalProject) {
+        textStyle = textStyle.merge(inspector_text_styles.regularBold);
+      }
+
+      String description = diagnostic.description;
+      if (propertyType != null && properties != null) {
+        switch (propertyType) {
+          case 'Color':
+            {
+              final int alpha = JsonUtils.getIntMember(properties, 'alpha');
+              final int red = JsonUtils.getIntMember(properties, 'red');
+              final int green = JsonUtils.getIntMember(properties, 'green');
+              final int blue = JsonUtils.getIntMember(properties, 'blue');
+              String radix(int chan) => chan.toRadixString(16).padLeft(2, '0');
+              if (alpha == 255) {
+                description = '#${radix(red)}${radix(green)}${radix(blue)}';
+              } else {
+                description =
+                    '#${radix(alpha)}${radix(red)}${radix(green)}${radix(blue)}';
+              }
+
+              final Color color = Color.fromARGB(alpha, red, green, blue);
+              builder.addIcon(_colorIconMaker.getCustomIcon(color));
+              break;
+            }
+
+          case 'IconData':
+            {
+              final int codePoint =
+                  JsonUtils.getIntMember(properties, 'codePoint');
+              if (codePoint > 0) {
+                final DevToolsIcon icon =
+                    FlutterMaterialIcons.getIconForCodePoint(codePoint);
+                if (icon != null) {
+                  builder.addIcon(icon);
+                }
+              }
+              break;
+            }
+        }
+      }
+
+      if (_showRenderObjectPropertiesAsLinks &&
+          propertyType == 'RenderObject') {
+        textStyle = textStyle..merge(inspector_text_styles.link);
+      }
+
+      // TODO(jacobr): custom display for units, iterables, and padding.
+      _renderDescription(builder, description, textStyle, isProperty: true);
+
+      if (diagnostic.level == DiagnosticLevel.fine &&
+          diagnostic.hasDefaultValue) {
+        builder.appendText(' ', textStyle);
+        builder.addIcon(defaultIcon);
+      }
+    } else {
+      // Non property, regular node case.
+      if (name?.isNotEmpty == true && diagnostic.showName && name != 'child') {
+        if (name.startsWith('child ')) {
+          builder.appendText(name, inspector_text_styles.unimportant);
+        } else {
+          builder.appendText(name, textStyle);
+        }
+
+        if (diagnostic.showSeparator) {
+          builder.appendText(
+              diagnostic.separator, inspector_text_styles.unimportant);
+          if (diagnostic.separator != ' ' &&
+              diagnostic.description.isNotEmpty) {
+            builder.appendText(' ', inspector_text_styles.unimportant);
+          }
+        }
+      }
+
+      if (!diagnostic.isSummaryTree && diagnostic.isCreatedByLocalProject) {
+        textStyle = textStyle.merge(inspector_text_styles.regularBold);
+      }
+
+      _renderDescription(builder, diagnostic.description, textStyle,
+          isProperty: false);
+    }
+    _renderObject = builder.build();
+    return _renderObject;
+  }
+
+  void _renderDescription(
+    InspectorTreeNodeRenderBuilder builder,
+    String description,
+    TextStyle textStyle, {
+    bool isProperty,
+  }) {
+    if (diagnostic.isDiagnosticableValue) {
+      final match = treeNodePrimaryDescriptionPattern.firstMatch(description);
+      if (match != null) {
+        builder.appendText(match.group(1), textStyle);
+        if (match.group(2).isNotEmpty) {
+          builder.appendText(match.group(2), inspector_text_styles.unimportant);
+        }
+        return;
+      }
+    } else if (diagnostic.type == 'ErrorDescription') {
+      final match = assertionThrownBuildingError.firstMatch(description);
+      if (match != null) {
+        builder.appendText(match.group(1), textStyle);
+        builder.appendText(match.group(3), textStyle);
+        return;
+      }
+    }
+    if (description?.isNotEmpty == true) {
+      builder.appendText(description, textStyle);
+    }
+  }
+
+  InspectorTreeNodeRender _renderObject;
+
+  @override
+  set isDirty(bool dirty) {
+    if (dirty) {
+      _renderObject = null;
+    }
+    super.isDirty = dirty;
+  }
+}

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_web.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_web.dart
@@ -3,12 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:html_shim/html.dart';
-
 import '../ui/html_elements.dart';
 import 'inspector_tree.dart';
 
 /// Base class for all inspector tree classes that can be used on the web.
-mixin InspectorTreeWeb implements InspectorTree, CoreElementView {
+mixin InspectorTreeWeb implements InspectorTreeController, CoreElementView {
   void addKeyboardListeners(CoreElement element) {
     element.onKeyDown.listen((KeyboardEvent e) {
       // TODO(jacobr): PgUp/PgDown/Home/End?

--- a/packages/devtools_app/lib/src/logging/html_logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/html_logging_screen.dart
@@ -149,7 +149,7 @@ class HtmlLogDetails extends CoreElement {
   CoreElement content;
   CoreElement message;
 
-  void onShowDetails({String text, InspectorTree tree}) {
+  void onShowDetails({String text, InspectorTreeController tree}) {
     // Reset the vertical scroll value if any.
     content.element.scrollTop = 0;
     message.clear();
@@ -162,8 +162,10 @@ class HtmlLogDetails extends CoreElement {
   }
 
   InspectorTreeWeb createLoggingTree({VoidCallback onSelectionChange}) {
-    return InspectorTreeHtml(
+    final tree = InspectorTreeHtml();
+    tree.config = InspectorTreeConfig(
       summaryTree: false,
+      onNodeAdded: null,
       treeType: FlutterTreeType.widget,
       onHover: (node, icon) {
         element.style.cursor = (node?.diagnostic?.isDiagnosticableValue == true)
@@ -172,6 +174,7 @@ class HtmlLogDetails extends CoreElement {
       },
       onSelectionChange: onSelectionChange,
     );
+    return tree;
   }
 }
 

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -32,10 +32,14 @@ bool _verboseDebugging = false;
 
 typedef OnLogCountStatusChanged = void Function(String status);
 
-typedef OnShowDetails = void Function({String text, InspectorTree tree});
+typedef OnShowDetails = void Function({
+  String text,
+  InspectorTreeController tree,
+});
 
-typedef CreateLoggingTree = InspectorTree Function(
-    {VoidCallback onSelectionChange});
+typedef CreateLoggingTree = InspectorTreeController Function({
+  VoidCallback onSelectionChange,
+});
 
 class LoggingDetailsController {
   LoggingDetailsController({
@@ -58,7 +62,7 @@ class LoggingDetailsController {
   /// type.
   final CreateLoggingTree createLoggingTree;
 
-  InspectorTree tree;
+  InspectorTreeController tree;
 
   void setData(LogData data) {
     this.data = data;

--- a/packages/devtools_testing/lib/inspector_controller_test.dart
+++ b/packages/devtools_testing/lib/inspector_controller_test.dart
@@ -10,7 +10,7 @@ import 'dart:async';
 import 'package:devtools_app/src/inspector/flutter_widget.dart';
 import 'package:devtools_app/src/inspector/inspector_controller.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
-import 'package:devtools_app/src/inspector/inspector_tree.dart';
+import 'package:devtools_app/src/inspector/inspector_tree_legacy.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
 import 'package:meta/meta.dart';
 import 'package:test/test.dart';
@@ -48,23 +48,8 @@ Future<void> runInspectorControllerTests(FlutterTestEnvironment env) async {
     await inspectorService.inferPubRootDirectoryIfNeeded();
 
     inspectorController = InspectorController(
-      inspectorTreeFactory: ({
-        summaryTree,
-        treeType,
-        onNodeAdded,
-        onSelectionChange,
-        onExpand,
-        onHover,
-      }) {
-        return FakeInspectorTree(
-          summaryTree: summaryTree,
-          treeType: treeType,
-          onNodeAdded: onNodeAdded,
-          onSelectionChange: onSelectionChange,
-          onExpand: onExpand,
-          onHover: onHover,
-        );
-      },
+      inspectorTree: FakeInspectorTree(),
+      detailsTree: FakeInspectorTree(),
       inspectorService: inspectorService,
       treeType: FlutterTreeType.widget,
     );
@@ -168,8 +153,9 @@ Future<void> runInspectorControllerTests(FlutterTestEnvironment env) async {
       const int rowIndex = 2;
       final double y = detailsTree.getRowY(rowIndex);
       final textAlignRow = detailsTree.getRow(Offset(0, y));
-      final FakePaintEntry lastIconEntry = textAlignRow
-          .node.renderObject.entries
+      final FakeInspectorTreeNode node = textAlignRow.node;
+      final FakePaintEntry lastIconEntry =
+          node.renderObject.entries
           .firstWhere((entry) => entry.icon == defaultIcon, orElse: () => null);
       // If the entry doesn't have the defaultIcon then the tree has changed
       // and the rest of this test case won't make sense.

--- a/packages/devtools_testing/lib/logging_controller_test.dart
+++ b/packages/devtools_testing/lib/logging_controller_test.dart
@@ -109,20 +109,21 @@ Future<void> runLoggingControllerTests(FlutterTestEnvironment env) async {
       );
       loggingController.detailsController = LoggingDetailsController(
         onShowInspector: () {},
-        onShowDetails: ({String text, InspectorTree tree}) {
+        onShowDetails: ({String text, InspectorTreeController tree}) {
           currentDetailsTree = tree;
           currentDetailsText = text;
           detailsSelectionController.add(null);
         },
         createLoggingTree: ({VoidCallback onSelectionChange}) {
-          return FakeInspectorTree(
-            summaryTree: false,
-            treeType: FlutterTreeType.widget,
-            onNodeAdded: (_, __) {},
-            onSelectionChange: onSelectionChange,
-            onExpand: (_) {},
-            onHover: (_, __) {},
-          );
+          return FakeInspectorTree()
+            ..config = InspectorTreeConfig(
+              summaryTree: false,
+              treeType: FlutterTreeType.widget,
+              onNodeAdded: (_, __) {},
+              onSelectionChange: onSelectionChange,
+              onExpand: (_) {},
+              onHover: (_, __) {},
+            );
         },
       );
     }


### PR DESCRIPTION
Refactor of the inspector implementation in the dart:html version of the devtools app to prepare for flutter.
Move functionality out of InspectorTree that doesn't make sense in Flutter.
Simplify creating inspector trees by adding a Config object to reduce duplicated parameters in multiple named constructors.
All code in classes with Legacy in the name will be removed after the port to Flutter Web is complete.