### PR TITLE
Smoothly animate the tab bar between narrow and wide screen widths

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -108,9 +108,6 @@ class DevToolsAppState extends State<DevToolsApp> {
             actions: [
               HotReloadButton(),
               HotRestartButton(),
-              const Padding(
-                padding: EdgeInsets.only(left: 8.0),
-              ),
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -175,7 +175,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     Widget flexibleSpace;
     Size preferredSize;
     if (widget.tabs.length > 1) {
-      TabBar tabs = TabBar(
+      final tabs = TabBar(
         controller: _controller,
         isScrollable: true,
         onTap: _pushScreenToLocalPageRoute,
@@ -195,16 +195,13 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         end: 0.0,
       ).evaluate(appBarCurve);
       flexibleSpace = Align(
-        alignment: Alignment.topRight,
-        child: Align(
-          alignment: animatedAlignment,
-          child: Padding(
-            padding: EdgeInsets.only(
-              top: 4.0,
-              right: animatedRightPadding,
-            ),
-            child: tabs,
+        alignment: animatedAlignment,
+        child: Padding(
+          padding: EdgeInsets.only(
+            top: 4.0,
+            right: animatedRightPadding,
           ),
+          child: tabs,
         ),
       );
     }
@@ -231,60 +228,6 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
       ),
     );
   }
-}
-
-/// AppBar that places the TabBar inline when it is wide enough.
-class SizeAnimatingAppBar extends StatefulWidget
-    implements PreferredSizeWidget {
-  const SizeAnimatingAppBar({
-    Key key,
-    @required this.actions,
-    @required this.title,
-    @required this.tabBar,
-    @required this.expanded,
-  }) : super(key: key);
-
-  final List<Widget> actions;
-  final Widget title;
-  final PreferredSizeWidget tabBar;
-  final bool expanded;
-
-  @override
-  SizeAnimatingAppBarState createState() => SizeAnimatingAppBarState();
-
-  @override
-  // TODO: implement preferredSize
-  Size get preferredSize => null;
-}
-
-class SizeAnimatingAppBarState extends State<SizeAnimatingAppBar> {
-  @override
-  Widget build(BuildContext context) {
-    // TODO: implement build
-    return null;
-  }
-}
-
-/// Wrapper that places a [PreferredSizeWidget] in a [Hero] such that
-/// it can still be passed to fields like [Scaffold.appBar], which
-/// requires a [PreferredSizeWidget].
-class _PreferredSizeHero extends StatelessWidget
-    implements PreferredSizeWidget {
-  const _PreferredSizeHero({@required this.tag, @required this.child});
-
-  /// The tag to pass to [Hero.tag] when building the [Hero] widget.
-  final Object tag;
-
-  /// The [PreferredSizeWidget] to delegate to for the [preferredSize].
-  final PreferredSizeWidget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return Hero(tag: tag, child: child);
-  }
-
-  @override
-  Size get preferredSize => child.preferredSize;
 }
 
 class _SimpleScreen extends Screen {


### PR DESCRIPTION
Fixes #1307 

To consider:

* To do this, we have to make assumptions about how large the actions we're giving to the Scaffold are.  My thinking is that for accessibility, we want 48dp tap targets in general, so this is not an issue.
* An alternative would be to create our own layout for the FlexibleSpace in the tabbar.  This is something that we may want to consider as a FR for Flutter Web: lots of wide-screen apps may want to place tabs inline with the toolbar.

As-is, this change was fairly simple to put together, and it satisfies all of our own use cases, so I think this route is fine for our prototype.