### PR TITLE
[Story of Layout] Disable feature on unsupported Flutter version (< 1.12.16)

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -46,6 +46,7 @@ class InspectorScreenBody extends StatefulWidget {
 class _InspectorScreenBodyState extends State<InspectorScreenBody>
     with BlockingActionMixin, AutoDisposeMixin {
   bool _expandCollapseSupported = false;
+  bool _layoutDetailsSupported = false;
   bool connectionInProgress = false;
   InspectorService inspectorService;
 
@@ -151,6 +152,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
               detailsTree: detailsTree,
               controller: inspectorController,
               actionButtons: _expandCollapseButtons(),
+              layoutDetailsSupported: _layoutDetailsSupported,
             ),
           ),
         ),
@@ -203,6 +205,12 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
     });
   }
 
+  void _onLayoutDetailsSupported() {
+    setState(() {
+      _layoutDetailsSupported = true;
+    });
+  }
+
   void _handleConnectionStart(VmService service) async {
     setState(() {
       connectionInProgress = true;
@@ -233,6 +241,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         inspectorService: inspectorService,
         treeType: FlutterTreeType.widget,
         onExpandCollapseSupported: _onExpandCollapseSupported,
+        onLayoutDetailsSupported: _onLayoutDetailsSupported,
       );
 
       // TODO(jacobr): move this notice display to once a day.

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -15,12 +15,14 @@ class InspectorDetailsTabController extends StatelessWidget {
     this.detailsTree,
     this.actionButtons,
     this.controller,
+    this.layoutDetailsSupported,
     Key key,
   }) : super(key: key);
 
   final Widget detailsTree;
   final Widget actionButtons;
   final InspectorController controller;
+  final bool layoutDetailsSupported;
 
   Widget _buildTab(String tabName) {
     return Tab(
@@ -35,15 +37,16 @@ class InspectorDetailsTabController extends StatelessWidget {
   Widget build(BuildContext context) {
     final tabs = <Tab>[
       _buildTab('Details Tree'),
-      _buildTab('Layout Details'),
+      if (layoutDetailsSupported) _buildTab('Layout Details'),
     ];
     final tabViews = <Widget>[
       detailsTree,
-      Banner(
-        message: 'PROTOTYPE',
-        location: BannerLocation.topStart,
-        child: LayoutDetailsTab(controller: controller),
-      ),
+      if (layoutDetailsSupported)
+        Banner(
+          message: 'PROTOTYPE',
+          location: BannerLocation.topStart,
+          child: LayoutDetailsTab(controller: controller),
+        ),
     ];
     final focusColor = Theme.of(context).focusColor;
     return Container(

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -41,12 +41,7 @@ class InspectorDetailsTabController extends StatelessWidget {
     ];
     final tabViews = <Widget>[
       detailsTree,
-      if (layoutDetailsSupported)
-        Banner(
-          message: 'PROTOTYPE',
-          location: BannerLocation.topStart,
-          child: LayoutDetailsTab(controller: controller),
-        ),
+      if (layoutDetailsSupported) LayoutDetailsTab(controller: controller),
     ];
     final focusColor = Theme.of(context).focusColor;
     return Container(

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -64,6 +64,7 @@ class InspectorController extends DisposableController
     this.parent,
     this.isSummaryTree = true,
     this.onExpandCollapseSupported,
+    this.onLayoutDetailsSupported,
   })  : _treeGroups = InspectorObjectGroupManager(inspectorService, 'tree'),
         _selectionGroups =
             InspectorObjectGroupManager(inspectorService, 'selection') {
@@ -98,6 +99,7 @@ class InspectorController extends DisposableController
     });
 
     _checkForExpandCollapseSupport();
+    _checkForLayoutDetailsSupport();
 
     // This logic only needs to be run once so run it in the outermost
     // controller.
@@ -175,6 +177,8 @@ class InspectorController extends DisposableController
 
   final VoidFunction onExpandCollapseSupported;
 
+  final VoidFunction onLayoutDetailsSupported;
+
   /// Parent InspectorController if this is a details subtree.
   InspectorController parent;
 
@@ -205,6 +209,7 @@ class InspectorController extends DisposableController
 
   /// Node being highlighted due to the current hover.
   InspectorTreeNode get currentShowNode => inspectorTree.hover;
+
   set currentShowNode(InspectorTreeNode node) => inspectorTree.hover = node;
 
   bool flutterAppFrameReady = false;
@@ -846,25 +851,38 @@ class InspectorController extends DisposableController
     details.animateTo(details.inspectorTree.selection);
   }
 
-  void _checkForExpandCollapseSupport() {
-    if (onExpandCollapseSupported == null) return;
-
+  /// execute given [callback] when minimum Flutter [version] is met.
+  void _onVersionSupported(SemanticVersion version, Function callback) {
     serviceManager.hasRegisteredService(
       registrations.flutterVersion.service,
       (serviceAvailable) async {
         if (serviceAvailable) {
           final flutterVersion = FlutterVersion.parse(
               (await serviceManager.getFlutterVersion()).json);
-          // Configurable subtree depth is available in versions of Flutter
-          // greater than or equal to 1.9.7, but the flutterVersion service is
-          // not available until 1.10.1, so we will check for 1.10.1 here.
-          if (flutterVersion.isSupported(
-              supportedVersion:
-                  SemanticVersion(major: 1, minor: 10, patch: 1))) {
-            onExpandCollapseSupported();
+          if (flutterVersion.isSupported(supportedVersion: version)) {
+            callback();
           }
         }
       },
+    );
+  }
+
+  void _checkForExpandCollapseSupport() {
+    if (onExpandCollapseSupported == null) return;
+    // Configurable subtree depth is available in versions of Flutter
+    // greater than or equal to 1.9.7, but the flutterVersion service is
+    // not available until 1.10.1, so we will check for 1.10.1 here.
+    _onVersionSupported(
+      SemanticVersion(major: 1, minor: 10, patch: 1),
+      onExpandCollapseSupported,
+    );
+  }
+
+  void _checkForLayoutDetailsSupport() {
+    if (onExpandCollapseSupported == null) return;
+    _onVersionSupported(
+      SemanticVersion(major: 1, minor: 12, patch: 16),
+      onLayoutDetailsSupported,
     );
   }
 }

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -852,7 +852,7 @@ class InspectorController extends DisposableController
   }
 
   /// execute given [callback] when minimum Flutter [version] is met.
-  void _onVersionSupported(SemanticVersion version, Function callback) {
+  void _onVersionSupported(SemanticVersion version, VoidCallback callback) {
     serviceManager.hasRegisteredService(
       registrations.flutterVersion.service,
       (serviceAvailable) async {


### PR DESCRIPTION
Fixes #1406.
Disable Layout Details tab and it's features on Flutter version less than *1.12.6*.