### PR TITLE
Remove --trace-skia to improve performance in debug / profile builds.

### DIFF
--- a/packages/devtools_app/macos/MainFlutterWindow.swift
+++ b/packages/devtools_app/macos/MainFlutterWindow.swift
@@ -23,7 +23,6 @@ class MainFlutterWindow: NSWindow {
     let arguments = [
       "--enable-dart-profiling",
       "--trace-systrace",
-      "--trace-skia"
     ]
     project.engineSwitches = arguments
     let flutterViewController = FlutterViewController.init(project: project)


### PR DESCRIPTION
This flag is making it difficult to get an accurate performance reading from a profile build. We have been chasing down performance problems that are really caused by the added overhead from this flag.