### PR TITLE
Hook Flutter Timeline up to real data.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/controllers.dart
+++ b/packages/devtools_app/lib/src/flutter/controllers.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../auto_dispose.dart';
 import '../globals.dart';
 import '../logging/logging_controller.dart';
+import '../timeline/timeline_controller.dart';
 
 /// Container for controllers that should outlive individual screens of the app.
 ///
@@ -14,7 +15,9 @@ import '../logging/logging_controller.dart';
 /// particular [ProvidedControllers] instance again.
 @immutable
 class ProvidedControllers implements DisposableController {
-  const ProvidedControllers({@required this.logging}) : assert(logging != null);
+  const ProvidedControllers({@required this.logging, @required this.timeline})
+      : assert(logging != null),
+        assert(timeline != null);
 
   /// Builds the default providers for the app.
   factory ProvidedControllers.defaults() {
@@ -25,14 +28,17 @@ class ProvidedControllers implements DisposableController {
         // That way, it is visible if it has listeners and invisible otherwise.
         isVisible: () => true,
       ),
+      timeline: TimelineController(),
     );
   }
 
   final LoggingController logging;
+  final TimelineController timeline;
 
   @override
   void dispose() {
     logging.dispose();
+    // TODO(kenz): make timeline controller disposable.
   }
 }
 

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -4,18 +4,74 @@
 
 import 'package:flutter/material.dart';
 
-class FlutterFramesChart extends StatelessWidget {
+import '../../flutter/controllers.dart';
+import '../../ui/fake_flutter/_real_flutter.dart';
+import '../timeline_controller.dart';
+import '../timeline_model.dart';
+
+class FlutterFramesChart extends StatefulWidget {
+  @override
+  _FlutterFramesChartState createState() => _FlutterFramesChartState();
+}
+
+class _FlutterFramesChartState extends State<FlutterFramesChart> {
+  TimelineController _controller;
+
+  List<TimelineFrame> frames = [];
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _controller = Controllers.of(context).timeline;
+  }
+
+  @override
+  void dispose() {
+    // TODO(kenz): dispose [_controller] here.
+    super.dispose();
+  }
+
+  // TODO(terry): replace this temporary UI with the bar chart.
   @override
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8.0),
       child: Container(
         height: 150.0,
-        color: Colors.black26,
-        child: const Center(
-          child: Text('TODO Flutter Frames Chart'),
+        child: StreamBuilder(
+          // TODO(terry): we should listen to this stream to add a frame /
+          // data point to the bar chart.
+          stream: _controller.frameBasedTimeline.onFrameAdded,
+          builder: (context, snapshot) {
+            if (snapshot.hasData) {
+              frames.add(snapshot.data);
+              return ListView.builder(
+                scrollDirection: Axis.horizontal,
+                itemCount: frames.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return _createFrameWidget(frames[index]);
+                },
+              );
+            } else {
+              return Container();
+            }
+          },
         ),
       ),
+    );
+  }
+
+  Widget _createFrameWidget(TimelineFrame frame) {
+    return InkWell(
+      child: Container(
+        width: 50.0,
+        height: 100.0,
+        color: frames.indexOf(frame) % 2 == 0
+            ? Colors.blueAccent
+            : Colors.lightBlueAccent,
+      ),
+      // TODO(terry): this should be used in onSelect for a bar chart bar.
+      onTap: () => _controller.frameBasedTimeline.selectFrame(frame),
     );
   }
 }

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -2,11 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_icons/flutter_icons.dart';
 
+import '../../flutter/controllers.dart';
 import '../../flutter/screen.dart';
-
 import '../../flutter/split.dart';
 import '../../service_extensions.dart';
 import '../../ui/flutter/label.dart';
@@ -38,8 +40,9 @@ class TimelineScreenBody extends StatefulWidget {
 }
 
 class TimelineScreenBodyState extends State<TimelineScreenBody> {
-  @visibleForTesting
-  final controller = TimelineController();
+  TimelineController controller;
+
+  StreamSubscription selectedFrameSubscription;
 
   @override
   void initState() {
@@ -47,9 +50,25 @@ class TimelineScreenBodyState extends State<TimelineScreenBody> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    controller = Controllers.of(context).timeline;
+    controller.timelineService.updateListeningState(true);
+
+    // TODO(kenz): use Notifier class to register and unregister listeners.
+    selectedFrameSubscription?.cancel();
+    selectedFrameSubscription =
+        controller.frameBasedTimeline.onSelectedFrame.listen((_) {
+      setState(() {});
+    });
+  }
+
+  @override
   void dispose() {
     // TODO(kenz): make TimelineController disposable via
     // DisposableController and dispose here.
+    controller.timelineService.updateListeningState(false);
+    selectedFrameSubscription.cancel();
     super.dispose();
   }
 

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -417,14 +417,14 @@ class HtmlTimelineScreen extends HtmlScreen {
 
   @override
   void entering() async {
-    await _updateListeningState();
+    await timelineController.timelineService.updateListeningState(true);
     _updateButtonStates();
     await _profileGranularitySelector.setGranularity();
   }
 
   @override
   void exiting() async {
-    await _updateListeningState();
+    await timelineController.timelineService.updateListeningState(false);
     _updateButtonStates();
   }
 
@@ -466,7 +466,8 @@ class HtmlTimelineScreen extends HtmlScreen {
     timelineController.frameBasedTimeline.pause(manual: true);
     ga.select(ga.timeline, ga.pause);
     _updateButtonStates();
-    await _updateListeningState();
+    await timelineController.timelineService
+        .updateListeningState(isCurrentScreen);
   }
 
   Future<void> _resumeFrameRecording() async {
@@ -474,7 +475,8 @@ class HtmlTimelineScreen extends HtmlScreen {
     timelineController.frameBasedTimeline.resume();
     ga.select(ga.timeline, ga.resume);
     _updateButtonStates();
-    await _updateListeningState();
+    await timelineController.timelineService
+        .updateListeningState(isCurrentScreen);
   }
 
   Future<void> _startFullRecording() async {
@@ -573,20 +575,6 @@ class HtmlTimelineScreen extends HtmlScreen {
     _recordingStatus.hidden(true);
     eventDetails
         .hidden(timelineController.timelineMode == TimelineMode.frameBased);
-  }
-
-  Future<void> _updateListeningState() async {
-    final bool shouldBeRunning =
-        (!timelineController.frameBasedTimeline.manuallyPaused ||
-                timelineController.fullTimeline.recording) &&
-            !offlineMode &&
-            isCurrentScreen;
-    final bool isRunning = !timelineController.frameBasedTimeline.paused ||
-        timelineController.fullTimeline.recording;
-    await timelineController.timelineService.updateListeningState(
-      shouldBeRunning: shouldBeRunning,
-      isRunning: isRunning,
-    );
   }
 
   Future<void> clearTimeline() async {

--- a/packages/devtools_app/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_service.dart
@@ -140,7 +140,21 @@ class TimelineService {
     }
   }
 
-  Future<void> updateListeningState({
+  Future<void> updateListeningState(bool isCurrentScreen) async {
+    final bool shouldBeRunning =
+        (!timelineController.frameBasedTimeline.manuallyPaused ||
+                timelineController.fullTimeline.recording) &&
+            !offlineMode &&
+            isCurrentScreen;
+    final bool isRunning = !timelineController.frameBasedTimeline.paused ||
+        timelineController.fullTimeline.recording;
+    await _updateListeningState(
+      shouldBeRunning: shouldBeRunning,
+      isRunning: isRunning,
+    );
+  }
+
+  Future<void> _updateListeningState({
     @required bool shouldBeRunning,
     @required bool isRunning,
   }) async {


### PR DESCRIPTION
This CL connects the Flutter timeline to live data. It also adds some temporary UI to visualize frames in the timeline, which @terrylucas will rip out and replace with a bar chart in https://github.com/flutter/devtools/pull/1335

Verified this does not break the dart:html app.