### PR TITLE
Expand width of connect dialog to fit whole URI.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -82,7 +82,7 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         SizedBox(
-          width: 240.0,
+          width: 300.0,
           child: TextField(
             onSubmitted: _connect,
             decoration: const InputDecoration(


### PR DESCRIPTION
Width of text box now fits entire hint text and entire vm service uri
<img width="425" alt="Screen Shot 2020-01-09 at 9 40 21 AM" src="https://user-images.githubusercontent.com/43759233/72091097-40c73f80-32c4-11ea-93b6-bd889f7f97f8.png">
<img width="427" alt="Screen Shot 2020-01-09 at 9 40 33 AM" src="https://user-images.githubusercontent.com/43759233/72091099-42910300-32c4-11ea-9323-a5cb1659cd9d.png">

Fixes https://github.com/flutter/devtools/issues/1516.