### PR TITLE
Use old RTI

### DIFF
--- a/packages/devtools_app/build.yaml
+++ b/packages/devtools_app/build.yaml
@@ -5,3 +5,4 @@ targets:
         options:
           dart2js_args:
           - -O1
+          - --use-old-rti


### PR DESCRIPTION
Mitigates #1610 

We need to push a cherrypick release with this commit to fix the production build.