### PR TITLE
Stop manually converting parent ids to hex in timeline

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.11-dev.1
+## 0.1.11-dev.2
 * Add full timeline mode with support for async and recorded tracing.
 * Add event summary section that shows metadata for non-ui events on the Timeline page.
 * Fix a message manager bug.

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -766,9 +766,7 @@ class SyncTimelineEvent extends TimelineEvent {
 class AsyncTimelineEvent extends TimelineEvent {
   AsyncTimelineEvent(TraceEventWrapper firstTraceEvent)
       : asyncId = firstTraceEvent.event.id,
-        parentId = firstTraceEvent.event.args[parentIdKey] != null
-            ? (firstTraceEvent.event.args[parentIdKey] as int).toRadixString(16)
-            : null,
+        parentId = firstTraceEvent.event.args[parentIdKey],
         super(firstTraceEvent) {
     type = TimelineEventType.async;
   }

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -514,7 +514,7 @@ final asyncStartBTrace = testTraceEventWrapper({
   'ts': 193937113560,
   'ph': 'b',
   'id': '2',
-  'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'},
+  'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'},
 });
 final asyncEndBTrace = testTraceEventWrapper({
   'name': 'B',
@@ -534,7 +534,7 @@ final asyncStartB1Trace = testTraceEventWrapper({
   'ts': 193937141769,
   'ph': 'b',
   'id': 'd',
-  'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'},
+  'args': {'parentId': '2', 'isolateId': 'isolates/2139247553966975'},
 });
 final asyncEndB1Trace = testTraceEventWrapper({
   'name': 'B1',
@@ -554,7 +554,7 @@ final asyncStartB2Trace = testTraceEventWrapper({
   'ts': 193937173019,
   'ph': 'b',
   'id': 'e',
-  'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'},
+  'args': {'parentId': '2', 'isolateId': 'isolates/2139247553966975'},
 });
 final asyncEndB2Trace = testTraceEventWrapper({
   'name': 'B2',
@@ -574,7 +574,7 @@ final asyncStartCTrace = testTraceEventWrapper({
   'ts': 193937168961,
   'ph': 'b',
   'id': '3',
-  'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'},
+  'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'},
 });
 final asyncEndCTrace = testTraceEventWrapper({
   'name': 'C',
@@ -594,7 +594,7 @@ final asyncStartC1Trace = testTraceEventWrapper({
   'ts': 193937220903,
   'ph': 'b',
   'id': '11',
-  'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+  'args': {'parentId': '3', 'isolateId': 'isolates/2139247553966975'}
 });
 final asyncEndC1Trace = testTraceEventWrapper({
   'name': 'C1',
@@ -614,7 +614,7 @@ final asyncStartC2Trace = testTraceEventWrapper({
   'ts': 193937378812,
   'ph': 'b',
   'id': '12',
-  'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+  'args': {'parentId': '3', 'isolateId': 'isolates/2139247553966975'}
 });
 final asyncEndC2Trace = testTraceEventWrapper({
   'name': 'C2',


### PR DESCRIPTION
Parent ids are sent in hex as of this [commit](https://github.com/dart-lang/sdk/commit/38f78c01f3643e3b009a55f7f11bc3fc253e3f14), so we no longer need to manually convert decimal ints to hex strings.