### PR TITLE
Reduce chance of race conditions on early disconnects + re-enabled server API tests

### DIFF
--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -137,6 +137,8 @@ class ServiceConnectionManager {
 
     connectedApp = ConnectedApp();
 
+    unawaited(onClosed.then((_) => vmServiceClosed()));
+
     void handleServiceEvent(Event e) {
       if (e.kind == EventKind.kServiceRegistered) {
         if (!_registeredMethodsForService.containsKey(e.service)) {
@@ -162,8 +164,6 @@ class ServiceConnectionManager {
     service.onIsolateEvent.listen(_isolateManager._handleIsolateEvent);
     service.onExtensionEvent
         .listen(_serviceExtensionManager._handleExtensionEvent);
-
-    unawaited(onClosed.then((_) => vmServiceClosed()));
 
     final streamIds = [
       EventStreams.kDebug,

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -251,9 +251,7 @@ void main() {
           equals(appFixture.serviceUri.toString()));
     }, timeout: const Timeout.factor(10));
     // The API only works in release mode.
-    // TODO(dantup): Remove '|| true' once tests are not flaky.
-    //   https://github.com/flutter/devtools/issues/1236
-  }, skip: !testInReleaseMode || true);
+  }, skip: !testInReleaseMode);
 }
 
 Future<Map<String, dynamic>> launchDevTools({


### PR DESCRIPTION
I *think* I finally got to the bottom of the Server API flakes...

On a fork I changed the tests to spawn Chrome with the debug port and connect it to DevTools, then made the tests "reuse" that Window, giving access to anything that's `console.log`'d during the tests. Then I littered hundreds of `print()` statements everywhere.

I found that sometimes when we terminated the Flutter app the close-handling code was never run. This was because the code looked like this:

1. Connect to the VM
1. Do a bunch of async work (get VM version, register all the services, etc.)
1. Set up a close handler

The work in 2 was (relatively) slow (mostly `IsolateManager._initIsolates`), so if the connection was terminated before it had completed, the close handler would not fire, and DevTools would not correctly disconnect (meaning it would never tell the server it disconnected).

This change moves attaching the close handler to before the isolate setup (but still after all the variables it clears are set, to avoid things getting into a bad state on early-disconnections). There's still a very small race here (if you disconnect the app before `getVM` completes), but eliminating that will need a bit more refactoring and I think it's *very* unlikely to be hit - though Travis may prove me wrong shortly :-)