### PR TITLE
Fix 2 blocking bugs in dart:html app.

### DIFF
--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -61,7 +61,7 @@ class FrameworkCore {
         return false;
       }
     } else {
-      errorReporter('Unable to connect to VM service at "$uri"', null);
+      // Don't report an error here because we do not have a URI to connect to.
       return false;
     }
   }

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -102,7 +102,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
       final link = CoreElement('a')
         ..add(<CoreElement>[
           span(c: 'octicon ${screen.iconClass}'),
-          span(text: ' ${screen.name}', c: 'optional-1060')
+          span(text: ' ${screen.name}', c: 'optional-1140')
         ]);
       if (screen.disabled) {
         link

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -34,5 +34,5 @@ void main() {
     group('logging', loggingTests);
     // Temporarily skip tests. See https://github.com/flutter/devtools/issues/1343.
     group('debugging', debuggingTests, skip: true);
-  }, timeout: const Timeout.factor(4));
+  }, timeout: const Timeout.factor(6));
 }

--- a/packages/devtools_app/web/debugger_screen.html
+++ b/packages/devtools_app/web/debugger_screen.html
@@ -62,37 +62,37 @@
             <a disabled>
                 <span class="octicon octicon-device-mobile"></span>
                 <span>
-                    <span class="optional-1060">Flutter Inspector</span>
+                    <span class="optional-1140">Flutter Inspector</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-pulse"></span>
                 <span>
-                    <span class="optional-1060">Timeline</span>
+                    <span class="optional-1140">Timeline</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-dashboard"></span>
                 <span>
-                    <span class="optional-1060">Performance</span>
+                    <span class="optional-1140">Performance</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-package"></span>
                 <span>
-                    <span class="optional-1060">Memory</span>
+                    <span class="optional-1140">Memory</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-bug"></span>
                 <span>
-                    <span class="optional-1060">Debugger</span>
+                    <span class="optional-1140">Debugger</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-clippy"></span>
                 <span>
-                    <span class="optional-1060">Logging</span>
+                    <span class="optional-1140">Logging</span>
                 </span>
             </a>
         </nav>

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -102,37 +102,37 @@
             <a disabled>
                 <span class="octicon octicon-device-mobile"></span>
                 <span>
-                    <span class="optional-1060">Flutter Inspector</span>
+                    <span class="optional-1140">Flutter Inspector</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-pulse"></span>
                 <span>
-                    <span class="optional-1060">Timeline</span>
+                    <span class="optional-1140">Timeline</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-dashboard"></span>
                 <span>
-                    <span class="optional-1060">Performance</span>
+                    <span class="optional-1140">Performance</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-package"></span>
                 <span>
-                    <span class="optional-1060">Memory</span>
+                    <span class="optional-1140">Memory</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-bug"></span>
                 <span>
-                    <span class="optional-1060">Debugger</span>
+                    <span class="optional-1140">Debugger</span>
                 </span>
             </a>
             <a disabled>
                 <span class="octicon octicon-clippy"></span>
                 <span>
-                    <span class="optional-1060">Logging</span>
+                    <span class="optional-1140">Logging</span>
                 </span>
             </a>
         </nav>

--- a/packages/devtools_app/web/styles.css
+++ b/packages/devtools_app/web/styles.css
@@ -1180,7 +1180,7 @@ span.strong {
 @media all and (max-width: 550px) { .optional-550 { display: none; } }
 @media all and (max-width: 700px) { .optional-700 { display: none; } }
 @media all and (max-width: 1000px) { .optional-1000 { display: none; } }
-@media all and (max-width: 1060px) { .optional-1060 { display: none; } }
+@media all and (max-width: 1140px) { .optional-1140 { display: none; } }
 
 /*
  * Support tagging btn-groups with collapsible that can have children tagged


### PR DESCRIPTION
- Fixes screen width at which items in the nav bar will collapse to use only icons
- Fixes regression where we were reporting an error on the connect screen. Extra error report added in https://github.com/flutter/devtools/commit/9446cb6d911842e32b803fd38233f7e3dced65f9, but we should not be reporting an error when URI is null.