### PR TITLE
Support persisting the collected heap samples.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/controllers.dart
+++ b/packages/devtools_app/lib/src/flutter/controllers.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 import '../auto_dispose.dart';
 import '../globals.dart';
 import '../logging/logging_controller.dart';
-import '../memory/memory_controller.dart';
+import '../memory/flutter/memory_controller.dart';
 import '../timeline/timeline_controller.dart';
 
 /// Container for controllers that should outlive individual screens of the app.

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -185,9 +185,8 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   }
 
   HeapSample getValues(int timestamp) {
-    final data = controller.offline
-        ? memoryTimeline.offflineData
-        : memoryTimeline.data;
+    final data =
+        controller.offline ? memoryTimeline.offflineData : memoryTimeline.data;
     for (var index = 0; index < data.length; index++) {
       if (data[index].timestamp == timestamp) {
         return data[index];

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -36,8 +36,8 @@ import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/controllers.dart';
 import '../../flutter/theme.dart';
 import '../../ui/theme.dart';
-import '../memory_controller.dart';
-import '../memory_protocol.dart';
+import 'memory_controller.dart';
+import 'memory_protocol.dart';
 
 class MemoryChart extends StatefulWidget {
   @override

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -67,9 +67,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newController = Controllers.of(context).memory;
-    if (newController == controller) return;
-    controller = newController;
+    controller = Controllers.of(context).memory;
 
     controller.memoryTimeline.image = _img;
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -264,89 +264,16 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   void processMemoryLogFileData() {
     assert(_controller.offline);
     assert(_memoryTimeline.offflineData.isNotEmpty);
-
-    final List<HeapSample> chartData = _memoryTimeline.offflineData;
-
-    _processData(chartData, 0);
-/*
-    for (var feedIndex = 0; feedIndex < chartData.length; feedIndex++) {
-      final sample = chartData[feedIndex];
-      final timestamp = sample.timestamp.toDouble();
-
-      final capacity = sample.capacity.toDouble();
-      final used = sample.used.toDouble();
-      final external = sample.external.toDouble();
-
-      final extEntry = Entry(
-        x: timestamp,
-        y: external,
-        icon: _img,
-      );
-      final usedEntry = Entry(
-        x: timestamp,
-        y: used + external,
-        icon: _img,
-      );
-      final capacityEntry = Entry(
-        x: timestamp,
-        y: capacity,
-        icon: _img,
-      );
-
-      setState(() {
-        _externalHeap.add(extEntry);
-        _used.add(usedEntry);
-        _capacity.add(capacityEntry);
-      });
-    }
-
-    updateChart();
-*/
+    _processData(_memoryTimeline.offflineData, 0);
   }
 
   void processLiveData([bool reloadAllData = false]) {
-    // Don't process live data our memory source is a JSON file.
-    if (_controller.offline) return;
+    assert(!_controller.offline);
+    assert(_memoryTimeline.data.isNotEmpty);
 
     final List<HeapSample> liveFeed = _memoryTimeline.data;
     if (_used.length != liveFeed.length || reloadAllData) {
       _processData(liveFeed, _used.length);
-/*
-      for (var feedIndex = _used.length;
-          feedIndex < liveFeed.length;
-          feedIndex++) {
-        final sample = liveFeed[feedIndex];
-        final timestamp = sample.timestamp.toDouble();
-
-        final capacity = sample.capacity.toDouble();
-        final used = sample.used.toDouble();
-        final external = sample.external.toDouble();
-
-        final extEntry = Entry(
-          x: timestamp,
-          y: external,
-          icon: _img,
-        );
-        final usedEntry = Entry(
-          x: timestamp,
-          y: used + external,
-          icon: _img,
-        );
-        final capacityEntry = Entry(
-          x: timestamp,
-          y: capacity,
-          icon: _img,
-        );
-
-        setState(() {
-          _externalHeap.add(extEntry);
-          _used.add(usedEntry);
-          _capacity.add(capacityEntry);
-        });
-      }
-
-      updateChart();
-*/
     }
   }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 import 'dart:async';
 import 'dart:convert';
+import 'dart:ui' as dart_ui;
 
 import 'package:intl/intl.dart';
 import 'package:mp_chart/mp/core/entry/entry.dart';
@@ -527,9 +528,9 @@ class MemoryTimeline {
   ValueNotifier<bool> get pausedNotifier => _pausedNotifier;
 
   /// dart_ui.Image Image asset displayed for each entry plotted in a chart.
-  dynamic _img;
+  dart_ui.Image _img;
 
-  set image(var img) {
+  set image(dart_ui.Image img) {
     _img = img;
   }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -2,23 +2,111 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'dart:async';
+import 'dart:convert';
 
+import 'package:intl/intl.dart';
+import 'package:mp_chart/mp/core/entry/entry.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../config_specific/logger.dart';
-import '../globals.dart';
-import '../vm_service_wrapper.dart';
-import 'memory_protocol.dart';
-import 'memory_service.dart';
+import '../../config_specific/logger.dart';
+import '../../globals.dart';
+import '../../ui/fake_file/fake_file.dart';
+import '../../ui/fake_flutter/fake_flutter.dart';
+import '../../vm_service_wrapper.dart';
 
+import '../memory_service.dart';
+import 'memory_protocol.dart';
+
+typedef chartStateListener = void Function();
+
+// TODO(terry): Consider supporting more than one file since app was launched.
+// Memory Log filename.
+final String _memoryLogFilename =
+    '${MemoryController.logFilenamePrefix}${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
+
+// TODO(terry): Implement a dispose method and call in ProvidedControllers dispose.
 /// This class contains the business logic for [memory.dart].
 ///
 /// This class must not have direct dependencies on dart:html. This allows tests
 /// of the complicated logic in this class to run on the VM and will help
 /// simplify porting this code to work with Flutter Web.
 class MemoryController {
-  MemoryController();
+  MemoryController() {
+    memoryTimeline = MemoryTimeline(this);
+    memoryLog = MemoryLog(this);
+  }
+
+  static const String logFilenamePrefix = 'memory_log_';
+
+  MemoryTimeline memoryTimeline;
+
+  MemoryLog memoryLog;
+
+  /// Source of memory heap samples. False live data, True loaded from a
+  /// memory_log file.
+  bool offline = false;
+
+  int selectedSample = -1;
+
+  static const String liveFeed = 'Live Feed';
+
+  /// Notifies that the source of the memory feed has changed.
+  ValueListenable get memorySourceNotifier => _memorySourceNotifier;
+
+  final _memorySourceNotifier = ValueNotifier<String>(liveFeed);
+
+  set memorySource(String source) {
+    _memorySourceNotifier.value = source;
+  }
+
+  String get memorySource => _memorySourceNotifier.value;
+
+  /// MemorySource has changed update the view.
+  void updatedMemorySource() {
+    if (memorySource == MemoryController.liveFeed) {
+      if (offline) {
+        // User is switching back to 'Live Feed'.
+        memoryTimeline.offlineData.clear();
+        offline = false; // We're live again...
+      } else {
+        // Still a live feed - keep collecting.
+        assert(!offline);
+      }
+    } else {
+      // Switching to an offline memory log (JSON file in /tmp).
+      memoryLog.loadOffline(memorySource);
+    }
+
+    // The memory source has changed, clear all plotted values.
+    memoryTimeline.chartData.reset();
+  }
+
+  void processData([bool reloadAllData = false]) {
+    final args = offline
+        ? memoryTimeline.processMemoryLogFileData()
+        : memoryTimeline.processLiveData(reloadAllData);
+
+    for (var arg in args) {
+      memoryTimeline.chartData.addTraceEntries(
+        capacityValue: arg[MemoryTimeline.capcityValueKey],
+        usedValue: arg[MemoryTimeline.usedValueKey],
+        externalValue: arg[MemoryTimeline.externalValueKey],
+      );
+    }
+  }
+
+  bool _paused = false;
+
+  bool get paused => _paused;
+
+  void pauseLiveFeed() {
+    _paused = true;
+  }
+
+  void resumeLiveFeed() {
+    _paused = false;
+  }
 
   final SettingsModel settings = SettingsModel();
 
@@ -49,7 +137,7 @@ class MemoryController {
   }
 
   void _handleConnectionStart(VmServiceWrapper service) {
-    _memoryTracker = MemoryTracker(service);
+    _memoryTracker = MemoryTracker(service, this);
     _memoryTracker.start();
 
     _memoryTracker.onChange.listen((_) {
@@ -371,4 +459,245 @@ class LibraryCollection {
 
   bool isOtherLibrary(String classId) =>
       findOtherLibrary(displayClasses[classId]) != null;
+}
+
+/// Prepare data to plot in MPChart.
+class MPChartData {
+  /// Datapoint entries for each used heap value.
+  final List<Entry> used = <Entry>[];
+
+  /// Datapoint entries for each capacity heap value.
+  final List<Entry> capacity = <Entry>[];
+
+  /// Datapoint entries for each external memory value.
+  final List<Entry> externalHeap = <Entry>[];
+
+  /// Add each entry to its corresponding trace.
+  void addTraceEntries({
+    Entry capacityValue,
+    Entry usedValue,
+    Entry externalValue,
+  }) {
+    externalHeap.add(externalValue);
+    used.add(usedValue);
+    capacity.add(capacityValue);
+  }
+
+  /// Remove all plotted entries in all traces.
+  void reset() {
+    used.clear();
+    capacity.clear();
+    externalHeap.clear();
+  }
+}
+
+/// All Raw data received from the VM and offline data loaded from a memory log file.
+class MemoryTimeline {
+  MemoryTimeline(this.controller);
+
+  /// Keys used in a map to store all the MPChart Entries we construct to be plotted.
+  static const capcityValueKey = 'capacityValue';
+  static const usedValueKey = 'usedValue';
+  static const externalValueKey = 'externalValue';
+
+  final MemoryController controller;
+
+  final chartData = MPChartData();
+
+  /// Return the data payload that is active.
+  List<HeapSample> get data => controller.offline ? offlineData : liveData;
+
+  /// Raw Heap sampling data from the VM.
+  final List<HeapSample> liveData = [];
+
+  /// Data of the last selected offline memory source (JSON file in /tmp).
+  final List<HeapSample> offlineData = [];
+
+  /// Notifies that a new Heap sample has been added to the timeline.
+  final _sampleAddedNotifier = ValueNotifier<HeapSample>(null);
+
+  ValueListenable<HeapSample> get sampleAddedNotifier => _sampleAddedNotifier;
+
+  /// Whether the timeline has been manually paused via the Pause button.
+  bool manuallyPaused = false;
+
+  /// Notifies that the timeline has been paused.
+  final _pausedNotifier = ValueNotifier<bool>(false);
+
+  ValueNotifier<bool> get pausedNotifier => _pausedNotifier;
+
+  /// dart_ui.Image Image asset displayed for each entry plotted in a chart.
+  dynamic _img;
+
+  set image(var img) {
+    _img = img;
+  }
+
+  /// Common utility function to handle loading of the data into the
+  /// chart for either offline or live Feed.
+  List<Map> _processData(List<HeapSample> data, int startingDataIndex) {
+    final result = <Map<String, Entry>>[];
+
+    for (var dataIndex = startingDataIndex;
+        dataIndex < data.length;
+        dataIndex++) {
+      final sample = data[dataIndex];
+      final timestamp = sample.timestamp.toDouble();
+
+      final capacity = sample.capacity.toDouble();
+      final used = sample.used.toDouble();
+      final external = sample.external.toDouble();
+
+      final extEntry = Entry(
+        x: timestamp,
+        y: external,
+        icon: _img,
+      );
+      final usedEntry = Entry(
+        x: timestamp,
+        y: used + external,
+        icon: _img,
+      );
+      final capacityEntry = Entry(
+        x: timestamp,
+        y: capacity,
+        icon: _img,
+      );
+
+      result.add({
+        capcityValueKey: capacityEntry,
+        usedValueKey: usedEntry,
+        externalValueKey: extEntry,
+      });
+    }
+
+    return result;
+  }
+
+  /// Fetch all the data in the loaded from a memory log (JSON file in /tmp).
+  List<Map> processMemoryLogFileData() {
+    assert(controller.offline);
+    assert(offlineData.isNotEmpty);
+    return _processData(offlineData, 0);
+  }
+
+  List<Map> processLiveData([bool reloadAllData = false]) {
+    assert(!controller.offline);
+    assert(liveData.isNotEmpty);
+
+    final usedSize = chartData.used.length;
+    if (usedSize != liveData.length || reloadAllData) {
+      return _processData(liveData, usedSize);
+    }
+
+    return [];
+  }
+
+  /// Given a list of HeapSample, encode as a Json string.
+  static String encodeHeapSamples(List<HeapSample> data) {
+    final List encodeHeapSamples = data.map((f) => jsonEncode(f)).toList();
+    return jsonEncode({'samples': encodeHeapSamples});
+  }
+
+  // Given a JSON string representing an array of HeapSample, decode to a List of HeapSample.
+  static List<HeapSample> decodeHeapSamples(String jsonString) {
+    final Map<String, dynamic> decodedMap = jsonDecode(jsonString);
+    final List dynamicList = decodedMap['samples'];
+    final List<HeapSample> samples = [];
+    for (var index = 0; index < dynamicList.length; index++) {
+      final Map<String, dynamic> entry = jsonDecode(dynamicList[index]);
+      final sample = HeapSample.fromJson(entry);
+      samples.add(sample);
+    }
+
+    return samples;
+  }
+
+  void pause({bool manual = false}) {
+    manuallyPaused = manual;
+    _pausedNotifier.value = true;
+  }
+
+  void resume() {
+    manuallyPaused = false;
+    _pausedNotifier.value = false;
+  }
+
+  void addSample(HeapSample sample) {
+    // Always record the heap sample in the raw set of data (liveFeed).
+    liveData.add(sample);
+
+    // Only notify that new sample has arrived if the
+    // memory source is 'Live Feed'.
+    if (!controller.offline) {
+      _sampleAddedNotifier.value = sample;
+    }
+  }
+}
+
+/// Supports saving and loading memory samples.
+class MemoryLog {
+  MemoryLog(this.controller);
+
+  /// Use in memory or local file system based on Flutter Web/Desktop.
+  static final _fs = MemoryFiles();
+
+  MemoryController controller;
+
+  /// Persist the the live memory data to a JSON file in the /tmp directory.
+  void exportMemory() async {
+    final liveData = controller.memoryTimeline.liveData;
+
+    bool pseudoData = false;
+    if (liveData.isEmpty) {
+      // TODO(terry): Can eliminate once I add loading a canned data source
+      //              see TODO in memory_screen_test.
+      // Used to create empty memory log for test.
+      pseudoData = true;
+      liveData.add(HeapSample(
+        DateTime.now().microsecondsSinceEpoch,
+        0,
+        0,
+        0,
+        0,
+        false,
+      ));
+    }
+
+    final jsonPayload = MemoryTimeline.encodeHeapSamples(liveData);
+    final realData = MemoryTimeline.decodeHeapSamples(jsonPayload);
+
+    assert(realData.length == liveData.length);
+
+    _fs.writeStringToFile(_memoryLogFilename, jsonPayload);
+
+    // TODO(terry): Display filename created in a toast.
+
+    if (pseudoData) liveData.clear();
+  }
+
+  /// Return a list of offline memory logs filenames in the /tmp directory
+  /// that are available to open.
+  List<String> offlineFiles() {
+    final memoryLogs = _fs.list(prefix: MemoryController.logFilenamePrefix);
+
+    // Sort by newest file top-most (DateTime is in the filename).
+    memoryLogs.sort((a, b) => b.compareTo(a));
+
+    return memoryLogs;
+  }
+
+  /// Load the memory profile data from a saved memory log file.
+  void loadOffline(String filename) async {
+    controller.offline = true;
+
+    final jsonPayload = _fs.readStringFromFile(filename);
+    final realData = MemoryTimeline.decodeHeapSamples(jsonPayload);
+
+    controller.memoryTimeline.offlineData.clear();
+    controller.memoryTimeline.offlineData.addAll(realData);
+  }
+
+  @visibleForTesting
+  bool removeOfflineFile(String filename) => _fs.deleteFile(filename);
 }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -7,17 +7,22 @@ import 'dart:math' as math;
 
 import 'package:vm_service/vm_service.dart';
 
-import '../globals.dart';
-import '../version.dart';
-import '../vm_service_wrapper.dart';
-import 'heap_space.dart';
+import '../../globals.dart';
+import '../../version.dart';
+import '../../vm_service_wrapper.dart';
+
+import '../heap_space.dart';
+import 'memory_controller.dart';
 
 class MemoryTracker {
-  MemoryTracker(this.service);
+  MemoryTracker(this.service, this.memoryController);
 
   static const Duration kUpdateDelay = Duration(milliseconds: 200);
 
   VmServiceWrapper service;
+
+  final MemoryController memoryController;
+
   Timer _pollingTimer;
 
   final List<HeapSample> samples = <HeapSample>[];
@@ -119,6 +124,15 @@ class MemoryTracker {
     }
 
     _addSample(HeapSample(time, processRss, capacity, used, external, fromGC));
+
+    memoryController.memoryTimeline.addSample(HeapSample(
+      time,
+      processRss,
+      capacity,
+      used,
+      external,
+      fromGC,
+    ));
   }
 
   void _addSample(HeapSample sample) {
@@ -135,14 +149,43 @@ class MemoryTracker {
 }
 
 class HeapSample {
-  HeapSample(this.timestamp, this.rss, this.capacity, this.used, this.external,
-      this.isGC);
+  HeapSample(
+    this.timestamp,
+    this.rss,
+    this.capacity,
+    this.used,
+    this.external,
+    this.isGC,
+  );
+
+  factory HeapSample.fromJson(Map<String, dynamic> json) => HeapSample(
+        json['timestamp'] as int,
+        json['rss'] as int,
+        json['capacity'] as int,
+        json['used'] as int,
+        json['external'] as int,
+        json['gc'] as bool,
+      );
+
+  Map<String, dynamic> toJson() => <String, dynamic>{
+        'timestamp': timestamp,
+        'rss': rss,
+        'capacity': capacity,
+        'used': used,
+        'external': external,
+        'gc': isGC,
+      };
 
   final int timestamp;
+
   final int rss;
+
   final int capacity;
+
   final int used;
+
   final int external;
+
   final bool isGC;
 }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -10,8 +10,8 @@ import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
 import '../../globals.dart';
 import '../../ui/flutter/label.dart';
-import '../memory_controller.dart';
 import 'memory_chart.dart';
+import 'memory_controller.dart';
 
 class MemoryScreen extends Screen {
   const MemoryScreen();

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -125,16 +125,17 @@ class MemoryBodyState extends State<MemoryBody> {
 
           if (memorySource == _liveFeed) {
             if (_controller.offline) {
-            // User is switching back to 'Live Feed'.
-            _controller.memoryTimeline.offflineData.clear();
-            _controller.offline = false;  // We're live again...
+              // User is switching back to 'Live Feed'.
+              _controller.memoryTimeline.offflineData.clear();
+              _controller.offline = false; // We're live again...
             } else {
-              assert(!_controller.offline); // We've still live - keep collecting.
+              // Still a live feed - keep collecting.
+              assert(!_controller.offline);
             }
-          } else{
+          } else {
             // Switching to an offline memory log (JSON file in /tmp).
             _loadOffline(memorySource);
-          } 
+          }
 
           // Notify the Chart state there's new data from a different memory
           // source to plot.
@@ -263,7 +264,7 @@ class MemoryBodyState extends State<MemoryBody> {
   final String _memoryLogFilename =
       '$_filenamePrefix${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
 
-  // Persist the the live data to a JSON file in the /tmp directory.
+  /// Persist the the live data to a JSON file in the /tmp directory.
   void _exportMemory() {
     final liveData = _controller.memoryTimeline.data;
 
@@ -283,6 +284,8 @@ class MemoryBodyState extends State<MemoryBody> {
     final openFile = memoryLogFile.openSync(mode: FileMode.write);
     memoryLogFile.writeAsStringSync(jsonPayload);
     openFile.closeSync();
+
+    // TODO(terry): Display filename created in a toast.
 
     Directory.current = previousCurrentDirectory;
   }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:path_provider/path_provider.dart';
 
 import '../../flutter/controllers.dart';
 import '../../flutter/octicons.dart';
@@ -127,6 +130,15 @@ class MemoryBodyState extends State<MemoryBody> {
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
         OutlineButton(
+          onPressed: _exportMemory,
+          child: MaterialIconLabel(
+            Icons.file_download,
+            'Export',
+            minIncludeTextWidth: 1100,
+          ),
+        ),
+        const SizedBox(width: 32.0),
+        OutlineButton(
           onPressed: _snapshot,
           child: MaterialIconLabel(
             Icons.camera,
@@ -167,6 +179,34 @@ class MemoryBodyState extends State<MemoryBody> {
     _controller.resumeLiveFeed();
     setState(() {});
   }
+
+  void _exportMemory() async {
+    final liveData = _controller.memoryTimeline.data;
+
+    final jsonPayload = MemoryTimeline.encodeHeapSamples(liveData);
+    final realData = MemoryTimeline.decodeHeapSamples(jsonPayload);
+
+    assert(realData.length == liveData.length);
+
+    Directory systemTemp = Directory.systemTemp;
+    print(">>> systemTemp ${systemTemp.uri} , ${systemTemp.path}");
+
+    File()
+
+
+    final Directory tempDir = await getTemporaryDirectory();
+    final String tempPath = tempDir.path;
+
+    final Directory appDocDir = await getApplicationDocumentsDirectory();
+    final String appDocPath = appDocDir.path;
+
+    print("getTemporaryDirectory -> $tempPath");
+    print("getApplicationDocumentsDirectory -> $appDocPath");
+
+    setState(() {});
+  }
+
+  void _loadOffline() {}
 
   void _snapshot() {
     // TODO(terry): Implementation needed.

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -35,6 +35,8 @@ class MemoryScreen extends Screen {
   @visibleForTesting
   static const gcButtonKey = Key('GC Button');
 
+  static const memorySourceMenuItemPrefix = 'Source: ';
+
   @override
   Widget build(BuildContext context) => const MemoryBody();
 
@@ -119,7 +121,7 @@ class MemoryBodyState extends State<MemoryBody> {
         key: MemoryScreen.memorySourcesMenuItem,
         value: value,
         child: Text(
-          value,
+          '${MemoryScreen.memorySourceMenuItemPrefix}$value',
           key: MemoryScreen.memorySourcesKey,
         ),
       );
@@ -189,14 +191,7 @@ class MemoryBodyState extends State<MemoryBody> {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        Row(children: [
-          Text(
-            'Source:',
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const SizedBox(width: 5),
-          _memorySourceDropdown(),
-        ]),
+        _memorySourceDropdown(),
         const SizedBox(width: 16.0),
         OutlineButton(
           key: MemoryScreen.snapshotButtonKey,

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -18,6 +18,12 @@ import '../../ui/flutter/label.dart';
 import '../memory_controller.dart';
 import 'memory_chart.dart';
 
+const String _filenamePrefix = 'memory_log_';
+
+// Memory Log filename.
+final String _memoryLogFilename =
+    '$_filenamePrefix${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
+
 class MemoryScreen extends Screen {
   const MemoryScreen();
 
@@ -257,12 +263,6 @@ class MemoryBodyState extends State<MemoryBody> {
     _controller.resumeLiveFeed();
     setState(() {});
   }
-
-  static const String _filenamePrefix = 'memory_log_';
-
-  // Memory Log filename.
-  final String _memoryLogFilename =
-      '$_filenamePrefix${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
 
   /// Persist the the live data to a JSON file in the /tmp directory.
   void _exportMemory() {

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 import 'dart:ui' as dart_ui show Image;
 
 // Abstracted memory and local file system access for Flutter Web/Desktop.
-import 'package:devtools_app/src/ui/analytics_constants.dart';
 import 'package:file/file.dart';
 import 'package:file/memory.dart';
 import 'package:file/local.dart';

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -1,6 +1,10 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
+// TODO(terry): File is deprecated (HTML only app) and should be removed
+//              when the DevTools app is the package:flutter version.
+
 import 'dart:async';
 
 import 'package:pedantic/pedantic.dart';

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -20,11 +20,9 @@ import 'memory_service.dart';
 
 typedef chartStateListener = void Function();
 
-const String _filenamePrefix = 'memory_log_';
-
 // Memory Log filename.
 final String _memoryLogFilename =
-    '$_filenamePrefix${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
+    '${MemoryController.filenamePrefix}${DateFormat("yyyyMMdd_hh_mm").format(DateTime.now())}';
 
 // TODO(terry): Implement a dispose method and call in ProvidedControllers dispose.
 /// This class contains the business logic for [memory.dart].
@@ -37,6 +35,8 @@ class MemoryController {
     memoryTimeline = MemoryTimeline(this);
     memoryLog = MemoryLog(this);
   }
+
+  static const String filenamePrefix = 'memory_log_';
 
   MemoryTimeline memoryTimeline;
 
@@ -542,7 +542,7 @@ class MemoryLog {
     for (FileSystemEntity entry in allFiles) {
       final basename = _path.basename(entry.path);
       if (FileSystemEntity.isFileSync(entry.path) &&
-          basename.startsWith(_filenamePrefix)) {
+          basename.startsWith(MemoryController.filenamePrefix)) {
         memoryLogs.add(basename);
       }
     }

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(terry): File is deprecated (HTML only app) and should be removed
+//              when the DevTools app is the package:flutter version.
+
 import 'dart:async';
 import 'dart:math' as math;
 

--- a/packages/devtools_app/lib/src/ui/fake_file/_fake_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_fake_file.dart
@@ -8,6 +8,7 @@ import 'file_io.dart';
 class MemoryFiles implements FileIO {
   // TODO(terry): Implement Web based file IO.
 
+  /// Key is filename and value is content of the file.
   final Map<String, String> _files = {};
 
   @override

--- a/packages/devtools_app/lib/src/ui/fake_file/_fake_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_fake_file.dart
@@ -1,0 +1,27 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'file_io.dart';
+
+/// Abstracted memory file system access for Flutter Web.
+class MemoryFiles implements FileIO {
+  // TODO(terry): Implement Web based file IO.
+
+  final Map<String, String> _files = {};
+
+  @override
+  void writeStringToFile(String filename, String contents) {
+    _files.putIfAbsent(filename, () => contents);
+  }
+
+  @override
+  String readStringFromFile(String filename) =>
+      _files.containsKey(filename) ? _files[filename] : null;
+
+  @override
+  List<String> list({String prefix}) => _files.keys.toList();
+
+  @override
+  bool deleteFile(String filename) => _files.remove(filename) != null;
+}

--- a/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 /// Abstracted local file system access for Flutter Desktop.
 
 import 'package:file/file.dart';

--- a/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
@@ -1,0 +1,83 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+
+/// Abstracted memory and local file system access for Flutter Desktop.
+
+import 'package:file/file.dart';
+import 'package:file/local.dart';
+import 'package:path/path.dart' as _path;
+
+import 'file_io.dart';
+
+class MemoryFiles implements FileIO {
+  final _fs = const LocalFileSystem();
+
+  @override
+  void writeStringToFile(String filename, String contents) {
+    // TODO(terry): Consider path_provider's getTemporaryDirectory
+    //              or getApplicationDocumentsDirectory when
+    //              available in Flutter Web/Desktop.
+    final memoryLogFile = _fs.systemTempDirectory.childFile(filename);
+    memoryLogFile.writeAsStringSync(contents, flush: true);
+  }
+
+  @override
+  String readStringFromFile(String filename) {
+    final previousCurrentDirectory = _fs.currentDirectory;
+
+    // TODO(terry): Use path_provider when available?
+    _fs.currentDirectory = _fs.systemTempDirectory;
+
+    final memoryLogFile = _fs.currentDirectory.childFile(filename);
+
+    final jsonPayload = memoryLogFile.readAsStringSync();
+
+    _fs.currentDirectory = previousCurrentDirectory;
+
+    return jsonPayload;
+  }
+
+  @override
+  List<String> list({String prefix}) {
+    final List<String> memoryLogs = [];
+
+    final previousCurrentDirectory = _fs.currentDirectory;
+
+    // TODO(terry): Use path_provider when available?
+    _fs.currentDirectory = _fs.systemTempDirectory;
+
+    final allFiles = _fs.currentDirectory.listSync();
+
+    for (FileSystemEntity entry in allFiles) {
+      final basename = _path.basename(entry.path);
+      if (_fs.isFileSync(entry.path) && basename.startsWith(prefix)) {
+        memoryLogs.add(basename);
+      }
+    }
+
+    // Sort by newest file top-most (DateTime is in the filename).
+    memoryLogs.sort((a, b) => b.compareTo(a));
+
+    _fs.currentDirectory = previousCurrentDirectory;
+
+    return memoryLogs;
+  }
+
+  @override
+  bool deleteFile(String path) {
+    final previousCurrentDirectory = _fs.currentDirectory;
+
+    // TODO(terry): Use path_provider when available?
+    _fs.currentDirectory = _fs.systemTempDirectory;
+
+    if (!_fs.isFileSync(path)) return false;
+
+    _fs.file(path).deleteSync();
+
+    _fs.currentDirectory = previousCurrentDirectory;
+
+    return true;
+  }
+}

--- a/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 
-/// Abstracted memory and local file system access for Flutter Desktop.
+/// Abstracted local file system access for Flutter Desktop.
 
 import 'package:file/file.dart';
 import 'package:file/local.dart';

--- a/packages/devtools_app/lib/src/ui/fake_file/fake_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/fake_file.dart
@@ -1,0 +1,5 @@
+// TODO(terry): rename this library to file or something else with a followup CL.
+
+export '_fake_file.dart'
+    if (dart.library.io) '_real_file.dart'
+    if (dart.library.html) '_fake_file.dart';

--- a/packages/devtools_app/lib/src/ui/fake_file/file_io.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/file_io.dart
@@ -3,11 +3,17 @@
 // found in the LICENSE file.
 
 abstract class FileIO {
+  /// Create file in a directory (default Desktop in \tmp).
+  // TODO(terry): Better directory for Flutter Desktop when API available.
+  // TODO(terry): Flutter Web/HTML port code to create file in Download directory.
   void writeStringToFile(String filename, String contents);
 
+  /// Returns content of filename or null if file is unknown or content empty.
   String readStringFromFile(String filename);
 
+  /// List of files (basename only).
   List<String> list();
 
+  /// Delete exported files created for testing only.
   bool deleteFile(String path);
 }

--- a/packages/devtools_app/lib/src/ui/fake_file/file_io.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/file_io.dart
@@ -1,0 +1,13 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+abstract class FileIO {
+  void writeStringToFile(String filename, String contents);
+
+  String readStringFromFile(String filename);
+
+  List<String> list();
+
+  bool deleteFile(String path);
+}

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -32,7 +32,8 @@ dependencies:
   intl: ^0.16.0
   js: ^0.6.1+1
   meta: ^1.1.0
-  mp_chart: ^0.0.7
+  mp_chart: 
+    ^0.0.7
   #  path: ../../third_party/packages/mp_chart
   path: ^1.6.0
   path_provider: ^1.4.5

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -36,7 +36,6 @@ dependencies:
     ^0.0.7
   #  path: ../../third_party/packages/mp_chart
   path: ^1.6.0
-  path_provider: ^1.4.5
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   vm_service: ^1.2.0

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   mp_chart: ^0.0.7
   #  path: ../../third_party/packages/mp_chart
   path: ^1.6.0
+  path_provider: ^1.4.5
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
   vm_service: ^1.2.0

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   codemirror: ^0.5.10
   collection: ^1.14.11
   devtools_server: 0.1.12
+  file: ^5.1.0
   http: ^0.12.0+1
   html_shim: ^0.0.2
   #    path: ../html_shim

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -9,7 +9,7 @@ import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/memory/flutter/memory_chart.dart';
 import 'package:devtools_app/src/memory/flutter/memory_screen.dart';
-import 'package:devtools_app/src/memory/memory_controller.dart';
+import 'package:devtools_app/src/memory/flutter/memory_controller.dart';
 import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -66,11 +66,7 @@ void main() {
       expect(find.byKey(MemoryScreen.pauseButtonKey), findsOneWidget);
       expect(find.byKey(MemoryScreen.resumeButtonKey), findsOneWidget);
 
-      expect(find.byKey(MemoryScreen.memorySourceStatusKey), findsOneWidget);
-      final Text memorySourceText = tester.firstWidget(find.byKey(
-        MemoryScreen.memorySourceStatusKey,
-      )) as Text;
-      expect(memorySourceText.data, MemoryBodyState.liveFeed);
+      expect(controller.memorySource, MemoryController.liveFeed);
 
       expect(find.byKey(MemoryScreen.snapshotButtonKey), findsOneWidget);
       expect(find.byKey(MemoryScreen.resetButtonKey), findsOneWidget);
@@ -78,8 +74,8 @@ void main() {
 
       expect(find.byType(MemoryChart), findsOneWidget);
 
-      expect(controller.memoryTimeline.data.isEmpty, isTrue);
-      expect(controller.memoryTimeline.offflineData.isEmpty, isTrue);
+      expect(controller.memoryTimeline.liveData.isEmpty, isTrue);
+      expect(controller.memoryTimeline.offlineData.isEmpty, isTrue);
 
       // Verify the state of the splitter.
       splitFinder = find.byType(Split);
@@ -88,14 +84,14 @@ void main() {
       expect(splitter.initialFirstFraction, equals(0.25));
 
       // Check memory sources available.
-      await tester.tap(find.byKey(MemoryScreen.popupSourceMenuButtonKey));
+      await tester.tap(find.byKey(MemoryScreen.dropdownSourceMenuButtonKey));
       await tester.pump();
 
       // Should only be one source 'Live Feed' in the popup menu.
       final Text memorySources = tester.firstWidget(find.byKey(
         MemoryScreen.memorySourcesKey,
       )) as Text;
-      expect(memorySources.data, MemoryBodyState.liveFeed);
+      expect(memorySources.data, MemoryController.liveFeed);
     });
 
     testWidgetsWithWindowSize('export current memory profile', windowSize,
@@ -112,8 +108,8 @@ void main() {
       await tester.pump();
 
       expect(controller.offline, isFalse);
-      expect(controller.memoryTimeline.data.isEmpty, isTrue);
-      expect(controller.memoryTimeline.offflineData.isEmpty, isTrue);
+      expect(controller.memoryTimeline.liveData.isEmpty, isTrue);
+      expect(controller.memoryTimeline.offlineData.isEmpty, isTrue);
 
       final currentMemoryLogs = controller.memoryLog.offlineFiles();
       expect(previousMemoryLogs.length + 1 == currentMemoryLogs.length, isTrue);
@@ -126,9 +122,21 @@ void main() {
       // Verify initial state - collecting live feed.
       expect(controller.offline, isFalse);
 
+      // Live feed should be default selected.
+      expect(controller.memorySource, MemoryController.liveFeed);
+
       // Export memory to a memory log file.
-      await tester.tap(find.byKey(MemoryScreen.popupSourceMenuButtonKey));
+      await tester.tap(find.byKey(MemoryScreen.dropdownSourceMenuButtonKey));
       await tester.pump();
+
+      // Last item in dropdown list of memory source should be memory log file.
+      await tester.tap(find.byKey(MemoryScreen.memorySourcesMenuItem).last);
+      await tester.pump();
+
+      expect(
+        controller.memorySource.startsWith(MemoryController.logFilenamePrefix),
+        isTrue,
+      );
 
       // TODO(terry): Load canned test data.
       final filenames = controller.memoryLog.offlineFiles();

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -152,7 +152,7 @@ void main() {
 
       expect(controller.offline, isTrue);
 
-      // Remove the memory log, in desk top only version.  Don't want to polute
+      // Remove the memory log, in desktop only version.  Don't want to polute
       // our temp directory when this test runs locally.
       expect(controller.memoryLog.removeOfflineFile(filename), isTrue);
     });

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -1,0 +1,140 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+
+import 'package:devtools_app/src/flutter/split.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/memory/flutter/memory_chart.dart';
+import 'package:devtools_app/src/memory/flutter/memory_screen.dart';
+import 'package:devtools_app/src/memory/memory_controller.dart';
+import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../support/mocks.dart';
+import 'wrappers.dart';
+
+void main() {
+  MemoryScreen screen;
+  MemoryController controller;
+  FakeServiceManager fakeServiceManager;
+
+  Future<void> pumpMemoryScreen(
+    WidgetTester tester, {
+    MemoryController memoryController,
+  }) async {
+    // Set a wide enough screen width that we do not run into overflow.
+    await tester.pumpWidget(wrapWithControllers(
+      const MemoryBody(),
+      memoryController: controller = memoryController ?? MemoryController(),
+    ));
+    expect(find.byType(MemoryBody), findsOneWidget);
+  }
+
+  const windowSize = Size(1599.0, 1000.0);
+
+  group('MemoryScreen', () {
+    setUp(() async {
+      await ensureInspectorDependencies();
+      fakeServiceManager = FakeServiceManager(useFakeService: true);
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      when(serviceManager.connectedApp.isDartWebApp)
+          .thenAnswer((_) => Future.value(false));
+      screen = const MemoryScreen();
+    });
+
+    testWidgets('builds its tab', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
+      expect(find.text('Memory'), findsOneWidget);
+    });
+
+    testWidgetsWithWindowSize('builds proper content for state', windowSize,
+        (WidgetTester tester) async {
+      await pumpMemoryScreen(tester);
+
+      // Should be collecting live feed.
+      expect(controller.offline, isFalse);
+
+      var splitFinder = find.byType(Split);
+
+      // Verify Memory, Memory Source, and Memory Sources content.
+      expect(splitFinder, findsOneWidget);
+      expect(find.byKey(MemoryScreen.pauseButtonKey), findsOneWidget);
+      expect(find.byKey(MemoryScreen.resumeButtonKey), findsOneWidget);
+
+      expect(find.byKey(MemoryScreen.memorySourceStatusKey), findsOneWidget);
+      final Text memorySourceText = tester.firstWidget(find.byKey(
+        MemoryScreen.memorySourceStatusKey,
+      )) as Text;
+      expect(memorySourceText.data, MemoryBodyState.liveFeed);
+
+      expect(find.byKey(MemoryScreen.snapshotButtonKey), findsOneWidget);
+      expect(find.byKey(MemoryScreen.resetButtonKey), findsOneWidget);
+      expect(find.byKey(MemoryScreen.gcButtonKey), findsOneWidget);
+
+      expect(find.byType(MemoryChart), findsOneWidget);
+
+      expect(controller.memoryTimeline.data.isEmpty, isTrue);
+      expect(controller.memoryTimeline.offflineData.isEmpty, isTrue);
+
+      // Verify the state of the splitter.
+      splitFinder = find.byType(Split);
+      expect(splitFinder, findsOneWidget);
+      final Split splitter = tester.widget(splitFinder);
+      expect(splitter.initialFirstFraction, equals(0.25));
+
+      // Check memory sources available.
+      await tester.tap(find.byKey(MemoryScreen.popupSourceMenuButtonKey));
+      await tester.pump();
+
+      // Should only be one source 'Live Feed' in the popup menu.
+      final Text memorySources = tester.firstWidget(find.byKey(
+        MemoryScreen.memorySourcesKey,
+      )) as Text;
+      expect(memorySources.data, MemoryBodyState.liveFeed);
+    });
+
+    testWidgetsWithWindowSize('export current memory profile', windowSize,
+        (WidgetTester tester) async {
+      await pumpMemoryScreen(tester);
+
+      // Verify initial state - collecting live feed.
+      expect(controller.offline, isFalse);
+
+      final previousMemoryLogs = controller.memoryLog.offlineFiles();
+
+      // Export memory to a memory log file.
+      await tester.tap(find.byKey(MemoryScreen.exportButtonKey));
+      await tester.pump();
+
+      expect(controller.offline, isFalse);
+      expect(controller.memoryTimeline.data.isEmpty, isTrue);
+      expect(controller.memoryTimeline.offflineData.isEmpty, isTrue);
+
+      final currentMemoryLogs = controller.memoryLog.offlineFiles();
+      expect(previousMemoryLogs.length + 1 == currentMemoryLogs.length, isTrue);
+    });
+
+    testWidgetsWithWindowSize('load memory log profile', windowSize,
+        (WidgetTester tester) async {
+      await pumpMemoryScreen(tester);
+
+      // Verify initial state - collecting live feed.
+      expect(controller.offline, isFalse);
+
+      // Export memory to a memory log file.
+      await tester.tap(find.byKey(MemoryScreen.popupSourceMenuButtonKey));
+      await tester.pump();
+
+      // TODO(terry): Load canned test data.
+      final filenames = controller.memoryLog.offlineFiles();
+      controller.memoryLog.loadOffline(filenames[0]);
+
+      expect(controller.offline, isTrue);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/wrappers.dart
+++ b/packages/devtools_app/test/flutter/wrappers.dart
@@ -5,7 +5,7 @@
 import 'package:devtools_app/src/flutter/controllers.dart';
 import 'package:devtools_app/src/flutter/theme.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
-import 'package:devtools_app/src/memory/memory_controller.dart';
+import 'package:devtools_app/src/memory/flutter/memory_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';

--- a/packages/devtools_app/test/flutter/wrappers.dart
+++ b/packages/devtools_app/test/flutter/wrappers.dart
@@ -39,7 +39,7 @@ Widget wrapWithControllers(
         overrideProviders: () {
           return ProvidedControllers(
             logging: loggingController ?? MockLoggingController(),
-            memory: memoryController ?? MockMemoryController(),
+            memory: memoryController ?? MockFlutterMemoryController(),
             timeline: timelineController ?? MockTimelineController(),
           );
         },

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -13,6 +13,7 @@ import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/stream_value_listenable.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
+import 'package:devtools_app/src/memory/flutter/memory_controller.dart' as flutterMemory;
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
@@ -154,6 +155,8 @@ class MockConnectedApp extends Mock implements ConnectedApp {}
 class MockLoggingController extends Mock implements LoggingController {}
 
 class MockMemoryController extends Mock implements MemoryController {}
+
+class MockFlutterMemoryController extends Mock implements flutterMemory.MemoryController {}
 
 class MockTimelineController extends Mock implements TimelineController {}
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -14,7 +14,7 @@ import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/stream_value_listenable.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/memory/flutter/memory_controller.dart'
-    as flutterMemory;
+    as flutter_memory;
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
@@ -158,7 +158,7 @@ class MockLoggingController extends Mock implements LoggingController {}
 class MockMemoryController extends Mock implements MemoryController {}
 
 class MockFlutterMemoryController extends Mock
-    implements flutterMemory.MemoryController {}
+    implements flutter_memory.MemoryController {}
 
 class MockTimelineController extends Mock implements TimelineController {}
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -13,7 +13,8 @@ import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/stream_value_listenable.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
-import 'package:devtools_app/src/memory/flutter/memory_controller.dart' as flutterMemory;
+import 'package:devtools_app/src/memory/flutter/memory_controller.dart'
+    as flutterMemory;
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
@@ -156,7 +157,8 @@ class MockLoggingController extends Mock implements LoggingController {}
 
 class MockMemoryController extends Mock implements MemoryController {}
 
-class MockFlutterMemoryController extends Mock implements flutterMemory.MemoryController {}
+class MockFlutterMemoryController extends Mock
+    implements flutterMemory.MemoryController {}
 
 class MockTimelineController extends Mock implements TimelineController {}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2055873/70833675-3e4cf500-1dad-11ea-950a-cae78345004d.png)

- Added support to encode memory samples collected to a JSON payload and save the file locally  (/tmp directory) exposed with an Export button e.g.,

![image](https://user-images.githubusercontent.com/2055873/70583434-921fca00-1b72-11ea-9aaf-28907e054d9a.png)

- Added support to load the saved JSON payloads and render the collected heap samples in the chart.  Exposed with a drop-down menu e.g.,

![image](https://user-images.githubusercontent.com/2055873/70833004-85d28180-1dab-11ea-92a6-4187366bba7f.png)

![image](https://user-images.githubusercontent.com/2055873/70833057-a4d11380-1dab-11ea-9cc7-570295cf1b6a.png)

- Allow switching between 'Live Feed' and collected memory profiles on disk.

![image](https://user-images.githubusercontent.com/2055873/70833616-18bfeb80-1dad-11ea-904d-272a3ec852ea.png)

![image](https://user-images.githubusercontent.com/2055873/70832977-6dfafd80-1dab-11ea-8642-5a95c66d90c0.png)

The saved files are prefixed with `memory_log_` and the current date/time using the format `yyyyMMdd_hh_mm` e.g.,

`memory_log_20191210_08_33` contains memory profiling from Dec 10, 2019 @ 8:33.  Clicking again on Export re-writes current state of all memory profiling to the same file.

Need to display the name of the filename exported in a toast style window (don't think we currently have a mechanism to do that).