### PR TITLE
Port Timeline event details section to flutter.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -14,6 +14,9 @@ class PaddedDivider extends StatelessWidget {
     this.padding = const EdgeInsets.only(bottom: 10.0),
   }) : super(key: key);
 
+  const PaddedDivider.thin({Key key})
+      : padding = const EdgeInsets.only(bottom: 4.0);
+
   /// The padding to place around the divider.
   final EdgeInsets padding;
 

--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
@@ -1,0 +1,54 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:flutter/material.dart';
+
+import '../../ui/fake_flutter/_real_flutter.dart';
+
+class CpuProfilerView extends StatelessWidget {
+  static const cpuProfilerTabs = [
+    Tab(text: 'CPU Flame Chart'),
+    Tab(text: 'Call Tree'),
+    Tab(text: 'Bottom Up'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: cpuProfilerTabs.length,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          const TabBar(
+            isScrollable: true,
+            tabs: cpuProfilerTabs,
+          ),
+          Expanded(
+            child: TabBarView(
+              children: _buildProfilerViews(),
+            ),
+          )
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildProfilerViews() {
+    const cpuFlameChart = Center(
+      child: Text(
+        'TODO CPU flame chart',
+      ),
+    );
+    const callTree = Center(
+      child: Text(
+        'TODO CPU call tree',
+      ),
+    );
+    const bottomUp = Center(
+      child: Text(
+        'TODO CPU bottom up',
+      ),
+    );
+    return [cpuFlameChart, callTree, bottomUp];
+  }
+}

--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
@@ -6,6 +6,8 @@ import 'package:flutter/material.dart';
 import '../../ui/fake_flutter/_real_flutter.dart';
 
 class CpuProfilerView extends StatelessWidget {
+  // TODO(kenz): the summary tab should be available for UI events in the
+  // timeline.
   static const cpuProfilerTabs = [
     Tab(text: 'CPU Flame Chart'),
     Tab(text: 'Call Tree'),
@@ -33,6 +35,7 @@ class CpuProfilerView extends StatelessWidget {
     );
   }
 
+  // TODO(kenz): implement all of these views.
   List<Widget> _buildProfilerViews() {
     const cpuFlameChart = Center(
       child: Text(

--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -42,13 +42,11 @@ class EventDetails extends StatelessWidget {
 
 class EventSummary extends StatelessWidget {
   EventSummary(this.event)
-      : _connectedEvents = event.isAsyncEvent
-            ? [
-                ...event.children.where((e) =>
-                    e.traceEvents.first.event.phase ==
-                    TraceEvent.asyncInstantPhase)
-              ]
-            : [],
+      : _connectedEvents = [
+          if (event.isAsyncEvent)
+            ...event.children.where((e) =>
+                e.traceEvents.first.event.phase == TraceEvent.asyncInstantPhase)
+        ],
         _eventArgs = Map.from(event.traceEvents.first.event.args)
           ..addAll({for (var trace in event.traceEvents) ...trace.event.args});
 
@@ -122,7 +120,11 @@ class EventSummary extends StatelessWidget {
 
   Widget _formattedArgs(Map<String, dynamic> args) {
     final formattedArgs = encoder.convert(args);
-    return Text(formattedArgs.replaceAll('"', ''));
+    return Text(
+      formattedArgs.replaceAll('"', ''),
+      // TODO(kenz): make monospace font work for flutter desktop.
+      style: const TextStyle(fontFamily: 'monospace'),
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -2,16 +2,291 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
-class EventDetails extends StatelessWidget {
+import '../../flutter/common_widgets.dart';
+import '../../profiler/flutter/cpu_profiler.dart';
+import '../../ui/fake_flutter/_real_flutter.dart';
+import '../../utils.dart';
+import '../timeline_model.dart';
+
+class EventDetails extends StatefulWidget {
+  @override
+  _EventDetailsState createState() => _EventDetailsState();
+}
+
+class _EventDetailsState extends State<EventDetails> {
+  // TODO(kenz): use selected event from controller once data is hooked up.
+  TimelineEvent selectedEvent;
+
+  @override
+  void initState() {
+    super.initState();
+    selectedEvent = stubUiEvent;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Container(
-      color: Colors.black26,
-      child: const Center(
-        child: Text('TODO Event Details Section'),
-      ),
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.only(top: 8.0),
+          child: Text(
+            '${selectedEvent.name} - ${msText(selectedEvent.time.duration)}',
+            style: Theme.of(context).textTheme.title,
+          ),
+        ),
+        const PaddedDivider.thin(),
+        Expanded(
+          child: Container(
+            child: Stack(
+              children: [
+                if (selectedEvent.isUiEvent) CpuProfilerView(),
+                if (!selectedEvent.isUiEvent) EventSummary(selectedEvent),
+              ],
+            ),
+          ),
+        ),
+      ],
     );
   }
 }
+
+class EventSummary extends StatefulWidget {
+  const EventSummary(this.event);
+
+  final TimelineEvent event;
+
+  @override
+  _EventSummaryState createState() => _EventSummaryState();
+}
+
+class _EventSummaryState extends State<EventSummary> {
+  _EventSummaryState();
+
+  static const encoder = JsonEncoder.withIndent('    ');
+
+  List<AsyncTimelineEvent> _connectedEvents;
+
+  Map<String, dynamic> _eventArgs;
+
+  TraceEvent get firstTraceEvent => widget.event.traceEvents.first.event;
+
+  @override
+  void initState() {
+    super.initState();
+    _connectedEvents ??= widget.event.isAsyncEvent
+        ? [
+            ...widget.event.children.where((e) =>
+                e.traceEvents.first.event.phase == TraceEvent.asyncInstantPhase)
+          ]
+        : [];
+    _eventArgs ??= Map.from(firstTraceEvent.args)
+      ..addAll(
+          {for (var trace in widget.event.traceEvents) ...trace.event.args});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView(
+      children: [
+        ListTile(
+          title: const Text('Thread id'),
+          subtitle: Text('${firstTraceEvent.threadId}'),
+        ),
+        ListTile(
+          title: const Text('Process id'),
+          subtitle: Text('${firstTraceEvent.processId}'),
+        ),
+        ListTile(
+          title: const Text('Category'),
+          subtitle: Text(firstTraceEvent.category),
+        ),
+        if (_connectedEvents.isNotEmpty) _buildConnectedEvents(),
+        if (_eventArgs.isNotEmpty) _buildArguments(),
+      ],
+    );
+  }
+
+  Widget _buildConnectedEvents() {
+    return ExpansionTile(
+      title: const Text('Connected events'),
+      children: [
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            for (var e in _connectedEvents) _buildConnectedEvent(e),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildConnectedEvent(TimelineEvent e) {
+    final eventArgs = {
+      'startTime': msText(e.time.start - widget.event.time.start),
+      'args': e.traceEvents.first.event.args,
+    };
+    return ListTile(
+      title: Text(e.name),
+      subtitle: _formattedArgs(eventArgs),
+    );
+  }
+
+  Widget _buildArguments() {
+    return ExpansionTile(
+      title: const Text('Arguments'),
+      children: [
+        ListTile(
+          subtitle: _formattedArgs(_eventArgs),
+        ),
+      ],
+    );
+  }
+
+  Widget _formattedArgs(Map<String, dynamic> args) {
+    final formattedArgs = encoder.convert(args);
+    return Text(formattedArgs.replaceAll('"', ''));
+  }
+}
+
+// TODO(kenz): remove stub data once timeline is hooked up to real data.
+final stubAsyncEvent = AsyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'PipelineItem',
+    'cat': 'Embedder',
+    'tid': 19333,
+    'pid': 94955,
+    'ts': 118039650806,
+    'ph': 's',
+    'id': 'f1',
+    'args': {
+      'isolateId': 'id_001',
+      'parentId': '07bf',
+    },
+  }))),
+  0,
+))
+  ..addEndEvent(TraceEventWrapper(
+    TraceEvent(jsonDecode(jsonEncode({
+      'name': 'PipelineItem',
+      'cat': 'Embedder',
+      'tid': 19334,
+      'pid': 94955,
+      'ts': 118039679872,
+      'ph': 'f',
+      'bp': 'e',
+      'id': 'f1',
+      'args': {},
+    }))),
+    1,
+  ))
+  ..type = TimelineEventType.async
+  ..children.addAll([
+    instantAsync1..time.end = instantAsync1.time.start,
+    instantAsync2..time.end = instantAsync2.time.start,
+    instantAsync3..time.end = instantAsync3.time.start,
+  ]);
+
+final instantAsync1 = AsyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'Connection established',
+    'cat': 'Dart',
+    'tid': 19333,
+    'pid': 94955,
+    'ts': 118039660806,
+    'ph': 'n',
+    'id': 'f1',
+    'args': {
+      'isolateId': 'id_001',
+    },
+  }))),
+  0,
+));
+
+final instantAsync2 = AsyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'Connection established',
+    'cat': 'Dart',
+    'tid': 19334,
+    'pid': 94955,
+    'ts': 118039665806,
+    'ph': 'n',
+    'id': 'f1',
+    'args': {
+      'isolateId': 'id_001',
+    },
+  }))),
+  1,
+));
+
+final instantAsync3 = AsyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'Connection established',
+    'cat': 'Dart',
+    'tid': 19334,
+    'pid': 94955,
+    'ts': 118039670806,
+    'ph': 'n',
+    'id': 'f1',
+    'args': {
+      'isolateId': 'id_001',
+    },
+  }))),
+  1,
+));
+
+final stubUiEvent = SyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'VSYNC',
+    'cat': 'Embedder',
+    'tid': 19333,
+    'pid': 94955,
+    'ts': 118039650802,
+    'ph': 'B',
+    'args': {},
+  }))),
+  0,
+))
+  ..addEndEvent(TraceEventWrapper(
+    TraceEvent(jsonDecode(jsonEncode({
+      'name': 'VSYNC',
+      'cat': 'Embedder',
+      'tid': 19333,
+      'pid': 94955,
+      'ts': 118039652422,
+      'ph': 'E',
+      'args': {},
+    }))),
+    1,
+  ))
+  ..type = TimelineEventType.ui;
+
+final stubGpuEvent = SyncTimelineEvent(TraceEventWrapper(
+  TraceEvent(jsonDecode(jsonEncode({
+    'name': 'GPURasterizer::Draw',
+    'cat': 'Embedder',
+    'tid': 19334,
+    'pid': 94955,
+    'ts': 118039651469,
+    'ph': 'B',
+    'args': {},
+  }))),
+  0,
+))
+  ..addEndEvent(TraceEventWrapper(
+    TraceEvent(jsonDecode(jsonEncode({
+      'name': 'GPURasterizer::Draw',
+      'cat': 'Embedder',
+      'tid': 19334,
+      'pid': 94955,
+      'ts': 118039679873,
+      'ph': 'E',
+      'args': {},
+    }))),
+    1,
+  ))
+  ..type = TimelineEventType.gpu;

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -76,7 +76,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody> {
             axis: Axis.vertical,
             firstChild: TimelineFlameChart(),
             secondChild: EventDetails(),
-            initialFirstFraction: 0.8,
+            initialFirstFraction: 0.6,
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -75,7 +75,9 @@ class TimelineScreenBodyState extends State<TimelineScreenBody> {
           child: Split(
             axis: Axis.vertical,
             firstChild: TimelineFlameChart(),
-            secondChild: EventDetails(),
+            // TODO(kenz): use StreamBuilder to get selected event from
+            // controller once data is hooked up.
+            secondChild: EventDetails(stubAsyncEvent),
             initialFirstFraction: 0.6,
           ),
         ),

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -36,6 +36,7 @@ void main() {
     });
   });
 
+  // TODO(kenz): add golden images for these tests.
   group('EventSummary', () {
     EventSummary eventSummary;
     testWidgets('event with connected events', (WidgetTester tester) async {

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/profiler/flutter/cpu_profiler.dart';
+import 'package:devtools_app/src/timeline/flutter/event_details.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'wrappers.dart';
+
+void main() {
+  group('EventDetails', () {
+    EventDetails eventDetails;
+    testWidgets('builds for UI event', (WidgetTester tester) async {
+      eventDetails = EventDetails(stubUiEvent);
+      await tester.pumpWidget(wrap(eventDetails));
+      expect(find.byType(EventDetails), findsOneWidget);
+      expect(find.byType(CpuProfilerView), findsOneWidget);
+      expect(find.byType(EventSummary), findsNothing);
+    });
+
+    testWidgets('builds for GPU event', (WidgetTester tester) async {
+      eventDetails = EventDetails(stubGpuEvent);
+      await tester.pumpWidget(wrap(eventDetails));
+      expect(find.byType(EventDetails), findsOneWidget);
+      expect(find.byType(CpuProfilerView), findsNothing);
+      expect(find.byType(EventSummary), findsOneWidget);
+    });
+
+    testWidgets('builds for ASYNC event', (WidgetTester tester) async {
+      eventDetails = EventDetails(stubAsyncEvent);
+      await tester.pumpWidget(wrap(eventDetails));
+      expect(find.byType(EventDetails), findsOneWidget);
+      expect(find.byType(CpuProfilerView), findsNothing);
+      expect(find.byType(EventSummary), findsOneWidget);
+    });
+  });
+
+  group('EventSummary', () {
+    EventSummary eventSummary;
+    testWidgets('event with connected events', (WidgetTester tester) async {
+      eventSummary = EventSummary(stubAsyncEvent);
+      await tester.pumpWidget(wrap(eventSummary));
+      expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Thread id'), findsOneWidget);
+      expect(find.text('Process id'), findsOneWidget);
+      expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Connected events'), findsOneWidget);
+    });
+
+    testWidgets('event without connected events', (WidgetTester tester) async {
+      eventSummary = EventSummary(stubUiEvent);
+      await tester.pumpWidget(wrap(eventSummary));
+      expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Thread id'), findsOneWidget);
+      expect(find.text('Process id'), findsOneWidget);
+      expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Connected events'), findsNothing);
+    });
+
+    testWidgets('event with args', (WidgetTester tester) async {
+      eventSummary = EventSummary(stubGpuEvent);
+      await tester.pumpWidget(wrap(eventSummary));
+      expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Thread id'), findsOneWidget);
+      expect(find.text('Process id'), findsOneWidget);
+      expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Arguments'), findsOneWidget);
+    });
+
+    testWidgets('event without args', (WidgetTester tester) async {
+      eventSummary = EventSummary(stubUiEvent);
+      await tester.pumpWidget(wrap(eventSummary));
+      expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Thread id'), findsOneWidget);
+      expect(find.text('Process id'), findsOneWidget);
+      expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Arguments'), findsNothing);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/timeline_screen_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_screen_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/flutter/split.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/timeline/flutter/event_details.dart';
@@ -42,6 +43,12 @@ void main() {
       expect(find.byType(TimelineScreenBody), findsOneWidget);
       final TimelineScreenBodyState state =
           tester.state(find.byType(TimelineScreenBody));
+
+      // Verify the state of the splitter.
+      final splitFinder = find.byType(Split);
+      expect(splitFinder, findsOneWidget);
+      final Split splitter = tester.widget(splitFinder);
+      expect(splitter.initialFirstFraction, equals(0.6));
 
       // Verify TimelineMode.frameBased content.
       expect(state.controller.timelineMode, equals(TimelineMode.frameBased));


### PR DESCRIPTION
![Screen Shot 2019-11-12 at 2 50 06 PM](https://user-images.githubusercontent.com/43759233/68718345-cb5a1f80-055d-11ea-91b3-6bca7e4e385c.png)
Tiles with additional information are expandable: 
![Screen Shot 2019-11-13 at 10 40 44 AM](https://user-images.githubusercontent.com/43759233/68793440-188fcd00-0602-11ea-8875-f6a20d25b25e.png)
This CL also adds the skeleton for the CPU profiler:
![Screen Shot 2019-11-12 at 2 55 49 PM](https://user-images.githubusercontent.com/43759233/68718402-f6447380-055d-11ea-85b3-d5c116945371.png)
Note: this code still needs to be hooked up to real timeline data