### PR TITLE
Fix bug causing overlapping async timeline events.

### DIFF
--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -141,9 +141,9 @@ class _VersionInformation extends StatelessWidget {
           ],
         ),
         Row(
-          children: [
-            const Text('DevTools:', style: boldText),
-            const SizedBox(width: contentPadding),
+          children: const [
+            Text('DevTools:', style: boldText),
+            SizedBox(width: contentPadding),
             Text(devtools.version),
           ],
         ),

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -997,7 +997,7 @@ class AsyncTimelineEvent extends TimelineEvent {
         math.min(event.displayDepth, currentLargestRowIndex - displayRow);
     for (int level = 0; level < maxLevelToVerify; level++) {
       final lastEventAtLevel = _displayRows[displayRow + level].safeLast;
-      final firstNewEventAtLevel = event.displayRows[level].first;
+      final firstNewEventAtLevel = event.displayRows[level].safeFirst;
       if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
         // Events overlap one another, so [event] does not fit at [displayRow].
         if (lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time)) {

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -997,7 +997,7 @@ class AsyncTimelineEvent extends TimelineEvent {
         math.min(event.displayDepth, currentLargestRowIndex - displayRow);
     for (int level = 0; level < maxLevelToVerify; level++) {
       final lastEventAtLevel = _displayRows[displayRow + level].safeLast;
-      final firstNewEventAtLevel = event.firstChildNodeAtLevel(level);
+      final firstNewEventAtLevel = event.displayRows[level].first;
       if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
         // Events overlap one another, so [event] does not fit at [displayRow].
         if (lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time)) {


### PR DESCRIPTION
We were comparing the logical nodes at a given level instead of the display nodes at a given level.

this CL also fixes a const warning.