### PR TITLE
Add timing and id information to event details summary.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -111,6 +111,11 @@ class EventSummary extends StatelessWidget {
     return ListView(
       children: [
         ListTile(
+          title: const Text('Time'),
+          subtitle: Text('${event.time.start.inMicroseconds} μs —  '
+              '${event.time.end.inMicroseconds} μs'),
+        ),
+        ListTile(
           title: const Text('Thread id'),
           subtitle: Text('${firstTraceEvent.threadId}'),
         ),
@@ -122,6 +127,11 @@ class EventSummary extends StatelessWidget {
           title: const Text('Category'),
           subtitle: Text(firstTraceEvent.category),
         ),
+        if (event.isAsyncEvent)
+          ListTile(
+            title: const Text('Async id'),
+            subtitle: Text('${(event as AsyncTimelineEvent).asyncId}'),
+          ),
         if (_connectedEvents.isNotEmpty) _buildConnectedEvents(),
         if (_eventArgs.isNotEmpty) _buildArguments(),
       ],

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -76,9 +76,11 @@ void main() {
       eventSummary = EventSummary(asyncEventWithInstantChildren);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Time'), findsOneWidget);
       expect(find.text('Thread id'), findsOneWidget);
       expect(find.text('Process id'), findsOneWidget);
       expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Async id'), findsOneWidget);
       expect(find.text('Connected events'), findsOneWidget);
     });
 
@@ -86,9 +88,11 @@ void main() {
       eventSummary = EventSummary(goldenUiTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Time'), findsOneWidget);
       expect(find.text('Thread id'), findsOneWidget);
       expect(find.text('Process id'), findsOneWidget);
       expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Async id'), findsNothing);
       expect(find.text('Connected events'), findsNothing);
     });
 
@@ -96,9 +100,11 @@ void main() {
       eventSummary = EventSummary(goldenGpuTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Time'), findsOneWidget);
       expect(find.text('Thread id'), findsOneWidget);
       expect(find.text('Process id'), findsOneWidget);
       expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Async id'), findsNothing);
       expect(find.text('Arguments'), findsOneWidget);
     });
 
@@ -106,9 +112,11 @@ void main() {
       eventSummary = EventSummary(goldenUiTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
+      expect(find.text('Time'), findsOneWidget);
       expect(find.text('Thread id'), findsOneWidget);
       expect(find.text('Process id'), findsOneWidget);
       expect(find.text('Category'), findsOneWidget);
+      expect(find.text('Async id'), findsNothing);
       expect(find.text('Arguments'), findsNothing);
     });
   });


### PR DESCRIPTION
Fixes an issue on the dream(g3) timeline hotlist
![image](https://user-images.githubusercontent.com/43759233/71699217-5a700080-2d73-11ea-8dca-28bb004a979e.png)

Fix also added in html version. Generally, we should be adding new features in the flutter version of devtools, but this was an easy fix and it is helpful for my development, so I added the change in both versions of devtools.