### PR TITLE
Listen for vm flag changes in info page.

### DIFF
--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -43,19 +43,12 @@ class InfoScreenBody extends StatefulWidget {
 class _InfoScreenBodyState extends State<InfoScreenBody> {
   FlutterVersion _flutterVersion;
 
-  FlagList _flagList;
   InfoController _controller;
 
   @override
   void initState() {
     super.initState();
     _controller = InfoController(
-      onFlagListChanged: (flagList) {
-        if (!mounted) return;
-        setState(() {
-          _flagList = flagList;
-        });
-      },
       onFlutterVersionChanged: (flutterVersion) {
         if (!mounted) return;
         setState(
@@ -91,10 +84,17 @@ class _InfoScreenBodyState extends State<InfoScreenBody> {
           style: textTheme.headline,
         ),
         const PaddedDivider(padding: EdgeInsets.only(top: 4.0, bottom: 0.0)),
-        if (_flagList != null)
-          Expanded(
-            child: _FlagList(_flagList),
+        Expanded(
+          child: ValueListenableBuilder<FlagList>(
+            valueListenable: _controller.flagListNotifier,
+            builder: (context, flagList, _) {
+              if (flagList == null || flagList.flags.isEmpty) {
+                return const SizedBox();
+              }
+              return _FlagList(flagList);
+            },
           ),
+        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/info/info_controller.dart
+++ b/packages/devtools_app/lib/src/info/info_controller.dart
@@ -10,6 +10,7 @@ import 'package:vm_service/vm_service.dart';
 import '../auto_dispose.dart';
 import '../globals.dart';
 import '../service_registrations.dart' as registrations;
+import '../ui/fake_flutter/fake_flutter.dart';
 import '../version.dart';
 
 // TODO(kenz): we should listen for flag value updates and update the info
@@ -24,7 +25,7 @@ class InfoController extends DisposableController
     with AutoDisposeControllerMixin {
   InfoController({
     @required this.onFlutterVersionChanged,
-    @required this.onFlagListChanged,
+    this.onFlagListChanged,
   });
 
   final OnFlutterVersionChanged onFlutterVersionChanged;
@@ -33,8 +34,16 @@ class InfoController extends DisposableController
 
   final flutterVersionServiceAvailable = Completer();
 
+  ValueNotifier<FlagList> get flagListNotifier =>
+      serviceManager.vmFlagManager.flags;
+
   Future<void> entering() async {
-    onFlagListChanged(await serviceManager.service.getFlagList());
+    // Once the html app is deleted, this code and the [onFlagListChanged] var
+    // can be removed. The flutter version of DevTools listens to [flagNotifier]
+    // for changes.
+    if (onFlagListChanged != null) {
+      onFlagListChanged(await serviceManager.service.getFlagList());
+    }
     await _listenForFlutterVersionChanges();
   }
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -818,6 +818,7 @@ class VmFlagManager {
   void _initFlags() async {
     final flagList = await service.getFlagList();
     _flags.value = flagList;
+    if (flagList == null) return;
 
     final flags = <String, Flag>{};
     for (var flag in flagList.flags) {

--- a/packages/devtools_app/test/flutter/info_screen_test.dart
+++ b/packages/devtools_app/test/flutter/info_screen_test.dart
@@ -8,7 +8,6 @@ import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../support/mocks.dart';
 import 'wrappers.dart';
@@ -17,55 +16,35 @@ void main() {
   InfoScreen screen;
   group('Info Screen', () {
     setUp(() {
-      setGlobal(ServiceConnectionManager, FakeServiceManager());
-      when(serviceManager.service.getFlagList()).thenAnswer((_) => null);
-      when(serviceManager.connectedApp.isAnyFlutterApp)
-          .thenAnswer((_) => Future.value(true));
+      setGlobal(
+        ServiceConnectionManager,
+        FakeServiceManager(useFakeService: true),
+      );
+      mockIsFlutterApp(serviceManager.connectedApp);
 
       screen = const InfoScreen();
     });
-
-    void mockFlags() {
-      when(serviceManager.service.getFlagList()).thenAnswer((invocation) {
-        return Future.value(FlagList(
-          flags: [
-            Flag(
-              name: 'flag 1 name',
-              comment: 'flag 1 comment contains some very long text '
-                  'that the renderer will have to wrap around to prevent '
-                  'it from overflowing the screen. This will cause a '
-                  'failure if one of the two Row entries the flags lay out '
-                  'in is not wrapped in an Expanded(), which tells the Row '
-                  'allocate only the remaining space to the Expanded. '
-                  'Without the expanded, the underlying RichTexts will try '
-                  'to consume as much of the layout as they can and cause '
-                  'an overflow.',
-              valueAsString: 'flag 1 value',
-              modified: false,
-            ),
-          ],
-        ));
-      });
-    }
 
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
       expect(find.text('Info'), findsOneWidget);
     });
 
-    testWidgets('builds with no data', (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(InfoScreenBody), findsOneWidget);
-      expect(find.byKey(InfoScreen.flutterVersionKey), findsNothing);
-      expect(find.byKey(InfoScreen.flagListKey), findsNothing);
-    });
-
     testWidgets('builds with flags data', (WidgetTester tester) async {
-      mockFlags();
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       await tester.pumpAndSettle();
       expect(find.byKey(InfoScreen.flutterVersionKey), findsNothing);
       expect(find.byKey(InfoScreen.flagListKey), findsOneWidget);
+    });
+
+    testWidgets('builds with no data', (WidgetTester tester) async {
+      setGlobal(ServiceConnectionManager, FakeServiceManager());
+      when(serviceManager.service.getFlagList()).thenAnswer((_) => null);
+      mockIsFlutterApp(serviceManager.connectedApp);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(InfoScreenBody), findsOneWidget);
+      expect(find.byKey(InfoScreen.flutterVersionKey), findsNothing);
+      expect(find.byKey(InfoScreen.flagListKey), findsNothing);
     });
 
     // There's not an easy way to mock out the flutter version retrieval,

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -33,8 +33,7 @@ void main() {
       fakeExtensionManager = fakeServiceManager.serviceExtensionManager;
 
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      when(serviceManager.connectedApp.isAnyFlutterApp)
-          .thenAnswer((_) => Future.value(true));
+      mockIsFlutterApp(serviceManager.connectedApp);
 
       screen = const InspectorScreen();
     });

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -30,9 +30,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   FakeServiceManager({bool useFakeService = false, this.hasConnection = true})
       : service =
             useFakeService ? FakeVmService(_flagManager) : MockVmService() {
-    if (useFakeService) {
-      _flagManager.service = service;
-    }
+    _flagManager.service = service;
   }
   static final _flagManager = VmFlagManager();
 
@@ -507,4 +505,8 @@ Future<void> ensureInspectorDependencies() async {
     "To fix this, mark the failing test as @TestOn('vm')",
   );
   await initializer.ensureInspectorDependencies();
+}
+
+void mockIsFlutterApp(MockConnectedApp connectedApp) {
+  when(connectedApp.isAnyFlutterApp).thenAnswer((_) => Future.value(true));
 }

--- a/packages/devtools_testing/lib/info_controller_test.dart
+++ b/packages/devtools_testing/lib/info_controller_test.dart
@@ -37,21 +37,10 @@ Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
 
       await infoController.entering();
 
-      // TODO(kenzie): remove the try catch block once Flutter stable supports
-      // the flutterVersion service. Revisit this end of November 2019.
-      try {
-        final flutterVersionResponse = await serviceManager.getFlutterVersion();
-        final expectedFlutterVersion =
-            FlutterVersion.parse(flutterVersionResponse.json);
-        expect(flutterVersion, equals(expectedFlutterVersion));
-      } catch (e) {
-        expect(flutterVersion, isNull);
-        expect(
-          e.toString(),
-          equals('Exception: There are no registered methods for service'
-              ' "flutterVersion"'),
-        );
-      }
+      final flutterVersionResponse = await serviceManager.getFlutterVersion();
+      final expectedFlutterVersion =
+          FlutterVersion.parse(flutterVersionResponse.json);
+      expect(flutterVersion, equals(expectedFlutterVersion));
 
       expect(flags, isNotNull);
 
@@ -87,9 +76,7 @@ Future<void> runInfoControllerTests(FlutterTestEnvironment env) async {
       );
 
       await env.tearDownEnvironment(force: true);
-      // TODO(kenz): unskip once flake is addressed. See
-      // https://github.com/flutter/devtools/issues/1193.
-    }, skip: true);
+    });
   }, timeout: const Timeout.factor(8));
   // TODO: Add a test that uses DartVM instead of Flutter
 }


### PR DESCRIPTION
Info page flag list listens for flag changes and updates values accordingly. I have verified that when two instances of devtools are connnected to the same app, modifying a flag from one instance of devtools updates the flag value in the other.

Fixes https://github.com/flutter/devtools/issues/988