### PR TITLE
Re-skip API tests

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -251,7 +251,9 @@ void main() {
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
     // The API only works in release mode.
-  }, skip: !testInReleaseMode);
+    // TODO(dantup): Remove '|| true' once tests are not flaky.
+    //   https://github.com/flutter/devtools/issues/1236
+  }, skip: !testInReleaseMode || true);
 }
 
 Future<Map<String, dynamic>> launchDevTools({


### PR DESCRIPTION
The change in #1245 did not fix #1236, saw the same failure in the very next commit. This re-skips the tests while I investigate further.