### PR TITLE
Don't check for debugDidSendFirstFrameEvent when adding service extensions for Dart VM apps.

### DIFF
--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -533,13 +533,11 @@ class ServiceExtensionManager {
               extensions.didSendFirstFrameEvent,
               isolateId: _isolateManager.selectedIsolate.id,
             );
-            didSendFirstFrameEvent =
-                value != null && value.json['enabled'] == 'true';
+            didSendFirstFrameEvent = value?.json['enabled'] == 'true';
           } else {
             final EvalOnDartLibrary flutterLibrary = EvalOnDartLibrary(
               [
                 'package:flutter/src/widgets/binding.dart',
-                'package:flutter_web/src/widgets/binding.dart',
               ],
               _service,
             );


### PR DESCRIPTION
eval_on_dart_library was throwing an error because flutter libs are not available for DartVM apps. For dart vm apps, we should add service extensions immediately.