### PR TITLE
Simplify publishing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ env:
   - BOT=test_dart2js PLATFORM=chrome
   - BOT=integration_ddc
   - BOT=integration_dart2js
-  - BOT=integration_dart2js USE_LOCAL_DEPENDENCIES=true
 
 script: ./tool/travis.sh
 

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -23,11 +23,11 @@ dependencies:
   intl: ^0.16.0
 
 dependency_overrides:
-# The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
-# tests can run using the in-repo version of these dependencies instead of
-# only the live Pub version.
-#OVERRIDE_FOR_TESTS   devtools_server:
-#OVERRIDE_FOR_TESTS     path: ../devtools_server
+# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+# All overriden dependencies and published together so there is no harm
+# in treating them like they are part of a mono-repo while developing.
+  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
 
 executables:
   devtools:

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-# All overriden dependencies and published together so there is no harm
+# All overriden dependencies are published together so there is no harm
 # in treating them like they are part of a mono-repo while developing.
   devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -123,7 +123,7 @@ flutter:
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-# All overriden dependencies and published together so there is no harm
+# All overriden dependencies are published together so there is no harm
 # in treating them like they are part of a mono-repo while developing.
   devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -122,12 +122,12 @@ flutter:
         - asset: fonts/Octicons.ttf
 
 dependency_overrides:
-  devtools_shared:
-    path: ../devtools_shared
-  # The text "#OVERRIDE_FOR_TESTS" is stripped out for some CI bots so that the
-  # tests can run using the in-repo version of these dependencies instead of
-  # only the live Pub version.
-  devtools_server:
-    path: ../devtools_server
-  devtools_testing:
-    path: ../devtools_testing
+# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+# All overriden dependencies and published together so there is no harm
+# in treating them like they are part of a mono-repo while developing.
+  devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_testing:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_testing  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-# All overriden dependencies and published together so there is no harm
+# All overriden dependencies are published together so there is no harm
 # in treating them like they are part of a mono-repo while developing.
   devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -26,5 +26,8 @@ dependencies:
   vm_service: ^4.0.0
 
 dependency_overrides:
-  devtools_shared:
-    path: ../devtools_shared
+# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+# All overriden dependencies and published together so there is no harm
+# in treating them like they are part of a mono-repo while developing.
+  devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -22,10 +22,12 @@ dependencies:
   vm_service: ^4.0.0
 
 dependency_overrides:
-  devtools_app:
-    path: ../devtools_app
-  devtools_server:
-    path: ../devtools_server
-  devtools_shared:
-    path: ../devtools_shared
-
+# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+# All overriden dependencies and published together so there is no harm
+# in treating them like they are part of a mono-repo while developing.
+  devtools_app:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_app  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-# All overriden dependencies and published together so there is no harm
+# All overriden dependencies are published together so there is no harm
 # in treating them like they are part of a mono-repo while developing.
   devtools_app:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_app  #OVERRIDE_FOR_DEVELOPMENT

--- a/tool/README.md
+++ b/tool/README.md
@@ -105,9 +105,10 @@ popd
 
 ```
 
-#### Revert the change to .gitignore
+#### Revert the change to .gitignore and pubspec files
 ```shell
 git checkout .gitignore
+git checkout packages/*/pubspec.yaml
 ```
 
 #### Create the tag for this release and push to the remote repository.

--- a/tool/publish.sh
+++ b/tool/publish.sh
@@ -18,10 +18,9 @@ pub get
 perl -pi -e "s/^build\/\$/\# build\//g" .gitignore
 popd
 
+echo "Updating pubspecs to remove dependency overrides for development"
+perl -pi -e 's/^.*#OVERRIDE_FOR_DEVELOPMENT.*//' packages/*/pubspec.yaml
+
 set +x
 echo "Ready to publish."
-echo "Verify the package works, then publish the package, and finally, revert the change to .gitignore."
-echo "Publish by:"
-echo "cd packages/devtools"
-echo "pub publish"
-echo "git checkout .gitignore"
+echo "Verify the package works, then follow the steps in tool/README.md to publish"

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -31,14 +31,6 @@ function flutter {
     fi
 }
 
-if [ -z "$USE_LOCAL_DEPENDENCIES" ]; then
-    echo "Using dependencies from Pub"
-else
-    echo "Updating pubspecs to use local dependencies"
-    perl -pi -e 's/#OVERRIDE_FOR_TESTS//' packages/devtools/pubspec.yaml
-    perl -pi -e 's/#OVERRIDE_FOR_TESTS//' packages/devtools_app/pubspec.yaml
-fi
-
 # Some integration tests assume the devtools package is up to date and located
 # adjacent to the devtools_app package.
 pushd packages/devtools


### PR DESCRIPTION
Remove obsolete OVERRIDE_FOR_TESTS functionality as we are now always overriding
and keeping the 4 mono-repo packages version locked so we can stop worrying
about versioning and just write code.