### PR TITLE
change reload, restart notifications to use Notifications.of()

### DIFF
--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -406,10 +406,10 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
       await action();
 
       if (widget.completedText != null) {
-        Notifications.of(context)?.push(widget.completedText);
+        Notifications.of(context).push(widget.completedText);
       }
     } catch (e) {
-      Notifications.of(context)?.push(widget.describeError(e));
+      Notifications.of(context).push(widget.describeError(e));
     } finally {
       setState(() {
         disabled = false;

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
+import '../../flutter/notifications.dart';
 import '../../globals.dart';
 import '../../service_extensions.dart';
 import '../../service_registrations.dart';
@@ -169,7 +170,7 @@ class HotReloadButton extends StatelessWidget {
       serviceDescription: hotReload,
       action: serviceManager.performHotReload,
       inProgressText: 'Performing hot reload',
-      completedText: 'Hot reload completed',
+      completedText: 'Hot reload completed.',
       describeError: (error) => 'Unable to hot reload the app: $error',
     );
   }
@@ -183,7 +184,7 @@ class HotRestartButton extends StatelessWidget {
       serviceDescription: hotRestart,
       action: serviceManager.performHotRestart,
       inProgressText: 'Performing hot restart',
-      completedText: 'Hot restart completed',
+      completedText: 'Hot restart completed.',
       describeError: (error) => 'Unable to hot restart the app: $error',
     );
   }
@@ -390,36 +391,25 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
     if (disabled) {
       return;
     }
+
     setState(() {
       disabled = true;
     });
-    // TODO(https://github.com/flutter/devtools/issues/1249): Avoid adding
-    // and removing snackbars so often as we do here.
-    ScaffoldFeatureController<SnackBar, SnackBarClosedReason> snackBar;
+
     if (widget.inProgressText != null) {
-      Scaffold.of(context)
-          .removeCurrentSnackBar(reason: SnackBarClosedReason.remove);
-      // Push a snackbar that the action is in progress.
-      snackBar = Scaffold.of(context).showSnackBar(
-        SnackBar(content: Text(widget.inProgressText)),
-      );
+      // TODO(devoncarew): Display this 'starting work' message in the status
+      // bar.
+
     }
+
     try {
       await action();
-      // If the action was successful, remove the snack bar and show a new
-      // one with action success.
-      snackBar?.close();
+
       if (widget.completedText != null) {
-        Scaffold.of(context).showSnackBar(
-          SnackBar(content: Text(widget.completedText)),
-        );
+        Notifications.of(context).push(widget.completedText);
       }
     } catch (e) {
-      // On a failure, remove the snack bar and replace it with the failure.
-      snackBar?.close();
-      Scaffold.of(context).showSnackBar(
-        SnackBar(content: Text(widget.describeError(e))),
-      );
+      Notifications.of(context).push(widget.describeError(e));
     } finally {
       setState(() {
         disabled = false;

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -406,10 +406,10 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
       await action();
 
       if (widget.completedText != null) {
-        Notifications.of(context).push(widget.completedText);
+        Notifications.of(context)?.push(widget.completedText);
       }
     } catch (e) {
-      Notifications.of(context).push(widget.describeError(e));
+      Notifications.of(context)?.push(widget.describeError(e));
     } finally {
       setState(() {
         disabled = false;

--- a/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:devtools_app/src/flutter/notifications.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_extensions.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -19,6 +20,7 @@ import 'wrappers.dart';
 
 void main() {
   MockServiceManager mockServiceManager;
+
   setUp(() {
     mockServiceManager = MockServiceManager();
     when(mockServiceManager.serviceExtensionManager)
@@ -28,6 +30,7 @@ void main() {
       mockServiceManager,
     );
   });
+
   group('Hot Reload Button', () {
     int reloads = 0;
 
@@ -43,7 +46,9 @@ void main() {
         (WidgetTester tester) async {
       registerServiceExtension(mockServiceManager, hotReload);
       final button = HotReloadButton();
-      await tester.pumpWidget(wrap(Scaffold(body: Center(child: button))));
+      await tester.pumpWidget(
+        wrap(wrapWithNotifications(Scaffold(body: Center(child: button)))),
+      );
       expect(find.byWidget(button), findsOneWidget);
       await tester.pumpAndSettle();
       expect(reloads, 0);
@@ -86,7 +91,9 @@ void main() {
         (WidgetTester tester) async {
       registerServiceExtension(mockServiceManager, hotRestart);
       final button = HotRestartButton();
-      await tester.pumpWidget(wrap(Scaffold(body: Center(child: button))));
+      await tester.pumpWidget(
+        wrap(wrapWithNotifications(Scaffold(body: Center(child: button)))),
+      );
       expect(find.byWidget(button), findsOneWidget);
       await tester.pumpAndSettle();
       expect(restarts, 0);
@@ -172,6 +179,10 @@ void main() {
       expect(toggle.value, false, reason: 'The extension is disabled.');
     });
   });
+}
+
+Widget wrapWithNotifications(Widget child) {
+  return Notifications(child: child);
 }
 
 void registerServiceExtension(


### PR DESCRIPTION
- change reload, restart notifications to use Notifications.of()

The full-page width, docked to the bottom Scaffold / SnackBar notifications looked odd in a desktop app. This switches reload and restart notifications to our Notifications.of() system. Also, added a TODO: to better integrate this into a status line progress system when that exists.