### PR TITLE
various updates to the logging page

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_desktop.dart
+++ b/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_desktop.dart
@@ -10,8 +10,7 @@ String initializePlatform() {
   // platform is not officially supported. This is not needed for web.
   debugDefaultTargetPlatformOverride = TargetPlatform.fuchsia;
   // TODO(jacobr): we don't yet have a direct analog to the URL on flutter
-  // desktop.
-  // Hard code to the dark theme as the majority of users are on the dark
-  // theme.
+  // desktop. Hard code to the dark theme as the majority of users are on the
+  // dark theme.
   return '/?theme=dark';
 }

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -65,8 +65,8 @@ class DevToolsAppState extends State<DevToolsApp> {
       if (!kIsWeb) return;
       setState(() {
         final themeQueryParameter = uri.queryParameters['theme'];
-        // We refer to the legacy theme to make sure the
-        // debugging page stays in-sync with the rest of the app.
+        // We refer to the legacy theme to make sure the debugging page stays
+        // in-sync with the rest of the app.
         devtools_theme.initializeTheme(themeQueryParameter);
         theme = themeFor(isDarkTheme: devtools_theme.isDarkTheme);
       });

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -28,7 +28,7 @@ class FlatTable<T> extends StatefulWidget {
     Key key,
     @required this.columns,
     @required this.data,
-    this.populateInReverse = false,
+    this.reverse = false,
     @required this.keyFactory,
     @required this.onItemSelected,
   })  : assert(columns != null),
@@ -43,9 +43,9 @@ class FlatTable<T> extends StatefulWidget {
 
   /// Display list items reversed and from the bottom up.
   ///
-  /// Note: this is a workaround for implmenting auto-scrolling in order to
+  /// Note: this is a workaround for implementing auto-scrolling in order to
   /// always display newly added items.
-  final bool populateInReverse;
+  final bool reverse;
 
   /// Factory that creates keys for each row in this table.
   final Key Function(T data) keyFactory;
@@ -86,7 +86,7 @@ class _FlatTableState<T> extends State<FlatTable<T>> {
       itemCount: widget.data.length,
       columns: widget.columns,
       columnWidths: columnWidths,
-      populateInReverse: widget.populateInReverse,
+      reverse: widget.reverse,
       rowBuilder: _buildRow,
     );
   }
@@ -340,12 +340,12 @@ class _Table<T> extends StatefulWidget {
     @required this.columns,
     @required this.columnWidths,
     @required this.rowBuilder,
-    this.populateInReverse = false,
+    this.reverse = false,
   }) : super(key: key);
 
   final int itemCount;
 
-  final bool populateInReverse;
+  final bool reverse;
   final List<ColumnData<T>> columns;
   final List<double> columnWidths;
   final IndexedScrollableWidgetBuilder rowBuilder;
@@ -382,7 +382,7 @@ class __TableState<T> extends State<_Table<T>> {
       (2 * _Table.rowHorizontalPadding);
 
   Widget _buildItem(BuildContext context, int index) {
-    if (widget.populateInReverse) {
+    if (widget.reverse) {
       index = widget.itemCount - index - 1;
     }
 
@@ -419,7 +419,7 @@ class __TableState<T> extends State<_Table<T>> {
             Expanded(
               child: Scrollbar(
                 child: ListView.custom(
-                  reverse: widget.populateInReverse,
+                  reverse: widget.reverse,
                   childrenDelegate: itemDelegate,
                 ),
               ),
@@ -629,16 +629,9 @@ class _TableRowState<T> extends State<TableRow<T>>
     }
   }
 
-  TextStyle _fixedFontStyle(BuildContext context) {
-    return Theme.of(context)
-        .textTheme
-        .bodyText2
-        .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
-  }
-
   /// Presents the content of this row.
   Widget tableRowFor(BuildContext context) {
-    final fixedFontStyle = _fixedFontStyle(context);
+    final fontStyle = fixedFontStyle(context);
 
     Widget columnFor(ColumnData<T> column, double columnWidth) {
       Widget content;
@@ -657,7 +650,7 @@ class _TableRowState<T> extends State<TableRow<T>>
         content ??= Text(
           '${column.getDisplayValue(node)}',
           overflow: TextOverflow.ellipsis,
-          style: fixedFontStyle,
+          style: fontStyle,
         );
 
         if (column == widget.expandableColumn) {

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -9,8 +9,7 @@ import '../ui/theme.dart';
 
 /// Constructs the light or dark theme for the app.
 ThemeData themeFor({@required bool isDarkTheme}) {
-  final theme = isDarkTheme ? _darkTheme() : _lightTheme();
-  return theme;
+  return isDarkTheme ? _darkTheme() : _lightTheme();
 }
 
 ThemeData _darkTheme() {
@@ -132,3 +131,11 @@ final chartBoldTypeFace = TypeFace(
 );
 
 const lightSelection = Color(0xFFD4D7DA);
+
+/// Return the fixed font style for DevTools.
+TextStyle fixedFontStyle(BuildContext context) {
+  return Theme.of(context)
+      .textTheme
+      .bodyText2
+      .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
+}

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -27,7 +27,8 @@ const inspectorLibraryUriCandidates = [
 ];
 
 bool _inspectorDependenciesLoaded = false;
-// This method must be called before any methods on the Inspector are used.
+
+/// This method must be called before any methods on the Inspector are used.
 Future<void> ensureInspectorServiceDependencies() async {
   if (_inspectorDependenciesLoaded) {
     return;

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
@@ -14,6 +16,13 @@ import '../../flutter/theme.dart';
 import '../../table_data.dart';
 import '../../ui/flutter/service_extension_widgets.dart';
 import '../logging_controller.dart';
+
+// TODO(devoncarew): Show rows starting from the top (and have them grow down).
+// TODO(devoncarew): We should keep new items visible (if the last item was
+// already visible).
+
+// TODO(devoncarew): The last column of a table should take up all remaining
+// width.
 
 /// Presents logs from the connected app.
 class LoggingScreen extends Screen {
@@ -37,38 +46,77 @@ class LoggingScreenBody extends StatefulWidget {
 
 class _LoggingScreenState extends State<LoggingScreenBody>
     with AutoDisposeMixin {
-  LoggingController get controller => Controllers.of(context).logging;
   LogData selected;
+  TextEditingController filterController;
+
+  LoggingController get controller => Controllers.of(context).logging;
+
+  @override
+  void initState() {
+    super.initState();
+
+    filterController = TextEditingController();
+  }
 
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+
     cancel();
-    addAutoDisposeListener(controller.onLogsUpdated);
+
+    filterController.text = controller.filterText;
+    filterController.addListener(() {
+      controller.filterText = filterController.text;
+    });
+
+    addAutoDisposeListener(controller.onLogsUpdated, () {
+      setState(() {
+        if (selected != null) {
+          final List<LogData> items = controller.filteredData;
+          if (!items.contains(selected)) {
+            selected = null;
+          }
+        }
+      });
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Column(children: [
       Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
           RaisedButton(
             child: const Text('Clear logs'),
             onPressed: _clearLogs,
           ),
+          const Spacer(),
+          Container(
+            width: 200.0,
+            height: 36.0,
+            child: TextField(
+              controller: filterController,
+              decoration: const InputDecoration(
+                isDense: true,
+                border: OutlineInputBorder(),
+                labelText: 'Search',
+              ),
+            ),
+          ),
+          const SizedBox(width: 8.0),
           StructuredErrorsToggle(),
         ],
       ),
       Expanded(
         child: Split(
-          axis: Split.axisFor(context, 1.0),
+          axis: Axis.vertical,
           firstChild: LogsTable(
-            data: controller.data,
+            data: controller.filteredData,
             onItemSelected: _select,
           ),
           secondChild: LogDetails(log: selected),
-          initialFirstFraction: 0.6,
+          initialFirstFraction: 0.78,
         ),
       ),
     ]);
@@ -81,12 +129,14 @@ class _LoggingScreenState extends State<LoggingScreenBody>
   void _clearLogs() {
     setState(() {
       controller.clear();
+      selected = null;
     });
   }
 }
 
 class LogsTable extends StatelessWidget {
   const LogsTable({Key key, this.data, this.onItemSelected}) : super(key: key);
+
   final List<LogData> data;
   final ItemCallback<LogData> onItemSelected;
 
@@ -101,6 +151,7 @@ class LogsTable extends StatelessWidget {
     return FlatTable<LogData>(
       columns: columns,
       data: data,
+      populateInReverse: true,
       keyFactory: (LogData data) => ValueKey<LogData>(data),
       onItemSelected: onItemSelected,
     );
@@ -172,16 +223,19 @@ class _LogDetailsState extends State<LogDetails>
       builder: (context, _) {
         return Container(
           color: Theme.of(context).cardColor,
-          child: Stack(children: [
-            Opacity(
-              opacity: crossFade.value,
-              child: _buildContent(context, widget.log),
-            ),
-            Opacity(
-              opacity: 1 - crossFade.value,
-              child: _buildContent(context, _oldLog),
-            ),
-          ]),
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Opacity(
+                opacity: crossFade.value,
+                child: _buildContent(context, widget.log),
+              ),
+              Opacity(
+                opacity: 1 - crossFade.value,
+                child: _buildContent(context, _oldLog),
+              ),
+            ],
+          ),
         );
       },
     );
@@ -201,15 +255,11 @@ class _LogDetailsState extends State<LogDetails>
   Widget _buildInspector(BuildContext context, LogData log) => const SizedBox();
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
-    // TODO(https://github.com/flutter/devtools/issues/1339): Present with monospaced fonts.
     return Scrollbar(
       child: SingleChildScrollView(
         child: Text(
           log.prettyPrinted ?? '',
-          style: Theme.of(context)
-              .textTheme
-              .subtitle1
-              .copyWith(fontFamily: 'RobotoMono'),
+          style: _fixedFontStyle(context),
         ),
       ),
     );
@@ -227,20 +277,92 @@ class _WhenColumn extends LogWhenColumn {
   String getValue(LogData dataObject) => render(dataObject.timestamp);
 }
 
-class _KindColumn extends LogKindColumn {
+class _KindColumn extends LogKindColumn implements ColumnRenderer<LogData> {
   @override
   String getValue(LogData dataObject) => dataObject.kind;
 
   @override
-  double get fixedWidthPx => 120;
+  double get fixedWidthPx => 140;
+
+  @override
+  Widget build(BuildContext context, LogData item) {
+    final String kind = item.kind;
+
+    Color color = const Color.fromARGB(0xff, 0x61, 0x61, 0x61);
+
+    if (kind == 'stderr' || item.isError || kind == 'flutter.error') {
+      color = const Color.fromARGB(0xff, 0xF4, 0x43, 0x36);
+    } else if (kind == 'stdout') {
+      color = const Color.fromARGB(0xff, 0x78, 0x90, 0x9C);
+    } else if (kind.startsWith('flutter')) {
+      color = const Color.fromARGB(0xff, 0x00, 0x91, 0xea);
+    } else if (kind == 'gc') {
+      color = const Color.fromARGB(0xff, 0x42, 0x42, 0x42);
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 3.0),
+      decoration: BoxDecoration(
+        color: color,
+        borderRadius: BorderRadius.circular(3.0),
+      ),
+      child: Text(
+        kind,
+        overflow: TextOverflow.ellipsis,
+        style: _fixedFontStyle(context),
+      ),
+    );
+  }
 }
 
-class _MessageColumn extends LogMessageColumn {
+class _MessageColumn extends LogMessageColumn
+    implements ColumnRenderer<LogData> {
   _MessageColumn(String Function(String) logMessageToHtml)
       : super(logMessageToHtml);
 
-  /// TODO(djshuckerow): Do better than showing raw HTML here.
   @override
   String getValue(LogData dataObject) =>
       dataObject.summary ?? dataObject.details;
+
+  @override
+  Widget build(BuildContext context, LogData data) {
+    if (data.kind == 'flutter.frame') {
+      const Color color = Color.fromARGB(0xff, 0x00, 0x91, 0xea);
+      final Text text = Text(
+        '${getDisplayValue(data)}',
+        overflow: TextOverflow.ellipsis,
+        style: _fixedFontStyle(context),
+      );
+
+      double frameLength = 0.0;
+      try {
+        final int micros = jsonDecode(data.details)['elapsed'];
+        frameLength = micros * 3.0 / 1000.0;
+      } catch (e) {
+        // ignore
+      }
+
+      return Row(
+        children: <Widget>[
+          text,
+          Flexible(
+            child: Container(
+              height: 12.0,
+              width: frameLength,
+              decoration: const BoxDecoration(color: color),
+            ),
+          ),
+        ],
+      );
+    } else {
+      return null;
+    }
+  }
+}
+
+TextStyle _fixedFontStyle(BuildContext context) {
+  return Theme.of(context)
+      .textTheme
+      .bodyText2
+      .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
 }

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -151,7 +151,7 @@ class LogsTable extends StatelessWidget {
     return FlatTable<LogData>(
       columns: columns,
       data: data,
-      populateInReverse: true,
+      reverse: true,
       keyFactory: (LogData data) => ValueKey<LogData>(data),
       onItemSelected: onItemSelected,
     );
@@ -259,7 +259,7 @@ class _LogDetailsState extends State<LogDetails>
       child: SingleChildScrollView(
         child: Text(
           log.prettyPrinted ?? '',
-          style: _fixedFontStyle(context),
+          style: fixedFontStyle(context),
         ),
       ),
     );
@@ -300,6 +300,12 @@ class _KindColumn extends LogKindColumn implements ColumnRenderer<LogData> {
       color = const Color.fromARGB(0xff, 0x42, 0x42, 0x42);
     }
 
+    // Use a font color that contrasts with the colored backgrounds.
+    final textStyle = Theme.of(context)
+        .primaryTextTheme
+        .bodyText2
+        .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
+
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 3.0),
       decoration: BoxDecoration(
@@ -309,7 +315,7 @@ class _KindColumn extends LogKindColumn implements ColumnRenderer<LogData> {
       child: Text(
         kind,
         overflow: TextOverflow.ellipsis,
-        style: _fixedFontStyle(context),
+        style: textStyle,
       ),
     );
   }
@@ -331,7 +337,7 @@ class _MessageColumn extends LogMessageColumn
       final Text text = Text(
         '${getDisplayValue(data)}',
         overflow: TextOverflow.ellipsis,
-        style: _fixedFontStyle(context),
+        style: fixedFontStyle(context),
       );
 
       double frameLength = 0.0;
@@ -358,11 +364,4 @@ class _MessageColumn extends LogMessageColumn
       return null;
     }
   }
-}
-
-TextStyle _fixedFontStyle(BuildContext context) {
-  return Theme.of(context)
-      .textTheme
-      .bodyText2
-      .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
 }

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-
 import 'dart:async';
 
 import 'package:devtools_app/src/globals.dart';
@@ -24,6 +23,7 @@ void main() {
   LoggingScreen screen;
   group('Logging Screen', () {
     MockLoggingController mockLoggingController;
+
     Widget wrap(Widget widget) =>
         wrapWithControllers(widget, logging: mockLoggingController);
 
@@ -31,6 +31,7 @@ void main() {
       await ensureInspectorDependencies();
       mockLoggingController = MockLoggingController();
       when(mockLoggingController.data).thenReturn([]);
+      when(mockLoggingController.filteredData).thenReturn([]);
       when(mockLoggingController.onLogsUpdated).thenReturn(Reporter());
 
       setGlobal(
@@ -54,6 +55,7 @@ void main() {
       expect(find.byType(LogsTable), findsOneWidget);
       expect(find.byType(LogDetails), findsOneWidget);
       expect(find.text('Clear logs'), findsOneWidget);
+      expect(find.byType(TextField), findsOneWidget);
       expect(find.byType(StructuredErrorsToggle), findsOneWidget);
     });
 
@@ -62,6 +64,13 @@ void main() {
       verifyNever(mockLoggingController.clear());
       await tester.tap(find.text('Clear logs'));
       verify(mockLoggingController.clear()).called(1);
+    });
+
+    testWidgets('can enter filter text', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      verifyNever(mockLoggingController.clear());
+      await tester.enterText(find.byType(TextField), 'abc');
+      verify(mockLoggingController.filterText = 'abc');
     });
 
     testWidgets('can toggle structured errors', (WidgetTester tester) async {
@@ -86,6 +95,7 @@ void main() {
     group('with data', () {
       setUp(() {
         when(mockLoggingController.data).thenReturn(fakeLogData);
+        when(mockLoggingController.filteredData).thenReturn(fakeLogData);
       });
 
       testWidgets('shows most recent logs first', (WidgetTester tester) async {

--- a/packages/devtools_app/test/logging_controller_fixture_test.dart
+++ b/packages/devtools_app/test/logging_controller_fixture_test.dart
@@ -1,0 +1,20 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'package:test/test.dart';
+
+import 'package:devtools_testing/logging_controller_test.dart';
+import 'package:devtools_testing/support/flutter_test_driver.dart'
+    show FlutterRunConfiguration;
+import 'package:devtools_testing/support/flutter_test_environment.dart';
+
+void main() async {
+  final FlutterTestEnvironment env = FlutterTestEnvironment(
+    const FlutterRunConfiguration(withDebugger: true),
+    testAppDirectory: 'fixtures/flutter_error_app',
+  );
+
+  await runLoggingControllerTests(env);
+}

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -2,19 +2,99 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/inspector/inspector_service.dart';
+import 'package:devtools_app/src/logging/logging_controller.dart';
+import 'package:devtools_app/src/service_manager.dart';
 @TestOn('vm')
 import 'package:test/test.dart';
 
-import 'package:devtools_testing/logging_controller_test.dart';
-import 'package:devtools_testing/support/flutter_test_driver.dart'
-    show FlutterRunConfiguration;
-import 'package:devtools_testing/support/flutter_test_environment.dart';
+import 'flutter/inspector_screen_test.dart';
+import 'support/mocks.dart';
 
-void main() async {
-  final FlutterTestEnvironment env = FlutterTestEnvironment(
-    const FlutterRunConfiguration(withDebugger: true),
-    testAppDirectory: 'fixtures/flutter_error_app',
-  );
+void main() {
+  group('LoggingController', () {
+    LoggingController controller;
 
-  await runLoggingControllerTests(env);
+    void addStdoutData(String message) {
+      controller.log(LogData(
+        'stdout',
+        jsonEncode({'kind': 'stdout', 'message': message}),
+        0,
+        summary: message,
+      ));
+    }
+
+    setUp(() async {
+      setGlobal(
+        ServiceConnectionManager,
+        FakeServiceManager(useFakeService: true),
+      );
+
+      final InspectorService inspectorService = MockInspectorService();
+
+      controller = LoggingController(
+        isVisible: () => true,
+        onLogCountStatusChanged: (String status) {
+          // We don't use the status for these tests.
+        },
+        inspectorService: inspectorService,
+      );
+    });
+
+    test('initial state', () {
+      expect(controller.data, isEmpty);
+      expect(controller.filteredData, isEmpty);
+      expect(controller.filterText, isNull);
+    });
+
+    test('receives data', () {
+      expect(controller.data, isEmpty);
+
+      addStdoutData('Abc.');
+
+      expect(controller.data, isNotEmpty);
+      expect(controller.filteredData, isNotEmpty);
+
+      expect(controller.data.first.summary, contains('Abc'));
+    });
+
+    test('clear', () {
+      addStdoutData('Abc.');
+
+      expect(controller.data, isNotEmpty);
+      expect(controller.filteredData, isNotEmpty);
+
+      controller.clear();
+
+      expect(controller.data, isEmpty);
+      expect(controller.filteredData, isEmpty);
+    });
+
+    test('filteredData', () {
+      addStdoutData('abc');
+      addStdoutData('def');
+      addStdoutData('abc ghi');
+
+      expect(controller.data, hasLength(3));
+      expect(controller.filteredData, hasLength(3));
+
+      controller.filterText = 'abc';
+
+      expect(controller.data, hasLength(3));
+      expect(controller.filteredData, hasLength(2));
+
+      controller.filterText = 'def';
+
+      expect(controller.data, hasLength(3));
+      expect(controller.filteredData, hasLength(1));
+
+      controller.filterText = null;
+
+      expect(controller.data, hasLength(3));
+      expect(controller.filteredData, hasLength(3));
+    });
+  });
 }


### PR DESCRIPTION
Various updates to the logging page:
- make the table rows more compact
- change the table to render in monospaced font
- change the logging 'kind' column to render with a colored background
- allow for specific rows to have custom rendering
- use the custom rendering to display frame duration as different length bars for `flutter.frame` events
- have the logging details area display across the bottom of the page
- fix an issue with the logging details area not using the full width of its area
- add a new `'Search'` text field to the logging page, and use it to filter the displayed rows
- some changes to `LoggingController` to allow us to test just the controller (new tests in `logging_controller_test.dart`)
- added a bunch of todos for future work and improvements

<img width="1307" alt="Screen Shot 2020-03-15 at 6 05 59 AM" src="https://user-images.githubusercontent.com/1269969/76712709-66176600-66d8-11ea-959e-3a084ebd0590.png">

<img width="1034" alt="Screen Shot 2020-03-15 at 6 06 26 AM" src="https://user-images.githubusercontent.com/1269969/76712719-73345500-66d8-11ea-9456-be7b46c7d427.png">

<img width="1001" alt="Screen Shot 2020-03-15 at 6 06 41 AM" src="https://user-images.githubusercontent.com/1269969/76712727-7a5b6300-66d8-11ea-9533-13aafed00421.png">
