### PR TITLE
Add event summary section for viewing timeline event metadata.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/timeline.css
+++ b/packages/devtools_app/lib/src/timeline/timeline.css
@@ -169,3 +169,21 @@
     /* 100% height minus the height of the event-details-heading */
     height: calc(100% - 27px);
 }
+
+.event-summary {
+    padding-top: 4px;
+    padding-left: 8px;
+    position: absolute;
+    overflow-y: scroll;
+    height: 100%;
+    width: 100%;
+}
+
+.event-summary span {
+    font-weight: bold;
+    padding-right: 4px;
+}
+
+.event-args {
+    white-space: pre-wrap;
+}

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -263,7 +263,9 @@ class OfflineFrameBasedTimelineData extends FrameBasedTimelineData
     final Map<String, dynamic> selectedEventJson =
         json[TimelineData.selectedEventKey] ?? {};
     final OfflineTimelineEvent selectedEvent = selectedEventJson.isNotEmpty
-        ? OfflineTimelineEvent(selectedEventJson[TimelineEvent.firstTraceKey])
+        ? OfflineTimelineEvent(
+            (selectedEventJson[TimelineEvent.firstTraceKey] ?? {})
+                .cast<String, dynamic>())
         : null;
 
     final double displayRefreshRate =
@@ -328,7 +330,9 @@ class OfflineFullTimelineData extends FullTimelineData
     final Map<String, dynamic> selectedEventJson =
         json[TimelineData.selectedEventKey] ?? {};
     final OfflineTimelineEvent selectedEvent = selectedEventJson.isNotEmpty
-        ? OfflineTimelineEvent(selectedEventJson[TimelineEvent.firstTraceKey])
+        ? OfflineTimelineEvent(
+            (selectedEventJson[TimelineEvent.firstTraceKey] ?? {})
+                .cast<String, dynamic>())
         : null;
 
     return OfflineFullTimelineData._(

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -263,12 +263,7 @@ class OfflineFrameBasedTimelineData extends FrameBasedTimelineData
     final Map<String, dynamic> selectedEventJson =
         json[TimelineData.selectedEventKey] ?? {};
     final OfflineTimelineEvent selectedEvent = selectedEventJson.isNotEmpty
-        ? OfflineTimelineEvent(
-            selectedEventJson[TimelineEvent.eventNameKey],
-            selectedEventJson[TimelineEvent.eventTypeKey],
-            selectedEventJson[TimelineEvent.eventStartTimeKey],
-            selectedEventJson[TimelineEvent.eventDurationKey],
-          )
+        ? OfflineTimelineEvent(selectedEventJson[TimelineEvent.firstTraceKey])
         : null;
 
     final double displayRefreshRate =
@@ -333,12 +328,7 @@ class OfflineFullTimelineData extends FullTimelineData
     final Map<String, dynamic> selectedEventJson =
         json[TimelineData.selectedEventKey] ?? {};
     final OfflineTimelineEvent selectedEvent = selectedEventJson.isNotEmpty
-        ? OfflineTimelineEvent(
-            selectedEventJson[TimelineEvent.eventNameKey],
-            selectedEventJson[TimelineEvent.eventTypeKey],
-            selectedEventJson[TimelineEvent.eventStartTimeKey],
-            selectedEventJson[TimelineEvent.eventDurationKey],
-          )
+        ? OfflineTimelineEvent(selectedEventJson[TimelineEvent.firstTraceKey])
         : null;
 
     return OfflineFullTimelineData._(
@@ -380,20 +370,18 @@ mixin OfflineData<T extends TimelineData> on TimelineData {
 /// We extend TimelineEvent so that our CPU profiler code requiring a selected
 /// timeline event will work as it does when we are not loading from offline.
 class OfflineTimelineEvent extends TimelineEvent {
-  OfflineTimelineEvent(
-      String name, String eventType, int startMicros, int durationMicros)
+  OfflineTimelineEvent(Map<String, dynamic> firstTrace)
       : super(TraceEventWrapper(
-          TraceEvent({
-            TraceEvent.nameKey: name,
-            TraceEvent.timestampKey: startMicros,
-            TraceEvent.durationKey: durationMicros,
-            TraceEvent.argsKey: {TraceEvent.typeKey: eventType},
-          }),
+          TraceEvent(firstTrace),
           0, // 0 is an arbitrary value for [TraceEventWrapper.timeReceived].
         )) {
-    time.end = Duration(microseconds: startMicros + durationMicros);
+    time.end = Duration(
+        microseconds: firstTrace[TraceEvent.timestampKey] +
+            firstTrace[TraceEvent.durationKey]);
     type = TimelineEventType.values.firstWhere(
-        (t) => t.toString() == eventType.toString(),
+        (t) =>
+            t.toString() ==
+            firstTrace[TraceEvent.argsKey][TraceEvent.typeKey].toString(),
         orElse: () => TimelineEventType.unknown);
   }
 
@@ -533,6 +521,7 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
     time.start = Duration(microseconds: firstTraceEvent.event.timestampMicros);
   }
 
+  static const firstTraceKey = 'firstTrace';
   static const eventNameKey = 'name';
   static const eventTypeKey = 'type';
   static const eventStartTimeKey = 'startMicros';
@@ -696,12 +685,14 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
   }
 
   Map<String, dynamic> get json {
-    return {
-      eventNameKey: name,
-      eventTypeKey: type.toString(),
-      eventStartTimeKey: time.start.inMicroseconds,
-      eventDurationKey: time.duration.inMicroseconds,
-    };
+    final modifiedTrace = Map.from(beginTraceEventJson);
+    modifiedTrace[TraceEvent.argsKey]
+        .addAll({TraceEvent.typeKey: type.toString()});
+    if (!modifiedTrace.containsKey(TraceEvent.durationKey)) {
+      modifiedTrace
+          .addAll({TraceEvent.durationKey: time.duration.inMicroseconds});
+    }
+    return {firstTraceKey: modifiedTrace};
   }
 
   @visibleForTesting

--- a/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_protocol.dart
@@ -586,9 +586,16 @@ class FrameBasedTimelineProcessor extends TimelineProcessor {
   void reset() {
     pendingFrames.clear();
     pendingEvents.clear();
-    currentEventNodes.clear();
-    _previousDurationEndEvents.clear();
-    heaps.clear();
+    for (var heap in heaps) {
+      heap.clear();
+    }
+    // Reset initial states.
+    currentEventNodes
+      ..clear()
+      ..addAll([null, null]);
+    _previousDurationEndEvents
+      ..clear()
+      ..addAll([null, null]);
   }
 }
 

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -169,15 +169,16 @@ void main() {
       expect(offlineData.selectedFrame, isNull);
       expect(offlineData.selectedFrameId, equals('PipelineItem-1'));
       expect(offlineData.selectedEvent, isA<OfflineTimelineEvent>());
+
+      final expectedFirstTraceJson =
+          Map<String, dynamic>.from(vsyncEvent.beginTraceEventJson);
+      expectedFirstTraceJson[TraceEvent.argsKey]
+          .addAll({TraceEvent.typeKey: TimelineEventType.ui});
+      expectedFirstTraceJson.addAll(
+          {TraceEvent.durationKey: vsyncEvent.time.duration.inMicroseconds});
       expect(
         offlineData.selectedEvent.json,
-        equals({
-          TimelineEvent.eventNameKey: vsyncEvent.name,
-          TimelineEvent.eventTypeKey: vsyncEvent.type.toString(),
-          TimelineEvent.eventStartTimeKey: vsyncEvent.time.start.inMicroseconds,
-          TimelineEvent.eventDurationKey:
-              vsyncEvent.time.duration.inMicroseconds,
-        }),
+        equals({TimelineEvent.firstTraceKey: expectedFirstTraceJson}),
       );
       expect(offlineData.displayRefreshRate, equals(120));
       expect(offlineData.cpuProfileData.json, equals(goldenCpuProfileDataJson));
@@ -214,15 +215,16 @@ void main() {
         equals(goldenTraceEventsJson),
       );
       expect(offlineData.selectedEvent, isA<OfflineTimelineEvent>());
+
+      final expectedFirstTraceJson =
+          Map<String, dynamic>.from(vsyncEvent.beginTraceEventJson);
+      expectedFirstTraceJson[TraceEvent.argsKey]
+          .addAll({TraceEvent.typeKey: TimelineEventType.ui});
+      expectedFirstTraceJson.addAll(
+          {TraceEvent.durationKey: vsyncEvent.time.duration.inMicroseconds});
       expect(
         offlineData.selectedEvent.json,
-        equals({
-          TimelineEvent.eventNameKey: vsyncEvent.name,
-          TimelineEvent.eventTypeKey: vsyncEvent.type.toString(),
-          TimelineEvent.eventStartTimeKey: vsyncEvent.time.start.inMicroseconds,
-          TimelineEvent.eventDurationKey:
-              vsyncEvent.time.duration.inMicroseconds,
-        }),
+        equals({TimelineEvent.firstTraceKey: expectedFirstTraceJson}),
       );
       expect(offlineData.cpuProfileData.json, equals(goldenCpuProfileDataJson));
       expect(offlineData.timelineMode, equals(TimelineMode.full));


### PR DESCRIPTION
In the Timeline page, this summary section will show after selecting a non-ui timeline event. For UI events, we will still show the CPU profiler. Eventually, we should add a Summary tab to the CPU profiler tabs so that the event metadata is available for UI events as well, but we can do this after porting to flutter web. 
<img width="827" alt="Screen Shot 2019-11-01 at 10 26 39 AM" src="https://user-images.githubusercontent.com/43759233/68044384-72080b80-fc94-11e9-9da1-ab07658872ec.png">

This section will be important for timeline events with args, which are displayed in this section if `args.isNotEmpty`.
