### PR TITLE
ignore lib/generated_plugin_registrant.dart from the POV of analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,8 +14,7 @@ pubspec.lock
 .DS_Store
 
 # Generated files not intended to be checked in to version control
-flutter_export_environment.sh
 .flutter-plugins
-generated_plugin_registrant.dart
+flutter_export_environment.sh
 Podfile
 Podfile.lock

--- a/packages/devtools_app/.gitignore
+++ b/packages/devtools_app/.gitignore
@@ -3,3 +3,6 @@ build/
 
 # Directory created by dartdoc
 doc/api/
+
+# Generated files not intended to be checked in to version control
+lib/generated_plugin_registrant.dart

--- a/packages/devtools_app/analysis_options.yaml
+++ b/packages/devtools_app/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - lib/generated_plugin_registrant.dart


### PR DESCRIPTION
- some minor surgery to ignore `lib/generated_plugin_registrant.dart` from the POV of analysis
