### PR TITLE
add a new StatusLine widget at the bottom of the flutter web app

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -30,7 +30,7 @@ const double sideInsetSmall = 40.0;
 // [PointerHoverEvent.localPosition] is actually the absolute position right
 // now, so for mouse position detection in the flame chart container, we use
 // this offset. Use `localPosition` once this is fixed.
-const flameChartContainerOffset = 33.0;
+const flameChartContainerOffset = 17.0;
 
 // TODO(kenz): consider cleaning up by changing to a flame chart code to use a
 // composition pattern instead of a class extension pattern.

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -87,6 +87,7 @@ class DevToolsAppState extends State<DevToolsApp> {
       }());
       return MaterialPageRoute(settings: settings, builder: builder);
     }
+
     // Return a page not found.
     return MaterialPageRoute(
       settings: settings,
@@ -186,8 +187,8 @@ class ReportBugAction extends StatelessWidget {
         }
       },
       child: Container(
-        width: 48.0,
-        height: 48.0,
+        width: DevToolsScaffold.actionWidgetSize,
+        height: DevToolsScaffold.actionWidgetSize,
         alignment: Alignment.center,
         child: Icon(
           Icons.bug_report,

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../ui/flutter/label.dart';
+import 'scaffold.dart';
 
 const tooltipWait = Duration(milliseconds: 500);
 
@@ -289,7 +290,8 @@ class BulletSpacer extends StatelessWidget {
     // TODO(devoncarew): Use the theme's AppBar unselected text color for the
     // bullet character.
     return Container(
-      constraints: const BoxConstraints.tightFor(width: 24.0, height: 48.0),
+      width: DevToolsScaffold.actionWidgetSize / 2,
+      height: DevToolsScaffold.actionWidgetSize,
       alignment: Alignment.center,
       child: const Text('•'),
     );

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:pedantic/pedantic.dart';
 
-import '../../devtools.dart' as devtools;
 import '../../src/framework/framework_core.dart';
 import '../url_utils.dart';
 import 'common_widgets.dart';
@@ -74,12 +73,6 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
             // TODO(https://github.com/flutter/devtools/issues/1111): support drag-and-drop of snapshot files here.
           ],
         ),
-        Center(
-          child: Text(
-            'Version ${devtools.version}',
-            style: textTheme.subtitle1,
-          ),
-        )
       ],
     );
   }

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -48,12 +48,8 @@ class DevToolsScaffold extends StatefulWidget {
   static const double actionWidgetSize = 48.0;
 
   /// The border around the content in the DevTools UI.
-  static const EdgeInsets borderInsets = EdgeInsets.only(
-    top: 16.0,
-    right: 16.0,
-    bottom: 8.0,
-    left: 16.0,
-  );
+  static const EdgeInsets appPadding =
+      EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0);
 
   /// All of the [Screen]s that it's possible to navigate to from this Scaffold.
   final List<Screen> tabs;
@@ -185,7 +181,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         Align(
           alignment: Alignment.topLeft,
           child: Padding(
-            padding: DevToolsScaffold.borderInsets,
+            padding: DevToolsScaffold.appPadding,
             child: screen.build(context),
           ),
         ),
@@ -283,16 +279,20 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   }
 
   Widget _buildStatusLine(BuildContext context) {
-    final inset = DevToolsScaffold.borderInsets.bottom;
+    const appPadding = DevToolsScaffold.appPadding;
 
     return Container(
       height: 48.0,
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: <Widget>[
-          const PaddedDivider(padding: EdgeInsets.all(0.0)),
+        children: [
+          const PaddedDivider(padding: EdgeInsets.zero),
           Padding(
-            padding: EdgeInsets.only(right: inset, bottom: inset, left: inset),
+            padding: EdgeInsets.only(
+              left: appPadding.left,
+              right: appPadding.right,
+              bottom: appPadding.bottom,
+            ),
             child: StatusLine(),
           ),
         ],

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -11,9 +11,11 @@ import '../config_specific/flutter/drag_and_drop/drag_and_drop.dart';
 import '../config_specific/flutter/import_export/import_export.dart';
 import '../globals.dart';
 import 'app.dart';
+import 'common_widgets.dart';
 import 'controllers.dart';
 import 'notifications.dart';
 import 'screen.dart';
+import 'status_line.dart';
 import 'theme.dart';
 
 /// Scaffolding for a screen and navigation in the DevTools App.
@@ -44,6 +46,14 @@ class DevToolsScaffold extends StatefulWidget {
 
   /// The size that all actions on this widget are expected to have.
   static const double actionWidgetSize = 48.0;
+
+  /// The border around the content in the DevTools UI.
+  static const EdgeInsets borderInsets = EdgeInsets.only(
+    top: 16.0,
+    right: 16.0,
+    bottom: 8.0,
+    left: 16.0,
+  );
 
   /// All of the [Screen]s that it's possible to navigate to from this Scaffold.
   final List<Screen> tabs;
@@ -175,11 +185,12 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         Align(
           alignment: Alignment.topLeft,
           child: Padding(
-            padding: const EdgeInsets.all(32.0),
+            padding: DevToolsScaffold.borderInsets,
             child: screen.build(context),
           ),
         ),
     ];
+
     return DragAndDrop(
       handleDrop: _importController.importData,
       child: AnimatedBuilder(
@@ -188,6 +199,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           return Scaffold(
             appBar: _buildAppBar(),
             body: child,
+            bottomNavigationBar: _buildStatusLine(context),
           );
         },
         child: TabBarView(
@@ -266,6 +278,24 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
       child: Hero(
         tag: _appBarTag,
         child: appBar,
+      ),
+    );
+  }
+
+  Widget _buildStatusLine(BuildContext context) {
+    final inset = DevToolsScaffold.borderInsets.bottom;
+
+    return Container(
+      height: 48.0,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: <Widget>[
+          const PaddedDivider(padding: EdgeInsets.all(0.0)),
+          Padding(
+            padding: EdgeInsets.only(right: inset, bottom: inset, left: inset),
+            child: StatusLine(),
+          ),
+        ],
       ),
     );
   }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -16,8 +16,6 @@ class StatusLine extends StatelessWidget {
     final textTheme = Theme.of(context).textTheme;
 
     return Container(
-      // Used to diagnose the layout.
-      //color: Colors.grey,
       height: 24.0,
       child: Center(
         child: Text(

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -17,11 +17,10 @@ class StatusLine extends StatelessWidget {
 
     return Container(
       height: 24.0,
-      child: Center(
-        child: Text(
-          'DevTools ${devtools.version}',
-          style: textTheme.bodyText2,
-        ),
+      alignment: Alignment.centerLeft,
+      child: Text(
+        'DevTools ${devtools.version}',
+        style: textTheme.bodyText2,
       ),
     );
   }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -1,0 +1,30 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '../../devtools.dart' as devtools;
+
+/// The status line widget displayed at the bottom of DevTools.
+class StatusLine extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    // TODO(devoncarew): Break this into an isolates area, a connection status
+    // area, a page specific area, and a documentation link area.
+
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      // Used to diagnose the layout.
+      //color: Colors.grey,
+      height: 24.0,
+      child: Center(
+        child: Text(
+          'DevTools ${devtools.version}',
+          style: textTheme.bodyText2,
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
- add a new StatusLine widget at the bottom of the flutter web app
- some minor cleanup wrt constants from a previous PR

This is the UI portion of the change. We'd need to follow up with additional changes to show things like page specific statuses, an isolate selector (for the pages where that applies), possibly connection status, and possibly page specific help links. Adding some of those items would get us back to parity with the dart:html version of the app.

<img width="1109" alt="Screen Shot 2020-03-13 at 8 48 09 AM" src="https://user-images.githubusercontent.com/1269969/76640602-74fded00-650d-11ea-9c8e-9b5d1eaff8b0.png">

