### PR TITLE
make the rollback help text consistent with the other commands

### DIFF
--- a/tool/lib/commands/rollback.dart
+++ b/tool/lib/commands/rollback.dart
@@ -18,7 +18,7 @@ class RollbackCommand extends Command {
   String get name => 'rollback';
 
   @override
-  String get description => 'Rolls back to a specific DevTools version';
+  String get description => 'Rolls back to a specific DevTools version.';
 
   @override
   Future run() async {


### PR DESCRIPTION
- make the rollback help text consistent with the other commands

cc @DaveShuckerow 