### PR TITLE
Compute FPS high water mark.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -117,7 +117,6 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
         () {
       final newFrame = _controller.frameBasedTimeline.frameAddedNotifier.value;
       if (newFrame == null) return;
-
       setState(() {
         // If frames not in sync with charting data (_frameDurations)?
         if (frames.isEmpty && _frameDurations.length == 1) {

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -61,7 +61,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
 
   final int totalFramesToChart = 150;
 
-  /// Compute the FPS highwater mark.
+  /// Compute the FPS highwater mark, 60 FPS is 16.6 ms and 120 FPS is 8 ms.
   void _setupFPSHighwaterLine() async {
     if (_chartController.axisLeftSettingFunction == null) {
       final fpsRate =
@@ -75,7 +75,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
           ..textColor = defaultForeground
           ..drawGridLines = false
           ..setValueFormatter(YAxisUnitFormatter())
-          ..addLimitLine(LimitLine(fpsInMs, '${fpsRate.toInt()} FPS')
+          ..addLimitLine(LimitLine(fpsInMs, '$fpsRate FPS')
             // TODO(terry): LEFT_TOP is clipped need to fix in MPFlutterChart.
             ..labelPosition = LimitLabelPosition.RIGHT_TOP
             ..textSize = 10

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -68,13 +68,11 @@ dependency_overrides:
   # See: https://github.com/flutter/devtools/pull/1342
   devtools_server:
     path: ../devtools_server
-  json_serializable: ^3.2.0
 
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ^0.10.0
   build_web_compilers: '>=2.6.2 <3.0.0'
-  json_serializable: ^3.2.0
   matcher: ^0.12.3
   mockito: ^4.0.0
   test: ^1.0.0

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -44,7 +44,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
 
   @override
   Future<double> getDisplayRefreshRate() async => 60;
-  
+
   @override
   final bool hasConnection;
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -43,6 +43,9 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   Stream<VmServiceWrapper> get onConnectionAvailable => Stream.value(service);
 
   @override
+  Future<double> getDisplayRefreshRate() async => 60;
+  
+  @override
   final bool hasConnection;
 
   @override


### PR DESCRIPTION
Compute the FPS high water mark based on the displayRefreshRate in FrameBasedTimeline.

60 FPS sets the high water mark (y axis) to 16.6 ms
120 FPS sets the high water mark (y axis) to 8.3 ms 