### PR TITLE
Fixes and improvements for async timeline event display.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,8 +1,6 @@
 ## 0.1.14-dev.2
-* Update package:vm_service dependency to ^2.2.0.
-
-## 0.1.14-dev.1
 * Fix issues with async trace event rendering.
+* Update package:vm_service dependency to ^2.2.0.
 
 ## 0.1.13 - 2019-12-10
 * Fix crash opening macOS desktop apps in DevTools.

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -281,13 +281,12 @@ class _FullTimelineFlameChartState
       final FullTimelineEventGroup group = widget.data.eventGroups[groupName];
       // Expand rows to fit nodes in [group].
       assert(rows.length == currentRowIndex);
-      final groupDisplaySize =
-          group.eventsByRow.length + rowOffsetForSectionSpacer;
+      final groupDisplaySize = group.rows.length + rowOffsetForSectionSpacer;
       expandRows(rows.length + groupDisplaySize);
 
-      for (int i = 0; i < group.eventsByRow.length; i++) {
-        final row = group.eventsByRow[i];
-        for (var event in row) {
+      for (int i = 0; i < group.rows.length; i++) {
+        final rowEvents = group.rows[i].events;
+        for (var event in rowEvents) {
           createChartNode(
             event,
             currentRowIndex + i,

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -285,8 +285,7 @@ class _FullTimelineFlameChartState
       expandRows(rows.length + groupDisplaySize);
 
       for (int i = 0; i < group.rows.length; i++) {
-        final rowEvents = group.rows[i].events;
-        for (var event in rowEvents) {
+        for (var event in group.rows[i].events) {
           createChartNode(
             event,
             currentRowIndex + i,

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -261,11 +261,11 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
       final FullTimelineEventGroup group = data.eventGroups[groupName];
       // Expand rows to fit nodes in [group].
       assert(rows.length == currentRowIndex);
-      expandRows(rows.length + group.eventsByRow.length);
+      expandRows(rows.length + group.rows.length);
 
-      for (int i = 0; i < group.eventsByRow.length; i++) {
-        final row = group.eventsByRow[i];
-        for (var event in row) {
+      for (int i = 0; i < group.rows.length; i++) {
+        final rowEvents = group.rows[i].events;
+        for (var event in rowEvents) {
           createChartNode(
             event,
             currentRowIndex + i,
@@ -314,7 +314,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
       rows[currentRowIndex].addNode(currentSectionLabel, index: 0);
 
       // Increment for next section.
-      currentRowIndex += group.eventsByRow.length;
+      currentRowIndex += group.rows.length;
       currentSectionIndex++;
     }
 

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -344,7 +344,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
             final verticalGuidelineX = node.rect.left + 1;
             final verticalGuidelineStartY = node.rect.bottom;
             final verticalGuidelineEndY =
-                chartNodesByEvent[event.children.last].rect.centerLeft.dy;
+                chartNodesByEvent[event.lowestDisplayChild].rect.centerLeft.dy;
             verticalGuidelines.add(VerticalLineSegment(
               Offset(verticalGuidelineX, verticalGuidelineStartY),
               Offset(verticalGuidelineX, verticalGuidelineEndY),

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -264,8 +264,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
       expandRows(rows.length + group.rows.length);
 
       for (int i = 0; i < group.rows.length; i++) {
-        final rowEvents = group.rows[i].events;
-        for (var event in rowEvents) {
+        for (var event in group.rows[i].events) {
           createChartNode(
             event,
             currentRowIndex + i,

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -508,11 +508,6 @@ class OfflineTimelineEvent extends TimelineEvent {
           'instance of OfflineTimelineEvent');
 
   @override
-  bool get hasOverlappingChildren =>
-      throw UnimplementedError('This method should never be called for an '
-          'instance of OfflineTimelineEvent');
-
-  @override
   List<List<TimelineEvent>> _calculateDisplayRows() =>
       throw UnimplementedError('This method should never be called for an '
           'instance of OfflineTimelineEvent');
@@ -679,8 +674,6 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
   /// This value could come from the end time of [this] event or from the end
   /// time of any of its descendant events.
   int get maxEndMicros;
-
-  bool get hasOverlappingChildren;
 
   bool couldBeParentOf(TimelineEvent e);
 
@@ -890,9 +883,6 @@ class SyncTimelineEvent extends TimelineEvent {
   int get maxEndMicros => time.end.inMicroseconds;
 
   @override
-  bool get hasOverlappingChildren => false;
-
-  @override
   List<List<TimelineEvent>> _calculateDisplayRows() {
     assert(_displayRows == null);
     _expandDisplayRows(depth);
@@ -1024,38 +1014,6 @@ class AsyncTimelineEvent extends TimelineEvent {
       }
     }
     return true;
-  }
-
-  @override
-  bool get hasOverlappingChildren {
-    if (_hasOverlappingChildren != null) return _hasOverlappingChildren;
-    for (int i = 0; i < children.length; i++) {
-      final AsyncTimelineEvent currentChild = children[i];
-      // We do not have to look back because children will be ordered by their
-      // start times.
-      for (int j = i + 1; j < children.length; j++) {
-        final AsyncTimelineEvent sibling = children[j];
-        if (currentChild.isSubtreeOverlapping(sibling)) {
-          return _hasOverlappingChildren = true;
-        }
-      }
-    }
-    return _hasOverlappingChildren = false;
-  }
-
-  bool _hasOverlappingChildren;
-
-  // Warning: this method may be expensive to call for very deep trees.
-  bool isSubtreeOverlapping(TimelineEvent other) {
-    final maxLevelToVerify = math.min(depth, other.depth);
-    for (int level = 0; level < maxLevelToVerify; level++) {
-      final lastEventAtLevel = lastChildNodeAtLevel(level);
-      final otherFirstEventAtLevel = other.firstChildNodeAtLevel(level);
-      if (lastEventAtLevel.time.overlaps(otherFirstEventAtLevel.time)) {
-        return true;
-      }
-    }
-    return false;
   }
 
   @override

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -231,7 +231,7 @@ class FullTimelineEventGroup {
       final lastEventAtLevel = displayRow + level < rows.length
           ? rows[displayRow + level].lastEvent
           : null;
-      final firstNewEventAtLevel = event.displayRows[level].nullSafeFirst();
+      final firstNewEventAtLevel = event.displayRows[level].safeFirst();
       if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
         // Events overlap one another, so [event] does not fit at [displayRow].
         if (lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time)) {
@@ -995,7 +995,7 @@ class AsyncTimelineEvent extends TimelineEvent {
     final maxLevelToVerify =
         math.min(event.displayDepth, currentLargestRowIndex - displayRow);
     for (int level = 0; level < maxLevelToVerify; level++) {
-      final lastEventAtLevel = _displayRows[displayRow + level].nullSafeLast();
+      final lastEventAtLevel = _displayRows[displayRow + level].safeLast();
       final firstNewEventAtLevel = event.firstChildNodeAtLevel(level);
       if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
         // Events overlap one another, so [event] does not fit at [displayRow].

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -200,10 +200,18 @@ class FullTimelineEventGroup {
   ///   [timeline_event_B],
   ///   [timeline_event_D],
   /// ]
-  final List<List<TimelineEvent>> eventsByRow = [];
+  final eventsByRow = <List<TimelineEvent>>[];
+
+  /// At each index in the list, this stores the last event for each row, where
+  /// last means the event has the latest end time in the row.
+  ///
+  /// The most recently added event for the row is not guaranteed to be the last
+  /// event for the row.
+  final lastEventsByRow = <TimelineEvent>[];
 
   int get displayDepth => eventsByRow.length;
 
+  // TODO(kenz): prevent guideline "elbows" from overlapping other events.
   void addEventAtCalculatedRow(TimelineEvent event, {int displayRow = 0}) {
     final currentLargestRowIndex = eventsByRow.length;
     while (displayRow < currentLargestRowIndex) {
@@ -217,7 +225,7 @@ class FullTimelineEventGroup {
       if (eventFitsAtDisplayRow) break;
       displayRow++;
     }
-    _addEvent(event, row: displayRow);
+    _addEventAtDisplayRow(event, row: displayRow);
   }
 
   bool _eventFitsAtDisplayRow(
@@ -228,15 +236,17 @@ class FullTimelineEventGroup {
     final maxLevelToVerify =
         math.min(event.displayDepth, currentLargestRowIndex - displayRow);
     for (int level = 0; level < maxLevelToVerify; level++) {
-      final lastEventAtDisplayRow =
-          eventsByRow[displayRow + level].nullSafeLast();
-      final firstNewEventAtLevel = event.firstChildNodeAtLevel(level);
-      if (lastEventAtDisplayRow != null && firstNewEventAtLevel != null) {
+      final lastEventAtLevel = displayRow + level < lastEventsByRow.length
+          ? lastEventsByRow[displayRow + level]
+          : null;
+      final firstNewEventAtLevel = event.displayRows[level].nullSafeFirst();
+      if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
         final eventsOverlap =
-            lastEventAtDisplayRow.time.overlaps(firstNewEventAtLevel.time);
-        final newEventStartsBeforeLastEventAtRow =
-            lastEventAtDisplayRow.time.start > firstNewEventAtLevel.time.end;
-        if (eventsOverlap || newEventStartsBeforeLastEventAtRow) {
+            lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time);
+        final newEventStartsBeforeLastEvent =
+            lastEventAtLevel.time.start > firstNewEventAtLevel.time.end;
+
+        if (eventsOverlap || newEventStartsBeforeLastEvent) {
           // [event] does not fit at [displayRow].
           return false;
         }
@@ -245,30 +255,22 @@ class FullTimelineEventGroup {
     return true;
   }
 
-  void _addEvent(TimelineEvent event, {@required int row}) {
-    if (row >= eventsByRow.length) {
-      for (int i = eventsByRow.length; i <= row; i++) {
+  void _addEventAtDisplayRow(TimelineEvent event, {@required int row}) {
+    if (row + event.displayDepth >= eventsByRow.length) {
+      for (int i = eventsByRow.length; i <= row + event.displayDepth; i++) {
         eventsByRow.add([]);
+        lastEventsByRow.add(null);
       }
     }
-    eventsByRow[row].add(event);
 
-    var overlappingChildrenOffset = 0;
-    final nextRow = row + 1;
-    for (int i = 0; i < event.children.length; i++) {
-      final child = event.children[i];
-      if (i != 0 && event.hasOverlappingChildren) {
-        if (_eventFitsAtDisplayRow(child, nextRow, eventsByRow.length)) {
-          _addEvent(child, row: nextRow);
-        } else {
-          // If [child] does not fit on the target row, add it below the
-          // previous child.
-          final previousChild = event.children[i - 1];
-          overlappingChildrenOffset += previousChild.displayDepth;
-          _addEvent(child, row: nextRow + overlappingChildrenOffset);
+    for (int i = 0; i < event.displayDepth; i++) {
+      final displayRow = event.displayRows[i];
+      for (var e in displayRow) {
+        eventsByRow[row + i].add(e);
+        if (e.time.end >
+            (lastEventsByRow[row + i]?.time?.end ?? const Duration())) {
+          lastEventsByRow[row + i] = e;
         }
-      } else {
-        _addEvent(child, row: nextRow);
       }
     }
   }
@@ -506,12 +508,12 @@ class OfflineTimelineEvent extends TimelineEvent {
           'instance of OfflineTimelineEvent');
 
   @override
-  int get displayDepth =>
+  bool get hasOverlappingChildren =>
       throw UnimplementedError('This method should never be called for an '
           'instance of OfflineTimelineEvent');
 
   @override
-  bool get hasOverlappingChildren =>
+  List<List<TimelineEvent>> _calculateDisplayRows() =>
       throw UnimplementedError('This method should never be called for an '
           'instance of OfflineTimelineEvent');
 }
@@ -678,11 +680,50 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
   /// time of any of its descendant events.
   int get maxEndMicros;
 
-  int get displayDepth;
-
   bool get hasOverlappingChildren;
 
   bool couldBeParentOf(TimelineEvent e);
+
+  /// Tracks the start row for the lowest visual child in the display for this
+  /// TimelineEvent.
+  int _lowestDisplayChildRow = 1;
+
+  /// The lowest visual child in the display for this TimelineEvent.
+  TimelineEvent get lowestDisplayChild => _lowestDisplayChild;
+  TimelineEvent _lowestDisplayChild;
+
+  int get displayDepth => displayRows.length;
+
+  List<List<TimelineEvent>> _displayRows;
+  List<List<TimelineEvent>> get displayRows =>
+      _displayRows ??= _calculateDisplayRows();
+
+  List<List<TimelineEvent>> _calculateDisplayRows();
+
+  void _expandDisplayRows(int newRowLength) {
+    _displayRows ??= [];
+    final currentLength = _displayRows.length;
+    for (int i = currentLength; i < newRowLength; i++) {
+      _displayRows.add([]);
+    }
+  }
+
+  void _mergeChildDisplayRows(int mergeStartLevel, TimelineEvent child) {
+    assert(
+      mergeStartLevel <= _displayRows.length,
+      'mergeStartLevel $mergeStartLevel is greater than _displayRows.length'
+      ' ${_displayRows.length}',
+    );
+    final childDisplayRows = child.displayRows;
+    _expandDisplayRows(mergeStartLevel + childDisplayRows.length);
+    for (int i = 0; i < childDisplayRows.length; i++) {
+      displayRows[mergeStartLevel + i].addAll(childDisplayRows[i]);
+    }
+    if (mergeStartLevel >= _lowestDisplayChildRow) {
+      _lowestDisplayChildRow = mergeStartLevel;
+      _lowestDisplayChild = child;
+    }
+  }
 
   void addEndEvent(TraceEventWrapper eventWrapper) {
     time.end = Duration(microseconds: eventWrapper.event.timestampMicros);
@@ -849,10 +890,19 @@ class SyncTimelineEvent extends TimelineEvent {
   int get maxEndMicros => time.end.inMicroseconds;
 
   @override
-  int get displayDepth => depth;
+  bool get hasOverlappingChildren => false;
 
   @override
-  bool get hasOverlappingChildren => false;
+  List<List<TimelineEvent>> _calculateDisplayRows() {
+    assert(_displayRows == null);
+    _expandDisplayRows(depth);
+
+    _displayRows[0].add(this);
+    for (final child in children) {
+      _mergeChildDisplayRows(1, child);
+    }
+    return _displayRows;
+  }
 
   @override
   bool couldBeParentOf(TimelineEvent e) {
@@ -881,6 +931,8 @@ class SyncTimelineEvent extends TimelineEvent {
   }
 }
 
+// TODO(kenz): calculate and store async guidelines here instead of in the UI
+// code.
 class AsyncTimelineEvent extends TimelineEvent {
   AsyncTimelineEvent(TraceEventWrapper firstTraceEvent)
       : asyncId = firstTraceEvent.event.id,
@@ -914,40 +966,64 @@ class AsyncTimelineEvent extends TimelineEvent {
   }
 
   @override
-  int get displayDepth => _displayDepth ?? _calculateDisplayDepth();
+  List<List<TimelineEvent>> _calculateDisplayRows() {
+    assert(_displayRows == null);
+    _expandDisplayRows(1);
 
-  int _displayDepth;
+    const currentRow = 0;
+    _displayRows[currentRow].add(this);
 
-  // TODO(kenz): fix this algorithm so that it calculates the exact display
-  // depth, not the max. Not sure why this works as is - need to investigate.
-  int _calculateDisplayDepth() {
-    // Base case.
-    if (children.isEmpty) {
-      return _displayDepth = 1;
-    }
-
-    var displayDepth = 1;
-    if (hasOverlappingChildren) {
-      // If any children have overlapping timestamps, assume they all overlap
-      // and need to be displayed each on a new row.
-      for (AsyncTimelineEvent child in children) {
-        // TODO(kenz): in order to calculate the exact display depth, this needs
-        // to not sum all depths but instead use the [_eventFitsAtDisplayRow]
-        // logic from [FullTimelineEventGroup] to calculate where events fit.
-        // This should work as long as the tree is traversed depth first.
-        displayDepth += child._calculateDisplayDepth();
+    const mainChildRow = currentRow + 1;
+    for (int i = 0; i < children.length; i++) {
+      final AsyncTimelineEvent child = children[i];
+      if (i == 0 ||
+          _eventFitsAtDisplayRow(child, mainChildRow, _displayRows.length)) {
+        _mergeChildDisplayRows(mainChildRow, child);
+      } else {
+        // If [child] does not fit on the target row, add it below the current
+        // deepest display row.
+        _mergeChildDisplayRows(displayRows.length, child);
       }
-    } else {
-      int maxChildDepth = -1;
-      for (AsyncTimelineEvent child in children) {
-        maxChildDepth = math.max(
-          maxChildDepth,
-          child._calculateDisplayDepth(),
-        );
-      }
-      displayDepth += maxChildDepth;
     }
-    return _displayDepth = displayDepth;
+    return _displayRows;
+  }
+
+  bool _eventFitsAtDisplayRow(
+    AsyncTimelineEvent event,
+    int displayRow,
+    int currentLargestRowIndex,
+  ) {
+    final maxLevelToVerify =
+        math.min(event.displayDepth, currentLargestRowIndex - displayRow);
+    for (int level = 0; level < maxLevelToVerify; level++) {
+      final lastEventAtLevel = _displayRows[displayRow + level].nullSafeLast();
+      final firstNewEventAtLevel = event.firstChildNodeAtLevel(level);
+      if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
+        final eventsOverlap =
+            lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time);
+        final newEventStartsBeforeLastEvent =
+            lastEventAtLevel.time.start > firstNewEventAtLevel.time.end;
+
+        final lastEventParent = lastEventAtLevel.parent;
+        final firstNewEventParent = firstNewEventAtLevel.parent;
+        // If the two events are non-overlapping siblings and their parent ends
+        // before [lastEventAtLevel], drawing a subsequent guideline from
+        // [lastEventParent] to [firstNewEventAtLevel] would overlap
+        // [lastEventAtLevel], so we cannot place [event] on this row.
+        final siblingsWouldCauseOverlappingGuideline =
+            lastEventParent != null &&
+                firstNewEventParent != null &&
+                lastEventParent == firstNewEventParent &&
+                lastEventAtLevel.time.end >= lastEventParent.time.end;
+        if (eventsOverlap ||
+            newEventStartsBeforeLastEvent ||
+            siblingsWouldCauseOverlappingGuideline) {
+          // [event] does not fit at [displayRow].
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   @override

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -269,7 +269,7 @@ class FullTimelineEventGroup {
 }
 
 class FullTimelineRowData {
-  /// Timeline events that will be painted in this row in a visualization of a
+  /// Timeline events that will be displayed in this row in a visualization of a
   /// [FullTimelineEventGroup].
   final List<TimelineEvent> events = [];
 
@@ -1015,12 +1015,12 @@ class AsyncTimelineEvent extends TimelineEvent {
         // before [lastEventAtLevel], drawing a subsequent guideline from
         // [lastEventParent] to [firstNewEventAtLevel] would overlap
         // [lastEventAtLevel], so we cannot place [event] on this row.
-        final siblingsWouldCauseOverlappingGuideline =
-            lastEventParent != null &&
-                firstNewEventParent != null &&
-                lastEventParent == firstNewEventParent &&
-                lastEventAtLevel.time.end >= lastEventParent.time.end;
-        if (siblingsWouldCauseOverlappingGuideline) return false;
+        if (lastEventParent != null &&
+            firstNewEventParent != null &&
+            lastEventParent == firstNewEventParent &&
+            lastEventAtLevel.time.end >= lastEventParent.time.end) {
+          return false;
+        }
       }
     }
     return true;

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -257,7 +257,7 @@ class FullTimelineEventGroup {
 
   void _addEventAtDisplayRow(TimelineEvent event, {@required int row}) {
     if (row + event.displayDepth >= eventsByRow.length) {
-      for (int i = eventsByRow.length; i <= row + event.displayDepth; i++) {
+      for (int i = eventsByRow.length; i < row + event.displayDepth; i++) {
         eventsByRow.add([]);
         lastEventsByRow.add(null);
       }

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -518,7 +518,14 @@ class ImmediateValueNotifier<T> extends ValueNotifier<T> {
   }
 }
 
-extension NullSafeLast<T> on List<T> {
+extension NullSafeAccess<T> on List<T> {
+  T nullSafeFirst() {
+    if (isEmpty) {
+      return null;
+    }
+    return first;
+  }
+
   T nullSafeLast() {
     if (isEmpty) {
       return null;

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -519,18 +519,12 @@ class ImmediateValueNotifier<T> extends ValueNotifier<T> {
 }
 
 extension NullSafeAccess<T> on List<T> {
-  T nullSafeFirst() {
-    if (isEmpty) {
-      return null;
-    }
-    return first;
+  T safeFirst() {
+    return safeGet(0);
   }
 
-  T nullSafeLast() {
-    if (isEmpty) {
-      return null;
-    }
-    return last;
+  T safeLast() {
+    return safeGet(length - 1);
   }
 
   T safeGet(int index) {

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -532,4 +532,12 @@ extension NullSafeAccess<T> on List<T> {
     }
     return last;
   }
+
+  T safeGet(int index) {
+    if (index < 0 || index >= length) {
+      return null;
+    } else {
+      return this[index];
+    }
+  }
 }

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -356,27 +356,6 @@ void main() {
       expect(asyncEventWithDeepOverlap.displayDepth, equals(5));
     });
 
-    test('hasOverlappingChildren', () {
-      expect(asyncEventA.hasOverlappingChildren, isTrue);
-      expect(asyncEventB.hasOverlappingChildren, isTrue);
-      expect(asyncEventC.hasOverlappingChildren, isFalse);
-      expect(asyncEventD.hasOverlappingChildren, isFalse);
-    });
-
-    test('isSubtreeOverlapping', () {
-      expect(
-        asyncEventWithDeepOverlap1.time
-            .overlaps(asyncEventWithDeepOverlap2.time),
-        isFalse,
-      );
-      expect(asyncEvent3.time.overlaps(asyncEvent4.time), isTrue);
-      expect(
-        asyncEventWithDeepOverlap1
-            .isSubtreeOverlapping(asyncEventWithDeepOverlap2),
-        isTrue,
-      );
-    });
-
     test('couldBeParentOf', () {
       expect(asyncEventA.couldBeParentOf(asyncEventB1), isFalse);
       expect(asyncEventB.couldBeParentOf(asyncEventB1), isTrue);

--- a/packages/devtools_app/test/timeline_model_test.dart
+++ b/packages/devtools_app/test/timeline_model_test.dart
@@ -119,19 +119,19 @@ void main() {
       expect(timelineData.eventGroups, isEmpty);
       timelineData.initializeEventGroups();
       expect(
-        timelineData.eventGroups[FullTimelineData.uiKey].eventsByRow[0].length,
+        timelineData.eventGroups[FullTimelineData.uiKey].rows[0].events.length,
         equals(1),
       );
       expect(
-        timelineData.eventGroups[FullTimelineData.gpuKey].eventsByRow[0].length,
+        timelineData.eventGroups[FullTimelineData.gpuKey].rows[0].events.length,
         equals(1),
       );
       expect(
         timelineData
-            .eventGroups[FullTimelineData.unknownKey].eventsByRow[0].length,
+            .eventGroups[FullTimelineData.unknownKey].rows[0].events.length,
         equals(1),
       );
-      expect(timelineData.eventGroups['A'].eventsByRow[0].length, equals(1));
+      expect(timelineData.eventGroups['A'].rows[0].events.length, equals(1));
     });
 
     test('event bucket compare', () {

--- a/packages/devtools_app/test/timeline_protocol_test.dart
+++ b/packages/devtools_app/test/timeline_protocol_test.dart
@@ -336,7 +336,7 @@ void main() {
         equals(TimelineEventType.gpu),
       );
       expect(
-        processor.inferEventType(unknownEventTrace.event),
+        processor.inferEventType(unknownEventBeginTrace.event),
         equals(TimelineEventType.unknown),
       );
     });

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -433,6 +433,15 @@ void main() {
         list.add(null);
         expect(list.nullSafeLast(), isNull);
       });
+
+      test('safeGet', () {
+        final list = [];
+        expect(list.safeGet(0), isNull);
+        list.addAll([1, 2]);
+        expect(list.safeGet(0), equals(1));
+        expect(list.safeGet(1), equals(2));
+        expect(list.safeGet(-1), isNull);
+      });
     });
   });
 }

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -418,20 +418,20 @@ void main() {
     group('null safe list', () {
       test('nullSafeFirst', () {
         final list = [];
-        expect(list.nullSafeFirst(), isNull);
+        expect(list.safeFirst(), isNull);
         list.addAll([1, 2, 3]);
-        expect(list.nullSafeFirst(), equals(1));
+        expect(list.safeFirst(), equals(1));
         list.insert(0, null);
-        expect(list.nullSafeFirst(), isNull);
+        expect(list.safeFirst(), isNull);
       });
 
       test('nullSafeLast', () {
         final list = [];
-        expect(list.nullSafeLast(), isNull);
+        expect(list.safeLast(), isNull);
         list.addAll([1, 2, 3]);
-        expect(list.nullSafeLast(), equals(3));
+        expect(list.safeLast(), equals(3));
         list.add(null);
-        expect(list.nullSafeLast(), isNull);
+        expect(list.safeLast(), isNull);
       });
 
       test('safeGet', () {

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -416,6 +416,15 @@ void main() {
     });
 
     group('null safe list', () {
+      test('nullSafeFirst', () {
+        final list = [];
+        expect(list.nullSafeFirst(), isNull);
+        list.addAll([1, 2, 3]);
+        expect(list.nullSafeFirst(), equals(1));
+        list.insert(0, null);
+        expect(list.nullSafeFirst(), isNull);
+      });
+
       test('nullSafeLast', () {
         final list = [];
         expect(list.nullSafeLast(), isNull);

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -553,7 +553,8 @@ final asyncEventC2 = AsyncTimelineEvent(asyncStartC2Trace)
 final asyncEventD = AsyncTimelineEvent(asyncStartDTrace)
   ..addEndEvent(asyncEndDTrace);
 
-final asyncEventWithDeepOverlap = AsyncTimelineEvent(asyncStartTraceEventWithDeepOverlap)
+final asyncEventWithDeepOverlap = AsyncTimelineEvent(
+    asyncStartTraceEventWithDeepOverlap)
   ..addEndEvent(asyncEndTraceEventWithDeepOverlap)
   ..addAllChildren([asyncEventWithDeepOverlap1, asyncEventWithDeepOverlap2]);
 final asyncEventWithDeepOverlap1 = AsyncTimelineEvent(asyncStart1Trace)

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -916,14 +916,25 @@ final asyncChildEndId2 = testTraceEventWrapper({
 });
 
 // Mark: unknown event
-final unknownEvent = SyncTimelineEvent(unknownEventTrace);
-final unknownEventTrace = testTraceEventWrapper({
+final unknownEvent = SyncTimelineEvent(unknownEventBeginTrace)
+  ..addEndEvent(unknownEventEndTrace);
+final unknownEventBeginTrace = testTraceEventWrapper({
   'name': 'Unknown trace event',
   'cat': 'Dart',
   'tid': testUnknownThreadId,
   'pid': 51385,
   'ts': 193938741076,
   'ph': 'B',
+  'id': '7',
+  'args': {'isolateId': 'isolates/2139247553966975'},
+});
+final unknownEventEndTrace = testTraceEventWrapper({
+  'name': 'Unknown trace event',
+  'cat': 'Dart',
+  'tid': testUnknownThreadId,
+  'pid': 51385,
+  'ts': 193938742076,
+  'ph': 'E',
   'id': '7',
   'args': {'isolateId': 'isolates/2139247553966975'},
 });


### PR DESCRIPTION
- Fixed a bug where async timeline events and guidelines could overlap other events.
- Fixed and improved logic for calculating display depth - now each event is responsible for calculating its own display depth, instead of the FullTimelineEventGroup being responsible for calculating the display depth for the entire event group. The logic changes are covered by existing tests for displayDepth