### PR TITLE
[Story of Your Layout] Fix null queries and make it faster

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/story_of_your_layout/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/story_of_your_layout/flex.dart
@@ -240,7 +240,7 @@ class _StoryOfYourFlexWidgetState extends State<StoryOfYourFlexWidget>
   Future<FlexLayoutProperties> fetchFlexLayoutProperties() async {
     objectGroupManager?.cancelNext();
     final nextObjectGroup = objectGroupManager.next;
-    final node = await nextObjectGroup.getDetailsSubtreeWithRenderObject(
+    final node = await nextObjectGroup.getSummarySubtreeWithRenderObject(
       getRoot(selectedNode),
       subtreeDepth: 1,
     );

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -955,13 +955,14 @@ class ObjectGroup {
     ));
   }
 
-  Future<RemoteDiagnosticsNode> getDetailsSubtreeWithRenderObject(
+  Future<RemoteDiagnosticsNode> getSummarySubtreeWithRenderObject(
     RemoteDiagnosticsNode node, {
     int subtreeDepth = 1,
   }) async {
     if (node == null) return null;
     final id = node.dartDiagnosticRef.id;
     String command = '''
+      if (SchedulerBinding.instance.schedulerPhase != SchedulerPhase.idle) return null; 
       final root = WidgetInspectorService.instance.toObject('$id');
       if (root == null) {
         return null;
@@ -970,9 +971,9 @@ class ObjectGroup {
         root,
         InspectorSerializationDelegate(
             groupName: '$groupName',
-            summaryTree: false,
+            summaryTree: true,
             subtreeDepth: $subtreeDepth,
-            includeProperties: true,
+            includeProperties: false,
             service: WidgetInspectorService.instance,
             addAdditionalPropertiesCallback: (node, delegate) {
               final Map<String, Object> additionalJson = <String, Object>{};
@@ -1020,7 +1021,11 @@ class ObjectGroup {
       return WidgetInspectorService.instance._safeJsonEncode(result);
     ''';
     command = '((){${command.split('\n').join()}})()';
-    final result = await inspectorLibrary.eval(command, isAlive: this);
+    InstanceRef result;
+    while (true) {
+      result = await inspectorLibrary.eval(command, isAlive: this);
+      if(result != null) break;
+    }
     return await parseDiagnosticsNodeDaemon(instanceRefToJson(result));
   }
 }

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -1024,7 +1024,7 @@ class ObjectGroup {
     InstanceRef result;
     while (true) {
       result = await inspectorLibrary.eval(command, isAlive: this);
-      if(result != null) break;
+      if (result != null) break;
     }
     return await parseDiagnosticsNodeDaemon(instanceRefToJson(result));
   }


### PR DESCRIPTION
as @DaveShuckerow  pointed out, currently the query can return null if the render object is still laying out, this fixes that and also try to make the query faster by not including properties