### PR TITLE
Fix broken inspector using ValueNotifiers instead of Streams for service registration

### DIFF
--- a/packages/devtools_app/lib/src/info/info_controller.dart
+++ b/packages/devtools_app/lib/src/info/info_controller.dart
@@ -40,22 +40,19 @@ class InfoController extends DisposableController
 
   Future<void> _listenForFlutterVersionChanges() async {
     if (await serviceManager.connectedApp.isAnyFlutterApp) {
-      autoDispose(
-        serviceManager.hasRegisteredService(
-          registrations.flutterVersion.service,
-          (bool serviceAvailable) async {
-            if (serviceAvailable &&
-                !flutterVersionServiceAvailable.isCompleted) {
-              flutterVersionServiceAvailable.complete();
-              final FlutterVersion version = FlutterVersion.parse(
-                  (await serviceManager.getFlutterVersion()).json);
-              onFlutterVersionChanged(version);
-            } else {
-              onFlutterVersionChanged(null);
-            }
-          },
-        ),
-      );
+      final flutterVersionServiceListenable = serviceManager
+          .getRegisteredServiceListenable(registrations.flutterVersion.service);
+      addAutoDisposeListener(flutterVersionServiceListenable, () async {
+        final serviceAvailable = flutterVersionServiceListenable.value;
+        if (serviceAvailable && !flutterVersionServiceAvailable.isCompleted) {
+          flutterVersionServiceAvailable.complete();
+          final FlutterVersion version = FlutterVersion.parse(
+              (await serviceManager.getFlutterVersion()).json);
+          onFlutterVersionChanged(version);
+        } else {
+          onFlutterVersionChanged(null);
+        }
+      });
     } else {
       onFlutterVersionChanged(null);
     }

--- a/packages/devtools_app/lib/src/info/info_controller.dart
+++ b/packages/devtools_app/lib/src/info/info_controller.dart
@@ -41,7 +41,7 @@ class InfoController extends DisposableController
   Future<void> _listenForFlutterVersionChanges() async {
     if (await serviceManager.connectedApp.isAnyFlutterApp) {
       final flutterVersionServiceListenable = serviceManager
-          .getRegisteredServiceListenable(registrations.flutterVersion.service);
+          .registeredServiceListenable(registrations.flutterVersion.service);
       addAutoDisposeListener(flutterVersionServiceListenable, () async {
         final serviceAvailable = flutterVersionServiceListenable.value;
         if (serviceAvailable && !flutterVersionServiceAvailable.isCompleted) {

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -16,7 +16,6 @@ import '../../service_extensions.dart' as extensions;
 import '../../ui/flutter/label.dart';
 import '../../ui/flutter/service_extension_widgets.dart';
 import '../../ui/icons.dart';
-import '../../utils.dart';
 import '../inspector_controller.dart';
 import '../inspector_service.dart';
 import 'inspector_screen_details_tab.dart';
@@ -241,9 +240,8 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         detailsTree: detailsTreeController,
         inspectorService: inspectorService,
         treeType: FlutterTreeType.widget,
-        onExpandCollapseSupported:
-            SingleRunCallback(_onExpandCollapseSupported),
-        onLayoutDetailsSupported: SingleRunCallback(_onLayoutDetailsSupported),
+        onExpandCollapseSupported: _onExpandCollapseSupported,
+        onLayoutDetailsSupported: _onLayoutDetailsSupported,
       );
 
       // TODO(jacobr): move this notice display to once a day.

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -16,6 +16,7 @@ import '../../service_extensions.dart' as extensions;
 import '../../ui/flutter/label.dart';
 import '../../ui/flutter/service_extension_widgets.dart';
 import '../../ui/icons.dart';
+import '../../utils.dart';
 import '../inspector_controller.dart';
 import '../inspector_service.dart';
 import 'inspector_screen_details_tab.dart';
@@ -240,8 +241,9 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         detailsTree: detailsTreeController,
         inspectorService: inspectorService,
         treeType: FlutterTreeType.widget,
-        onExpandCollapseSupported: _onExpandCollapseSupported,
-        onLayoutDetailsSupported: _onLayoutDetailsSupported,
+        onExpandCollapseSupported:
+            SingleRunCallback(_onExpandCollapseSupported),
+        onLayoutDetailsSupported: SingleRunCallback(_onLayoutDetailsSupported),
       );
 
       // TODO(jacobr): move this notice display to once a day.

--- a/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
@@ -23,7 +23,6 @@ import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/service_extension_elements.dart';
 import '../ui/ui_utils.dart';
-import '../utils.dart';
 import 'inspector_controller.dart';
 import 'inspector_service.dart';
 import 'inspector_tree.dart';
@@ -165,7 +164,7 @@ class HtmlInspectorScreen extends HtmlScreen {
       detailsTree: detailsInspectorTree,
       inspectorService: inspectorService,
       treeType: FlutterTreeType.widget,
-      onExpandCollapseSupported: SingleRunCallback(_onExpandCollapseSupported),
+      onExpandCollapseSupported: _onExpandCollapseSupported,
     );
 
     final elements = <Element>[

--- a/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/html_inspector_screen.dart
@@ -5,9 +5,9 @@
 library inspector;
 
 import 'dart:async';
+
 import 'package:html_shim/html.dart' show Element;
 import 'package:html_shim/html.dart' as html;
-
 import 'package:split/split.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -23,6 +23,7 @@ import '../ui/icons.dart';
 import '../ui/primer.dart';
 import '../ui/service_extension_elements.dart';
 import '../ui/ui_utils.dart';
+import '../utils.dart';
 import 'inspector_controller.dart';
 import 'inspector_service.dart';
 import 'inspector_tree.dart';
@@ -164,7 +165,7 @@ class HtmlInspectorScreen extends HtmlScreen {
       detailsTree: detailsInspectorTree,
       inspectorService: inspectorService,
       treeType: FlutterTreeType.widget,
-      onExpandCollapseSupported: _onExpandCollapseSupported,
+      onExpandCollapseSupported: SingleRunCallback(_onExpandCollapseSupported),
     );
 
     final elements = <Element>[

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -175,9 +175,9 @@ class InspectorController extends DisposableController
 
   final bool isSummaryTree;
 
-  final VoidFunction onExpandCollapseSupported;
+  final SingleRunCallback onExpandCollapseSupported;
 
-  final VoidFunction onLayoutDetailsSupported;
+  final SingleRunCallback onLayoutDetailsSupported;
 
   /// Parent InspectorController if this is a details subtree.
   InspectorController parent;
@@ -852,19 +852,22 @@ class InspectorController extends DisposableController
   }
 
   /// execute given [callback] when minimum Flutter [version] is met.
-  void _onVersionSupported(SemanticVersion version, VoidCallback callback) {
-    serviceManager.hasRegisteredService(
+  void _onVersionSupported(
+    SemanticVersion version,
+    SingleRunCallback callback,
+  ) {
+    autoDispose(serviceManager.hasRegisteredService(
       registrations.flutterVersion.service,
       (serviceAvailable) async {
         if (serviceAvailable) {
           final flutterVersion = FlutterVersion.parse(
               (await serviceManager.getFlutterVersion()).json);
           if (flutterVersion.isSupported(supportedVersion: version)) {
-            callback();
+            callback.run();
           }
         }
       },
-    );
+    ));
   }
 
   void _checkForExpandCollapseSupport() {
@@ -879,7 +882,7 @@ class InspectorController extends DisposableController
   }
 
   void _checkForLayoutDetailsSupport() {
-    if (onExpandCollapseSupported == null) return;
+    if (onLayoutDetailsSupported == null) return;
     _onVersionSupported(
       SemanticVersion(major: 1, minor: 12, patch: 16),
       onLayoutDetailsSupported,

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -175,9 +175,9 @@ class InspectorController extends DisposableController
 
   final bool isSummaryTree;
 
-  final SingleRunCallback onExpandCollapseSupported;
+  final VoidCallback onExpandCollapseSupported;
 
-  final SingleRunCallback onLayoutDetailsSupported;
+  final VoidCallback onLayoutDetailsSupported;
 
   /// Parent InspectorController if this is a details subtree.
   InspectorController parent;
@@ -854,20 +854,20 @@ class InspectorController extends DisposableController
   /// execute given [callback] when minimum Flutter [version] is met.
   void _onVersionSupported(
     SemanticVersion version,
-    SingleRunCallback callback,
+    VoidCallback callback,
   ) {
-    autoDispose(serviceManager.hasRegisteredService(
-      registrations.flutterVersion.service,
-      (serviceAvailable) async {
-        if (serviceAvailable) {
-          final flutterVersion = FlutterVersion.parse(
-              (await serviceManager.getFlutterVersion()).json);
-          if (flutterVersion.isSupported(supportedVersion: version)) {
-            callback.run();
-          }
+    final flutterVersionServiceListenable = serviceManager
+        .getRegisteredServiceListenable(registrations.flutterVersion.service);
+    addAutoDisposeListener(flutterVersionServiceListenable, () async {
+      final registered = flutterVersionServiceListenable.value;
+      if (registered) {
+        final flutterVersion = FlutterVersion.parse(
+            (await serviceManager.getFlutterVersion()).json);
+        if (flutterVersion.isSupported(supportedVersion: version)) {
+          callback();
         }
-      },
-    ));
+      }
+    });
   }
 
   void _checkForExpandCollapseSupport() {

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -857,7 +857,7 @@ class InspectorController extends DisposableController
     VoidCallback callback,
   ) {
     final flutterVersionServiceListenable = serviceManager
-        .getRegisteredServiceListenable(registrations.flutterVersion.service);
+        .registeredServiceListenable(registrations.flutterVersion.service);
     addAutoDisposeListener(flutterVersionServiceListenable, () async {
       final registered = flutterVersionServiceListenable.value;
       if (registered) {

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -278,7 +278,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
 
   void _initHotReloadRestartServiceListeners() {
     final hotReloadListenable = serviceManager
-        .getRegisteredServiceListenable(registrations.hotReload.service);
+        .registeredServiceListenable(registrations.hotReload.service);
     hotReloadListenable.addListener(() {
       final reloadServiceAvailable = hotReloadListenable.value;
       if (reloadServiceAvailable) {
@@ -289,7 +289,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
     });
 
     final hotRestartListenable = serviceManager
-        .getRegisteredServiceListenable(registrations.hotReload.service);
+        .registeredServiceListenable(registrations.hotReload.service);
     hotRestartListenable.addListener(() {
       final restartServiceAvailable = hotRestartListenable.value;
       if (restartServiceAvailable) {

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -277,27 +277,27 @@ class HtmlPerfToolFramework extends HtmlFramework {
   }
 
   void _initHotReloadRestartServiceListeners() {
-    serviceManager.hasRegisteredService(
-      registrations.hotReload.service,
-      (bool reloadServiceAvailable) {
-        if (reloadServiceAvailable) {
-          _buildReloadButton();
-        } else {
-          removeGlobalAction(_reloadActionId);
-        }
-      },
-    );
+    final hotReloadListenable = serviceManager
+        .getRegisteredServiceListenable(registrations.hotReload.service);
+    hotReloadListenable.addListener(() {
+      final reloadServiceAvailable = hotReloadListenable.value;
+      if (reloadServiceAvailable) {
+        _buildReloadButton();
+      } else {
+        removeGlobalAction(_reloadActionId);
+      }
+    });
 
-    serviceManager.hasRegisteredService(
-      registrations.hotRestart.service,
-      (bool reloadServiceAvailable) {
-        if (reloadServiceAvailable) {
-          _buildRestartButton();
-        } else {
-          removeGlobalAction(_restartActionId);
-        }
-      },
-    );
+    final hotRestartListenable = serviceManager
+        .getRegisteredServiceListenable(registrations.hotReload.service);
+    hotRestartListenable.addListener(() {
+      final restartServiceAvailable = hotRestartListenable.value;
+      if (restartServiceAvailable) {
+        _buildRestartButton();
+      } else {
+        removeGlobalAction(_restartActionId);
+      }
+    });
   }
 
   void _buildReloadButton() async {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -99,7 +99,7 @@ class ServiceConnectionManager {
     );
   }
 
-  ValueListenable<bool> getRegisteredServiceListenable(String name) {
+  ValueListenable<bool> registeredServiceListenable(String name) {
     final listenable = _registeredServiceNotifiers.putIfAbsent(
       name,
       () => ImmediateValueNotifier(false),

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -16,6 +16,7 @@ import 'service_extensions.dart' as extensions;
 import 'service_registrations.dart' as registrations;
 import 'stream_value_listenable.dart';
 import 'ui/fake_flutter/fake_flutter.dart';
+import 'utils.dart';
 import 'vm_service_wrapper.dart';
 
 // TODO(kenz): add an offline service manager implementation.
@@ -50,12 +51,11 @@ class ServiceConnectionManager {
     return _serviceCapabilities;
   }
 
-  final Map<String, StreamController<bool>> _serviceRegistrationController =
-      <String, StreamController<bool>>{};
-  final Map<String, List<String>> _registeredMethodsForService = {};
+  final _registeredServiceNotifiers = <String, ImmediateValueNotifier<bool>>{};
 
   Map<String, List<String>> get registeredMethodsForService =>
       _registeredMethodsForService;
+  final Map<String, List<String>> _registeredMethodsForService = {};
 
   IsolateManager _isolateManager;
   ServiceExtensionManager _serviceExtensionManager;
@@ -99,27 +99,12 @@ class ServiceConnectionManager {
     );
   }
 
-  StreamSubscription<bool> hasRegisteredService(
-    String name,
-    void onData(bool value),
-  ) {
-    if (_registeredMethodsForService.containsKey(name) && onData != null) {
-      onData(true);
-    }
-    final StreamController<bool> streamController =
-        _getServiceRegistrationController(name);
-    return streamController.stream.listen(onData);
-  }
-
-  StreamController<bool> _getServiceRegistrationController(String name) {
-    return _getStreamController(
+  ValueListenable<bool> getRegisteredServiceListenable(String name) {
+    final listenable = _registeredServiceNotifiers.putIfAbsent(
       name,
-      _serviceRegistrationController,
-      onFirstListenerSubscribed: () {
-        _serviceRegistrationController[name]
-            .add(_registeredMethodsForService.containsKey(name));
-      },
+      () => ImmediateValueNotifier(false),
     );
+    return listenable;
   }
 
   Future<void> vmServiceOpened(
@@ -145,14 +130,25 @@ class ServiceConnectionManager {
 
     void handleServiceEvent(Event e) {
       if (e.kind == EventKind.kServiceRegistered) {
-        if (!_registeredMethodsForService.containsKey(e.service)) {
-          _registeredMethodsForService[e.service] = [e.method];
-          final StreamController<bool> streamController =
-              _getServiceRegistrationController(e.service);
-          streamController.add(true);
-        } else {
-          _registeredMethodsForService[e.service].add(e.method);
-        }
+        final serviceName = e.service;
+        _registeredMethodsForService
+            .putIfAbsent(serviceName, () => [])
+            .add(e.method);
+        final serviceNotifier = _registeredServiceNotifiers.putIfAbsent(
+          serviceName,
+          () => ImmediateValueNotifier(true),
+        );
+        serviceNotifier.value = true;
+      }
+
+      if (e.kind == EventKind.kServiceUnregistered) {
+        final serviceName = e.service;
+        _registeredMethodsForService.remove(serviceName);
+        final serviceNotifier = _registeredServiceNotifiers.putIfAbsent(
+          serviceName,
+          () => ImmediateValueNotifier(false),
+        );
+        serviceNotifier.value = false;
       }
     }
 

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -234,7 +234,7 @@ class _RegisteredServiceExtensionButtonState
 
     // Only show the button if the device supports the given service.
     final serviceRegisteredListenable = serviceManager
-        .getRegisteredServiceListenable(widget.serviceDescription.service);
+        .registeredServiceListenable(widget.serviceDescription.service);
     addAutoDisposeListener(serviceRegisteredListenable, () {
       final registered = serviceRegisteredListenable.value;
       setState(() {

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -231,17 +231,16 @@ class _RegisteredServiceExtensionButtonState
   @override
   void initState() {
     super.initState();
+
     // Only show the button if the device supports the given service.
-    autoDispose(
-      serviceManager.hasRegisteredService(
-        widget.serviceDescription.service,
-        (registered) {
-          setState(() {
-            _hidden = !registered;
-          });
-        },
-      ),
-    );
+    final serviceRegisteredListenable = serviceManager
+        .getRegisteredServiceListenable(widget.serviceDescription.service);
+    addAutoDisposeListener(serviceRegisteredListenable, () {
+      final registered = serviceRegisteredListenable.value;
+      setState(() {
+        _hidden = !registered;
+      });
+    });
   }
 
   @override

--- a/packages/devtools_app/lib/src/ui/service_extension_elements.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_elements.dart
@@ -170,12 +170,12 @@ class RegisteredServiceExtensionButton {
       ..hidden(true);
 
     // Only show the button if the device supports the given service.
-    serviceManager.hasRegisteredService(
-      serviceDescription.service,
-      (registered) {
-        button.hidden(!registered);
-      },
-    );
+    final serviceRegisteredListenable = serviceManager
+        .getRegisteredServiceListenable(serviceDescription.service);
+    serviceRegisteredListenable.addListener(() {
+      final registered = serviceRegisteredListenable.value;
+      button.hidden(!registered);
+    });
 
     button.click(() => _click());
   }

--- a/packages/devtools_app/lib/src/ui/service_extension_elements.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_elements.dart
@@ -170,8 +170,8 @@ class RegisteredServiceExtensionButton {
       ..hidden(true);
 
     // Only show the button if the device supports the given service.
-    final serviceRegisteredListenable = serviceManager
-        .getRegisteredServiceListenable(serviceDescription.service);
+    final serviceRegisteredListenable =
+        serviceManager.registeredServiceListenable(serviceDescription.service);
     serviceRegisteredListenable.addListener(() {
       final registered = serviceRegisteredListenable.value;
       button.hidden(!registered);

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -199,6 +199,21 @@ typedef VoidFunction = void Function();
 /// future.
 typedef VoidAsyncFunction = Future<void> Function();
 
+class SingleRunCallback {
+  SingleRunCallback(this._callback);
+
+  final VoidFunction _callback;
+
+  bool hasRan = false;
+
+  void run() {
+    if (!hasRan) {
+      _callback();
+      hasRan = true;
+    }
+  }
+}
+
 /// Batch up calls to the given closure. Repeated calls to [invoke] will
 /// overwrite the closure to be called. We'll delay at least [minDelay] before
 /// calling the closure, but will not delay more than [maxDelay].

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -199,21 +199,6 @@ typedef VoidFunction = void Function();
 /// future.
 typedef VoidAsyncFunction = Future<void> Function();
 
-class SingleRunCallback {
-  SingleRunCallback(this._callback);
-
-  final VoidFunction _callback;
-
-  bool hasRan = false;
-
-  void run() {
-    if (!hasRan) {
-      _callback();
-      hasRan = true;
-    }
-  }
-}
-
 /// Batch up calls to the given closure. Repeated calls to [invoke] will
 /// overwrite the closure to be called. We'll delay at least [minDelay] before
 /// calling the closure, but will not delay more than [maxDelay].
@@ -527,6 +512,18 @@ class ValueReporter<T> extends Reporter implements ValueListenable<T> {
 
 String toStringAsFixed(double num, [int fractionDigit = 1]) {
   return num.toStringAsFixed(fractionDigit);
+}
+
+/// A value notifier that calls each listener immediately when registered.
+class ImmediateValueNotifier<T> extends ValueNotifier<T> {
+  ImmediateValueNotifier(T value) : super(value);
+
+  /// Adds a listener and calls the listener upon registration.
+  @override
+  void addListener(VoidCallback listener) {
+    super.addListener(listener);
+    listener();
+  }
 }
 
 extension NullSafeLast<T> on List<T> {

--- a/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
@@ -179,7 +179,7 @@ void registerServiceExtension(
   RegisteredServiceDescription description, {
   bool serviceAvailable = true,
 }) {
-  when(mockServiceManager.getRegisteredServiceListenable(description.service))
+  when(mockServiceManager.registeredServiceListenable(description.service))
       .thenAnswer((invocation) {
     final listenable = ImmediateValueNotifier(serviceAvailable);
     return listenable;

--- a/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
@@ -9,6 +9,7 @@ import 'package:devtools_app/src/service_extensions.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/service_registrations.dart';
 import 'package:devtools_app/src/ui/flutter/service_extension_widgets.dart';
+import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -178,10 +179,10 @@ void registerServiceExtension(
   RegisteredServiceDescription description, {
   bool serviceAvailable = true,
 }) {
-  when(mockServiceManager.hasRegisteredService(description.service, any))
+  when(mockServiceManager.getRegisteredServiceListenable(description.service))
       .thenAnswer((invocation) {
-    final onData = invocation.positionalArguments[1];
-    return Stream<bool>.value(serviceAvailable).listen(onData);
+    final listenable = ImmediateValueNotifier(serviceAvailable);
+    return listenable;
   });
 }
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -50,11 +50,8 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
       FakeServiceExtensionManager();
 
   @override
-  ValueListenable<bool> registeredServiceListenable(
-    String name,
-  ) {
-    final ValueListenable listenable = ImmediateValueNotifier(false);
-    return listenable;
+  ValueListenable<bool> registeredServiceListenable(String name) {
+    return ImmediateValueNotifier(false);
   }
 
   @override

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -50,7 +50,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
       FakeServiceExtensionManager();
 
   @override
-  ValueListenable<bool> getRegisteredServiceListenable(
+  ValueListenable<bool> registeredServiceListenable(
     String name,
   ) {
     final ValueListenable listenable = ImmediateValueNotifier(false);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -14,6 +14,7 @@ import 'package:devtools_app/src/stream_value_listenable.dart';
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
+import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_app/src/vm_service_wrapper.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
@@ -49,11 +50,11 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
       FakeServiceExtensionManager();
 
   @override
-  StreamSubscription<bool> hasRegisteredService(
+  ValueListenable<bool> getRegisteredServiceListenable(
     String name,
-    void onData(bool value),
   ) {
-    return Stream.value(false).listen(onData);
+    final ValueListenable listenable = ImmediateValueNotifier(false);
+    return listenable;
   }
 
   @override


### PR DESCRIPTION
The `onExpandCollapseSupported` callback was being called more than once due to multiple service events coming in on the service registered stream.

Switching to use ValueNotifier instead of stream ensures that a callback is not called if the value is unchanged.  Fixes https://github.com/flutter/devtools/issues/1418