### PR TITLE
Stop skipping duplicate trace events in full timeline processor.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_processor.dart
@@ -644,8 +644,6 @@ class FullTimelineProcessor extends TimelineProcessor {
   /// This is guaranteed because we process the events in timestamp order.
   SyncTimelineEvent _pendingRootCompleteEvent;
 
-  TraceEventWrapper _previousTraceEvent;
-
   Future<void> processTimeline(List<TraceEventWrapper> traceEvents) async {
     // Reset the processor before processing.
     reset();
@@ -717,13 +715,6 @@ class FullTimelineProcessor extends TimelineProcessor {
       final eventWrapper = traceEvents[i];
       _traceEventsProcessed++;
 
-      // This is a duplicate trace event. Skip it.
-      // See https://github.com/flutter/flutter/issues/47020.
-      if (_previousTraceEvent != null &&
-          collectionEquals(eventWrapper.json, _previousTraceEvent.json)) {
-        continue;
-      }
-
       // TODO(kenz): stop manually setting the type once we have that data
       // from the engine.
       eventWrapper.event.type = inferEventType(eventWrapper.event);
@@ -755,7 +746,6 @@ class FullTimelineProcessor extends TimelineProcessor {
         default:
           break;
       }
-      _previousTraceEvent = eventWrapper;
     }
   }
 

--- a/packages/devtools_app/test/timeline_processor_test.dart
+++ b/packages/devtools_app/test/timeline_processor_test.dart
@@ -312,6 +312,20 @@ void main() {
         equals('  D [193937061035 μs - 193938741076 μs]\n'),
       );
     });
+
+    test('processes trace with duplicate events', () async {
+      expect(
+        processor.timelineController.fullTimeline.data.timelineEvents,
+        isEmpty,
+      );
+      await processor.processTimeline(durationEventsWithDuplicateTraces);
+      // If the processor is not handling duplicates properly, this value would
+      // be 0.
+      expect(
+        processor.timelineController.fullTimeline.data.timelineEvents.length,
+        equals(1),
+      );
+    });
   });
 
   group('TimelineProcessor', () {

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -962,3 +962,53 @@ final offlineFullTimelineDataJson = {
   TimelineData.timelineModeKey: TimelineMode.full.toString(),
   TimelineData.devToolsScreenKey: timelineScreenId,
 };
+
+// Mark: Duration events with duplicate traces
+final transformLayerStart1 = testTraceEventWrapper({
+  'name': 'TransformLayer::Preroll',
+  'cat': 'Embedder',
+  'tid': testGpuThreadId,
+  'pid': 22283,
+  'ts': 118039651669,
+  'tts': 733287,
+  'ph': 'B',
+  'args': {}
+});
+final transformLayerStart2 = testTraceEventWrapper({
+  'name': 'TransformLayer::Preroll',
+  'cat': 'Embedder',
+  'tid': testGpuThreadId,
+  'pid': 22283,
+  'ts': 118039651869,
+  'tts': 733289,
+  'ph': 'B',
+  'args': {}
+});
+final transformLayerEnd2 = testTraceEventWrapper({
+  'name': 'TransformLayer::Preroll',
+  'cat': 'Embedder',
+  'tid': testGpuThreadId,
+  'pid': 22283,
+  'ts': 118039679673,
+  'tts': 733656,
+  'ph': 'E',
+  'args': {}
+});
+final transformLayerEnd1 = testTraceEventWrapper({
+  'name': 'TransformLayer::Preroll',
+  'cat': 'Embedder',
+  'tid': testGpuThreadId,
+  'pid': 22283,
+  'ts': 118039679673,
+  'tts': 733656,
+  'ph': 'E',
+  'args': {}
+});
+final durationEventsWithDuplicateTraces = [
+  gpuRasterizerDrawTrace,
+  transformLayerStart1,
+  transformLayerStart2,
+  transformLayerEnd2,
+  transformLayerEnd1,
+  endGpuRasterizerDrawTrace,
+];


### PR DESCRIPTION
Some duplicate trace events are completely valid and necessary to complete an event tree. 

Example:

```
{"name":"TransformLayer::Preroll","cat":"Embedder","tid":22323,"pid":22283,"ts":448075317652,"tts":733287,"ph":"B","args":{}},
{"name":"TransformLayer::Preroll","cat":"Embedder","tid":22323,"pid":22283,"ts":448075317654,"tts":733289,"ph":"B","args":{}},
...
{"name":"TransformLayer::Preroll","cat":"Embedder","tid":22323,"pid":22283,"ts":448075318021,"tts":733656,"ph":"E","args":{}},
{"name":"TransformLayer::Preroll","cat":"Embedder","tid":22323,"pid":22283,"ts":448075318021,"tts":733656,"ph":"E","args":{}},
```

If we skip the last trace event, we will put the tree in an unrecoverable state.

For duplicate events that are part of bad input (https://github.com/flutter/flutter/issues/47020), we have logic in `_handleDurationEndEvent` to recover.