### PR TITLE
Make splitter stick to the mouse on desktop.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math';
 
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 /// A widget that takes two children, lays them out along [axis], and allows
@@ -157,6 +158,10 @@ class _SplitState extends State<Split> {
         behavior: HitTestBehavior.translucent,
         onHorizontalDragUpdate: isHorizontal ? updateSpacing : null,
         onVerticalDragUpdate: isHorizontal ? null : updateSpacing,
+        // DartStartBehavior.down is needed to keep the mouse pointer stuck to
+        // the drag bar. There still appears to be a few frame lag before the
+        // drag action triggers which is't ideal but isn't a launch blocker.
+        dragStartBehavior: DragStartBehavior.down,
         child: SizedBox(
           width: isHorizontal ? Split.dividerMainAxisSize : width,
           height: isHorizontal ? height : Split.dividerMainAxisSize,

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -307,7 +307,7 @@ class _TreeNodeState<T extends TreeNode<T>> extends State<_TreeNodeWidget<T>>
               widget.node.isExpandable
                   ? RotationTransition(
                       turns: expandAnimation,
-                      child: Icon(
+                      child: const Icon(
                         Icons.expand_more,
                         size: 16.0,
                       ),

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
@@ -532,7 +532,7 @@ class InspectorRowContent extends StatelessWidget {
                       onTap: onToggle,
                       child: RotationTransition(
                         turns: expandAnimation,
-                        child: Icon(
+                        child: const Icon(
                           Icons.expand_more,
                           size: 16.0,
                         ),


### PR DESCRIPTION
Add missing "const".