### PR TITLE
Support for ADB (Android Java memory info), multiple charts, Display …

### DIFF
--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -791,7 +791,8 @@ class SelectedDataPoint extends LineChartMarker {
     final bool isGced = values.isGC;
 
     // Alpha filled stacked:
-    final num memoryOther = values.memoryInfo.other.toDouble(); // Purple-ish
+    final num memorySystemAndOther = values.memoryInfo.system.toDouble() +
+        values.memoryInfo.other.toDouble(); // Purple-ish
     final num memoryCode = values.memoryInfo.code.toDouble(); // Gray Purple
     final num memoryNativeHeap =
         values.memoryInfo.nativeHeap.toDouble(); // Blue-ish
@@ -801,9 +802,6 @@ class SelectedDataPoint extends LineChartMarker {
     final num memoryGraphics = values.memoryInfo.graphics.toDouble(); // Orangy
 
     final num memoryTotal = values.memoryInfo.total.toDouble(); // dashed line
-
-    final num memorySystem =
-        values.memoryInfo.system.toDouble(); // Should report as system+other
 
     final TextPainter painter = type == ChartType.DartHeaps
         ? PainterUtils.create(null, _titlesDartVm, textColor, fontSize)
@@ -828,7 +826,7 @@ class SelectedDataPoint extends LineChartMarker {
             null,
             '${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
             '${_formatter.getFormattedValue1(memoryTotal)}\n'
-            '${_formatter.getFormattedValue1(memoryOther)}\n'
+            '${_formatter.getFormattedValue1(memorySystemAndOther)}\n'
             '${_formatter.getFormattedValue1(memoryCode)}\n'
             '${_formatter.getFormattedValue1(memoryNativeHeap)}\n'
             '${_formatter.getFormattedValue1(memoryJavaHeap)}\n'

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -854,6 +854,9 @@ class SelectedDataPoint extends LineChartMarker {
     painter.layout();
     painterValues.layout();
 
+    // Compute avg text line height from the painter's height
+    // of the marker text after layout, divided by # of lines
+    // in the TextPainter.
     final double avgLineHeight = painter.height /
         (type == ChartType.DartHeaps
             ? _titlesDartVmLines

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -854,6 +854,10 @@ class SelectedDataPoint extends LineChartMarker {
     painter.layout();
     painterValues.layout();
 
+    final double avgLineHeight = painter.height /
+        (type == ChartType.DartHeaps
+            ? _titlesDartVmLines
+            : _titlesAndroidLines);
     final Offset pos = calculatePos(
       posX + offset.x,
       posY + offset.y - positionAboveBar,
@@ -877,6 +881,7 @@ class SelectedDataPoint extends LineChartMarker {
       canvas,
       paint,
       pos,
+      avgLineHeight,
     );
 
     // Paint the static text.
@@ -892,12 +897,14 @@ class SelectedDataPoint extends LineChartMarker {
     canvas.restore();
   }
 
-  final String _titlesDartVm = 'Time\n'
+  static const String _titlesDartVm = 'Time\n'
       'Capacity\n'
       'Used\n'
       'External\n'
       'RSS\n'
       'GC';
+
+  final int _titlesDartVmLines = _titlesDartVm.split('\n').length;
 
   // These are the alpha blended values.
   final List<Color> _dartVMColors = [
@@ -906,7 +913,7 @@ class SelectedDataPoint extends LineChartMarker {
     const Color(0xff77aed5), // Light-Blue (External)
   ];
 
-  final String _titlesAndroid = 'Time\n'
+  static const String _titlesAndroid = 'Time\n'
       'Total\n'
       'Other\n'
       'Code\n'
@@ -914,6 +921,8 @@ class SelectedDataPoint extends LineChartMarker {
       'Java Heap\n'
       'Stack\n'
       'Graphics';
+
+  final int _titlesAndroidLines = _titlesAndroid.split('\n').length;
 
   // These are the alpha blended values.
   final List<Color> _androidColors = [
@@ -931,6 +940,7 @@ class SelectedDataPoint extends LineChartMarker {
     Canvas canvas,
     Paint paint,
     Offset pos,
+    double swatchYOffset,
   ) {
     const dashDrawWidth = 4.0;
     const dashSkipWidth = 2.0;
@@ -938,8 +948,7 @@ class SelectedDataPoint extends LineChartMarker {
     const swatchHeight = 8.0;
     const swatchWidth = 10.0;
     const swatchXOffset = 12.0;
-    const swatchYOffset = 11.0;
-    const swatchYHalfOffset = swatchYOffset ~/ 2.0;
+    final swatchYHalfOffset = swatchYOffset ~/ 2.0;
 
     final xOffset = pos.dx - swatchXOffset;
     var yOffset = pos.dy + swatchYOffset + swatchYHalfOffset; // Dashed line
@@ -956,13 +965,13 @@ class SelectedDataPoint extends LineChartMarker {
     canvas.drawLine(p1, p2, paint);
 
     // Color swatches start vertically after time and dashed line entries.
-    yOffset = swatchYOffset * 2 + 1;
+    yOffset = pos.dy + swatchYOffset * 2 + 1;
 
     paint.style = PaintingStyle.fill;
     for (var index = 1; index < colors.length; index++) {
       paint.color = colors[index];
       canvas.drawRect(
-        Rect.fromLTWH(xOffset, pos.dy + yOffset, swatchWidth, swatchHeight),
+        Rect.fromLTWH(xOffset, yOffset, swatchWidth, swatchHeight),
         paint,
       );
       yOffset += swatchYOffset;

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -225,7 +225,9 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
                 padding: const EdgeInsets.fromLTRB(20, 10, 0, 5),
                 child: OutlineButton(
                   key: MemoryChartState.androidChartButtonKey,
-                  onPressed: _toggleAndroidChart,
+                  onPressed: controller.isConnectedDeviceAndroid
+                      ? _toggleAndroidChart
+                      : null,
                   child: androidMemoryButton,
                 ),
               ),

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -10,6 +10,7 @@ import 'package:intl/intl.dart' as intl;
 import 'package:mp_chart/mp/chart/line_chart.dart';
 import 'package:mp_chart/mp/controller/line_chart_controller.dart';
 import 'package:mp_chart/mp/core/adapter_android_mp.dart';
+import 'package:mp_chart/mp/core/common_interfaces.dart';
 import 'package:mp_chart/mp/core/data/line_data.dart';
 import 'package:mp_chart/mp/core/data_set/line_data_set.dart';
 import 'package:mp_chart/mp/core/description.dart';
@@ -28,13 +29,13 @@ import 'package:mp_chart/mp/core/marker/line_chart_marker.dart';
 import 'package:mp_chart/mp/core/poolable/point.dart';
 import 'package:mp_chart/mp/core/utils/color_utils.dart';
 import 'package:mp_chart/mp/core/utils/painter_utils.dart';
-import 'package:mp_chart/mp/core/value_formatter/default_value_formatter.dart';
 import 'package:mp_chart/mp/core/value_formatter/large_value_formatter.dart';
 import 'package:mp_chart/mp/core/value_formatter/value_formatter.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/controllers.dart';
 import '../../flutter/theme.dart';
+import '../../ui/flutter/label.dart';
 import '../../ui/theme.dart';
 import 'memory_controller.dart';
 import 'memory_protocol.dart';
@@ -45,6 +46,9 @@ class MemoryChart extends StatefulWidget {
 }
 
 class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
+  @visibleForTesting
+  static const androidChartButtonKey = Key('Android Chart');
+
   LineChartController chartController;
 
   MemoryController controller;
@@ -56,7 +60,10 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
   @override
   void initState() {
-    _initController();
+    _initChartController();
+
+    // Setup for Flutter Engine chart (Android ADB dumpsys meminfo).
+    _setupEngineChartController();
 
     _preloadResources();
 
@@ -69,9 +76,8 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
     controller = Controllers.of(context).memory;
 
-    controller.memoryTimeline.image = _img;
-
     _setupChart();
+    _setupEngineChartData();
 
     cancel();
 
@@ -80,17 +86,54 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       setState(() {
         controller.updatedMemorySource();
 
-        // Plot all offline or online data (based on memorySource).  If
-        // not offline then all new heap samples will be plotted as it
-        // appears via the sampleAddedNotifier.
-        _processAndUpdate(true);
+        // Reset all plotted data sets (Entries).
+        controller.memoryTimeline.chartData.reset();
+        controller.memoryTimeline.engineChartData.reset();
+
+        if (controller.offline) {
+          _recomputeOfflineData();
+          controller.memoryTimeline.chartData.reset();
+          controller.memoryTimeline.engineChartData.reset();
+          _processAndUpdate();
+        } else {
+          // Recompute data to display.
+          _recomputeChartData();
+
+          // Plot all offline or online data (based on memorySource).  If
+          // not offline then all new heap samples will be plotted as it
+          // appears via the sampleAddedNotifier and update all charts.
+          _processAndUpdate();
+        }
       });
+    });
+
+    // Display charts of the data collected in the last n Minutes or all.
+    addAutoDisposeListener(controller.displayIntervalNotifier, () {
+      // Reset all plotted data sets (Entries).
+      controller.memoryTimeline.chartData.reset();
+      controller.memoryTimeline.engineChartData.reset();
+
+      if (controller.offline) {
+        _recomputeOfflineData();
+        controller.memoryTimeline.chartData.reset();
+        controller.memoryTimeline.engineChartData.reset();
+        _processAndUpdate();
+      } else {
+        // Recompute data to display.
+        _recomputeChartData();
+
+        // Process and plot data in this new display interval.
+        _processAndUpdate();
+      }
     });
 
     // Plot each heap sample as it is received.
     addAutoDisposeListener(
       memoryTimeline.sampleAddedNotifier,
-      _processAndUpdate,
+      () {
+        // Process incoming Samples and update the charts.
+        _processAndUpdate();
+      },
     );
   }
 
@@ -100,12 +143,127 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     _img ??= await ImageLoader.loadImage('assets/img/star.png');
   }
 
+  Slider timelineSlider;
+
+  double sliderValue = 1.0;
+
+  // Number of interval chunks e.g., 5 minute interval has 3 chunks for 15 minutes of collected data
+  int numberOfChunks = 0;
+
+  /// Compute lables for slider.
+  String timelineSliderLabel(double value) {
+    if (value == 0)
+      return 'Starting Time';
+    else if (value == numberOfChunks) return 'Ending Time';
+
+    var unitsAgo = numberOfChunks - value;
+
+    switch (controller.pruneInterval) {
+      case MemoryController.displayOneMinute:
+        unitsAgo = unitsAgo;
+        break;
+      case MemoryController.displayFiveMinutes:
+        unitsAgo = unitsAgo * 5;
+        break;
+      case MemoryController.displayTenMinutes:
+        unitsAgo = unitsAgo * 10;
+        break;
+    }
+
+    return '$unitsAgo Minute${unitsAgo != 1 ? 's' : ''} Ago';
+  }
+
   @override
   Widget build(BuildContext context) {
+    controller.memoryTimeline.image = _img;
+
+    final androidMemoryButton = MaterialIconLabel(
+      controller.isAndroidChartVisible ? Icons.close : Icons.show_chart,
+      'Android Memory',
+      minIncludeTextWidth: 900,
+    );
+
+    int chunks = 0;
+
+    if (controller.memoryTimeline.data.isNotEmpty) {
+      final lastSampleTimestamp =
+          controller.memoryTimeline.data.last.timestamp.toDouble();
+      final firstSampleTimestamp =
+          controller.memoryTimeline.data.first.timestamp.toDouble();
+      chunks = ((lastSampleTimestamp - firstSampleTimestamp) /
+              controller.pruneIntervalDurationInMs)
+          .round();
+    }
+
+    if (chunks != numberOfChunks) {
+      // TODO(terry): Need to stay on the same chunk as more chunks arrive.
+      // We have more reset to last.
+      numberOfChunks = chunks;
+      sliderValue = chunks.toDouble();
+    }
+
+    timelineSlider = Slider.adaptive(
+      label: timelineSliderLabel(sliderValue),
+      activeColor: Colors.indigoAccent,
+      min: 0.0,
+      max: numberOfChunks == 0 ? 1.0 : numberOfChunks.toDouble(),
+      inactiveColor: Colors.grey,
+      onChanged: numberOfChunks > 0
+          ? (newValue) {
+              final newChunk = newValue.roundToDouble();
+              setState(() {
+                sliderValue = newChunk;
+                // TODO(terry): Compute:
+                // startingIndex = sliderValue * controller.pruneIntervalDurationInMs
+              });
+            }
+          : null,
+      value: sliderValue,
+      divisions: numberOfChunks == 0 ? 1 : numberOfChunks,
+      semanticFormatterCallback: (double newValue) {
+        return 'Slot $newValue';
+        return '${newValue.round()} dollars';
+      },
+    );
+
     if (memoryTimeline.liveData.isNotEmpty) {
-      return Center(
-        child: LineChart(chartController),
-      );
+      return Column(
+          mainAxisSize: MainAxisSize.max,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            const Padding(
+              padding: EdgeInsets.fromLTRB(20, 10, 0, 5),
+              child: Text('Flutter Framework Heap'),
+            ),
+            Expanded(
+              child: LineChart(chartController),
+              flex: 1,
+            ),
+            Row(children: [
+              Padding(
+                padding: const EdgeInsets.fromLTRB(20, 10, 0, 5),
+                child: OutlineButton(
+                  key: MemoryChartState.androidChartButtonKey,
+                  onPressed: _toggleAndroidChart,
+                  child: androidMemoryButton,
+                ),
+              ),
+              Expanded(
+                child: timelineSlider,
+                flex: 1,
+              ),
+              const Text('Time Range')
+            ]),
+            controller.isAndroidChartVisible
+                ? Expanded(
+                    child: LineChart(engineChartController),
+                    flex: 1,
+                  )
+                : const Padding(
+                    padding: EdgeInsets.fromLTRB(20, 10, 0, 5),
+                    child: Text(''),
+                  ),
+          ]);
     }
 
     return const Center(
@@ -113,8 +271,19 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     );
   }
 
-  void _initController() {
+  void _toggleAndroidChart() {
+    // TODO(terry): Implement real pause when connected to live feed.
+    controller.toggleAndroidChart();
+    setState(() {});
+  }
+
+  void _initChartController() {
     final desc = Description()..enabled = false;
+    final selectedMarker = SelectedDataPoint(
+      ChartType.DartHeaps,
+      onSelected: onPointSelected,
+      getAllValues: getValues,
+    );
 
     chartController = LineChartController(
       axisLeftSettingFunction: (axisLeft, controller) {
@@ -144,47 +313,257 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       legendSettingFunction: (legend, controller) {
         legend.enabled = false;
         // TODO(terry): Need to support legend with a smaller text size.
-        // legend
-        //   ..shape = LegendForm.LINE
-        //   ..verticalAlignment = LegendVerticalAlignment.TOP
-        //   ..enabled = true
-        //   ..orientation = LegendOrientation.HORIZONTAL
-        //   ..typeface = legendTypeFace
-        //   ..xOffset = 20
-        //   ..drawInside = false
-        //   ..horizontalAlignment = LegendHorizontalAlignment.CENTER
-        //   ..textSize = 6.0;
+/*
+        legend
+          ..shape = LegendForm.LINE
+          ..verticalAlignment = LegendVerticalAlignment.TOP
+          ..enabled = true
+          ..orientation = LegendOrientation.HORIZONTAL
+          ..typeface = legendTypeFace
+          ..xOffset = 20
+          ..drawInside = false
+          ..horizontalAlignment = LegendHorizontalAlignment.CENTER
+          ..textSize = 2.0;
+*/
+      },
+      highLightPerTapEnabled: true,
+      backgroundColor: chartBackgroundColor,
+      doubleTapToZoomEnabled: false,
+      drawGridBackground: false,
+      dragXEnabled: true,
+      dragYEnabled: true,
+      // TODO(terry): For now disable zoom with double-click.
+      scaleXEnabled: true,
+      scaleYEnabled: true,
+      pinchZoomEnabled: false,
+      description: desc,
+      marker: selectedMarker,
+      selectionListener: MySelectionListener(selectedMarker),
+    );
+
+    // Compute padding around chart.
+    chartController.setViewPortOffsets(50, 20, 10, 0);
+  }
+
+  /// Plots the Android ADB memory info (Flutter Engine).
+  LineChartController engineChartController;
+
+  void _setupEngineChartController() {
+    final desc = Description()..enabled = false;
+    final selectedMarker = SelectedDataPoint(
+      ChartType.AndroidHeaps,
+      onSelected: onPointSelected,
+      getAllValues: getValues,
+    );
+    engineChartController = LineChartController(
+      axisLeftSettingFunction: (axisLeft, controller) {
+        axisLeft
+          ..position = YAxisLabelPosition.OUTSIDE_CHART
+          ..setValueFormatter(LargeValueFormatter())
+          ..drawGridLines = (true)
+          ..granularityEnabled = (true)
+          ..setStartAtZero(
+              true) // Set to baseline min and auto track max axis range.
+          ..textColor = defaultForeground;
+      },
+      axisRightSettingFunction: (axisRight, controller) {
+        axisRight.enabled = false;
+      },
+      xAxisSettingFunction: (xAxis, controller) {
+        xAxis
+          ..position = XAxisPosition.BOTTOM
+          ..textSize = 10
+          ..drawAxisLine = false
+          ..drawGridLines = true
+          ..textColor = defaultForeground
+          ..centerAxisLabels = true
+          ..setGranularity(1)
+          ..setValueFormatter(XAxisFormatter());
+      },
+      legendSettingFunction: (legend, controller) {
+        legend.enabled = false;
+        // TODO(terry): Need to support legend with a smaller text size.
+/*
+        legend
+          ..shape = LegendForm.LINE
+          ..verticalAlignment = LegendVerticalAlignment.TOP
+          ..enabled = true
+          ..orientation = LegendOrientation.HORIZONTAL
+          ..typeface = legendTypeFace
+          ..xOffset = 20
+          ..drawInside = false
+          ..horizontalAlignment = LegendHorizontalAlignment.CENTER
+          ..textSize = 2.0;
+*/
       },
       highLightPerTapEnabled: true,
       backgroundColor: chartBackgroundColor,
       drawGridBackground: false,
       dragXEnabled: true,
       dragYEnabled: true,
-      scaleXEnabled: true,
-      scaleYEnabled: true,
+      // TOD(terry): For now disable zoom via double-click. Consider +/- button
+      //             for a controlled zoom in/zoom out.
+      scaleXEnabled: false,
+      scaleYEnabled: false,
       pinchZoomEnabled: false,
       description: desc,
-      marker: SelectedDataPoint(
-          onSelected: onPointSelected, getAllValues: getValues),
+      marker: selectedMarker,
+      selectionListener: MySelectionListener(selectedMarker),
     );
 
     // Compute padding around chart.
-    chartController.setViewPortOffsets(50, 10, 10, 30);
+    engineChartController.setViewPortOffsets(50, 0, 10, 30);
   }
 
-  void onPointSelected(int index) {
-    controller.selectedSample = index;
+  void _setupTrace(LineDataSet traceSet, Color color, int alpha) {
+    traceSet
+      ..setAxisDependency(AxisDependency.LEFT)
+      ..setColor1(color)
+      ..setValueTextColor(color)
+      ..setLineWidth(.7)
+      ..setDrawCircles(false)
+      ..setDrawValues(false)
+      ..setDrawCircleHole(false)
+      // Fill in area under set.
+      ..setDrawFilled(true)
+      ..setFillColor(color)
+      ..setFillAlpha(alpha);
+  }
+
+  void _setupEngineChartData() {
+    final engineChartData = memoryTimeline.engineChartData;
+
+    stackSizeSet = LineDataSet(engineChartData.stack, 'Stack');
+    _setupTrace(stackSizeSet, ColorUtils.WHITE, 220);
+
+    graphicsSizeSet = LineDataSet(engineChartData.graphics, 'Graphics');
+    _setupTrace(graphicsSizeSet, ColorUtils.HOLO_ORANGE_DARK, 180);
+
+    // Create Native Heap dataset.
+    nativeHeapSet = LineDataSet(engineChartData.nativeHeap, 'Native Heap');
+    _setupTrace(nativeHeapSet, ColorUtils.HOLO_BLUE_LIGHT, 140);
+    nativeHeapSet.setDrawIcons(true);
+
+    javaHeapSet = LineDataSet(engineChartData.javaHeap, 'Java Heap');
+    _setupTrace(javaHeapSet, ColorUtils.YELLOW, 100);
+
+    codeSizeSet = LineDataSet(engineChartData.code, 'Code');
+    _setupTrace(codeSizeSet, ColorUtils.GRAY, 80);
+
+    otherSizeSet = LineDataSet(engineChartData.other, 'Other');
+    _setupTrace(otherSizeSet, ColorUtils.HOLO_PURPLE, 40);
+
+    /// TODO(terry): The last trace combine system and other.
+    systemSizeSet = LineDataSet(engineChartData.system, 'System');
+    _setupTrace(systemSizeSet, ColorUtils.HOLO_GREEN_DARK, 0);
+
+    totalSizeSet = LineDataSet(engineChartData.total, 'Total')
+      ..setAxisDependency(AxisDependency.LEFT)
+      ..setColor1(ColorUtils.LTGRAY)
+      ..setValueTextColor(ColorUtils.LTGRAY)
+      ..setLineWidth(.5)
+      ..enableDashedLine(5, 5, 0)
+      ..setDrawCircles(false)
+      ..setDrawValues(false)
+      ..setFillAlpha(255)
+      ..setFillColor(ColorUtils.LTGRAY)
+      ..setDrawCircleHole(false);
+
+    // Create a data object with all the data sets.
+    chartController.data = LineData.fromList(
+      []
+        ..add(javaHeapSet)
+        ..add(nativeHeapSet)
+        ..add(codeSizeSet)
+        ..add(stackSizeSet)
+        ..add(graphicsSizeSet)
+        ..add(otherSizeSet)
+        ..add(systemSizeSet)
+        ..add(totalSizeSet),
+    );
+
+    chartController.data
+      ..setValueTextColor(ColorUtils.getHoloBlue())
+      ..setValueTextSize(9);
+  }
+
+  // Trace #1 Java Heap.
+  LineDataSet javaHeapSet;
+
+  // Trace #2 Native Heap.
+  LineDataSet nativeHeapSet;
+
+  // Trace #3 Code Size.
+  LineDataSet codeSizeSet;
+
+  // Trace #4 Stack Size.
+  LineDataSet stackSizeSet;
+
+  // Trace #5 Graphics Size.
+  LineDataSet graphicsSizeSet;
+
+  // Trace #6 Other Size.
+  LineDataSet otherSizeSet;
+
+  // Trace #7 System Size.
+  LineDataSet systemSizeSet;
+
+  // Trace #8 Total Size.
+  LineDataSet totalSizeSet;
+
+  /// When point selected e.g., LineChartMarker find the HeapSample.
+  void onPointSelected(int xValueTimestamp) {
+    if (controller.selectedSample?.timestamp != xValueTimestamp) {
+      controller.selectedSample = null;
+
+      final data = controller.memoryTimeline.data;
+      for (var index = 0; index < data.length; index++) {
+        if (data[index].timestamp == xValueTimestamp) {
+          controller.selectedSample = data[index];
+        }
+      }
+    }
   }
 
   HeapSample getValues(int timestamp) {
     final data = controller.memoryTimeline.data;
-    for (var index = 0; index < data.length; index++) {
-      if (data[index].timestamp == timestamp) {
-        return data[index];
+    final start = controller.memoryTimeline.startingIndex;
+
+    // Is the marker being displayed in the visible range?
+    if (timestamp > data[start].timestamp) {
+      if (controller.selectedSample?.timestamp == timestamp)
+        return controller.selectedSample;
+
+      controller.selectedSample = null;
+
+      for (var index = 0; index < data.length; index++) {
+        if (data[index].timestamp == timestamp) {
+          controller.selectedSample = data[index];
+          break;
+        }
       }
+    } else {
+      // Marker no longer in visible range.
+      controller.selectedSample = null;
+      // TODO(terry): BUG in MP chart / Dart bug unable to unselect the highlighted values.
+      // Failure in method drawMarkers in lib/mp/painter/painter.dart @ the line
+      //
+      //      for (int i = 0; i < _indicesToHighlight.length; i++) {
+      //
+      // This line shouldn't execute  _indicesToHighlight is null, first line in drawMarkers
+      // below should cause return
+      //
+      //   if (_marker == null || !_drawMarkers || !valuesToHighlight()) return;
+      //
+      // For some reason valuesToHightlight() isn't false, however, valuesToHighlight
+      // seems correct.
+      //
+      // Below line should be:
+      //    chartController.painter.highlightValues(null);
+      chartController.painter.highlightValues([]);
     }
 
-    return null;
+    return controller.selectedSample;
   }
 
   @override
@@ -201,26 +580,69 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   // Trace #3 External Memory used.
   LineDataSet externalMemorySet;
 
-  /// General utility function handles loading all heap samples (online or offline) and
-  /// or the latest
-  /// heap sample.
+  /// Loads all heap samples (live data or offline).
   void _processAndUpdate([bool reloadAllData = false]) {
     setState(() {
+      if (reloadAllData) {
+        controller.recomputeData();
+      }
+
       controller.processData(reloadAllData);
-      _updateChart();
+
+      // Display all charts with the new data.
+      _updateCharts();
+    });
+  }
+
+  void _recomputeOfflineData() {
+    setState(() {
+      controller.recomputeOfflineData();
+
+      // Display all charts with the new data.
+      _updateCharts();
+    });
+  }
+
+  /// Recompute the startingIndex and endingIndex from all HeapSample to
+  /// the chart's LineDataSet (entries) based on the curent display interval.
+  void _recomputeChartData() {
+    setState(() {
+      controller.recomputeData();
     });
   }
 
   /// Display any newly received heap sample(s) in the chart.
-  void _updateChart() {
+  void _updateCharts() {
     setState(() {
-      // Signal data has changed.
+      // Update Dart VM chart datasets.
+      chartController.data = LineData.fromList(
+          []..add(usedHeapSet)..add(externalMemorySet)..add(capacityHeapSet));
+
+      // Received new samples ready to plot, signal data has changed.
       usedHeapSet.notifyDataSetChanged();
       capacityHeapSet.notifyDataSetChanged();
       externalMemorySet.notifyDataSetChanged();
 
-      chartController.data = LineData.fromList(
-          []..add(usedHeapSet)..add(externalMemorySet)..add(capacityHeapSet));
+      // Update Android Memory chart datasets.
+      engineChartController.data = LineData.fromList([]
+        ..add(javaHeapSet)
+        ..add(nativeHeapSet)
+        ..add(codeSizeSet)
+        ..add(stackSizeSet)
+        ..add(graphicsSizeSet)
+        ..add(otherSizeSet)
+        ..add(systemSizeSet)
+        ..add(totalSizeSet));
+
+      // Received ADB memory info from samples ready to plot, signal data has changed.
+      javaHeapSet.notifyDataSetChanged();
+      nativeHeapSet.notifyDataSetChanged();
+      codeSizeSet.notifyDataSetChanged();
+      stackSizeSet.notifyDataSetChanged();
+      graphicsSizeSet.notifyDataSetChanged();
+      otherSizeSet.notifyDataSetChanged();
+      systemSizeSet.notifyDataSetChanged();
+      totalSizeSet.notifyDataSetChanged();
     });
   }
 
@@ -309,17 +731,17 @@ typedef SelectionCallback = void Function(int timestamp);
 
 typedef AllValuesCallback = HeapSample Function(int timestamp);
 
+enum ChartType { DartHeaps, AndroidHeaps }
+
 /// Selection of a point in the Bar chart displays the data point values
 /// UI duration and GPU duration. Also, highlight the selected stacked bar.
 /// Uses marker/highlight mechanism which lags because it uses onTapUp maybe
 /// onTapDown would be less laggy.
 ///
-/// TODO(terry): Highlighting is not efficient, a faster mechanism to return
-/// the Entry being clicked is needed.
-///
 /// onSelected callback function invoked when bar entry is selected.
 class SelectedDataPoint extends LineChartMarker {
-  SelectedDataPoint({
+  SelectedDataPoint(
+    this.type, {
     this.textColor,
     this.backColor,
     this.fontSize,
@@ -327,15 +749,21 @@ class SelectedDataPoint extends LineChartMarker {
     this.getAllValues,
   }) {
     _timestampFormatter = XAxisFormatter();
-    _formatter = DefaultValueFormatter(0);
+    _formatter = LargeValueFormatter();
     textColor ??= ColorUtils.WHITE;
     backColor ??= const Color.fromARGB(127, 0, 0, 0);
     fontSize ??= 10;
   }
 
+  ChartType type;
+
   Entry _entry;
 
-  DefaultValueFormatter _formatter;
+  set entry(Entry e) {
+    _entry = e;
+  }
+
+  LargeValueFormatter _formatter;
 
   XAxisFormatter _timestampFormatter;
 
@@ -345,8 +773,6 @@ class SelectedDataPoint extends LineChartMarker {
 
   double fontSize;
 
-  int _lastTimestmap = -1;
-
   final SelectionCallback onSelected;
 
   final AllValuesCallback getAllValues;
@@ -354,12 +780,24 @@ class SelectedDataPoint extends LineChartMarker {
   @override
   void draw(Canvas canvas, double posX, double posY) {
     const positionAboveBar = 15;
-    const paddingAroundText = 5;
+    const xPaddingAroundText = 15;
+    const yPaddingAroundText = xPaddingAroundText ~/ 4;
     const rectangleCurve = 5.0;
+
+    /// Text X starting position for Dart VM values.
+    const dartValuesXOffset = 48.0;
+
+    /// Text X starting position for Android values.
+    const androidValuesXOffset = 65.0;
+
+    if (_entry == null) return;
 
     final timestampAsInt = _entry.x.toInt();
 
     final values = getAllValues(timestampAsInt);
+
+    // No values selected or values are out of range, so no marker to display.
+    if (values == null) return;
 
     assert(values.timestamp == timestampAsInt);
 
@@ -369,17 +807,54 @@ class SelectedDataPoint extends LineChartMarker {
     final num rss = values.rss.toDouble();
     final bool isGced = values.isGC;
 
-    final TextPainter painter = PainterUtils.create(
-      null,
-      'Time       ${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
-      'Capacity ${_formatter.getFormattedValue1(heapCapacity)}\n'
-      'Used       ${_formatter.getFormattedValue1(heapUsed)}\n'
-      'External  ${_formatter.getFormattedValue1(external)}\n'
-      'RSS        ${_formatter.getFormattedValue1(rss)}\n'
-      'GC          $isGced',
-      textColor,
-      fontSize,
-    )..textAlign = TextAlign.left;
+    // Alpha filled stacked:
+    final num memoryOther = values.memoryInfo.other.toDouble(); // Purple-ish
+    final num memoryCode = values.memoryInfo.code.toDouble(); // Gray Purple
+    final num memoryNativeHeap =
+        values.memoryInfo.nativeHeap.toDouble(); // Blue-ish
+    final num memoryJavaHeap =
+        values.memoryInfo.javaHeap.toDouble(); // Green-ish
+    final num memoryStack = values.memoryInfo.stack.toDouble(); // White-ish
+    final num memoryGraphics = values.memoryInfo.graphics.toDouble(); // Orangy
+
+    final num memoryTotal = values.memoryInfo.total.toDouble(); // dashed line
+
+    final num memorySystem =
+        values.memoryInfo.system.toDouble(); // Should report as system+other
+
+    final TextPainter painter = type == ChartType.DartHeaps
+        ? PainterUtils.create(null, _titlesDartVm, textColor, fontSize)
+        : PainterUtils.create(null, _titlesAndroid, textColor, fontSize);
+
+    painter.textAlign = TextAlign.left;
+
+    // Compute the values of each point for a particular x position (timestamp).
+    final TextPainter painterValues = type == ChartType.DartHeaps
+        ? PainterUtils.create(
+            null,
+            '${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
+            '${_formatter.getFormattedValue1(heapCapacity)}\n'
+            '${_formatter.getFormattedValue1(heapUsed)}\n'
+            '${_formatter.getFormattedValue1(external)}\n'
+            '${_formatter.getFormattedValue1(rss)}\n'
+            '$isGced',
+            textColor,
+            fontSize,
+          )
+        : PainterUtils.create(
+            null,
+            '${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
+            '${_formatter.getFormattedValue1(memoryTotal)}\n'
+            '${_formatter.getFormattedValue1(memoryOther)}\n'
+            '${_formatter.getFormattedValue1(memoryCode)}\n'
+            '${_formatter.getFormattedValue1(memoryNativeHeap)}\n'
+            '${_formatter.getFormattedValue1(memoryJavaHeap)}\n'
+            '${_formatter.getFormattedValue1(memoryStack)}\n'
+            '${_formatter.getFormattedValue1(memoryGraphics)}',
+            textColor,
+            fontSize,
+          );
+    painterValues.textAlign = TextAlign.right;
 
     final Paint paint = Paint()
       ..color = backColor
@@ -393,36 +868,137 @@ class SelectedDataPoint extends LineChartMarker {
     );
 
     canvas.save();
+
     // translate to the correct position and draw
     painter.layout();
+    painterValues.layout();
+
     final Offset pos = calculatePos(
       posX + offset.x,
       posY + offset.y - positionAboveBar,
-      painter.width,
+      painter.width + painterValues.width,
       painter.height,
     );
+
     canvas.drawRRect(
       RRect.fromLTRBR(
-        pos.dx - paddingAroundText,
-        pos.dy - paddingAroundText,
-        pos.dx + painter.width + paddingAroundText,
-        pos.dy + painter.height + paddingAroundText,
+        pos.dx - xPaddingAroundText,
+        pos.dy - yPaddingAroundText,
+        pos.dx + painter.width + painterValues.width + xPaddingAroundText,
+        pos.dy + painter.height + yPaddingAroundText,
         const Radius.circular(rectangleCurve),
       ),
       paint,
     );
+
+    _drawColorLegend(
+      type == ChartType.DartHeaps ? _dartVMColors : _androidColors,
+      canvas,
+      paint,
+      pos,
+    );
+
+    // Paint the static text.
     painter.paint(canvas, pos);
+
+    // Paint the computed text values.
+    final valuePos = pos.translate(
+      type == ChartType.DartHeaps ? dartValuesXOffset : androidValuesXOffset,
+      0,
+    );
+    painterValues.paint(canvas, valuePos);
+
     canvas.restore();
   }
 
-  @override
-  void refreshContent(Entry e, Highlight highlight) async {
-    _entry = e;
-    final timestamp = _entry.x.toInt();
-    if (onSelected != null && _lastTimestmap != timestamp) {
-      _lastTimestmap = timestamp;
-      WidgetsBinding.instance
-          .addPostFrameCallback((_) => onSelected(timestamp));
+  final String _titlesDartVm = 'Time\n'
+      'Capacity\n'
+      'Used\n'
+      'External\n'
+      'RSS\n'
+      'GC';
+
+  // These are the alpha blended values.
+  final List<Color> _dartVMColors = [
+    ColorUtils.GRAY, // Total dashed line (Capacity)
+    const Color(0xff315a69), // Aqua (Used)
+    const Color(0xff77aed5), // Light-Blue (External)
+  ];
+
+  final String _titlesAndroid = 'Time\n'
+      'Total\n'
+      'Other\n'
+      'Code\n'
+      'Native Heap\n'
+      'Java Heap\n'
+      'Stack\n'
+      'Graphics';
+
+  // These are the alpha blended values.
+  final List<Color> _androidColors = [
+    ColorUtils.WHITE, // Total dashed line (Total)
+    const Color(0xff945caf), // Purple-ish (Other)
+    const Color(0xff6a5caf), // Gray Purple-ish (Code)
+    const Color(0xff607ebe), // Blue-ish (Native Heap)
+    const Color(0xff75b479), // Green-ish (Java Heap)
+    const Color(0xffe1dbea), // White-ish (Stack)
+    const Color(0xffec935d), // Orangy (Graphics)
+  ];
+
+  void _drawColorLegend(
+    List<Color> colors,
+    Canvas canvas,
+    Paint paint,
+    Offset pos,
+  ) {
+    const dashDrawWidth = 4.0;
+    const dashSkipWidth = 2.0;
+
+    const swatchHeight = 8.0;
+    const swatchWidth = 10.0;
+    const swatchXOffset = 12.0;
+    const swatchYOffset = 11.0;
+    const swatchYHalfOffset = swatchYOffset ~/ 2.0;
+
+    final xOffset = pos.dx - swatchXOffset;
+    var yOffset = pos.dy + swatchYOffset + swatchYHalfOffset; // Dashed line
+
+    // Draw the dashed line key.
+    paint.color = colors[0];
+    paint.strokeWidth = 2;
+    paint.style = PaintingStyle.stroke;
+    var p1 = Offset(xOffset, yOffset);
+    var p2 = p1.translate(dashDrawWidth, 0);
+    canvas.drawLine(p1, p2, paint);
+    p1 = p2.translate(dashSkipWidth, 0);
+    p2 = p1.translate(dashDrawWidth, 0);
+    canvas.drawLine(p1, p2, paint);
+
+    // Color swatches start vertically after time and dashed line entries.
+    yOffset = swatchYOffset * 2 + 1;
+
+    paint.style = PaintingStyle.fill;
+    for (var index = 1; index < colors.length; index++) {
+      paint.color = colors[index];
+      canvas.drawRect(
+        Rect.fromLTWH(xOffset, pos.dy + yOffset, swatchWidth, swatchHeight),
+        paint,
+      );
+      yOffset += swatchYOffset;
     }
+  }
+}
+
+class MySelectionListener implements OnChartValueSelectedListener {
+  MySelectionListener(this.selectedDataPoint);
+
+  SelectedDataPoint selectedDataPoint;
+
+  @override
+  void onNothingSelected() {}
+
+  @override
+  void onValueSelected(Entry e, Highlight h) {
+    selectedDataPoint.entry = e;
   }
 }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -968,7 +968,7 @@ class SelectedDataPoint extends LineChartMarker {
     canvas.drawLine(p1, p2, paint);
 
     // Color swatches start vertically after time and dashed line entries.
-    yOffset = pos.dy + swatchYOffset * 2 + 1;
+    yOffset = pos.dy + swatchYOffset * 2 + 2;
 
     paint.style = PaintingStyle.fill;
     for (var index = 1; index < colors.length; index++) {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -784,9 +784,11 @@ class SelectedDataPoint extends LineChartMarker {
     final num memoryJavaHeap =
         values.adbMemoryInfo.javaHeap.toDouble(); // Green-ish
     final num memoryStack = values.adbMemoryInfo.stack.toDouble(); // White-ish
-    final num memoryGraphics = values.adbMemoryInfo.graphics.toDouble(); // Orangy
+    final num memoryGraphics =
+        values.adbMemoryInfo.graphics.toDouble(); // Orangy
 
-    final num memoryTotal = values.adbMemoryInfo.total.toDouble(); // dashed line
+    final num memoryTotal =
+        values.adbMemoryInfo.total.toDouble(); // dashed line
 
     final TextPainter painter = type == ChartType.DartHeaps
         ? PainterUtils.create(null, _titlesDartVm, textColor, fontSize)

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -49,7 +49,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   @visibleForTesting
   static const androidChartButtonKey = Key('Android Chart');
 
-  LineChartController chartController;
+  LineChartController dartChartController;
 
   MemoryController controller;
 
@@ -60,10 +60,10 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
   @override
   void initState() {
-    _initChartController();
+    _setupDartChartController();
 
     // Setup for Flutter Engine chart (Android ADB dumpsys meminfo).
-    _setupEngineChartController();
+    _setupAndroidChartController();
 
     _preloadResources();
 
@@ -76,8 +76,13 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
     controller = Controllers.of(context).memory;
 
-    _setupChart();
-    _setupEngineChartData();
+    // Hookup access to the MemoryController when a data point is clicked
+    // in a chart.
+    _selectedDartChart?.memoryController = controller;
+    _selectedAndroidChart?.memoryController = controller;
+
+    _setupDartChartData();
+    _setupAndroidChartData();
 
     cancel();
 
@@ -85,46 +90,21 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     addAutoDisposeListener(controller.memorySourceNotifier, () {
       setState(() {
         controller.updatedMemorySource();
-
-        // Reset all plotted data sets (Entries).
-        controller.memoryTimeline.chartData.reset();
-        controller.memoryTimeline.engineChartData.reset();
-
-        if (controller.offline) {
-          _recomputeOfflineData();
-          controller.memoryTimeline.chartData.reset();
-          controller.memoryTimeline.engineChartData.reset();
-          _processAndUpdate();
-        } else {
-          // Recompute data to display.
-          _recomputeChartData();
-
-          // Plot all offline or online data (based on memorySource).  If
-          // not offline then all new heap samples will be plotted as it
-          // appears via the sampleAddedNotifier and update all charts.
-          _processAndUpdate();
-        }
+        _refreshCharts();
       });
     });
 
     // Display charts of the data collected in the last n Minutes or all.
     addAutoDisposeListener(controller.displayIntervalNotifier, () {
-      // Reset all plotted data sets (Entries).
-      controller.memoryTimeline.chartData.reset();
-      controller.memoryTimeline.engineChartData.reset();
+      _refreshCharts();
+    });
 
-      if (controller.offline) {
-        _recomputeOfflineData();
-        controller.memoryTimeline.chartData.reset();
-        controller.memoryTimeline.engineChartData.reset();
-        _processAndUpdate();
-      } else {
-        // Recompute data to display.
-        _recomputeChartData();
+    addAutoDisposeListener(memoryTimeline.markerHiddenNotifier, () {
+      controller.setSelectedSample(ChartType.DartHeaps, null);
+      hideMarkers(ChartType.DartHeaps);
 
-        // Process and plot data in this new display interval.
-        _processAndUpdate();
-      }
+      controller.setSelectedSample(ChartType.AndroidHeaps, null);
+      hideMarkers(ChartType.AndroidHeaps);
     });
 
     // Plot each heap sample as it is received.
@@ -137,6 +117,26 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     );
   }
 
+  void _refreshCharts() {
+    // Reset all plotted data sets (Entries).
+    controller.memoryTimeline.dartChartData.reset();
+    controller.memoryTimeline.androidChartData.reset();
+
+    if (controller.offline) {
+      _recomputeOfflineData();
+      controller.memoryTimeline.dartChartData.reset();
+      controller.memoryTimeline.androidChartData.reset();
+    } else {
+      // Recompute data to display.
+      _recomputeChartData();
+    }
+
+    // Plot all offline or online data (based on memorySource).  If
+    // not offline then all new heap samples will be plotted as it
+    // appears via the sampleAddedNotifier and update all charts.
+    _processAndUpdate();
+  }
+
   dart_ui.Image _img;
 
   void _preloadResources() async {
@@ -145,16 +145,19 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
   Slider _timelineSlider;
 
+  SelectedDataPoint _selectedDartChart;
+  SelectedDataPoint _selectedAndroidChart;
+
   /// Compute increments for slider and lables for slider increments based on the
   /// current display interval time period.
   String timelineSliderLabel(double value) {
     if (value == 0)
       return 'Starting Time';
-    else if (value == controller.numberOfChunks) return 'Ending Time';
+    else if (value == controller.numberOfStops) return 'Ending Time';
 
-    var unitsAgo = controller.numberOfChunks - value;
+    var unitsAgo = controller.numberOfStops - value;
 
-    switch (controller.pruneInterval) {
+    switch (controller.displayInterval) {
       case MemoryController.displayOneMinute:
         unitsAgo = unitsAgo;
         break;
@@ -169,112 +172,116 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     return '$unitsAgo Minute${unitsAgo != 1 ? 's' : ''} Ago';
   }
 
+  Slider createTimelineSlider() => Slider.adaptive(
+        label: timelineSliderLabel(controller.sliderValue),
+        activeColor: Colors.indigoAccent,
+        min: 0.0,
+        max: controller.numberOfStops.toDouble(),
+        inactiveColor: Colors.grey,
+        onChanged: controller.numberOfStops > 0
+            ? (newValue) {
+                final newChunk = newValue.roundToDouble();
+                setState(() {
+                  controller.sliderValue = newChunk;
+                  // TODO(terry): Compute:
+                  //    startingIndex = sliderValue * controller.intervalDurationInMs
+                });
+              }
+            : null,
+        value: controller.sliderValue,
+        divisions: controller.numberOfStops,
+      );
+
+  OutlineButton createToggleAdbMemoryButton() => OutlineButton(
+        key: MemoryChartState.androidChartButtonKey,
+        onPressed: controller.isConnectedDeviceAndroid
+            ? _toggleAndroidChartVisibility
+            : null,
+        child: MaterialIconLabel(
+          controller.isAndroidChartVisible ? Icons.close : Icons.show_chart,
+          'Android Memory',
+          minIncludeTextWidth: 900,
+        ),
+      );
+
   @override
   Widget build(BuildContext context) {
+    if (memoryTimeline.liveData.isEmpty)
+      return const Center(child: Text('No data'));
+
     controller.memoryTimeline.image = _img;
 
-    final androidMemoryButton = MaterialIconLabel(
-      controller.isAndroidChartVisible ? Icons.close : Icons.show_chart,
-      'Android Memory',
-      minIncludeTextWidth: 900,
-    );
-
-    final chunks = controller.computeChunks();
-    if (chunks != controller.numberOfChunks) {
-      // TODO(terry): Need to stay on the same chunk as more chunks arrive.
+    // Compute number of stops for the timeline slider.
+    final stops = controller.computeStops();
+    if (stops != controller.numberOfStops) {
+      // TODO(terry): Need to stay on the same stop as more stops created.
       // Move reset to last?
-      controller.sliderValue = chunks.toDouble();
+      controller.sliderValue = stops.toDouble();
     }
-    controller.numberOfChunks = chunks;
+    controller.numberOfStops = stops;
 
-    _timelineSlider = Slider.adaptive(
-      label: timelineSliderLabel(controller.sliderValue),
-      activeColor: Colors.indigoAccent,
-      min: 0.0,
-      max: controller.numberOfChunks.toDouble(),
-      inactiveColor: Colors.grey,
-      onChanged: controller.numberOfChunks > 0
-          ? (newValue) {
-              final newChunk = newValue.roundToDouble();
-              setState(() {
-                controller.sliderValue = newChunk;
-                // TODO(terry): Compute:
-                //    startingIndex = sliderValue * controller.pruneIntervalDurationInMs
-              });
-            }
-          : null,
-      value: controller.sliderValue,
-      divisions: controller.numberOfChunks,
-    );
+    _timelineSlider = createTimelineSlider();
 
-    if (memoryTimeline.liveData.isNotEmpty) {
-      return Column(
-          mainAxisSize: MainAxisSize.max,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: <Widget>[
-            const Padding(
-              padding: EdgeInsets.fromLTRB(20, 10, 0, 5),
-              child: Text('Flutter Framework Heap'),
+    const edgeSpacing = EdgeInsets.fromLTRB(20, 10, 0, 5);
+
+    return Column(
+      mainAxisSize: MainAxisSize.max,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        const Padding(
+          padding: edgeSpacing,
+          child: Text('Flutter Framework Heap'),
+        ),
+        Expanded(
+          child: LineChart(dartChartController),
+          flex: 1,
+        ),
+        Row(
+          children: [
+            Padding(
+              padding: edgeSpacing,
+              child: createToggleAdbMemoryButton(),
             ),
             Expanded(
-              child: LineChart(chartController),
+              child: _timelineSlider,
               flex: 1,
             ),
-            Row(children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(20, 10, 0, 5),
-                child: OutlineButton(
-                  key: MemoryChartState.androidChartButtonKey,
-                  onPressed: controller.isConnectedDeviceAndroid
-                      ? _toggleAndroidChart
-                      : null,
-                  child: androidMemoryButton,
-                ),
-              ),
-              Expanded(
-                child: _timelineSlider,
+            const Text('Time Range')
+          ],
+        ),
+        controller.isAndroidChartVisible
+            ? Expanded(
+                child: LineChart(androidChartController),
                 flex: 1,
+              )
+            : const Padding(
+                padding: edgeSpacing,
+                child: Text(''),
               ),
-              const Text('Time Range')
-            ]),
-            controller.isAndroidChartVisible
-                ? Expanded(
-                    child: LineChart(engineChartController),
-                    flex: 1,
-                  )
-                : const Padding(
-                    padding: EdgeInsets.fromLTRB(20, 10, 0, 5),
-                    child: Text(''),
-                  ),
-          ]);
-    }
-
-    return const Center(
-      child: Text('No data'),
+      ],
     );
   }
 
-  void _toggleAndroidChart() {
-    // TODO(terry): Implement real pause when connected to live feed.
-    controller.toggleAndroidChart();
-    setState(() {});
+  void _toggleAndroidChartVisibility() {
+    setState(() {
+      controller.toggleAndroidChartVisibility();
+    });
   }
 
-  void _initChartController() {
+  void _setupDartChartController() {
     final desc = Description()..enabled = false;
-    final selectedMarker = SelectedDataPoint(
+    _selectedDartChart = SelectedDataPoint(
       ChartType.DartHeaps,
-      onSelected: onPointSelected,
-      getAllValues: getValues,
+      getSelectedSampleValue: getDartSelectedSample,
     );
 
-    chartController = LineChartController(
+    dartChartController = LineChartController(
       axisLeftSettingFunction: (axisLeft, controller) {
         axisLeft
           ..position = YAxisLabelPosition.OUTSIDE_CHART
           ..setValueFormatter(LargeValueFormatter())
-          ..drawGridLines = (true)
-          ..granularityEnabled = (true)
+          ..drawGridLines = true
+          ..granularityEnabled = true
           ..setStartAtZero(
               true) // Set to baseline min and auto track max axis range.
           ..textColor = defaultForeground;
@@ -320,33 +327,32 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       scaleYEnabled: true,
       pinchZoomEnabled: false,
       description: desc,
-      marker: selectedMarker,
-      selectionListener: MySelectionListener(selectedMarker),
+      marker: _selectedDartChart,
+      selectionListener: DataPointSelectedistener(_selectedDartChart),
     );
 
     // Compute padding around chart.
-    chartController.setViewPortOffsets(50, 20, 10, 0);
+    dartChartController.setViewPortOffsets(50, 20, 10, 0);
   }
 
   /// Plots the Android ADB memory info (Flutter Engine).
-  LineChartController engineChartController;
+  LineChartController androidChartController;
 
-  void _setupEngineChartController() {
+  void _setupAndroidChartController() {
     final desc = Description()..enabled = false;
-    final selectedMarker = SelectedDataPoint(
+    _selectedAndroidChart = SelectedDataPoint(
       ChartType.AndroidHeaps,
-      onSelected: onPointSelected,
-      getAllValues: getValues,
+      getSelectedSampleValue: getAndroidSelectedSample,
     );
-    engineChartController = LineChartController(
+    androidChartController = LineChartController(
       axisLeftSettingFunction: (axisLeft, controller) {
         axisLeft
           ..position = YAxisLabelPosition.OUTSIDE_CHART
           ..setValueFormatter(LargeValueFormatter())
-          ..drawGridLines = (true)
-          ..granularityEnabled = (true)
-          ..setStartAtZero(
-              true) // Set to baseline min and auto track max axis range.
+          ..drawGridLines = true
+          ..granularityEnabled = true
+          // Set to baseline min and auto track max axis range.
+          ..setStartAtZero(true)
           ..textColor = defaultForeground;
       },
       axisRightSettingFunction: (axisRight, controller) {
@@ -384,18 +390,18 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       drawGridBackground: false,
       dragXEnabled: true,
       dragYEnabled: true,
-      // TOD(terry): For now disable zoom via double-click. Consider +/- button
+      // TOD(terry): Disable zoom via double-click. Consider +/- button
       //             for a controlled zoom in/zoom out.
       scaleXEnabled: false,
       scaleYEnabled: false,
       pinchZoomEnabled: false,
       description: desc,
-      marker: selectedMarker,
-      selectionListener: MySelectionListener(selectedMarker),
+      marker: _selectedAndroidChart,
+      selectionListener: DataPointSelectedistener(_selectedAndroidChart),
     );
 
     // Compute padding around chart.
-    engineChartController.setViewPortOffsets(50, 0, 10, 30);
+    androidChartController.setViewPortOffsets(50, 0, 10, 30);
   }
 
   void _setupTrace(LineDataSet traceSet, Color color, int alpha) {
@@ -413,34 +419,34 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       ..setFillAlpha(alpha);
   }
 
-  void _setupEngineChartData() {
-    final engineChartData = memoryTimeline.engineChartData;
+  void _setupAndroidChartData() {
+    final androidChartData = memoryTimeline.androidChartData;
 
-    stackSizeSet = LineDataSet(engineChartData.stack, 'Stack');
+    stackSizeSet = LineDataSet(androidChartData.stack, 'Stack');
     _setupTrace(stackSizeSet, ColorUtils.WHITE, 220);
 
-    graphicsSizeSet = LineDataSet(engineChartData.graphics, 'Graphics');
+    graphicsSizeSet = LineDataSet(androidChartData.graphics, 'Graphics');
     _setupTrace(graphicsSizeSet, ColorUtils.HOLO_ORANGE_DARK, 180);
 
     // Create Native Heap dataset.
-    nativeHeapSet = LineDataSet(engineChartData.nativeHeap, 'Native Heap');
+    nativeHeapSet = LineDataSet(androidChartData.nativeHeap, 'Native Heap');
     _setupTrace(nativeHeapSet, ColorUtils.HOLO_BLUE_LIGHT, 140);
     nativeHeapSet.setDrawIcons(true);
 
-    javaHeapSet = LineDataSet(engineChartData.javaHeap, 'Java Heap');
+    javaHeapSet = LineDataSet(androidChartData.javaHeap, 'Java Heap');
     _setupTrace(javaHeapSet, ColorUtils.YELLOW, 100);
 
-    codeSizeSet = LineDataSet(engineChartData.code, 'Code');
+    codeSizeSet = LineDataSet(androidChartData.code, 'Code');
     _setupTrace(codeSizeSet, ColorUtils.GRAY, 80);
 
-    otherSizeSet = LineDataSet(engineChartData.other, 'Other');
+    otherSizeSet = LineDataSet(androidChartData.other, 'Other');
     _setupTrace(otherSizeSet, ColorUtils.HOLO_PURPLE, 40);
 
     /// TODO(terry): The last trace combine system and other.
-    systemSizeSet = LineDataSet(engineChartData.system, 'System');
+    systemSizeSet = LineDataSet(androidChartData.system, 'System');
     _setupTrace(systemSizeSet, ColorUtils.HOLO_GREEN_DARK, 0);
 
-    totalSizeSet = LineDataSet(engineChartData.total, 'Total')
+    totalSizeSet = LineDataSet(androidChartData.total, 'Total')
       ..setAxisDependency(AxisDependency.LEFT)
       ..setColor1(ColorUtils.LTGRAY)
       ..setValueTextColor(ColorUtils.LTGRAY)
@@ -453,100 +459,85 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       ..setDrawCircleHole(false);
 
     // Create a data object with all the data sets.
-    chartController.data = LineData.fromList(
-      []
-        ..add(javaHeapSet)
-        ..add(nativeHeapSet)
-        ..add(codeSizeSet)
-        ..add(stackSizeSet)
-        ..add(graphicsSizeSet)
-        ..add(otherSizeSet)
-        ..add(systemSizeSet)
-        ..add(totalSizeSet),
+    androidChartController.data = LineData.fromList(
+      [
+        javaHeapSet,
+        nativeHeapSet,
+        codeSizeSet,
+        stackSizeSet,
+        graphicsSizeSet,
+        otherSizeSet,
+        systemSizeSet,
+        totalSizeSet,
+      ],
     );
 
-    chartController.data
+    androidChartController.data
       ..setValueTextColor(ColorUtils.getHoloBlue())
       ..setValueTextSize(9);
   }
 
-  // Trace #1 Java Heap.
+  /// Trace #1 Java Heap.
   LineDataSet javaHeapSet;
 
-  // Trace #2 Native Heap.
+  /// Trace #2 Native Heap.
   LineDataSet nativeHeapSet;
 
-  // Trace #3 Code Size.
+  /// Trace #3 Code Size.
   LineDataSet codeSizeSet;
 
-  // Trace #4 Stack Size.
+  /// Trace #4 Stack Size.
   LineDataSet stackSizeSet;
 
-  // Trace #5 Graphics Size.
+  /// Trace #5 Graphics Size.
   LineDataSet graphicsSizeSet;
 
-  // Trace #6 Other Size.
+  /// Trace #6 Other Size.
   LineDataSet otherSizeSet;
 
-  // Trace #7 System Size.
+  /// Trace #7 System Size.
   LineDataSet systemSizeSet;
 
-  // Trace #8 Total Size.
+  /// Trace #8 Total Size.
   LineDataSet totalSizeSet;
 
-  /// When point selected e.g., LineChartMarker find the HeapSample.
-  void onPointSelected(int xValueTimestamp) {
-    if (controller.selectedSample?.timestamp != xValueTimestamp) {
-      controller.selectedSample = null;
+  /// Get the HeapSample that is selected for the Dart chart.
+  HeapSample getDartSelectedSample(int timestamp) =>
+      _getValues(ChartType.DartHeaps, timestamp);
 
-      final data = controller.memoryTimeline.data;
-      for (var index = 0; index < data.length; index++) {
-        if (data[index].timestamp == xValueTimestamp) {
-          controller.selectedSample = data[index];
-        }
-      }
-    }
-  }
+  /// Get the HeapSample that is selected for the Android chart.
+  HeapSample getAndroidSelectedSample(int timestamp) =>
+      _getValues(ChartType.AndroidHeaps, timestamp);
 
-  HeapSample getValues(int timestamp) {
-    final data = controller.memoryTimeline.data;
+  HeapSample _getValues(ChartType type, int timestamp) {
     final start = controller.memoryTimeline.startingIndex;
 
-    // Is the marker being displayed in the visible range?
-    if (timestamp > data[start].timestamp) {
-      if (controller.selectedSample?.timestamp == timestamp)
-        return controller.selectedSample;
-
-      controller.selectedSample = null;
-
-      for (var index = 0; index < data.length; index++) {
-        if (data[index].timestamp == timestamp) {
-          controller.selectedSample = data[index];
-          break;
-        }
-      }
-    } else {
-      // Marker no longer in visible range.
-      controller.selectedSample = null;
-      // TODO(terry): BUG in MP chart / Dart bug unable to unselect the highlighted values.
-      // Failure in method drawMarkers in lib/mp/painter/painter.dart @ the line
-      //
-      //      for (int i = 0; i < _indicesToHighlight.length; i++) {
-      //
-      // This line shouldn't execute  _indicesToHighlight is null, first line in drawMarkers
-      // below should cause return
-      //
-      //   if (_marker == null || !_drawMarkers || !valuesToHighlight()) return;
-      //
-      // For some reason valuesToHightlight() isn't false, however, valuesToHighlight
-      // seems correct.
-      //
-      // Below line should be:
-      //    chartController.painter.highlightValues(null);
-      chartController.painter.highlightValues([]);
+    // Is this sample still in the visible range?
+    if (timestamp < controller.memoryTimeline.data[start].timestamp) {
+      // No, remove the selection.
+      controller.setSelectedSample(type, null);
     }
 
-    return controller.selectedSample;
+    if (controller.getSelectedSample(type) == null) {
+      hideMarkers(type);
+    }
+
+    final currentSelection = controller.getSelectedSample(type);
+    assert(currentSelection != null
+        ? currentSelection.timestamp == timestamp
+        : true);
+    return currentSelection;
+  }
+
+  void hideMarkers(ChartType type) {
+    switch (type) {
+      case ChartType.DartHeaps:
+        dartChartController.painter?.highlightValues([null]);
+        break;
+      case ChartType.AndroidHeaps:
+        androidChartController?.painter?.highlightValues([null]);
+        break;
+    }
   }
 
   @override
@@ -573,7 +564,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       controller.processData(reloadAllData);
 
       // Display all charts with the new data.
-      _updateCharts();
+      _updateAllCharts();
     });
   }
 
@@ -582,7 +573,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       controller.recomputeOfflineData();
 
       // Display all charts with the new data.
-      _updateCharts();
+      _updateAllCharts();
     });
   }
 
@@ -595,11 +586,14 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
   }
 
   /// Display any newly received heap sample(s) in the chart.
-  void _updateCharts() {
+  void _updateAllCharts() {
     setState(() {
       // Update Dart VM chart datasets.
-      chartController.data = LineData.fromList(
-          []..add(usedHeapSet)..add(externalMemorySet)..add(capacityHeapSet));
+      dartChartController.data = LineData.fromList([
+        usedHeapSet,
+        externalMemorySet,
+        capacityHeapSet,
+      ]);
 
       // Received new samples ready to plot, signal data has changed.
       usedHeapSet.notifyDataSetChanged();
@@ -607,15 +601,16 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       externalMemorySet.notifyDataSetChanged();
 
       // Update Android Memory chart datasets.
-      engineChartController.data = LineData.fromList([]
-        ..add(javaHeapSet)
-        ..add(nativeHeapSet)
-        ..add(codeSizeSet)
-        ..add(stackSizeSet)
-        ..add(graphicsSizeSet)
-        ..add(otherSizeSet)
-        ..add(systemSizeSet)
-        ..add(totalSizeSet));
+      androidChartController.data = LineData.fromList([
+        javaHeapSet,
+        nativeHeapSet,
+        codeSizeSet,
+        stackSizeSet,
+        graphicsSizeSet,
+        otherSizeSet,
+        systemSizeSet,
+        totalSizeSet,
+      ]);
 
       // Received ADB memory info from samples ready to plot, signal data has changed.
       javaHeapSet.notifyDataSetChanged();
@@ -629,11 +624,11 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
     });
   }
 
-  void _setupChart() {
-    final chartData = memoryTimeline.chartData;
+  void _setupDartChartData() {
+    final dartChartData = memoryTimeline.dartChartData;
 
     // Create heap used dataset.
-    usedHeapSet = LineDataSet(chartData.used, 'Used');
+    usedHeapSet = LineDataSet(dartChartData.used, 'Used');
     usedHeapSet
       ..setAxisDependency(AxisDependency.LEFT)
       ..setColor1(ColorUtils.getHoloBlue())
@@ -650,7 +645,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       ..setFillAlpha(80);
 
     // Create heap capacity dataset.
-    capacityHeapSet = LineDataSet(chartData.capacity, 'Capacity')
+    capacityHeapSet = LineDataSet(dartChartData.capacity, 'Capacity')
       ..setAxisDependency(AxisDependency.LEFT)
       ..setColor1(ColorUtils.GRAY)
       ..setValueTextColor(ColorUtils.GRAY)
@@ -667,7 +662,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
         Color.fromARGB(0xff, 0x42, 0xa5, 0xf5); // Color.blue[400]
     const externalColor =
         Color.fromARGB(0xff, 0x90, 0xca, 0xf9); // Color.blue[200]
-    externalMemorySet = LineDataSet(chartData.externalHeap, 'External');
+    externalMemorySet = LineDataSet(dartChartData.externalHeap, 'External');
     externalMemorySet
       ..setAxisDependency(AxisDependency.LEFT)
       ..setColor1(externalColorLine)
@@ -682,20 +677,15 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       ..setFillAlpha(190);
 
     // Create a data object with all the data sets.
-    chartController.data = LineData.fromList(
-      []
-        ..add(
-          usedHeapSet,
-        )
-        ..add(
-          externalMemorySet,
-        )
-        ..add(
-          capacityHeapSet,
-        ),
+    dartChartController.data = LineData.fromList(
+      [
+        usedHeapSet,
+        externalMemorySet,
+        capacityHeapSet,
+      ],
     );
 
-    chartController.data
+    dartChartController.data
       ..setValueTextColor(ColorUtils.getHoloBlue())
       ..setValueTextSize(9);
   }
@@ -712,24 +702,19 @@ class XAxisFormatter extends ValueFormatter {
 
 typedef SelectionCallback = void Function(int timestamp);
 
-typedef AllValuesCallback = HeapSample Function(int timestamp);
-
-enum ChartType { DartHeaps, AndroidHeaps }
+typedef SelectSampleCallback = HeapSample Function(int timestamp);
 
 /// Selection of a point in the Bar chart displays the data point values
 /// UI duration and GPU duration. Also, highlight the selected stacked bar.
 /// Uses marker/highlight mechanism which lags because it uses onTapUp maybe
 /// onTapDown would be less laggy.
-///
-/// onSelected callback function invoked when bar entry is selected.
 class SelectedDataPoint extends LineChartMarker {
   SelectedDataPoint(
     this.type, {
     this.textColor,
     this.backColor,
     this.fontSize,
-    this.onSelected,
-    this.getAllValues,
+    this.getSelectedSampleValue,
   }) {
     _timestampFormatter = XAxisFormatter();
     _formatter = LargeValueFormatter();
@@ -739,6 +724,8 @@ class SelectedDataPoint extends LineChartMarker {
   }
 
   ChartType type;
+
+  MemoryController memoryController;
 
   Entry _entry;
 
@@ -756,9 +743,7 @@ class SelectedDataPoint extends LineChartMarker {
 
   double fontSize;
 
-  final SelectionCallback onSelected;
-
-  final AllValuesCallback getAllValues;
+  final SelectSampleCallback getSelectedSampleValue;
 
   @override
   void draw(Canvas canvas, double posX, double posY) {
@@ -777,7 +762,7 @@ class SelectedDataPoint extends LineChartMarker {
 
     final timestampAsInt = _entry.x.toInt();
 
-    final values = getAllValues(timestampAsInt);
+    final values = getSelectedSampleValue(timestampAsInt);
 
     // No values selected or values are out of range, so no marker to display.
     if (values == null) return;
@@ -791,17 +776,17 @@ class SelectedDataPoint extends LineChartMarker {
     final bool isGced = values.isGC;
 
     // Alpha filled stacked:
-    final num memorySystemAndOther = values.memoryInfo.system.toDouble() +
-        values.memoryInfo.other.toDouble(); // Purple-ish
-    final num memoryCode = values.memoryInfo.code.toDouble(); // Gray Purple
+    final num memorySystemAndOther = values.adbMemoryInfo.system.toDouble() +
+        values.adbMemoryInfo.other.toDouble(); // Purple-ish
+    final num memoryCode = values.adbMemoryInfo.code.toDouble(); // Gray Purple
     final num memoryNativeHeap =
-        values.memoryInfo.nativeHeap.toDouble(); // Blue-ish
+        values.adbMemoryInfo.nativeHeap.toDouble(); // Blue-ish
     final num memoryJavaHeap =
-        values.memoryInfo.javaHeap.toDouble(); // Green-ish
-    final num memoryStack = values.memoryInfo.stack.toDouble(); // White-ish
-    final num memoryGraphics = values.memoryInfo.graphics.toDouble(); // Orangy
+        values.adbMemoryInfo.javaHeap.toDouble(); // Green-ish
+    final num memoryStack = values.adbMemoryInfo.stack.toDouble(); // White-ish
+    final num memoryGraphics = values.adbMemoryInfo.graphics.toDouble(); // Orangy
 
-    final num memoryTotal = values.memoryInfo.total.toDouble(); // dashed line
+    final num memoryTotal = values.adbMemoryInfo.total.toDouble(); // dashed line
 
     final TextPainter painter = type == ChartType.DartHeaps
         ? PainterUtils.create(null, _titlesDartVm, textColor, fontSize)
@@ -809,11 +794,14 @@ class SelectedDataPoint extends LineChartMarker {
 
     painter.textAlign = TextAlign.left;
 
+    final timestampFormatted =
+        _timestampFormatter.getFormattedValue1(timestampAsInt.toDouble());
+
     // Compute the values of each point for a particular x position (timestamp).
     final TextPainter painterValues = type == ChartType.DartHeaps
         ? PainterUtils.create(
             null,
-            '${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
+            '$timestampFormatted\n'
             '${_formatter.getFormattedValue1(heapCapacity)}\n'
             '${_formatter.getFormattedValue1(heapUsed)}\n'
             '${_formatter.getFormattedValue1(external)}\n'
@@ -824,7 +812,7 @@ class SelectedDataPoint extends LineChartMarker {
           )
         : PainterUtils.create(
             null,
-            '${_timestampFormatter.getFormattedValue1(timestampAsInt.toDouble())}\n'
+            '$timestampFormatted\n'
             '${_formatter.getFormattedValue1(memoryTotal)}\n'
             '${_formatter.getFormattedValue1(memorySystemAndOther)}\n'
             '${_formatter.getFormattedValue1(memoryCode)}\n'
@@ -982,16 +970,68 @@ class SelectedDataPoint extends LineChartMarker {
   }
 }
 
-class MySelectionListener implements OnChartValueSelectedListener {
-  MySelectionListener(this.selectedDataPoint);
+/// Listener finds the nearest data-point (Entry) that matches the click
+/// position in a chart based on the ChartType stored in the SelectedDataPoint.
+class DataPointSelectedistener implements OnChartValueSelectedListener {
+  DataPointSelectedistener(this._selectedDataPoint);
 
-  SelectedDataPoint selectedDataPoint;
+  final SelectedDataPoint _selectedDataPoint;
 
   @override
   void onNothingSelected() {}
 
   @override
   void onValueSelected(Entry e, Highlight h) {
-    selectedDataPoint.entry = e;
+    _selectedDataPoint.entry = e;
+    _computeSelection(e);
+  }
+
+  int _binarySearch(List<HeapSample> orderedByTimestamp, int xValueTimestamp) {
+    int min = 0;
+    int max = orderedByTimestamp.length - 1;
+
+    while (min <= max) {
+      final mid = ((min + max) / 2).floor();
+      if (xValueTimestamp == orderedByTimestamp[mid].timestamp) {
+        return mid;
+      } else if (xValueTimestamp < orderedByTimestamp[mid].timestamp) {
+        max = mid - 1;
+      } else {
+        min = mid + 1;
+      }
+    }
+
+    return -1;
+  }
+
+  /// Find the raw data (HeapSample) that matches the chart's clicked on data
+  /// point Entry. The Entry only has the x, y position (x being the timestamp).
+  /// So, using the timestamp find for the raw HeapSample that represents this
+  /// timeseries entry.
+  void _computeSelection(Entry e) {
+    final controller = _selectedDataPoint.memoryController;
+    final data = controller.memoryTimeline.data;
+    final start = controller.memoryTimeline.startingIndex;
+
+    final oldSample = controller.getSelectedSample(_selectedDataPoint.type);
+
+    // Assume datapoint doesn't point to a sample.
+    controller.setSelectedSample(_selectedDataPoint.type, null);
+
+    final timestamp = e.x.toInt();
+
+    // Is the marker being displayed in the visible range?
+    if (timestamp > data[start].timestamp) {
+      // Marker is visible, just return.
+      if (oldSample?.timestamp == timestamp) {
+        controller.setSelectedSample(_selectedDataPoint.type, oldSample);
+      }
+
+      final foundIndex = _binarySearch(data, timestamp);
+      // If found, return new selectable data point and display new marker.
+      if (foundIndex != -1) {
+        controller.setSelectedSample(_selectedDataPoint.type, data[foundIndex]);
+      }
+    }
   }
 }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -13,7 +13,6 @@ import 'package:vm_service/vm_service.dart';
 import '../../auto_dispose.dart';
 import '../../config_specific/logger.dart';
 import '../../globals.dart';
-import '../../service_registrations.dart' as registrations;
 import '../../ui/fake_file/fake_file.dart';
 import '../../ui/fake_flutter/fake_flutter.dart';
 import '../../vm_service_wrapper.dart';
@@ -106,8 +105,9 @@ class MemoryController extends DisposableController
   /// 1 minute in milliseconds.
   static const int minuteInMs = 60 * 1000;
 
-  /// A big number ms (largest for int).
-  static const int bigTimeInMs = 9223372036854775807;
+  /// Largest int in ms for VM could be 9223372036854775807 (2^64)
+  /// however, use JS largest possible int  9007199254740991 (2^53).
+  static const int bigTimeInMs = 9007199254740991;
 
   /// Return the pruning interval in milliseconds.
   int get pruneIntervalDurationInMs => (pruneInterval == displayAllMinutes)
@@ -893,6 +893,7 @@ class MemoryTimeline {
   ValueNotifier<bool> get pausedNotifier => _pausedNotifier;
 
   /// dart_ui.Image Image asset displayed for each entry plotted in a chart.
+  // ignore: unused_field
   dart_ui.Image _img;
 
   // TODO(terry): Look at using _img for each data point (at least last N).

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -54,13 +54,7 @@ class MemoryController extends DisposableController
 
   static const String liveFeed = 'Live Feed';
 
-  String _memorySourcePrefix;
-
-  set memorySourcePrefix(String prefix) {
-    _memorySourcePrefix = prefix;
-  }
-
-  String get memorySourcePrefix => _memorySourcePrefix;
+  String memorySourcePrefix;
 
   /// Notifies that the source of the memory feed has changed.
   ValueListenable get memorySourceNotifier => _memorySourceNotifier;

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -182,29 +182,6 @@ class MemoryController extends DisposableController
     processDataset(args);
   }
 
-  void _onAdbMemoryInfo(
-    VoidCallback callback,
-  ) {
-    final flutterVersionServiceListenable = serviceManager
-        .registeredServiceListenable(registrations.flutterVersion.service);
-//    addAutoDisposeListener(flutterVersionServiceListenable, () async {
-    flutterVersionServiceListenable.addListener(() async {
-      final registered = flutterVersionServiceListenable.value;
-      if (registered) {
-        var data = (await serviceManager.getAdbMemoryInfo()).json;
-        print(">>>>>> adb memory json = $data");
-        callback();
-/*
-        final flutterVersion = FlutterVersion.parse(
-            (await serviceManager.getFlutterVersion()).json);
-        if (flutterVersion.isSupported(supportedVersion: version)) {
-          callback();
-        }
-*/
-      }
-    });
-  }
-
   bool _paused = false;
 
   bool get paused => _paused;
@@ -401,6 +378,7 @@ class MemoryController extends DisposableController
   @override
   void dispose() {
     super.dispose();
+    _pruneInterfaceNoifier.dispose();
     _memorySourceNotifier.dispose();
     _disconnectController.close();
     _memoryTrackerController.close();

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -56,7 +56,9 @@ class MemoryController extends DisposableController
 
   String _memorySourcePrefix;
 
-  set memorySourcePrefix(String prefix) { _memorySourcePrefix = prefix; }
+  set memorySourcePrefix(String prefix) {
+    _memorySourcePrefix = prefix;
+  }
 
   String get memorySourcePrefix => _memorySourcePrefix;
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -54,6 +54,12 @@ class MemoryController extends DisposableController
 
   static const String liveFeed = 'Live Feed';
 
+  String _memorySourcePrefix;
+
+  set memorySourcePrefix(String prefix) { _memorySourcePrefix = prefix; }
+
+  String get memorySourcePrefix => _memorySourcePrefix;
+
   /// Notifies that the source of the memory feed has changed.
   ValueListenable get memorySourceNotifier => _memorySourceNotifier;
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -69,7 +69,7 @@ class MemoryTracker {
 
   // TODO(terry): Discuss need a record/stop record for memory?  Unless expensive probably not.
   Future<void> _pollMemory() async {
-    if (!hasConnection) {
+    if (!hasConnection || memoryController.memoryTracker == null) {
       return;
     }
 
@@ -88,13 +88,16 @@ class MemoryTracker {
       }
     }));
 
-    // Polls for current meminfo using:
+    // Polls for current Android meminfo using:
     //    > adb shell dumpsys meminfo -d <package_name>
-    memoryInfo = await _fetchAdbInfo();
+    if (vm.operatingSystem == 'android')
+      memoryInfo = await _fetchAdbInfo();
+    else
+      // TODO(terry): TBD alternative for iOS memory info - all values zero.
+      memoryInfo = AdbMemoryInfo.empty();
 
     // Polls for current RSS size.
     _update(vm, isolates);
-
     _pollingTimer = Timer(kUpdateDelay, _pollMemory);
   }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -320,17 +320,6 @@ class AdbMemoryInfo {
     this.total,
   );
 
-  /// JSON keys of data retrieved from ADB tool.
-  static const String realTimeKey = 'Realtime';
-  static const String javaHeapKey = 'Java Heap';
-  static const String nativeHeapKey = 'Native Heap';
-  static const String codeKey = 'Code';
-  static const String stackKey = 'Stack';
-  static const String graphicsKey = 'Graphics';
-  static const String otherKey = 'Private Other';
-  static const String systemKey = 'System';
-  static const String totalKey = 'Total';
-
   factory AdbMemoryInfo.fromJson(Map<String, dynamic> json) => AdbMemoryInfo(
         json[realTimeKey] as int,
         json[javaHeapKey] as int,
@@ -342,6 +331,17 @@ class AdbMemoryInfo {
         json[systemKey] as int,
         json[totalKey] as int,
       );
+
+  /// JSON keys of data retrieved from ADB tool.
+  static const String realTimeKey = 'Realtime';
+  static const String javaHeapKey = 'Java Heap';
+  static const String nativeHeapKey = 'Native Heap';
+  static const String codeKey = 'Code';
+  static const String stackKey = 'Stack';
+  static const String graphicsKey = 'Graphics';
+  static const String otherKey = 'Private Other';
+  static const String systemKey = 'System';
+  static const String totalKey = 'Total';
 
   Map<String, dynamic> toJson() => <String, dynamic>{
         realTimeKey: realtime,

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -33,7 +33,7 @@ class MemoryTracker {
   int processRss;
 
   /// Polled adb dumpsys meminfo values.
-  AdbMemoryInfo memoryInfo;
+  AdbMemoryInfo adbMemoryInfo;
 
   bool get hasConnection => service != null;
 
@@ -90,11 +90,12 @@ class MemoryTracker {
 
     // Polls for current Android meminfo using:
     //    > adb shell dumpsys meminfo -d <package_name>
-    if (vm.operatingSystem == 'android')
-      memoryInfo = await _fetchAdbInfo();
-    else
+    if (vm.operatingSystem == 'android') {
+      adbMemoryInfo = await _fetchAdbInfo();
+    } else {
       // TODO(terry): TBD alternative for iOS memory info - all values zero.
-      memoryInfo = AdbMemoryInfo.empty();
+      adbMemoryInfo = AdbMemoryInfo.empty();
+    }
 
     // Polls for current RSS size.
     _update(vm, isolates);
@@ -156,7 +157,7 @@ class MemoryTracker {
       used,
       external,
       fromGC,
-      memoryInfo,
+      adbMemoryInfo,
     ));
 
     memoryController.memoryTimeline.addSample(HeapSample(
@@ -166,7 +167,7 @@ class MemoryTracker {
       used,
       external,
       fromGC,
-      memoryInfo,
+      adbMemoryInfo,
     ));
   }
 
@@ -191,7 +192,7 @@ class HeapSample {
     this.used,
     this.external,
     this.isGC,
-    this.memoryInfo,
+    this.adbMemoryInfo,
   );
 
   factory HeapSample.fromJson(Map<String, dynamic> json) => HeapSample(
@@ -211,7 +212,7 @@ class HeapSample {
         'used': used,
         'external': external,
         'gc': isGC,
-        'adb_memoryInfo': memoryInfo.toJson(),
+        'adb_memoryInfo': adbMemoryInfo.toJson(),
       };
 
   final int timestamp;
@@ -226,11 +227,12 @@ class HeapSample {
 
   final bool isGC;
 
-  final AdbMemoryInfo memoryInfo;
+  final AdbMemoryInfo adbMemoryInfo;
 
   @override
-  String toString() => 'timestamp=$timestamp, rss=$rss, capacity=$capacity, '
-      'used=$used, external=$external, isGC=$isGC\n AdbMemoryInfo:\n$memoryInfo';
+  String toString() => '[HeapSample timestamp: $timestamp, rss: $rss, '
+      'capacity: $capacity, used: $used, external: $external, '
+      'isGC: $isGC, AdbMemoryInfo: $adbMemoryInfo]';
 }
 
 // Heap Statistics
@@ -306,38 +308,59 @@ class ClassHeapDetailStats {
 // TODO(terry): Need the iOS version of this data.
 /// Android ADB dumpsys meminfo data.
 class AdbMemoryInfo {
-  AdbMemoryInfo(this.realtime, this.javaHeap, this.nativeHeap, this.code,
-      this.stack, this.graphics, this.other, this.system, this.total);
+  AdbMemoryInfo(
+    this.realtime,
+    this.javaHeap,
+    this.nativeHeap,
+    this.code,
+    this.stack,
+    this.graphics,
+    this.other,
+    this.system,
+    this.total,
+  );
+
+  /// JSON keys of data retrieved from ADB tool.
+  static const String realTimeKey = 'Realtime';
+  static const String javaHeapKey = 'Java Heap';
+  static const String nativeHeapKey = 'Native Heap';
+  static const String codeKey = 'Code';
+  static const String stackKey = 'Stack';
+  static const String graphicsKey = 'Graphics';
+  static const String otherKey = 'Private Other';
+  static const String systemKey = 'System';
+  static const String totalKey = 'Total';
 
   factory AdbMemoryInfo.fromJson(Map<String, dynamic> json) => AdbMemoryInfo(
-        json['Realtime'] as int,
-        json['Java Heap'] as int,
-        json['Native Heap'] as int,
-        json['Code'] as int,
-        json['Stack'] as int,
-        json['Graphics'] as int,
-        json['Private Other'] as int,
-        json['System'] as int,
-        json['Total'] as int,
+        json[realTimeKey] as int,
+        json[javaHeapKey] as int,
+        json[nativeHeapKey] as int,
+        json[codeKey] as int,
+        json[stackKey] as int,
+        json[graphicsKey] as int,
+        json[otherKey] as int,
+        json[systemKey] as int,
+        json[totalKey] as int,
       );
 
   Map<String, dynamic> toJson() => <String, dynamic>{
-        'Realtime': realtime,
-        'Java Heap': javaHeap,
-        'Native Heap': nativeHeap,
-        'Code': code,
-        'Stack': stack,
-        'Graphics': graphics,
-        'Private Other': other,
-        'System': system,
-        'Total': total,
+        realTimeKey: realtime,
+        javaHeapKey: javaHeap,
+        nativeHeapKey: nativeHeap,
+        codeKey: code,
+        stackKey: stack,
+        graphicsKey: graphics,
+        otherKey: other,
+        systemKey: system,
+        totalKey: total,
       };
 
   /// Create an empty AdbMemoryInfo (all values are)
   static AdbMemoryInfo empty() => AdbMemoryInfo(0, 0, 0, 0, 0, 0, 0, 0, 0);
 
-  /// Number of milliseconds since the device was booted (value zero) including deep
-  /// sleep.  This clock is guaranteed to be monotonic, and continues to tick even
+  /// Milliseconds since the device was booted (value zero) including deep sleep.
+  ///
+  /// This clock is guaranteed to be monotonic, and continues to tick even
   /// in power saving mode. The value zero is Unix Epoch UTC (Jan 1, 1970 00:00:00).
   /// This DateTime, from USA PST, would be Dec 31, 1960 16:00:00 (UTC - 8 hours).
   final int realtime;
@@ -364,17 +387,12 @@ class AdbMemoryInfo {
   Duration get bootDuration => Duration(milliseconds: realtime);
 
   @override
-  String toString() => '  realtime=$realtime\n'
-      '  realtimeDT=$realtimeDT\n'
-      '  durationBoot=$bootDuration\n'
-      '  Java Heap=$javaHeap\n'
-      '  Native Heap=$nativeHeap\n'
-      '  Code=$code\n'
-      '  Stack=$stack\n'
-      '  Graphics=$graphics\n'
-      '  Other=$other\n'
-      '  System=$system\n'
-      '  Total=$total';
+  String toString() => '[AdbMemoryInfo $realTimeKey: $realtime'
+      ', realtimeDT: $realtimeDT, durationBoot: $bootDuration'
+      ', $javaHeapKey: $javaHeap, $nativeHeapKey: $nativeHeap'
+      ', $codeKey: $code, $stackKey: $stack, $graphicsKey: $graphics'
+      ', $otherKey: $other, $systemKey: $system'
+      ', $totalKey: $total]';
 }
 
 class InstanceSummary {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -12,7 +12,6 @@ import '../../globals.dart';
 import '../../ui/flutter/label.dart';
 import 'memory_chart.dart';
 import 'memory_controller.dart';
-import 'memory_protocol.dart';
 
 class MemoryScreen extends Screen {
   const MemoryScreen();

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -10,6 +10,7 @@ import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
 import '../../globals.dart';
 import '../../ui/flutter/label.dart';
+import '../../ui/material_icons.dart';
 import 'memory_chart.dart';
 import 'memory_controller.dart';
 
@@ -81,8 +82,16 @@ class MemoryBodyState extends State<MemoryBody> {
     _updateListeningState();
   }
 
+  /// When to have verbose Dropdown based on media width.
+  static const verboseDropDownMininumWidth = 950;
+
   @override
   Widget build(BuildContext context) {
+    final mediaWidth = MediaQuery.of(context).size.width;
+    controller.memorySourcePrefix = mediaWidth > verboseDropDownMininumWidth
+        ? MemoryScreen.memorySourceMenuItemPrefix
+        : '';
+
     _memoryChart = MemoryChart();
 
     return Column(
@@ -112,6 +121,9 @@ class MemoryBodyState extends State<MemoryBody> {
     // First item is 'Live Feed', then followed by memory log filenames.
     files.insert(0, MemoryController.liveFeed);
 
+    final mediaWidth = MediaQuery.of(context).size.width;
+    final isVerbaseDropdown = mediaWidth > verboseDropDownMininumWidth;
+
     final _displayTypes = [
       MemoryController.displayOneMinute,
       MemoryController.displayFiveMinutes,
@@ -124,7 +136,7 @@ class MemoryBodyState extends State<MemoryBody> {
         key: MemoryScreen.pruneMenuItem,
         value: value,
         child: Text(
-          'Display $value '
+          '${isVerbaseDropdown ? 'Display' : ''} $value '
           'Minute${value == MemoryController.displayOneMinute ? '' : 's'}',
           key: MemoryScreen.pruneIntervalKey,
         ),
@@ -158,7 +170,7 @@ class MemoryBodyState extends State<MemoryBody> {
         key: MemoryScreen.memorySourcesMenuItem,
         value: value,
         child: Text(
-          '${MemoryScreen.memorySourceMenuItemPrefix}$value',
+          '${controller.memorySourcePrefix}$value',
           key: MemoryScreen.memorySourcesKey,
         ),
       );
@@ -198,90 +210,118 @@ class MemoryBodyState extends State<MemoryBody> {
 */
   }
 
+  static const minIncludeTextLeftButtons = 1300;
+  static const minIncludeTextRightButtons = 1100;
+
   Widget _leftsideButtons() {
-    return Row(
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        OutlineButton(
-          key: MemoryScreen.pauseButtonKey,
-          onPressed: controller.paused ? null : _pauseLiveTimeline,
-          child: const MaterialIconLabel(
-            Icons.pause,
-            'Pause',
-            minIncludeTextWidth: 900,
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      // Add a semi-transparent background to the
+      // expand and collapse buttons so they don't interfere
+      // too badly with the tree content when the tree
+      // is narrow.
+      color: Theme.of(context).scaffoldBackgroundColor.withAlpha(200),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          OutlineButton(
+            key: MemoryScreen.pauseButtonKey,
+            onPressed: controller.paused ? null : _pauseLiveTimeline,
+            child: Label(
+              pauseIcon,
+              'Pause',
+              minIncludeTextWidth: 1300,
+            ),
           ),
-        ),
-        OutlineButton(
-          key: MemoryScreen.resumeButtonKey,
-          onPressed: controller.paused ? _resumeLiveTimeline : null,
-          child: const MaterialIconLabel(
-            Icons.play_arrow,
-            'Resume',
-            minIncludeTextWidth: 900,
+          OutlineButton(
+            key: MemoryScreen.resumeButtonKey,
+            onPressed: controller.paused ? _resumeLiveTimeline : null,
+            child: Label(
+              playIcon,
+              'Resume',
+              minIncludeTextWidth: 1300,
+            ),
           ),
-        ),
-        const SizedBox(width: 16.0),
-        OutlineButton(
-            key: MemoryScreen.clearButtonKey,
-            onPressed: controller.memorySource == MemoryController.liveFeed
-                ? _clearTimeline
-                : null,
-            child: const MaterialIconLabel(
-              Icons.block,
-              'Clear',
-              minIncludeTextWidth: 900,
-            )),
-        const SizedBox(width: 16.0),
-        _pruneDropdown(),
-      ],
+          const SizedBox(width: 16.0),
+          OutlineButton(
+              key: MemoryScreen.clearButtonKey,
+              onPressed: controller.memorySource == MemoryController.liveFeed
+                  ? _clearTimeline
+                  : null,
+              child: Label(
+                clearIcon,
+                'Clear',
+                minIncludeTextWidth: 1300,
+              )),
+          const SizedBox(width: 16.0),
+          _pruneDropdown(),
+        ],
+      ),
     );
   }
 
   Widget _rightsideButtons() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.end,
-      children: [
-        _memorySourceDropdown(),
-        const SizedBox(width: 16.0),
-        OutlineButton(
-          key: MemoryScreen.snapshotButtonKey,
-          onPressed: _snapshot,
-          child: MaterialIconLabel(
-            Icons.camera,
-            'Snapshot',
-            minIncludeTextWidth: 1100,
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 6),
+      // Add a semi-transparent background to the
+      // expand and collapse buttons so they don't interfere
+      // too badly with the tree content when the tree
+      // is narrow.
+      color: Theme.of(context).scaffoldBackgroundColor.withAlpha(200),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          _memorySourceDropdown(),
+          const SizedBox(width: 16.0),
+          Flexible(
+            child: OutlineButton(
+              key: MemoryScreen.snapshotButtonKey,
+              onPressed: _snapshot,
+              child: Label(
+                memorySnapshot,
+                'Snapshot',
+                minIncludeTextWidth: 1100,
+              ),
+            ),
           ),
-        ),
-        OutlineButton(
-          key: MemoryScreen.resetButtonKey,
-          onPressed: _reset,
-          child: MaterialIconLabel(
-            Icons.settings_backup_restore,
-            'Reset',
-            minIncludeTextWidth: 1100,
+          Flexible(
+            child: OutlineButton(
+              key: MemoryScreen.resetButtonKey,
+              onPressed: _reset,
+              child: Label(
+                memoryReset,
+                'Reset',
+                minIncludeTextWidth: 1100,
+              ),
+            ),
           ),
-        ),
-        OutlineButton(
-          key: MemoryScreen.gcButtonKey,
-          onPressed: _gc,
-          child: MaterialIconLabel(
-            Icons.delete_sweep,
-            'GC',
-            minIncludeTextWidth: 1100,
+          Flexible(
+            child: OutlineButton(
+              key: MemoryScreen.gcButtonKey,
+              onPressed: _gc,
+              child: Label(
+                memoryGC,
+                'GC',
+                minIncludeTextWidth: 1100,
+              ),
+            ),
           ),
-        ),
-        const SizedBox(width: 16.0),
-        OutlineButton(
-          key: MemoryScreen.exportButtonKey,
-          onPressed:
-              controller.offline ? null : controller.memoryLog.exportMemory,
-          child: MaterialIconLabel(
-            Icons.file_download,
-            'Export',
-            minIncludeTextWidth: 1100,
+          const SizedBox(width: 16.0),
+          Flexible(
+            child: OutlineButton(
+              key: MemoryScreen.exportButtonKey,
+              onPressed:
+                  controller.offline ? null : controller.memoryLog.exportMemory,
+              child: Label(
+                exportIcon,
+                'Export',
+                minIncludeTextWidth: 1100,
+              ),
+            ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -24,11 +24,12 @@ class MemoryScreen extends Screen {
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');
   @visibleForTesting
-  static const dropdownPruneMenuButtonKey = Key('Dropdown Prune Menu Button');
+  static const dropdownIntervalMenuButtonKey =
+      Key('Dropdown Interval Menu Button');
   @visibleForTesting
-  static const pruneMenuItem = Key('Memory Prune Menu Item');
+  static const intervalMenuItem = Key('Memory Interval Menu Item');
   @visibleForTesting
-  static const pruneIntervalKey = Key('Memory Prune Interval');
+  static const intervalKey = Key('Memory Interval');
 
   @visibleForTesting
   static const dropdownSourceMenuButtonKey = Key('Dropdown Source Menu Button');
@@ -99,8 +100,8 @@ class MemoryBodyState extends State<MemoryBody> {
         Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
-            _leftsideButtons(),
-            _rightsideButtons(),
+            _buildPrimaryStateControls(),
+            _buildMemoryControls(),
           ],
         ),
         Expanded(
@@ -115,43 +116,47 @@ class MemoryBodyState extends State<MemoryBody> {
     );
   }
 
-  Widget _pruneDropdown() {
+  Widget _intervalDropdown() {
     final files = controller.memoryLog.offlineFiles();
 
     // First item is 'Live Feed', then followed by memory log filenames.
     files.insert(0, MemoryController.liveFeed);
 
     final mediaWidth = MediaQuery.of(context).size.width;
-    final isVerbaseDropdown = mediaWidth > verboseDropDownMininumWidth;
+    final isVerboseDropdown = mediaWidth > verboseDropDownMininumWidth;
 
     final _displayTypes = [
       MemoryController.displayOneMinute,
       MemoryController.displayFiveMinutes,
       MemoryController.displayTenMinutes,
       MemoryController.displayAllMinutes,
-    ].map<DropdownMenuItem<String>>((
-      String value,
-    ) {
-      return DropdownMenuItem<String>(
-        key: MemoryScreen.pruneMenuItem,
-        value: value,
-        child: Text(
-          '${isVerbaseDropdown ? 'Display' : ''} $value '
-          'Minute${value == MemoryController.displayOneMinute ? '' : 's'}',
-          key: MemoryScreen.pruneIntervalKey,
-        ),
-      );
-    }).toList();
+    ].map<DropdownMenuItem<String>>(
+      (
+        String value,
+      ) {
+        return DropdownMenuItem<String>(
+          key: MemoryScreen.intervalMenuItem,
+          value: value,
+          child: Text(
+            '${isVerboseDropdown ? 'Display' : ''} $value '
+            'Minute${value == MemoryController.displayOneMinute ? '' : 's'}',
+            key: MemoryScreen.intervalKey,
+          ),
+        );
+      },
+    ).toList();
 
     return DropdownButton<String>(
-      key: MemoryScreen.dropdownPruneMenuButtonKey,
-      value: controller.pruneInterval,
+      key: MemoryScreen.dropdownIntervalMenuButtonKey,
+      value: controller.displayInterval,
       iconSize: 20,
       style: TextStyle(fontWeight: FontWeight.w100),
       onChanged: (String newValue) {
-        setState(() {
-          controller.pruneInterval = newValue;
-        });
+        setState(
+          () {
+            controller.displayInterval = newValue;
+          },
+        );
       },
       items: _displayTypes,
     );
@@ -219,10 +224,10 @@ class MemoryBodyState extends State<MemoryBody> {
 */
   }
 
-  static const minIncludeTextLeftButtons = 1300;
-  static const minIncludeTextRightButtons = 1100;
+  /// Width of application when primary buttons loose their text.
+  static const double _primaryControlsMinVerboseWidth = 1300;
 
-  Widget _leftsideButtons() {
+  Widget _buildPrimaryStateControls() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6),
       // Add a semi-transparent background to the
@@ -239,7 +244,7 @@ class MemoryBodyState extends State<MemoryBody> {
             child: Label(
               pauseIcon,
               'Pause',
-              minIncludeTextWidth: 1300,
+              minIncludeTextWidth: _primaryControlsMinVerboseWidth,
             ),
           ),
           OutlineButton(
@@ -248,35 +253,34 @@ class MemoryBodyState extends State<MemoryBody> {
             child: Label(
               playIcon,
               'Resume',
-              minIncludeTextWidth: 1300,
+              minIncludeTextWidth: _primaryControlsMinVerboseWidth,
             ),
           ),
           const SizedBox(width: 16.0),
           OutlineButton(
               key: MemoryScreen.clearButtonKey,
+              // TODO(terry): Button needs to be Delete for offline data.
               onPressed: controller.memorySource == MemoryController.liveFeed
                   ? _clearTimeline
                   : null,
               child: Label(
                 clearIcon,
                 'Clear',
-                minIncludeTextWidth: 1300,
+                minIncludeTextWidth: _primaryControlsMinVerboseWidth,
               )),
           const SizedBox(width: 16.0),
-          _pruneDropdown(),
+          _intervalDropdown(),
         ],
       ),
     );
   }
 
-  Widget _rightsideButtons() {
+  /// Width of application when memory buttons loose their text.
+  static const double _memoryControlsMinVerboseWidth = 1100;
+
+  Widget _buildMemoryControls() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6),
-      // Add a semi-transparent background to the
-      // expand and collapse buttons so they don't interfere
-      // too badly with the tree content when the tree
-      // is narrow.
-      color: Theme.of(context).scaffoldBackgroundColor.withAlpha(200),
       child: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.end,
@@ -290,7 +294,7 @@ class MemoryBodyState extends State<MemoryBody> {
               child: Label(
                 memorySnapshot,
                 'Snapshot',
-                minIncludeTextWidth: 1100,
+                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
               ),
             ),
           ),
@@ -301,7 +305,7 @@ class MemoryBodyState extends State<MemoryBody> {
               child: Label(
                 memoryReset,
                 'Reset',
-                minIncludeTextWidth: 1100,
+                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
               ),
             ),
           ),
@@ -312,7 +316,7 @@ class MemoryBodyState extends State<MemoryBody> {
               child: Label(
                 memoryGC,
                 'GC',
-                minIncludeTextWidth: 1100,
+                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
               ),
             ),
           ),
@@ -325,7 +329,7 @@ class MemoryBodyState extends State<MemoryBody> {
               child: Label(
                 exportIcon,
                 'Export',
-                minIncludeTextWidth: 1100,
+                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
               ),
             ),
           ),

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -108,7 +108,7 @@ class MemoryBodyState extends State<MemoryBody> {
             axis: Axis.vertical,
             firstChild: _memoryChart,
             secondChild: const Text('Memory Panel TBD capacity'),
-            initialFirstFraction: 0.25,
+            initialFirstFraction: 0.50,
           ),
         ),
       ],
@@ -160,17 +160,26 @@ class MemoryBodyState extends State<MemoryBody> {
   Widget _memorySourceDropdown() {
     final files = controller.memoryLog.offlineFiles();
 
+    // Can we display dropdowns in verbose mode?
+    final isVerbose = controller.memorySourcePrefix ==
+        MemoryScreen.memorySourceMenuItemPrefix;
+
     // First item is 'Live Feed', then followed by memory log filenames.
     files.insert(0, MemoryController.liveFeed);
 
     final allMemorySources = files.map<DropdownMenuItem<String>>((
       String value,
     ) {
+      // If narrow width compact the displayed name (remove prefix 'memory_log_').
+      final displayValue =
+          (!isVerbose && value.startsWith(MemoryController.logFilenamePrefix))
+              ? value.substring(MemoryController.logFilenamePrefix.length)
+              : value;
       return DropdownMenuItem<String>(
         key: MemoryScreen.memorySourcesMenuItem,
         value: value,
         child: Text(
-          '${controller.memorySourcePrefix}$value',
+          '${controller.memorySourcePrefix}$displayValue',
           key: MemoryScreen.memorySourcesKey,
         ),
       );

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -108,7 +108,7 @@ class MemoryBodyState extends State<MemoryBody> {
             axis: Axis.vertical,
             firstChild: _memoryChart,
             secondChild: const Text('Memory Panel TBD capacity'),
-            initialFirstFraction: 0.50,
+            initialFirstFraction: 0.40,
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -233,6 +233,13 @@ class ServiceConnectionManager {
     );
   }
 
+  Future<Response> getAdbMemoryInfo() async {
+    return await callService(
+      registrations.flutterMemory.service,
+      isolateId: _isolateManager.selectedIsolate.id,
+    );
+  }
+
   Future<double> getDisplayRefreshRate() async {
     if (connectedApp == null || !await connectedApp.isAnyFlutterApp) {
       return null;

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -50,8 +50,7 @@ const RegisteredServiceDescription flutterVersion =
 ///
 /// We call this service to get version information about the Flutter Android memory info
 /// using Android's ADB.
-RegisteredServiceDescription flutterMemory =
-    RegisteredServiceDescription._(
+RegisteredServiceDescription flutterMemory = RegisteredServiceDescription._(
   service: 'flutterMemoryInfo',
   title: 'Flutter Memory Info',
   icon: memoryIcon,

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'ui/icons.dart';
-import 'ui/material_icons.dart';
 
 class RegisteredServiceDescription {
   const RegisteredServiceDescription._({
@@ -53,7 +52,8 @@ const RegisteredServiceDescription flutterVersion =
 RegisteredServiceDescription flutterMemory = RegisteredServiceDescription._(
   service: 'flutterMemoryInfo',
   title: 'Flutter Memory Info',
-  icon: memoryIcon,
+  // TODO(terry): Better icon - package or memory looking for now snapshop is memory.
+  icon: FlutterIcons.snapshot,
 );
 
 const flutterListViews = '_flutter.listViews';

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'ui/icons.dart';
+import 'ui/material_icons.dart';
 
 class RegisteredServiceDescription {
   const RegisteredServiceDescription._({
@@ -47,13 +48,13 @@ const RegisteredServiceDescription flutterVersion =
 
 /// Flutter memory service registered by Flutter Tools.
 ///
-/// We call this service to get version information about the Flutter framework,
-/// the Flutter engine, and the Dart sdk.
-const RegisteredServiceDescription flutterMemory =
+/// We call this service to get version information about the Flutter Android memory info
+/// using Android's ADB.
+RegisteredServiceDescription flutterMemory =
     RegisteredServiceDescription._(
   service: 'flutterMemoryInfo',
   title: 'Flutter Memory Info',
-  icon: FlutterIcons.flutter,
+  icon: memoryIcon,
 );
 
 const flutterListViews = '_flutter.listViews';

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -56,7 +56,6 @@ const RegisteredServiceDescription flutterMemory =
   icon: FlutterIcons.flutter,
 );
 
-
 const flutterListViews = '_flutter.listViews';
 
 const displayRefreshRate = '_flutter.getDisplayRefreshRate';

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -45,6 +45,18 @@ const RegisteredServiceDescription flutterVersion =
   icon: FlutterIcons.flutter,
 );
 
+/// Flutter memory service registered by Flutter Tools.
+///
+/// We call this service to get version information about the Flutter framework,
+/// the Flutter engine, and the Dart sdk.
+const RegisteredServiceDescription flutterMemory =
+    RegisteredServiceDescription._(
+  service: 'flutterMemoryInfo',
+  title: 'Flutter Memory Info',
+  icon: FlutterIcons.flutter,
+);
+
+
 const flutterListViews = '_flutter.listViews';
 
 const displayRefreshRate = '_flutter.getDisplayRefreshRate';

--- a/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
@@ -18,7 +18,20 @@ class MemoryFiles implements FileIO {
     // TODO(terry): Consider path_provider's getTemporaryDirectory
     //              or getApplicationDocumentsDirectory when
     //              available in Flutter Web/Desktop.
-    final memoryLogFile = _fs.systemTempDirectory.childFile(filename);
+    File memoryLogFile;
+
+    // TODO(terry): iOS returns /var/folders/xxx/yyy for temporary. Where
+    // xxx & yyy are generated names hard to locate the json file.
+    if (_fs.systemTempDirectory.dirname.startsWith('/var/')) {
+      // TODO(terry): For now export the file to the user's Desktop.
+      final dirPath = _fs.currentDirectory.dirname.split('/');
+      final desktopPath = '/${dirPath[1]}/${dirPath[2]}/Desktop';
+      final desktopDirectory = _fs.directory(desktopPath);
+      memoryLogFile = desktopDirectory.childFile(filename);
+    } else {
+      memoryLogFile = _fs.systemTempDirectory.childFile(filename);
+    }
+
     memoryLogFile.writeAsStringSync(contents, flush: true);
   }
 

--- a/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
+++ b/packages/devtools_app/lib/src/ui/fake_file/_real_file.dart
@@ -13,25 +13,21 @@ import 'file_io.dart';
 class MemoryFiles implements FileIO {
   final _fs = const LocalFileSystem();
 
-  @override
-  void writeStringToFile(String filename, String contents) {
-    // TODO(terry): Consider path_provider's getTemporaryDirectory
-    //              or getApplicationDocumentsDirectory when
-    //              available in Flutter Web/Desktop.
-    File memoryLogFile;
-
+  Directory exportDirectory() {
     // TODO(terry): iOS returns /var/folders/xxx/yyy for temporary. Where
     // xxx & yyy are generated names hard to locate the json file.
     if (_fs.systemTempDirectory.dirname.startsWith('/var/')) {
       // TODO(terry): For now export the file to the user's Desktop.
       final dirPath = _fs.currentDirectory.dirname.split('/');
       final desktopPath = '/${dirPath[1]}/${dirPath[2]}/Desktop';
-      final desktopDirectory = _fs.directory(desktopPath);
-      memoryLogFile = desktopDirectory.childFile(filename);
-    } else {
-      memoryLogFile = _fs.systemTempDirectory.childFile(filename);
+      return _fs.directory(desktopPath);
     }
+    return _fs.systemTempDirectory;
+  }
 
+  @override
+  void writeStringToFile(String filename, String contents) {
+    final memoryLogFile = exportDirectory().childFile(filename);
     memoryLogFile.writeAsStringSync(contents, flush: true);
   }
 
@@ -40,7 +36,7 @@ class MemoryFiles implements FileIO {
     final previousCurrentDirectory = _fs.currentDirectory;
 
     // TODO(terry): Use path_provider when available?
-    _fs.currentDirectory = _fs.systemTempDirectory;
+    _fs.currentDirectory = exportDirectory();
 
     final memoryLogFile = _fs.currentDirectory.childFile(filename);
 
@@ -58,7 +54,7 @@ class MemoryFiles implements FileIO {
     final previousCurrentDirectory = _fs.currentDirectory;
 
     // TODO(terry): Use path_provider when available?
-    _fs.currentDirectory = _fs.systemTempDirectory;
+    _fs.currentDirectory = exportDirectory();
 
     final allFiles = _fs.currentDirectory.listSync();
 
@@ -82,7 +78,7 @@ class MemoryFiles implements FileIO {
     final previousCurrentDirectory = _fs.currentDirectory;
 
     // TODO(terry): Use path_provider when available?
-    _fs.currentDirectory = _fs.systemTempDirectory;
+    _fs.currentDirectory = exportDirectory();
 
     if (!_fs.isFileSync(path)) return false;
 

--- a/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
@@ -16,6 +16,7 @@ class Icons {
   static const IconData refresh = IconData(0xe5d5);
   static const IconData stop = IconData(0xe047);
   static const IconData pause = IconData(0xe034);
+  static const IconData package = IconData(0xf174);
   static const IconData play_arrow = IconData(0xe037);
   static const IconData camera = IconData(0xe3af);
   static const IconData settings_backup_restore = IconData(0xe8ba);

--- a/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
@@ -16,7 +16,7 @@ class Icons {
   static const IconData refresh = IconData(0xe5d5);
   static const IconData stop = IconData(0xe047);
   static const IconData pause = IconData(0xe034);
-  static const IconData play = IconData(0xe037);
+  static const IconData play_arrow = IconData(0xe037);
   static const IconData camera = IconData(0xe3af);
   static const IconData settings_backup_restore = IconData(0xe8ba);
   static const IconData delete_sweep = IconData(0xe16c);

--- a/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
@@ -16,7 +16,6 @@ class Icons {
   static const IconData refresh = IconData(0xe5d5);
   static const IconData stop = IconData(0xe047);
   static const IconData pause = IconData(0xe034);
-  static const IconData package = IconData(0xf174);
   static const IconData play_arrow = IconData(0xe037);
   static const IconData camera = IconData(0xe3af);
   static const IconData settings_backup_restore = IconData(0xe8ba);

--- a/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
+++ b/packages/devtools_app/lib/src/ui/fake_flutter/icons.dart
@@ -15,4 +15,9 @@ class Icons {
   static const IconData open_in_new = IconData(0xe89e);
   static const IconData refresh = IconData(0xe5d5);
   static const IconData stop = IconData(0xe047);
+  static const IconData pause = IconData(0xe034);
+  static const IconData play = IconData(0xe037);
+  static const IconData camera = IconData(0xe3af);
+  static const IconData settings_backup_restore = IconData(0xe8ba);
+  static const IconData delete_sweep = IconData(0xe16c);
 }

--- a/packages/devtools_app/lib/src/ui/material_icons.dart
+++ b/packages/devtools_app/lib/src/ui/material_icons.dart
@@ -6,8 +6,6 @@ library material_icons;
 
 import 'package:meta/meta.dart';
 
-import '../../src/flutter/octicons.dart';
-
 import 'fake_flutter/fake_flutter.dart' hide required;
 import 'icons.dart';
 import 'theme.dart';
@@ -38,9 +36,6 @@ final DevToolsIcon pauseIcon = MaterialIcon('pause', defaultButtonIconColor,
 
 final DevToolsIcon playIcon = MaterialIcon('play_arrow', defaultButtonIconColor,
     codePoint: Icons.play_arrow.codePoint);
-
-final DevToolsIcon memoryIcon = MaterialIcon('package', defaultButtonIconColor,
-    codePoint: Octicons.package.codePoint);
 
 final DevToolsIcon memorySnapshot = MaterialIcon(
     'camera', defaultButtonIconColor,

--- a/packages/devtools_app/lib/src/ui/material_icons.dart
+++ b/packages/devtools_app/lib/src/ui/material_icons.dart
@@ -34,16 +34,16 @@ final DevToolsIcon stop = MaterialIcon('stop', defaultButtonIconColor,
 final DevToolsIcon pauseIcon = MaterialIcon('pause', defaultButtonIconColor,
     codePoint: Icons.pause.codePoint);
 
-final DevToolsIcon playIcon = MaterialIcon('play', defaultButtonIconColor,
+final DevToolsIcon playIcon = MaterialIcon('play_arrow', defaultButtonIconColor,
     codePoint: Icons.play_arrow.codePoint);
 
-final DevToolsIcon memorySnapshot = MaterialIcon('snapshot', defaultButtonIconColor,
+final DevToolsIcon memorySnapshot = MaterialIcon('camera', defaultButtonIconColor,
     codePoint: Icons.camera.codePoint);
 
-final DevToolsIcon memoryReset = MaterialIcon('reset', defaultButtonIconColor,
+final DevToolsIcon memoryReset = MaterialIcon('settings_backup_restore', defaultButtonIconColor,
     codePoint: Icons.settings_backup_restore.codePoint);
 
-final DevToolsIcon memoryGC = MaterialIcon('gc', defaultButtonIconColor,
+final DevToolsIcon memoryGC = MaterialIcon('delete_sweep', defaultButtonIconColor,
     codePoint: Icons.delete_sweep.codePoint);
 
 // TODO(jacobr): remove this class completely once the migration to Flutter

--- a/packages/devtools_app/lib/src/ui/material_icons.dart
+++ b/packages/devtools_app/lib/src/ui/material_icons.dart
@@ -6,6 +6,8 @@ library material_icons;
 
 import 'package:meta/meta.dart';
 
+import '../../src/flutter/octicons.dart';
+
 import 'fake_flutter/fake_flutter.dart' hide required;
 import 'icons.dart';
 import 'theme.dart';
@@ -36,6 +38,9 @@ final DevToolsIcon pauseIcon = MaterialIcon('pause', defaultButtonIconColor,
 
 final DevToolsIcon playIcon = MaterialIcon('play_arrow', defaultButtonIconColor,
     codePoint: Icons.play_arrow.codePoint);
+
+final DevToolsIcon memoryIcon = MaterialIcon('package', defaultButtonIconColor,
+    codePoint: Octicons.package.codePoint);
 
 final DevToolsIcon memorySnapshot = MaterialIcon(
     'camera', defaultButtonIconColor,

--- a/packages/devtools_app/lib/src/ui/material_icons.dart
+++ b/packages/devtools_app/lib/src/ui/material_icons.dart
@@ -37,13 +37,16 @@ final DevToolsIcon pauseIcon = MaterialIcon('pause', defaultButtonIconColor,
 final DevToolsIcon playIcon = MaterialIcon('play_arrow', defaultButtonIconColor,
     codePoint: Icons.play_arrow.codePoint);
 
-final DevToolsIcon memorySnapshot = MaterialIcon('camera', defaultButtonIconColor,
+final DevToolsIcon memorySnapshot = MaterialIcon(
+    'camera', defaultButtonIconColor,
     codePoint: Icons.camera.codePoint);
 
-final DevToolsIcon memoryReset = MaterialIcon('settings_backup_restore', defaultButtonIconColor,
+final DevToolsIcon memoryReset = MaterialIcon(
+    'settings_backup_restore', defaultButtonIconColor,
     codePoint: Icons.settings_backup_restore.codePoint);
 
-final DevToolsIcon memoryGC = MaterialIcon('delete_sweep', defaultButtonIconColor,
+final DevToolsIcon memoryGC = MaterialIcon(
+    'delete_sweep', defaultButtonIconColor,
     codePoint: Icons.delete_sweep.codePoint);
 
 // TODO(jacobr): remove this class completely once the migration to Flutter

--- a/packages/devtools_app/lib/src/ui/material_icons.dart
+++ b/packages/devtools_app/lib/src/ui/material_icons.dart
@@ -31,6 +31,21 @@ final DevToolsIcon record = MaterialIcon(
 final DevToolsIcon stop = MaterialIcon('stop', defaultButtonIconColor,
     codePoint: Icons.stop.codePoint);
 
+final DevToolsIcon pauseIcon = MaterialIcon('pause', defaultButtonIconColor,
+    codePoint: Icons.pause.codePoint);
+
+final DevToolsIcon playIcon = MaterialIcon('play', defaultButtonIconColor,
+    codePoint: Icons.play_arrow.codePoint);
+
+final DevToolsIcon memorySnapshot = MaterialIcon('snapshot', defaultButtonIconColor,
+    codePoint: Icons.camera.codePoint);
+
+final DevToolsIcon memoryReset = MaterialIcon('reset', defaultButtonIconColor,
+    codePoint: Icons.settings_backup_restore.codePoint);
+
+final DevToolsIcon memoryGC = MaterialIcon('gc', defaultButtonIconColor,
+    codePoint: Icons.delete_sweep.codePoint);
+
 // TODO(jacobr): remove this class completely once the migration to Flutter
 // desktop is complete and just use Flutter native support for Material icons.
 /// Class for icons consistent with

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -90,7 +90,6 @@ dev_dependencies:
 flutter:
   uses-material-design: true
   assets:
-    - assets/img/star.png
     - web/widgets.json
     - web/icons/
     - web/icons/actions/
@@ -100,6 +99,7 @@ flutter:
     - web/icons/inspector/
     - web/icons/memory/
     - web/icons/perf/
+    - assets/
     - assets/img/
     - assets/img/layout_explorer/
     - assets/img/layout_explorer/main_axis_alignment/

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -35,7 +35,7 @@ void main() {
     expect(find.byType(MemoryBody), findsOneWidget);
   }
 
-  const windowSize = Size(1599.0, 1000.0);
+  const windowSize = Size(2225.0, 1000.0);
 
   group('MemoryScreen', () {
     setUp(() async {

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -91,9 +91,10 @@ void main() {
       final memorySources = tester.firstWidget(find.byKey(
         MemoryScreen.memorySourcesKey,
       )) as Text;
+
       expect(
         memorySources.data,
-        '${MemoryScreen.memorySourceMenuItemPrefix}${MemoryController.liveFeed}',
+        '${controller.memorySourcePrefix}${MemoryController.liveFeed}',
       );
     });
 

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -81,7 +81,7 @@ void main() {
       splitFinder = find.byType(Split);
       expect(splitFinder, findsOneWidget);
       final Split splitter = tester.widget(splitFinder);
-      expect(splitter.initialFirstFraction, equals(0.25));
+      expect(splitter.initialFirstFraction, equals(0.40));
 
       // Check memory sources available.
       await tester.tap(find.byKey(MemoryScreen.dropdownSourceMenuButtonKey));


### PR DESCRIPTION
Features added in this PR:

- Added collecting ADB (Android Java memory info)
- Added multiple charts (Dart VM and ADB memory information)
- Added Display interval e.g., 1 minute, 5 minutes, 10 minutes, etc.
- Updated exported JSON format both Dart VM and ADB memory information.
- Beginning of timeline slider to select beginning interval 5 minutes ago, 10 minutes ago, etc. Not fully implemented but correctly displays the historical starting points based on current display interval with temporal change as data is collected.
- Added robust marker (legend of a datapoint values for a particular timestamp).
- Handle iOS devices graying the ADB Memory chart button.
- Graceful resize of button/drop-downs for narrow windows (e.g., MediaQuery is narrow).
- Correctly, handle canceling timers (other cleanup) when widgets disposed.
- Cleaned up buttons to use only Material Icons.
- Fixed markers computations based on text height fixes layout in both Flutter Desktop Mac vs Linux.
- Added a Clear button on the left-side to dispose of any collected live data.
- A number of charting bugs have also been fixed e.g., NaN and INF values (uninitialized data attempting to be plotted), scale factors for both X and Y axis.

Memory View now has the ability to display collected ADB memory statistics (Java Heap).

![image](https://user-images.githubusercontent.com/2055873/73010704-bf91a180-3dc7-11ea-90d7-a2bb858ee2a3.png)

On startup the Memory Profile View is displayed with a chart of the collect Dart VM memory statistics:

![image](https://user-images.githubusercontent.com/2055873/73007168-e4364b00-3dc0-11ea-809e-c80158f42988.png)

Clicking on the Android Memory button

![image](https://user-images.githubusercontent.com/2055873/73007421-5f97fc80-3dc1-11ea-8e99-3140b8bc6a55.png)

Will display a second chart of Android's memory e.g.,

![image](https://user-images.githubusercontent.com/2055873/73009442-717b9e80-3dc5-11ea-8c3e-e2c62e14ffa4.png)

![image](https://user-images.githubusercontent.com/2055873/73009891-24e49300-3dc6-11ea-9ff2-5aafbbd15d0d.png)

**Other**
Other private memory usage corresponds to the Private Other field output in the App Summary.Android Studio: Memory used by the app that the system isn't sure how to categorize.

**System**
Shared and system memory usage in kB. This corresponds to the System field output in the App Summary.

**Note:** The Other trace (plot in the chart) is the combined values of Other and System.

**Code**
The memory usage for static code and resources corresponds to the Code field in the App Summary..Android Studio: Memory that your app uses for code and resources, such as dex byte code, optimized or compiled dex code, .so libraries, and fonts.

**Native Heap**
The private Native Heap usage corresponds to the Native Heap field in the App Summary.Android Studio: Memory from objects allocated from C or C++ code. Even if you're not using C++ in your app, you might see some native memory used here because the Android framework uses native memory to handle various tasks on your behalf, such as when handling image assets and other graphics—even though the code you've written is in Java or Kotlin.

**Java Heap**
The private Java Heap usage corresponds to the Java Heap field in the App Summary. Android Studio: Memory from objects allocated from Java or Kotlin code.

**Stack**
The stack usage corresponds to the Stack field in the App Summary.Android Studio: Memory used by both native and Java stacks in your app. This usually relates to how many threads your app is running.

**Graphics**
The graphics usage corresponds to the Graphics field in the App Summary.Android Studio: Memory used for graphics buffer queues to display pixels to the screen, including GL surfaces, GL textures, and so on. (Note that this is memory shared with the CPU, not dedicated GPU memory.)

**Display Interval Feature**
The display interval is a drop-down setting the viewport of the chart to a period of time e.g., 1 minute, 5 minutes, 10 minutes or all minutes.

![image](https://user-images.githubusercontent.com/2055873/73009641-ce775480-3dc5-11ea-8311-d10735614e3f.png)

Graceful resize of button/drop-downs for compact displays normally for wide DevTools app the toolbar is:

![image](https://user-images.githubusercontent.com/2055873/73010292-06cb6280-3dc7-11ea-9ae8-6b6ad9a13e4c.png)

As  the application's width narrows portions of the memory actions (buttons and drop-downs) will narrow (icon only) the first is the left-side buttons e.g.,

![image](https://user-images.githubusercontent.com/2055873/73010413-3ed2a580-3dc7-11ea-8b8c-c2fe08f30ed8.png)

Then the right-side buttons e.g.,

![image](https://user-images.githubusercontent.com/2055873/73010477-5a3db080-3dc7-11ea-8268-9f8a0e326fac.png)

And, finally the drop-downs narrow e.g.,

![image](https://user-images.githubusercontent.com/2055873/73010535-73466180-3dc7-11ea-89fe-f86c85f7c2f8.png)

The JSON format of collected memory statistics is:

```
{
  "samples" : {
    "version" : 1,
    // data is an array of collected memory statistics with a different timestamp.
    "data" : [
      {
        "timestamp" : 1579794829976,
        "rss" : 236605440,
        "capacity" : 71211528,
        "used" : 66910904,
        "external" : 223752,
        "gc" : false,
        "adb_memoryInfo" : {
          "Realtime" : 1154887,
          "Java Heap" : 7680,
          "Native Heap" : 12088,
          "Code" : 19328,
          "Stack" : 64,
          "Graphics" : 0,
          "Private Other" : 114384,
          "System" : 6323,
          "Total" : 159867
        }
      },
      {
       "timestamp" : 1579794830276,
        "rss" : 236380160,
...
        "adb_memoryInfo" : {
          "Realtime" : 1155191,
...
        }
      },
    ],
  }
}
```