### PR TITLE
Prep for 0.2.2 release.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.16 2020-02-28
+## 0.2.3 2020-02-28
 * Remove cpu profiling timeout [#1683]((https://github.com/flutter/devtools/pull/1683)
 * Prep for Q1 DevTools survey [#1574](https://github.com/flutter/devtools/pull/1574)
 * Use ExtentDelegateListView for flame chart rows [#1676](https://github.com/flutter/devtools/pull/1676)

--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.3 2020-02-28
+## 0.2.2 2020-02-28
 * Remove cpu profiling timeout [#1683]((https://github.com/flutter/devtools/pull/1683)
 * Prep for Q1 DevTools survey [#1574](https://github.com/flutter/devtools/pull/1574)
 * Use ExtentDelegateListView for flame chart rows [#1676](https://github.com/flutter/devtools/pull/1676)

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.2.3
+version: 0.2.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -9,7 +9,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.1.16
+version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.1.16';
+const String version = '0.2.3';

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -5,4 +5,4 @@
 /// The DevTools application version.
 // Note: when updating this, please update the corresponding version in the
 // pubspec.
-const String version = '0.2.3';
+const String version = '0.2.2';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Main package implementing web-based performance tooling for Dart an
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.2.3
+version: 0.2.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Main package implementing web-based performance tooling for Dart an
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.1.16
+version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -62,13 +62,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
 
-dependency_overrides:
-  devtools_shared:
-    path: ../devtools_shared
-  # The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
-  # tests can run using the in-repo version of these dependencies instead of
-  # only the live Pub version.
-
 dev_dependencies:
   build_runner: ^1.3.0
   build_test: ^0.10.0
@@ -79,8 +72,7 @@ dev_dependencies:
   webkit_inspection_protocol: ^0.5.0
   devtools: #^0.1.7
     path: ../devtools
-  devtools_testing:
-    path: ../devtools_testing
+  devtools_testing: 0.2.2
   flutter_test:
     sdk: flutter
 
@@ -137,3 +129,12 @@ flutter:
       web:
         pluginClass: DebuggerHtmlPlugin
         fileName: debugger_html_plugin.dart
+
+dependency_overrides:
+  devtools_shared:
+    path: ../devtools_shared
+  # The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
+  # tests can run using the in-repo version of these dependencies instead of
+  # only the live Pub version.
+  devtools_testing:
+    path: ../devtools_testing

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.1.16
-- Rev version number for coordinated release with DevTools 0.1.16.
+## 0.2.3
+- Coordinated release with DevTools 0.2.3.
 
 ## 0.1.15
 - Added new setActiveSurvey requests.  Set will create the survey e.g., Q1-2020 and subsequent surveys will perform on the current activeSurvey.

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.2.3
-- Coordinated release with DevTools 0.2.3.
+## 0.2.2
+- Coordinated release with DevTools 0.2.2.
 
 ## 0.1.15
 - Added new setActiveSurvey requests.  Set will create the survey e.g., Q1-2020 and subsequent surveys will perform on the current activeSurvey.

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,5 +1,9 @@
+## 0.1.16
+- Rev version number for coordinated release with DevTools 0.1.16.
+
 ## 0.1.15
 - Added new setActiveSurvey requests.  Set will create the survey e.g., Q1-2020 and subsequent surveys will perform on the current activeSurvey.
+
 ## 0.1.14
 - Added CLI support to collect memory profile statistics to collect run run:</br>
 `dart ../devtools/bin/devtools.dart --vm-uri `**VM_Auth_URI**` --profile-memory `**FileName**` --verbose`</br></br>

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.16
+version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.2.3
+version: 0.2.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools
@@ -22,3 +22,7 @@ dependencies:
   http_multi_server: ^2.2.0
   usage: ^3.4.1
   vm_service: ^2.3.1
+
+dependency_overrides:
+  devtools_shared:
+    path: ../devtools_shared

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
-version: 0.1.15
+version: 0.1.16
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.2.3
-- Coordinated release with DevTools 0.2.3.
+## 0.2.2
+- Coordinated release with DevTools 0.2.2.
 ## 0.2.2
 - Simplified devtools_api.dart.
 ## 0.2.1

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 0.1.16
+- Rev version number for coordinated release with DevTools 0.1.16.
 ## 0.2.2
 - Simplified devtools_api.dart.
 ## 0.2.1

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,5 +1,5 @@
-## 0.1.16
-- Rev version number for coordinated release with DevTools 0.1.16.
+## 0.2.3
+- Coordinated release with DevTools 0.2.3.
 ## 0.2.2
 - Simplified devtools_api.dart.
 ## 0.2.1

--- a/packages/devtools_shared/lib/src/devtools_api.dart
+++ b/packages/devtools_shared/lib/src/devtools_api.dart
@@ -20,8 +20,9 @@ const String apiSetDevToolsEnabled = '${apiPrefix}setDevToolsEnabled';
 const String devToolsEnabledPropertyName = 'enabled';
 
 /// Survey properties APIs:
-/// setActiveSurvey sets the survey property to fetch and save JSON values e.g., Q1-2020 
+/// setActiveSurvey sets the survey property to fetch and save JSON values e.g., Q1-2020
 const String apiSetActiveSurvey = '${apiPrefix}setActiveSurvey';
+
 /// Survey name passed in apiSetActiveSurvey, the activeSurveyName is the property name
 /// passed as a queryParameter and is the property in ~/.devtools too.
 const String activeSurveyName = 'activeSurveyName';
@@ -29,8 +30,9 @@ const String activeSurveyName = 'activeSurveyName';
 /// Returns the surveyActionTaken of the activeSurvey (apiSetActiveSurvey).
 const String apiGetSurveyActionTaken = '${apiPrefix}getSurveyActionTaken';
 
-/// Sets the surveyActionTaken of the of the activeSurvey (apiSetActiveSurvey). 
+/// Sets the surveyActionTaken of the of the activeSurvey (apiSetActiveSurvey).
 const String apiSetSurveyActionTaken = '${apiPrefix}setSurveyActionTaken';
+
 /// Property name to apiSetSurveyActionTaken the surveyActionTaken is the name
 /// passed in queryParameter:
 const String surveyActionTakenPropertyName = 'surveyActionTaken';
@@ -38,6 +40,6 @@ const String surveyActionTakenPropertyName = 'surveyActionTaken';
 /// Returns the surveyShownCount of the of the activeSurvey (apiSetActiveSurvey).
 const String apiGetSurveyShownCount = '${apiPrefix}getSurveyShownCount';
 
-/// Increments the surveyShownCount of the of the activeSurvey (apiSetActiveSurvey). 
+/// Increments the surveyShownCount of the of the activeSurvey (apiSetActiveSurvey).
 const String apiIncrementSurveyShownCount =
     '${apiPrefix}incrementSurveyShownCount';

--- a/packages/devtools_shared/lib/src/memory/memory_json.dart
+++ b/packages/devtools_shared/lib/src/memory/memory_json.dart
@@ -66,9 +66,8 @@ class MemoryJson {
 
     // Iterate over all HeapSamples collected.
     data.map((f) {
-      final encode = result.isNotEmpty
-          ? encodeAnotherHeapSample(f)
-          : encodeHeapSample(f);
+      final encode =
+          result.isNotEmpty ? encodeAnotherHeapSample(f) : encodeHeapSample(f);
       result.write(encode);
     }).toList();
 

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app and devtools_server.
 
-version: 0.2.2
+version: 0.1.16
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app and devtools_server.
 
-version: 0.2.3
+version: 0.2.2
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app and devtools_server.
 
-version: 0.1.16
+version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/flutter/devtools

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -1,14 +1,24 @@
 name: devtools_testing
-version: 3.0.0
+description: Package of shared testing code for Dart DevTools.
+version: 0.2.2
+
+homepage: https://github.com/flutter/devtools
+
 environment:
   sdk: '>=2.3.0 <3.0.0'
+
 dependencies:
-  devtools_app: ^0.2.2
-  devtools_server: ^0.2.2
+  devtools_app: ^0.1.15
   devtools_shared: ^0.2.2
+  flutter_test:
+    sdk: flutter
+  matcher: ^0.12.3
   meta: ^1.1.0
   package_resolver: ^1.0.0
+  pedantic: ^1.7.0
   test: ^1.0.0
+  vm_service: ^2.3.1
+
 dependency_overrides:
   devtools_app:
     path: ../devtools_app
@@ -16,7 +26,4 @@ dependency_overrides:
     path: ../devtools_server
   devtools_shared:
     path: ../devtools_shared
-dev_dependencies:
-  flutter_test:
-    sdk: flutter
 

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -3,9 +3,9 @@ version: 3.0.0
 environment:
   sdk: '>=2.3.0 <3.0.0'
 dependencies:
-  devtools_app: ^0.1.15
-  devtools_server: ^0.1.14
-  devtools_shared: ^0.2.0
+  devtools_app: ^0.2.2
+  devtools_server: ^0.2.2
+  devtools_shared: ^0.2.2
   meta: ^1.1.0
   package_resolver: ^1.0.0
   test: ^1.0.0


### PR DESCRIPTION
Bump all package version to 0.2.3 so that they can be consistent. devtools_shared's previous version number is 0.2.2 so we can't bump it back to 0.1.16. 