### PR TITLE
improve the error reporting on connection issues

### DIFF
--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -222,7 +222,7 @@ class _NotificationState extends State<_Notification>
                 child: Text(
                   widget.message,
                   style: theme.textTheme.bodyText1,
-                  overflow: TextOverflow.ellipsis,
+                  overflow: TextOverflow.visible,
                   maxLines: 6,
                 ),
               ),

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -58,13 +58,13 @@ class FrameworkCore {
           );
           return true;
         } else {
-          errorReporter(
-              'Unable to connect to VM service at "$uri" without error', null);
+          errorReporter('Unable to connect to VM service at $uri', null);
           return false;
         }
-      } catch (e) {
-        errorReporter(
-            'Unable to connect to VM service at "$uri" with error $e', e);
+      } catch (e, st) {
+        log('$e\n$st', LogLevel.error);
+
+        errorReporter('Unable to connect to VM service at $uri: $e', e);
         return false;
       }
     } else {


### PR DESCRIPTION
improve the error reporting on connection issues:
- log the error and stack trace when there are connection issues
- modify the error toast display so that errors longer than a single line are displayed

This doesn't fix https://github.com/flutter/devtools/issues/1633, but may make it easier to track down the issue.

Here's the new display of a connection error:

<img width="390" alt="Screen Shot 2020-02-14 at 12 25 14 PM" src="https://user-images.githubusercontent.com/1269969/74565004-17ce4600-4f25-11ea-8237-f3b9ebe8e7f2.png">
