### PR TITLE
Enable timeline page for Dart CLI apps.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.11-dev.2
 * Add full timeline mode with support for async and recorded tracing.
 * Add event summary section that shows metadata for non-ui events on the Timeline page.
+* Enable full timeline for Dart CLI applications.
 * Fix a message manager bug.
 * Fix a bug with processing CPU profile responses.
 * Reduce race conditions in integration tests.

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -36,6 +36,9 @@ class ConnectedApp {
 
   bool get isRunningOnDartVM => serviceManager.vm.name != 'ChromeDebugProxy';
 
+  Future<bool> get isDartCliApp async =>
+      isRunningOnDartVM && !(await isFlutterApp);
+
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
     // Only flutter apps have profile and non-profile builds. If this changes in

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -128,7 +128,7 @@ class EvalOnDartLibrary {
       }
       return result;
     } catch (e, stack) {
-      _handleError(e, stack);
+      _handleError('$e - $expression', stack);
     }
     return null;
   }

--- a/packages/devtools_app/lib/src/framework/html_framework.dart
+++ b/packages/devtools_app/lib/src/framework/html_framework.dart
@@ -188,7 +188,7 @@ class HtmlFramework {
       orElse: () => null,
     );
     if (timelineScreen == null) {
-      addScreen(timelineScreen = HtmlTimelineScreen());
+      addScreen(timelineScreen = HtmlTimelineScreen(timelineMode));
     }
     navigateTo(timelineScreenId);
 

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -235,7 +235,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
     ));
     addScreen(HtmlTimelineScreen(
       isDartCliApp ? TimelineMode.full : TimelineMode.frameBased,
-      enabled: (isFlutterApp && !isFlutterWebApp) || isDartCliApp,
+      enabled: app.isRunningOnDartVM,
       disabledTooltip:
           isFlutterWebApp ? notFlutterWebMsg : notRunningFlutterMsg,
     ));

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -21,6 +21,7 @@ import 'performance/html_performance_screen.dart';
 import 'server_api_client.dart';
 import 'service_registrations.dart' as registrations;
 import 'timeline/html_timeline_screen.dart';
+import 'timeline/timeline_controller.dart';
 import 'ui/analytics.dart' as ga;
 import 'ui/analytics_platform.dart' as ga_platform;
 import 'ui/html_custom.dart';
@@ -204,7 +205,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
 
     final isDartWebApp = await app.isDartWebApp;
     final isFlutterApp = await app.isFlutterApp;
-    final isDartCliApp = app.isRunningOnDartVM && !isFlutterApp;
+    final isDartCliApp = await app.isDartCliApp;
     final isFlutterVmApp = isFlutterApp && !isDartWebApp;
     final isFlutterVmProfileBuild =
         isFlutterVmApp && (await app.isProfileBuild);
@@ -233,7 +234,8 @@ class HtmlPerfToolFramework extends HtmlFramework {
           : notRunningFlutterMsg,
     ));
     addScreen(HtmlTimelineScreen(
-      enabled: isFlutterApp && !isFlutterWebApp,
+      isDartCliApp ? TimelineMode.full : TimelineMode.frameBased,
+      enabled: (isFlutterApp && !isFlutterWebApp) || isDartCliApp,
       disabledTooltip:
           isFlutterWebApp ? notFlutterWebMsg : notRunningFlutterMsg,
     ));

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -562,8 +562,7 @@ class HtmlTimelineScreen extends HtmlScreen {
 
   void _updateVisibilityForTimelineMode() {
     _updateButtonStates();
-    framesBarChart
-        .hidden(timelineController.timelineMode == TimelineMode.full);
+    framesBarChart.hidden(timelineController.timelineMode == TimelineMode.full);
     flameChartContainer
         .hidden(timelineController.timelineMode == TimelineMode.frameBased);
     _recordingInstructions

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -44,7 +44,7 @@ const enableMultiModeTimeline = true;
 
 class HtmlTimelineScreen extends HtmlScreen {
   HtmlTimelineScreen(
-    TimelineMode startMode, {
+    this.startTimelineMode, {
     bool enabled,
     String disabledTooltip,
   }) : super(
@@ -55,8 +55,10 @@ class HtmlTimelineScreen extends HtmlScreen {
           disabledTooltip: disabledTooltip,
         ) {
     _initContent();
-    _setTimelineMode(timelineMode: startMode);
+    _setTimelineMode(timelineMode: startTimelineMode);
   }
+
+  final TimelineMode startTimelineMode;
 
   TimelineController timelineController = TimelineController();
 
@@ -444,14 +446,10 @@ class HtmlTimelineScreen extends HtmlScreen {
     // changes the value of [offlineMode], which the button states depend on.
     framework.exitOfflineMode();
 
-    // Revert to the previously selected mode on offline exit, unless there is
-    // only one allowed mode for the connected app. We already cleared the
-    // timeline data - do not repeat this action.
-    final mode = await serviceManager.connectedApp.isDartCliApp
-        ? TimelineMode.full
-        : timelineController.timelineMode;
+    // Revert to [startTimelineMode]. We already cleared the timeline data - do
+    // not repeat this action.
     _setTimelineMode(
-      timelineMode: mode,
+      timelineMode: startTimelineMode,
       clearTimeline: false,
     );
     _updateButtonStates();

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -261,7 +261,7 @@ Future<Map<String, dynamic>> launchDevTools({
   final launchEvent = events.where((e) => e['event'] == 'client.launch').first;
   await appFixture.serviceConnection.callMethod(
     registeredServices['launchDevTools'],
-    args: reuseWindows ? {'reuseWindows': true, 'page': page} : null,
+    args: {'reuseWindows': reuseWindows, 'page': page},
   );
   final response = await launchEvent;
   return response['params'];


### PR DESCRIPTION
Dart CLI apps will have access to the Full DevTools timeline. When connected to a Dart CLI app we remove the option to switch between timeline modes.

![Screen Shot 2019-11-06 at 10 41 33 AM](https://user-images.githubusercontent.com/43759233/68327730-c17a7d00-0082-11ea-995d-eb3a45701c2b.png)
