### PR TITLE
Remove cpu profiling timeout.

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -61,7 +61,7 @@ class CpuProfilerController {
 
     _processingNotifier.value = true;
 
-    const Duration processingTimeout = Duration(seconds: 5);
+    const Duration processingTimeout = Duration(minutes: 10);
     var cpuProfileData = baseStateCpuProfileData;
     try {
       _dataNotifier.value = null;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:meta/meta.dart';
 
-import '../config_specific/logger/logger.dart';
 import '../profiler/cpu_profile_model.dart';
 import '../profiler/cpu_profile_service.dart';
 import '../profiler/cpu_profile_transformer.dart';


### PR DESCRIPTION
calling `getCpuProfile` on the vm service can take a while for large payloads. By timing out, we restrict the size of profile that can be pulled.

This is blocking dream (g3) from profiling their app. It will likely affect other large apps as well.