### PR TITLE
Add track widget builds button to dart:html app.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.1.14-dev.2
+* Add Track Widget Builds toggle to Timeline.
 * Fix issues with async trace event rendering in Timeline.
 * Add timing and id information in Timeline event summary.
 * Improve hint text on connect screen.

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -87,6 +87,8 @@ class HtmlTimelineScreen extends HtmlScreen {
 
   ServiceExtensionButton performanceOverlayButton;
 
+  ServiceExtensionButton trackWidgetBuildsButton;
+
   ProfileGranularitySelector _profileGranularitySelector;
 
   CoreElement _timelineModeSettingContainer;
@@ -172,6 +174,8 @@ class HtmlTimelineScreen extends HtmlScreen {
 
     performanceOverlayButton = ServiceExtensionButton(performanceOverlay);
 
+    trackWidgetBuildsButton = ServiceExtensionButton(profileWidgetBuilds);
+
     _profileGranularitySelector = ProfileGranularitySelector(framework);
 
     _timelineModeCheckbox = CoreElement('input', classes: 'checkbox')
@@ -194,22 +198,25 @@ class HtmlTimelineScreen extends HtmlScreen {
     upperButtonSection = div(c: 'section')
       ..layoutHorizontal()
       ..add(<CoreElement>[
-        div(c: 'btn-group collapsible-1015')
+        div(c: 'btn-group collapsible-1150')
           ..add([
             pauseButton,
             resumeButton,
             _startRecordingButton,
             _stopRecordingButton,
           ]),
-        div(c: 'btn-group collapsible-800')..add(clearButton),
+        div(c: 'btn-group collapsible-950')..add(clearButton),
         exitOfflineModeButton,
         div()..flex(),
         debugButtonSection = div(c: 'btn-group'),
         if (enableMultiModeTimeline) _timelineModeSettingContainer,
         _profileGranularitySelector.selector..clazz('margin-left'),
-        div(c: 'btn-group collapsible-800 margin-left')
-          ..add(performanceOverlayButton.button),
-        div(c: 'btn-group collapsible-800')..add(exportButton),
+        div(c: 'btn-group collapsible-950 margin-left')
+          ..add([
+            performanceOverlayButton.button,
+            trackWidgetBuildsButton.button,
+          ]),
+        div(c: 'btn-group collapsible-950')..add(exportButton),
       ]);
 
     _maybeAddDebugButtons();

--- a/packages/devtools_app/web/styles.css
+++ b/packages/devtools_app/web/styles.css
@@ -1209,23 +1209,23 @@ span.strong {
     }
 }
 
-@media all and (max-width: 800px) {
-    .btn-group.collapsible-800 .optional-text span:not(.octicon) {
-        display: none;
-    }
-
-    .btn-group.collapsible-800 .btn .flutter-icon {
-        margin-right: 0;
-        box-sizing: content-box;
-    }
-}
-
 @media all and (max-width: 885px) {
     .btn-group.collapsible-885 .optional-text span:not(.octicon) {
         display: none;
     }
 
     .btn-group.collapsible-885 .btn .flutter-icon {
+        margin-right: 0;
+        box-sizing: content-box;
+    }
+}
+
+@media all and (max-width: 950px) {
+    .btn-group.collapsible-950 .optional-text span:not(.octicon) {
+        display: none;
+    }
+
+    .btn-group.collapsible-950 .btn .flutter-icon {
         margin-right: 0;
         box-sizing: content-box;
     }
@@ -1242,12 +1242,12 @@ span.strong {
     }
 }
 
-@media all and (max-width: 1015px) {
-    .btn-group.collapsible-1015 .optional-text span:not(.octicon) {
+@media all and (max-width: 1150px) {
+    .btn-group.collapsible-1150 .optional-text span:not(.octicon) {
         display: none;
     }
 
-    .btn-group.collapsible-1015 .btn .flutter-icon {
+    .btn-group.collapsible-1150 .btn .flutter-icon {
         margin-right: 0;
         box-sizing: content-box;
     }


### PR DESCRIPTION
![Screen Shot 2020-01-21 at 3 37 57 PM](https://user-images.githubusercontent.com/43759233/72852691-3877e880-3c64-11ea-8b54-d08c2a2ea37e.png)
This is already in the flutter version of DevTools. Adding to the html version because this is low hanging fruit, and we are referencing this feature at upcoming conference.