### PR TITLE
Add async guidelines to flutter flame chart.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -95,20 +95,20 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     super.initState();
     initFlameChartElements();
 
-    linkedHorizontalScrollControllerGroup = LinkedScrollControllerGroup();
-    linkedHorizontalScrollControllerGroup.onOffsetChanged(() {
-      setState(() {
-        horizontalScrollOffset = linkedHorizontalScrollControllerGroup.offset;
-      });
-    });
-    verticalScrollController = ScrollController();
-    verticalScrollController.addListener(() {
-      if (verticalScrollOffset != verticalScrollController.offset) {
+    linkedHorizontalScrollControllerGroup = LinkedScrollControllerGroup()
+      ..onOffsetChanged(() {
         setState(() {
-          verticalScrollOffset = verticalScrollController.offset;
+          horizontalScrollOffset = linkedHorizontalScrollControllerGroup.offset;
         });
-      }
-    });
+      });
+    verticalScrollController = ScrollController()
+      ..addListener(() {
+        if (verticalScrollOffset != verticalScrollController.offset) {
+          setState(() {
+            verticalScrollOffset = verticalScrollController.offset;
+          });
+        }
+      });
   }
 
   @override
@@ -132,14 +132,15 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     return LayoutBuilder(
       builder: (context, constraints) {
         final customPaints = buildCustomPaints(constraints);
+        final flameChart = _buildFlameChart(constraints);
         return customPaints.isNotEmpty
             ? Stack(
                 children: [
-                  _buildFlameChart(constraints),
+                  flameChart,
                   ...customPaints,
                 ],
               )
-            : _buildFlameChart(constraints);
+            : flameChart;
       },
     );
   }

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -84,19 +84,10 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
 
   int get startTimeOffset => widget.data.time.start.inMicroseconds;
 
-  /// Whether the flame chart has custom paints that need to be painted on top
-  /// of the chart.
+  /// Provides CustomPaint widgets to be painted on top of the flame chart, if
+  /// overridden.
   ///
-  /// This needs to be overridden to return true if [buildCustomPaints] is overridden
-  /// to return a non-empty list of painters.
-  bool get hasCustomPaints => false;
-
-  // Override this method if custom painters need to be painted on top of the
-  // flame chart. The painters will be painted in the order that they are
-  // returned by the provider.
-  //
-  // In order for the painters to be build, [hasCustomPainters] must be
-  // overridden to return true.
+  /// The painters will be painted in the order that they are returned.
   List<CustomPaint> buildCustomPaints(BoxConstraints constraints) => [];
 
   @override

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -96,7 +96,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     initFlameChartElements();
 
     linkedHorizontalScrollControllerGroup = LinkedScrollControllerGroup()
-      ..onOffsetChanged(() {
+      ..addOffsetChangedListener(() {
         setState(() {
           horizontalScrollOffset = linkedHorizontalScrollControllerGroup.offset;
         });

--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profile_flame_chart.dart
@@ -16,7 +16,7 @@ class CpuProfileFlameChart extends FlameChart<CpuProfileData, CpuStackFrame> {
     @required Function(CpuStackFrame stackFrame) onSelected,
   }) : super(
           data,
-          duration: data.profileMetaData.time.duration,
+          time: data.profileMetaData.time,
           totalStartingWidth: width,
           startInset: sideInsetSmall,
           endInset: sideInsetSmall,
@@ -61,7 +61,7 @@ class _CpuProfileFlameChartState
         onSelected: (dynamic frame) => widget.onSelected(frame),
       );
 
-      rows[row].nodes.add(node);
+      rows[row].addNode(node);
 
       for (CpuStackFrame child in stackFrame.children) {
         createChartNodes(child, row + 1);

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -64,7 +64,7 @@ class TimelineFlameChart extends StatelessWidget {
     return !fullTimelineEmpty
         ? FullTimelineFlameChart(
             controller.fullTimeline.data,
-            // TODO(kenz): remove * 4 once zooming is possible. This is so that we can
+            // TODO(kenz): remove * 8 once zooming is possible. This is so that we can
             // test horizontal scrolling functionality.
             width: constraints.maxWidth * 8,
             selected: selectedEvent,
@@ -94,6 +94,7 @@ class FrameBasedTimelineFlameChart
       FrameBasedTimelineFlameChartState();
 }
 
+// TODO(kenz): override buildCustomPaints to provide TimelineGridPainter.
 class FrameBasedTimelineFlameChartState
     extends FlameChartState<FrameBasedTimelineFlameChart, TimelineEvent> {
   // Add one for the spacer offset between UI and GPU nodes.
@@ -352,9 +353,6 @@ class _FullTimelineFlameChartState
   }
 
   @override
-  bool get hasCustomPaints => true;
-
-  @override
   List<CustomPaint> buildCustomPaints(BoxConstraints constraints) {
     // TODO(kenz): add TimelineGridPainter to this list.
     return [
@@ -371,9 +369,6 @@ class _FullTimelineFlameChartState
     ];
   }
 
-  // TODO(kenz): fix this. The calculation is wrong because the nodes are not
-  // absolutely positioned like they were in the dart:html app. They are
-  // positioned within their own rows in the flutter app.
   void _calculateAsyncGuidelines() {
     // Padding to be added between a subsequent guideline and the child event
     // it is connecting.

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -515,7 +515,7 @@ class AsyncGuidelinePainter extends CustomPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final Rect visible = Rect.fromLTWH(
+    final visible = Rect.fromLTWH(
       horizontalScrollOffset,
       verticalScrollOffset,
       constraints.maxWidth,
@@ -583,6 +583,8 @@ class AsyncGuidelinePainter extends CustomPainter {
     }
   }
 
+  // TODO(kenz): does this have to return true all the time? Is it cheaper to
+  // compare delegates or to just paint?
   @override
   bool shouldRepaint(AsyncGuidelinePainter oldDelegate) => true;
 }

--- a/packages/devtools_app/lib/src/timeline/simple_trace_example.dart
+++ b/packages/devtools_app/lib/src/timeline/simple_trace_example.dart
@@ -73,7 +73,7 @@ final simpleTraceEvents = {
       'ts': 193937113560,
       'ph': 'b',
       'id': '2',
-      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Bb',
@@ -83,7 +83,7 @@ final simpleTraceEvents = {
       'ts': 193937117450,
       'ph': 'b',
       'id': '8',
-      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '7', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'B1',
@@ -93,7 +93,7 @@ final simpleTraceEvents = {
       'ts': 193937141769,
       'ph': 'b',
       'id': 'd',
-      'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '2', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Bb1',
@@ -103,7 +103,7 @@ final simpleTraceEvents = {
       'ts': 193937141961,
       'ph': 'b',
       'id': 'f',
-      'args': {'parentId': 8, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '8', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'C',
@@ -113,7 +113,7 @@ final simpleTraceEvents = {
       'ts': 193937168961,
       'ph': 'b',
       'id': '3',
-      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Cc',
@@ -123,7 +123,7 @@ final simpleTraceEvents = {
       'ts': 193937169662,
       'ph': 'b',
       'id': '9',
-      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '7', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'B2',
@@ -133,7 +133,7 @@ final simpleTraceEvents = {
       'ts': 193937173019,
       'ph': 'b',
       'id': 'e',
-      'args': {'parentId': 2, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '2', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Bb2',
@@ -143,7 +143,7 @@ final simpleTraceEvents = {
       'ts': 193937173132,
       'ph': 'b',
       'id': '10',
-      'args': {'parentId': 8, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '8', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'C1',
@@ -153,7 +153,7 @@ final simpleTraceEvents = {
       'ts': 193937220903,
       'ph': 'b',
       'id': '11',
-      'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '3', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Cc1',
@@ -163,7 +163,7 @@ final simpleTraceEvents = {
       'ts': 193937221087,
       'ph': 'b',
       'id': '13',
-      'args': {'parentId': 9, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '9', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'B1',
@@ -233,7 +233,7 @@ final simpleTraceEvents = {
       'ts': 193937378812,
       'ph': 'b',
       'id': '12',
-      'args': {'parentId': 3, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '3', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Cc2',
@@ -243,7 +243,7 @@ final simpleTraceEvents = {
       'ts': 193937378989,
       'ph': 'b',
       'id': '14',
-      'args': {'parentId': 9, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '9', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'B',
@@ -313,7 +313,7 @@ final simpleTraceEvents = {
       'ts': 193937574832,
       'ph': 'b',
       'id': '4',
-      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Dd',
@@ -323,7 +323,7 @@ final simpleTraceEvents = {
       'ts': 193937575344,
       'ph': 'b',
       'id': 'a',
-      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '7', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'E',
@@ -333,7 +333,7 @@ final simpleTraceEvents = {
       'ts': 193937630473,
       'ph': 'b',
       'id': '5',
-      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ee',
@@ -343,7 +343,7 @@ final simpleTraceEvents = {
       'ts': 193937631341,
       'ph': 'b',
       'id': 'b',
-      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '7', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'D',
@@ -373,7 +373,7 @@ final simpleTraceEvents = {
       'ts': 193937681385,
       'ph': 'b',
       'id': '15',
-      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '5', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ee1',
@@ -383,7 +383,7 @@ final simpleTraceEvents = {
       'ts': 193937682955,
       'ph': 'b',
       'id': '19',
-      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '11', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'F',
@@ -393,7 +393,7 @@ final simpleTraceEvents = {
       'ts': 193937735555,
       'ph': 'b',
       'id': '6',
-      'args': {'parentId': 1, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '1', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ff',
@@ -403,7 +403,7 @@ final simpleTraceEvents = {
       'ts': 193937736205,
       'ph': 'b',
       'id': 'c',
-      'args': {'parentId': 7, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '7', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'E2',
@@ -413,7 +413,7 @@ final simpleTraceEvents = {
       'ts': 193937736389,
       'ph': 'b',
       'id': '16',
-      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '5', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ee2',
@@ -423,7 +423,7 @@ final simpleTraceEvents = {
       'ts': 193937736537,
       'ph': 'b',
       'id': '1a',
-      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '11', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'W',
@@ -445,7 +445,7 @@ final simpleTraceEvents = {
       'ts': 193937788218,
       'ph': 'b',
       'id': '17',
-      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '5', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ee3',
@@ -455,7 +455,7 @@ final simpleTraceEvents = {
       'ts': 193937788380,
       'ph': 'b',
       'id': '1b',
-      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '11', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'E1',
@@ -557,7 +557,7 @@ final simpleTraceEvents = {
       'ts': 193938105406,
       'ph': 'b',
       'id': '18',
-      'args': {'parentId': 5, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '5', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'Ee4',
@@ -567,7 +567,7 @@ final simpleTraceEvents = {
       'ts': 193938105579,
       'ph': 'b',
       'id': '1c',
-      'args': {'parentId': 11, 'isolateId': 'isolates/2139247553966975'}
+      'args': {'parentId': '11', 'isolateId': 'isolates/2139247553966975'}
     },
     {
       'name': 'E4',

--- a/packages/devtools_app/lib/src/timeline/timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_processor.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../config_specific/logger.dart';
 import '../utils.dart';
-//import 'simple_trace_example.dart';
+import 'simple_trace_example.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
 
@@ -650,12 +650,12 @@ class FullTimelineProcessor extends TimelineProcessor {
 
   void processTimeline(List<TraceEventWrapper> traceEvents) async {
 // Uncomment this code for testing the timeline.
-//    traceEvents = simpleTraceEvents['traceEvents']
-//        .where((json) =>
-//            json.containsKey(TraceEvent.timestampKey)) // thread_name events
-//        .map((e) => TraceEventWrapper(
-//            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
-//        .toList();
+    traceEvents = simpleTraceEvents['traceEvents']
+        .where((json) =>
+            json.containsKey(TraceEvent.timestampKey)) // thread_name events
+        .map((e) => TraceEventWrapper(
+            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
+        .toList();
     final _traceEvents = (traceEvents
         // Throw out timeline events that do not have a timestamp
         // (e.g. thread_name events).

--- a/packages/devtools_app/lib/src/timeline/timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_processor.dart
@@ -9,7 +9,7 @@ import 'package:meta/meta.dart';
 
 import '../config_specific/logger.dart';
 import '../utils.dart';
-import 'simple_trace_example.dart';
+//import 'simple_trace_example.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
 
@@ -650,12 +650,12 @@ class FullTimelineProcessor extends TimelineProcessor {
 
   void processTimeline(List<TraceEventWrapper> traceEvents) async {
 // Uncomment this code for testing the timeline.
-    traceEvents = simpleTraceEvents['traceEvents']
-        .where((json) =>
-            json.containsKey(TraceEvent.timestampKey)) // thread_name events
-        .map((e) => TraceEventWrapper(
-            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
-        .toList();
+//    traceEvents = simpleTraceEvents['traceEvents']
+//        .where((json) =>
+//            json.containsKey(TraceEvent.timestampKey)) // thread_name events
+//        .map((e) => TraceEventWrapper(
+//            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
+//        .toList();
     final _traceEvents = (traceEvents
         // Throw out timeline events that do not have a timestamp
         // (e.g. thread_name events).

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -518,7 +518,7 @@ class ImmediateValueNotifier<T> extends ValueNotifier<T> {
   }
 }
 
-extension NullSafeAccess<T> on List<T> {
+extension SafeAccess<T> on List<T> {
   T safeFirst() {
     return safeGet(0);
   }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -63,7 +63,9 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_widgets: ^0.1.8
+  flutter_widgets:
+  #^0.1.8
+    path: ../../../flutter.widgets
 
 dependency_overrides:
   # When this is removed, don't forget to add back the override for test tag.

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -63,9 +63,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_widgets:
-  #^0.1.8
-    path: ../../../flutter.widgets
+  flutter_widgets: ^0.1.9
 
 dependency_overrides:
   # When this is removed, don't forget to add back the override for test tag.

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -415,8 +415,8 @@ void main() {
       });
     });
 
-    group('null safe list', () {
-      test('nullSafeFirst', () {
+    group('SafeAccess', () {
+      test('safeFirst', () {
         final list = [];
         expect(list.safeFirst(), isNull);
         list.addAll([1, 2, 3]);
@@ -425,7 +425,7 @@ void main() {
         expect(list.safeFirst(), isNull);
       });
 
-      test('nullSafeLast', () {
+      test('safeLast', () {
         final list = [];
         expect(list.safeLast(), isNull);
         list.addAll([1, 2, 3]);


### PR DESCRIPTION
Add async guidelines to flutter flame chart.
![Screen Shot 2020-01-08 at 2 22 49 PM](https://user-images.githubusercontent.com/43759233/72022912-6e5dab80-3226-11ea-9adb-59f01e97ba2d.png)

Much of this code is reused from the existing html code. The guideline calculation for y positioned had to be modified since the nodes in the flutter flame chart have y values relative to their containing row, whereas the y values in the html flame chart are absolute within the entire chart.

Depends on a publish of flutter_widgets 0.1.9