### PR TITLE
Render chronologically overlapping timeline events w/o visual overlap

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -100,7 +100,8 @@ abstract class FlameChart<T> {
   double get calculatedWidth;
 
   void expandRows(int newRows) {
-    for (int i = rows.length; i < rows.length + newRows; i++) {
+    final currentLength = rows.length;
+    for (int i = currentLength; i < currentLength + newRows; i++) {
       rows.add(FlameChartRow());
     }
   }

--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -99,9 +99,9 @@ abstract class FlameChart<T> {
 
   double get calculatedWidth;
 
-  void expandRows(int newRows) {
+  void expandRows(int newRowLength) {
     final currentLength = rows.length;
-    for (int i = currentLength; i < currentLength + newRows; i++) {
+    for (int i = currentLength; i < newRowLength; i++) {
       rows.add(FlameChartRow());
     }
   }

--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -76,9 +76,9 @@ abstract class FlameChart<T> {
 
   FlameChartNode selectedNode;
 
-  List<FlameChartRow> rows = [];
+  final List<FlameChartRow> rows = [];
 
-  List<FlameChartSection> sections = [];
+  final List<FlameChartSection> sections = [];
 
   TimelineGrid timelineGrid;
 
@@ -91,9 +91,19 @@ abstract class FlameChart<T> {
   // scroll offset to reduce floating point error when zooming.
   num floatingPointScrollLeft = 0;
 
-  void initUiElements();
+  @mustCallSuper
+  void initUiElements() {
+    rows.clear();
+    sections.clear();
+  }
 
   double get calculatedWidth;
+
+  void expandRows(int newRows) {
+    for (int i = rows.length; i < rows.length + newRows; i++) {
+      rows.add(FlameChartRow());
+    }
+  }
 
   void selectNodeAtOffset(Offset offset) {
     final node = nodeAtOffset(offset);
@@ -378,8 +388,7 @@ abstract class FlameChartCanvas<T> extends FlameChart {
 }
 
 class FlameChartRow {
-  FlameChartRow({@required this.nodes});
-  final List<FlameChartNode> nodes;
+  final List<FlameChartNode> nodes = [];
 }
 
 class FlameChartSection {

--- a/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart_canvas.dart
@@ -378,13 +378,8 @@ abstract class FlameChartCanvas<T> extends FlameChart {
 }
 
 class FlameChartRow {
-  const FlameChartRow({
-    @required this.nodes,
-    @required this.index,
-  });
-
+  FlameChartRow({@required this.nodes});
   final List<FlameChartNode> nodes;
-  final int index;
 }
 
 class FlameChartSection {

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -113,9 +113,9 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     sections.clear();
   }
 
-  void expandRows(int newRows) {
+  void expandRows(int newRowLength) {
     final currentLength = rows.length;
-    for (int i = currentLength; i < currentLength + newRows; i++) {
+    for (int i = currentLength; i < newRowLength; i++) {
       rows.add(FlameChartRow());
     }
   }

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -292,13 +292,8 @@ class FlameChartSection {
 }
 
 class FlameChartRow {
-  const FlameChartRow({
-    @required this.nodes,
-    @required this.index,
-  });
-
+  FlameChartRow({@required this.nodes});
   final List<FlameChartNode> nodes;
-  final int index;
 }
 
 class FlameChartNode<T> {

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -114,7 +114,8 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
   }
 
   void expandRows(int newRows) {
-    for (int i = rows.length; i < rows.length + newRows; i++) {
+    final currentLength = rows.length;
+    for (int i = currentLength; i < currentLength + newRows; i++) {
       rows.add(FlameChartRow());
     }
   }

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -109,6 +109,14 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
   @mustCallSuper
   void initFlameChartElements() {
     resetColorOffsets();
+    rows.clear();
+    sections.clear();
+  }
+
+  void expandRows(int newRows) {
+    for (int i = rows.length; i < rows.length + newRows; i++) {
+      rows.add(FlameChartRow());
+    }
   }
 }
 
@@ -292,8 +300,7 @@ class FlameChartSection {
 }
 
 class FlameChartRow {
-  FlameChartRow({@required this.nodes});
-  final List<FlameChartNode> nodes;
+  final List<FlameChartNode> nodes = [];
 }
 
 class FlameChartNode<T> {

--- a/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
@@ -133,7 +133,7 @@ class CpuFlameChartCanvas extends FlameChartCanvas<CpuProfileData> {
   @override
   void initUiElements() {
     for (int i = 0; i < data.cpuProfileRoot.depth; i++) {
-      rows.add(FlameChartRow(nodes: [], index: i));
+      rows.add(FlameChartRow(nodes: []));
     }
 
     final totalWidth = width - 2 * sideInset;

--- a/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/html_cpu_profile_flame_chart.dart
@@ -132,9 +132,8 @@ class CpuFlameChartCanvas extends FlameChartCanvas<CpuProfileData> {
 
   @override
   void initUiElements() {
-    for (int i = 0; i < data.cpuProfileRoot.depth; i++) {
-      rows.add(FlameChartRow(nodes: []));
-    }
+    super.initUiElements();
+    expandRows(data.cpuProfileRoot.depth);
 
     final totalWidth = width - 2 * sideInset;
 

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -318,9 +318,10 @@ class _FullTimelineFlameChartState
     for (String groupName in widget.data.eventGroups.keys) {
       final FullTimelineEventGroup group = widget.data.eventGroups[groupName];
       // Expand rows to fit nodes in [group].
+      assert(rows.length == currentRowIndex);
       final groupDisplaySize =
           group.eventsByRow.length + _rowOffsetForSectionSpacer;
-      expandRows(groupDisplaySize);
+      expandRows(rows.length + groupDisplaySize);
 
       for (int i = 0; i < group.eventsByRow.length; i++) {
         final row = group.eventsByRow[i];

--- a/packages/devtools_app/lib/src/timeline/html_event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/html_event_details.dart
@@ -205,8 +205,8 @@ class _CpuProfiler extends HtmlCpuProfiler {
   @override
   bool maybeShowMessageOnUpdate() {
     if (offlineMode &&
-        !collectionEquals(_timelineController.timeline.data.selectedEvent.json,
-            _timelineController.offlineTimelineData?.selectedEvent?.json)) {
+        !collectionEquals(_timelineController.timeline.data.selectedEvent?.json,
+            _timelineController.offlineTimelineData.selectedEvent?.json)) {
       final offlineModeMessage = div()
         ..add(span(
             text:

--- a/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
@@ -193,6 +193,8 @@ class PlotlyDivGraph extends CoreElement {
   void processNextFrame() async {
     final frame =
         timelineController.frameBasedTimeline.frameAddedNotifier.value;
+    if (frame == null) return;
+
     if (frame.uiDurationMs > 0 && frame.gpuDurationMs > 0) {
       dataIndexes.add(_frameIndex);
       uiDurations.add(frame.uiDurationMs);

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -248,7 +248,9 @@ class HtmlTimelineScreen extends HtmlScreen {
     }
 
     timelineController.frameBasedTimeline.selectedFrameNotifier.addListener(() {
-      _selectFrame();
+      final frame = timelineController.frameBasedTimeline.data.selectedFrame;
+      if (frame == null) return;
+      _selectFrame(frame);
     });
 
     timelineController.fullTimeline
@@ -296,7 +298,8 @@ class HtmlTimelineScreen extends HtmlScreen {
         if (offlineData.selectedFrameId == null) {
           _destroySplitter();
         } else {
-          _selectFrame();
+          _selectFrame(
+              timelineController.frameBasedTimeline.data.selectedFrame);
         }
       }
 
@@ -350,10 +353,8 @@ class HtmlTimelineScreen extends HtmlScreen {
     flameChartContainer.replace(0, flameChart);
   }
 
-  void _selectFrame() {
+  void _selectFrame(TimelineFrame frame) {
     flameChartContainer.hidden(false);
-    final TimelineFrame frame =
-        timelineController.frameBasedTimeline.data.selectedFrame;
     timelineFlameChartCanvas = FrameBasedTimelineFlameChartCanvas(
       data: frame,
       width: flameChartContainer.element.clientWidth.toDouble(),
@@ -376,7 +377,8 @@ class HtmlTimelineScreen extends HtmlScreen {
   }
 
   double _frameBasedTimelineChartHeight() {
-    return (timelineController.frameBasedTimeline.data.displayDepth + 1) *
+    // +2 for an extra row at top and bottom of the chart.
+    return (timelineController.frameBasedTimeline.data.displayDepth + 2) *
             rowHeightWithPadding +
         FrameBasedTimelineFlameChartCanvas.sectionSpacing;
   }

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -384,7 +384,7 @@ class HtmlTimelineScreen extends HtmlScreen {
   double _fullTimelineChartHeight() {
     return (timelineController.fullTimeline.data.displayDepth + 1) *
             rowHeightWithPadding +
-        (timelineController.fullTimeline.data.eventBuckets.length) *
+        (timelineController.fullTimeline.data.eventGroups.length) *
             sectionSpacing;
   }
 

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -300,8 +300,8 @@ class FrameBasedTimeline
     data.selectedFrame = frame;
     _selectedFrameNotifier.value = frame;
 
-    _timelineController._selectedTimelineEventNotifier.value = null;
     data.selectedEvent = null;
+    _timelineController._selectedTimelineEventNotifier.value = null;
     data.cpuProfileData = null;
 
     if (debugTimeline && frame != null) {
@@ -409,7 +409,7 @@ class FullTimeline
   @override
   void processTraceEvents(List<TraceEventWrapper> traceEvents) {
     processor.processTimeline(traceEvents);
-    _timelineController.fullTimeline.data.initializeEventBuckets();
+    _timelineController.fullTimeline.data.initializeEventGroups();
   }
 
   @override

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -297,8 +297,8 @@ class FrameBasedTimeline
     if (frame == null || data.selectedFrame == frame || !hasStarted) {
       return;
     }
-    _selectedFrameNotifier.value = frame;
     data.selectedFrame = frame;
+    _selectedFrameNotifier.value = frame;
 
     _timelineController._selectedTimelineEventNotifier.value = null;
     data.selectedEvent = null;

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -264,7 +264,8 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
     for (String groupName in data.eventGroups.keys) {
       final FullTimelineEventGroup group = data.eventGroups[groupName];
       // Expand rows to fit nodes in [group].
-      expandRows(group.eventsByRow.length);
+      assert(rows.length == currentRowIndex);
+      expandRows(rows.length + group.eventsByRow.length);
 
       for (int i = 0; i < group.eventsByRow.length; i++) {
         final row = group.eventsByRow[i];

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -38,10 +38,9 @@ class FrameBasedTimelineFlameChartCanvas
   void initUiElements() {
     rows = List.generate(
       data.uiEventFlow.depth + data.gpuEventFlow.depth,
-      (i) => FlameChartRow(nodes: [], index: i),
+      (_) => FlameChartRow(nodes: []),
     );
     final int frameStartOffset = data.time.start.inMicroseconds;
-
     double getTopForRow(int row) {
       // This accounts for the section spacing between the UI events and the GPU
       // events.
@@ -163,7 +162,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
 
     final measurementCanvas = CanvasElement().context2D
       ..font = fontStyleToCss(const TextStyle(fontSize: fontSize));
-    for (String bucketName in data.eventBuckets.keys) {
+    for (String bucketName in data.eventGroups.keys) {
       final measuredWidth =
           measurementCanvas.measureText(bucketName).width.toDouble();
       maxSectionLabelWidth = measuredWidth > maxSectionLabelWidth
@@ -190,6 +189,12 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
 
   @override
   void initUiElements() {
+    final int startTimeOffset = data.time.start.inMicroseconds;
+
+    // Pixels per microsecond in order to fit the entire frame in view.
+    final double pxPerMicro =
+        totalStartingWidth / data.time.duration.inMicroseconds;
+
     double getTopForRow(int row, int section) {
       // This accounts for section spacing between different threads of events.
       final additionalPadding = section * sectionSpacing;
@@ -197,39 +202,26 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
           .toDouble();
     }
 
-    void expandRowsToFitCurrentRow(int row) {
-      if (row >= rows.length) {
-        rows.addAll(List.generate(
-          row - rows.length + 1,
-          (i) => FlameChartRow(nodes: [], index: i),
-        ));
-      }
-    }
+    double leftForEvent(TimelineEvent event) =>
+        (event.time.start.inMicroseconds - startTimeOffset) * pxPerMicro +
+        startInset;
 
-    final int startTimeOffset = data.time.start.inMicroseconds;
-
-    // Pixels per microsecond in order to fit the entire frame in view.
-    final double pxPerMicro =
-        totalStartingWidth / data.time.duration.inMicroseconds;
+    double rightForEvent(TimelineEvent event) =>
+        (event.time.end.inMicroseconds - startTimeOffset) * pxPerMicro +
+        startInset;
 
     double maxRight = -1;
-    void createChartNodes(TimelineEvent event, int row, int section) {
+    void createChartNode(TimelineEvent event, int row, int section) {
       // TODO(kenz): we should do something more clever here by inferring the
       // missing start/end time based on ancestors/children. Skip for now.
       if (!event.isWellFormed) return;
-
-      expandRowsToFitCurrentRow(row);
 
       // Do not round these values. Rounding the left could cause us to have
       // inaccurately placed events on the chart. Rounding the width could cause
       // us to lose very small events if the width rounds to zero.
       final top = getTopForRow(row, section);
-      final double left =
-          (event.time.start.inMicroseconds - startTimeOffset) * pxPerMicro +
-              startInset;
-      final double right =
-          (event.time.end.inMicroseconds - startTimeOffset) * pxPerMicro +
-              startInset;
+      final double left = leftForEvent(event);
+      final double right = rightForEvent(event);
       if (right > maxRight) {
         maxRight = right;
         widestRow = row;
@@ -265,38 +257,41 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
       chartNodesByEvent[event] = node;
 
       rows[row].nodes.add(node);
-
-      var nextRow = row + 1;
-      for (var child in event.children) {
-        createChartNodes(child, nextRow, section);
-        if (event.hasOverlappingChildren) {
-          nextRow += child.displayDepth;
-        }
-      }
     }
 
     int currentRowIndex = 0;
     int currentSectionIndex = 0;
-    for (String bucketName in data.eventBuckets.keys) {
-      final List<TimelineEvent> bucket = data.eventBuckets[bucketName];
-      int sectionDepth = 0;
-      for (TimelineEvent event in bucket) {
-        _resetColorOffsets();
-        sectionDepth = math.max(sectionDepth, event.displayDepth);
-        createChartNodes(event, currentRowIndex, currentSectionIndex);
+    for (String groupName in data.eventGroups.keys) {
+      final FullTimelineEventGroup group = data.eventGroups[groupName];
+      // Expand rows to fit nodes in [group].
+      rows.addAll(List.generate(
+        group.eventsByRow.length,
+        (_) => FlameChartRow(nodes: []),
+      ));
+
+      for (int rowInGroup = 0;
+          rowInGroup < group.eventsByRow.length;
+          rowInGroup++) {
+        for (var event in group.eventsByRow[rowInGroup]) {
+          createChartNode(
+            event,
+            currentRowIndex + rowInGroup,
+            currentSectionIndex,
+          );
+        }
       }
 
       final section = FlameChartSection(
         currentSectionIndex,
         startRow: currentRowIndex,
-        endRow: currentRowIndex + sectionDepth,
+        endRow: currentRowIndex + group.displayDepth,
         absStartY: getTopForRow(currentRowIndex, currentSectionIndex),
       );
       sections.add(section);
 
       // Add section label node.
       Color sectionLabelBackgroundColor;
-      switch (bucketName) {
+      switch (groupName) {
         case FullTimelineData.uiKey:
           sectionLabelBackgroundColor = mainUiColor;
           break;
@@ -315,18 +310,18 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
       const sectionLabelPadding = 13.0;
 
       final currentSectionLabel = sectionLabel(
-        bucketName,
+        groupName,
         sectionLabelBackgroundColor,
         top: getTopForRow(currentRowIndex, currentSectionIndex),
         width: math.max(
           FlameChartNode.minWidthForText,
-          sectionLabelWidths[bucketName] + sectionLabelPadding,
+          sectionLabelWidths[groupName] + sectionLabelPadding,
         ),
       );
       rows[currentRowIndex].nodes.insert(0, currentSectionLabel);
 
       // Increment for next section.
-      currentRowIndex += sectionDepth;
+      currentRowIndex += group.eventsByRow.length;
       currentSectionIndex++;
     }
 
@@ -511,11 +506,4 @@ Color _nextUnknownColor() {
       unknownColorPalette[_unknownColorOffset % unknownColorPalette.length];
   _unknownColorOffset++;
   return color;
-}
-
-void _resetColorOffsets() {
-  _asyncColorOffset = 0;
-  _uiColorOffset = 0;
-  _gpuColorOffset = 0;
-  _unknownColorOffset = 0;
 }

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -36,10 +36,9 @@ class FrameBasedTimelineFlameChartCanvas
 
   @override
   void initUiElements() {
-    rows = List.generate(
-      data.uiEventFlow.depth + data.gpuEventFlow.depth,
-      (_) => FlameChartRow(nodes: []),
-    );
+    super.initUiElements();
+    expandRows(data.uiEventFlow.depth + data.gpuEventFlow.depth);
+
     final int frameStartOffset = data.time.start.inMicroseconds;
     double getTopForRow(int row) {
       // This accounts for the section spacing between the UI events and the GPU
@@ -189,6 +188,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
 
   @override
   void initUiElements() {
+    super.initUiElements();
     final int startTimeOffset = data.time.start.inMicroseconds;
 
     // Pixels per microsecond in order to fit the entire frame in view.
@@ -264,18 +264,14 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
     for (String groupName in data.eventGroups.keys) {
       final FullTimelineEventGroup group = data.eventGroups[groupName];
       // Expand rows to fit nodes in [group].
-      rows.addAll(List.generate(
-        group.eventsByRow.length,
-        (_) => FlameChartRow(nodes: []),
-      ));
+      expandRows(group.eventsByRow.length);
 
-      for (int rowInGroup = 0;
-          rowInGroup < group.eventsByRow.length;
-          rowInGroup++) {
-        for (var event in group.eventsByRow[rowInGroup]) {
+      for (int i = 0; i < group.eventsByRow.length; i++) {
+        final row = group.eventsByRow[i];
+        for (var event in row) {
           createChartNode(
             event,
-            currentRowIndex + rowInGroup,
+            currentRowIndex + i,
             currentSectionIndex,
           );
         }

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -103,7 +103,7 @@ class FullTimelineData extends TimelineData {
     if (_displayDepth != null) return _displayDepth;
 
     if (eventGroups.isEmpty) {
-      initializeEventBuckets();
+      initializeEventGroups();
     }
 
     int depth = 0;
@@ -115,7 +115,7 @@ class FullTimelineData extends TimelineData {
 
   int _displayDepth;
 
-  void initializeEventBuckets() {
+  void initializeEventGroups() {
     timelineEvents.sort((a, b) =>
         a.time.start.inMicroseconds.compareTo(b.time.start.inMicroseconds));
     for (TimelineEvent event in timelineEvents) {

--- a/packages/devtools_app/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_service.dart
@@ -150,7 +150,10 @@ class TimelineService {
             isCurrentScreen;
     final bool isRunning = serviceManager.serviceAvailable.isCompleted &&
         (!timelineController.frameBasedTimeline.pausedNotifier.value ||
-            timelineController.fullTimeline.recordingNotifier.value);
+            timelineController.fullTimeline.recordingNotifier.value) &&
+        (await serviceManager.service.getVMTimelineFlags())
+            .recordedStreams
+            .isNotEmpty;
     await _updateListeningState(
       shouldBeRunning: shouldBeRunning,
       isRunning: isRunning,
@@ -162,12 +165,10 @@ class TimelineService {
     @required bool isRunning,
   }) async {
     await serviceManager.serviceAvailable.future;
-    if (shouldBeRunning && isRunning && !timelineController.hasStarted) {
+    if (shouldBeRunning) {
       await startTimeline();
     } else if (shouldBeRunning && !isRunning) {
       timelineController.frameBasedTimeline.resume();
-      await allowedError(serviceManager.service
-          .setVMTimelineFlags(<String>['GC', 'Dart', 'Embedder']));
     } else if (!shouldBeRunning && isRunning) {
       // TODO(devoncarew): turn off the events
       timelineController.frameBasedTimeline.pause();

--- a/packages/devtools_app/lib/src/timeline/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_service.dart
@@ -148,9 +148,9 @@ class TimelineService {
                 timelineController.fullTimeline.recordingNotifier.value) &&
             !offlineMode &&
             isCurrentScreen;
-    final bool isRunning =
-        !timelineController.frameBasedTimeline.pausedNotifier.value ||
-            timelineController.fullTimeline.recordingNotifier.value;
+    final bool isRunning = serviceManager.serviceAvailable.isCompleted &&
+        (!timelineController.frameBasedTimeline.pausedNotifier.value ||
+            timelineController.fullTimeline.recordingNotifier.value);
     await _updateListeningState(
       shouldBeRunning: shouldBeRunning,
       isRunning: isRunning,

--- a/packages/devtools_app/lib/src/trees.dart
+++ b/packages/devtools_app/lib/src/trees.dart
@@ -144,6 +144,8 @@ class TreeNode<T extends TreeNode<T>> {
     while (node.level < level) {
       // Walk down the tree until we find the node at [level].
       if (node.children.isNotEmpty) {
+        // Since we have already ensured that [level] < [depth], at least one
+        // child is guaranteed to meet the firstWhere condition.
         node = node.children.firstWhere((n) => n.depth > level - n.level);
       }
     }

--- a/packages/devtools_app/lib/src/trees.dart
+++ b/packages/devtools_app/lib/src/trees.dart
@@ -137,6 +137,18 @@ class TreeNode<T extends TreeNode<T>> {
       returnCondition: condition,
     );
   }
+
+  T firstNodeAtLevel(int level) {
+    if (level >= depth) return null;
+    var node = this;
+    while (node.level < level) {
+      // Walk down the tree until we find the node at [level].
+      if (node.children.isNotEmpty) {
+        node = node.children.firstWhere((n) => n.depth > level - n.level);
+      }
+    }
+    return node;
+  }
 }
 
 /// Traverses a tree in breadth-first order.
@@ -147,8 +159,11 @@ class TreeNode<T extends TreeNode<T>> {
 /// searching for. [action] specifies an action that we will execute on each
 /// node. For example, if we need to traverse a tree and change a property on
 /// every single node, we would do this through the [action] param.
-T breadthFirstTraversal<T extends TreeNode<T>>(T root,
-    {bool returnCondition(T node), void action(T node)}) {
+T breadthFirstTraversal<T extends TreeNode<T>>(
+  T root, {
+  bool returnCondition(T node),
+  void action(T node),
+}) {
   final queue = Queue.of([root]);
   while (queue.isNotEmpty) {
     final node = queue.removeFirst();

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -389,7 +389,8 @@ class TimeRange {
 
   bool overlaps(TimeRange t) {
     return (t.start >= start && t.start <= end) ||
-        (t.end >= start && t.end <= end);
+        (t.end >= start && t.end <= end) ||
+        (t.start <= start && t.end >= end);
   }
 
   @override

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -387,11 +387,7 @@ class TimeRange {
 
   Duration get duration => end - start;
 
-  bool overlaps(TimeRange t) {
-    return (t.start >= start && t.start <= end) ||
-        (t.end >= start && t.end <= end) ||
-        (t.start <= start && t.end >= end);
-  }
+  bool overlaps(TimeRange t) => t.end > start && t.start < end;
 
   @override
   String toString({TimeUnit unit}) {
@@ -482,4 +478,13 @@ class Notifier {
 
 String toStringAsFixed(double num, [int fractionDigit = 1]) {
   return num.toStringAsFixed(fractionDigit);
+}
+
+extension NullSafeLast<T> on List<T> {
+  T nullSafeLast() {
+    if (isEmpty) {
+      return null;
+    }
+    return last;
+  }
 }

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -89,6 +89,7 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   final _vmTimelineFlags = <String, dynamic>{
     'type': 'TimelineFlags',
     'recordedStreams': [],
+    'availableStreams': [],
   };
 
   @override

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -117,7 +117,7 @@ void main() {
 
     test('initializeEventBuckets', () {
       expect(timelineData.eventGroups, isEmpty);
-      timelineData.initializeEventBuckets();
+      timelineData.initializeEventGroups();
       expect(
         timelineData.eventGroups[FullTimelineData.uiKey].eventsByRow[0].length,
         equals(1),

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -116,31 +116,32 @@ void main() {
     });
 
     test('initializeEventBuckets', () {
-      expect(timelineData.eventBuckets, isEmpty);
+      expect(timelineData.eventGroups, isEmpty);
       timelineData.initializeEventBuckets();
       expect(
-        timelineData.eventBuckets[FullTimelineData.uiKey].length,
+        timelineData.eventGroups[FullTimelineData.uiKey].eventsByRow[0].length,
         equals(1),
       );
       expect(
-        timelineData.eventBuckets[FullTimelineData.gpuKey].length,
+        timelineData.eventGroups[FullTimelineData.gpuKey].eventsByRow[0].length,
         equals(1),
       );
       expect(
-        timelineData.eventBuckets[FullTimelineData.unknownKey].length,
+        timelineData
+            .eventGroups[FullTimelineData.unknownKey].eventsByRow[0].length,
         equals(1),
       );
-      expect(timelineData.eventBuckets['A'].length, equals(1));
+      expect(timelineData.eventGroups['A'].eventsByRow[0].length, equals(1));
     });
 
     test('event bucket compare', () {
-      expect(FullTimelineData.eventBucketComparator('UI', 'GPU'), equals(-1));
-      expect(FullTimelineData.eventBucketComparator('GPU', 'UI'), equals(1));
-      expect(FullTimelineData.eventBucketComparator('UI', 'UI'), equals(0));
-      expect(FullTimelineData.eventBucketComparator('UI', 'Async'), equals(1));
-      expect(FullTimelineData.eventBucketComparator('A', 'B'), equals(-1));
+      expect(FullTimelineData.eventGroupComparator('UI', 'GPU'), equals(-1));
+      expect(FullTimelineData.eventGroupComparator('GPU', 'UI'), equals(1));
+      expect(FullTimelineData.eventGroupComparator('UI', 'UI'), equals(0));
+      expect(FullTimelineData.eventGroupComparator('UI', 'Async'), equals(1));
+      expect(FullTimelineData.eventGroupComparator('A', 'B'), equals(-1));
       expect(
-        FullTimelineData.eventBucketComparator('Z', 'Unknown'),
+        FullTimelineData.eventGroupComparator('Z', 'Unknown'),
         equals(-1),
       );
     });

--- a/packages/devtools_app/test/trees_test.dart
+++ b/packages/devtools_app/test/trees_test.dart
@@ -94,27 +94,35 @@ void main() {
       expect(parent.children.first, equals(child));
       expect(child.parent, equals(parent));
     });
-  });
 
-  test('containsChildWithCondition', () {
-    expect(
-      treeNode0.containsChildWithCondition((TestTreeNode node) {
-        return node == treeNode1;
-      }),
-      isTrue,
-    );
-    expect(
-      treeNode0.containsChildWithCondition((TestTreeNode node) {
-        return node.children.length == 2;
-      }),
-      isTrue,
-    );
-    expect(
-      treeNode0.containsChildWithCondition((TestTreeNode node) {
-        return node.isExpanded;
-      }),
-      isFalse,
-    );
+    test('containsChildWithCondition', () {
+      expect(
+        treeNode0.containsChildWithCondition((TestTreeNode node) {
+          return node == treeNode1;
+        }),
+        isTrue,
+      );
+      expect(
+        treeNode0.containsChildWithCondition((TestTreeNode node) {
+          return node.children.length == 2;
+        }),
+        isTrue,
+      );
+      expect(
+        treeNode0.containsChildWithCondition((TestTreeNode node) {
+          return node.isExpanded;
+        }),
+        isFalse,
+      );
+    });
+
+    test('firstNodeAtLevel', () {
+      expect(testTreeNode.firstNodeAtLevel(0), equals(treeNode0));
+      expect(testTreeNode.firstNodeAtLevel(1), equals(treeNode1));
+      expect(testTreeNode.firstNodeAtLevel(2), equals(treeNode3));
+      expect(testTreeNode.firstNodeAtLevel(3), equals(treeNode5));
+      expect(testTreeNode.firstNodeAtLevel(4), isNull);
+    });
   });
 }
 

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -143,6 +143,9 @@ void main() {
       final overlapEnd = TimeRange()
         ..start = const Duration(milliseconds: 150)
         ..end = const Duration(milliseconds: 250);
+      final overlapAll = TimeRange()
+        ..start = const Duration(milliseconds: 50)
+        ..end = const Duration(milliseconds: 250);
       final noOverlap = TimeRange()
         ..start = const Duration(milliseconds: 300)
         ..end = const Duration(milliseconds: 400);
@@ -151,6 +154,7 @@ void main() {
       expect(t.overlaps(overlapBeginning), isTrue);
       expect(t.overlaps(overlapMiddle), isTrue);
       expect(t.overlaps(overlapEnd), isTrue);
+      expect(t.overlaps(overlapAll), isTrue);
       expect(t.overlaps(noOverlap), isFalse);
     });
 

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -331,6 +331,17 @@ void main() {
         expect(safeDivide(-50.0, 0.0, ifNotFinite: 10.0), 10.0);
       });
     });
+
+    group('null safe list', () {
+      test('nullSafeLast', () {
+        final list = [];
+        expect(list.nullSafeLast(), isNull);
+        list.addAll([1, 2, 3]);
+        expect(list.nullSafeLast(), equals(3));
+        list.add(null);
+        expect(list.nullSafeLast(), isNull);
+      });
+    });
   });
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1319. This is how Catapult renders overlapping events.

This both fixes a P0 for dream (g3) and unblocks further optimization on the Flutter implementation of the DevTools timeline (win-win!).

Before:
![image](https://user-images.githubusercontent.com/43759233/69686038-4699f600-1073-11ea-9798-00ad1b12d71d.png)
After:
<img width="852" alt="Screen Shot 2019-11-26 at 4 17 59 PM" src="https://user-images.githubusercontent.com/43759233/69686055-51548b00-1073-11ea-9246-58a8d60a784a.png">
