### PR TITLE
normalize padding on the info screen

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -13,8 +13,11 @@ import '../../globals.dart';
 
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
-      : super(DevToolsScreenType.debugger,
-            title: 'Debugger', icon: Octicons.bug);
+      : super(
+          DevToolsScreenType.debugger,
+          title: 'Debugger',
+          icon: Octicons.bug,
+        );
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -14,18 +14,22 @@ import '../info_controller.dart';
 
 class InfoScreen extends Screen {
   const InfoScreen()
-      : super(DevToolsScreenType.info, title: 'Info', icon: Octicons.info);
+      : super(
+          DevToolsScreenType.info,
+          title: 'Info',
+          icon: Octicons.info,
+        );
 
   @override
   Widget build(BuildContext context) => InfoScreenBody();
 
-  /// The key to identify the flag list view
-  @visibleForTesting
-  static const Key flagListKey = Key('Info Screen Flag List');
-
   /// The key to identify the flutter version view.
   @visibleForTesting
   static const Key flutterVersionKey = Key('Info Screen Flutter Version');
+
+  /// The key to identify the flag list view
+  @visibleForTesting
+  static const Key flagListKey = Key('Info Screen Flag List');
 }
 
 class InfoScreenBody extends StatefulWidget {
@@ -69,9 +73,11 @@ class _InfoScreenBodyState extends State<InfoScreenBody> {
           'Version Information',
           style: textTheme.headline5,
         ),
-        const PaddedDivider(),
-        if (_flutterVersion != null) _VersionInformation(_flutterVersion),
+        const PaddedDivider(padding: EdgeInsets.only(top: 4.0, bottom: 0.0)),
+        if (_flutterVersion != null)
+          _VersionInformation(_flutterVersion),
         const Padding(padding: EdgeInsets.only(top: 16.0)),
+        // TODO(devoncarew): Move this information into an advanced page.
         Text(
           'Dart VM Flag List',
           style: textTheme.headline5,
@@ -101,45 +107,29 @@ class _VersionInformation extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const boldText = TextStyle(fontWeight: FontWeight.bold);
-    const contentPadding = 8.0;
+
+    final versions = {
+      'DevTools': devtools.version,
+      'Flutter': flutterVersion.version,
+      'Framework': flutterVersion.frameworkRevision,
+      'Engine': flutterVersion.engineRevision,
+      'Dart': flutterVersion.dartSdkVersion,
+    };
+
     return Column(
       key: InfoScreen.flutterVersionKey,
       children: [
-        Row(
-          children: [
-            const Text('Flutter:', style: boldText),
-            const SizedBox(width: contentPadding),
-            Text(flutterVersion.flutterVersionSummary),
-          ],
-        ),
-        Row(
-          children: [
-            const Text('Framework:', style: boldText),
-            const SizedBox(width: contentPadding),
-            Text(flutterVersion.frameworkVersionSummary),
-          ],
-        ),
-        Row(
-          children: [
-            const Text('Engine:', style: boldText),
-            const SizedBox(width: contentPadding),
-            Text(flutterVersion.engineVersionSummary),
-          ],
-        ),
-        Row(
-          children: [
-            const Text('Dart SDK:', style: boldText),
-            const SizedBox(width: contentPadding),
-            Text(flutterVersion.dartSdkVersion),
-          ],
-        ),
-        Row(
-          children: const [
-            Text('DevTools:', style: boldText),
-            SizedBox(width: contentPadding),
-            Text(devtools.version),
-          ],
-        ),
+        for (var name in versions.keys)
+          Padding(
+            padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
+            child: Row(
+              children: [
+                Text(name, style: boldText),
+                const SizedBox(width: 8.0),
+                Text(versions[name]),
+              ],
+            ),
+          ),
       ],
     );
   }
@@ -161,7 +151,7 @@ class _FlagList extends StatelessWidget {
           final flag = flagList.flags[index];
           final modifiedStatusText = flag.modified ? 'modified' : 'default';
           return Padding(
-            padding: const EdgeInsets.all(10.0),
+            padding: const EdgeInsets.only(left: 8.0, bottom: 8.0),
             child: Row(
               crossAxisAlignment: CrossAxisAlignment.start,
               mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -23,8 +23,11 @@ import 'inspector_tree_flutter.dart';
 
 class InspectorScreen extends Screen {
   const InspectorScreen()
-      : super(DevToolsScreenType.inspector,
-            title: 'Flutter Inspector', icon: Octicons.deviceMobile);
+      : super(
+          DevToolsScreenType.inspector,
+          title: 'Flutter Inspector',
+          icon: Octicons.deviceMobile,
+        );
 
   @override
   Widget build(BuildContext context) => const InspectorScreenBody();

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -18,8 +18,11 @@ import '../logging_controller.dart';
 /// Presents logs from the connected app.
 class LoggingScreen extends Screen {
   const LoggingScreen()
-      : super(DevToolsScreenType.logging,
-            title: 'Logging', icon: Octicons.clippy);
+      : super(
+          DevToolsScreenType.logging,
+          title: 'Logging',
+          icon: Octicons.clippy,
+        );
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -16,8 +16,11 @@ import 'memory_controller.dart';
 
 class MemoryScreen extends Screen {
   const MemoryScreen()
-      : super(DevToolsScreenType.memory,
-            title: 'Memory', icon: Octicons.package);
+      : super(
+          DevToolsScreenType.memory,
+          title: 'Memory',
+          icon: Octicons.package,
+        );
 
   @visibleForTesting
   static const pauseButtonKey = Key('Pause Button');

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -15,8 +15,11 @@ import 'network_model.dart';
 
 class NetworkScreen extends Screen {
   const NetworkScreen()
-      : super(DevToolsScreenType.network,
-            title: 'Network', icon: Icons.network_check);
+      : super(
+          DevToolsScreenType.network,
+          title: 'Network',
+          icon: Icons.network_check,
+        );
 
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -18,8 +18,11 @@ import '../../ui/flutter/vm_flag_widgets.dart';
 
 class PerformanceScreen extends Screen {
   const PerformanceScreen()
-      : super(DevToolsScreenType.performance,
-            title: 'Performance', icon: Octicons.dashboard);
+      : super(
+          DevToolsScreenType.performance,
+          title: 'Performance',
+          icon: Octicons.dashboard,
+        );
 
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -30,8 +30,11 @@ import 'timeline_model.dart';
 
 class TimelineScreen extends Screen {
   const TimelineScreen()
-      : super(DevToolsScreenType.timeline,
-            title: 'Timeline', icon: Octicons.pulse);
+      : super(
+          DevToolsScreenType.timeline,
+          title: 'Timeline',
+          icon: Octicons.pulse,
+        );
 
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');

--- a/packages/devtools_app/test/flutter/scaffold_test.dart
+++ b/packages/devtools_app/test/flutter/scaffold_test.dart
@@ -73,8 +73,12 @@ void main() {
 
 class _TestScreen extends Screen {
   const _TestScreen(this.name, this.key, {Key tabKey})
-      : super(DevToolsScreenType.simple,
-            title: name, icon: Icons.computer, tabKey: tabKey);
+      : super(
+          DevToolsScreenType.simple,
+          title: name,
+          icon: Icons.computer,
+          tabKey: tabKey,
+        );
 
   final String name;
   final Key key;


### PR DESCRIPTION
- normalize padding on the info screen
- some formatting changes from review comments from a previous PR

Make the ws and padding on the info screen consistent. Also, add a todo: to remove the VM flags from this screen - it's much more advanced than a typical user would need.

<img width="756" alt="Screen Shot 2020-03-11 at 10 16 43 PM" src="https://user-images.githubusercontent.com/1269969/76534574-e74fce00-6436-11ea-9877-e91da8a1606a.png">
