### PR TITLE
Remove swipe behavior on main scaffold tab bar.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -162,6 +162,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         );
       },
       child: TabBarView(
+        physics: const NeverScrollableScrollPhysics(),
         controller: _controller,
         children: tabBodies,
       ),


### PR DESCRIPTION
Swiping between top level tabs is not a standard web behavior. This is also getting in the way of gesture detection in things like the flame chart.