### PR TITLE
Update changelog for 0.1.12

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.12-dev.2
+* Fix a regression that showed an inaccurate error on the connect screen.
 * Fix bug causing async events with the same name to overlap each other in the Timeline.
+* Include previously omitted args in Timeline event summary.
+* Include "connected events" in the Timeline event summary, which are created via the dart:developer TimelineTask api.
+* Reset debugger search bar on hot reload.
 * Check for a debug service extension instead of using eval to distinguish between debug and profile builds.
 * Depend on the latest `package:sse`.
 

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.12-dev.2
+## 0.1.12 - 2019-12-06
 * Fix a regression that showed an inaccurate error on the connect screen.
 * Fix bug causing async events with the same name to overlap each other in the Timeline.
 * Include previously omitted args in Timeline event summary.


### PR DESCRIPTION
Left out anything related to the Flutter Web app, since it won't be accessible in the initial 0.1.12 release.