### PR TITLE
Correct vertical scrollbar issue for tables by using LinkedScrollControllerGroup

### DIFF
--- a/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,7 +6,9 @@ import FlutterMacOS
 import Foundation
 
 import path_provider_macos
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }


### PR DESCRIPTION
Bonus fixes: switched to using ListView.builder instead of Row to define rows.
Stopped making unclickable headers look like they were clickable.