### PR TITLE
Allow launching DevTools directly over the JSON stdin API

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -121,7 +121,7 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a request to launch DevTools in a browser.
-        await launchDevTools(useVmService: useVmService);
+        await _sendLaunchDevToolsRequest(useVmService: useVmService);
 
         final serverResponse =
             await _waitForClients(requiredConnectionState: true);
@@ -137,7 +137,8 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a request to launch at a certain page.
-        await launchDevTools(useVmService: useVmService, page: 'memory');
+        await _sendLaunchDevToolsRequest(
+            useVmService: useVmService, page: 'memory');
 
         final serverResponse = await _waitForClients(requiredPage: 'memory');
         expect(serverResponse, isNotNull);
@@ -152,11 +153,12 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Launch on the memory page and wait for the connection.
-        await launchDevTools(useVmService: useVmService, page: 'memory');
+        await _sendLaunchDevToolsRequest(
+            useVmService: useVmService, page: 'memory');
         await _waitForClients(requiredPage: 'memory');
 
         // Re-launch, allowing reuse and with a different page.
-        await launchDevTools(
+        await _sendLaunchDevToolsRequest(
             useVmService: useVmService,
             reuseWindows: true,
             page: 'performance');
@@ -177,7 +179,7 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a request to launch DevTools in a browser.
-        await launchDevTools(useVmService: useVmService);
+        await _sendLaunchDevToolsRequest(useVmService: useVmService);
 
         // Wait for the DevTools to inform server that it's connected.
         await _waitForClients(requiredConnectionState: true);
@@ -205,7 +207,7 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a request to launch DevTools in a browser.
-        await launchDevTools(useVmService: useVmService);
+        await _sendLaunchDevToolsRequest(useVmService: useVmService);
 
         {
           final serverResponse =
@@ -215,7 +217,7 @@ void main() {
 
         // Request again, allowing reuse, and server emits an event saying the
         // window was reused.
-        final launchResponse = await launchDevTools(
+        final launchResponse = await _sendLaunchDevToolsRequest(
             useVmService: useVmService, reuseWindows: true);
         expect(launchResponse['reused'], isTrue);
 
@@ -232,7 +234,7 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a request to launch DevTools in a browser.
-        await launchDevTools(useVmService: useVmService);
+        await _sendLaunchDevToolsRequest(useVmService: useVmService);
 
         // Wait for the DevTools to inform server that it's connected.
         await _waitForClients(requiredConnectionState: true);
@@ -248,7 +250,8 @@ void main() {
         await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
         // Send a new request to launch.
-        await launchDevTools(useVmService: useVmService, reuseWindows: true);
+        await _sendLaunchDevToolsRequest(
+            useVmService: useVmService, reuseWindows: true);
 
         // Ensure we now have a single connected client.
         final serverResponse =
@@ -263,7 +266,7 @@ void main() {
   }
 }
 
-Future<Map<String, dynamic>> launchDevTools({
+Future<Map<String, dynamic>> _sendLaunchDevToolsRequest({
   @required bool useVmService,
   String page,
   bool reuseWindows = false,

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -112,7 +112,11 @@ void main() {
     }
   }, timeout: const Timeout.factor(10));
 
-  for (final bool useVmService in [true, false]) {
+  // TODO(dantup): We can't run tests using the stdin API for devTools.launch unless
+  // we're running with a new server version. This check can be removed (and always use
+  // both) after the next server release (after the PR lands).
+  for (final bool useVmService
+      in serverDevToolsLaunchViaStdin ? [true, false] : [true]) {
     group('Server (${useVmService ? 'VM Service' : 'API'})', () {
       test(
           'DevTools connects back to server API and registers that it is connected',

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:devtools_testing/support/file_utils.dart';
+import 'package:meta/meta.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -111,158 +112,178 @@ void main() {
     }
   }, timeout: const Timeout.factor(10));
 
-  group('Server API', () {
-    test(
-        'DevTools connects back to server API and registers that it is connected',
-        () async {
-      // Register the VM.
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+  for (final bool useVmService in [true, false]) {
+    group('Server (${useVmService ? 'VM Service' : 'API'})', () {
+      test(
+          'DevTools connects back to server API and registers that it is connected',
+          () async {
+        // Register the VM.
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Send a request to launch DevTools in a browser.
-      await launchDevTools();
+        // Send a request to launch DevTools in a browser.
+        await launchDevTools(useVmService: useVmService);
 
-      final serverResponse =
-          await _waitForClients(requiredConnectionState: true);
-      expect(serverResponse, isNotNull);
-      expect(serverResponse['clients'], hasLength(1));
-      expect(serverResponse['clients'][0]['hasConnection'], isTrue);
-      expect(serverResponse['clients'][0]['vmServiceUri'],
-          equals(appFixture.serviceUri.toString()));
-    }, timeout: const Timeout.factor(10));
+        final serverResponse =
+            await _waitForClients(requiredConnectionState: true);
+        expect(serverResponse, isNotNull);
+        expect(serverResponse['clients'], hasLength(1));
+        expect(serverResponse['clients'][0]['hasConnection'], isTrue);
+        expect(serverResponse['clients'][0]['vmServiceUri'],
+            equals(appFixture.serviceUri.toString()));
+      }, timeout: const Timeout.factor(10));
 
-    test('can launch on a specific page', () async {
-      // Register the VM.
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+      test('can launch on a specific page', () async {
+        // Register the VM.
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Send a request to launch at a certain page.
-      await launchDevTools(page: 'memory');
+        // Send a request to launch at a certain page.
+        await launchDevTools(useVmService: useVmService, page: 'memory');
 
-      final serverResponse = await _waitForClients(requiredPage: 'memory');
-      expect(serverResponse, isNotNull);
-      expect(serverResponse['clients'], hasLength(1));
-      expect(serverResponse['clients'][0]['hasConnection'], isTrue);
-      expect(serverResponse['clients'][0]['vmServiceUri'],
-          equals(appFixture.serviceUri.toString()));
-      expect(serverResponse['clients'][0]['currentPage'], equals('memory'));
-    }, timeout: const Timeout.factor(10));
+        final serverResponse = await _waitForClients(requiredPage: 'memory');
+        expect(serverResponse, isNotNull);
+        expect(serverResponse['clients'], hasLength(1));
+        expect(serverResponse['clients'][0]['hasConnection'], isTrue);
+        expect(serverResponse['clients'][0]['vmServiceUri'],
+            equals(appFixture.serviceUri.toString()));
+        expect(serverResponse['clients'][0]['currentPage'], equals('memory'));
+      }, timeout: const Timeout.factor(10));
 
-    test('can switch page', () async {
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+      test('can switch page', () async {
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Launch on the memory page and wait for the connection.
-      await launchDevTools(page: 'memory');
-      await _waitForClients(requiredPage: 'memory');
+        // Launch on the memory page and wait for the connection.
+        await launchDevTools(useVmService: useVmService, page: 'memory');
+        await _waitForClients(requiredPage: 'memory');
 
-      // Re-launch, allowing reuse and with a different page.
-      await launchDevTools(reuseWindows: true, page: 'performance');
+        // Re-launch, allowing reuse and with a different page.
+        await launchDevTools(
+            useVmService: useVmService,
+            reuseWindows: true,
+            page: 'performance');
 
-      final serverResponse = await _waitForClients(requiredPage: 'performance');
-      expect(serverResponse, isNotNull);
-      expect(serverResponse['clients'], hasLength(1));
-      expect(serverResponse['clients'][0]['hasConnection'], isTrue);
-      expect(serverResponse['clients'][0]['vmServiceUri'],
-          equals(appFixture.serviceUri.toString()));
-      expect(
-          serverResponse['clients'][0]['currentPage'], equals('performance'));
-    }, timeout: const Timeout.factor(10));
+        final serverResponse =
+            await _waitForClients(requiredPage: 'performance');
+        expect(serverResponse, isNotNull);
+        expect(serverResponse['clients'], hasLength(1));
+        expect(serverResponse['clients'][0]['hasConnection'], isTrue);
+        expect(serverResponse['clients'][0]['vmServiceUri'],
+            equals(appFixture.serviceUri.toString()));
+        expect(
+            serverResponse['clients'][0]['currentPage'], equals('performance'));
+      }, timeout: const Timeout.factor(10));
 
-    test('DevTools reports disconnects from a VM', () async {
-      // Register the VM.
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+      test('DevTools reports disconnects from a VM', () async {
+        // Register the VM.
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Send a request to launch DevTools in a browser.
-      await launchDevTools();
+        // Send a request to launch DevTools in a browser.
+        await launchDevTools(useVmService: useVmService);
 
-      // Wait for the DevTools to inform server that it's connected.
-      await _waitForClients(requiredConnectionState: true);
+        // Wait for the DevTools to inform server that it's connected.
+        await _waitForClients(requiredConnectionState: true);
 
-      // Terminate the VM.
-      await appFixture.teardown();
+        // Terminate the VM.
+        await appFixture.teardown();
 
-      // Ensure the client is marked as disconnected.
-      final serverResponse =
-          await _waitForClients(requiredConnectionState: false);
-      expect(serverResponse['clients'], hasLength(1));
-      expect(serverResponse['clients'][0]['hasConnection'], isFalse);
-      expect(serverResponse['clients'][0]['vmServiceUri'], isNull);
-    }, timeout: const Timeout.factor(10));
+        // Ensure the client is marked as disconnected.
+        final serverResponse =
+            await _waitForClients(requiredConnectionState: false);
+        expect(serverResponse['clients'], hasLength(1));
+        expect(serverResponse['clients'][0]['hasConnection'], isFalse);
+        expect(serverResponse['clients'][0]['vmServiceUri'], isNull);
+      }, timeout: const Timeout.factor(10));
 
-    test('server removes clients that disconnect from the API', () async {
-      // TODO(dantup): This requires the ability for us to shut down Chrome,
-      // probably via a command to the server, which needs
-      // https://github.com/dart-lang/browser_launcher/pull/12
-    }, timeout: const Timeout.factor(10), skip: true);
+      test('server removes clients that disconnect from the API', () async {
+        // TODO(dantup): This requires the ability for us to shut down Chrome,
+        // probably via a command to the server, which needs
+        // https://github.com/dart-lang/browser_launcher/pull/12
+      }, timeout: const Timeout.factor(10), skip: true);
 
-    test('Server reuses DevTools instance if already connected to same VM',
-        () async {
-      // Register the VM.
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+      test('Server reuses DevTools instance if already connected to same VM',
+          () async {
+        // Register the VM.
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Send a request to launch DevTools in a browser.
-      await launchDevTools();
+        // Send a request to launch DevTools in a browser.
+        await launchDevTools(useVmService: useVmService);
 
-      {
+        {
+          final serverResponse =
+              await _waitForClients(requiredConnectionState: true);
+          expect(serverResponse['clients'], hasLength(1));
+        }
+
+        // Request again, allowing reuse, and server emits an event saying the
+        // window was reused.
+        final launchResponse = await launchDevTools(
+            useVmService: useVmService, reuseWindows: true);
+        expect(launchResponse['reused'], isTrue);
+
+        // Ensure there's still only one connection (eg. we didn't spawn a new one
+        // we reused the existing one).
         final serverResponse =
             await _waitForClients(requiredConnectionState: true);
         expect(serverResponse['clients'], hasLength(1));
-      }
+      }, timeout: const Timeout.factor(10));
 
-      // Request again, allowing reuse, and server emits an event saying the
-      // window was reused.
-      final launchResponse = await launchDevTools(reuseWindows: true);
-      expect(launchResponse['reused'], isTrue);
+      test('Server reuses DevTools instance if not connected to a VM',
+          () async {
+        // Register the VM.
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Ensure there's still only one connection (eg. we didn't spawn a new one
-      // we reused the existing one).
-      final serverResponse =
-          await _waitForClients(requiredConnectionState: true);
-      expect(serverResponse['clients'], hasLength(1));
-    }, timeout: const Timeout.factor(10));
+        // Send a request to launch DevTools in a browser.
+        await launchDevTools(useVmService: useVmService);
 
-    test('Server reuses DevTools instance if not connected to a VM', () async {
-      // Register the VM.
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
+        // Wait for the DevTools to inform server that it's connected.
+        await _waitForClients(requiredConnectionState: true);
 
-      // Send a request to launch DevTools in a browser.
-      await launchDevTools();
+        // Terminate the VM.
+        await appFixture.teardown();
 
-      // Wait for the DevTools to inform server that it's connected.
-      await _waitForClients(requiredConnectionState: true);
+        // Ensure the client is marked as disconnected.
+        await _waitForClients(requiredConnectionState: false);
 
-      // Terminate the VM.
-      await appFixture.teardown();
+        // Start up a new app.
+        await _startApp();
+        await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
 
-      // Ensure the client is marked as disconnected.
-      await _waitForClients(requiredConnectionState: false);
+        // Send a new request to launch.
+        await launchDevTools(useVmService: useVmService, reuseWindows: true);
 
-      // Start up a new app.
-      await _startApp();
-      await _send('vm.register', {'uri': appFixture.serviceUri.toString()});
-
-      // Send a new request to launch.
-      await launchDevTools(reuseWindows: true);
-
-      // Ensure we now have a single connected client.
-      final serverResponse =
-          await _waitForClients(requiredConnectionState: true);
-      expect(serverResponse['clients'], hasLength(1));
-      expect(serverResponse['clients'][0]['hasConnection'], isTrue);
-      expect(serverResponse['clients'][0]['vmServiceUri'],
-          equals(appFixture.serviceUri.toString()));
-    }, timeout: const Timeout.factor(10));
-    // The API only works in release mode.
-  }, skip: !testInReleaseMode);
+        // Ensure we now have a single connected client.
+        final serverResponse =
+            await _waitForClients(requiredConnectionState: true);
+        expect(serverResponse['clients'], hasLength(1));
+        expect(serverResponse['clients'][0]['hasConnection'], isTrue);
+        expect(serverResponse['clients'][0]['vmServiceUri'],
+            equals(appFixture.serviceUri.toString()));
+      }, timeout: const Timeout.factor(10));
+      // The API only works in release mode.
+    }, skip: !testInReleaseMode);
+  }
 }
 
 Future<Map<String, dynamic>> launchDevTools({
+  @required bool useVmService,
   String page,
   bool reuseWindows = false,
 }) async {
   final launchEvent = events.where((e) => e['event'] == 'client.launch').first;
-  await appFixture.serviceConnection.callMethod(
-    registeredServices['launchDevTools'],
-    args: {'reuseWindows': reuseWindows, 'page': page},
-  );
+  if (useVmService) {
+    await appFixture.serviceConnection.callMethod(
+      registeredServices['launchDevTools'],
+      args: {
+        'reuseWindows': reuseWindows,
+        'page': page,
+      },
+    );
+  } else {
+    await _send('devTools.launch', {
+      'vmServiceUri': appFixture.serviceUri.toString(),
+      'reuseWindows': reuseWindows,
+      'page': page,
+    });
+  }
   final response = await launchEvent;
   return response['params'];
 }

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -10,6 +10,10 @@ import 'chrome.dart';
 
 const verbose = true;
 
+// TODO(dantup): Remove this when the live Pub version supports devTools.launch.
+final bool serverDevToolsLaunchViaStdin =
+    Platform.environment['USE_LOCAL_DEPENDENCIES'] == 'true';
+
 class DevToolsServerDriver {
   DevToolsServerDriver._(this._process, this._stdin, Stream<String> _stdout,
       Stream<String> _stderr)

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -69,9 +69,11 @@ This request is only used for testing purposes so is currently "undocumented"
 This request lists all DevTools instances that are currently connected back to the server along with which VM services they're connected to and the pages they are showing. The request requires no `params`.
 -->
 
-### launchDevTools Request (VM Service)
+### devTools.launch Request / launchDevTools VM Service
 
-`launchDevTools` is registered as a VM service (it is *not* sent over stdin to the server) and takes the following params:
+DevTools can be launched either through the daemon API using the `devTools.launch` request or via the VM Service protocol by calling the `launchDevTools` service.
+
+Both methods take the same parameters.
 
 - `reuseWindows` - whether an existing DevTools instance that is not connected to a VM (or is connected to the same one) should be reused
 - `notify` - whether to send a browser notification to the user in the case where a DevTools instance is reused, to help them find the window
@@ -87,7 +89,9 @@ This request lists all DevTools instances that are currently connected back to t
 {
 	'id': '123',
 	// The `method` field is populated based on the ServiceRegistered VM event
-	'method': 's2.launchDevTools',
+	// if sending over the VM Service protocol.
+	// 'method': 's2.launchDevTools',
+	'method': 'devTools.launch',
 	'params': {
 		'notify': true,
 		'page': 'inspector',
@@ -103,4 +107,5 @@ This request lists all DevTools instances that are currently connected back to t
 
 ## Changelog
 
+- 1.1.0: Add a `devTools.launch` request to launch DevTools directly via the server API
 - 1.0.0: Initial documentation for DevTools server API

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -69,12 +69,11 @@ This request is only used for testing purposes so is currently "undocumented"
 This request lists all DevTools instances that are currently connected back to the server along with which VM services they're connected to and the pages they are showing. The request requires no `params`.
 -->
 
-### devTools.launch Request / launchDevTools VM Service
+### devTools.launch Request
 
-DevTools can be launched either through the daemon API using the `devTools.launch` request or via the VM Service protocol by calling the `launchDevTools` service.
+DevTools can be launched in a browser using the `devTools.launch` request with the following parameters.
 
-Both methods take the same parameters.
-
+- `vmServiceUri` - the URI of the VM service that DevTools should connect to
 - `reuseWindows` - whether an existing DevTools instance that is not connected to a VM (or is connected to the same one) should be reused
 - `notify` - whether to send a browser notification to the user in the case where a DevTools instance is reused, to help them find the window
 - `page` - the page to launch DevTools on (matches the IDs used in DevTools that show in the URL fragments) or - if reusing a window - to switch to
@@ -88,10 +87,32 @@ Both methods take the same parameters.
 ```js
 {
 	'id': '123',
-	// The `method` field is populated based on the ServiceRegistered VM event
-	// if sending over the VM Service protocol.
-	// 'method': 's2.launchDevTools',
 	'method': 'devTools.launch',
+	'params': {
+		'vmServiceUri': 'ws://127.0.0.1/ABCDEF=/ws',
+		'notify': true,
+		'page': 'inspector',
+		'queryParams': {
+			'hide': 'debugger',
+			'ide': 'VSCode',
+			'theme': 'dark'
+		},
+		'reuseWindows': true
+	}
+}
+```
+
+### launchDevTools VM Service
+
+DevTools can also be launched via the VM Service protocol by calling the `launchDevTools` service. It takes the same parameters as the `devTools.launch` request, except without the `vmServiceUri` parameter since that's already known by the service.
+
+#### Example
+
+```js
+{
+	'id': '123',
+	// The `method` field is populated based on the ServiceRegistered VM event
+	'method': 's2.launchDevTools',
 	'params': {
 		'notify': true,
 		'page': 'inspector',

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -462,19 +462,6 @@ Future<Map<String, dynamic>> launchDevTools(
     String devToolsUrl,
     bool headlessMode,
     bool machineMode) async {
-  // Prints a launch event to stdout so consumers of the DevTools server
-  // can see when clients are being launched/reused.
-  void emitLaunchEvent({@required bool reused, @required bool notified}) {
-    printOutput(
-      null,
-      {
-        'event': 'client.launch',
-        'params': {'reused': reused, 'notified': notified},
-      },
-      machineMode: machineMode,
-    );
-  }
-
   // First see if we have an existing DevTools client open that we can
   // reuse.
   final canReuse = params != null &&
@@ -490,7 +477,8 @@ Future<Map<String, dynamic>> launchDevTools(
         page,
         shouldNotify,
       )) {
-    emitLaunchEvent(reused: true, notified: shouldNotify);
+    _emitLaunchEvent(
+        reused: true, notified: shouldNotify, machineMode: machineMode);
     return {'reused': true, 'notified': shouldNotify};
   }
 
@@ -538,8 +526,24 @@ Future<Map<String, dynamic>> launchDevTools(
         : <String>[];
     await Chrome.start([uriToLaunch.toString()], args: args);
   }
-  emitLaunchEvent(reused: false, notified: false);
+  _emitLaunchEvent(reused: false, notified: false, machineMode: machineMode);
   return {'reused': false, 'notified': false};
+}
+
+/// Prints a launch event to stdout so consumers of the DevTools server
+/// can see when clients are being launched/reused.
+void _emitLaunchEvent(
+    {@required bool reused,
+    @required bool notified,
+    @required bool machineMode}) {
+  printOutput(
+    null,
+    {
+      'event': 'client.launch',
+      'params': {'reused': reused, 'notified': notified},
+    },
+    machineMode: machineMode,
+  );
 }
 
 // TODO(dantup): This method was adapted from devtools and should be upstreamed

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -261,12 +261,7 @@ Future<void> _handleVmRegister(
   // Lots of things are considered valid URIs (including empty strings
   // and single letters) since they can be relative, so we need to do some
   // extra checks.
-  if (uri != null &&
-      uri.isAbsolute &&
-      (uri.isScheme('ws') ||
-          uri.isScheme('wss') ||
-          uri.isScheme('http') ||
-          uri.isScheme('https'))) {
+  if (_isValidVmServiceUri(uri)) {
     await registerLaunchDevToolsService(
         uri, id, devToolsUrl, machineMode, headlessMode);
   } else {
@@ -504,6 +499,14 @@ bool _isAccessibleToChromeOSNativeBrowser(Uri uri) {
   const tunneledPorts = {8000, 8008, 8080, 8085, 8888, 9005, 3000, 4200, 5000};
   return uri != null && uri.hasPort && tunneledPorts.contains(uri.port);
 }
+
+bool _isValidVmServiceUri(Uri uri) =>
+    uri != null &&
+    uri.isAbsolute &&
+    (uri.isScheme('ws') ||
+        uri.isScheme('wss') ||
+        uri.isScheme('http') ||
+        uri.isScheme('https'));
 
 Future<VmService> _connectToVmService(Uri uri) async {
   // Fix up the various acceptable URI formats into a WebSocket URI to connect.


### PR DESCRIPTION
@devoncarew this will let you launch DevTools directly over the JSON API without needing to use the VM service. Both are supported and take the same parameters. If you want to know if an instance was reused, you can wait for the `client.launch` event.