### PR TITLE
Fix initial load analytics

### DIFF
--- a/packages/devtools_app/lib/src/framework/html_framework.dart
+++ b/packages/devtools_app/lib/src/framework/html_framework.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 import 'dart:convert';
-import 'package:html_shim/html.dart' hide Screen;
 
+import 'package:html_shim/html.dart' hide Screen;
 import 'package:meta/meta.dart';
 
 import '../globals.dart';
@@ -275,7 +275,7 @@ class HtmlFramework {
       screen ??= screens.firstWhere((screen) => !screen.disabled,
           orElse: () => screens.first);
       if (screen != null) {
-        ga_platform.setupAndGaScreen(id);
+        ga_platform.setupAndGaScreen(screen.id);
         load(screen);
       } else {
         load(HtmlNotFoundScreen());


### PR DESCRIPTION
The `id` may be empty / null on an initial page load. We should be passing the screen's `id` to properly track metrics.