### PR TITLE
Support new inspector api for showing the inspector overlay while keeping the device interactive.

### DIFF
--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -1,0 +1,73 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:meta/meta.dart';
+
+import 'ui/fake_flutter/fake_flutter.dart';
+
+/// Provides functionality to simplify listening to streams and ValueNotifiers.
+///
+/// See also:
+/// * [AutoDisposeMixin], which integrates this functionality with [State]
+///   objects.
+mixin AutoDisposeBase {
+  final List<StreamSubscription> _subscriptions = [];
+
+  final List<Listenable> _listenables = [];
+  final List<VoidCallback> _listeners = [];
+
+  /// Track a stream subscription to be automatically cancelled on dispose.
+  void autoDispose(StreamSubscription subscription) {
+    if (subscription == null) return;
+    _subscriptions.add(subscription);
+  }
+
+  /// Add a listener to a Listenable object that is automatically removed when
+  /// cancel is called.
+  void addAutoDisposeListener(Listenable listenable, VoidCallback listener) {
+    if (listenable == null || listener == null) return;
+    _listenables.add(listenable);
+    _listeners.add(listener);
+    listenable.addListener(listener);
+  }
+
+  /// Cancel all listeners added.
+  ///
+  /// It is fine to call this method and then add additional listeners.
+  void cancel() {
+    for (StreamSubscription subscription in _subscriptions) {
+      subscription.cancel();
+    }
+    _subscriptions.clear();
+
+    assert(_listenables.length == _listeners.length);
+    for (int i = 0; i < _listenables.length; ++i) {
+      _listenables[i].removeListener(_listeners[i]);
+    }
+    _listenables.clear();
+    _listeners.clear();
+  }
+}
+
+/// Base class for controllers that need to manage their lifecycle.
+class DisposableController {
+  @mustCallSuper
+  void dispose() {}
+}
+
+/// Mixin to simplifying managing the lifetime of listeners used by a
+/// [DisposableController].
+///
+/// See also:
+/// * [AutoDisposeMixin], which provides the same functionality for a
+///   [StatefulWidget].
+mixin AutoDisposeControllerMixin on DisposableController, AutoDisposeBase {
+  @override
+  void dispose() {
+    cancel();
+    super.dispose();
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/flutter/auto_dispose_mixin.dart
@@ -2,27 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/widgets.dart';
 
-/// Provides functionality to automatically unsubscribe from streams on dispose.
+import '../auto_dispose.dart';
+
+/// Mixin to simplifying managing the lifetime of listeners used by a
+/// [StatefulWidget].
 ///
-/// Use this class to ensure you don't leak stream subscriptions.
-mixin AutoDisposeMixin<T extends StatefulWidget> on State<T> {
-  final List<StreamSubscription> _subscriptions = [];
-
-  /// Track a stream subscription to be automatically cancelled on dispose.
-  void autoDispose(StreamSubscription subscription) {
-    _subscriptions.add(subscription);
-  }
-
+/// See also:
+/// * [AutoDisposeControllerMixin], which provides the same functionality for
+///   controller classes.
+mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>, AutoDisposeBase {
   @override
   void dispose() {
-    for (StreamSubscription subscription in _subscriptions) {
-      subscription.cancel();
-    }
-    _subscriptions.clear();
+    cancel();
     super.dispose();
   }
 }

--- a/packages/devtools_app/lib/src/flutter/initializer.dart
+++ b/packages/devtools_app/lib/src/flutter/initializer.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../auto_dispose.dart';
 import '../framework/framework_core.dart';
 import '../globals.dart';
 import '../url_utils.dart';
@@ -42,7 +43,7 @@ class Initializer extends StatefulWidget {
 }
 
 class _InitializerState extends State<Initializer>
-    with SingleTickerProviderStateMixin, AutoDisposeMixin {
+    with SingleTickerProviderStateMixin, AutoDisposeBase, AutoDisposeMixin {
   /// Checks if the [service.serviceManager] is connected.
   ///
   /// This is a method and not a getter to communicate that its value may

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -44,18 +44,33 @@ class _InfoScreenBodyState extends State<InfoScreenBody> {
   FlutterVersion _flutterVersion;
 
   FlagList _flagList;
+  InfoController _controller;
 
   @override
   void initState() {
     super.initState();
-    InfoController(
-      onFlagListChanged: (flagList) => setState(() {
-        _flagList = flagList;
-      }),
-      onFlutterVersionChanged: (flutterVersion) => setState(() {
-        _flutterVersion = flutterVersion;
-      }),
+    _controller = InfoController(
+      onFlagListChanged: (flagList) {
+        if (!mounted) return;
+        setState(() {
+          _flagList = flagList;
+        });
+      },
+      onFlutterVersionChanged: (flutterVersion) {
+        if (!mounted) return;
+        setState(
+          () {
+            _flutterVersion = flutterVersion;
+          },
+        );
+      },
     )..entering();
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
   }
 
   @override

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -104,7 +104,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             ServiceExtensionButtonGroup(
-              extensions: [extensions.toggleSelectWidgetMode],
+              extensions: [extensions.toggleOnDeviceWidgetInspector],
               minIncludeTextWidth: 800,
             ),
             OutlineButton(

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 import 'package:vm_service/vm_service.dart' hide Stack;
 
+import '../../auto_dispose.dart';
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/blocking_action_mixin.dart';
 import '../../flutter/screen.dart';
@@ -45,7 +46,7 @@ class InspectorScreenBody extends StatefulWidget {
 }
 
 class _InspectorScreenBodyState extends State<InspectorScreenBody>
-    with BlockingActionMixin, AutoDisposeMixin {
+    with BlockingActionMixin, AutoDisposeBase, AutoDisposeMixin {
   bool _expandCollapseSupported = false;
   bool connectionInProgress = false;
   InspectorService inspectorService;
@@ -103,9 +104,20 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         Row(
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
-            ServiceExtensionButtonGroup(
-              extensions: [extensions.toggleOnDeviceWidgetInspector],
-              minIncludeTextWidth: 800,
+            ValueListenableBuilder(
+              valueListenable: serviceManager.serviceExtensionManager
+                  .hasServiceExtensionListener(
+                      extensions.toggleSelectWidgetMode.extension),
+              builder: (_, selectModeSupported, __) {
+                return ServiceExtensionButtonGroup(
+                  extensions: [
+                    selectModeSupported
+                        ? extensions.toggleSelectWidgetMode
+                        : extensions.toggleOnDeviceWidgetInspector
+                  ],
+                  minIncludeTextWidth: 800,
+                );
+              },
             ),
             OutlineButton(
               onPressed: _refreshInspector,

--- a/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
@@ -80,7 +80,7 @@ class HtmlInspectorScreen extends HtmlScreen {
         div(c: 'btn-group collapsible-750 nowrap')
           ..add([
             ServiceExtensionButton(
-              extensions.toggleSelectWidgetMode,
+              extensions.toggleOnDeviceWidgetInspector,
             ).button,
             refreshTreeButton =
                 PButton.icon('Refresh Tree', FlutterIcons.refresh)

--- a/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
@@ -211,6 +211,9 @@ class HtmlInspectorScreen extends HtmlScreen {
     inspectorController?.dispose();
     inspectorController = null;
 
+    inspectorService?.dispose();
+    inspectorService = null;
+
     splitterSubscription?.cancel();
     splitterSubscription = null;
   }

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -19,8 +19,10 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../auto_dispose.dart';
 import '../config_specific/logger.dart';
 import '../globals.dart';
+import '../service_extensions.dart' as extensions;
 import '../service_registrations.dart' as registrations;
 import '../ui/fake_flutter/fake_flutter.dart';
 import '../ui/icons.dart';
@@ -51,7 +53,9 @@ TextStyle textStyleForLevel(DiagnosticLevel level) {
 /// plugin with some refactors to make it more of a true controller than a view.
 ///
 /// No changes to this class are allowed to pull in dependencies on dart:html.
-class InspectorController implements InspectorServiceClient {
+class InspectorController extends DisposableController
+    with AutoDisposeBase, AutoDisposeControllerMixin
+    implements InspectorServiceClient {
   InspectorController({
     @required this.inspectorService,
     @required this.inspectorTree,
@@ -94,7 +98,27 @@ class InspectorController implements InspectorServiceClient {
     });
 
     _checkForExpandCollapseSupport();
+
+    // This logic only needs to be run once so run it in the outermost
+    // controller.
+    if (parent == null) {
+      // If select mode is available, enable the on device inspector as it
+      // won't interfere with users.
+      addAutoDisposeListener(_supportsToggleSelectWidgetMode, () {
+        if (_supportsToggleSelectWidgetMode.value) {
+          serviceManager.serviceExtensionManager.setServiceExtensionState(
+            extensions.enableOnDeviceInspector.extension,
+            true,
+            true,
+          );
+        }
+      });
+    }
   }
+
+  ValueListenable<bool> get _supportsToggleSelectWidgetMode => serviceManager
+      .serviceExtensionManager
+      .hasServiceExtensionListener(extensions.toggleSelectWidgetMode.extension);
 
   void _onClientChange(bool added) {
     _clientCount += added ? 1 : -1;
@@ -150,8 +174,6 @@ class InspectorController implements InspectorServiceClient {
   final bool isSummaryTree;
 
   final VoidFunction onExpandCollapseSupported;
-  ValueListenable<bool> get selectModeSupported => _selectModeSupported;
-  final ValueNotifier<bool> _selectModeSupported = ValueNotifier<bool>(null);
 
   /// Parent InspectorController if this is a details subtree.
   InspectorController parent;
@@ -769,6 +791,7 @@ class InspectorController implements InspectorServiceClient {
     //  navigate operation.
   }
 
+  @override
   void dispose() {
     assert(!_disposed);
     _disposed = true;
@@ -782,6 +805,7 @@ class InspectorController implements InspectorServiceClient {
     _selectionGroups = null;
     debugSummaryLayoutEnabled.dispose();
     details?.dispose();
+    super.dispose();
   }
 
   static String treeTypeDisplayName(FlutterTreeType treeType) {
@@ -820,28 +844,6 @@ class InspectorController implements InspectorServiceClient {
   void collapseDetailsToSelected() {
     details.inspectorTree.collapseToSelected();
     details.animateTo(details.inspectorTree.selection);
-  }
-
-  Future<bool> isSelectModeAvailable() async{
-    if (onExpandCollapseSupported == null) return;
-
-    serviceManager.hasRegisteredService(
-      registrations.flutterVersion.service,
-          (serviceAvailable) async {
-        if (serviceAvailable) {
-          final flutterVersion = FlutterVersion.parse(
-              (await serviceManager.getFlutterVersion()).json);
-          // Configurable subtree depth is available in versions of Flutter
-          // greater than or equal to 1.9.7, but the flutterVersion service is
-          // not available until 1.10.1, so we will check for 1.10.1 here.
-          if (flutterVersion.isSupported(
-              supportedVersion:
-              SemanticVersion(major: 1, minor: 10, patch: 1))) {
-            onExpandCollapseSupported();
-          }
-        }
-      },
-    );
   }
 
   void _checkForExpandCollapseSupport() {

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -174,7 +174,7 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
 final toggleOnDeviceWidgetInspector =
     ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.show',
-  // Technically this enables the on device widget inspector but for older
+  // Technically this enables the on-device widget inspector but for older
   // versions of package:flutter it makes sense to describe this extension as
   // toggling widget select mode as it is the only way to toggle that mode.
   description: 'Select Widget Mode',
@@ -201,19 +201,19 @@ final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.selectWidgetMode,
 );
 
-/// Toggle whether the inspector on device overlay is enabled.
+/// Toggle whether the inspector on-device overlay is enabled.
 ///
 /// When available, the inspector overlay can be enabled at any time as it will
 /// not interfere with user interaction with the app unless inspector select
 /// mode is triggered.
 final enableOnDeviceInspector = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.enable',
-  description: 'Enable on device inspector',
+  description: 'Enable on-device inspector',
   icon: FlutterIcons.locate,
   enabledValue: true,
   disabledValue: false,
-  enabledTooltip: 'Exit on device inspector',
-  disabledTooltip: 'Enter on device inspector',
+  enabledTooltip: 'Exit on-device inspector',
+  disabledTooltip: 'Enter on-device inspector',
   gaScreenName: ga.inspector,
   gaItem: ga.enableOnDeviceInspector,
 );

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -170,14 +170,30 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
   gaItem: ga.togglePlatform,
 );
 
-final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
+/// This extension should typically not be shown as a button when the
+final toggleOnDeviceWidgetInspector = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.show',
+  // Technically this enables the on device widget inspector but for older
+  // versions of package:flutter it makes sense to describe this extension as
+  // toggling widget select mode as it is the only way to toggle that mode.
+  description: 'Select Widget Mode [OLD]',
+  icon: FlutterIcons.locate,
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'Disable select widget mode',
+  disabledTooltip: 'Enable select widget mode',
+  gaScreenName: ga.inspector,
+  gaItem: ga.onDeviceInspector,
+);
+
+final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.flutter.inspector.selectMode',
   description: 'Select Widget Mode',
   icon: FlutterIcons.locate,
   enabledValue: true,
   disabledValue: false,
-  enabledTooltip: 'Disable Select Widget Mode',
-  disabledTooltip: 'Enable Select Widget Mode',
+  enabledTooltip: 'Exit select widget mode',
+  disabledTooltip: 'Enter select widget mode',
   gaScreenName: ga.inspector,
   gaItem: ga.selectWidgetMode,
 );
@@ -205,7 +221,7 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   performanceOverlay,
   debugAllowBanner,
   profileWidgetBuilds,
-  toggleSelectWidgetMode,
+  toggleOnDeviceWidgetInspector,
   togglePlatformMode,
   slowAnimations,
   structuredErrors,

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -170,25 +170,28 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
   gaItem: ga.togglePlatform,
 );
 
-/// This extension should typically not be shown as a button when the
-final toggleOnDeviceWidgetInspector = ToggleableServiceExtensionDescription<bool>._(
+// Legacy extension to show the inspector and enable inspector select mode.
+final toggleOnDeviceWidgetInspector =
+    ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.show',
   // Technically this enables the on device widget inspector but for older
   // versions of package:flutter it makes sense to describe this extension as
   // toggling widget select mode as it is the only way to toggle that mode.
-  description: 'Select Widget Mode [OLD]',
+  description: 'Select Widget Mode',
   icon: FlutterIcons.locate,
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Disable select widget mode',
   disabledTooltip: 'Enable select widget mode',
   gaScreenName: ga.inspector,
-  gaItem: ga.onDeviceInspector,
+  gaItem: ga.showOnDeviceInspector,
 );
 
+/// Toggle whether interacting with the device selects widgets or triggers
+/// normal interactions.
 final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.selectMode',
-  description: 'Select Widget Mode',
+  description: 'Select widget mode',
   icon: FlutterIcons.locate,
   enabledValue: true,
   disabledValue: false,
@@ -196,6 +199,23 @@ final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   disabledTooltip: 'Enter select widget mode',
   gaScreenName: ga.inspector,
   gaItem: ga.selectWidgetMode,
+);
+
+/// Toggle whether the inspector on device overlay is enabled.
+///
+/// When available, the inspector overlay can be enabled at any time as it will
+/// not interfere with user interaction with the app unless inspector select
+/// mode is triggered.
+final enableOnDeviceInspector = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.flutter.inspector.enable',
+  description: 'Enable on device inspector',
+  icon: FlutterIcons.locate,
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'Exit on device inspector',
+  disabledTooltip: 'Enter on device inspector',
+  gaScreenName: ga.inspector,
+  gaItem: ga.enableOnDeviceInspector,
 );
 
 final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
@@ -222,6 +242,8 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   debugAllowBanner,
   profileWidgetBuilds,
   toggleOnDeviceWidgetInspector,
+  toggleSelectWidgetMode,
+  enableOnDeviceInspector,
   togglePlatformMode,
   slowAnimations,
   structuredErrors,

--- a/packages/devtools_app/lib/src/stream_value_listenable.dart
+++ b/packages/devtools_app/lib/src/stream_value_listenable.dart
@@ -1,0 +1,59 @@
+import 'dart:async';
+
+import 'ui/fake_flutter/fake_flutter.dart';
+
+// TODO(jacobr): remove this class and port the rest of the code in DevTools to
+// use ValueListenable directly instead of StreamBuilder.
+/// A [ChangeNotifier] to help convert stream based code to use
+/// [ValueListenable].
+class StreamValueListenable<T> extends ChangeNotifier
+    implements ValueListenable<T> {
+  StreamValueListenable(this._onListen, this._lookupValue);
+
+  StreamSubscription subscription;
+
+  final StreamSubscription Function(StreamValueListenable<T> notifier)
+      _onListen;
+  final T Function() _lookupValue;
+
+  // Cached last value that may be out of date if no listeners are attached.
+  T _value;
+
+  /// The current value stored in this notifier.
+  ///
+  /// When the value is replaced, this class notifies its listeners.
+  @override
+  T get value {
+    if (!hasListeners) {
+      _value = _lookupValue();
+    }
+    return _value;
+  }
+
+  set value(T newValue) {
+    if (_value == newValue) return;
+    _value = newValue;
+    notifyListeners();
+  }
+
+  @override
+  String toString() => '${describeIdentity(this)}($value)';
+
+  @override
+  void addListener(listener) {
+    if (!hasListeners) {
+      subscription = _onListen(this);
+      _value = _lookupValue();
+    }
+    super.addListener(listener);
+  }
+
+  @override
+  void removeListener(listener) {
+    super.removeListener(listener);
+    if (!hasListeners) {
+      subscription?.cancel();
+      subscription = null;
+    }
+  }
+}

--- a/packages/devtools_app/lib/src/ui/analytics_constants.dart
+++ b/packages/devtools_app/lib/src/ui/analytics_constants.dart
@@ -44,7 +44,8 @@ const String debugBanner = 'debugBanner';
 const String trackRebuilds = 'trackRebuilds';
 const String togglePlatform = 'togglePlatform';
 const String selectWidgetMode = 'selectWidgetMode';
-const String onDeviceInspector = 'onDeviceInspector';
+const String enableOnDeviceInspector = 'enableOnDeviceInspector';
+const String showOnDeviceInspector = 'showInspector';
 
 // Timeline UX actions:
 const String timelineFrame = 'frame'; // Frame selected in frame chart

--- a/packages/devtools_app/lib/src/ui/analytics_constants.dart
+++ b/packages/devtools_app/lib/src/ui/analytics_constants.dart
@@ -44,6 +44,7 @@ const String debugBanner = 'debugBanner';
 const String trackRebuilds = 'trackRebuilds';
 const String togglePlatform = 'togglePlatform';
 const String selectWidgetMode = 'selectWidgetMode';
+const String onDeviceInspector = 'onDeviceInspector';
 
 // Timeline UX actions:
 const String timelineFrame = 'frame'; // Frame selected in frame chart

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../auto_dispose.dart';
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../globals.dart';
 import '../../service_extensions.dart';
 import '../../service_registrations.dart';
 import '../../utils.dart';
+import '../fake_flutter/fake_flutter.dart';
 import 'flutter_icon_renderer.dart';
 import 'label.dart';
 
@@ -45,7 +47,8 @@ class ExtensionState {
 }
 
 class _ServiceExtensionButtonGroupState
-    extends State<ServiceExtensionButtonGroup> with AutoDisposeMixin {
+    extends State<ServiceExtensionButtonGroup>
+    with AutoDisposeBase, AutoDisposeMixin {
   List<ExtensionState> _extensionStates;
 
   @override
@@ -54,7 +57,10 @@ class _ServiceExtensionButtonGroupState
     // To use ToggleButtons we have to track states for all buttons in the
     // group here rather than tracking state with the individual button widgets
     // which would be more natural.
+    _initExtensionState();
+  }
 
+  void _initExtensionState() {
     _extensionStates = [for (var e in widget.extensions) ExtensionState(e)];
 
     for (var extension in _extensionStates) {
@@ -79,6 +85,16 @@ class _ServiceExtensionButtonGroupState
         },
       ));
     }
+  }
+
+  @override
+  void didUpdateWidget(ServiceExtensionButtonGroup oldWidget) {
+    if (!listEquals(oldWidget.extensions, widget.extensions)) {
+      cancel();
+      _initExtensionState();
+      setState(() {});
+    }
+    super.didUpdateWidget(oldWidget);
   }
 
   @override

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -38,11 +38,11 @@ void main() {
 
     void mockExtensions() {
       fakeExtensionManager.extensionValueOnDevice = {
-        extensions.toggleSelectWidgetMode.extension: true,
+        extensions.toggleOnDeviceWidgetInspector.extension: true,
         extensions.debugPaint.extension: false,
       };
       fakeExtensionManager
-          .fakeAddServiceExtension(extensions.toggleSelectWidgetMode.extension);
+          .fakeAddServiceExtension(extensions.toggleOnDeviceWidgetInspector.extension);
       fakeExtensionManager
           .fakeAddServiceExtension(extensions.debugPaint.extension);
       fakeExtensionManager.fakeFrame();
@@ -50,7 +50,7 @@ void main() {
 
     void mockNoExtensionsAvailable() {
       fakeExtensionManager.extensionValueOnDevice = {
-        extensions.toggleSelectWidgetMode.extension: true,
+        extensions.toggleOnDeviceWidgetInspector.extension: true,
         extensions.debugPaint.extension: false,
       };
       // Don't actually send any events to the client indicating that service
@@ -68,7 +68,7 @@ void main() {
       await setWindowSize(const Size(2600.0, 1200.0));
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleSelectWidgetMode.description),
+      expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
           findsOneWidget);
       expect(find.text(extensions.debugPaint.description), findsOneWidget);
       // Make sure there is not an overflow if the window is narrow.
@@ -90,27 +90,27 @@ void main() {
       );
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleSelectWidgetMode.extension],
+            extensions.toggleOnDeviceWidgetInspector.extension],
         isTrue,
       );
 
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleSelectWidgetMode.description),
+      expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
           findsOneWidget);
       expect(find.text(extensions.debugPaint.description), findsOneWidget);
       await tester.pump();
 
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleSelectWidgetMode.extension],
+            extensions.toggleOnDeviceWidgetInspector.extension],
         isTrue,
       );
       await tester
-          .tap(find.text(extensions.toggleSelectWidgetMode.description));
+          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleSelectWidgetMode.extension],
+            extensions.toggleOnDeviceWidgetInspector.extension],
         isFalse,
       );
       // Verify the the other service extension's state hasn't changed.
@@ -121,10 +121,10 @@ void main() {
       );
 
       await tester
-          .tap(find.text(extensions.toggleSelectWidgetMode.description));
+          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleSelectWidgetMode.extension],
+            extensions.toggleOnDeviceWidgetInspector.extension],
         isTrue,
       );
 
@@ -148,30 +148,30 @@ void main() {
       );
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleSelectWidgetMode.extension],
+            extensions.toggleOnDeviceWidgetInspector.extension],
         isTrue,
       );
 
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleSelectWidgetMode.description),
+      expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
           findsOneWidget);
       expect(find.text(extensions.debugPaint.description), findsOneWidget);
       await tester.pump();
 
       await tester
-          .tap(find.text(extensions.toggleSelectWidgetMode.description));
+          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
       // Verify the service extension state has not changed.
       expect(
           fakeExtensionManager.extensionValueOnDevice[
-              extensions.toggleSelectWidgetMode.extension],
+              extensions.toggleOnDeviceWidgetInspector.extension],
           isTrue);
       await tester
-          .tap(find.text(extensions.toggleSelectWidgetMode.description));
+          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
       // Verify the service extension state has not changed.
       expect(
           fakeExtensionManager.extensionValueOnDevice[
-              extensions.toggleSelectWidgetMode.extension],
+              extensions.toggleOnDeviceWidgetInspector.extension],
           isTrue);
 
       // TODO(jacobr): also verify that the service extension buttons look

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -103,13 +103,15 @@ void main() {
       expect(
         fakeExtensionManager.extensionValueOnDevice[
             extensions.toggleSelectWidgetMode.extension],
-        true,
+        isTrue,
       );
 
       // We need a frame to find out that the service extension state has changed.
       expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleSelectWidgetMode.description),
-          findsOneWidget);
+      expect(
+        find.text(extensions.toggleSelectWidgetMode.description),
+        findsOneWidget,
+      );
       expect(find.text(extensions.debugPaint.description), findsOneWidget);
       await tester.pump();
       await tester

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -38,19 +38,24 @@ void main() {
 
     void mockExtensions() {
       fakeExtensionManager.extensionValueOnDevice = {
+        extensions.toggleSelectWidgetMode.extension: true,
+        extensions.enableOnDeviceInspector.extension: true,
         extensions.toggleOnDeviceWidgetInspector.extension: true,
         extensions.debugPaint.extension: false,
       };
       fakeExtensionManager
-          .fakeAddServiceExtension(extensions.toggleOnDeviceWidgetInspector.extension);
-      fakeExtensionManager
-          .fakeAddServiceExtension(extensions.debugPaint.extension);
-      fakeExtensionManager.fakeFrame();
+        ..fakeAddServiceExtension(
+            extensions.toggleOnDeviceWidgetInspector.extension)
+        ..fakeAddServiceExtension(extensions.toggleSelectWidgetMode.extension)
+        ..fakeAddServiceExtension(extensions.enableOnDeviceInspector.extension)
+        ..fakeAddServiceExtension(extensions.debugPaint.extension)
+        ..fakeFrame();
     }
 
     void mockNoExtensionsAvailable() {
       fakeExtensionManager.extensionValueOnDevice = {
         extensions.toggleOnDeviceWidgetInspector.extension: true,
+        extensions.toggleSelectWidgetMode.extension: false,
         extensions.debugPaint.extension: false,
       };
       // Don't actually send any events to the client indicating that service
@@ -68,8 +73,7 @@ void main() {
       await setWindowSize(const Size(2600.0, 1200.0));
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
-          findsOneWidget);
+      expect(find.text('Refresh Tree'), findsOneWidget);
       expect(find.text(extensions.debugPaint.description), findsOneWidget);
       // Make sure there is not an overflow if the window is narrow.
       // TODO(jacobr): determine why there are overflows in the test environment
@@ -95,22 +99,24 @@ void main() {
       );
 
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(InspectorScreenBody), findsOneWidget);
-      expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
-          findsOneWidget);
-      expect(find.text(extensions.debugPaint.description), findsOneWidget);
-      await tester.pump();
 
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleOnDeviceWidgetInspector.extension],
-        isTrue,
+            extensions.toggleSelectWidgetMode.extension],
+        true,
       );
+
+      // We need a frame to find out that the service extension state has changed.
+      expect(find.byType(InspectorScreenBody), findsOneWidget);
+      expect(find.text(extensions.toggleSelectWidgetMode.description),
+          findsOneWidget);
+      expect(find.text(extensions.debugPaint.description), findsOneWidget);
+      await tester.pump();
       await tester
-          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
+          .tap(find.text(extensions.toggleSelectWidgetMode.description));
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleOnDeviceWidgetInspector.extension],
+            extensions.toggleSelectWidgetMode.extension],
         isFalse,
       );
       // Verify the the other service extension's state hasn't changed.
@@ -121,10 +127,10 @@ void main() {
       );
 
       await tester
-          .tap(find.text(extensions.toggleOnDeviceWidgetInspector.description));
+          .tap(find.text(extensions.toggleSelectWidgetMode.description));
       expect(
         fakeExtensionManager.extensionValueOnDevice[
-            extensions.toggleOnDeviceWidgetInspector.extension],
+            extensions.toggleSelectWidgetMode.extension],
         isTrue,
       );
 
@@ -153,6 +159,7 @@ void main() {
       );
 
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      await tester.pump();
       expect(find.byType(InspectorScreenBody), findsOneWidget);
       expect(find.text(extensions.toggleOnDeviceWidgetInspector.description),
           findsOneWidget);

--- a/packages/devtools_app/test/stream_value_listenable_test.dart
+++ b/packages/devtools_app/test/stream_value_listenable_test.dart
@@ -1,0 +1,79 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:devtools_app/src/stream_value_listenable.dart';
+import 'package:test/test.dart';
+
+void main() {
+  StreamController<int> controller;
+  int currentValue;
+  List<int> values;
+  StreamValueListenable listenable;
+
+  void updateValue(int v) {
+    currentValue = v;
+    controller.add(v);
+  }
+
+  final listener = () {
+    values.add(listenable.value);
+  };
+
+  setUp(() {
+    values = [];
+    currentValue = null;
+    controller = StreamController<int>.broadcast(sync: true);
+    listenable = StreamValueListenable<int>(
+      (notifier) {
+        return controller.stream.listen((value) {
+          notifier.value = value;
+        });
+      },
+      () => currentValue,
+    );
+  });
+
+  group('StreamValueListenable', () {
+    test('no listener', () {
+      expect(listenable.value, isNull);
+      updateValue(42);
+      expect(listenable.value, equals(42));
+      expect(values, isEmpty);
+      updateValue(7);
+      expect(values, isEmpty);
+      expect(listenable.value, equals(7));
+      updateValue(19);
+      expect(values, isEmpty);
+      expect(listenable.value, equals(19));
+    });
+
+    test('listener', () {
+      expect(listenable.value, isNull);
+      listenable.addListener(listener);
+      expect(values, isEmpty);
+      updateValue(42);
+      expect(listenable.value, equals(42));
+      expect(values.length, equals(1));
+      expect(values.last, equals(42));
+      // Verify that updating again does not trigger the listener to send a
+      // spurious event.
+      updateValue(42);
+      expect(values.length, equals(1));
+      expect(values.last, equals(42));
+      updateValue(7);
+      expect(values.length, equals(2));
+      expect(values.last, equals(7));
+      expect(listenable.value, equals(7));
+
+      listenable.removeListener(listener);
+      updateValue(19);
+
+      // Verify no event was dispatched but the value is still up to date.
+      expect(values.length, equals(2));
+      expect(listenable.value, equals(19));
+    });
+  });
+}


### PR DESCRIPTION
I'm adding an extra api to the on device inspector to enable showing the inspector overlay even when select mode isn't enabled. This CL uses that api when not available.

This CL scope creeped a bit as I found some existing lifecycle bugs in the flutter app along the way and added some extra machinery to make it harder to add similar bugs in the future.