### PR TITLE
Reenable tests for #1351

### DIFF
--- a/packages/devtools_testing/lib/logging_controller_test.dart
+++ b/packages/devtools_testing/lib/logging_controller_test.dart
@@ -282,9 +282,7 @@ Future<void> runLoggingControllerTests(FlutterTestEnvironment env) async {
       }
       await env.tearDownEnvironment();
     });
-    // TODO(kenz): Unskip this once
-    // https://github.com/flutter/devtools/issues/1351 is fixed.
-  }, skip: true, timeout: const Timeout.factor(8));
+  }, timeout: const Timeout.factor(8));
 }
 
 /// Normalize text in error messages that is likely unstable.


### PR DESCRIPTION
Passes locally.  Fixes #1351.