### PR TITLE
extent_delegate_list

### DIFF
--- a/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
@@ -310,8 +310,9 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
     } else {
       collectGarbage(0, 0);
       if (!addInitialChild(
-          index: firstIndex,
-          layoutOffset: _extentDelegate.layoutOffset(firstIndex))) {
+        index: firstIndex,
+        layoutOffset: _extentDelegate.layoutOffset(firstIndex),
+      )) {
         // There are either no children, or we are past the end of all our children.
         // If it is the latter, we will need to find the first available child.
         double max;
@@ -353,11 +354,11 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
         // Reset the scroll offset to offset all items prior and up to the
         // missing item. Let parent re-layout everything.
         geometry = SliverGeometry(
-            scrollOffsetCorrection: _extentDelegate.layoutOffset(index));
+          scrollOffsetCorrection: _extentDelegate.layoutOffset(index),
+        );
         return;
       }
-      final SliverMultiBoxAdaptorParentData childParentData =
-          child.parentData as SliverMultiBoxAdaptorParentData;
+      final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
       childParentData.layoutOffset = _extentDelegate.layoutOffset(index);
       assert(childParentData.index == index);
       trailingChildWithLayout ??= child;
@@ -366,7 +367,7 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
     if (trailingChildWithLayout == null) {
       firstChild.layout(buildChildConstraints(firstIndex));
       final SliverMultiBoxAdaptorParentData childParentData =
-          firstChild.parentData as SliverMultiBoxAdaptorParentData;
+          firstChild.parentData;
       childParentData.layoutOffset = _extentDelegate.layoutOffset(firstIndex);
       trailingChildWithLayout = firstChild;
     }
@@ -378,8 +379,10 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
         ++index) {
       RenderBox child = childAfter(trailingChildWithLayout);
       if (child == null || indexOf(child) != index) {
-        child = insertAndLayoutChild(buildChildConstraints(index),
-            after: trailingChildWithLayout);
+        child = insertAndLayoutChild(
+          buildChildConstraints(index),
+          after: trailingChildWithLayout,
+        );
         if (child == null) {
           // We have run out of children.
           estimatedMaxScrollOffset = _extentDelegate.layoutOffset(index + 1);
@@ -390,8 +393,7 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
       }
       trailingChildWithLayout = child;
       assert(child != null);
-      final SliverMultiBoxAdaptorParentData childParentData =
-          child.parentData as SliverMultiBoxAdaptorParentData;
+      final SliverMultiBoxAdaptorParentData childParentData = child.parentData;
       assert(childParentData.index == index);
       childParentData.layoutOffset =
           _extentDelegate.layoutOffset(childParentData.index);

--- a/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
@@ -309,6 +309,9 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
       collectGarbage(leadingGarbage, trailingGarbage);
     } else {
       collectGarbage(0, 0);
+    }
+
+    if (firstChild == null) {
       if (!addInitialChild(
         index: firstIndex,
         layoutOffset: _extentDelegate.layoutOffset(firstIndex),
@@ -341,6 +344,7 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
           maxPaintExtent: max,
         );
         childManager.didFinishLayout();
+        return;
       }
     }
 

--- a/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
@@ -1,0 +1,459 @@
+import 'dart:math' as math;
+
+import 'package:collection/collection.dart' as collection;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+
+/// Base class for delegate providing extent information for items in a list.
+abstract class ExtentDelegate {
+  /// Optional callback to execute after the layout of the extents is modified.
+  VoidCallback onLayoutDirty;
+
+  int get length;
+
+  /// The main-axis extent of each item.
+  double getItemExtent(int index);
+
+  /// The layout offset for the child with the given index.
+  double indexToLayoutOffset(int index);
+
+  /// The minimum child index that is visible at the given scroll offset.
+  ///
+  /// Implementations should take no more than O(log n) time.
+  int getMinChildIndexForScrollOffset(double scrollOffset);
+
+  /// The maximum child index that is visible at the given scroll offset.
+  ///
+  /// Implementations should take no more than O(log n) time.
+  /// Surprisingly, getMaxChildIndexForScrollOffset should be 1 less than
+  /// getMinChildIndexForScrollOffset if the scrollOffset is right at the
+  /// boundary between two items.
+  int getMaxChildIndexForScrollOffset(double scrollOffset);
+
+  @mustCallSuper
+  void recompute() {
+    if (onLayoutDirty != null) {
+      onLayoutDirty();
+    }
+  }
+}
+
+/// [ExtentDelegate]  implementation for the case where sizes for each
+/// item are known but absolute positions are not known.
+class FixedExtentDelegate extends ExtentDelegate {
+  FixedExtentDelegate({
+    @required this.computeExtent,
+    @required this.computeLength,
+  }) {
+    recompute();
+  }
+
+  List<double> _totalExtent;
+
+  @override
+  int get length => _totalExtent.length - 1;
+
+  final double Function(int index) computeExtent;
+  final int Function() computeLength;
+
+  @override
+  void recompute() {
+    final length = computeLength();
+    _totalExtent = List(length + 1);
+    double total = 0;
+    _totalExtent[0] = 0;
+    for (int i = 0; i < length; ++i) {
+      total += computeExtent(i);
+      _totalExtent[i + 1] = total;
+    }
+
+    super.recompute();
+  }
+
+  @override
+  double getItemExtent(int index) {
+    if (index >= length) return 0;
+    return _totalExtent[index + 1] - _totalExtent[index];
+  }
+
+  @override
+  double indexToLayoutOffset(int index) {
+    if (index >= _totalExtent.length) return _totalExtent.last;
+    return _totalExtent[index];
+  }
+
+  @override
+  int getMinChildIndexForScrollOffset(double scrollOffset) {
+    int index = collection.lowerBound(_totalExtent, scrollOffset);
+    if (index == 0) return 0;
+    if (index >= _totalExtent.length ||
+        (_totalExtent[index] - scrollOffset).abs() > precisionErrorTolerance) {
+      index--;
+    }
+    assert(_totalExtent[index] <= scrollOffset + precisionErrorTolerance);
+    return index;
+  }
+
+  @override
+  int getMaxChildIndexForScrollOffset(double scrollOffset) {
+    int index = collection.lowerBound(_totalExtent, scrollOffset);
+    // TODO(jacobr): review.
+    if (index == 0) return 0;
+    index--;
+    assert(_totalExtent[index] < scrollOffset);
+    return index;
+  }
+}
+
+/// A scrollable list of widgets arranged linearly where each item has an extent
+/// specified by the [extentDelegate].
+///
+/// This class is inspired by the functionality in [ListView] where
+/// `itemExtent` is specified. The difference is the extentDelegate provided
+/// here specifies different extents for each item in the list and provides
+/// the ability to animate extents without rebuilding the list. You should use
+/// ListView instead for the simpler case where all items have the same extent.
+///
+/// Using this class is more efficient than using a ListView without specifying
+/// itemExtent as only items visible on screen need to be built and laid out.
+/// This class is more robust than ListView for cases where ListView items off
+/// screen need to be animated.
+class ExtentDelegateListView extends BoxScrollView {
+  const ExtentDelegateListView({
+    Key key,
+    Axis scrollDirection = Axis.vertical,
+    bool reverse = false,
+    ScrollController controller,
+    bool primary,
+    ScrollPhysics physics,
+    bool shrinkWrap = false,
+    EdgeInsetsGeometry padding,
+    @required this.childrenDelegate,
+    @required this.extentDelegate,
+    int semanticChildCount,
+  })  : assert(childrenDelegate != null),
+        super(
+          key: key,
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: controller,
+          primary: primary,
+          physics: physics,
+          shrinkWrap: shrinkWrap,
+          padding: padding,
+          semanticChildCount: semanticChildCount,
+        );
+
+  /// A delegate that provides the children for the [ExtentDelegateListView].
+  final SliverChildDelegate childrenDelegate;
+
+  /// A delegate that provides item extents for the children of the
+  ///  [ExtentDelegateListView].
+  final ExtentDelegate extentDelegate;
+
+  @override
+  Widget buildChildLayout(BuildContext context) {
+    return SliverExtentDelegateList(
+      delegate: childrenDelegate,
+      extentDelegate: extentDelegate,
+    );
+  }
+}
+
+/// A sliver that places multiple box children in a linear array.
+///
+/// The  main axis extents on each child are specified by a delegate.
+///
+/// This class is inspired by [SliverFixedExtentList] which provides similar
+/// functionality for the case where all items have the same extent.
+class SliverExtentDelegateList extends SliverMultiBoxAdaptorWidget {
+  /// Creates a sliver that places box children with the same main axis extent
+  /// in a linear array.
+  const SliverExtentDelegateList({
+    Key key,
+    @required SliverChildDelegate delegate,
+    @required this.extentDelegate,
+  }) : super(key: key, delegate: delegate);
+
+  /// The extent the children are forced to have in the main axis.
+  final ExtentDelegate extentDelegate;
+
+  @override
+  RenderSliverExtentDelegateBoxAdaptor createRenderObject(
+      BuildContext context) {
+    final SliverMultiBoxAdaptorElement element =
+        context as SliverMultiBoxAdaptorElement;
+    return RenderSliverExtentDelegateBoxAdaptor(
+      childManager: element,
+      extentDelegate: extentDelegate,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, RenderSliverExtentDelegateBoxAdaptor renderObject) {
+    renderObject.markNeedsLayout();
+    renderObject.extentDelegate = extentDelegate;
+  }
+}
+
+/// A sliver that contains multiple box children that each have known extent
+/// along the main axis.
+///
+/// This class is inspired by [RenderSliverFixedExtentBoxAdaptor] which provides
+/// similar functionality for the case where all items have the same extent.
+class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
+  /// Creates a sliver that contains multiple box children each of which have
+  /// extent along the main axis provided by [extentDelegate].
+  ///
+  /// The [childManager] argument must not be null.
+  RenderSliverExtentDelegateBoxAdaptor({
+    @required RenderSliverBoxChildManager childManager,
+    @required ExtentDelegate extentDelegate,
+  }) : super(childManager: childManager) {
+    this.extentDelegate = extentDelegate;
+  }
+
+  set extentDelegate(ExtentDelegate delegate) {
+    // We need to listen for when the delegate changes its layout.
+    delegate.onLayoutDirty = markNeedsLayout;
+    _extentDelegate = delegate;
+  }
+
+  ExtentDelegate _extentDelegate;
+
+  /// Called to estimate the total scrollable extents of this object.
+  ///
+  /// Must return the total distance from the start of the child with the
+  /// earliest possible index to the end of the child with the last possible
+  /// index.
+  ///
+  /// By default, defers to [RenderSliverBoxChildManager.estimateMaxScrollOffset].
+  @protected
+  double estimateMaxScrollOffset(
+    SliverConstraints constraints, {
+    int firstIndex,
+    int lastIndex,
+    double leadingScrollOffset,
+    double trailingScrollOffset,
+  }) {
+    return childManager.estimateMaxScrollOffset(
+      constraints,
+      firstIndex: firstIndex,
+      lastIndex: lastIndex,
+      leadingScrollOffset: leadingScrollOffset,
+      trailingScrollOffset: trailingScrollOffset,
+    );
+  }
+
+  int _calculateLeadingGarbage(int firstIndex) {
+    RenderBox walker = firstChild;
+    int leadingGarbage = 0;
+    while (walker != null && indexOf(walker) < firstIndex) {
+      leadingGarbage += 1;
+      walker = childAfter(walker);
+    }
+    return leadingGarbage;
+  }
+
+  int _calculateTrailingGarbage(int targetLastIndex) {
+    RenderBox walker = lastChild;
+    int trailingGarbage = 0;
+    while (walker != null && indexOf(walker) > targetLastIndex) {
+      trailingGarbage += 1;
+      walker = childBefore(walker);
+    }
+    return trailingGarbage;
+  }
+
+  BoxConstraints buildChildConstraints(int index) {
+    final currentItemExtent = _extentDelegate.getItemExtent(index);
+    return constraints.asBoxConstraints(
+      minExtent: currentItemExtent,
+      maxExtent: currentItemExtent,
+    );
+  }
+
+  // This method is is a fork of RenderSliverFixedExtentBoxAdaptor.performLayout
+  // where we defer computations about offsets to the _extendDelegate and try
+  // to avoid logic only applicable if all children have the same extent.
+  @override
+  void performLayout() {
+    childManager.didStartLayout();
+    childManager.setDidUnderflow(false);
+
+    final double scrollOffset =
+        constraints.scrollOffset + constraints.cacheOrigin;
+    assert(scrollOffset >= 0.0);
+    final double remainingExtent = constraints.remainingCacheExtent;
+    assert(remainingExtent >= 0.0);
+    final double targetEndScrollOffset = scrollOffset + remainingExtent;
+
+    final int firstIndex =
+        _extentDelegate.getMinChildIndexForScrollOffset(scrollOffset);
+    final int targetLastIndex = targetEndScrollOffset.isFinite
+        ? _extentDelegate.getMaxChildIndexForScrollOffset(targetEndScrollOffset)
+        : null;
+
+    if (firstChild != null) {
+      final int leadingGarbage = _calculateLeadingGarbage(firstIndex);
+      final int trailingGarbage = _calculateTrailingGarbage(targetLastIndex);
+      collectGarbage(leadingGarbage, trailingGarbage);
+    } else {
+      collectGarbage(0, 0);
+    }
+
+    if (firstChild == null) {
+      if (!addInitialChild(
+          index: firstIndex,
+          layoutOffset: _extentDelegate.indexToLayoutOffset(firstIndex))) {
+        // There are either no children, or we are past the end of all our children.
+        // If it is the latter, we will need to find the first available child.
+        double max;
+        if (childManager.childCount != null) {
+          // TODO(jacobr): is this correct?
+          // This matches the logic from sliver_fixed_extent_list but it seems
+          // a little odd. This is only right if the childManager contains all
+          // children added to the list view.
+          max = _extentDelegate.indexToLayoutOffset(childManager.childCount);
+        } else if (firstIndex <= 0) {
+          max = 0.0;
+        } else {
+          // We will have to find it manually.
+          int possibleFirstIndex = firstIndex - 1;
+          while (possibleFirstIndex > 0 &&
+              !addInitialChild(
+                index: possibleFirstIndex,
+                layoutOffset:
+                    _extentDelegate.indexToLayoutOffset(possibleFirstIndex),
+              )) {
+            possibleFirstIndex -= 1;
+          }
+          max = _extentDelegate.indexToLayoutOffset(possibleFirstIndex);
+        }
+        geometry = SliverGeometry(
+          scrollExtent: max,
+          maxPaintExtent: max,
+        );
+        childManager.didFinishLayout();
+        return;
+      }
+    }
+
+    RenderBox trailingChildWithLayout;
+
+    for (int index = indexOf(firstChild) - 1; index >= firstIndex; --index) {
+      final RenderBox child =
+          insertAndLayoutLeadingChild(buildChildConstraints(index));
+      if (child == null) {
+        // Items before the previously first child are no longer present.
+        // Reset the scroll offset to offset all items prior and up to the
+        // missing item. Let parent re-layout everything.
+        geometry = SliverGeometry(
+            scrollOffsetCorrection: _extentDelegate.indexToLayoutOffset(index));
+        return;
+      }
+      final SliverMultiBoxAdaptorParentData childParentData =
+          child.parentData as SliverMultiBoxAdaptorParentData;
+      childParentData.layoutOffset = _extentDelegate.indexToLayoutOffset(index);
+      assert(childParentData.index == index);
+      trailingChildWithLayout ??= child;
+    }
+
+    if (trailingChildWithLayout == null) {
+      firstChild.layout(buildChildConstraints(firstIndex));
+      final SliverMultiBoxAdaptorParentData childParentData =
+          firstChild.parentData as SliverMultiBoxAdaptorParentData;
+      childParentData.layoutOffset =
+          _extentDelegate.indexToLayoutOffset(firstIndex);
+      trailingChildWithLayout = firstChild;
+    }
+
+    double estimatedMaxScrollOffset =
+        _extentDelegate.indexToLayoutOffset(_extentDelegate.length);
+    for (int index = indexOf(trailingChildWithLayout) + 1;
+        targetLastIndex == null || index <= targetLastIndex;
+        ++index) {
+      RenderBox child = childAfter(trailingChildWithLayout);
+      if (child == null || indexOf(child) != index) {
+        child = insertAndLayoutChild(buildChildConstraints(index),
+            after: trailingChildWithLayout);
+        if (child == null) {
+          // We have run out of children.
+          estimatedMaxScrollOffset =
+              _extentDelegate.indexToLayoutOffset(index + 1);
+          break;
+        }
+      } else {
+        child.layout(buildChildConstraints(index));
+      }
+      trailingChildWithLayout = child;
+      assert(child != null);
+      final SliverMultiBoxAdaptorParentData childParentData =
+          child.parentData as SliverMultiBoxAdaptorParentData;
+      assert(childParentData.index == index);
+      childParentData.layoutOffset =
+          _extentDelegate.indexToLayoutOffset(childParentData.index);
+    }
+
+    final int lastIndex = indexOf(lastChild);
+    final double leadingScrollOffset =
+        _extentDelegate.indexToLayoutOffset(firstIndex);
+    final double trailingScrollOffset =
+        _extentDelegate.indexToLayoutOffset(lastIndex + 1);
+
+    assert(firstIndex == 0 ||
+        childScrollOffset(firstChild) - scrollOffset <=
+            precisionErrorTolerance);
+    assert(debugAssertChildListIsNonEmptyAndContiguous());
+    assert(indexOf(firstChild) == firstIndex);
+    assert(targetLastIndex == null || lastIndex <= targetLastIndex);
+
+    estimatedMaxScrollOffset = math.min(
+      estimatedMaxScrollOffset,
+      estimateMaxScrollOffset(
+        constraints,
+        firstIndex: firstIndex,
+        lastIndex: lastIndex,
+        leadingScrollOffset: leadingScrollOffset,
+        trailingScrollOffset: trailingScrollOffset,
+      ),
+    );
+
+    final double paintExtent = calculatePaintOffset(
+      constraints,
+      from: leadingScrollOffset,
+      to: trailingScrollOffset,
+    );
+
+    final double cacheExtent = calculateCacheOffset(
+      constraints,
+      from: leadingScrollOffset,
+      to: trailingScrollOffset,
+    );
+
+    final double targetEndScrollOffsetForPaint =
+        constraints.scrollOffset + constraints.remainingPaintExtent;
+    final int targetLastIndexForPaint = targetEndScrollOffsetForPaint.isFinite
+        ? _extentDelegate
+            .getMaxChildIndexForScrollOffset(targetEndScrollOffsetForPaint)
+        : null;
+    geometry = SliverGeometry(
+      scrollExtent: estimatedMaxScrollOffset,
+      paintExtent: paintExtent,
+      cacheExtent: cacheExtent,
+      maxPaintExtent: estimatedMaxScrollOffset,
+      // Conservative to avoid flickering away the clip during scroll.
+      hasVisualOverflow: (targetLastIndexForPaint != null &&
+              lastIndex >= targetLastIndexForPaint) ||
+          constraints.scrollOffset > 0.0,
+    );
+
+    // We may have started the layout while scrolled to the end, which would not
+    // expose a new child.
+    if (estimatedMaxScrollOffset == trailingScrollOffset)
+      childManager.setDidUnderflow(true);
+    childManager.didFinishLayout();
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
@@ -107,7 +107,6 @@ class FixedExtentDelegate extends ExtentDelegate {
   @override
   int maxChildIndexForScrollOffset(double scrollOffset) {
     int index = collection.lowerBound(_offsets, scrollOffset);
-    // TODO(jacobr): review.
     if (index == 0) return 0;
     index--;
     assert(_offsets[index] < scrollOffset);
@@ -158,7 +157,7 @@ class ExtentDelegateListView extends BoxScrollView {
   final SliverChildDelegate childrenDelegate;
 
   /// A delegate that provides item extents for the children of the
-  ///  [ExtentDelegateListView].
+  /// [ExtentDelegateListView].
   final ExtentDelegate extentDelegate;
 
   @override
@@ -172,7 +171,7 @@ class ExtentDelegateListView extends BoxScrollView {
 
 /// A sliver that places multiple box children in a linear array.
 ///
-/// The  main axis extents on each child are specified by a delegate.
+/// The main axis extents on each child are specified by a delegate.
 ///
 /// This class is inspired by [SliverFixedExtentList] which provides similar
 /// functionality for the case where all items have the same extent.
@@ -191,8 +190,7 @@ class SliverExtentDelegateList extends SliverMultiBoxAdaptorWidget {
   @override
   RenderSliverExtentDelegateBoxAdaptor createRenderObject(
       BuildContext context) {
-    final SliverMultiBoxAdaptorElement element =
-        context as SliverMultiBoxAdaptorElement;
+    final SliverMultiBoxAdaptorElement element = context;
     return RenderSliverExtentDelegateBoxAdaptor(
       childManager: element,
       extentDelegate: extentDelegate,
@@ -311,9 +309,6 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
       collectGarbage(leadingGarbage, trailingGarbage);
     } else {
       collectGarbage(0, 0);
-    }
-
-    if (firstChild == null) {
       if (!addInitialChild(
           index: firstIndex,
           layoutOffset: _extentDelegate.layoutOffset(firstIndex))) {
@@ -345,7 +340,6 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
           maxPaintExtent: max,
         );
         childManager.didFinishLayout();
-        return;
       }
     }
 
@@ -457,8 +451,9 @@ class RenderSliverExtentDelegateBoxAdaptor extends RenderSliverMultiBoxAdaptor {
 
     // We may have started the layout while scrolled to the end, which would not
     // expose a new child.
-    if (estimatedMaxScrollOffset == trailingScrollOffset)
+    if (estimatedMaxScrollOffset == trailingScrollOffset) {
       childManager.setDidUnderflow(true);
+    }
     childManager.didFinishLayout();
   }
 }

--- a/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
@@ -1,0 +1,243 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/extent_delegate_list.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'rendering_tester.dart';
+
+class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
+  TestRenderSliverBoxChildManager({
+    @required this.children,
+    @required this.extentDelegate,
+  });
+
+  RenderSliverExtentDelegateBoxAdaptor _renderObject;
+  List<RenderBox> children;
+
+  RenderSliverExtentDelegateBoxAdaptor createRenderSliverExtentDelegate() {
+    assert(_renderObject == null);
+    _renderObject = RenderSliverExtentDelegateBoxAdaptor(
+      childManager: this,
+      extentDelegate: extentDelegate,
+    );
+    return _renderObject;
+  }
+
+  final ExtentDelegate extentDelegate;
+
+  int _currentlyUpdatingChildIndex;
+
+  @override
+  void createChild(int index, {@required RenderBox after}) {
+    if (index < 0 || index >= children.length) return;
+    try {
+      _currentlyUpdatingChildIndex = index;
+      _renderObject.insert(children[index], after: after);
+    } finally {
+      _currentlyUpdatingChildIndex = null;
+    }
+  }
+
+  @override
+  void removeChild(RenderBox child) {
+    _renderObject.remove(child);
+  }
+
+  @override
+  double estimateMaxScrollOffset(
+    SliverConstraints constraints, {
+    int firstIndex,
+    int lastIndex,
+    double leadingScrollOffset,
+    double trailingScrollOffset,
+  }) {
+    assert(lastIndex >= firstIndex);
+    return children.length *
+        (trailingScrollOffset - leadingScrollOffset) /
+        (lastIndex - firstIndex + 1);
+  }
+
+  @override
+  int get childCount => children.length;
+
+  @override
+  void didAdoptChild(RenderBox child) {
+    assert(_currentlyUpdatingChildIndex != null);
+    final SliverMultiBoxAdaptorParentData childParentData =
+        child.parentData as SliverMultiBoxAdaptorParentData;
+    childParentData.index = _currentlyUpdatingChildIndex;
+  }
+
+  @override
+  void setDidUnderflow(bool value) {}
+}
+
+void main() {
+  group('RenderSliverFixedExtentList', () {
+    group('extentDelegate', () {
+      test('itemExtent', () {
+        final extents = [100.0, 200.0, 50.0, 100.0];
+        final extentDelegate = FixedExtentDelegate(
+            // Create items with increasing extents.
+            computeExtent: (index) => extents[index],
+            computeLength: () => extents.length);
+
+        expect(extentDelegate.length, equals(4));
+        for (int i = 0; i < extents.length; i++) {
+          expect(extentDelegate.getItemExtent(i), extents[i]);
+        }
+        expect(extentDelegate.getItemExtent(1), 200.0);
+        extents[1] = 500.0;
+        extentDelegate.recompute();
+        expect(extentDelegate.getItemExtent(1), 500.0);
+      });
+
+      test('getMinChildIndexForScrollOffset', () {
+        final extents = [100.0, 200.0, 50.0, 100.0];
+        final extentDelegate = FixedExtentDelegate(
+            // Create items with increasing extents.
+            computeExtent: (index) => extents[index],
+            computeLength: () => extents.length);
+
+        expect(extentDelegate.getMinChildIndexForScrollOffset(0), 0);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(-1000), 0);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(99), 0);
+        expect(
+            extentDelegate.getMinChildIndexForScrollOffset(99.99999999999), 1);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(250), 1);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(299), 1);
+        expect(
+            extentDelegate.getMinChildIndexForScrollOffset(299.99999999999), 2);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(300), 2);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(330), 2);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(350), 3);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(449), 3);
+        // Off the end of the list.
+        expect(extentDelegate.getMinChildIndexForScrollOffset(450), 4);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(1000000), 4);
+      });
+
+      try {
+        test('getMaxChildIndexForScrollOffset', () {
+          final extents = [100.0, 200.0, 50.0, 100.0];
+          final extentDelegate = FixedExtentDelegate(
+              // Create items with increasing extents.
+              computeExtent: (index) => extents[index],
+              computeLength: () => extents.length);
+
+          // The behavior is a bit counter intuitive but this matching the
+          // existing fixed extent behavior. The max child for an offset is
+          // actually intentionally less than the min child for the case that
+          // the child is right on the boundary.
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(0), 0);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(-1000), 0);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(99), 0);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(99.99999999999),
+              0);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(250), 1);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(299), 1);
+          expect(
+              extentDelegate.getMaxChildIndexForScrollOffset(299.99999999999),
+              1);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(300), 1);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(330), 2);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(350), 2);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(449), 3);
+          // Off the end of the list.
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(450), 3);
+          expect(extentDelegate.getMaxChildIndexForScrollOffset(1000000), 4);
+        });
+      } catch (e, s) {
+        print(s);
+      }
+
+      test('zeroHeightChildren', () {
+        // Zero height children could cause problems for the logic to find the
+        // min and max matching children.
+        final extents = [100.0, 200.0, 0.0, 0.0, 0.0, 100.0];
+        final extentDelegate = FixedExtentDelegate(
+            // Create items with increasing extents.
+            computeExtent: (index) => extents[index],
+            computeLength: () => extents.length);
+
+        expect(extentDelegate.getMinChildIndexForScrollOffset(299), 1);
+        expect(extentDelegate.getMaxChildIndexForScrollOffset(299), 1);
+        expect(
+            extentDelegate.getMinChildIndexForScrollOffset(299.999999999), 1);
+        expect(
+            extentDelegate.getMaxChildIndexForScrollOffset(299.999999999), 1);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(300), 2);
+        expect(extentDelegate.getMaxChildIndexForScrollOffset(300), 1);
+        expect(extentDelegate.getMinChildIndexForScrollOffset(301), 5);
+        expect(extentDelegate.getMaxChildIndexForScrollOffset(301), 5);
+      });
+    });
+
+    test('layout test - rounding error', () {
+      // These heights are ignored as the FixedExtentDelegate determines the
+      // size.
+      final List<RenderBox> children = <RenderBox>[
+        RenderSizedBox(const Size(400.0, 100.0)),
+        RenderSizedBox(const Size(400.0, 100.0)),
+        RenderSizedBox(const Size(400.0, 100.0)),
+      ];
+
+      // Value to tweak to change how large the items are.
+      double extentFactor = 800.0;
+      final extentDelegate = FixedExtentDelegate(
+          // Create items with increasing extents.
+          computeExtent: (index) => (index + 1) * extentFactor,
+          computeLength: () => children.length);
+      final TestRenderSliverBoxChildManager childManager =
+          TestRenderSliverBoxChildManager(
+        children: children,
+        extentDelegate: extentDelegate,
+      );
+      final RenderViewport root = RenderViewport(
+        axisDirection: AxisDirection.down,
+        crossAxisDirection: AxisDirection.right,
+        offset: ViewportOffset.zero(),
+        cacheExtent: 0,
+        children: <RenderSliver>[
+          childManager.createRenderSliverExtentDelegate(),
+        ],
+      );
+      layout(root);
+      // viewport is 800x600
+      // items have height 800, 1600, and 2400.
+      expect(children[0].attached, true);
+      expect(children[1].attached, false);
+
+      root.offset = ViewportOffset.fixed(800);
+      pumpFrame();
+      expect(children[0].attached, false);
+      expect(children[1].attached, true);
+      expect(children[2].attached, false);
+
+      // Simulate double precision error.
+      root.offset = ViewportOffset.fixed(2399.999999999998);
+      pumpFrame();
+      expect(children[0].attached, false);
+      expect(children[1].attached, false);
+      expect(children[2].attached, true);
+
+      root.offset = ViewportOffset.fixed(800);
+      pumpFrame();
+      expect(children[0].attached, false);
+      expect(children[1].attached, true);
+      expect(children[2].attached, false);
+
+      // simulate an animation.
+      extentFactor = 1000.0;
+      extentDelegate.recompute();
+      pumpFrame();
+      expect(children[0].attached, true);
+      expect(children[1].attached, true);
+      expect(children[2].attached, false);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
@@ -88,12 +88,12 @@ void main() {
 
         expect(extentDelegate.length, equals(4));
         for (int i = 0; i < extents.length; i++) {
-          expect(extentDelegate.getItemExtent(i), extents[i]);
+          expect(extentDelegate.itemExtent(i), extents[i]);
         }
-        expect(extentDelegate.getItemExtent(1), 200.0);
+        expect(extentDelegate.itemExtent(1), 200.0);
         extents[1] = 500.0;
         extentDelegate.recompute();
-        expect(extentDelegate.getItemExtent(1), 500.0);
+        expect(extentDelegate.itemExtent(1), 500.0);
       });
 
       test('getMinChildIndexForScrollOffset', () {
@@ -103,22 +103,22 @@ void main() {
             computeExtent: (index) => extents[index],
             computeLength: () => extents.length);
 
-        expect(extentDelegate.getMinChildIndexForScrollOffset(0), 0);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(-1000), 0);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(99), 0);
+        expect(extentDelegate.minChildIndexForScrollOffset(0), 0);
+        expect(extentDelegate.minChildIndexForScrollOffset(-1000), 0);
+        expect(extentDelegate.minChildIndexForScrollOffset(99), 0);
         expect(
-            extentDelegate.getMinChildIndexForScrollOffset(99.99999999999), 1);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(250), 1);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(299), 1);
+            extentDelegate.minChildIndexForScrollOffset(99.99999999999), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(250), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(299), 1);
         expect(
-            extentDelegate.getMinChildIndexForScrollOffset(299.99999999999), 2);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(300), 2);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(330), 2);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(350), 3);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(449), 3);
+            extentDelegate.minChildIndexForScrollOffset(299.99999999999), 2);
+        expect(extentDelegate.minChildIndexForScrollOffset(300), 2);
+        expect(extentDelegate.minChildIndexForScrollOffset(330), 2);
+        expect(extentDelegate.minChildIndexForScrollOffset(350), 3);
+        expect(extentDelegate.minChildIndexForScrollOffset(449), 3);
         // Off the end of the list.
-        expect(extentDelegate.getMinChildIndexForScrollOffset(450), 4);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(1000000), 4);
+        expect(extentDelegate.minChildIndexForScrollOffset(450), 4);
+        expect(extentDelegate.minChildIndexForScrollOffset(1000000), 4);
       });
 
       try {
@@ -133,23 +133,23 @@ void main() {
           // existing fixed extent behavior. The max child for an offset is
           // actually intentionally less than the min child for the case that
           // the child is right on the boundary.
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(0), 0);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(-1000), 0);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(99), 0);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(99.99999999999),
+          expect(extentDelegate.maxChildIndexForScrollOffset(0), 0);
+          expect(extentDelegate.maxChildIndexForScrollOffset(-1000), 0);
+          expect(extentDelegate.maxChildIndexForScrollOffset(99), 0);
+          expect(extentDelegate.maxChildIndexForScrollOffset(99.99999999999),
               0);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(250), 1);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(299), 1);
+          expect(extentDelegate.maxChildIndexForScrollOffset(250), 1);
+          expect(extentDelegate.maxChildIndexForScrollOffset(299), 1);
           expect(
-              extentDelegate.getMaxChildIndexForScrollOffset(299.99999999999),
+              extentDelegate.maxChildIndexForScrollOffset(299.99999999999),
               1);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(300), 1);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(330), 2);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(350), 2);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(449), 3);
+          expect(extentDelegate.maxChildIndexForScrollOffset(300), 1);
+          expect(extentDelegate.maxChildIndexForScrollOffset(330), 2);
+          expect(extentDelegate.maxChildIndexForScrollOffset(350), 2);
+          expect(extentDelegate.maxChildIndexForScrollOffset(449), 3);
           // Off the end of the list.
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(450), 3);
-          expect(extentDelegate.getMaxChildIndexForScrollOffset(1000000), 4);
+          expect(extentDelegate.maxChildIndexForScrollOffset(450), 3);
+          expect(extentDelegate.maxChildIndexForScrollOffset(1000000), 4);
         });
       } catch (e, s) {
         print(s);
@@ -164,16 +164,16 @@ void main() {
             computeExtent: (index) => extents[index],
             computeLength: () => extents.length);
 
-        expect(extentDelegate.getMinChildIndexForScrollOffset(299), 1);
-        expect(extentDelegate.getMaxChildIndexForScrollOffset(299), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(299), 1);
+        expect(extentDelegate.maxChildIndexForScrollOffset(299), 1);
         expect(
-            extentDelegate.getMinChildIndexForScrollOffset(299.999999999), 1);
+            extentDelegate.minChildIndexForScrollOffset(299.999999999), 1);
         expect(
-            extentDelegate.getMaxChildIndexForScrollOffset(299.999999999), 1);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(300), 2);
-        expect(extentDelegate.getMaxChildIndexForScrollOffset(300), 1);
-        expect(extentDelegate.getMinChildIndexForScrollOffset(301), 5);
-        expect(extentDelegate.getMaxChildIndexForScrollOffset(301), 5);
+            extentDelegate.maxChildIndexForScrollOffset(299.999999999), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(300), 2);
+        expect(extentDelegate.maxChildIndexForScrollOffset(300), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(301), 5);
+        expect(extentDelegate.maxChildIndexForScrollOffset(301), 5);
       });
     });
 

--- a/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
@@ -106,12 +106,10 @@ void main() {
         expect(extentDelegate.minChildIndexForScrollOffset(0), 0);
         expect(extentDelegate.minChildIndexForScrollOffset(-1000), 0);
         expect(extentDelegate.minChildIndexForScrollOffset(99), 0);
-        expect(
-            extentDelegate.minChildIndexForScrollOffset(99.99999999999), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(99.99999999999), 1);
         expect(extentDelegate.minChildIndexForScrollOffset(250), 1);
         expect(extentDelegate.minChildIndexForScrollOffset(299), 1);
-        expect(
-            extentDelegate.minChildIndexForScrollOffset(299.99999999999), 2);
+        expect(extentDelegate.minChildIndexForScrollOffset(299.99999999999), 2);
         expect(extentDelegate.minChildIndexForScrollOffset(300), 2);
         expect(extentDelegate.minChildIndexForScrollOffset(330), 2);
         expect(extentDelegate.minChildIndexForScrollOffset(350), 3);
@@ -136,13 +134,12 @@ void main() {
           expect(extentDelegate.maxChildIndexForScrollOffset(0), 0);
           expect(extentDelegate.maxChildIndexForScrollOffset(-1000), 0);
           expect(extentDelegate.maxChildIndexForScrollOffset(99), 0);
-          expect(extentDelegate.maxChildIndexForScrollOffset(99.99999999999),
-              0);
+          expect(
+              extentDelegate.maxChildIndexForScrollOffset(99.99999999999), 0);
           expect(extentDelegate.maxChildIndexForScrollOffset(250), 1);
           expect(extentDelegate.maxChildIndexForScrollOffset(299), 1);
           expect(
-              extentDelegate.maxChildIndexForScrollOffset(299.99999999999),
-              1);
+              extentDelegate.maxChildIndexForScrollOffset(299.99999999999), 1);
           expect(extentDelegate.maxChildIndexForScrollOffset(300), 1);
           expect(extentDelegate.maxChildIndexForScrollOffset(330), 2);
           expect(extentDelegate.maxChildIndexForScrollOffset(350), 2);
@@ -166,10 +163,8 @@ void main() {
 
         expect(extentDelegate.minChildIndexForScrollOffset(299), 1);
         expect(extentDelegate.maxChildIndexForScrollOffset(299), 1);
-        expect(
-            extentDelegate.minChildIndexForScrollOffset(299.999999999), 1);
-        expect(
-            extentDelegate.maxChildIndexForScrollOffset(299.999999999), 1);
+        expect(extentDelegate.minChildIndexForScrollOffset(299.999999999), 1);
+        expect(extentDelegate.maxChildIndexForScrollOffset(299.999999999), 1);
         expect(extentDelegate.minChildIndexForScrollOffset(300), 2);
         expect(extentDelegate.maxChildIndexForScrollOffset(300), 1);
         expect(extentDelegate.minChildIndexForScrollOffset(301), 5);

--- a/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_list_test.dart
@@ -127,13 +127,13 @@ void main() {
               computeExtent: (index) => extents[index],
               computeLength: () => extents.length);
 
+          expect(extentDelegate.maxChildIndexForScrollOffset(0), 0);
+          expect(extentDelegate.maxChildIndexForScrollOffset(-1000), 0);
+          expect(extentDelegate.maxChildIndexForScrollOffset(99), 0);
           // The behavior is a bit counter intuitive but this matching the
           // existing fixed extent behavior. The max child for an offset is
           // actually intentionally less than the min child for the case that
           // the child is right on the boundary.
-          expect(extentDelegate.maxChildIndexForScrollOffset(0), 0);
-          expect(extentDelegate.maxChildIndexForScrollOffset(-1000), 0);
-          expect(extentDelegate.maxChildIndexForScrollOffset(99), 0);
           expect(
               extentDelegate.maxChildIndexForScrollOffset(99.99999999999), 0);
           expect(extentDelegate.maxChildIndexForScrollOffset(250), 1);
@@ -157,9 +157,10 @@ void main() {
         // min and max matching children.
         final extents = [100.0, 200.0, 0.0, 0.0, 0.0, 100.0];
         final extentDelegate = FixedExtentDelegate(
-            // Create items with increasing extents.
-            computeExtent: (index) => extents[index],
-            computeLength: () => extents.length);
+          // Create items with increasing extents.
+          computeExtent: (index) => extents[index],
+          computeLength: () => extents.length,
+        );
 
         expect(extentDelegate.minChildIndexForScrollOffset(299), 1);
         expect(extentDelegate.maxChildIndexForScrollOffset(299), 1);
@@ -184,9 +185,10 @@ void main() {
       // Value to tweak to change how large the items are.
       double extentFactor = 800.0;
       final extentDelegate = FixedExtentDelegate(
-          // Create items with increasing extents.
-          computeExtent: (index) => (index + 1) * extentFactor,
-          computeLength: () => children.length);
+        // Create items with increasing extents.
+        computeExtent: (index) => (index + 1) * extentFactor,
+        computeLength: () => children.length,
+      );
       final TestRenderSliverBoxChildManager childManager =
           TestRenderSliverBoxChildManager(
         children: children,

--- a/packages/devtools_app/test/flutter/rendering_tester.dart
+++ b/packages/devtools_app/test/flutter/rendering_tester.dart
@@ -1,0 +1,299 @@
+// Copyright 2020 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// This file is copied from package:flutter/test/rendering_tester.dart
+// and is convenient for adding tests to render object behavior similar to
+// existing tests implemented in package:flutter.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart' show EnginePhase, fail;
+
+export 'package:flutter/foundation.dart' show FlutterError, FlutterErrorDetails;
+export 'package:flutter_test/flutter_test.dart' show EnginePhase;
+
+class TestRenderingFlutterBinding extends BindingBase
+    with
+        ServicesBinding,
+        GestureBinding,
+        SchedulerBinding,
+        PaintingBinding,
+        SemanticsBinding,
+        RendererBinding {
+  /// Creates a binding for testing rendering library functionality.
+  ///
+  /// If [onErrors] is not null, it is called if [FlutterError] caught any errors
+  /// while drawing the frame. If [onErrors] is null and [FlutterError] caught at least
+  /// one error, this function fails the test. A test may override [onErrors] and
+  /// inspect errors using [takeFlutterErrorDetails].
+  TestRenderingFlutterBinding({this.onErrors});
+
+  final List<FlutterErrorDetails> _errors = <FlutterErrorDetails>[];
+
+  /// A function called after drawing a frame if [FlutterError] caught any errors.
+  ///
+  /// This function is expected to inspect these errors and decide whether they
+  /// are expected or not. Use [takeFlutterErrorDetails] to take one error at a
+  /// time, or [takeAllFlutterErrorDetails] to iterate over all errors.
+  VoidCallback onErrors;
+
+  /// Returns the error least recently caught by [FlutterError] and removes it
+  /// from the list of captured errors.
+  ///
+  /// Returns null if no errors were captures, or if the list was exhausted by
+  /// calling this method repeatedly.
+  FlutterErrorDetails takeFlutterErrorDetails() {
+    if (_errors.isEmpty) {
+      return null;
+    }
+    return _errors.removeAt(0);
+  }
+
+  /// Returns all error details caught by [FlutterError] from least recently caught to
+  /// most recently caught, and removes them from the list of captured errors.
+  ///
+  /// The returned iterable takes errors lazily. If, for example, you iterate over 2
+  /// errors, but there are 5 errors total, this binding will still fail the test.
+  /// Tests are expected to take and inspect all errors.
+  Iterable<FlutterErrorDetails> takeAllFlutterErrorDetails() sync* {
+    // sync* and yield are used for lazy evaluation. Otherwise, the list would be
+    // drained eagerly and allow a test pass with unexpected errors.
+    while (_errors.isNotEmpty) {
+      yield _errors.removeAt(0);
+    }
+  }
+
+  /// Returns all exceptions caught by [FlutterError] from least recently caught to
+  /// most recently caught, and removes them from the list of captured errors.
+  ///
+  /// The returned iterable takes errors lazily. If, for example, you iterate over 2
+  /// errors, but there are 5 errors total, this binding will still fail the test.
+  /// Tests are expected to take and inspect all errors.
+  Iterable<dynamic> takeAllFlutterExceptions() sync* {
+    // sync* and yield are used for lazy evaluation. Otherwise, the list would be
+    // drained eagerly and allow a test pass with unexpected errors.
+    while (_errors.isNotEmpty) {
+      yield _errors.removeAt(0).exception;
+    }
+  }
+
+  EnginePhase phase = EnginePhase.composite;
+
+  @override
+  void drawFrame() {
+    assert(phase != EnginePhase.build,
+        'rendering_tester does not support testing the build phase; use flutter_test instead');
+    final FlutterExceptionHandler oldErrorHandler = FlutterError.onError;
+    FlutterError.onError = (FlutterErrorDetails details) {
+      _errors.add(details);
+    };
+    try {
+      pipelineOwner.flushLayout();
+      if (phase == EnginePhase.layout) return;
+      pipelineOwner.flushCompositingBits();
+      if (phase == EnginePhase.compositingBits) return;
+      pipelineOwner.flushPaint();
+      if (phase == EnginePhase.paint) return;
+      renderView.compositeFrame();
+      if (phase == EnginePhase.composite) return;
+      pipelineOwner.flushSemantics();
+      if (phase == EnginePhase.flushSemantics) return;
+      assert(phase == EnginePhase.flushSemantics ||
+          phase == EnginePhase.sendSemanticsUpdate);
+    } finally {
+      FlutterError.onError = oldErrorHandler;
+      if (_errors.isNotEmpty) {
+        if (onErrors != null) {
+          onErrors();
+          if (_errors.isNotEmpty) {
+            _errors.forEach(FlutterError.dumpErrorToConsole);
+            fail(
+                'There are more errors than the test inspected using TestRenderingFlutterBinding.takeFlutterErrorDetails.');
+          }
+        } else {
+          _errors.forEach(FlutterError.dumpErrorToConsole);
+          fail(
+              'Caught error while rendering frame. See preceding logs for details.');
+        }
+      }
+    }
+  }
+}
+
+TestRenderingFlutterBinding _renderer;
+TestRenderingFlutterBinding get renderer {
+  _renderer ??= TestRenderingFlutterBinding();
+  return _renderer;
+}
+
+/// Place the box in the render tree, at the given size and with the given
+/// alignment on the screen.
+///
+/// If you've updated `box` and want to lay it out again, use [pumpFrame].
+///
+/// Once a particular [RenderBox] has been passed to [layout], it cannot easily
+/// be put in a different place in the tree or passed to [layout] again, because
+/// [layout] places the given object into another [RenderBox] which you would
+/// need to unparent it from (but that box isn't itself made available).
+///
+/// The EnginePhase must not be [EnginePhase.build], since the rendering layer
+/// has no build phase.
+///
+/// If `onErrors` is not null, it is set as [TestRenderingFlutterBinding.onError].
+void layout(
+  RenderBox box, {
+  BoxConstraints constraints,
+  Alignment alignment = Alignment.center,
+  EnginePhase phase = EnginePhase.layout,
+  VoidCallback onErrors,
+}) {
+  assert(box !=
+      null); // If you want to just repump the last box, call pumpFrame().
+  assert(box.parent ==
+      null); // We stick the box in another, so you can't reuse it easily, sorry.
+
+  renderer.renderView.child = null;
+  if (constraints != null) {
+    box = RenderPositionedBox(
+      alignment: alignment,
+      child: RenderConstrainedBox(
+        additionalConstraints: constraints,
+        child: box,
+      ),
+    );
+  }
+  renderer.renderView.child = box;
+
+  pumpFrame(phase: phase, onErrors: onErrors);
+}
+
+/// Pumps a single frame.
+///
+/// If `onErrors` is not null, it is set as [TestRenderingFlutterBinding.onError].
+void pumpFrame(
+    {EnginePhase phase = EnginePhase.layout, VoidCallback onErrors}) {
+  assert(renderer != null);
+  assert(renderer.renderView != null);
+  assert(renderer.renderView.child != null); // call layout() first!
+
+  if (onErrors != null) {
+    renderer.onErrors = onErrors;
+  }
+
+  renderer.phase = phase;
+  renderer.drawFrame();
+}
+
+class TestCallbackPainter extends CustomPainter {
+  const TestCallbackPainter({this.onPaint});
+
+  final VoidCallback onPaint;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    onPaint();
+  }
+
+  @override
+  bool shouldRepaint(TestCallbackPainter oldPainter) => true;
+}
+
+class RenderSizedBox extends RenderBox {
+  RenderSizedBox(this._size);
+
+  final Size _size;
+
+  @override
+  double computeMinIntrinsicWidth(double height) {
+    return _size.width;
+  }
+
+  @override
+  double computeMaxIntrinsicWidth(double height) {
+    return _size.width;
+  }
+
+  @override
+  double computeMinIntrinsicHeight(double width) {
+    return _size.height;
+  }
+
+  @override
+  double computeMaxIntrinsicHeight(double width) {
+    return _size.height;
+  }
+
+  @override
+  bool get sizedByParent => true;
+
+  @override
+  void performResize() {
+    size = constraints.constrain(_size);
+  }
+
+  @override
+  void performLayout() {}
+
+  @override
+  bool hitTestSelf(Offset position) => true;
+}
+
+class FakeTickerProvider implements TickerProvider {
+  @override
+  Ticker createTicker(TickerCallback onTick, [bool disableAnimations = false]) {
+    return FakeTicker();
+  }
+}
+
+class FakeTicker implements Ticker {
+  @override
+  bool muted;
+
+  @override
+  void absorbTicker(Ticker originalTicker) {}
+
+  @override
+  String get debugLabel => null;
+
+  @override
+  bool get isActive => null;
+
+  @override
+  bool get isTicking => null;
+
+  @override
+  bool get scheduled => null;
+
+  @override
+  bool get shouldScheduleTick => null;
+
+  @override
+  void dispose() {}
+
+  @override
+  void scheduleTick({bool rescheduling = false}) {}
+
+  @override
+  TickerFuture start() {
+    return null;
+  }
+
+  @override
+  void stop({bool canceled = false}) {}
+
+  @override
+  void unscheduleTick() {}
+
+  @override
+  String toString({bool debugIncludeStack = false}) => super.toString();
+
+  @override
+  DiagnosticsNode describeForError(String name) {
+    return DiagnosticsProperty<Ticker>(name, this,
+        style: DiagnosticsTreeStyle.errorProperty);
+  }
+}


### PR DESCRIPTION
This class forks and extends the RenderSliverFixedExtentBoxAdaptor from package:flutter to support
lists where each element can have a custom extent provided by a delegate.
This makes animating the inspector tree practical and will greatly improve performance in the flame chart.
This list shares the benefit of the ListView constructors specifying a fixed extent in that only list view items in view need to built instead of building all items to measure the list.
It still makes sense to leave RenderSliverFixedExtentBoxAdaptor as is in package:flutter as completely fixed extents are a bit more efficient than this implementation. For example, there are const object optimizations only practical in the fixed case and a typical implementation of ExtentDelegate will take O(log n) for some opterations that are O(1) for the fixed case.


