### PR TITLE
Skip flaky info_controller test.

### DIFF
--- a/packages/devtools_testing/lib/info_controller_test.dart
+++ b/packages/devtools_testing/lib/info_controller_test.dart
@@ -87,7 +87,9 @@ Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
       );
 
       await env.tearDownEnvironment(force: true);
-    });
+      // TODO(kenz): unskip once flake is addressed. See
+      // https://github.com/flutter/devtools/issues/1193.
+    }, skip: true);
   }, timeout: const Timeout.factor(8));
   // TODO: Add a test that uses DartVM instead of Flutter
 }


### PR DESCRIPTION
Skipping this for now as it is slowing down development with the constant need to re-run travis builds.

This test should be unskipped once the source of the flake is resolved: https://github.com/flutter/devtools/issues/1193