### PR TITLE
Remove dependency on package:flutter_widgets.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -7,10 +7,10 @@ import 'dart:ui';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_widgets/flutter_widgets.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
+import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/theme.dart';
 import '../../ui/colors.dart';
 import '../../ui/fake_flutter/_real_flutter.dart';

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -7,9 +7,9 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter_widgets/flutter_widgets.dart';
 
 import '../ui/flutter/label.dart';
+import 'flutter_widgets/tagged_text.dart';
 
 const tooltipWait = Duration(milliseconds: 500);
 

--- a/packages/devtools_app/lib/src/flutter/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/flutter/flutter_widgets/linked_scroll_controller.dart
@@ -5,7 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
-// This file is copied from package:flutter_widgets.
+// This file was originally forked from package:flutter_widgets. Note that the
+// source may diverge over time.
 
 /// Sets up a collection of scroll controllers that mirror their movements to
 /// each other.

--- a/packages/devtools_app/lib/src/flutter/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/flutter/flutter_widgets/linked_scroll_controller.dart
@@ -1,0 +1,369 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+// This file is copied from package:flutter_widgets.
+
+/// Sets up a collection of scroll controllers that mirror their movements to
+/// each other.
+///
+/// Controllers are added and returned via [addAndGet]. The initial offset
+/// of the newly created controller is synced to the current offset.
+/// Controllers must be `dispose`d when no longer in use to prevent memory
+/// leaks and performance degradation.
+///
+/// If controllers are disposed over the course of the lifetime of this
+/// object the corresponding scrollables should be given unique keys.
+/// Without the keys, Flutter may reuse a controller after it has been disposed,
+/// which can cause the controller offsets to fall out of sync.
+class LinkedScrollControllerGroup {
+  LinkedScrollControllerGroup() {
+    _offsetNotifier = _LinkedScrollControllerGroupOffsetNotifier(this);
+  }
+
+  final _allControllers = <_LinkedScrollController>[];
+
+  _LinkedScrollControllerGroupOffsetNotifier _offsetNotifier;
+
+  /// The current scroll offset of the group.
+  double get offset {
+    assert(
+      _attachedControllers.isNotEmpty,
+      'LinkedScrollControllerGroup does not have any scroll controllers '
+      'attached.',
+    );
+    return _attachedControllers.first.offset;
+  }
+
+  /// Creates a new controller that is linked to any existing ones.
+  ScrollController addAndGet() {
+    final initialScrollOffset = _attachedControllers.isEmpty
+        ? 0.0
+        : _attachedControllers.first.position.pixels;
+    final controller =
+        _LinkedScrollController(this, initialScrollOffset: initialScrollOffset);
+    _allControllers.add(controller);
+    controller.addListener(_offsetNotifier.notifyListeners);
+    return controller;
+  }
+
+  /// Adds a callback that will be called when the value of [offset] changes.
+  void addOffsetChangedListener(VoidCallback onChanged) {
+    _offsetNotifier.addListener(onChanged);
+  }
+
+  /// Removes the specified offset changed listener.
+  void removeOffsetChangedListener(VoidCallback listener) {
+    _offsetNotifier.removeListener(listener);
+  }
+
+  Iterable<_LinkedScrollController> get _attachedControllers =>
+      _allControllers.where((controller) => controller.hasClients);
+
+  /// Animates the scroll position of all linked controllers to [offset].
+  Future<void> animateTo(
+    double offset, {
+    @required Curve curve,
+    @required Duration duration,
+  }) async {
+    final animations = <Future<void>>[];
+    for (final controller in _attachedControllers) {
+      animations
+          .add(controller.animateTo(offset, duration: duration, curve: curve));
+    }
+    return Future.wait<void>(animations).then<void>((List<void> _) => null);
+  }
+
+  /// Jumps the scroll position of all linked controllers to [value].
+  void jumpTo(double value) {
+    for (final controller in _attachedControllers) {
+      controller.jumpTo(value);
+    }
+  }
+
+  /// Resets the scroll position of all linked controllers to 0.
+  void resetScroll() {
+    jumpTo(0.0);
+  }
+}
+
+/// This class provides change notification for [LinkedScrollControllerGroup]'s
+/// scroll offset.
+///
+/// This change notifier de-duplicates change events by only firing listeners
+/// when the scroll offset of the group has changed.
+class _LinkedScrollControllerGroupOffsetNotifier extends ChangeNotifier {
+  _LinkedScrollControllerGroupOffsetNotifier(this.controllerGroup);
+
+  final LinkedScrollControllerGroup controllerGroup;
+
+  /// The cached offset for the group.
+  ///
+  /// This value will be used in determining whether to notify listeners.
+  double _cachedOffset;
+
+  @override
+  void notifyListeners() {
+    final currentOffset = controllerGroup.offset;
+    if (currentOffset != _cachedOffset) {
+      _cachedOffset = currentOffset;
+      super.notifyListeners();
+    }
+  }
+}
+
+/// A scroll controller that mirrors its movements to a peer, which must also
+/// be a [_LinkedScrollController].
+class _LinkedScrollController extends ScrollController {
+  _LinkedScrollController(this._controllers, {double initialScrollOffset})
+      : super(initialScrollOffset: initialScrollOffset);
+
+  final LinkedScrollControllerGroup _controllers;
+
+  @override
+  void dispose() {
+    _controllers._allControllers.remove(this);
+    super.dispose();
+  }
+
+  @override
+  void attach(ScrollPosition position) {
+    assert(
+        position is _LinkedScrollPosition,
+        '_LinkedScrollControllers can only be used with'
+        ' _LinkedScrollPositions.');
+    final _LinkedScrollPosition linkedPosition = position;
+    assert(linkedPosition.owner == this,
+        '_LinkedScrollPosition cannot change controllers once created.');
+    super.attach(position);
+  }
+
+  @override
+  _LinkedScrollPosition createScrollPosition(ScrollPhysics physics,
+      ScrollContext context, ScrollPosition oldPosition) {
+    return _LinkedScrollPosition(
+      this,
+      physics: physics,
+      context: context,
+      initialPixels: initialScrollOffset,
+      oldPosition: oldPosition,
+    );
+  }
+
+  @override
+  _LinkedScrollPosition get position => super.position;
+
+  Iterable<_LinkedScrollController> get _allPeersWithClients =>
+      _controllers._attachedControllers.where((peer) => peer != this);
+
+  bool get canLinkWithPeers => _allPeersWithClients.isNotEmpty;
+
+  Iterable<_LinkedScrollActivity> linkWithPeers(_LinkedScrollPosition driver) {
+    assert(canLinkWithPeers);
+    return _allPeersWithClients
+        .map((peer) => peer.link(driver))
+        .expand((e) => e);
+  }
+
+  Iterable<_LinkedScrollActivity> link(_LinkedScrollPosition driver) {
+    assert(hasClients);
+    final activities = <_LinkedScrollActivity>[];
+    for (_LinkedScrollPosition position in positions) {
+      activities.add(position.link(driver));
+    }
+    return activities;
+  }
+}
+
+// Implementation details: Whenever position.setPixels or position.forcePixels
+// is called on a _LinkedScrollPosition (which may happen programmatically, or
+// as a result of a user action),  the _LinkedScrollPosition creates a
+// _LinkedScrollActivity for each linked position and uses it to move to or jump
+// to the appropriate offset.
+//
+// When a new activity begins, the set of peer activities is cleared.
+class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
+  _LinkedScrollPosition(
+    this.owner, {
+    ScrollPhysics physics,
+    ScrollContext context,
+    double initialPixels,
+    ScrollPosition oldPosition,
+  })  : assert(owner != null),
+        super(
+          physics: physics,
+          context: context,
+          initialPixels: initialPixels,
+          oldPosition: oldPosition,
+        );
+
+  final _LinkedScrollController owner;
+
+  final Set<_LinkedScrollActivity> _peerActivities = <_LinkedScrollActivity>{};
+
+  // We override hold to propagate it to all peer controllers.
+  @override
+  ScrollHoldController hold(VoidCallback holdCancelCallback) {
+    for (final controller in owner._allPeersWithClients) {
+      controller.position._holdInternal();
+    }
+    return super.hold(holdCancelCallback);
+  }
+
+  // Calls hold without propagating to peers.
+  void _holdInternal() {
+    // TODO: passing null to hold seems fishy, but it doesn't
+    // appear to hurt anything. Revisit this if bad things happen.
+    super.hold(null);
+  }
+
+  @override
+  void beginActivity(ScrollActivity newActivity) {
+    if (newActivity == null) {
+      return;
+    }
+    for (var activity in _peerActivities) {
+      activity.unlink(this);
+    }
+
+    _peerActivities.clear();
+
+    super.beginActivity(newActivity);
+  }
+
+  @override
+  double setPixels(double newPixels) {
+    if (newPixels == pixels) {
+      return 0.0;
+    }
+    updateUserScrollDirection(newPixels - pixels > 0.0
+        ? ScrollDirection.forward
+        : ScrollDirection.reverse);
+
+    if (owner.canLinkWithPeers) {
+      _peerActivities.addAll(owner.linkWithPeers(this));
+      for (var activity in _peerActivities) {
+        activity.moveTo(newPixels);
+      }
+    }
+
+    return setPixelsInternal(newPixels);
+  }
+
+  double setPixelsInternal(double newPixels) {
+    return super.setPixels(newPixels);
+  }
+
+  @override
+  void forcePixels(double value) {
+    if (value == pixels) {
+      return;
+    }
+    updateUserScrollDirection(value - pixels > 0.0
+        ? ScrollDirection.forward
+        : ScrollDirection.reverse);
+
+    if (owner.canLinkWithPeers) {
+      _peerActivities.addAll(owner.linkWithPeers(this));
+      for (var activity in _peerActivities) {
+        activity.jumpTo(value);
+      }
+    }
+
+    forcePixelsInternal(value);
+  }
+
+  void forcePixelsInternal(double value) {
+    super.forcePixels(value);
+  }
+
+  _LinkedScrollActivity link(_LinkedScrollPosition driver) {
+    if (this.activity is! _LinkedScrollActivity) {
+      beginActivity(_LinkedScrollActivity(this));
+    }
+    final _LinkedScrollActivity activity = this.activity;
+    activity.link(driver);
+    return activity;
+  }
+
+  void unlink(_LinkedScrollActivity activity) {
+    _peerActivities.remove(activity);
+  }
+
+  // We override this method to make it public (overridden method is protected)
+  @override
+  // ignore: unnecessary_overrides
+  void updateUserScrollDirection(ScrollDirection value) {
+    super.updateUserScrollDirection(value);
+  }
+
+  @override
+  void debugFillDescription(List<String> description) {
+    super.debugFillDescription(description);
+    description.add('owner: $owner');
+  }
+}
+
+class _LinkedScrollActivity extends ScrollActivity {
+  _LinkedScrollActivity(_LinkedScrollPosition delegate) : super(delegate);
+
+  @override
+  _LinkedScrollPosition get delegate => super.delegate;
+
+  final Set<_LinkedScrollPosition> drivers = <_LinkedScrollPosition>{};
+
+  void link(_LinkedScrollPosition driver) {
+    drivers.add(driver);
+  }
+
+  void unlink(_LinkedScrollPosition driver) {
+    drivers.remove(driver);
+    if (drivers.isEmpty) {
+      delegate?.goIdle();
+    }
+  }
+
+  @override
+  bool get shouldIgnorePointer => true;
+
+  @override
+  bool get isScrolling => true;
+
+  // _LinkedScrollActivity is not self-driven but moved by calls to the [moveTo]
+  // method.
+  @override
+  double get velocity => 0.0;
+
+  void moveTo(double newPixels) {
+    _updateUserScrollDirection();
+    delegate.setPixelsInternal(newPixels);
+  }
+
+  void jumpTo(double newPixels) {
+    _updateUserScrollDirection();
+    delegate.forcePixelsInternal(newPixels);
+  }
+
+  void _updateUserScrollDirection() {
+    assert(drivers.isNotEmpty);
+    ScrollDirection commonDirection;
+    for (var driver in drivers) {
+      commonDirection ??= driver.userScrollDirection;
+      if (driver.userScrollDirection != commonDirection) {
+        commonDirection = ScrollDirection.idle;
+      }
+    }
+    delegate.updateUserScrollDirection(commonDirection);
+  }
+
+  @override
+  void dispose() {
+    for (var driver in drivers) {
+      driver.unlink(this);
+    }
+    super.dispose();
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/flutter_widgets/tagged_text.dart
+++ b/packages/devtools_app/lib/src/flutter/flutter_widgets/tagged_text.dart
@@ -8,7 +8,8 @@ import 'package:html/dom.dart' as dom;
 import 'package:html/parser.dart';
 import 'package:meta/meta.dart';
 
-// This file is copied from package:flutter_widgets.
+// This file was originally forked from package:flutter_widgets. Note that the
+// source may diverge over time.
 
 /// Builds a [TextSpan] with the provided [text].
 typedef TextSpanBuilder = TextSpan Function(String text);

--- a/packages/devtools_app/lib/src/flutter/flutter_widgets/tagged_text.dart
+++ b/packages/devtools_app/lib/src/flutter/flutter_widgets/tagged_text.dart
@@ -1,0 +1,341 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/widgets.dart';
+import 'package:html/dom.dart' as dom;
+import 'package:html/parser.dart';
+import 'package:meta/meta.dart';
+
+// This file is copied from package:flutter_widgets.
+
+/// Builds a [TextSpan] with the provided [text].
+typedef TextSpanBuilder = TextSpan Function(String text);
+
+/// Displays the provided [content] in a [RichText] after parsing and replacing
+/// HTML tags using [tagToTextSpanBuilder].
+///
+/// This provides a convenient way to style localized text that is marked up
+/// with semantic tags.
+///
+/// Refer to the README file in this package for more info.
+class TaggedText extends StatefulWidget {
+  /// Creates a new [TaggedText].
+  ///
+  /// For unspecified parameters, the defaults in [RichText] will be used.
+  TaggedText(
+      {Key key,
+      @required this.content,
+      @required this.tagToTextSpanBuilder,
+      this.style,
+      this.textAlign = TextAlign.start,
+      this.textDirection,
+      this.softWrap = true,
+      this.overflow = TextOverflow.clip,
+      this.textScaleFactor,
+      this.maxLines})
+      : assert(
+            tagToTextSpanBuilder.keys.every((key) => key == key.toLowerCase())),
+        assert(() {
+          final htmlTags = {
+            'a',
+            'abbr',
+            'acronym',
+            'address',
+            'applet',
+            'area',
+            'article',
+            'aside',
+            'audio',
+            'b',
+            'base',
+            'basefont',
+            'bdi',
+            'bdo',
+            'bgsound',
+            'big',
+            'blink',
+            'blockquote',
+            'body',
+            'br',
+            'button',
+            'canvas',
+            'caption',
+            'center',
+            'cite',
+            'code',
+            'col',
+            'colgroup',
+            'command',
+            'content',
+            'data',
+            'datalist',
+            'dd',
+            'del',
+            'details',
+            'dfn',
+            'dialog',
+            'dir',
+            'div',
+            'dl',
+            'dt',
+            'element',
+            'em',
+            'embed',
+            'fieldset',
+            'figcaption',
+            'figure',
+            'font',
+            'footer',
+            'form',
+            'frame',
+            'frameset',
+            'h1',
+            'h2',
+            'h3',
+            'h4',
+            'h5',
+            'h6',
+            'head',
+            'header',
+            'hgroup',
+            'hr',
+            'html',
+            'i',
+            'iframe',
+            'image',
+            'img',
+            'input',
+            'ins',
+            'isindex',
+            'kbd',
+            'keygen',
+            'label',
+            'legend',
+            'li',
+            'link',
+            'listing',
+            'main',
+            'map',
+            'mark',
+            'marquee',
+            'menu',
+            'menuitem',
+            'meta',
+            'meter',
+            'multicol',
+            'nav',
+            'nextid',
+            'nobr',
+            'noembed',
+            'noframes',
+            'noscript',
+            'object',
+            'ol',
+            'optgroup',
+            'option',
+            'output',
+            'p',
+            'param',
+            'picture',
+            'plaintext',
+            'pre',
+            'progress',
+            'q',
+            'rb',
+            'rp',
+            'rt',
+            'rtc',
+            'ruby',
+            's',
+            'samp',
+            'script',
+            'section',
+            'select',
+            'shadow',
+            'slot',
+            'small',
+            'source',
+            'spacer',
+            'span',
+            'strike',
+            'strong',
+            'style',
+            'sub',
+            'summary',
+            'sup',
+            'table',
+            'tbody',
+            'td',
+            'template',
+            'textarea',
+            'tfoot',
+            'th',
+            'thead',
+            'time',
+            'title',
+            'tr',
+            'track',
+            'tt',
+            'u',
+            'ul',
+            'var',
+            'video',
+            'wbr',
+            'xmp'
+          };
+          htmlTags.retainAll(tagToTextSpanBuilder.keys);
+          return htmlTags.isEmpty;
+        }(), 'Tags that are actual HTML tags are not allowed'),
+        super(key: key);
+
+  /// The tagged content to render.
+  final String content;
+
+  /// A map of [TextSpanBuilder]s by lower-case HTML tag name. Tag names must be
+  /// lower-case.
+  ///
+  /// This is used to determine how to render each tag that is found in
+  /// [content].
+  ///
+  /// If a tag is missing, a warning will be printed and the text will be
+  /// rendered in the default [style].
+  ///
+  /// Tags that are actual HTML tags (e.g., "link") are not allowed and will
+  /// result in an assertion error being thrown.
+  // TODO: Consider changing implementation to use a simpler HTML
+  // parser. This would make the parsing faster and allow us to support HTML
+  // tags without getting weird behavior (e.g., since link tags don't support
+  // contents in an HTML document, the parser doesn't treat the contents as
+  // being part of the element).
+  final Map<String, TextSpanBuilder> tagToTextSpanBuilder;
+
+  /// Default style to use for all spans of text.
+  final TextStyle style;
+
+  /// Horizontal alignment of the spans of text.
+  ///
+  /// See [RichText.textAlign].
+  final TextAlign textAlign;
+
+  /// The directionality of the text.
+  ///
+  /// See [RichText.textDirection].
+  final TextDirection textDirection;
+
+  /// The choice of whether the spans of text should break at soft line breaks
+  ///
+  /// See [RichText.softWrap].
+  final bool softWrap;
+
+  /// The manner in which to handle visual overflow of the spans of text.
+  ///
+  /// See [RichText.overflow].
+  final TextOverflow overflow;
+
+  /// The number of font pixels for each logical pixel.
+  ///
+  /// When null, this will default to [MediaQueryData.textScaleFactor] when
+  /// available or 1.0.
+  ///
+  /// See [Text.textScaleFactor].
+  final double textScaleFactor;
+
+  /// An optional maximum number of lines for the spans of text.
+  ///
+  /// If they exceed the given number of lines, they will be truncated
+  /// according to [overflow].
+  ///
+  /// See [RichText.maxLines].
+  final int maxLines;
+
+  @override
+  State<StatefulWidget> createState() => _TaggedTextState();
+}
+
+/// [State] for [TaggedText].
+class _TaggedTextState extends State<TaggedText> {
+  bool _didParse;
+  dom.Node _document;
+  List<TextSpan> _textSpans;
+
+  @override
+  void initState() {
+    super.initState();
+    _parseContent();
+    _parseSpans();
+  }
+
+  @override
+  void didUpdateWidget(TaggedText oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.content != widget.content) {
+      _parseContent();
+      _parseSpans();
+    } else if (!(const MapEquality()
+        .equals(oldWidget.tagToTextSpanBuilder, widget.tagToTextSpanBuilder))) {
+      _parseSpans();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_didParse) return Container();
+    assert(_textSpans != null);
+
+    return RichText(
+        text: TextSpan(children: _textSpans, style: widget.style),
+        textAlign: widget.textAlign,
+        textDirection: widget.textDirection,
+        softWrap: widget.softWrap,
+        overflow: widget.overflow,
+        textScaleFactor: widget.textScaleFactor ??
+            MediaQuery.of(context, nullOk: true)?.textScaleFactor ??
+            1.0,
+        maxLines: widget.maxLines);
+  }
+
+  void _parseContent() {
+    try {
+      final document = parse(widget.content);
+      setState(() {
+        _document = document.body;
+        _didParse = true;
+      });
+    } on Exception catch (_) {
+      assert(false);
+      // Parse exceptions are not clearly documented.
+      setState(() => _didParse = false);
+    }
+  }
+
+  void _parseSpans() {
+    if (!_didParse) return;
+
+    _textSpans = _document.nodes
+        .map((node) {
+          if (node is dom.Text) {
+            return TextSpan(text: node.text);
+          }
+
+          if (node is! dom.Element) return null;
+          final element = node as dom.Element;
+
+          assert(element.children.isEmpty,
+              'Tags should not be placed within tags.');
+
+          // The parser always returns tag names as lower case.
+          final textSpanBuilder =
+              widget.tagToTextSpanBuilder[element.localName];
+
+          assert(textSpanBuilder != null);
+          if (textSpanBuilder == null) return TextSpan(text: element.text);
+
+          return textSpanBuilder(element.text);
+        })
+        .where((span) => span != null)
+        .toList();
+  }
+}

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -64,7 +64,6 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  flutter_widgets: ^0.1.10
   recase: ^2.0.1
 
 dependency_overrides:

--- a/packages/devtools_app/test/flutter/flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flame_chart_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/charts/flutter/flame_chart.dart';
+import 'package:devtools_app/src/flutter/flutter_widgets/linked_scroll_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/profiler/flutter/cpu_profile_flame_chart.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
@@ -13,7 +14,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_widgets/flutter_widgets.dart';
 
 void main() {
   const defaultZoom = 1.0;

--- a/packages/devtools_app/test/flutter/linked_scroll_controller_test.dart
+++ b/packages/devtools_app/test/flutter/linked_scroll_controller_test.dart
@@ -7,7 +7,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pedantic/pedantic.dart';
 
-// This file is copied from package:flutter_widgets.
+// This file was originally forked from package:flutter_widgets. Note that the
+// source may diverge over time.
 
 /// This test sets up two linked, side-by-side [ListView]s, one with letter
 /// captions and one with number captions, and verifies that they stay in sync

--- a/packages/devtools_app/test/flutter/linked_scroll_controller_test.dart
+++ b/packages/devtools_app/test/flutter/linked_scroll_controller_test.dart
@@ -1,0 +1,386 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/flutter_widgets/linked_scroll_controller.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pedantic/pedantic.dart';
+
+// This file is copied from package:flutter_widgets.
+
+/// This test sets up two linked, side-by-side [ListView]s, one with letter
+/// captions and one with number captions, and verifies that they stay in sync
+/// while scrolling.
+void main() {
+  group(LinkedScrollControllerGroup, () {
+    testWidgets('letters drive numbers - fling', (tester) async {
+      await tester.pumpWidget(Test());
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.fling(
+        find.text('Hello A'),
+        const Offset(0.0, -50.0),
+        10000.0,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsNothing);
+      expect(find.text('Hello 1'), findsNothing);
+      expect(find.text('Hello E'), findsOneWidget);
+      expect(find.text('Hello 5'), findsOneWidget);
+      await tester.fling(
+        find.text('Hello E'),
+        const Offset(0.0, 50.0),
+        10000.0,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+    });
+
+    testWidgets('letters drive numbers - drag', (tester) async {
+      await tester.pumpWidget(Test());
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsNothing);
+      expect(find.text('Hello 4'), findsNothing);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.drag(find.text('Hello B'), const Offset(0.0, -300.0));
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsNothing);
+      expect(find.text('Hello 1'), findsNothing);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsOneWidget);
+      expect(find.text('Hello 4'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.drag(find.text('Hello B'), const Offset(0.0, 300.0));
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsNothing);
+      expect(find.text('Hello 4'), findsNothing);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+    });
+
+    testWidgets('numbers drive letters - fling', (tester) async {
+      await tester.pumpWidget(Test());
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.fling(
+        find.text('Hello 1'),
+        const Offset(0.0, -50.0),
+        10000.0,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsNothing);
+      expect(find.text('Hello 1'), findsNothing);
+      expect(find.text('Hello E'), findsOneWidget);
+      expect(find.text('Hello 5'), findsOneWidget);
+      await tester.fling(
+        find.text('Hello 5'),
+        const Offset(0.0, 50.0),
+        10000.0,
+      );
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+    });
+
+    testWidgets('numbers drive letters - drag', (tester) async {
+      await tester.pumpWidget(Test());
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsNothing);
+      expect(find.text('Hello 4'), findsNothing);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -300.0));
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsNothing);
+      expect(find.text('Hello 1'), findsNothing);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsOneWidget);
+      expect(find.text('Hello 4'), findsOneWidget);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, 300.0));
+      await tester.pumpAndSettle();
+      expect(find.text('Hello A'), findsOneWidget);
+      expect(find.text('Hello 1'), findsOneWidget);
+      expect(find.text('Hello B'), findsOneWidget);
+      expect(find.text('Hello 2'), findsOneWidget);
+      expect(find.text('Hello C'), findsOneWidget);
+      expect(find.text('Hello 3'), findsOneWidget);
+      expect(find.text('Hello D'), findsNothing);
+      expect(find.text('Hello 4'), findsNothing);
+      expect(find.text('Hello E'), findsNothing);
+      expect(find.text('Hello 5'), findsNothing);
+    });
+
+    testWidgets('offset throws for empty group', (tester) async {
+      await tester.pumpWidget(TestEmptyGroup());
+
+      final state =
+          tester.state<TestEmptyGroupState>(find.byType(TestEmptyGroup));
+      expect(() {
+        state._controllers.offset;
+      }, throwsAssertionError);
+    });
+
+    testWidgets('offset returns current position', (tester) async {
+      await tester.pumpWidget(Test());
+
+      final state = tester.state<TestState>(find.byType(Test));
+      expect(state._controllers.offset, equals(0.0));
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -300.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(300.0));
+      expect(state._controllers.offset, equals(state._letters.offset));
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, 300.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(0.0));
+      expect(state._controllers.offset, equals(state._letters.offset));
+    });
+
+    testWidgets('onOffsetChanged fires on scroll', (tester) async {
+      await tester.pumpWidget(Test());
+      final state = tester.state<TestState>(find.byType(Test));
+
+      var onOffsetChangedCount = 0;
+      void listener() {
+        onOffsetChangedCount++;
+      }
+
+      state._controllers.addOffsetChangedListener(listener);
+
+      expect(state._controllers.offset, equals(0.0));
+      expect(onOffsetChangedCount, equals(0));
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -1.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(1.0));
+      // The count should be incremented since the scroll offset changed.
+      expect(onOffsetChangedCount, equals(1));
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, 0.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(1.0));
+      // The count should be unchanged since the scroll offset is unchanged.
+      expect(onOffsetChangedCount, equals(1));
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -1.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(2.0));
+      // The count should be incremented since the scroll offset changed.
+      expect(onOffsetChangedCount, equals(2));
+
+      state._controllers.removeOffsetChangedListener(listener);
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -1.0));
+      await tester.pumpAndSettle();
+      expect(state._controllers.offset, equals(3.0));
+      // The count should be unchanged since we removed the listener.
+      expect(onOffsetChangedCount, equals(2));
+    });
+
+    testWidgets('jumpTo jumps group to offset', (tester) async {
+      await tester.pumpWidget(Test());
+
+      final state = tester.state<TestState>(find.byType(Test));
+      expect(state._controllers.offset, equals(0.0));
+      expect(state._letters.position.pixels, equals(0.0));
+      expect(state._numbers.position.pixels, equals(0.0));
+
+      state._controllers.jumpTo(50.0);
+
+      expect(state._controllers.offset, equals(50.0));
+      expect(state._letters.position.pixels, equals(50.0));
+      expect(state._numbers.position.pixels, equals(50.0));
+    });
+
+    testWidgets('animateTo animates group to offset', (tester) async {
+      await tester.pumpWidget(Test());
+
+      final state = tester.state<TestState>(find.byType(Test));
+      expect(state._controllers.offset, equals(0.0));
+      expect(state._letters.position.pixels, equals(0.0));
+      expect(state._numbers.position.pixels, equals(0.0));
+
+      // The call to `animateTo` needs to be unawaited because the animation is
+      // handled by a [DrivenScrollActivity], which only completes when the
+      // scroll activity is disposed.
+      unawaited(state._controllers.animateTo(
+        50.0,
+        curve: Curves.easeInOutCubic,
+        duration: const Duration(milliseconds: 200),
+      ));
+      await tester.pumpAndSettle();
+
+      expect(state._controllers.offset, equals(50.0));
+      expect(state._letters.position.pixels, equals(50.0));
+      expect(state._numbers.position.pixels, equals(50.0));
+    });
+
+    testWidgets('resetScroll moves scroll back to 0', (tester) async {
+      await tester.pumpWidget(Test());
+
+      await tester.drag(find.text('Hello 2'), const Offset(0.0, -300.0));
+      await tester.pumpAndSettle();
+
+      final state = tester.state<TestState>(find.byType(Test));
+      state._controllers.resetScroll();
+
+      expect(state._letters.position.pixels, 0.0);
+      expect(state._numbers.position.pixels, 0.0);
+    });
+
+    testWidgets('jumpTo is synced', (tester) async {
+      await tester.pumpWidget(Test());
+      final state = tester.state<TestState>(find.byType(Test));
+
+      expect(state._letters.position.pixels, 0.0);
+      expect(state._numbers.position.pixels, 0.0);
+
+      state._letters.jumpTo(100.0);
+
+      await tester.pumpAndSettle();
+
+      expect(state._letters.position.pixels, 100.0);
+      expect(state._numbers.position.pixels, 100.0);
+    });
+
+    testWidgets('tap on another scrollable during fling stops scrolling',
+        (tester) async {
+      await tester.pumpWidget(Test());
+      final state = tester.state<TestState>(find.byType(Test));
+
+      await tester.fling(find.text('Hello A'), const Offset(0.0, -50.0), 500.0);
+      await tester.tap(find.text('Hello 1'));
+
+      await tester.pumpAndSettle();
+
+      // Position would be about 100 if the scroll were not stopped by the tap.
+      expect(state._letters.position.pixels, 50.0);
+      expect(state._numbers.position.pixels, 50.0);
+    });
+  });
+}
+
+class TestEmptyGroup extends StatefulWidget {
+  @override
+  TestEmptyGroupState createState() => TestEmptyGroupState();
+}
+
+class TestEmptyGroupState extends State<TestEmptyGroup> {
+  LinkedScrollControllerGroup _controllers;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = LinkedScrollControllerGroup();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const SizedBox();
+  }
+}
+
+class Test extends StatefulWidget {
+  @override
+  TestState createState() => TestState();
+}
+
+class TestState extends State<Test> {
+  LinkedScrollControllerGroup _controllers;
+  ScrollController _letters;
+  ScrollController _numbers;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = LinkedScrollControllerGroup();
+    _letters = _controllers.addAndGet();
+    _numbers = _controllers.addAndGet();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Directionality(
+      textDirection: TextDirection.ltr,
+      child: Row(
+        children: <Widget>[
+          Expanded(
+            child: ListView(
+              controller: _letters,
+              children: const <Widget>[
+                Tile('Hello A'),
+                Tile('Hello B'),
+                Tile('Hello C'),
+                Tile('Hello D'),
+                Tile('Hello E'),
+              ],
+            ),
+          ),
+          Expanded(
+            child: ListView(
+              controller: _numbers,
+              children: const <Widget>[
+                Tile('Hello 1'),
+                Tile('Hello 2'),
+                Tile('Hello 3'),
+                Tile('Hello 4'),
+                Tile('Hello 5'),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class Tile extends StatelessWidget {
+  const Tile(this.caption);
+
+  final String caption;
+
+  @override
+  Widget build(_) => Container(
+        margin: const EdgeInsets.all(8.0),
+        padding: const EdgeInsets.all(8.0),
+        height: 250.0,
+        child: Center(child: Text(caption)),
+      );
+}

--- a/packages/devtools_app/test/flutter/tagged_text_test.dart
+++ b/packages/devtools_app/test/flutter/tagged_text_test.dart
@@ -7,7 +7,8 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
-// This file is copied from package:flutter_widgets.
+// This file was originally forked from package:flutter_widgets. Note that the
+// source may diverge over time.
 
 const TextStyle greetingStyle = TextStyle(fontWeight: FontWeight.w100);
 const TextStyle nameStyle = TextStyle(fontWeight: FontWeight.w200);

--- a/packages/devtools_app/test/flutter/tagged_text_test.dart
+++ b/packages/devtools_app/test/flutter/tagged_text_test.dart
@@ -1,0 +1,326 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/flutter_widgets/tagged_text.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+// This file is copied from package:flutter_widgets.
+
+const TextStyle greetingStyle = TextStyle(fontWeight: FontWeight.w100);
+const TextStyle nameStyle = TextStyle(fontWeight: FontWeight.w200);
+const TextStyle defaultStyle = TextStyle(fontWeight: FontWeight.w500);
+
+void main() {
+  group('$TaggedText', () {
+    testWidgets('without tags', (tester) async {
+      const content = 'Hello, Bob';
+      final widget = TaggedText(
+        content: content,
+        tagToTextSpanBuilder: const {},
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, [const TextSpan(text: content)]);
+    });
+
+    testWidgets('with tags', (tester) async {
+      final widget = TaggedText(
+        content: '<greeting>Hello</greeting>, my name is <name>George</name>!',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, const [
+        TextSpan(text: 'Hello', style: greetingStyle),
+        TextSpan(text: ', my name is '),
+        TextSpan(text: 'George', style: nameStyle),
+        TextSpan(text: '!'),
+      ]);
+    });
+
+    testWidgets('content tags are case insensitive', (tester) async {
+      final widget = TaggedText(
+        content: '<GREEting>Hello</GREEting>, my name is <nAme>George</nAme>!',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, const [
+        TextSpan(text: 'Hello', style: greetingStyle),
+        TextSpan(text: ', my name is '),
+        TextSpan(text: 'George', style: nameStyle),
+        TextSpan(text: '!'),
+      ]);
+    });
+
+    testWidgets('asserts tags are not nested', (tester) async {
+      final widget = TaggedText(
+        content: '<greeting>Hello, my name is <name>George</name></greeting>!',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      expect(tester.takeException(), isAssertionError);
+    });
+
+    testWidgets('asserts all tags in content are found', (tester) async {
+      final widget = TaggedText(
+        content:
+            '<salutation>Hello</salutation>, my name is <name>George</name>!',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      expect(tester.takeException(), isAssertionError);
+    });
+
+    testWidgets('rebuilds when content changes', (tester) async {
+      final widget = TaggedText(
+        content: 'Hello, Bob',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+      await tester.pumpWidget(wrap(widget));
+      final newWidget = TaggedText(
+        content: 'Hello, <name>Bob</name>',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(newWidget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, const [
+        TextSpan(text: 'Hello, '),
+        TextSpan(text: 'Bob', style: nameStyle),
+      ]);
+    });
+
+    testWidgets('rebuilds when tagToTextSpanBuilder changes', (tester) async {
+      final widget = TaggedText(
+        content: 'Hello, <name>Bob</name>',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+      await tester.pumpWidget(wrap(widget));
+      const updatedStyle = TextStyle(decoration: TextDecoration.overline);
+      final newWidget = TaggedText(
+        content: 'Hello, <name>Bob</name>',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: updatedStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(newWidget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, const [
+        TextSpan(text: 'Hello, '),
+        TextSpan(text: 'Bob', style: updatedStyle),
+      ]);
+    });
+
+    testWidgets('does not rebuild when tagToTextSpanBuilder stays the same',
+        (tester) async {
+      // Set up.
+      final mockTextSpanBuilder = MockTextSpanBuilder();
+      const nameSpan = TextSpan(text: 'Bob', style: nameStyle);
+      when(mockTextSpanBuilder.call(any)).thenReturn(nameSpan);
+
+      const content = 'Hello, <name>Bob</name>';
+      final tagToTextSpanBuilder = <String, TextSpanBuilder>{
+        // TODO Eliminate this wrapper when the Dart 2 FE
+        // supports mocking and tearoffs.
+        'name': (x) => mockTextSpanBuilder(x),
+      };
+      final widget = TaggedText(
+        content: content,
+        tagToTextSpanBuilder: tagToTextSpanBuilder,
+      );
+      await tester.pumpWidget(wrap(widget));
+
+      // Clone map to make sure that equality is checked by the contents of the
+      // map.
+      final newWidget = TaggedText(
+        content: content,
+        tagToTextSpanBuilder: Map.from(tagToTextSpanBuilder),
+      );
+
+      // Act.
+      await tester.pumpWidget(wrap(newWidget));
+
+      // Assert.
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, [
+        const TextSpan(text: 'Hello, '),
+        nameSpan,
+      ]);
+      verify(mockTextSpanBuilder.call(any)).called(1);
+    });
+
+    testWidgets('requires tag names to be lower case', (tester) async {
+      expect(
+          () => TaggedText(
+                content: 'Hello, <name>Bob</name>',
+                tagToTextSpanBuilder: {
+                  'nAme': (text) => TextSpan(text: text, style: nameStyle),
+                },
+              ),
+          throwsA(anything));
+    });
+
+    testWidgets('throws error when known HTML tags are used', (tester) async {
+      expect(() {
+        TaggedText(
+          content: 'Hello, <link>Bob</link>',
+          tagToTextSpanBuilder: {
+            'link': (text) => TextSpan(text: text, style: nameStyle),
+          },
+        );
+      }, throwsA(anything));
+    });
+
+    testWidgets('ignores non-elements', (tester) async {
+      final widget = TaggedText(
+        content: 'Hello, <!-- comment is not an element and is ignored -->'
+            '<name>Bob</name>',
+        tagToTextSpanBuilder: {
+          'name': (text) => TextSpan(text: text, style: nameStyle),
+        },
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      final textSpan = getTextSpan(richText);
+      expect(textSpan.text, isNull);
+      expect(textSpan.children, const [
+        TextSpan(text: 'Hello, '),
+        TextSpan(text: 'Bob', style: nameStyle),
+      ]);
+    });
+
+    testWidgets('renders correct input styles', (tester) async {
+      final widget = TaggedText(
+        content: '<greeting>Hello</greeting>',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+        },
+        style: defaultStyle,
+        textAlign: TextAlign.center,
+        textDirection: TextDirection.rtl,
+        softWrap: false,
+        overflow: TextOverflow.ellipsis,
+        textScaleFactor: 1.5,
+        maxLines: 2,
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      expect(richText.text.style, equals(defaultStyle));
+      expect(richText.textAlign, equals(TextAlign.center));
+      expect(richText.textDirection, equals(TextDirection.rtl));
+      expect(richText.softWrap, isFalse);
+      expect(richText.overflow, equals(TextOverflow.ellipsis));
+      expect(richText.textScaleFactor, equals(1.5));
+      expect(richText.maxLines, equals(2));
+    });
+
+    testWidgets(
+        'uses 1.0 text scale factor when not specified and '
+        'MediaQuery unavailable', (tester) async {
+      final widget = TaggedText(
+        content: '<greeting>Hello</greeting>',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+        },
+        // Text scale factor not specified!
+      );
+
+      await tester.pumpWidget(wrap(widget));
+
+      final richText = findRichTextWidget(tester);
+      expect(richText.textScaleFactor, equals(1.0));
+    });
+
+    testWidgets('uses MediaQuery text scale factor when available',
+        (tester) async {
+      final widget = TaggedText(
+        content: '<greeting>Hello</greeting>',
+        tagToTextSpanBuilder: {
+          'greeting': (text) => TextSpan(text: text, style: greetingStyle),
+        },
+        // Text scale factor not specified!
+      );
+      const expectedTextScaleFactor = 123.4;
+
+      await tester.pumpWidget(wrap(MediaQuery(
+        data: const MediaQueryData(textScaleFactor: expectedTextScaleFactor),
+        child: widget,
+      )));
+
+      final richText = findRichTextWidget(tester);
+      expect(richText.textScaleFactor, equals(expectedTextScaleFactor));
+    });
+  });
+}
+
+RichText findRichTextWidget(WidgetTester tester) {
+  final richTextFinder = find.byType(RichText);
+  expect(richTextFinder, findsOneWidget);
+  return tester.widget(richTextFinder) as RichText;
+}
+
+TextSpan getTextSpan(RichText richText) {
+  expect(richText.text, isA<TextSpan>());
+  return richText.text as TextSpan;
+}
+
+Widget wrap(Widget widget) {
+  return Directionality(
+    textDirection: TextDirection.ltr,
+    child: widget,
+  );
+}
+
+class MockTextSpanBuilder extends Mock {
+  TextSpan call(String text);
+}


### PR DESCRIPTION
We use two widgets from this package: `LinkedScrollControllerGroup` and `TaggedText`. Copying these widgets into our codebase eliminates the dependency on flutter_widgets, which is creating challenges with package rolls into Google.