### PR TITLE
Tightened the version constraints to reflect that we want exactly matching

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -18,8 +18,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_server: ^0.2.3
-  devtools_shared: ^0.2.3
+  devtools_server: 0.2.3
+  devtools_shared: 0.2.3
   http: ^0.12.0+1
   intl: ^0.16.0
 

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -1,9 +1,8 @@
 name: devtools
 description: A suite of web-based performance tooling for Dart and Flutter.
 
-# Note: when updating this version, please update the corresponding entry in
-# ../devtools_app/lib/devtools.dart and the version in
-# ../devtools_app/pubspec.yaml
+# Note: this version should only be updated by running tools/update_version.sh
+# that updates all versions of packages from packages/devtools.
 #
 # All the real functionality has moved to the devtools_app package with this
 # package remaining purely as a container for the compiled copy of the devtools

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 /// The DevTools application version.
-// Note: when updating this, please update the corresponding version in the
-// pubspec.
+// This version should only be updated by running tools/update_version.sh
+// that updates all versions for DevTools.
+// Note: a regexp in tools/update_version.sh matches the following line so
+// if you change it you must also modify tools/update_version.sh.
 const String version = '0.2.3';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -1,8 +1,8 @@
 name: devtools_app
 description: Main package implementing web-based performance tooling for Dart and Flutter.
 
-# Note: when updating this version, please update the corresponding entry in
-# lib/devtools.dart and ../devtools/pubspec.yaml as well to the same version.
+# Note: this version should only be updated by running tools/update_version.sh
+# that updates all versions of packages from packages/devtools.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   #   path: ../../third_party/packages/ansi_up
   codemirror: ^0.5.10
   collection: ^1.14.11
-  devtools_shared: ^0.2.2
+  devtools_shared: 0.2.3
   file: ^5.1.0
   http: ^0.12.0+1
   intl: ^0.16.0

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.3
-  devtools_shared: ^0.2.2
+  devtools_shared: 0.2.3
   intl: ^0.16.0
   meta: ^1.1.0
   path: ^1.6.0

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -1,6 +1,8 @@
 name: devtools_server
 description: A server that supports Dart DevTools.
 
+# Note: this version should only be updated by running tools/update_version.sh
+# that updates all versions of packages from packages/devtools.
 version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,6 +1,8 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app and devtools_server.
 
+# Note: this version should only be updated by running tools/update_version.sh
+# that updates all versions of packages from packages/devtools.
 version: 0.2.3
 
 author: Dart Team <misc@dartlang.org>

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   devtools_app: ^0.1.15
-  devtools_shared: ^0.2.2
+  devtools_shared: 0.2.3
   flutter_test:
     sdk: flutter
   matcher: ^0.12.3

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -1,5 +1,7 @@
 name: devtools_testing
 description: Package of shared testing code for Dart DevTools.
+# Note: this version should only be updated by running tools/update_version.sh
+# that updates all versions of packages from packages/devtools.
 version: 0.2.3
 
 homepage: https://github.com/flutter/devtools
@@ -8,7 +10,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_app: ^0.1.15
+  devtools_app: 0.2.3
   devtools_shared: 0.2.3
   flutter_test:
     sdk: flutter

--- a/tool/README.md
+++ b/tool/README.md
@@ -28,7 +28,7 @@ git checkout -b release_0_0_15
 Verify that this script updated the pubspecs under packages/
 and updated all references to those packages. These packages always have their
 version numbers updated in lock step so we don't have to worry about
-versioning. Also make sure that tbe version constant in
+versioning. Also make sure that the version constant in
 **packages/devtools_app/lib/devtools.dart** was updated.
 
 ## Update the CHANGELOG.md
@@ -84,44 +84,26 @@ git pull upstream master
 #### Publish the packages
 ```shell
 pushd packages/devtools_shared
-
 pub publish
-...
-Looks great! Are you ready to upload your package (y/n)? y
-
 popd
 
-pushd packages/devtools_app
-
+pushd packages/devtools_server
 pub publish
-...
-Looks great! Are you ready to upload your package (y/n)? y
-
 popd
 
 pushd packages/devtools_testing
-
 pub publish
-...
-Looks great! Are you ready to upload your package (y/n)? y
+popd
 
+pushd packages/devtools_app
+pub publish
 popd
 
 pushd packages/devtools
-
 pub publish
-...
-Looks great! Are you ready to upload your package (y/n)? y
-```
-
-pushd packages/devtools_server
-
-pub publish
-
-...
-Looks great! Are you ready to upload your package (y/n)? y
-
 popd
+
+```
 
 #### Revert the change to .gitignore
 ```shell

--- a/tool/README.md
+++ b/tool/README.md
@@ -21,18 +21,15 @@ git checkout -b release_0_0_15
 
 ```
 
-## Update the release number in three files:
-- **packages/devtools/pubspec.yaml**
+## Update the release number by running files:
 
-Change ```version: 0.0.14``` to ```version: 0.0.15```
+./tool/update_version.sh 0_0_15
 
-- **packages/devtools_app/pubspec.yaml**
-
-Change ```version: 0.0.14``` to ```version: 0.0.15```
-
-- **packages/devtools_app/lib/devtools.dart**
-
-Change ```const String version = '0.0.14';``` to ```const String version = '0.0.15';```
+Verify that this script updated the pubspecs under packages/
+and updated all references to those packages. These packages always have their
+version numbers updated in lock step so we don't have to worry about
+versioning. Also make sure that tbe version constant in
+**packages/devtools_app/lib/devtools.dart** was updated.
 
 ## Update the CHANGELOG.md
 - **packages/devtools/CHANGELOG.md**
@@ -47,13 +44,6 @@ Add the release number and date followed by the features or changes e.g.,
 ## Push the local branch
 
 ```shell
-git add packages/devtools_app/lib/devtools.dart
-
-git add packages/devtools_app/pubspec.yaml
-
-git add packages/devtools/pubspec.yaml
-
-git add pavackages/devtools/CHANGELOG.md
 
 git commit -a -m “Prepare for v0.0.15 release.”
 
@@ -93,19 +83,45 @@ git pull upstream master
 
 #### Publish the packages
 ```shell
-cd packages/devtools_app
+pushd packages/devtools_shared
 
 pub publish
-
 ...
 Looks great! Are you ready to upload your package (y/n)? y
 
-cd packages/devtools
+popd
+
+pushd packages/devtools_app
+
+pub publish
+...
+Looks great! Are you ready to upload your package (y/n)? y
+
+popd
+
+pushd packages/devtools_testing
+
+pub publish
+...
+Looks great! Are you ready to upload your package (y/n)? y
+
+popd
+
+pushd packages/devtools
 
 pub publish
 ...
 Looks great! Are you ready to upload your package (y/n)? y
 ```
+
+pushd packages/devtools_server
+
+pub publish
+
+...
+Looks great! Are you ready to upload your package (y/n)? y
+
+popd
 
 #### Revert the change to .gitignore
 ```shell

--- a/tool/update_version.sh
+++ b/tool/update_version.sh
@@ -16,7 +16,12 @@ if [ -z "$VERSION" ]; then
 fi
 
 # If you add a package that is version locked, please add it to this list.
-PUBSPECS="./devtools_shared/pubspec.yaml ./devtools_server/pubspec.yaml ./devtools/pubspec.yaml ./devtools_app/pubspec.yaml ./devtools_testing/pubspec.yaml"
+PUBSPECS="./devtools_shared/pubspec.yaml \
+./devtools_server/pubspec.yaml \
+./devtools/pubspec.yaml \
+./devtools_app/pubspec.yaml \
+./devtools_testing/pubspec.yaml"
+
 echo "Updating pubspec versions"
 
 pushd packages

--- a/tool/update_version.sh
+++ b/tool/update_version.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2019 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+VERSION=$1
+LAST_VERSION="$(sed -n -e 's/^.*version: //p' packages/devtools_app/pubspec.yaml)"
+
+echo "The previous version was: $LAST_VERSION"
+
+if [ -z "$VERSION" ]; then
+    echo "No version specified."
+    echo "Usage: tool/update_version.sh NEW_VERSION_NUMBER"
+    exit 1
+fi
+
+# If you add a package that is version locked, please add it to this list.
+PUBSPECS="./devtools_shared/pubspec.yaml ./devtools_server/pubspec.yaml ./devtools/pubspec.yaml ./devtools_app/pubspec.yaml ./devtools_testing/pubspec.yaml"
+echo "Updating pubspec versions"
+
+pushd packages
+
+# We could use LAST_VERSION instead of allowing any previous version
+
+# Update the version of all packages.
+perl -pi -e "s/^(\\W*version:) [0-9.]+/\$1 $VERSION/g" $PUBSPECS
+
+# Update all references to package versions
+perl -pi -e "s/^(\\W*devtools_shared:) \\^?[0-9.]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_server:) \\^?[0-9.]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools:) \\^?[0-9.]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_app:) \\^?[0-9.]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_testing:) \\^?[0-9.]+/\$1 $VERSION/g" $PUBSPECS
+
+# Update version defined in the source code in devtools_app.
+perl -pi -e "s/^(\\W*const String version =) '[0-9.]+'/\$1 '$VERSION'/g" ./devtools_app/lib/devtools.dart
+
+popd
+
+NEW_VERSION="$(sed -n -e 's/^.*version: //p' packages/devtools_app/pubspec.yaml)"
+echo "Updated version to: $NEW_VERSION"
+


### PR DESCRIPTION
versions of the 4 devtools packages as that is how we test and deploy.

Otherwise we could have a breaking bug where devtools 0.2.3 grabs devtools
server 0.2.9 which could possibly break it.