### PR TITLE
Standardize url cleanup code for the Flutter and web versions of the app.

### DIFF
--- a/packages/devtools_app/lib/src/framework/html_framework.dart
+++ b/packages/devtools_app/lib/src/framework/html_framework.dart
@@ -789,7 +789,7 @@ class HtmlConnectDialog {
 
   void _tryConnect() {
     final InputElement inputElement = textfield.element;
-    String value = inputElement.value.trim();
+    final value = inputElement.value.trim();
     final int port = int.tryParse(value);
 
     void handleConnectError() {
@@ -808,12 +808,7 @@ class HtmlConnectDialog {
       });
     } else {
       try {
-        // Check to see if the user pasted in a urlencoded url ('://').
-        if (value.contains('%3A%2F%2F')) {
-          value = Uri.decodeFull(value);
-        }
-
-        final uri = getNormalizedTrimmedUri(value);
+        final uri = normalizeVmServiceUri(value);
         if (uri != null && uri.isAbsolute) {
           _connect(uri).catchError((dynamic error) {
             handleConnectError();

--- a/packages/devtools_app/lib/src/url_utils.dart
+++ b/packages/devtools_app/lib/src/url_utils.dart
@@ -27,11 +27,21 @@ String getSimplePackageUrl(String url) {
   return url;
 }
 
-/// Returns a trimmed vm service uri without any trailing characters.
+/// Returns a normalized vm service uri.
+///
+/// Removes trailing characters, trailing url fragments, and decodes urls that
+/// were accidentally encoded.
 ///
 /// For example, given a [value] of http://127.0.0.1:60667/72K34Xmq0X0=/#/vm,
 /// this method will return the URI http://127.0.0.1:60667/72K34Xmq0X0=/.
-Uri getNormalizedTrimmedUri(String value) {
+Uri normalizeVmServiceUri(String value) {
+  value = value.trim();
+
+  // Cleanup encoded urls likely copied from the uri of an existing running
+  // DevTools app.
+  if (value.contains('%3A%2F%2F')) {
+    value = Uri.decodeFull(value);
+  }
   final uri = Uri.parse(value.trim()).removeFragment();
   if (uri.path.endsWith('/')) return uri;
   return uri.replace(path: uri.path);

--- a/packages/devtools_app/test/url_utils_test.dart
+++ b/packages/devtools_app/test/url_utils_test.dart
@@ -24,29 +24,62 @@ void main() {
       );
     });
 
-    test('getTrimmedUri', () {
+    test('normalizeVmServiceUri', () {
       expect(
-        getNormalizedTrimmedUri('http://127.0.0.1:60667/72K34Xmq0X0=/#/vm')
+        normalizeVmServiceUri('http://127.0.0.1:60667/72K34Xmq0X0=/#/vm')
             .toString(),
         equals('http://127.0.0.1:60667/72K34Xmq0X0=/'),
       );
       expect(
-        getNormalizedTrimmedUri('http://127.0.0.1:60667/72K34Xmq0X0=')
-            .toString(),
+        normalizeVmServiceUri('http://127.0.0.1:60667/72K34Xmq0X0=').toString(),
         equals('http://127.0.0.1:60667/72K34Xmq0X0='),
       );
       expect(
-        getNormalizedTrimmedUri('http://127.0.0.1:60667/72K34Xmq0X0=/   ')
+        normalizeVmServiceUri('http://127.0.0.1:60667/72K34Xmq0X0=/   ')
             .toString(),
         equals('http://127.0.0.1:60667/72K34Xmq0X0=/'),
       );
       expect(
-        getNormalizedTrimmedUri('http://127.0.0.1:60667').toString(),
+        normalizeVmServiceUri('http://127.0.0.1:60667').toString(),
         equals('http://127.0.0.1:60667'),
       );
       expect(
-        getNormalizedTrimmedUri('http://127.0.0.1:60667/').toString(),
+        normalizeVmServiceUri('http://127.0.0.1:60667/').toString(),
         equals('http://127.0.0.1:60667/'),
+      );
+
+      // Leading and trailing characters
+      expect(
+        normalizeVmServiceUri('  http://127.0.0.1:60667/72K34Xmq0X0=/#/vm')
+            .toString(),
+        equals('http://127.0.0.1:60667/72K34Xmq0X0=/'),
+      );
+      expect(
+        normalizeVmServiceUri('  http://127.0.0.1:60667/72K34Xmq0X0=/#/vm  ')
+            .toString(),
+        equals('http://127.0.0.1:60667/72K34Xmq0X0=/'),
+      );
+
+      // Url-encoded
+
+      expect(
+        normalizeVmServiceUri('http%3A%2F%2F127.0.0.1%3A58824%2FCnvgRrQJG7w%3D')
+            .toString(),
+        equals('http://127.0.0.1:58824/CnvgRrQJG7w='),
+      );
+
+      expect(
+        normalizeVmServiceUri(
+          'http%3A%2F%2F127.0.0.1%3A58824%2FCnvgRrQJG7w%3D  ',
+        ).toString(),
+        equals('http://127.0.0.1:58824/CnvgRrQJG7w='),
+      );
+
+      expect(
+        normalizeVmServiceUri(
+          '  http%3A%2F%2F127.0.0.1%3A58824%2FCnvgRrQJG7w%3D   ',
+        ).toString(),
+        equals('http://127.0.0.1:58824/CnvgRrQJG7w='),
       );
     });
   });

--- a/packages/devtools_testing/lib/inspector_controller_test.dart
+++ b/packages/devtools_testing/lib/inspector_controller_test.dart
@@ -154,8 +154,7 @@ Future<void> runInspectorControllerTests(FlutterTestEnvironment env) async {
       final double y = detailsTree.getRowY(rowIndex);
       final textAlignRow = detailsTree.getRow(Offset(0, y));
       final FakeInspectorTreeNode node = textAlignRow.node;
-      final FakePaintEntry lastIconEntry =
-          node.renderObject.entries
+      final FakePaintEntry lastIconEntry = node.renderObject.entries
           .firstWhere((entry) => entry.icon == defaultIcon, orElse: () => null);
       // If the entry doesn't have the defaultIcon then the tree has changed
       // and the rest of this test case won't make sense.


### PR DESCRIPTION
Fix a bug where the VMService connection code wasn't reporting errors correctly.
If there is a timeout, we don't currently timeout quick enough.

Add url filtering code present in the web app but not the flutter app.