### PR TITLE
Remove the paste button from the desktop build

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
 import 'package:pedantic/pedantic.dart';
 
 import '../../src/framework/framework_core.dart';

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -72,21 +72,6 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
         ),
         const Padding(padding: EdgeInsets.only(top: 20.0)),
         _buildTextInput(),
-        // Workaround the lack of copy/paste in macOS shell text input
-        // https://github.com/flutter/flutter/issues/30709
-        // by providing a manual paste button.
-        if (!kIsWeb)
-          RaisedButton(
-            child: const Text(
-              'Paste from clipboard (Flutter Desktop paste support workaround)',
-            ),
-            onPressed: () async {
-              final data = await Clipboard.getData('text/plain');
-              if (data?.text?.isNotEmpty == true) {
-                controller.text = data?.text;
-              }
-            },
-          ),
         const PaddedDivider(padding: EdgeInsets.symmetric(vertical: 10.0)),
         // TODO(https://github.com/flutter/devtools/issues/1111): support drag-and-drop of snapshot files here.
       ],


### PR DESCRIPTION
cmd+v works on flutter macos now.

Fixes #1167 