### PR TITLE
Move OSX travis to FYI status

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 os:
   - linux
-  - osx
-  - windows
 
 language: dart
 dart:
@@ -39,14 +37,20 @@ matrix:
         - BOT=test_dart2js
         - BOT=integration_ddc
         - BOT=integration_dart2js
+    
   include:
     - dart: "dev/raw/latest"
       env: BOT=packages
+    # Skip OSX and Windows builds when submitting a PR, but still run them on master
+    # as post-submit tests.
+    - if: branch = master AND type = push AND fork = false
+      os: osx
+    - if: branch = master AND type = push AND fork = false
+      os: windows
   # Allow windows bots to fail until we can make the windows tests less flaky.
   # https://github.com/flutter/devtools/issues/963
   allow_failures:
     - os: windows
-    - os: osx
 
 env:
   - BOT=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ matrix:
   # https://github.com/flutter/devtools/issues/963
   allow_failures:
     - os: windows
+    - os: osx
 
 env:
   - BOT=main


### PR DESCRIPTION
OSX bots setup and run slower than the linux bots, so this can speed things up substantially.

Fixes #1413. 