### PR TITLE
Fix TabBar responsiveness in InspectorScreen

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -23,13 +23,22 @@ class InspectorDetailsTabController extends StatelessWidget {
   final Widget actionButtons;
   final InspectorController controller;
 
+  Widget buildTab(String tabName) {
+    return Tab(
+      child: Text(
+        tabName,
+        overflow: TextOverflow.ellipsis,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final enableExperimentalStoryOfLayout =
         InspectorController.enableExperimentalStoryOfLayout;
     final tabs = <Tab>[
-      const Tab(text: 'Details Tree'),
-      if (enableExperimentalStoryOfLayout) const Tab(text: 'Layout Details')
+      buildTab('Details Tree'),
+      if (enableExperimentalStoryOfLayout) buildTab('Layout Details'),
     ];
     final tabViews = <Widget>[
       detailsTree,
@@ -50,11 +59,13 @@ class InspectorDetailsTabController extends StatelessWidget {
               padding: const EdgeInsets.only(bottom: 8.0),
               child: Row(
                 children: <Widget>[
-                  Container(
-                    color: Theme.of(context).focusColor,
-                    child: TabBar(
-                      tabs: tabs,
-                      isScrollable: true,
+                  Flexible(
+                    child: Container(
+                      color: Theme.of(context).focusColor,
+                      child: TabBar(
+                        tabs: tabs,
+                        isScrollable: true,
+                      ),
                     ),
                   ),
                   if (actionButtons != null)

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -23,7 +23,7 @@ class InspectorDetailsTabController extends StatelessWidget {
   final Widget actionButtons;
   final InspectorController controller;
 
-  Widget buildTab(String tabName) {
+  Widget _buildTab(String tabName) {
     return Tab(
       child: Text(
         tabName,
@@ -37,8 +37,8 @@ class InspectorDetailsTabController extends StatelessWidget {
     final enableExperimentalStoryOfLayout =
         InspectorController.enableExperimentalStoryOfLayout;
     final tabs = <Tab>[
-      buildTab('Details Tree'),
-      if (enableExperimentalStoryOfLayout) buildTab('Layout Details'),
+      _buildTab('Details Tree'),
+      if (enableExperimentalStoryOfLayout) _buildTab('Layout Details'),
     ];
     final tabViews = <Widget>[
       detailsTree,


### PR DESCRIPTION
Due to #1271  that allows dynamic resizing of the details tab, current implementation will throw overflow error. This PR is to fix that