### PR TITLE
Provide static checking by refactoring how the service extensions used by layout_explorer are defined.

### DIFF
--- a/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
+++ b/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
@@ -1,0 +1,244 @@
+// The content of the addServiceExtensions method from this file is executed as
+// if it was part of the package:flutter/src/widgets/widget_inspector.dart
+// library to register additional dart:developer service extensions useful for
+// devtools that are not defined in package:flutter for all versions of
+// package:flutter that devtools needs to support.
+//
+// Using this library solves the problem that a single version of DevTools
+// should support a wide range of package:flutter versions and that new DevTools
+// features should be exposed with a wide range of Flutter versions to get
+// useful user feedback.
+//
+// We current execute this library using eval but that should be viewed as an
+// implementation detail as eval is simply the most expedient way to currently
+// late bind these service extensions. It could make sense to provide an
+// alternate eval like mechanism to inject additional libraries into an already
+// running Dart application. For example, the fact that we cannot define
+// additional classes using eval is a little limiting to what we can do within
+// this polyfill.
+//
+// Only code between the INSPECTOR_POLYFILL_SCRIPT_START and
+// the INSPECTOR_POLYFILL_SCRIPT_END tags are actually executed. All other code
+// exists purely to get consistent static warnings with what would be displayed
+// when this code is evaluated in the context of
+// package:flutter/src/widgets/widget_inspector.dart
+//
+// The imports in this file intentionally match the imports specified by
+// package:flutter/src/widgets/widget_inspector.dart so that we get consistent
+// static warnings and autocompletes while editing this file. Do not add
+// additional imports to this file.
+// ignore_for_file: unused_import
+
+// Code from this class is executed within the context of the
+// widget_inspector.dart library so using protected members is fine.
+// ignore_for_file: invalid_use_of_visible_for_testing_member
+// ignore_for_file: invalid_use_of_protected_member
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:developer' as developer;
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'dart:ui' as ui
+    show
+        ClipOp,
+        Image,
+        ImageByteFormat,
+        Paragraph,
+        Picture,
+        PictureRecorder,
+        PointMode,
+        SceneBuilder,
+        Vertices;
+import 'dart:ui' show Canvas, Offset;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/painting.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:vector_math/vector_math_64.dart';
+import 'package:flutter/src/widgets/app.dart';
+import 'package:flutter/src/widgets/basic.dart';
+import 'package:flutter/src/widgets/binding.dart';
+import 'package:flutter/src/widgets/debug.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter/src/widgets/gesture_detector.dart';
+import 'package:flutter/src/widgets/widget_inspector.dart';
+
+// This extension method is simply a hack to make a private member defined on
+// WidgetInspectorService show up as in scope as far as the analysis server is
+// concerned.
+extension WidgetInspectorServicePrivateMethods on WidgetInspectorService {
+  Map<String, Object> _nodeToJson(
+    DiagnosticsNode node,
+    InspectorSerializationDelegate delegate,
+  ) {
+    throw 'Dummy extension method to make the code type check when it calls private members';
+  }
+}
+
+void addServiceExtensions() {
+  // INSPECTOR_POLYFILL_SCRIPT_START
+  T toEnumEntry<T>(List<T> enumEntries, String name) {
+    for (T entry in enumEntries) {
+      if (entry.toString() == name) {
+        return entry;
+      }
+    }
+    return null;
+  }
+
+  Future<Map<String, dynamic>> getLayoutExplorerNode(
+      Map<String, String> parameters) {
+    final String id = parameters['id'];
+    final int subtreeDepth = int.parse(parameters['subtreeDepth']);
+    final String groupName = parameters['groupName'];
+    Map<String, Object> result = {};
+    final instance = WidgetInspectorService.instance;
+    final root = instance.toObject(id);
+    if (root == null) {
+      result = null;
+    } else {
+      result = instance._nodeToJson(
+        root,
+        InspectorSerializationDelegate(
+            groupName: groupName,
+            summaryTree: true,
+            subtreeDepth: subtreeDepth,
+            includeProperties: false,
+            service: instance,
+            addAdditionalPropertiesCallback: (node, delegate) {
+              final Map<String, Object> additionalJson = <String, Object>{};
+              final Object value = node.value;
+              if (value is Element) {
+                final renderObject = value.renderObject;
+                additionalJson['renderObject'] =
+                    renderObject.toDiagnosticsNode()?.toJsonMap(
+                          delegate.copyWith(
+                            subtreeDepth: 0,
+                            includeProperties: true,
+                          ),
+                        );
+                final Constraints constraints = renderObject.constraints;
+                if (constraints != null) {
+                  final Map<String, Object> constraintsProperty =
+                      <String, Object>{
+                    'type': constraints.runtimeType.toString(),
+                    'description': constraints.toString(),
+                  };
+                  if (constraints is BoxConstraints) {
+                    constraintsProperty.addAll(<String, Object>{
+                      'minWidth': constraints.minWidth.toString(),
+                      'minHeight': constraints.minHeight.toString(),
+                      'maxWidth': constraints.maxWidth.toString(),
+                      'maxHeight': constraints.maxHeight.toString(),
+                    });
+                  }
+                  additionalJson['constraints'] = constraintsProperty;
+                }
+                if (renderObject is RenderBox) {
+                  additionalJson['size'] = <String, Object>{
+                    'width': renderObject.size.width.toString(),
+                    'height': renderObject.size.height.toString(),
+                  };
+
+                  final ParentData parentData = renderObject.parentData;
+                  if (parentData is FlexParentData) {
+                    additionalJson['flexFactor'] = parentData.flex;
+                    additionalJson['flexFit'] =
+                        describeEnum(parentData.fit ?? FlexFit.tight);
+                  }
+                }
+              }
+              return additionalJson;
+            }),
+      );
+    }
+    return Future.value(<String, Object>{
+      'result': result,
+    });
+  }
+
+  Future<Map<String, dynamic>> setFlexFit(Map<String, String> parameters) {
+    final String id = parameters['id'];
+    final FlexFit flexFit =
+        toEnumEntry<FlexFit>(FlexFit.values, parameters['flexFit']);
+    final dynamic object = WidgetInspectorService.instance.toObject(id);
+    if (object == null) return null;
+    final render = object.renderObject;
+    final parentData = render.parentData;
+    bool succeed = false;
+    if (parentData is FlexParentData) {
+      parentData.fit = flexFit;
+      render.markNeedsLayout();
+      succeed = true;
+    }
+    return Future.value(<String, Object>{
+      'result': succeed,
+    });
+  }
+
+  Future<Map<String, dynamic>> setFlexFactor(Map<String, String> parameters) {
+    final String id = parameters['id'];
+    final String flexFactor = parameters['flexFactor'];
+    final int factor = flexFactor == 'null' ? null : int.parse(flexFactor);
+    final dynamic object = WidgetInspectorService.instance.toObject(id);
+    if (object == null) return null;
+    final render = object.renderObject;
+    final parentData = render.parentData;
+    bool succeed = false;
+    if (parentData is FlexParentData) {
+      parentData.flex = factor;
+      render.markNeedsLayout();
+      succeed = true;
+    }
+    return Future.value({'result': succeed});
+  }
+
+  Future<Map<String, dynamic>> setFlexProperties(
+      Map<String, String> parameters) {
+    final String id = parameters['id'];
+    final MainAxisAlignment mainAxisAlignment = toEnumEntry<MainAxisAlignment>(
+      MainAxisAlignment.values,
+      parameters['mainAxisAlignment'],
+    );
+    final CrossAxisAlignment crossAxisAlignment =
+        toEnumEntry<CrossAxisAlignment>(
+      CrossAxisAlignment.values,
+      parameters['crossAxisAlignment'],
+    );
+    final dynamic object = WidgetInspectorService.instance.toObject(id);
+    if (object == null) return null;
+    final render = object.renderObject;
+    bool succeed = false;
+    if (render is RenderFlex) {
+      render.mainAxisAlignment = mainAxisAlignment;
+      render.crossAxisAlignment = crossAxisAlignment;
+      render.markNeedsLayout();
+      render.markNeedsPaint();
+      succeed = true;
+    }
+    return Future.value(<String, Object>{'result': succeed});
+  }
+
+  void registerHelper(String name, ServiceExtensionCallback callback) {
+    try {
+      WidgetInspectorService.instance.registerServiceExtension(
+        name: name,
+        callback: callback,
+      );
+    } catch (e) {
+      // It is not a fatal error if some of the extensions fail to register
+      // as could be the case if some are already defined directly within
+      // package:flutter for the version of package:flutter being used.
+      print('Warning: unable to register service extension \'$name\'');
+    }
+  }
+
+  registerHelper('getLayoutExplorerNode', getLayoutExplorerNode);
+  registerHelper('setFlexFit', setFlexFit);
+  registerHelper('setFlexFactor', setFlexFactor);
+  registerHelper('setFlexProperties', setFlexProperties);
+  // INSPECTOR_POLYFILL_SCRIPT_END
+}

--- a/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
+++ b/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
@@ -9,7 +9,7 @@
 // features should be exposed with a wide range of Flutter versions to get
 // useful user feedback.
 //
-// We current execute this library using eval but that should be viewed as an
+// We currently execute this library using eval but that should be viewed as an
 // implementation detail as eval is simply the most expedient way to currently
 // late bind these service extensions. It could make sense to provide an
 // alternate eval like mechanism to inject additional libraries into an already
@@ -76,9 +76,17 @@ extension WidgetInspectorServicePrivateMethods on WidgetInspectorService {
   ) {
     throw 'Dummy extension method to make the code type check when it calls private members';
   }
+
+  String _safeJsonEncode(Object object) {
+    throw 'Dummy extension method to make the code type check when it calls private members';
+  }
 }
 
-void addServiceExtensions() {
+// Returns json describing which service extensions failed to load.
+//
+// The format of the json is:
+// {'extension_name_a': 'exception message_a', 'extension_name_b', 'exception_message_b', ...}
+String addServiceExtensions() {
   // INSPECTOR_POLYFILL_SCRIPT_START
   T toEnumEntry<T>(List<T> enumEntries, String name) {
     for (T entry in enumEntries) {
@@ -222,6 +230,7 @@ void addServiceExtensions() {
     return Future.value(<String, Object>{'result': succeed});
   }
 
+  final failures = <String, String>{};
   void registerHelper(String name, ServiceExtensionCallback callback) {
     try {
       WidgetInspectorService.instance.registerServiceExtension(
@@ -232,7 +241,7 @@ void addServiceExtensions() {
       // It is not a fatal error if some of the extensions fail to register
       // as could be the case if some are already defined directly within
       // package:flutter for the version of package:flutter being used.
-      print('Warning: unable to register service extension \'$name\'');
+      failures[name] = e.toString();
     }
   }
 
@@ -240,5 +249,8 @@ void addServiceExtensions() {
   registerHelper('setFlexFit', setFlexFit);
   registerHelper('setFlexFactor', setFlexFactor);
   registerHelper('setFlexProperties', setFlexProperties);
+  return failures.isNotEmpty
+      ? WidgetInspectorService.instance._safeJsonEncode(failures)
+      : null;
   // INSPECTOR_POLYFILL_SCRIPT_END
 }

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -254,6 +254,10 @@ class EvalOnDartLibrary {
       return value;
     });
   }
+
+  Future<String> retrieveFullValueAsString(InstanceRef stringRef) {
+    return service.retrieveFullStringValue(_isolateId, stringRef);
+  }
 }
 
 class LibraryNotFound implements Exception {

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_service_polyfill.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_service_polyfill.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../inspector_service.dart';
+
+// Magic tokens to detect the start and the end of the block of code from the
+// polyfill script to execute as an eval expression.
+const _inspectorPolyfillStart = '// INSPECTOR_POLYFILL_SCRIPT_START\n';
+const _inspectorPolyfillEnd = '// INSPECTOR_POLYFILL_SCRIPT_END\n';
+
+Future<String> loadPolyfillScript() {
+  return rootBundle.loadString('assets/scripts/inspector_polyfill_script.dart');
+}
+
+Future<void> invokeInspectorPolyfill(ObjectGroup group) async {
+  final String script = await loadPolyfillScript();
+  var startIndex = script.indexOf(_inspectorPolyfillStart);
+  final endIndex = script.indexOf(_inspectorPolyfillEnd);
+  if (startIndex == -1 || endIndex == -1) {
+    throw Exception(
+      '''Improperly formatted polyfill script. Expected to find expressions
+$_inspectorPolyfillStart
+and
+$_inspectorPolyfillEnd
+
+Script contents:
+$script''',
+    );
+  }
+  startIndex += _inspectorPolyfillStart.length;
+  final polyFillScript = script.substring(startIndex, endIndex);
+  final filteredLines = <String>[];
+  // The Dart eval  does not support multiple line expressions so we have to strip out
+  // line breaks.
+  for (var line in polyFillScript.split('\n')) {
+    line = line.trim();
+    // Omit lines with // comments as they will confuse the single line eval
+    // expression.
+    if (!line.startsWith('//')) {
+      filteredLines.add(line);
+    }
+  }
+
+  final expression = '((){${filteredLines.join()}})()';
+
+  await group.inspectorLibrary.eval(expression, isAlive: group);
+}

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_service_polyfill.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_service_polyfill.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/services.dart' show rootBundle;
 
+import '../../config_specific/logger/logger.dart';
 import '../inspector_service.dart';
 
 // Magic tokens to detect the start and the end of the block of code from the
@@ -42,5 +45,17 @@ $script''',
 
   final expression = '((){${filteredLines.join()}})()';
 
-  await group.inspectorLibrary.eval(expression, isAlive: group);
+  final result = await group.inspectorLibrary.eval(expression, isAlive: group);
+  final encodedResult =
+      await group.inspectorLibrary.retrieveFullValueAsString(result);
+  if (encodedResult != null) {
+    final Map<String, Object> decodedError = json.decode(encodedResult);
+    if (encodedResult != null) {
+      for (String name in decodedError.keys) {
+        log(
+          "Unable to add service extension '$name' due to error:\n${decodedError[name]}",
+        );
+      }
+    }
+  }
 }

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -41,6 +41,18 @@ typedef CreateLoggingTree = InspectorTreeController Function({
   VoidCallback onSelectionChange,
 });
 
+Future<String> _retrieveFullStringValue(
+  VmServiceWrapper service,
+  IsolateRef isolateRef,
+  InstanceRef stringRef,
+) {
+  return service.retrieveFullStringValue(
+    isolateRef.id,
+    stringRef,
+    onUnavailable: (truncatedValue) => '${stringRef.valueAsString}...',
+  );
+}
+
 class LoggingDetailsController {
   LoggingDetailsController({
     @required this.onShowInspector,
@@ -452,25 +464,6 @@ class LoggingController {
       summary: summary,
       detailsComputer: detailsComputer,
     ));
-  }
-
-  Future<String> _retrieveFullStringValue(
-    VmServiceWrapper service,
-    IsolateRef isolateRef,
-    InstanceRef stringRef,
-  ) async {
-    if (stringRef.valueAsStringIsTruncated != true) {
-      return stringRef.valueAsString;
-    }
-
-    final dynamic result = await service.getObject(isolateRef.id, stringRef.id,
-        offset: 0, count: stringRef.length);
-    if (result is Instance) {
-      final Instance obj = result;
-      return obj.valueAsString;
-    } else {
-      return '${stringRef.valueAsString}...';
-    }
   }
 
   void _handleConnectionStop(dynamic event) {}

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -783,11 +783,14 @@ class VmServiceWrapper implements VmService {
     if (stringRef.valueAsStringIsTruncated != true)
       return stringRef.valueAsString;
 
-    final dynamic result = await getObject(isolateId, stringRef.id,
-        offset: 0, count: stringRef.length);
+    final result = await getObject(
+      isolateId,
+      stringRef.id,
+      offset: 0,
+      count: stringRef.length,
+    );
     if (result is Instance) {
-      final Instance obj = result;
-      return obj.valueAsString;
+      return result.valueAsString;
     } else if (onUnavailable != null) {
       return onUnavailable(stringRef.valueAsString);
     } else {

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -766,6 +766,36 @@ class VmServiceWrapper implements VmService {
     ).isSupported(supportedVersion: supportedVersion);
   }
 
+  /// Retrieves the full string value of a [stringRef].
+  ///
+  /// The string value stored with the [stringRef] is returned unless the value
+  /// is truncated in which an extra getObject call is issued to return the
+  /// value. If the [stringRef] has expired so the full string is unavailable,
+  /// [onUnavailable] is called to return how the truncated value should be
+  /// displayed. If [onUnavailable] is not specified, an exception is thrown
+  /// if the full value cannot be retrieved.
+  Future<String> retrieveFullStringValue(
+    String isolateId,
+    InstanceRef stringRef, {
+    String onUnavailable(String truncatedValue),
+  }) async {
+    if (stringRef == null) return null;
+    if (stringRef.valueAsStringIsTruncated != true)
+      return stringRef.valueAsString;
+
+    final dynamic result = await getObject(isolateId, stringRef.id,
+        offset: 0, count: stringRef.length);
+    if (result is Instance) {
+      final Instance obj = result;
+      return obj.valueAsString;
+    } else if (onUnavailable != null) {
+      return onUnavailable(stringRef.valueAsString);
+    } else {
+      throw Exception(
+          'The full string for "{stringRef.valueAsString}..." is unavailable');
+    }
+  }
+
   /// Gets the name of the service stream for the connected VM service. Pre-v3.22
   /// this was a private API and named _Service and in v3.22 (July 2019) it was
   /// made public ("Service").

--- a/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
 }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -89,6 +89,7 @@ flutter:
     - assets/img/layout_explorer/
     - assets/img/layout_explorer/main_axis_alignment/
     - assets/img/layout_explorer/cross_axis_alignment/
+    - assets/scripts/inspector_polyfill_script.dart
 
   fonts:
     - family: Roboto


### PR DESCRIPTION
Previously these extensions were defined as string literals which eliminated static checking.
They are now defined as a slightly magical dart file under assets/scripts
which gives you full dart code completion and analysis server error checking.
With this change, writing these polyfills is simple enough that we should
write all new widget_inspector.dart functionality here rather than in
package:flutter/src/widgets/widget_inspector.dart only moving it to
widget_inspector.dart once we are confident we will use the feature for the long term.