### PR TITLE
Auto-dispose stream subscriptions in the memory controller

### DIFF
--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -62,25 +62,14 @@ class MemoryBodyState extends State<MemoryBody> {
   MemoryController controller;
 
   @override
-  void initState() {
-    _updateListeningState();
-
-    super.initState();
-  }
-
-  @override
-  void dispose() {
-    // TODO(terry): make my controller disposable via DisposableController and dispose here.
-    super.dispose();
-  }
-
-  @override
   void didChangeDependencies() {
     super.didChangeDependencies();
 
     final newController = Controllers.of(context).memory;
     if (newController == controller) return;
     controller = newController;
+
+    _updateListeningState();
   }
 
   @override


### PR DESCRIPTION
@terrylucas This will get rid of the errors, although it looks like the new controller isn't connecting properly afterwards.  I suspect there may be connections in the memory tracker that need to be closed too.

