### PR TITLE
Make the layout explorer more null safe.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_data_models.dart
@@ -674,8 +674,8 @@ class RenderProperties {
         height = size?.height ?? 0.0,
         realWidth = realSize?.width ?? 0.0,
         realHeight = realSize?.height ?? 0.0,
-        dx = offset?.dx ?? 0,
-        dy = offset?.dy ?? 0;
+        dx = offset?.dx ?? 0.0,
+        dy = offset?.dy ?? 0.0;
 
   final Axis axis;
 

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_data_models.dart
@@ -670,12 +670,12 @@ class RenderProperties {
     Size realSize,
     this.layoutProperties,
     this.isFreeSpace = false,
-  })  : width = size?.width,
-        height = size?.height,
-        realWidth = realSize?.width,
-        realHeight = realSize?.height,
-        dx = offset?.dx,
-        dy = offset?.dy;
+  })  : width = size?.width ?? 0.0,
+        height = size?.height ?? 0.0,
+        realWidth = realSize?.width ?? 0.0,
+        realHeight = realSize?.height ?? 0.0,
+        dx = offset?.dx ?? 0,
+        dy = offset?.dy ?? 0;
 
   final Axis axis;
 


### PR DESCRIPTION
This avoids a couple asserts in the flutter framework caused by the layout
explorer passing null where it shouldn't.