### PR TITLE
skip testing on windows on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 os:
   - linux
   - osx
-  - windows
+  # TODO(devoncarew): Skip testing on windows bots to work around a travis regression.
+  #- windows
 
 language: dart
 dart:


### PR DESCRIPTION
- skip testing on windows bots on the travis CI completely (to work around what looks like a travis regression - https://travis-ci.org/flutter/devtools/builds/660771129?utm_source=github_status&utm_medium=notification)
