### PR TITLE
make the connect notification dialog size to its height

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -139,8 +139,9 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
           routeNameWithQueryParams(context, '/', {'uri': '$uri'}),
         ),
       );
+      final shortUri = uri.replace(path: '');
       Notifications.of(context).push(
-        'Successfully connected to the VM Service at "$uri"',
+        'Successfully connected to $shortUri.',
       );
     } else if (uri == null) {
       Notifications.of(context).push(

--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -9,7 +9,8 @@ import 'package:flutter/scheduler.dart';
 
 import 'common_widgets.dart';
 
-final _notificationWidth = 160.0 * goldenRatio;
+const _notificationHeight = 160.0;
+final _notificationWidth = _notificationHeight * goldenRatio;
 
 /// Interface for pushing notifications in the app.
 ///

--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -9,8 +9,7 @@ import 'package:flutter/scheduler.dart';
 
 import 'common_widgets.dart';
 
-const _notificationHeight = 160.0;
-final _notificationWidth = _notificationHeight * goldenRatio;
+final _notificationWidth = 160.0 * goldenRatio;
 
 /// Interface for pushing notifications in the app.
 ///
@@ -214,12 +213,9 @@ class _NotificationState extends State<_Notification>
     return AnimatedBuilder(
       animation: controller,
       builder: (context, child) {
-        return SizedBox(
-          height: _notificationHeight * curve.value,
-          child: Opacity(
-            opacity: curve.value,
-            child: child,
-          ),
+        return Opacity(
+          opacity: curve.value,
+          child: child,
         );
       },
       child: Padding(


### PR DESCRIPTION
- make the connect notification dialog size to its height

Before, it would always have a min. height, even if the notification didn't need all the vertical space.

after this change:

<img width="373" alt="Screen Shot 2020-03-09 at 2 28 16 PM" src="https://user-images.githubusercontent.com/1269969/76260163-75983a00-6214-11ea-8587-45644f7b2d42.png">
