### PR TITLE
Fix crasher when an unexpected service extension value is used.

### DIFF
--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -163,8 +163,14 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
   extension: 'ext.flutter.platformOverride',
   description: 'Override target platform',
   icon: FlutterIcons.phone,
-  values: ['iOS', 'android', 'fuchsia'],
-  displayValues: ['Platform: iOS', 'Platform: Android', 'Platform: Fuchsia'],
+  values: ['iOS', 'android', 'fuchsia', 'macOS', 'linux'],
+  displayValues: [
+    'Platform: iOS',
+    'Platform: Android',
+    'Platform: Fuchsia',
+    'Platform: MacOS',
+    'Platform: Linux'
+  ],
   tooltips: ['Override Target Platform'],
   gaScreenName: ga.inspector,
   gaItem: ga.togglePlatform,


### PR DESCRIPTION
Switched to hiding instead of removing the "fuchsia" option so that
it doesn't get in the way of the logic to add new entries.