### PR TITLE
Alternate colors for table rows.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide TableRow;
 
 import '../table_data.dart';
 import '../trees.dart';
@@ -81,13 +81,13 @@ class _FlatTableState<T> extends State<FlatTable<T>> {
 
   Widget _buildRow(BuildContext context, int index) {
     final node = widget.data[index];
-    return _TableRow<T>(
+    return TableRow<T>(
       key: widget.keyFactory(node),
       node: node,
       onPressed: widget.onItemSelected,
       columns: widget.columns,
       columnWidths: columnWidths,
-      backgroundColor: _TableRow.colorFor(context, index),
+      backgroundColor: TableRow.colorFor(context, index),
     );
   }
 }
@@ -169,10 +169,11 @@ class _TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     // all is pressed. This will require listening to expansion changes across the
     // entire tree.
     if (widget.data.isExpanded != rootExpanded) {
-      if (rootExpanded)
+      if (rootExpanded) {
         widget.data.expand();
-      else
+      } else {
         widget.data.collapse();
+      }
       _onItemPressed(widget.data);
     }
   }
@@ -292,11 +293,11 @@ class _TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
 
   Widget _buildRow(BuildContext context, int index) {
     Widget rowForNode(T node) {
-      return _TableRow<T>(
+      return TableRow<T>(
         key: widget.keyFactory(node),
         node: node,
         onPressed: _onItemPressed,
-        backgroundColor: _TableRow.colorFor(context, index),
+        backgroundColor: TableRow.colorFor(context, index),
         columns: widget.columns,
         columnWidths: columnWidths,
         expandableColumn: widget.treeColumn,
@@ -379,7 +380,7 @@ class _Table<T> extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                _TableRow.tableHeader(
+                TableRow.tableHeader(
                   key: const Key('Table header'),
                   columns: columns,
                   columnWidths: columnWidths,
@@ -409,10 +410,11 @@ typedef ItemCallback<T> = void Function(T item);
 ///
 /// When the given [node] is null, this widget will instead present
 /// column headings.
-class _TableRow<T> extends StatefulWidget {
-  /// Constructs a [_TableRow] that presents the column values for
+@visibleForTesting
+class TableRow<T> extends StatefulWidget {
+  /// Constructs a [TableRow] that presents the column values for
   /// [node].
-  const _TableRow({
+  const TableRow({
     Key key,
     @required this.node,
     @required this.columns,
@@ -427,9 +429,9 @@ class _TableRow<T> extends StatefulWidget {
     this.isShown = true,
   }) : super(key: key);
 
-  /// Constructs a [_TableRow] that presents the column titles instead
+  /// Constructs a [TableRow] that presents the column titles instead
   /// of any [node].
-  const _TableRow.tableHeader({
+  const TableRow.tableHeader({
     Key key,
     @required this.columns,
     @required this.columnWidths,
@@ -492,7 +494,7 @@ class _TableRow<T> extends StatefulWidget {
   _TableRowState<T> createState() => _TableRowState<T>();
 }
 
-class _TableRowState<T> extends State<_TableRow<T>>
+class _TableRowState<T> extends State<TableRow<T>>
     with TickerProviderStateMixin, CollapsibleAnimationMixin {
   Key contentKey;
 
@@ -511,7 +513,7 @@ class _TableRowState<T> extends State<_TableRow<T>>
   }
 
   @override
-  void didUpdateWidget(_TableRow<T> oldWidget) {
+  void didUpdateWidget(TableRow<T> oldWidget) {
     super.didUpdateWidget(oldWidget);
     setExpanded(widget.isExpanded);
   }

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -296,6 +296,7 @@ class _TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
         key: widget.keyFactory(node),
         node: node,
         onPressed: _onItemPressed,
+        backgroundColor: _TableRow.colorFor(context, index),
         columns: widget.columns,
         columnWidths: columnWidths,
         expandableColumn: widget.treeColumn,

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -1,7 +1,7 @@
 import 'package:devtools_app/src/flutter/table.dart';
 import 'package:devtools_app/src/table_data.dart';
 import 'package:devtools_app/src/trees.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide TableRow;
 import 'package:flutter_test/flutter_test.dart';
 
 import 'wrappers.dart';
@@ -231,6 +231,83 @@ void main() {
       await tester.tap(find.byKey(const Key('Bar')));
       await tester.pumpAndSettle();
       expect(tree.children[0].isExpanded, false);
+    });
+
+    testWidgets('properly colors rows with alternating colors',
+        (WidgetTester tester) async {
+      final data = TestData('Foo', 0)
+        ..children.addAll([
+          TestData('Bar', 1)
+            ..children.addAll([
+              TestData('Baz', 2),
+              TestData('Qux', 3),
+              TestData('Snap', 4),
+            ]),
+          TestData('Crackle', 5),
+        ])
+        ..expandCascading();
+      final table = TreeTable<TestData>(
+        columns: [
+          _NumberColumn(),
+          treeColumn,
+        ],
+        data: data,
+        treeColumn: treeColumn,
+        keyFactory: (d) => Key(d.name),
+      );
+
+      final fooFinder = find.byKey(const Key('Foo'));
+      final barFinder = find.byKey(const Key('Bar'));
+      final bazFinder = find.byKey(const Key('Baz'));
+      final quxFinder = find.byKey(const Key('Qux'));
+      final snapFinder = find.byKey(const Key('Snap'));
+      final crackleFinder = find.byKey(const Key('Crackle'));
+
+      // Expected values returned through accessing Color.value property.
+      const color1Value = 4293585900;
+      const color2Value = 4294638330;
+
+      await tester.pumpWidget(wrap(table));
+      await tester.pumpAndSettle();
+      expect(tree.isExpanded, true);
+
+      expect(fooFinder, findsOneWidget);
+      expect(barFinder, findsOneWidget);
+      expect(bazFinder, findsOneWidget);
+      expect(quxFinder, findsOneWidget);
+      expect(snapFinder, findsOneWidget);
+      expect(crackleFinder, findsOneWidget);
+      TableRow fooRow = tester.widget(fooFinder);
+      TableRow barRow = tester.widget(barFinder);
+      final TableRow bazRow = tester.widget(bazFinder);
+      final TableRow quxRow = tester.widget(quxFinder);
+      final TableRow snapRow = tester.widget(snapFinder);
+      TableRow crackleRow = tester.widget(crackleFinder);
+
+      expect(fooRow.backgroundColor.value, equals(color1Value));
+      expect(barRow.backgroundColor.value, equals(color2Value));
+      expect(bazRow.backgroundColor.value, equals(color1Value));
+      expect(quxRow.backgroundColor.value, equals(color2Value));
+      expect(snapRow.backgroundColor.value, equals(color1Value));
+      expect(crackleRow.backgroundColor.value, equals(color2Value));
+
+      await tester.tap(barFinder);
+      await tester.pumpAndSettle();
+      expect(fooFinder, findsOneWidget);
+      expect(barFinder, findsOneWidget);
+      expect(bazFinder, findsNothing);
+      expect(quxFinder, findsNothing);
+      expect(snapFinder, findsNothing);
+      expect(crackleFinder, findsOneWidget);
+      fooRow = tester.widget(fooFinder);
+      barRow = tester.widget(barFinder);
+      crackleRow = tester.widget(crackleFinder);
+
+      expect(fooRow.backgroundColor.value, equals(color1Value));
+      expect(barRow.backgroundColor.value, equals(color2Value));
+      // [crackleRow] has a different background color after collapsing previous
+      // row (Bar).
+      expect(crackleRow.backgroundColor.value, equals(color1Value));
     });
 
     test('fails with no data', () {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1361
<img width="565" alt="Screen Shot 2020-01-22 at 9 15 29 AM" src="https://user-images.githubusercontent.com/43759233/72917035-f9937280-3cf7-11ea-998d-11f9356f4747.png">
