### PR TITLE
Stop disposing Notifications and Controllers from import_export.

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/flutter/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/config_specific/flutter/import_export/import_export.dart
@@ -17,13 +17,8 @@ class ImportController {
 
   final NotificationsState _notifications;
 
+  // ignore: unused_field
   final ProvidedControllers _controllers;
-
-  void dispose() {
-    // TODO(Kenzie): Disabled see issue https://github.com/flutter/devtools/issues/1637.
-//    notifications?.dispose();
-    _controllers?.dispose();
-  }
 
   void importData(Map<String, dynamic> json) {
     final devToolsScreen = json['dartDevToolsScreen'];

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -122,7 +122,6 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   @override
   void dispose() {
     _controller?.dispose();
-    _importController.dispose();
     appBarAnimation?.dispose();
     super.dispose();
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1637.