### PR TITLE
Enable testing for alpha flutter web app.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.1.12 - 2019-12-06
+* Enable testing the alpha version of DevTools written in Flutter. Click the "beaker" icon in the upper-right to launch DevTools in Flutter.
 * Fix a regression that showed an inaccurate error on the connect screen.
 * Fix bug causing async events with the same name to overlap each other in the Timeline.
 * Include previously omitted args in Timeline event summary.

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -33,8 +33,6 @@ import 'utils.dart';
 
 // TODO(devoncarew): make the screens more robust through restarts
 
-bool enableFlutterWebTesting = false;
-
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const flutterWebLibraryUri = 'package:flutter_web/src/widgets/binding.dart';
 
@@ -82,22 +80,20 @@ class HtmlPerfToolFramework extends HtmlFramework {
           .open('https://github.com/flutter/devtools/issues', '_feedback');
     });
 
-    if (enableFlutterWebTesting) {
-      // Listen for clicks on the 'Try DevTools on Flutter Web' button.
-      queryId('try-flutter-web-devtools')
-        ..hidden = false
-        ..onClick.listen((_) {
-          var href = '/flutter.html#/';
-          // Preserve query parameters when opening the Flutter demo so the
-          // user does not need to go through the connect dialog again.
-          final flutterQueryParams =
-              Uri.tryParse(html.window.location.href).queryParameters ?? {};
-          if (flutterQueryParams.isNotEmpty) {
-            href += Uri(queryParameters: flutterQueryParams).toString();
-          }
-          html.window.location.href = href;
-        });
-    }
+    // Listen for clicks on the 'Try DevTools on Flutter Web' button.
+    queryId('try-flutter-web-devtools')
+      ..hidden = false
+      ..onClick.listen((_) {
+        var href = '/flutter.html#/';
+        // Preserve query parameters when opening the Flutter demo so the
+        // user does not need to go through the connect dialog again.
+        final flutterQueryParams =
+            Uri.tryParse(html.window.location.href).queryParameters ?? {};
+        if (flutterQueryParams.isNotEmpty) {
+          href += Uri(queryParameters: flutterQueryParams).toString();
+        }
+        html.window.location.href = href;
+      });
 
     await serviceManager.serviceAvailable.future;
     await addScreens();


### PR DESCRIPTION
This CL enables the button to launch the flutter web version of DevTools

@DaveShuckerow I'm currently getting a not found error when clicking the button. Looks like flutter.html is not checked in. This is a release blocker: https://github.com/flutter/devtools/issues/1457