### PR TITLE
Prep for 0.1.12-dev.1 release.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.12-dev.1
+* Check for a debug service extension instead of using eval to distinguish between debug and profile builds.
+
 ## 0.1.11 - 2019-11-08
 * Add full timeline mode with support for async and recorded tracing.
 * Add event summary section that shows metadata for non-ui events on the Timeline page.

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.1.11
+version: 0.1.12-dev.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.1.11';
+const String version = '0.1.12-dev.1';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Main package implementing web-based performance tooling for Dart an
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.1.11
+version: 0.1.12-dev.1
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools


### PR DESCRIPTION
This will unblock a use case for dream (g3)