### PR TITLE
some visual tweaks to the timeline page and flame chart

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -45,7 +45,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
     this.endInset = sideInset,
   });
   static const minZoomLevel = 1.0;
-  static const maxZoomLevel = 1000.0;
+  static const maxZoomLevel = 32000.0;
   static const minScrollOffset = 0.0;
   static const rowOffsetForBottomPadding = 1;
   static const rowOffsetForSectionSpacer = 1;

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -47,6 +47,8 @@ class DevToolsScaffold extends StatefulWidget {
   /// The size that all actions on this widget are expected to have.
   static const double actionWidgetSize = 48.0;
 
+  // TODO: When changing this value, also update `flameChartContainerOffset`
+  // from flame_chart.dart.
   /// The border around the content in the DevTools UI.
   static const EdgeInsets appPadding =
       EdgeInsets.fromLTRB(16.0, 16.0, 16.0, 8.0);
@@ -74,8 +76,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
 
   /// The controller for animating between tabs.
   ///
-  /// This will be passed to both the [TabBar] and the [TabBarView] widgets
-  /// to coordinate their animation when the tab selection changes.
+  /// This will be passed to both the [TabBar] and the [TabBarView] widgets to
+  /// coordinate their animation when the tab selection changes.
   TabController _tabController;
 
   ImportController _importController;
@@ -89,6 +91,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   @override
   void didUpdateWidget(DevToolsScaffold oldWidget) {
     super.didUpdateWidget(oldWidget);
+
     if (widget.tabs.length != oldWidget.tabs.length) {
       var newIndex = 0;
       // Stay on the current tab if possible when the collection of tabs changes.
@@ -143,8 +146,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
 
   /// Pushes tab changes into the navigation history.
   ///
-  /// Note that this currently works very well, but it doesn't
-  /// integrate with the browser's history yet.
+  /// Note that this currently works very well, but it doesn't integrate with
+  /// the browser's history yet.
   void _pushScreenToLocalPageRoute(int newIndex) {
     final previousTabIndex = _tabController.previousIndex;
     if (newIndex != previousTabIndex) {

--- a/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/event_details.dart
@@ -44,7 +44,7 @@ class EventDetails extends StatelessWidget {
             selectedEvent != null
                 ? '${selectedEvent.name} - ${msText(selectedEvent.time.duration)}'
                 : noEventSelected,
-            style: textTheme.headline6,
+            style: textTheme.subtitle1,
           ),
         ),
         const PaddedDivider.thin(),

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -231,7 +231,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     return Padding(
       padding: const EdgeInsets.only(bottom: 8.0),
       child: Container(
-        height: 200.0,
+        height: 160.0,
         child: BarChart(_chartController),
       ),
     );


### PR DESCRIPTION
Some visual tweaks to the timeline page and flame chart:

- allow 32x more zooming
- add a todo: to update a value in flame_chart.dart when the app's padding changes
- adjust some text size in the timeline page
- make the FPS bar chart slightly less high (to give more space to the flame chart area)

@kenzieschmoll 