### PR TITLE
Fix timeline bug throwing error for empty recording

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -254,7 +254,8 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
 
   Widget _buildFlameChartSection() {
     Widget content;
-    final fullTimelineEmpty = controller.fullTimeline.data?.isEmpty ?? true;
+    final fullTimelineEmpty = (controller.fullTimeline.data?.isEmpty ?? true) ||
+        controller.fullTimeline.data.eventGroups.isEmpty;
     if (timelineMode == TimelineMode.full &&
         (recording || processing || fullTimelineEmpty)) {
       content = ValueListenableBuilder<bool>(

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -422,6 +422,9 @@ class FullTimeline
   FutureOr<void> processTraceEvents(List<TraceEventWrapper> traceEvents) async {
     await processor.processTimeline(traceEvents);
     _timelineController.fullTimeline.data.initializeEventGroups();
+    if (_timelineController.fullTimeline.data.eventGroups.isEmpty) {
+      _emptyRecordingNotifier.value = true;
+    }
   }
 
   @override


### PR DESCRIPTION
It is possible to have trace events but no timeline events (e.g. if we only received the begin trace event for a task, but not the end trace event). Previously, we were only checking that `traceEvents.isEmpty` to determine whether the full timeline is empty.