### PR TITLE
Delay terminating app process until the service connection has gone 

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -251,9 +251,7 @@ void main() {
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
     // The API only works in release mode.
-    // TODO(dantup): Remove '|| true' once tests are not flaky.
-    //   https://github.com/flutter/devtools/issues/1236
-  }, skip: !testInReleaseMode || true);
+  }, skip: !testInReleaseMode);
 }
 
 Future<Map<String, dynamic>> launchDevTools({

--- a/packages/devtools_app/test/support/cli_test_driver.dart
+++ b/packages/devtools_app/test/support/cli_test_driver.dart
@@ -57,6 +57,9 @@ class AppFixture {
 
   Future<void> teardown() async {
     serviceConnection.dispose();
+    // Dispose is synchronous, so wait for it to finish closing before
+    // terminating the process.
+    await serviceConnection.onDone;
     process.kill();
   }
 }


### PR DESCRIPTION
Running on my fork, this seems to fix #1236 (in a sample of a few runs, at least). It seems that terminating the process too quickly resulted in the connection not being closed properly.

(this change also un-skips the tests that were failing.. if we still see the failures after landing this, we can re-land the skip and investigate further)