### PR TITLE
add a feedback action to the appbar

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
 import '../../src/framework/framework_core.dart';
 import '../debugger/flutter/debugger_screen.dart';
@@ -56,8 +57,8 @@ class DevToolsAppState extends State<DevToolsApp> {
     final path = uri.path;
 
     // Update the theme based on the query parameters.
-    // TODO(djshuckerow): Update this with a NavigatorObserver to load the
-    // new theme a frame earlier.
+    // TODO(djshuckerow): Update this with a NavigatorObserver to load the new
+    // theme a frame earlier.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       // On desktop, don't change the theme on route changes.
       if (!kIsWeb) return;
@@ -117,8 +118,10 @@ class DevToolsAppState extends State<DevToolsApp> {
               InfoScreen(),
             ],
             actions: [
+              _BulletSpacer(),
               HotReloadButton(),
               HotRestartButton(),
+              ReportBugAction(),
             ],
           ),
         ),
@@ -160,6 +163,40 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
       location: BannerLocation.bottomEnd,
       child: Builder(
         builder: builder,
+      ),
+    );
+  }
+}
+
+class _BulletSpacer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      constraints: const BoxConstraints.tightFor(width: 24.0, height: 48.0),
+      alignment: Alignment.center,
+      child: const Text('•'),
+    );
+  }
+}
+
+class ReportBugAction extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: () async {
+        // TODO(devoncarew): Support analytics.
+        // ga.select(ga.devToolsMain, ga.feedback);
+
+        const reportIssuesUrl = 'https://github.com/flutter/devtools/issues';
+
+        if (await url_launcher.canLaunch(reportIssuesUrl)) {
+          await url_launcher.launch(reportIssuesUrl);
+        }
+      },
+      child: Container(
+        constraints: const BoxConstraints.tightFor(width: 48.0, height: 48.0),
+        alignment: Alignment.center,
+        child: Icon(Icons.bug_report),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -17,6 +17,7 @@ import '../performance/flutter/performance_screen.dart';
 import '../timeline/flutter/timeline_screen.dart';
 import '../ui/flutter/service_extension_widgets.dart';
 import '../ui/theme.dart' as devtools_theme;
+import 'common_widgets.dart';
 import 'connect_screen.dart';
 import 'initializer.dart';
 import 'notifications.dart';
@@ -118,7 +119,7 @@ class DevToolsAppState extends State<DevToolsApp> {
               InfoScreen(),
             ],
             actions: [
-              _BulletSpacer(),
+              BulletSpacer(),
               HotReloadButton(),
               HotRestartButton(),
               ReportBugAction(),
@@ -168,17 +169,6 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
   }
 }
 
-class _BulletSpacer extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      constraints: const BoxConstraints.tightFor(width: 24.0, height: 48.0),
-      alignment: Alignment.center,
-      child: const Text('•'),
-    );
-  }
-}
-
 class ReportBugAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -188,13 +178,16 @@ class ReportBugAction extends StatelessWidget {
         // ga.select(ga.devToolsMain, ga.feedback);
 
         const reportIssuesUrl = 'https://github.com/flutter/devtools/issues';
-
         if (await url_launcher.canLaunch(reportIssuesUrl)) {
           await url_launcher.launch(reportIssuesUrl);
+        } else {
+          Notifications.of(context).push('Unable to open url.');
+          Notifications.of(context).push('File issues at $reportIssuesUrl.');
         }
       },
       child: Container(
-        constraints: const BoxConstraints.tightFor(width: 48.0, height: 48.0),
+        width: 48.0,
+        height: 48.0,
         alignment: Alignment.center,
         child: Icon(
           Icons.bug_report,

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -196,7 +196,10 @@ class ReportBugAction extends StatelessWidget {
       child: Container(
         constraints: const BoxConstraints.tightFor(width: 48.0, height: 48.0),
         alignment: Alignment.center,
-        child: Icon(Icons.bug_report),
+        child: Icon(
+          Icons.bug_report,
+          size: 20.0,
+        ),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -281,6 +281,21 @@ Widget exitOfflineButton(FutureOr<void> Function() onPressed) {
   );
 }
 
+/// Display a single bullet character in order to act as a stylized spacer
+/// component.
+class BulletSpacer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // TODO(devoncarew): Use the theme's AppBar unselected text color for the
+    // bullet character.
+    return Container(
+      constraints: const BoxConstraints.tightFor(width: 24.0, height: 48.0),
+      alignment: Alignment.center,
+      child: const Text('•'),
+    );
+  }
+}
+
 /// Toggle button for use as a child of a [ToggleButtons] widget.
 class ToggleButton extends StatelessWidget {
   const ToggleButton({

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -224,9 +226,11 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
       final rightAdjust =
           isNarrow ? 0.0 : DevToolsScaffold.actionWidgetSize / 2;
       final animatedRightPadding = Tween<double>(
-        begin: DevToolsScaffold.actionWidgetSize *
-                (widget.actions?.length ?? 0.0) -
-            rightAdjust,
+        begin: math.max(
+            0.0,
+            DevToolsScaffold.actionWidgetSize *
+                    (widget.actions?.length ?? 0.0) -
+                rightAdjust),
         end: 0.0,
       ).evaluate(appBarCurve);
 

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -38,7 +38,7 @@ class DevToolsScaffold extends StatefulWidget {
   static const Key fullWidthKey = Key('Full-width Scaffold');
 
   /// The width at or below which we treat the scaffold as narrow-width.
-  static const double narrowWidthThreshold = 1000.0;
+  static const double narrowWidthThreshold = 1060.0;
 
   /// The size that all actions on this widget are expected to have.
   static const double actionWidgetSize = 48.0;
@@ -243,8 +243,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     }
 
     final appBar = AppBar(
-      // Turn off the appbar's back button on the web.
-      automaticallyImplyLeading: !kIsWeb,
+      // Turn off the appbar's back button.
+      automaticallyImplyLeading: false,
       title: title,
       actions: widget.actions,
       flexibleSpace: flexibleSpace,

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -221,12 +221,13 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         end: Alignment.bottomLeft,
       ).evaluate(appBarCurve);
 
-      final rightEdge = isNarrow ? 0.0 : DevToolsScaffold.actionWidgetSize / 2;
+      final rightAdjust =
+          isNarrow ? 0.0 : DevToolsScaffold.actionWidgetSize / 2;
       final animatedRightPadding = Tween<double>(
         begin: DevToolsScaffold.actionWidgetSize *
-                (widget.actions?.length ?? 0.0) +
-            rightEdge,
-        end: rightEdge,
+                (widget.actions?.length ?? 0.0) -
+            rightAdjust,
+        end: 0.0,
       ).evaluate(appBarCurve);
 
       flexibleSpace = Align(

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
+  url_launcher: ^5.0.0
   vm_service: ^4.0.0
   # We would use local dependencies for these packages if pub publish allowed it.
   octicons_css:


### PR DESCRIPTION
- add a feedback action to the appbar

This restores the feedback action we had in the dart:html version of the app. I'm not sure where the `ReportBugAction` class should go in the codebase.

Also, I tried to make the bullet spacer use the unselected app bar color, but wasn't able to get a non-null color value. I'd be interested in advice about how to calculate the right color...

<img width="262" alt="Screen Shot 2020-03-12 at 2 16 21 PM" src="https://user-images.githubusercontent.com/1269969/76567475-15033a00-646c-11ea-84c5-a9eb77fb4005.png">
