### PR TITLE
Remove --trace-systrace flag from MacOs and Linux configs.

### DIFF
--- a/packages/devtools_app/linux/main.cc
+++ b/packages/devtools_app/linux/main.cc
@@ -58,7 +58,6 @@ int main(int argc, char **argv) {
   // Arguments for the Flutter Engine.
   std::vector<std::string> arguments;
   arguments.push_back("--enable-dart-profiling");
-  arguments.push_back("--trace-systrace");
 
   flutter::FlutterWindowController flutter_controller(icu_data_path);
   flutter::WindowProperties window_properties = {};

--- a/packages/devtools_app/macos/MainFlutterWindow.swift
+++ b/packages/devtools_app/macos/MainFlutterWindow.swift
@@ -22,7 +22,6 @@ class MainFlutterWindow: NSWindow {
     let project = FlutterDartProject.init()
     let arguments = [
       "--enable-dart-profiling",
-      "--trace-systrace",
     ]
     project.engineSwitches = arguments
     let flutterViewController = FlutterViewController.init(project: project)


### PR DESCRIPTION
After https://dart-review.googlesource.com/c/sdk/+/131360, timeline events were being forward to system specific logging. This flag was a noop previously and now needs to be removed.

Related to https://github.com/flutter/devtools/issues/1609