### PR TITLE
Update to use latest package:vm_service 2.2.0

### DIFF
--- a/packages/devtools_app/lib/src/debugger/callstack_view.dart
+++ b/packages/devtools_app/lib/src/debugger/callstack_view.dart
@@ -61,9 +61,14 @@ class CallStackView implements CoreElementView {
   void showFrames(List<Frame> frames, {bool selectTop = false}) {
     if (frames.isEmpty) {
       // Create a marker frame for 'no call frames'.
-      final Frame frame = Frame()
-        ..kind = emptyStackMarker
-        ..code = (CodeRef()..name = '<no call frames>');
+      final Frame frame = Frame(
+        index: 0,
+        kind: emptyStackMarker,
+        code: CodeRef(
+          name: '<no call frames>',
+          kind: CodeKind.kStub,
+        ),
+      );
       _items.setItems([frame]);
     } else {
       _items.setItems(frames, selection: frames.isEmpty ? null : frames.first);

--- a/packages/devtools_app/lib/src/debugger/html_debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/html_debugger_screen.dart
@@ -321,18 +321,22 @@ class HtmlDebuggerScreen extends HtmlScreen {
         if (reportedException != null && frames.isNotEmpty) {
           final Frame frame = frames.first;
 
-          final Frame newFrame = Frame()
-            ..type = frame.type
-            ..index = frame.index
-            ..function = frame.function
-            ..code = frame.code
-            ..location = frame.location
-            ..kind = frame.kind;
+          final Frame newFrame = Frame(
+            index: frame.index,
+            function: frame.function,
+            code: frame.code,
+            location: frame.location,
+            kind: frame.kind,
+          );
 
           final List<BoundVariable> newVars = <BoundVariable>[];
-          newVars.add(BoundVariable()
-            ..name = '<exception>'
-            ..value = reportedException);
+          newVars.add(BoundVariable(
+            name: '<exception>',
+            value: reportedException,
+            scopeStartTokenPos: null,
+            scopeEndTokenPos: null,
+            declarationTokenPos: null,
+          ));
           newVars.addAll(frame.vars ?? []);
           newFrame.vars = newVars;
 

--- a/packages/devtools_app/lib/src/debugger/html_variables_view.dart
+++ b/packages/devtools_app/lib/src/debugger/html_variables_view.dart
@@ -129,27 +129,39 @@ class VariablesChildProvider extends ChildProvider<BoundVariable> {
             assoc.key.kind == InstanceKind.kString) {
           keyString = "'$keyString'";
         }
-        return BoundVariable()
-          ..name = '[$keyString]'
-          ..value = assoc.value;
+        return BoundVariable(
+          name: '[$keyString]',
+          value: assoc.value,
+          scopeStartTokenPos: null,
+          scopeEndTokenPos: null,
+          declarationTokenPos: null,
+        );
       }).toList();
     } else if (instance.elements != null) {
       final List<BoundVariable> result = [];
       int index = 0;
 
       for (dynamic value in instance.elements) {
-        result.add(BoundVariable()
-          ..name = '[$index]'
-          ..value = value);
+        result.add(BoundVariable(
+          name: '[$index]',
+          value: value,
+          scopeStartTokenPos: null,
+          scopeEndTokenPos: null,
+          declarationTokenPos: null,
+        ));
         index++;
       }
 
       return result;
     } else if (instance.fields != null) {
       return instance.fields.map((BoundField field) {
-        return BoundVariable()
-          ..name = field.decl.name
-          ..value = field.value;
+        return BoundVariable(
+          name: field.decl.name,
+          value: field.value,
+          scopeStartTokenPos: null,
+          scopeEndTokenPos: null,
+          declarationTokenPos: null,
+        );
       }).toList();
     } else {
       return [];

--- a/packages/devtools_app/lib/src/memory/html_memory_data_view.dart
+++ b/packages/devtools_app/lib/src/memory/html_memory_data_view.dart
@@ -130,19 +130,35 @@ class MemoryDataChildProvider extends ChildProvider<BoundField> {
 
             int index = 0;
             for (dynamic value in instance.elements) {
-              result.add(BoundField()
-                ..decl = (FieldRef()..name = '[$index]')
-                ..value = value);
+              result.add(BoundField(
+                decl: FieldRef(
+                  name: '[$index]',
+                  isStatic: null,
+                  owner: null,
+                  isFinal: null,
+                  declaredType: null,
+                  isConst: null,
+                ),
+                value: value,
+              ));
               index++;
             }
             return result;
           case InstanceKind.kMap:
             final List<BoundField> result = [];
             for (dynamic value in instance.associations) {
-              result.add(BoundField()
+              result.add(BoundField(
                 // TODO(terry): Need to handle nested objects for keys/values.
-                ..decl = (FieldRef()..name = '[\'${value.key.valueAsString}\']')
-                ..value = value.value.valueAsString);
+                decl: FieldRef(
+                  name: '[\'${value.key.valueAsString}\']',
+                  isStatic: null,
+                  owner: null,
+                  isFinal: null,
+                  declaredType: null,
+                  isConst: null,
+                ),
+                value: value.value.valueAsString,
+              ));
             }
             return result;
           case InstanceKind.kStackTrace:

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
@@ -27,7 +27,7 @@ class CpuProfilerService {
         .clearCpuSamples(serviceManager.isolateManager.selectedIsolate.id);
   }
 
-  Future<Success> setProfilePeriod(String value) {
+  Future<dynamic> setProfilePeriod(String value) {
     return serviceManager.service.setFlag(vm_flags.profilePeriod, value);
   }
 }

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -579,7 +579,7 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Success> setFlag(String name, String value) {
+  Future<dynamic> setFlag(String name, String value) {
     return _trackFuture('setFlag', _vmService.setFlag(name, value));
   }
 

--- a/packages/devtools_app/test/flutter/info_screen_test.dart
+++ b/packages/devtools_app/test/flutter/info_screen_test.dart
@@ -27,24 +27,24 @@ void main() {
 
     void mockFlags() {
       when(serviceManager.service.getFlagList()).thenAnswer((invocation) {
-        return Future.value(
-          FlagList()
-            ..flags = [
-              Flag()
-                ..name = 'flag 1 name'
-                ..comment = 'flag 1 comment contains some very long text '
-                    'that the renderer will have to wrap around to prevent '
-                    'it from overflowing the screen. This will cause a '
-                    'failure if one of the two Row entries the flags lay out '
-                    'in is not wrapped in an Expanded(), which tells the Row '
-                    'allocate only the remaining space to the Expanded. '
-                    'Without the expanded, the underlying RichTexts will try '
-                    'to consume as much of the layout as they can and cause '
-                    'an overflow.'
-                ..valueAsString = 'flag 1 value'
-                ..modified = false
-            ],
-        );
+        return Future.value(FlagList(
+          flags: [
+            Flag(
+              name: 'flag 1 name',
+              comment: 'flag 1 comment contains some very long text '
+                  'that the renderer will have to wrap around to prevent '
+                  'it from overflowing the screen. This will cause a '
+                  'failure if one of the two Row entries the flags lay out '
+                  'in is not wrapped in an Expanded(), which tells the Row '
+                  'allocate only the remaining space to the Expanded. '
+                  'Without the expanded, the underlying RichTexts will try '
+                  'to consume as much of the layout as they can and cause '
+                  'an overflow.',
+              valueAsString: 'flag 1 value',
+              modified: false,
+            ),
+          ],
+        ));
       });
     }
 


### PR DESCRIPTION
Some classes in the latest vm_service package have new required parameters (debugger / memory related classes). I was unclear on what to add for most of them, so reviewers please take a close look at these and comment if you think the values should be different.

@terrylucas @DaveShuckerow 

@bkonyi the change of the `setFlag` RPC to return `Future<dynamic>` instead of `Future<Success>` seems like it might be a regression. Was this change intentional?