### PR TITLE
Factor zoom level into flame chart node selection logic.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -543,9 +543,7 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
     while (min < max) {
       final mid = min + ((max - min) >> 1);
       final node = nodes[mid];
-      final zoomedNodeRect = node.selectable
-          ? node.zoomedRect(widget.zoom, widget.startInset)
-          : node.rect;
+      final zoomedNodeRect = node.zoomedRect(widget.zoom, widget.startInset);
       if (x >= zoomedNodeRect.left && x <= zoomedNodeRect.right) {
         return node;
       }
@@ -690,6 +688,10 @@ class FlameChartNode<T> {
   }
 
   Rect zoomedRect(double zoom, double chartStartInset) {
+    // If a node is not selectable (e.g. section labels "UI", "GPU", etc.), it
+    // will not be zoomed, so return the original rect.
+    if (!selectable) return rect;
+
     final zoomedLeft = (rect.left - chartStartInset) * zoom + chartStartInset;
     final zoomedWidth = rect.width * zoom;
     return Rect.fromLTWH(zoomedLeft, rect.top, zoomedWidth, rect.height);

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -543,13 +543,16 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
     while (min < max) {
       final mid = min + ((max - min) >> 1);
       final node = nodes[mid];
-      if (x >= node.rect.left && x <= node.rect.right) {
+      final zoomedNodeRect = node.selectable
+          ? node.zoomedRect(widget.zoom, widget.startInset)
+          : node.rect;
+      if (x >= zoomedNodeRect.left && x <= zoomedNodeRect.right) {
         return node;
       }
-      if (x < node.rect.left) {
+      if (x < zoomedNodeRect.left) {
         max = mid;
       }
-      if (x > node.rect.right) {
+      if (x > zoomedNodeRect.right) {
         min = mid + 1;
       }
     }
@@ -684,6 +687,12 @@ class FlameChartNode<T> {
     } else {
       return node;
     }
+  }
+
+  Rect zoomedRect(double zoom, double chartStartInset) {
+    final zoomedLeft = (rect.left - chartStartInset) * zoom + chartStartInset;
+    final zoomedWidth = rect.width * zoom;
+    return Rect.fromLTWH(zoomedLeft, rect.top, zoomedWidth, rect.height);
   }
 }
 

--- a/packages/devtools_app/test/flutter/flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flame_chart_test.dart
@@ -244,6 +244,28 @@ void main() {
       expect(rowState.binarySearchForNode(1060.0), isNull);
     });
 
+    testWidgets('binary search for node returns correct node in zoomed row',
+        (WidgetTester tester) async {
+      final rowState = await pumpRowAndGetState(tester, row: zoomedTestRow);
+      expect(rowState.binarySearchForNode(-10.0), isNull);
+      expect(rowState.binarySearchForNode(10.0), equals(labelNode));
+      expect(rowState.binarySearchForNode(49.0), isNull);
+      expect(rowState.binarySearchForNode(70.0), equals(testNode));
+      expect(rowState.binarySearchForNode(114.0), equals(testNode));
+      expect(rowState.binarySearchForNode(114.1), isNull);
+      expect(rowState.binarySearchForNode(169.9), isNull);
+      expect(rowState.binarySearchForNode(170.0), equals(testNode2));
+      expect(rowState.binarySearchForNode(270.0), equals(testNode2));
+      expect(rowState.binarySearchForNode(270.1), isNull);
+      expect(rowState.binarySearchForNode(289.9), isNull);
+      expect(rowState.binarySearchForNode(290.0), equals(testNode3));
+      expect(rowState.binarySearchForNode(409.9), isNull);
+      expect(rowState.binarySearchForNode(410.0), equals(testNode4));
+      expect(rowState.binarySearchForNode(1010.0), equals(testNode4));
+      expect(rowState.binarySearchForNode(1010.1), isNull);
+      expect(rowState.binarySearchForNode(10000), isNull);
+    });
+
     testWidgets('leftPaddingForNode returns correct value for un-zoomed row',
         (WidgetTester tester) async {
       var rowState = await pumpRowAndGetState(tester);
@@ -458,8 +480,8 @@ void main() {
 const narrowNodeKey = Key('narrow node');
 final narrowNode = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
-  text: 'Test node 2',
-  tooltip: 'Test node 2 tooltip',
+  text: 'Narrow test node',
+  tooltip: 'Narrow test node tooltip',
   rect: const Rect.fromLTWH(23.0, 0.0, 21.9, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,


### PR DESCRIPTION
We need to take zoom into account when doing a binary search for which node to select. This CL implements that.