### PR TITLE
Merge args from all event traces in Timeline summary.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/html_event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/html_event_details.dart
@@ -291,8 +291,11 @@ class HtmlEventSummary extends CoreElement {
       div(text: '${firstTraceEvent.processId}')
     ]);
     if (firstTraceEvent.args.isNotEmpty) {
+      // Merge args from all trace events.
+      final eventArgs = Map.from(firstTraceEvent.args)
+        ..addAll({for (var trace in event.traceEvents) ...trace.event.args});
       const encoder = JsonEncoder.withIndent('  ');
-      final formattedArgs = encoder.convert(firstTraceEvent.args);
+      final formattedArgs = encoder.convert(eventArgs);
       args.add([
         span(text: 'Arguments: '),
         div(text: formattedArgs, c: 'event-args'),


### PR DESCRIPTION
We were only using args from the begin trace event - now we merge args from all trace events.
<img width="936" alt="Screen Shot 2019-11-11 at 1 49 58 PM" src="https://user-images.githubusercontent.com/43759233/68624110-f758a080-048a-11ea-947c-c95587097dd3.png">
@bkonyi 