### PR TITLE
Add html specific controller method to unbreak html app.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -269,7 +269,7 @@ class HtmlTimelineScreen extends HtmlScreen {
         timelineFlameChartCanvas.onNodeSelected.listen((node) {
           eventDetails.titleBackgroundColor = node.backgroundColor;
           eventDetails.titleTextColor = node.textColor;
-          timelineController.selectTimelineEvent(node.data);
+          timelineController.htmlSelectTimelineEvent(node.data);
         });
         _setFlameChart(timelineFlameChartCanvas.element);
 
@@ -369,7 +369,7 @@ class HtmlTimelineScreen extends HtmlScreen {
     timelineFlameChartCanvas.onNodeSelected.listen((node) {
       eventDetails.titleBackgroundColor = node.backgroundColor;
       eventDetails.titleTextColor = node.textColor;
-      timelineController.selectTimelineEvent(node.data);
+      timelineController.htmlSelectTimelineEvent(node.data);
     });
     _setFlameChart(timelineFlameChartCanvas.element);
 

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -127,7 +127,6 @@ class TimelineController implements DisposableController {
   void htmlSelectTimelineEvent(TimelineEvent event) {
     if (event == null || timeline.data.selectedEvent == event) return;
     timeline.data.selectedEvent = event;
-    cpuProfilerController.resetNotifiers();
     _selectedTimelineEventNotifier.value = event;
   }
 

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -119,6 +119,18 @@ class TimelineController implements DisposableController {
     _selectedTimelineEventNotifier.value = event;
   }
 
+  // TODO(kenz): remove this method once html app is deleted. This is a
+  // workaround to avoid fixing bugs in the DevTools html app. Modifying
+  // [selectTimelineEvent] to work for Flutter DevTools broke the html app, so
+  // this method fixes the regression without wasting resources to make the html
+  // and flutter code 100% compatible.
+  void htmlSelectTimelineEvent(TimelineEvent event) {
+    if (event == null || timeline.data.selectedEvent == event) return;
+    timeline.data.selectedEvent = event;
+    cpuProfilerController.resetNotifiers();
+    _selectedTimelineEventNotifier.value = event;
+  }
+
   Future<void> getCpuProfileForSelectedEvent() async {
     final selectedEvent = timeline.data.selectedEvent;
     if (!selectedEvent.isUiEvent) return;


### PR DESCRIPTION
Some code added for flutter devtools broke the existing html app. Instead of spending resources trying to make the two apps 100% compatible, I'm adding an html specific method to fix the issue. This method will be deleted when we delete the html code.

fixes https://github.com/flutter/devtools/issues/1557