### PR TITLE
Remove an unused constructor

### DIFF
--- a/packages/devtools_app/lib/src/memory/html_memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/html_memory_screen.dart
@@ -1510,8 +1510,6 @@ class HtmlMemoryScreen extends HtmlScreen with HtmlSetStateMixin {
 ///      _hashCode [hashCode of instance]
 ///      field [field of parent class that has ref]
 class NavigationState {
-  NavigationState._() : _className = '';
-
   NavigationState.classSelect(this._className);
 
   NavigationState.instanceSelect(this._className, this._hashCode);


### PR DESCRIPTION
This constructor has started causing tuneup checks to fail.

This is a change in the behavior of package:tuneup that I think we should treat as a bug.