### PR TITLE
Unskip service manager test

### DIFF
--- a/packages/devtools_testing/lib/service_manager_test.dart
+++ b/packages/devtools_testing/lib/service_manager_test.dart
@@ -90,9 +90,7 @@ Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
       await _verifyExtensionStateInServiceManager(extensionName, true, true);
 
       await env.tearDownEnvironment();
-      // TODO(kenz): Unskip this once
-      // https://github.com/flutter/devtools/issues/1351 is fixed.
-    }, skip: true);
+    });
 
     test('toggle String service extension', () async {
       await env.setupEnvironment();
@@ -312,9 +310,6 @@ Future<void> runServiceManagerTestsWithDriverFactory(
     }
 
     test('all extension types', () async {
-      // TODO(kenz): Uncomment this once
-      // https://github.com/flutter/devtools/issues/1351 is fixed.
-      /*
       // Enable a boolean extension on the test device.
       final boolExtensionDescription = extensions.debugPaint;
       final boolArgs = {'enabled': true};
@@ -334,7 +329,6 @@ Future<void> runServiceManagerTestsWithDriverFactory(
         boolEvalExpression,
         boolLibrary,
       );
-      */
 
       // Enable a String extension on the test device.
       final stringExtensionDescription = extensions.togglePlatformMode;


### PR DESCRIPTION
Re-enable remaining tests skipped for #1351.  Fixes #1351.  