### PR TITLE
Add option to enable profiler when the vm 'profiler' flag is disabled.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -82,7 +82,7 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         SizedBox(
-          width: 300.0,
+          width: 350.0,
           child: TextField(
             onSubmitted: _connect,
             decoration: const InputDecoration(

--- a/packages/devtools_app/lib/src/memory/html_memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/html_memory_screen.dart
@@ -1510,8 +1510,6 @@ class HtmlMemoryScreen extends HtmlScreen with HtmlSetStateMixin {
 ///      _hashCode [hashCode of instance]
 ///      field [field of parent class that has ref]
 class NavigationState {
-  NavigationState._() : _className = '';
-
   NavigationState.classSelect(this._className);
 
   NavigationState.instanceSelect(this._className, this._hashCode);

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/common_widgets.dart';
 import '../../flutter/controllers.dart';
@@ -44,6 +45,17 @@ class PerformanceScreenBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final controller = Controllers.of(context).performance;
+    return ValueListenableBuilder<Flag>(
+      valueListenable: controller.cpuProfilerController.profilerFlagNotifier,
+      builder: (context, profilerFlag, _) {
+        return profilerFlag.valueAsString == 'true'
+            ? _buildPerformanceBody(controller)
+            : CpuProfilerDisabled(controller.cpuProfilerController);
+      },
+    );
+  }
+
+  Widget _buildPerformanceBody(PerformanceController controller) {
     return Column(
       children: [
         Row(
@@ -54,14 +66,17 @@ class PerformanceScreenBody extends StatelessWidget {
           ],
         ),
         Expanded(
-          child: ValueListenableBuilder(
+          child: ValueListenableBuilder<CpuProfileData>(
             valueListenable: controller.cpuProfilerController.dataNotifier,
             builder: (context, cpuProfileData, _) {
               if (cpuProfileData ==
                   CpuProfilerController.baseStateCpuProfileData) {
                 return _buildRecordingInfo(controller);
               }
-              return _buildCpuProfiler(controller, cpuProfileData);
+              return CpuProfiler(
+                data: cpuProfileData,
+                controller: controller.cpuProfilerController,
+              );
             },
           ),
         ),
@@ -71,7 +86,7 @@ class PerformanceScreenBody extends StatelessWidget {
 
   Widget _buildStateControls(PerformanceController controller) {
     const double minIncludeTextWidth = 600;
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<bool>(
       valueListenable: controller.recordingNotifier,
       builder: (context, recording, _) {
         return Row(
@@ -101,7 +116,7 @@ class PerformanceScreenBody extends StatelessWidget {
   }
 
   Widget _buildRecordingInfo(PerformanceController controller) {
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<bool>(
       valueListenable: controller.recordingNotifier,
       builder: (context, recording, _) {
         return recordingInfo(
@@ -109,24 +124,6 @@ class PerformanceScreenBody extends StatelessWidget {
           statusKey: PerformanceScreen.recordingStatusKey,
           recording: recording,
           recordedObject: 'CPU samples',
-        );
-      },
-    );
-  }
-
-  Widget _buildCpuProfiler(
-    PerformanceController controller,
-    CpuProfileData data,
-  ) {
-    return ValueListenableBuilder(
-      valueListenable:
-          controller.cpuProfilerController.selectedCpuStackFrameNotifier,
-      builder: (context, selectedStackFrame, _) {
-        return CpuProfiler(
-          data: data,
-          selectedStackFrame: selectedStackFrame,
-          onStackFrameSelected: (sf) =>
-              controller.cpuProfilerController.selectCpuStackFrame(sf),
         );
       },
     );

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
@@ -7,6 +7,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../globals.dart';
 import '../profiler/cpu_profile_model.dart';
+import '../ui/fake_flutter/fake_flutter.dart';
 import '../vm_flags.dart' as vm_flags;
 
 /// Manages interactions between the Cpu Profiler and the VmService.
@@ -22,6 +23,10 @@ class CpuProfilerService {
     );
   }
 
+  /// Notifies that the vm profiler flag has changed.
+  ValueNotifier<Flag> get profilerFlagNotifier =>
+      serviceManager.vmFlagManager.flag(vm_flags.profiler);
+
   Future<Success> clearCpuSamples() {
     return serviceManager.service
         .clearCpuSamples(serviceManager.isolateManager.selectedIsolate.id);
@@ -29,5 +34,9 @@ class CpuProfilerService {
 
   Future<dynamic> setProfilePeriod(String value) {
     return serviceManager.service.setFlag(vm_flags.profilePeriod, value);
+  }
+
+  Future<dynamic> enableCpuProfiler() async {
+    return await serviceManager.service.setFlag(vm_flags.profiler, 'true');
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
@@ -34,13 +34,15 @@ class CpuProfileTransformer {
 
     cpuProfileData.processed = true;
 
-    assert(
-      cpuProfileData.profileMetaData.sampleCount ==
-          cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
-      'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
-      ' != sample count from root '
-      '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
-    );
+// TODO(kenz): investigate why this assert is firing again.
+// https://github.com/flutter/devtools/issues/1529.
+//    assert(
+//      cpuProfileData.profileMetaData.sampleCount ==
+//          cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
+//      'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
+//      ' != sample count from root '
+//      '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
+//    );
   }
 
   void _processStackFrame(

--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
@@ -110,17 +110,9 @@ class _CpuProfilerState extends State<CpuProfiler>
               children: _buildProfilerViews(),
             );
     } else {
-      // If [data] is null, CPU profile data is either being processed or it is
-      // empty.
-      return ValueListenableBuilder<bool>(
-        valueListenable: widget.controller.processingNotifier,
-        builder: (context, processing, _) {
-          return processing
-              ? const Center(
-                  child: CircularProgressIndicator(),
-                )
-              : _buildEmptyDataView();
-        },
+      // If [data] is null, CPU profile data is being processed.
+      return const Center(
+        child: CircularProgressIndicator(),
       );
     }
   }
@@ -181,7 +173,7 @@ class CpuProfilerDisabled extends StatelessWidget {
             padding: const EdgeInsets.all(8.0),
             child: RaisedButton(
               child: const Text('Enable profiler'),
-              onPressed: () => controller.enableCpuProfiler(),
+              onPressed: controller.enableCpuProfiler,
             ),
           ),
         ],

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -57,13 +57,15 @@ class ServiceConnectionManager {
       _registeredMethodsForService;
   final Map<String, List<String>> _registeredMethodsForService = {};
 
-  IsolateManager _isolateManager;
-  ServiceExtensionManager _serviceExtensionManager;
+  VmFlagManager get vmFlagManager => _vmFlagManager;
+  final _vmFlagManager = VmFlagManager();
 
   IsolateManager get isolateManager => _isolateManager;
+  IsolateManager _isolateManager;
 
   ServiceExtensionManager get serviceExtensionManager =>
       _serviceExtensionManager;
+  ServiceExtensionManager _serviceExtensionManager;
 
   ConnectedApp connectedApp;
 
@@ -156,6 +158,7 @@ class ServiceConnectionManager {
 
     _isolateManager._service = service;
     _serviceExtensionManager._service = service;
+    _vmFlagManager.service = service;
 
     _stateController.add(true);
     _connectionAvailableController.add(service);
@@ -164,6 +167,7 @@ class ServiceConnectionManager {
     service.onIsolateEvent.listen(_isolateManager._handleIsolateEvent);
     service.onExtensionEvent
         .listen(_serviceExtensionManager._handleExtensionEvent);
+    service.onVMEvent.listen(_vmFlagManager.handleVmEvent);
 
     final streamIds = [
       EventStreams.kDebug,
@@ -791,6 +795,52 @@ class ServiceExtensionState {
   // For boolean service extensions, [enabled] should equal [value].
   final bool enabled;
   final dynamic value;
+}
+
+class VmFlagManager {
+  VmServiceWrapper get service => _service;
+  VmServiceWrapper _service;
+  set service(VmServiceWrapper service) {
+    _service = service;
+    // Upon setting the vm service, get initial values for vm flags.
+    _initFlags();
+  }
+
+  ValueListenable get flags => _flags;
+  final _flags = ValueNotifier<FlagList>(null);
+
+  final _flagNotifiers = <String, ValueNotifier<Flag>>{};
+
+  ValueNotifier<Flag> flag(String name) {
+    return _flagNotifiers.containsKey(name) ? _flagNotifiers[name] : null;
+  }
+
+  void _initFlags() async {
+    final flagList = await service.getFlagList();
+    _flags.value = flagList;
+
+    final flags = <String, Flag>{};
+    for (var flag in flagList.flags) {
+      flags[flag.name] = flag;
+      _flagNotifiers[flag.name] = ValueNotifier<Flag>(flag);
+    }
+  }
+
+  @visibleForTesting
+  void handleVmEvent(Event event) async {
+    if (event.kind == EventKind.kVMFlagUpdate) {
+      if (_flagNotifiers.containsKey(event.flag)) {
+        final currentFlag = _flagNotifiers[event.flag].value;
+        _flagNotifiers[event.flag].value = Flag.parse({
+          'name': currentFlag.name,
+          'comment': currentFlag.comment,
+          'modified': true,
+          'valueAsString': event.newValue,
+        });
+        _flags.value = await service.getFlagList();
+      }
+    }
+  }
 }
 
 class VmServiceCapabilities {

--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -5,10 +5,12 @@
 import 'dart:convert';
 
 import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart' hide TimelineEvent;
 
 import '../../flutter/common_widgets.dart';
 import '../../flutter/controllers.dart';
 import '../../profiler/cpu_profile_model.dart';
+import '../../profiler/cpu_profiler_controller.dart';
 import '../../profiler/flutter/cpu_profiler.dart';
 import '../../ui/fake_flutter/_real_flutter.dart';
 import '../../utils.dart';
@@ -51,26 +53,26 @@ class EventDetails extends StatelessWidget {
   }
 
   Widget _buildDetails(TimelineController controller) {
-    return selectedEvent.isUiEvent
-        ? ValueListenableBuilder(
-            valueListenable: controller.cpuProfilerController.dataNotifier,
-            builder: (context, cpuProfileData, _) {
-              return _buildCpuProfiler(cpuProfileData, controller);
-            },
-          )
-        : EventSummary(selectedEvent);
+    if (selectedEvent.isUiEvent) {
+      return ValueListenableBuilder<Flag>(
+        valueListenable: controller.cpuProfilerController.profilerFlagNotifier,
+        builder: (context, profilerFlag, _) {
+          return profilerFlag.valueAsString == 'true'
+              ? _buildCpuProfiler(controller.cpuProfilerController)
+              : CpuProfilerDisabled(controller.cpuProfilerController);
+        },
+      );
+    }
+    return EventSummary(selectedEvent);
   }
 
-  Widget _buildCpuProfiler(CpuProfileData data, TimelineController controller) {
-    return ValueListenableBuilder(
-      valueListenable:
-          controller.cpuProfilerController.selectedCpuStackFrameNotifier,
-      builder: (context, selectedStackFrame, _) {
+  Widget _buildCpuProfiler(CpuProfilerController cpuProfilerController) {
+    return ValueListenableBuilder<CpuProfileData>(
+      valueListenable: cpuProfilerController.dataNotifier,
+      builder: (context, cpuProfileData, _) {
         return CpuProfiler(
-          data: data,
-          selectedStackFrame: selectedStackFrame,
-          onStackFrameSelected: (sf) =>
-              controller.cpuProfilerController.selectCpuStackFrame(sf),
+          data: cpuProfileData,
+          controller: cpuProfilerController,
         );
       },
     );

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -15,6 +15,7 @@ import '../../ui/flutter/label.dart';
 import '../../ui/flutter/service_extension_widgets.dart';
 import '../../ui/flutter/vm_flag_widgets.dart';
 import '../timeline_controller.dart';
+import '../timeline_model.dart';
 import 'event_details.dart';
 import 'flutter_frames_chart.dart';
 import 'timeline_flame_chart.dart';
@@ -103,7 +104,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
           ],
         ),
         if (timelineMode == TimelineMode.frameBased) const FlutterFramesChart(),
-        ValueListenableBuilder(
+        ValueListenableBuilder<TimelineFrame>(
           valueListenable: controller.frameBasedTimeline.selectedFrameNotifier,
           builder: (context, selectedFrame, _) {
             return (timelineMode == TimelineMode.full || selectedFrame != null)
@@ -155,7 +156,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     List<Widget> sharedWidgets,
     double minIncludeTextWidth,
   ) {
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<bool>(
       valueListenable: controller.frameBasedTimeline.pausedNotifier,
       builder: (context, paused, _) {
         return Row(
@@ -189,7 +190,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     List<Widget> sharedWidgets,
     double minIncludeTextWidth,
   ) {
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<bool>(
       valueListenable: controller.fullTimeline.recordingNotifier,
       builder: (context, recording, _) {
         return Row(
@@ -242,7 +243,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     Widget content;
     final fullTimelineEmpty = controller.fullTimeline.data?.isEmpty ?? true;
     if (timelineMode == TimelineMode.full && fullTimelineEmpty) {
-      content = ValueListenableBuilder(
+      content = ValueListenableBuilder<bool>(
         valueListenable: controller.fullTimeline.emptyRecordingNotifier,
         builder: (context, emptyRecording, _) {
           return emptyRecording
@@ -267,7 +268,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
   }
 
   Widget _buildRecordingInfo() {
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<bool>(
       valueListenable: controller.fullTimeline.recordingNotifier,
       builder: (context, recording, _) {
         return recordingInfo(
@@ -281,7 +282,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
   }
 
   Widget _buildEventDetailsSection() {
-    return ValueListenableBuilder(
+    return ValueListenableBuilder<TimelineEvent>(
       valueListenable: controller.selectedTimelineEventNotifier,
       builder: (context, selectedEvent, _) {
         return EventDetails(selectedEvent);

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -108,8 +108,10 @@ class TimelineController {
 
     cpuProfilerController.resetNotifiers(useBaseStateData: false);
 
-    // Fetch a profile if we are not in offline mode.
-    if (!offlineMode || offlineTimelineData == null) {
+    // Fetch a profile if we are not in offline mode and if the profiler is
+    // enabled.
+    if ((!offlineMode || offlineTimelineData == null) &&
+        cpuProfilerController.profilerEnabled) {
       getCpuProfileForSelectedEvent();
     }
 

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -106,7 +106,7 @@ class TimelineController {
 
     timeline.data.selectedEvent = event;
 
-    cpuProfilerController.resetNotifiers(useBaseStateData: false);
+    cpuProfilerController.resetNotifiers();
 
     // Fetch a profile if we are not in offline mode and if the profiler is
     // enabled.

--- a/packages/devtools_app/lib/src/vm_flags.dart
+++ b/packages/devtools_app/lib/src/vm_flags.dart
@@ -5,6 +5,7 @@
 // Defined in SDK: https://github.com/dart-lang/sdk/blob/master/runtime/vm/flag_list.h.
 const asyncDebugger = 'async_debugger';
 const causalAsyncStacks = 'causal_async_stacks';
+const profiler = 'profiler';
 
 // Defined in SDK: https://github.com/dart-lang/sdk/blob/master/runtime/vm/profiler.cc#L36
 const profilePeriod = 'profile_period';

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -81,11 +81,6 @@ void main() {
         equals(CpuProfilerController.baseStateCpuProfileData),
       );
       expect(controller.selectedCpuStackFrameNotifier.value, isNull);
-
-      await pullProfileAndSelectFrame();
-      controller.resetNotifiers(useBaseStateData: false);
-      expect(controller.dataNotifier.value, isNull);
-      expect(controller.selectedCpuStackFrameNotifier.value, isNull);
     });
 
     test('disposes', () {

--- a/packages/devtools_app/test/flutter/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/flutter/cpu_profiler_test.dart
@@ -34,14 +34,6 @@ void main() {
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsOneWidget);
-      expect(find.byType(CircularProgressIndicator), findsNothing);
-      expect(find.byType(CpuProfileFlameChart), findsNothing);
-
-      // Null data while controller is pulling and processing data.
-      controller.processingValueNotifier.value = true;
-      await tester.pump();
-      expect(find.byType(TabBar), findsOneWidget);
       expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
       expect(find.byType(CpuProfileFlameChart), findsNothing);

--- a/packages/devtools_app/test/flutter/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/flutter/cpu_profiler_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_transformer.dart';
+import 'package:devtools_app/src/profiler/cpu_profiler_controller.dart';
 import 'package:devtools_app/src/profiler/flutter/cpu_profile_call_tree.dart';
 import 'package:devtools_app/src/profiler/flutter/cpu_profile_flame_chart.dart';
 import 'package:devtools_app/src/profiler/flutter/cpu_profiler.dart';
@@ -16,9 +17,11 @@ import 'wrappers.dart';
 void main() {
   CpuProfiler cpuProfiler;
   CpuProfileData cpuProfileData;
+  CpuProfilerController controller;
 
   setUp(() {
     final transformer = CpuProfileTransformer();
+    controller = CpuProfilerController();
     cpuProfileData = CpuProfileData.parse(goldenCpuProfileDataJson);
     transformer.processData(cpuProfileData);
   });
@@ -27,10 +30,17 @@ void main() {
     testWidgets('builds for null cpuProfileData', (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: null,
-        selectedStackFrame: null,
-        onStackFrameSelected: (_) {},
+        controller: controller,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.text(CpuProfiler.emptyCpuProfile), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsNothing);
+      expect(find.byType(CpuProfileFlameChart), findsNothing);
+
+      // Null data while controller is pulling and processing data.
+      controller.processingValueNotifier.value = true;
+      await tester.pump();
       expect(find.byType(TabBar), findsOneWidget);
       expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -41,8 +51,7 @@ void main() {
       cpuProfileData = CpuProfileData.parse(emptyCpuProfileDataJson);
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
-        selectedStackFrame: null,
-        onStackFrameSelected: (_) {},
+        controller: controller,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
@@ -54,8 +63,7 @@ void main() {
     testWidgets('builds for valid cpuProfileData', (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
-        selectedStackFrame: null,
-        onStackFrameSelected: (_) {},
+        controller: controller,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
@@ -68,8 +76,7 @@ void main() {
         (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
-        selectedStackFrame: null,
-        onStackFrameSelected: (_) {},
+        controller: controller,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
@@ -103,8 +110,7 @@ void main() {
         (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
-        selectedStackFrame: null,
-        onStackFrameSelected: (_) {},
+        controller: controller,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       await tester.tap(find.text('Call Tree'));

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/timeline/flutter/event_details.dart';
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
+import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:devtools_testing/support/timeline_test_data.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -20,7 +21,9 @@ void main() {
     EventDetails eventDetails;
 
     Future<void> pumpEventDetails(
-        TimelineEvent selectedEvent, WidgetTester tester) async {
+      TimelineEvent selectedEvent,
+      WidgetTester tester,
+    ) async {
       eventDetails = EventDetails(selectedEvent);
       await tester.pumpWidget(wrapWithControllers(
         eventDetails,
@@ -29,9 +32,10 @@ void main() {
       expect(find.byType(EventDetails), findsOneWidget);
     }
 
-    setUp(() async {
+    setUp(() {
       final fakeServiceManager = FakeServiceManager(useFakeService: true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      serviceManager.vmFlagManager.service = serviceManager.service;
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
     });
@@ -39,6 +43,7 @@ void main() {
     testWidgets('builds for UI event', (WidgetTester tester) async {
       await pumpEventDetails(goldenUiTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsOneWidget);
+      expect(find.byType(CpuProfilerDisabled), findsNothing);
       expect(find.byType(EventSummary), findsNothing);
       expect(find.text(EventDetails.noEventSelected), findsNothing);
       expect(find.text(EventDetails.instructions), findsNothing);
@@ -47,6 +52,7 @@ void main() {
     testWidgets('builds for GPU event', (WidgetTester tester) async {
       await pumpEventDetails(goldenGpuTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsNothing);
+      expect(find.byType(CpuProfilerDisabled), findsNothing);
       expect(find.byType(EventSummary), findsOneWidget);
       expect(find.text(EventDetails.noEventSelected), findsNothing);
       expect(find.text(EventDetails.instructions), findsNothing);
@@ -55,17 +61,37 @@ void main() {
     testWidgets('builds for ASYNC event', (WidgetTester tester) async {
       await pumpEventDetails(asyncEventWithInstantChildren, tester);
       expect(find.byType(CpuProfiler), findsNothing);
+      expect(find.byType(CpuProfilerDisabled), findsNothing);
       expect(find.byType(EventSummary), findsOneWidget);
       expect(find.text(EventDetails.noEventSelected), findsNothing);
       expect(find.text(EventDetails.instructions), findsNothing);
     });
 
-    testWidgets('builds UI for null event', (WidgetTester tester) async {
+    testWidgets('builds for null event', (WidgetTester tester) async {
       await pumpEventDetails(null, tester);
       expect(find.byType(CpuProfiler), findsNothing);
+      expect(find.byType(CpuProfilerDisabled), findsNothing);
       expect(find.byType(EventSummary), findsNothing);
       expect(find.text(EventDetails.noEventSelected), findsOneWidget);
       expect(find.text(EventDetails.instructions), findsOneWidget);
+    });
+
+    testWidgets('builds for disabled profiler', (WidgetTester tester) async {
+      await serviceManager.service.setFlag(vm_flags.profiler, 'false');
+      await pumpEventDetails(goldenUiTimelineEvent, tester);
+      expect(find.byType(CpuProfiler), findsNothing);
+      expect(find.byType(CpuProfilerDisabled), findsOneWidget);
+      expect(find.byType(EventSummary), findsNothing);
+      expect(find.text(EventDetails.noEventSelected), findsNothing);
+      expect(find.text(EventDetails.instructions), findsNothing);
+
+      await tester.tap(find.text('Enable profiler'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(CpuProfiler), findsOneWidget);
+      expect(find.text(CpuProfiler.emptyCpuProfile), findsOneWidget);
+      expect(find.byType(CpuProfilerDisabled), findsNothing);
+      expect(find.byType(EventSummary), findsNothing);
     });
   });
 

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -35,7 +35,6 @@ void main() {
     setUp(() {
       final fakeServiceManager = FakeServiceManager(useFakeService: true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      serviceManager.vmFlagManager.service = serviceManager.service;
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
     });

--- a/packages/devtools_app/test/flutter/performance_screen_test.dart
+++ b/packages/devtools_app/test/flutter/performance_screen_test.dart
@@ -24,7 +24,6 @@ void main() {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      serviceManager.vmFlagManager.service = serviceManager.service;
       screen = const PerformanceScreen();
     });
 

--- a/packages/devtools_app/test/flutter/performance_screen_test.dart
+++ b/packages/devtools_app/test/flutter/performance_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:devtools_app/src/profiler/flutter/cpu_profiler.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:devtools_app/src/ui/flutter/vm_flag_widgets.dart';
+import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -23,6 +24,7 @@ void main() {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      serviceManager.vmFlagManager.service = serviceManager.service;
       screen = const PerformanceScreen();
     });
 
@@ -86,5 +88,30 @@ void main() {
         verifyBaseState(perfScreenBody, tester);
       },
     );
+
+    testWidgetsWithWindowSize('builds for disabled profiler', windowSize,
+        (WidgetTester tester) async {
+      await serviceManager.service.setFlag(vm_flags.profiler, 'false');
+      final perfScreenBody = PerformanceScreenBody();
+      await tester.pumpWidget(wrapWithControllers(
+        perfScreenBody,
+        performanceController: PerformanceController(),
+      ));
+      expect(find.byType(CpuProfilerDisabled), findsOneWidget);
+      expect(
+        find.byKey(PerformanceScreen.recordingInstructionsKey),
+        findsNothing,
+      );
+      expect(find.byKey(PerformanceScreen.recordButtonKey), findsNothing);
+      expect(
+          find.byKey(PerformanceScreen.stopRecordingButtonKey), findsNothing);
+      expect(find.byKey(PerformanceScreen.clearButtonKey), findsNothing);
+      expect(find.byType(ProfileGranularityDropdown), findsNothing);
+
+      await tester.tap(find.text('Enable profiler'));
+      await tester.pumpAndSettle();
+
+      verifyBaseState(perfScreenBody, tester);
+    });
   });
 }

--- a/packages/devtools_app/test/flutter/vm_flag_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/vm_flag_widgets_test.dart
@@ -50,7 +50,7 @@ void main() {
       expect(dropdownButton.value, equals(ProfileGranularity.medium.value));
 
       var flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      expect(flagList, isEmpty);
+      expect(flagList.length, equals(2));
 
       // Switch to low granularity.
       await tester.tap(find.byKey(ProfileGranularityDropdown.dropdownKey));
@@ -62,7 +62,8 @@ void main() {
       expect(dropdownButton.value, equals(ProfileGranularity.low.value));
 
       flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      var profilePeriodFlag = flagList[0];
+      expect(flagList.length, equals(3));
+      var profilePeriodFlag = flagList.last;
       expect(profilePeriodFlag.name, equals(profilePeriod));
       expect(
         profilePeriodFlag.valueAsString,
@@ -79,7 +80,7 @@ void main() {
       expect(dropdownButton.value, equals(ProfileGranularity.high.value));
 
       flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      profilePeriodFlag = flagList[0];
+      profilePeriodFlag = flagList.last;
       expect(profilePeriodFlag.name, equals(profilePeriod));
       expect(
         profilePeriodFlag.valueAsString,

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -29,7 +29,11 @@ import 'package:vm_service/vm_service.dart';
 class FakeServiceManager extends Fake implements ServiceConnectionManager {
   FakeServiceManager({bool useFakeService = false, this.hasConnection = true})
       : service =
-            useFakeService ? FakeVmService(_flagManager) : MockVmService();
+            useFakeService ? FakeVmService(_flagManager) : MockVmService() {
+    if (useFakeService) {
+      _flagManager.service = service;
+    }
+  }
   static final _flagManager = VmFlagManager();
 
   @override

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -28,7 +28,9 @@ import 'package:vm_service/vm_service.dart';
 
 class FakeServiceManager extends Fake implements ServiceConnectionManager {
   FakeServiceManager({bool useFakeService = false, this.hasConnection = true})
-      : service = useFakeService ? FakeVmService() : MockVmService();
+      : service =
+            useFakeService ? FakeVmService(_flagManager) : MockVmService();
+  static final _flagManager = VmFlagManager();
 
   @override
   final VmServiceWrapper service;
@@ -55,6 +57,9 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   final IsolateManager isolateManager = FakeIsolateManager();
 
   @override
+  final VmFlagManager vmFlagManager = _flagManager;
+
+  @override
   final FakeServiceExtensionManager serviceExtensionManager =
       FakeServiceExtensionManager();
 
@@ -68,8 +73,33 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
 }
 
 class FakeVmService extends Fake implements VmServiceWrapper {
+  FakeVmService(this._vmFlagManager);
+
+  final VmFlagManager _vmFlagManager;
+
   final _flags = <String, dynamic>{
-    'flags': <Flag>[],
+    'flags': <Flag>[
+      Flag(
+        name: 'flag 1 name',
+        comment: 'flag 1 comment contains some very long text '
+            'that the renderer will have to wrap around to prevent '
+            'it from overflowing the screen. This will cause a '
+            'failure if one of the two Row entries the flags lay out '
+            'in is not wrapped in an Expanded(), which tells the Row '
+            'allocate only the remaining space to the Expanded. '
+            'Without the expanded, the underlying RichTexts will try '
+            'to consume as much of the layout as they can and cause '
+            'an overflow.',
+        valueAsString: 'flag 1 value',
+        modified: false,
+      ),
+      Flag(
+        name: 'profiler',
+        comment: 'Mock Flag',
+        valueAsString: 'true',
+        modified: false,
+      ),
+    ],
   };
 
   @override
@@ -87,6 +117,14 @@ class FakeVmService extends Fake implements VmServiceWrapper {
         'valueAsString': value,
       }));
     }
+
+    final fakeVmFlagUpdateEvent = Event(
+      kind: EventKind.kVMFlagUpdate,
+      flag: name,
+      newValue: value,
+      timestamp: 1, // 1 is arbitrary.
+    );
+    _vmFlagManager.handleVmEvent(fakeVmFlagUpdateEvent);
     return Future.value(Success());
   }
 

--- a/packages/devtools_testing/lib/service_manager_test.dart
+++ b/packages/devtools_testing/lib/service_manager_test.dart
@@ -265,7 +265,7 @@ Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
 
     test('notifies on flag change', () async {
       await env.setupEnvironment();
-      final profiler = 'profiler';
+      const profiler = 'profiler';
 
       final flagManager = serviceManager.vmFlagManager;
       final initialFlags = flagManager.flags.value;

--- a/packages/devtools_testing/lib/service_manager_test.dart
+++ b/packages/devtools_testing/lib/service_manager_test.dart
@@ -27,7 +27,7 @@ import 'support/flutter_test_environment.dart';
 const jsonRpcInvalidParamsCode = -32602;
 
 Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
-  group('serviceManagerTests', () {
+  group('ServiceConnectionManager', () {
     tearDownAll(() async {
       await env.tearDownEnvironment(force: true);
     });
@@ -38,7 +38,9 @@ Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
       expect(serviceManager.service, equals(env.service));
       expect(serviceManager.isolateManager, isNotNull);
       expect(serviceManager.serviceExtensionManager, isNotNull);
+      expect(serviceManager.vmFlagManager, isNotNull);
       expect(serviceManager.isolateManager.isolates, isNotEmpty);
+      expect(serviceManager.vmFlagManager.flags.value, isNotNull);
 
       if (serviceManager.isolateManager.selectedIsolate == null) {
         await serviceManager.isolateManager.onSelectedIsolateChanged
@@ -245,12 +247,48 @@ Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
       await env.tearDownEnvironment();
     });
   }, timeout: const Timeout.factor(4));
+
+  group('VmFlagManager', () {
+    tearDownAll(() async {
+      await env.tearDownEnvironment(force: true);
+    });
+
+    test('flags initialized on vm service opened', () async {
+      await env.setupEnvironment();
+
+      expect(serviceManager.service, equals(env.service));
+      expect(serviceManager.vmFlagManager, isNotNull);
+      expect(serviceManager.vmFlagManager.flags.value, isNotNull);
+
+      await env.tearDownEnvironment();
+    });
+
+    test('notifies on flag change', () async {
+      await env.setupEnvironment();
+      final profiler = 'profiler';
+
+      final flagManager = serviceManager.vmFlagManager;
+      final initialFlags = flagManager.flags.value;
+      final profilerFlagNotifier = flagManager.flag(profiler);
+      expect(profilerFlagNotifier.value.valueAsString, equals('true'));
+
+      await serviceManager.service.setFlag(profiler, 'false');
+      expect(profilerFlagNotifier.value.valueAsString, equals('false'));
+
+      // Await a delay so the new flags have time to be pulled and set.
+      await Future.delayed(const Duration(milliseconds: 5000));
+      final newFlags = flagManager.flags.value;
+      expect(newFlags, isNot(equals(initialFlags)));
+
+      await env.tearDownEnvironment();
+    });
+  }, timeout: const Timeout.factor(4));
 }
 
 Future<void> runServiceManagerTestsWithDriverFactory(
     {FlutterDriverFactory flutterDriverFactory =
         defaultFlutterRunDriver}) async {
-  group('serviceManagerTests - restoring device-enabled extension:', () {
+  group('ServiceConnectionManager - restoring device-enabled extension', () {
     FlutterRunTestDriver _flutter;
     String _flutterIsolateId;
     VmServiceWrapper service;


### PR DESCRIPTION
- Added VmFlagManager to store current state of vm flags and provide notifiers for flags - 
  - TODO: use this manager on the info screen as well as for updating the profile granularity dropdown (follow up CL). See https://github.com/flutter/devtools/issues/988

- Add button to enable profiler on both Performance and Timeline screens - fixes https://github.com/flutter/devtools/issues/1250

Timeline event details section:
<img width="988" alt="Screen Shot 2020-01-09 at 4 20 38 PM" src="https://user-images.githubusercontent.com/43759233/72275132-2fdb3e80-35e2-11ea-84d2-87935e7666c2.png">
Performance screen:
<img width="1020" alt="Screen Shot 2020-01-09 at 4 10 10 PM" src="https://user-images.githubusercontent.com/43759233/72275171-3f5a8780-35e2-11ea-87b9-8a235d14170f.png">
