### PR TITLE
Fix offline import bug in Timeline.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -537,7 +537,8 @@ class HtmlTimelineScreen extends HtmlScreen {
   }
 
   void _updateButtonStates() async {
-    final isDartCliApp = await serviceManager.connectedApp.isDartCliApp;
+    final isDartCliApp =
+        await serviceManager.connectedApp?.isDartCliApp ?? false;
     pauseButton
       ..disabled = timelineController.frameBasedTimeline.manuallyPaused
       ..hidden(offlineMode ||


### PR DESCRIPTION
When DevTools is not connected to an app, `connectedApp` is null and this line was throwing a null error. Fixed now.

This should be cherry picked into the release we send out on the morning of Interact.