### PR TITLE
Listen for flag changes to 'profile_period' vm flag.

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
@@ -27,6 +27,9 @@ class CpuProfilerService {
   ValueNotifier<Flag> get profilerFlagNotifier =>
       serviceManager.vmFlagManager.flag(vm_flags.profiler);
 
+  ValueNotifier<Flag> get profileGranularityFlagNotifier =>
+      serviceManager.vmFlagManager.flag(vm_flags.profilePeriod);
+
   Future<Success> clearCpuSamples() {
     return serviceManager.service
         .clearCpuSamples(serviceManager.isolateManager.selectedIsolate.id);

--- a/packages/devtools_app/lib/src/profiler/profile_granularity.dart
+++ b/packages/devtools_app/lib/src/profiler/profile_granularity.dart
@@ -50,4 +50,16 @@ extension ProfileGranularityExtension on ProfileGranularity {
         return highProfilePeriod;
     }
   }
+
+  static ProfileGranularity fromValue(String value) {
+    switch (value) {
+      case lowProfilePeriod:
+        return ProfileGranularity.low;
+      case highProfilePeriod:
+        return ProfileGranularity.high;
+      case mediumProfilePeriod:
+      default:
+        return ProfileGranularity.medium;
+    }
+  }
 }

--- a/packages/devtools_app/test/flutter/vm_flag_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/vm_flag_widgets_test.dart
@@ -7,8 +7,9 @@ import 'package:devtools_app/src/profiler/profile_granularity.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:devtools_app/src/ui/flutter/vm_flag_widgets.dart';
-import 'package:devtools_app/src/vm_flags.dart';
+import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:flutter_test/flutter_test.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../support/mocks.dart';
 import 'wrappers.dart';
@@ -49,8 +50,12 @@ void main() {
           tester.widget(find.byKey(ProfileGranularityDropdown.dropdownKey));
       expect(dropdownButton.value, equals(ProfileGranularity.medium.value));
 
-      var flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      expect(flagList.length, equals(2));
+      var profilePeriodFlag =
+          await getProfileGranularityFlag(fakeServiceManager);
+      expect(
+        profilePeriodFlag.valueAsString,
+        equals(ProfileGranularity.medium.value),
+      );
 
       // Switch to low granularity.
       await tester.tap(find.byKey(ProfileGranularityDropdown.dropdownKey));
@@ -61,10 +66,8 @@ void main() {
           tester.widget(find.byKey(ProfileGranularityDropdown.dropdownKey));
       expect(dropdownButton.value, equals(ProfileGranularity.low.value));
 
-      flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      expect(flagList.length, equals(3));
-      var profilePeriodFlag = flagList.last;
-      expect(profilePeriodFlag.name, equals(profilePeriod));
+      profilePeriodFlag = await getProfileGranularityFlag(fakeServiceManager);
+      expect(profilePeriodFlag.name, equals(vm_flags.profilePeriod));
       expect(
         profilePeriodFlag.valueAsString,
         equals(ProfileGranularity.low.value),
@@ -79,13 +82,62 @@ void main() {
           tester.widget(find.byKey(ProfileGranularityDropdown.dropdownKey));
       expect(dropdownButton.value, equals(ProfileGranularity.high.value));
 
-      flagList = (await fakeServiceManager.service.getFlagList()).flags;
-      profilePeriodFlag = flagList.last;
-      expect(profilePeriodFlag.name, equals(profilePeriod));
+      profilePeriodFlag = await getProfileGranularityFlag(fakeServiceManager);
+      expect(profilePeriodFlag.name, equals(vm_flags.profilePeriod));
       expect(
         profilePeriodFlag.valueAsString,
         equals(ProfileGranularity.high.value),
       );
     });
+
+    void testUpdatesForFlagChange(
+      WidgetTester tester, {
+      @required String newFlagValue,
+      @required String expectedFlagValue,
+    }) async {
+      await tester.pumpWidget(wrap(dropdown));
+      expect(find.byWidget(dropdown), findsOneWidget);
+      final dropdownButtonFinder =
+          find.byKey(ProfileGranularityDropdown.dropdownKey);
+      DropdownButton dropdownButton = tester.widget(dropdownButtonFinder);
+      expect(dropdownButton.value, equals(ProfileGranularity.medium.value));
+
+      await serviceManager.service.setFlag(
+        vm_flags.profilePeriod,
+        newFlagValue,
+      );
+      await tester.pumpAndSettle();
+      dropdownButton = tester.widget(dropdownButtonFinder);
+      expect(dropdownButton.value, equals(expectedFlagValue));
+    }
+
+    testWidgets('updates value for safe flag change',
+        (WidgetTester tester) async {
+      testUpdatesForFlagChange(
+        tester,
+        newFlagValue: ProfileGranularity.high.value,
+        expectedFlagValue: ProfileGranularity.high.value,
+      );
+    });
+
+    testWidgets('updates value for unsafe flag change',
+        (WidgetTester tester) async {
+      // 999 is not a value in the dropdown list.
+      testUpdatesForFlagChange(
+        tester,
+        newFlagValue: '999',
+        expectedFlagValue: ProfileGranularity.medium.value,
+      );
+    });
   });
+}
+
+Future<Flag> getProfileGranularityFlag(
+  FakeServiceManager serviceManager,
+) async {
+  final flagList = (await serviceManager.service.getFlagList()).flags;
+  return flagList.firstWhere(
+    (flag) => flag.name == vm_flags.profilePeriod,
+    orElse: () => null,
+  );
 }

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -13,6 +13,7 @@ import 'package:devtools_app/src/memory/flutter/memory_controller.dart'
 import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
+import 'package:devtools_app/src/profiler/profile_granularity.dart';
 import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/stream_value_listenable.dart';
@@ -20,6 +21,7 @@ import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
 import 'package:devtools_app/src/utils.dart';
+import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:devtools_app/src/vm_service_wrapper.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
 import 'package:meta/meta.dart';
@@ -98,9 +100,15 @@ class FakeVmService extends Fake implements VmServiceWrapper {
         modified: false,
       ),
       Flag(
-        name: 'profiler',
+        name: vm_flags.profiler,
         comment: 'Mock Flag',
         valueAsString: 'true',
+        modified: false,
+      ),
+      Flag(
+        name: vm_flags.profilePeriod,
+        comment: 'Mock Flag',
+        valueAsString: ProfileGranularity.medium.value,
         modified: false,
       ),
     ],


### PR DESCRIPTION
Verified that the ProfileGranularityDropdown updates across multiple DevTools instances.
Fixes https://github.com/flutter/devtools/issues/810