### PR TITLE
Theme

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -49,6 +49,8 @@ class DevToolsAppState extends State<DevToolsApp> {
     final path = uri.path;
 
     // Update the theme based on the query parameters.
+    // TODO(djshuckerow): Update this with a NavigatorObserver to load the
+    // new theme a frame earlier.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // On desktop, don't change the theme on route changes.
       if (!kIsWeb) return;

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -21,16 +21,6 @@ import 'scaffold.dart';
 import 'screen.dart';
 import 'theme.dart';
 
-ThemeData buildDevToolsTheme() {
-  final ThemeData theme =
-      devtools_theme.isDarkTheme ? ThemeData.dark() : ThemeData.light();
-  // TODO(jacobr): determine whether to update the theme to match the
-  // devtools_theme or update devtools_theme to match the flutter theme.
-  // For example, to match the devtools_theme we would write:
-  // theme.copyWith(backgroundColor: devtools_theme.defaultBackground);
-  return theme.copyWith(buttonTheme: theme.buttonTheme.copyWith(minWidth: 36));
-}
-
 /// Top-level configuration for the app.
 @immutable
 class DevToolsApp extends StatefulWidget {
@@ -126,7 +116,7 @@ class DevToolsAppState extends State<DevToolsApp> {
   Widget build(BuildContext context) {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
-      theme: buildDevToolsTheme(),
+      theme: theme,
       onGenerateRoute: _generateRoute,
     );
   }

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 
 import '../../src/framework/framework_core.dart';
 import 'common_widgets.dart';
+import 'navigation.dart';
 import 'screen.dart';
 
 /// The screen in the app responsible for connecting to the Dart VM.
@@ -136,8 +137,8 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
     );
 
     if (connected) {
-      final uriQuery = 'uri=${Uri.encodeQueryComponent(controller.text)}';
-      return Navigator.popAndPushNamed(context, '/?$uriQuery');
+      return Navigator.popAndPushNamed(context,
+          routeNameWithQueryParams(context, '/', {'uri': controller.text}));
     }
   }
 }

--- a/packages/devtools_app/lib/src/flutter/navigation.dart
+++ b/packages/devtools_app/lib/src/flutter/navigation.dart
@@ -1,0 +1,27 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+/// Returns [routeName] with [queryParameters] appended as [Uri] query
+/// parameters.
+///
+/// If not overridden, this will preserve the theme parameter across
+/// navigations.
+String routeNameWithQueryParams(BuildContext context, String routeName,
+    [Map<String, String> queryParameters]) {
+  final newQueryParams =
+      queryParameters == null ? null : Map.of(queryParameters);
+  final previousQueryParams =
+      Uri.parse(ModalRoute.of(context).settings.name ?? '').queryParameters;
+  // Preserve the theme across app-triggered navigations.
+  if (newQueryParams != null &&
+      !newQueryParams.containsKey('theme') &&
+      previousQueryParams.containsKey('theme')) {
+    newQueryParams['theme'] = previousQueryParams['theme'];
+  }
+  return Uri.parse(routeName)
+      .replace(queryParameters: newQueryParams)
+      .toString();
+}

--- a/packages/devtools_app/lib/src/flutter/navigation.dart
+++ b/packages/devtools_app/lib/src/flutter/navigation.dart
@@ -4,17 +4,34 @@
 
 import 'package:flutter/material.dart';
 
+import '../ui/theme.dart' as devtools_theme;
+
 /// Returns [routeName] with [queryParameters] appended as [Uri] query
 /// parameters.
 ///
 /// If not overridden, this will preserve the theme parameter across
 /// navigations.
+///
+///
+/// This will fail because we can't determine what the theme value for the app
+/// is.
 String routeNameWithQueryParams(BuildContext context, String routeName,
     [Map<String, String> queryParameters]) {
   final newQueryParams =
       queryParameters == null ? null : Map.of(queryParameters);
-  final previousQueryParams =
-      Uri.parse(ModalRoute.of(context).settings.name ?? '').queryParameters;
+
+  String previousQuery;
+  if (context == null) {
+    // We allow null context values to make easy pure-VM tests.
+    previousQuery = '';
+  } else {
+    previousQuery = ModalRoute.of(context).settings.name;
+    // When this function is invoked from an unnamed context,
+    // infer from the global theme configuration.
+    previousQuery ??= _inferThemeParameter;
+  }
+
+  final previousQueryParams = Uri.parse(previousQuery).queryParameters;
   // Preserve the theme across app-triggered navigations.
   if (newQueryParams != null &&
       !newQueryParams.containsKey('theme') &&
@@ -25,3 +42,18 @@ String routeNameWithQueryParams(BuildContext context, String routeName,
       .replace(queryParameters: newQueryParams)
       .toString();
 }
+
+/// Infers the app's theme from a global constant.
+///
+/// When calling from an unnamed route, we can't infer the theme
+/// value from the Uri. For example,
+///
+/// ```dart
+/// Navigator.of(context).push(MaterialPageRoute(builder: (innerContext) {
+///   routeNameWithQueryParams(innerContext, '/foo');
+/// }));
+/// ```
+///
+/// ModalRoute.of`(innerContext)` returns the unnamed page route.
+String get _inferThemeParameter =>
+    devtools_theme.isDarkTheme ? '/unnamedRoute?theme=dark' : '/unnamedRoute';

--- a/packages/devtools_app/lib/src/flutter/navigation.dart
+++ b/packages/devtools_app/lib/src/flutter/navigation.dart
@@ -35,8 +35,8 @@ String routeNameWithQueryParams(BuildContext context, String routeName,
   // Preserve the theme across app-triggered navigations.
   if (newQueryParams != null &&
       !newQueryParams.containsKey('theme') &&
-      previousQueryParams.containsKey('theme')) {
-    newQueryParams['theme'] = previousQueryParams['theme'];
+      previousQueryParams['theme'] == 'dark') {
+    newQueryParams['theme'] = 'dark';
   }
   return Uri.parse(routeName)
       .replace(queryParameters: newQueryParams)

--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -134,7 +134,7 @@ class _SplitState extends State<Split> {
             ),
             child: DecoratedBox(
               decoration: BoxDecoration(
-                color: Theme.of(context).indicatorColor,
+                color: Theme.of(context).dividerColor,
                 borderRadius: BorderRadius.circular(Split.dividerMainAxisSize),
               ),
               child: SizedBox(

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+/// Constructs the light or dark theme for the app.
 ThemeData themeFor({@required bool isDarkTheme}) {
   final theme = isDarkTheme ? _darkTheme() : _lightTheme();
   return theme;
@@ -34,16 +35,25 @@ ThemeData _lightTheme() {
 
 const buttonMinWidth = 36.0;
 
+/// Branded grey color.
+///
+/// Source: https://drive.google.com/open?id=1QBhMJqXyRt-CpRsHR6yw2LAfQtiNat4g
 const devtoolsGrey = ColorSwatch<int>(900, {
   900: Color(0xFF202124),
   600: Color(0xFF60646B),
   100: Color(0xFFD5D7Da),
 });
 
+/// Branded yellow color.
+///
+/// Source: https://drive.google.com/open?id=1QBhMJqXyRt-CpRsHR6yw2LAfQtiNat4g
 const devtoolsYellow = ColorSwatch<int>(700, {
   700: Color(0xFFFFC108),
 });
 
+/// Branded blue color.
+///
+/// Source: https://drive.google.com/open?id=1QBhMJqXyRt-CpRsHR6yw2LAfQtiNat4g
 const devtoolsBlue = ColorSwatch<int>(600, {
   700: Color(0xFF02569B),
   600: Color(0xFF0175C2),

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -6,30 +6,33 @@ import 'package:flutter/material.dart';
 
 ThemeData themeFor({@required bool isDarkTheme}) {
   final theme = isDarkTheme ? _darkTheme() : _lightTheme();
-  print(theme);
   return theme;
 }
 
 ThemeData _darkTheme() {
-  return ThemeData.dark().copyWith(
-    primaryColor: devtoolsGrey[900],
-    primaryColorDark: devtoolsBlue[700],
-    primaryColorLight: devtoolsBlue[400],
-    indicatorColor: devtoolsBlue[400],
-    accentColor: devtoolsBlue[400],
-    backgroundColor: devtoolsGrey[600],
-  );
+  final theme = ThemeData.dark();
+  return theme.copyWith(
+      primaryColor: devtoolsGrey[900],
+      primaryColorDark: devtoolsBlue[700],
+      primaryColorLight: devtoolsBlue[400],
+      indicatorColor: devtoolsBlue[400],
+      accentColor: devtoolsBlue[400],
+      backgroundColor: devtoolsGrey[600],
+      buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth));
 }
 
 ThemeData _lightTheme() {
-  return ThemeData.light().copyWith(
-    primaryColor: devtoolsBlue[600],
-    primaryColorDark: devtoolsBlue[700],
-    primaryColorLight: devtoolsBlue[400],
-    indicatorColor: Colors.yellowAccent[400],
-    accentColor: devtoolsBlue[400],
-  );
+  final theme = ThemeData.light();
+  return theme.copyWith(
+      primaryColor: devtoolsBlue[600],
+      primaryColorDark: devtoolsBlue[700],
+      primaryColorLight: devtoolsBlue[400],
+      indicatorColor: Colors.yellowAccent[400],
+      accentColor: devtoolsBlue[400],
+      buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth));
 }
+
+const buttonMinWidth = 36.0;
 
 const devtoolsGrey = ColorSwatch<int>(900, {
   900: Color(0xFF202124),
@@ -46,37 +49,3 @@ const devtoolsBlue = ColorSwatch<int>(600, {
   600: Color(0xFF0175C2),
   400: Color(0xFF13B9FD),
 });
-
-class ThemeObserver extends NavigatorObserver {
-  @override
-  void didPush(Route route, Route previousRoute) {
-    didUpdateRoute(route, previousRoute);
-  }
-
-  @override
-  void didPop(Route route, Route previousRoute) {
-    didUpdateRoute(route, previousRoute);
-  }
-
-  @override
-  void didRemove(Route route, Route previousRoute) {
-    didUpdateRoute(route, previousRoute);
-  }
-
-  @override
-  void didReplace({Route newRoute, Route oldRoute}) {
-    didUpdateRoute(newRoute, oldRoute);
-  }
-
-  void didUpdateRoute(Route route, Route previousRoute) {
-    final previousUri = Uri.parse(previousRoute.settings.name);
-    final newUri = Uri.parse(route.settings.name);
-    if (previousUri.queryParameters.containsKey('theme') &&
-        !newUri.queryParameters.containsKey('theme')) {
-      final newQueryParams = Map.of(newUri.queryParameters);
-      newQueryParams['theme'] = previousUri.queryParameters['theme'];
-      newUri.replace(queryParameters: newQueryParams);
-      route.settings.copyWith(name: newUri.toString());
-    }
-  }
-}

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -1,0 +1,82 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+ThemeData themeFor({@required bool isDarkTheme}) {
+  final theme = isDarkTheme ? _darkTheme() : _lightTheme();
+  print(theme);
+  return theme;
+}
+
+ThemeData _darkTheme() {
+  return ThemeData.dark().copyWith(
+    primaryColor: devtoolsGrey[900],
+    primaryColorDark: devtoolsBlue[700],
+    primaryColorLight: devtoolsBlue[400],
+    indicatorColor: devtoolsBlue[400],
+    accentColor: devtoolsBlue[400],
+    backgroundColor: devtoolsGrey[600],
+  );
+}
+
+ThemeData _lightTheme() {
+  return ThemeData.light().copyWith(
+    primaryColor: devtoolsBlue[600],
+    primaryColorDark: devtoolsBlue[700],
+    primaryColorLight: devtoolsBlue[400],
+    indicatorColor: Colors.yellowAccent[400],
+    accentColor: devtoolsBlue[400],
+  );
+}
+
+const devtoolsGrey = ColorSwatch<int>(900, {
+  900: Color(0xFF202124),
+  600: Color(0xFF60646B),
+  100: Color(0xFFD5D7Da),
+});
+
+const devtoolsYellow = ColorSwatch<int>(700, {
+  700: Color(0xFFFFC108),
+});
+
+const devtoolsBlue = ColorSwatch<int>(600, {
+  700: Color(0xFF02569B),
+  600: Color(0xFF0175C2),
+  400: Color(0xFF13B9FD),
+});
+
+class ThemeObserver extends NavigatorObserver {
+  @override
+  void didPush(Route route, Route previousRoute) {
+    didUpdateRoute(route, previousRoute);
+  }
+
+  @override
+  void didPop(Route route, Route previousRoute) {
+    didUpdateRoute(route, previousRoute);
+  }
+
+  @override
+  void didRemove(Route route, Route previousRoute) {
+    didUpdateRoute(route, previousRoute);
+  }
+
+  @override
+  void didReplace({Route newRoute, Route oldRoute}) {
+    didUpdateRoute(newRoute, oldRoute);
+  }
+
+  void didUpdateRoute(Route route, Route previousRoute) {
+    final previousUri = Uri.parse(previousRoute.settings.name);
+    final newUri = Uri.parse(route.settings.name);
+    if (previousUri.queryParameters.containsKey('theme') &&
+        !newUri.queryParameters.containsKey('theme')) {
+      final newQueryParams = Map.of(newUri.queryParameters);
+      newQueryParams['theme'] = previousUri.queryParameters['theme'];
+      newUri.replace(queryParameters: newQueryParams);
+      route.settings.copyWith(name: newUri.toString());
+    }
+  }
+}

--- a/packages/devtools_app/test/flutter/navigation_test.dart
+++ b/packages/devtools_app/test/flutter/navigation_test.dart
@@ -54,7 +54,8 @@ void main() {
       expect(generatedRoute, '/home?foo=bar&theme=dark');
     });
 
-    testWidgets('Respects light theme of the current route from the context',
+    testWidgets(
+        'Removes redundant light theme of the current route from the context',
         (WidgetTester tester) async {
       String generatedRoute;
       await tester.pumpWidget(
@@ -63,11 +64,11 @@ void main() {
               routeNameWithQueryParams(context, '/home', {'foo': 'bar'});
         }, initialRoute: '/?theme=light'),
       );
-      expect(generatedRoute, '/home?foo=bar&theme=light');
+      expect(generatedRoute, '/home?foo=bar');
     });
 
     testWidgets(
-        'Overrides theme of the current route from the context when a theme is given',
+        'Overrides dark theme of the current route when a replacement theme is given',
         (WidgetTester tester) async {
       String generatedRoute;
       await tester.pumpWidget(

--- a/packages/devtools_app/test/flutter/navigation_test.dart
+++ b/packages/devtools_app/test/flutter/navigation_test.dart
@@ -1,0 +1,6 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('Respects the theme value', () {});
+}

--- a/packages/devtools_app/test/flutter/navigation_test.dart
+++ b/packages/devtools_app/test/flutter/navigation_test.dart
@@ -100,7 +100,6 @@ void main() {
           WidgetsBinding.instance.addPostFrameCallback((_) {
             Navigator.of(context)
                 .push(MaterialPageRoute(builder: (innerContext) {
-              print(isDarkTheme);
               onUnnamedRouteBuild(innerContext);
               return const SizedBox();
             }));

--- a/packages/devtools_app/test/flutter/navigation_test.dart
+++ b/packages/devtools_app/test/flutter/navigation_test.dart
@@ -1,6 +1,137 @@
+import 'package:devtools_app/src/flutter/navigation.dart';
+import 'package:devtools_app/src/ui/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  test('Respects the theme value', () {});
+  group('routeNameWithQueryParams', () {
+    test('Generates a route name with params without a context', () {
+      expect(routeNameWithQueryParams(null, '/'), '/');
+      expect(routeNameWithQueryParams(null, '/home'), '/home');
+      expect(routeNameWithQueryParams(null, '/', {}), '/?');
+      expect(routeNameWithQueryParams(null, '/', {'foo': 'bar'}), '/?foo=bar');
+      expect(
+          routeNameWithQueryParams(null, '/', {'foo': 'bar', 'theme': 'dark'}),
+          '/?foo=bar&theme=dark');
+    });
+
+    /// Builds an app that calls [onBuild] when [initialRoute] loads.
+    Widget routeTestingApp(void Function(BuildContext) onBuild,
+        {String initialRoute = '/'}) {
+      return MaterialApp(
+        initialRoute: initialRoute,
+        routes: {
+          initialRoute: (context) {
+            onBuild(context);
+            return const SizedBox();
+          }
+        },
+      );
+    }
+
+    testWidgets(
+        'Generates a route name with parameters with an empty route in the context',
+        (WidgetTester tester) async {
+      String generatedRoute;
+      await tester.pumpWidget(
+        routeTestingApp((context) {
+          generatedRoute = routeNameWithQueryParams(
+              context, '/home', {'foo': 'bar', 'theme': 'dark'});
+        }),
+      );
+      expect(generatedRoute, '/home?foo=bar&theme=dark');
+    });
+
+    testWidgets('Respects dark theme of the current route from the context',
+        (WidgetTester tester) async {
+      String generatedRoute;
+      await tester.pumpWidget(
+        routeTestingApp((context) {
+          generatedRoute =
+              routeNameWithQueryParams(context, '/home', {'foo': 'bar'});
+        }, initialRoute: '/?theme=dark'),
+      );
+      expect(generatedRoute, '/home?foo=bar&theme=dark');
+    });
+
+    testWidgets('Respects light theme of the current route from the context',
+        (WidgetTester tester) async {
+      String generatedRoute;
+      await tester.pumpWidget(
+        routeTestingApp((context) {
+          generatedRoute =
+              routeNameWithQueryParams(context, '/home', {'foo': 'bar'});
+        }, initialRoute: '/?theme=light'),
+      );
+      expect(generatedRoute, '/home?foo=bar&theme=light');
+    });
+
+    testWidgets(
+        'Overrides theme of the current route from the context when a theme is given',
+        (WidgetTester tester) async {
+      String generatedRoute;
+      await tester.pumpWidget(
+        routeTestingApp((context) {
+          generatedRoute = routeNameWithQueryParams(
+              context, '/home', {'foo': 'bar', 'theme': 'light'});
+        }, initialRoute: '/?snap=crackle&theme=dark'),
+      );
+      expect(generatedRoute, '/home?foo=bar&theme=light');
+    });
+
+    testWidgets(
+        'Overrides other parameters of the current route from the context',
+        (WidgetTester tester) async {
+      String generatedRoute;
+      await tester.pumpWidget(
+        routeTestingApp((context) {
+          generatedRoute =
+              routeNameWithQueryParams(context, '/home', {'foo': 'baz'});
+        }, initialRoute: '/?foo=bar&baz=quux'),
+      );
+      expect(generatedRoute, '/home?foo=baz');
+    });
+
+    group('in an unnamed route', () {
+      /// Builds an app that loads an unnamed route and calls [onBuild] when
+      /// the unnamed route loads.
+      Widget unnamedRouteApp(void Function(BuildContext) onUnnamedRouteBuild) {
+        return routeTestingApp((context) {
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            Navigator.of(context)
+                .push(MaterialPageRoute(builder: (innerContext) {
+              print(isDarkTheme);
+              onUnnamedRouteBuild(innerContext);
+              return const SizedBox();
+            }));
+          });
+        });
+      }
+
+      testWidgets('Builds with global dark mode when dark mode is on',
+          (WidgetTester tester) async {
+        String generatedRoute;
+        initializeTheme('dark');
+        await tester.pumpWidget(unnamedRouteApp((context) {
+          generatedRoute =
+              routeNameWithQueryParams(context, '/home', {'foo': 'baz'});
+        }));
+        await tester.pumpAndSettle();
+        expect(generatedRoute, '/home?foo=baz&theme=dark');
+        // Teardown the global theme change
+        initializeTheme('light');
+      });
+
+      testWidgets('Builds with global light mode when dark mode is off',
+          (WidgetTester tester) async {
+        String generatedRoute;
+        await tester.pumpWidget(unnamedRouteApp((context) {
+          generatedRoute =
+              routeNameWithQueryParams(context, '/home', {'foo': 'baz'});
+        }));
+        await tester.pumpAndSettle();
+        expect(generatedRoute, '/home?foo=baz');
+      });
+    });
+  });
 }

--- a/packages/devtools_app/test/flutter/wrappers.dart
+++ b/packages/devtools_app/test/flutter/wrappers.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/flutter/app.dart';
+import 'package:devtools_app/src/flutter/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,7 +14,7 @@ import 'package:flutter_test/flutter_test.dart';
 /// draw ink effects.
 Widget wrap(Widget widget) {
   return MaterialApp(
-    theme: buildDevToolsTheme(),
+    theme: themeFor(isDarkTheme: false),
     home: Material(child: widget),
   );
 }


### PR DESCRIPTION
Fixes #1187 

Introduces a navigation utility for route names with parameters, allowing us to preserving the selected theme as we navigate.

Please take a careful look at the navigation utility, since I had to handle a special case for unnamed Flutter routes.

In general, I'm not sure how well those unnamed routes will work on the web, but there are situations where we could have them, like a modal dialog.

Dark & light modes:
![image](https://user-images.githubusercontent.com/14947366/67971858-c941a980-fbca-11e9-9c31-f0d36a61750c.png)
![image](https://user-images.githubusercontent.com/14947366/67971865-ccd53080-fbca-11e9-8564-f8386eace37c.png)

