### PR TITLE
Trigger travis

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -33,7 +33,7 @@ class DebuggerScreenBody extends StatelessWidget {
       final theme = Theme.of(context);
       final textStyle = Theme.of(context)
           .textTheme
-          .headline
+          .headline5
           .copyWith(color: theme.accentColor);
       return Center(
         child: Text(

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -89,7 +89,7 @@ class DevToolsAppState extends State<DevToolsApp> {
           child: Center(
             child: Text(
               'Sorry, $uri was not found.',
-              style: Theme.of(context).textTheme.display1,
+              style: Theme.of(context).textTheme.headline4,
             ),
           ),
         );

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -62,13 +62,13 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
           children: [
             Text(
               'Connect',
-              style: textTheme.headline,
+              style: textTheme.headline5,
               key: const Key('Connect Title'),
             ),
             const PaddedDivider(),
             Text(
               'Connect to a Running App',
-              style: textTheme.body2,
+              style: textTheme.bodyText1,
             ),
             Text(
               'Enter a URL to a running Dart or Flutter application',
@@ -83,7 +83,7 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
         Center(
           child: Text(
             'Version ${devtools.version}',
-            style: textTheme.subhead,
+            style: textTheme.subtitle1,
           ),
         )
       ],

--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -214,14 +214,14 @@ class _NotificationState extends State<_Notification>
           color: theme.snackBarTheme.backgroundColor,
           child: DefaultTextStyle(
             style: theme.snackBarTheme.contentTextStyle ??
-                theme.primaryTextTheme.subhead,
+                theme.primaryTextTheme.subtitle1,
             child: Padding(
               padding: const EdgeInsets.all(8.0),
               child: Align(
                 alignment: Alignment.topLeft,
                 child: Text(
                   widget.message,
-                  style: theme.textTheme.body1,
+                  style: theme.textTheme.bodyText1,
                   overflow: TextOverflow.ellipsis,
                   maxLines: 6,
                 ),

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -74,14 +74,14 @@ class _InfoScreenBodyState extends State<InfoScreenBody> {
       children: [
         Text(
           'Version Information',
-          style: textTheme.headline,
+          style: textTheme.headline5,
         ),
         const PaddedDivider(),
         if (_flutterVersion != null) _VersionInformation(_flutterVersion),
         const Padding(padding: EdgeInsets.only(top: 16.0)),
         Text(
           'Dart VM Flag List',
-          style: textTheme.headline,
+          style: textTheme.headline5,
         ),
         const PaddedDivider(padding: EdgeInsets.only(top: 4.0, bottom: 0.0)),
         Expanded(

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -83,7 +83,7 @@ class _InspectorDetailsTabControllerState
                     color: focusColor,
                     child: TabBar(
                       controller: _tabController,
-                      labelColor: Theme.of(context).textTheme.body1.color,
+                      labelColor: Theme.of(context).textTheme.bodyText1.color,
                       tabs: tabs,
                       isScrollable: true,
                     ),

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -208,7 +208,7 @@ class _LogDetailsState extends State<LogDetails>
       child: SingleChildScrollView(
         child: Text(
           log.prettyPrinted ?? '',
-          style: Theme.of(context).textTheme.subhead,
+          style: Theme.of(context).textTheme.subtitle1,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
@@ -85,7 +85,7 @@ class HttpRequestInspector extends StatelessWidget {
                 child: Text(
                   'No request selected',
                   key: noRequestSelectedKey,
-                  style: Theme.of(context).textTheme.title,
+                  style: Theme.of(context).textTheme.headline6,
                 ),
               )
             : tabbedContent,

--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector_views.dart
@@ -62,7 +62,7 @@ class HttpRequestHeadersView extends StatelessWidget {
         children: [
           Text(
             '$key: ',
-            style: Theme.of(context).textTheme.subtitle,
+            style: Theme.of(context).textTheme.subtitle2,
           ),
           Expanded(
             child: Text(
@@ -181,7 +181,7 @@ class HttpRequestCookiesView extends StatelessWidget {
         label: Expanded(
           child: Text(
             title ?? '--',
-            style: theme.textTheme.subhead,
+            style: theme.textTheme.subtitle1,
             overflow: TextOverflow.fade,
           ),
         ),
@@ -300,7 +300,7 @@ class HttpRequestTimingView extends StatelessWidget {
             children: [
               Text(
                 '$key: ',
-                style: Theme.of(context).textTheme.subtitle,
+                style: Theme.of(context).textTheme.subtitle2,
               ),
               Text(value),
             ],

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -109,8 +109,8 @@ class NetworkScreenBodyState extends State<NetworkScreenBody> {
   }
 
   Widget _buildHttpRequestTable() {
-    final titleTheme = Theme.of(context).textTheme.title;
-    final subheadTheme = Theme.of(context).textTheme.subhead;
+    final titleTheme = Theme.of(context).textTheme.headline6;
+    final subheadTheme = Theme.of(context).textTheme.subtitle1;
 
     DataColumn buildDataColumn(
       String name,

--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profiler.dart
@@ -69,7 +69,7 @@ class _CpuProfilerState extends State<CpuProfiler>
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             TabBar(
-              labelColor: textTheme.body1.color,
+              labelColor: textTheme.bodyText1.color,
               isScrollable: true,
               controller: _tabController,
               tabs: CpuProfiler.tabs,
@@ -121,7 +121,7 @@ class _CpuProfilerState extends State<CpuProfiler>
     return Center(
       child: Text(
         CpuProfiler.emptyCpuProfile,
-        style: Theme.of(context).textTheme.subhead,
+        style: Theme.of(context).textTheme.subtitle1,
       ),
     );
   }

--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -39,7 +39,7 @@ class EventDetails extends StatelessWidget {
             selectedEvent != null
                 ? '${selectedEvent.name} - ${msText(selectedEvent.time.duration)}'
                 : noEventSelected,
-            style: textTheme.title,
+            style: textTheme.headline6,
           ),
         ),
         const PaddedDivider.thin(),
@@ -82,7 +82,7 @@ class EventDetails extends StatelessWidget {
     return Center(
       child: Text(
         instructions,
-        style: textTheme.subhead,
+        style: textTheme.subtitle1,
       ),
     );
   }

--- a/packages/devtools_testing/goldens/inspector_controller_details_tree_scaffold.txt
+++ b/packages/devtools_testing/goldens/inspector_controller_details_tree_scaffold.txt
@@ -31,7 +31,7 @@
               │   ▶renderObject: _RenderInkFeatures#00000
               └─▼[/icons/inspector/resume.png]AnimatedDefaultTextStyle
                 │   duration: 200ms
-                │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
+                │   debugLabel: (englishLike body1 2014).merge(blackMountainView bodyText2)
                 │   inherit: false
                 │   color: [#000000dd]#00000000
                 │   family: Roboto
@@ -43,7 +43,7 @@
                 │   overflow: clip
                 │   ▶state: _AnimatedDefaultTextStyleState#00000(ticker inactive)
                 └─▼[/icons/inspector/textArea.png]DefaultTextStyle
-                  │   debugLabel: (englishLike body1 2014).merge(blackMountainView body1)
+                  │   debugLabel: (englishLike body1 2014).merge(blackMountainView bodyText2)
                   │   inherit: false
                   │   color: [#000000dd]#00000000
                   │   family: Roboto


### PR DESCRIPTION
Fix deprecated material design text theme names to use their new modern terms.  This fixes analyzers errors during Travis runs on the bots.

```
  info - 'headline' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline5. This feature was deprecated after v1.13.8. at lib/src/debugger/flutter/debugger_screen.dart:36:12 - (deprecated_member_use)
  info - 'display1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline4. This feature was deprecated after v1.13.8. at lib/src/flutter/app.dart:92:50 - (deprecated_member_use)
  info - 'headline' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline5. This feature was deprecated after v1.13.8. at lib/src/flutter/connect_screen.dart:65:32 - (deprecated_member_use)
  info - 'body2' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is bodyText1. This feature was deprecated after v1.13.8. at lib/src/flutter/connect_screen.dart:71:32 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/flutter/connect_screen.dart:86:30 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/flutter/notifications.dart:217:40 - (deprecated_member_use)
  info - 'body1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is bodyText1. This feature was deprecated after v1.13.8. at lib/src/flutter/notifications.dart:224:42 - (deprecated_member_use)
info - 'headline' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline5. This feature was deprecated after v1.13.8. at lib/src/info/flutter/info_screen.dart:77:28 - (deprecated_member_use)
  info - 'headline' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline5. This feature was deprecated after v1.13.8. at lib/src/info/flutter/info_screen.dart:84:28 - (deprecated_member_use)
  info - 'body1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is bodyText1. This feature was deprecated after v1.13.8. at lib/src/inspector/flutter/inspector_screen_details_tab.dart:86:63 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/logging/flutter/logging_screen.dart:211:46 - (deprecated_member_use)
  info - 'title' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline6. This feature was deprecated after v1.13.8. at lib/src/network/flutter/http_request_inspector.dart:88:54 - (deprecated_member_use)
  info - 'subtitle' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle2. This feature was deprecated after v1.13.8. at lib/src/network/flutter/http_request_inspector_views.dart:65:48 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/network/flutter/http_request_inspector_views.dart:184:36 - (deprecated_member_use)
  info - 'subtitle' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle2. This feature was deprecated after v1.13.8. at lib/src/network/flutter/http_request_inspector_views.dart:303:52 - (deprecated_member_use)
  info - 'title' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline6. This feature was deprecated after v1.13.8. at lib/src/network/flutter/network_screen.dart:112:52 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/network/flutter/network_screen.dart:113:54 - (deprecated_member_use)
  info - 'body1' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is bodyText1. This feature was deprecated after v1.13.8. at lib/src/profiler/flutter/cpu_profiler.dart:72:37 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/profiler/flutter/cpu_profiler.dart:124:44 - (deprecated_member_use)
  info - 'title' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is headline6. This feature was deprecated after v1.13.8. at lib/src/timeline/flutter/event_details.dart:42:30 - (deprecated_member_use)
  info - 'subhead' is deprecated and shouldn't be used. This is the term used in the 2014 version of material design. The modern term is subtitle1. This feature was deprecated after v1.13.8. at lib/src/timeline/flutter/event_details.dart:85:26 - (deprecated_member_use)
```