### PR TITLE
Bump min flutter version to 1.10.0.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
   # The flutter desktop support interacts with build scripts on the Flutter
   # side that are not yet stable, so it requires a very recent version of
   # Flutter. This version will increase regularly as the build scripts change.
-  flutter: '>=1.9.8-pre.31'
+  flutter: '>=1.10.0'
 
 dependencies:
   ansicolor: ^1.0.2


### PR DESCRIPTION
Getting this error on attempted publish of devtools_app:
```
* pubspec.yaml allows Flutter SDK version 1.9.x, which does not support the flutter.plugin.platforms key.
  Please consider increasing the Flutter SDK requirement to ^1.10.0 (environment.sdk.flutter)
```