### PR TITLE
Hide expand/collapse buttons when LayoutExplorer is in view.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -32,7 +32,7 @@ class InspectorDetailsTabController extends StatefulWidget {
 class _InspectorDetailsTabControllerState
     extends State<InspectorDetailsTabController>
     with TickerProviderStateMixin, AutoDisposeMixin {
-  static const _layoutExplorerTabIndex = 1;
+  static const _detailsTreeTabIndex = 0;
   static const _tabsLengthWithLayoutExplorer = 2;
   static const _tabsLengthWithoutLayoutExplorer = 1;
 
@@ -90,7 +90,7 @@ class _InspectorDetailsTabControllerState
                   ),
                 ),
                 if (widget.actionButtons != null &&
-                    _tabController.index != _layoutExplorerTabIndex)
+                    _tabController.index == _detailsTreeTabIndex)
                   Expanded(
                     child: widget.actionButtons,
                   ),

--- a/packages/devtools_app/test/flutter/scaffold_test.dart
+++ b/packages/devtools_app/test/flutter/scaffold_test.dart
@@ -73,9 +73,6 @@ void main() {
 
 class _TestScreen extends Screen {
   const _TestScreen(this.name, this.key, [this.tabKey]) : super();
-
-  static const contentKey = Key('DevToolsScaffold Content');
-
   final String name;
   final Key key;
   final Key tabKey;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1479