### PR TITLE
Fix initializer error

### DIFF
--- a/packages/devtools_app/lib/src/flutter/initializer.dart
+++ b/packages/devtools_app/lib/src/flutter/initializer.dart
@@ -103,6 +103,8 @@ class _InitializerState extends State<Initializer>
   Widget build(BuildContext context) {
     return _checkLoaded()
         ? widget.builder(context)
-        : const Center(child: CircularProgressIndicator());
+        : const Scaffold(
+            body: Center(child: CircularProgressIndicator()),
+          );
   }
 }

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -237,7 +237,6 @@ class _RegisteredServiceExtensionButtonState
       (registered) {
         setState(() {
           _hidden = !registered;
-          print(_hidden);
         });
       },
     );


### PR DESCRIPTION
To show a snackbar with an error message, we need to have a scaffold in the view.