### PR TITLE
Some flutter flame chart optimizations.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -252,6 +252,8 @@ class FlameChartNode<T> {
 
   static const _selectedNodeColor = mainUiColorSelectedLight;
 
+  static const _minWidthForText = 16.0;
+
   final Key key;
   final Rect rect;
   final String text;
@@ -273,10 +275,10 @@ class FlameChartNode<T> {
         child: Container(
           width: rect.width,
           height: rect.height,
-          padding: const EdgeInsets.only(left: 6.0),
+          padding: const EdgeInsets.symmetric(horizontal: 6.0),
           alignment: Alignment.centerLeft,
           color: selected ? _selectedNodeColor : backgroundColor,
-          child: rect.width > 10.0
+          child: rect.width > _minWidthForText
               ? Text(
                   text,
                   textAlign: TextAlign.left,

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -89,6 +89,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     return LayoutBuilder(
       builder: (context, constraints) {
         return ListView.builder(
+          addAutomaticKeepAlives: false,
           itemCount: rows.length,
           itemBuilder: (context, index) {
             return ScrollingFlameChartRow<V>(
@@ -174,6 +175,10 @@ class _ScrollingFlameChartRowState extends State<ScrollingFlameChartRow>
             height: rowHeightWithPadding,
             width: widget.width,
             child: ListView.builder(
+              addAutomaticKeepAlives: false,
+              // The flame chart nodes are inexpensive to paint, so removing the
+              // repaint boundary improves efficiency.
+              addRepaintBoundaries: false,
               controller: scrollController,
               scrollDirection: Axis.horizontal,
               itemCount: nodes.length,
@@ -259,28 +264,28 @@ class FlameChartNode<T> {
 
   Widget buildWidget(bool selected) {
     selected = selectable ? selected : false;
-    return SizedBox(
-      width: rect.width,
-      height: rect.height,
-      child: Tooltip(
-        message: tooltip,
-        waitDuration: tooltipWait,
-        preferBelow: false,
-        child: InkWell(
-          onTap: () => onSelected(data),
-          child: Container(
-            padding: const EdgeInsets.only(left: 6.0),
-            alignment: Alignment.centerLeft,
-            color: selected ? _selectedNodeColor : backgroundColor,
-            child: Text(
-              text,
-              textAlign: TextAlign.left,
-              overflow: TextOverflow.ellipsis,
-              style: TextStyle(
-                color: selected ? Colors.black : textColor,
-              ),
-            ),
-          ),
+    return Tooltip(
+      message: tooltip,
+      waitDuration: tooltipWait,
+      preferBelow: false,
+      child: GestureDetector(
+        onTap: () => onSelected(data),
+        child: Container(
+          width: rect.width,
+          height: rect.height,
+          padding: const EdgeInsets.only(left: 6.0),
+          alignment: Alignment.centerLeft,
+          color: selected ? _selectedNodeColor : backgroundColor,
+          child: rect.width > 10.0
+              ? Text(
+                  text,
+                  textAlign: TextAlign.left,
+                  overflow: TextOverflow.ellipsis,
+                  style: TextStyle(
+                    color: selected ? Colors.black : textColor,
+                  ),
+                )
+              : const SizedBox(),
         ),
       ),
     );


### PR DESCRIPTION
- disable `addAutomaticKeepAlives` for both vertical list and horizontal lists (rows)
- disable `addRepaintBoundaries ` for horizontal lists (rows), since the flame chart nodes are cheap to paint
- simplify flame chart node widget
- set min width for text on flame chart node widget