### PR TITLE
Various improvements to the status line

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -20,6 +20,12 @@ class DebuggerScreen extends Screen {
         );
 
   @override
+  String get docPageId => 'debugger';
+
+  @override
+  bool get usesIsolateSelector => true;
+
+  @override
   Widget build(BuildContext context) {
     return DebuggerScreenBody();
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -23,7 +23,7 @@ class DebuggerScreen extends Screen {
   String get docPageId => 'debugger';
 
   @override
-  bool get usesIsolateSelector => true;
+  bool get showIsolateSelector => true;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -162,7 +162,7 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
     return Banner(
       message: 'DEBUG',
       textDirection: TextDirection.ltr,
-      location: BannerLocation.bottomEnd,
+      location: BannerLocation.topStart,
       child: Builder(
         builder: builder,
       ),

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -63,7 +63,7 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
               'Connect to a Running App',
               style: textTheme.bodyText1,
             ),
-            const SizedBox(height: 6),
+            const SizedBox(height: 6.0),
             Text(
               'Enter a URL to a running Dart or Flutter application',
               style: textTheme.caption,

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -139,6 +139,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   @override
   void dispose() {
     _tabController?.dispose();
+    _currentScreen?.dispose();
     appBarAnimation?.dispose();
     super.dispose();
   }

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -81,7 +81,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   /// coordinate their animation when the tab selection changes.
   TabController _tabController;
 
-  ValueNotifier<Screen> _currentScreen;
+  final ValueNotifier<Screen> _currentScreen = ValueNotifier(null);
 
   ImportController _importController;
 
@@ -148,7 +148,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     _tabController?.dispose();
     _tabController = TabController(length: widget.tabs.length, vsync: this);
 
-    _currentScreen = ValueNotifier(widget.tabs[_tabController.index]);
+    _currentScreen.value = widget.tabs[_tabController.index];
     _tabController.addListener(() {
       _currentScreen.value = widget.tabs[_tabController.index];
     });

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
@@ -82,9 +81,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   /// coordinate their animation when the tab selection changes.
   TabController _tabController;
 
-  Screen _currentScreen;
-  final StreamController<Screen> _screenController =
-      StreamController.broadcast();
+  ValueNotifier<Screen> _currentScreen;
 
   ImportController _importController;
 
@@ -150,17 +147,10 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     _tabController?.dispose();
     _tabController = TabController(length: widget.tabs.length, vsync: this);
 
-    _handleScreenChange(widget.tabs[_tabController.index]);
+    _currentScreen = ValueNotifier(widget.tabs[_tabController.index]);
     _tabController.addListener(() {
-      _handleScreenChange(widget.tabs[_tabController.index]);
+      _currentScreen.value = widget.tabs[_tabController.index];
     });
-  }
-
-  void _handleScreenChange(Screen screen) {
-    if (screen?.type != _currentScreen?.type) {
-      _currentScreen = screen;
-      _screenController.add(_currentScreen);
-    }
   }
 
   /// Pushes tab changes into the navigation history.
@@ -209,11 +199,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         ),
     ];
 
-    return StreamProvider<Screen>(
-      create: (BuildContext context) {
-        return _screenController.stream;
-      },
-      initialData: _currentScreen,
+    return ValueListenableProvider<Screen>.value(
+      value: _currentScreen,
       child: DragAndDrop(
         handleDrop: _importController.importData,
         child: AnimatedBuilder(

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -31,17 +31,12 @@ abstract class Screen {
   /// testing).
   final Key tabKey;
 
-  /// Whether this screen provides a screen specific status.
-  ///
-  /// See also [buildStatus].
-  bool get providesStatus => false;
-
   /// Whether this screen should display the isolate selector in the status
   /// line.
   ///
   /// Some screens act on all isolates; for these screens, displaying a
   /// selector doesn't make sense.
-  bool get usesIsolateSelector => false;
+  bool get showIsolateSelector => false;
 
   /// The id to use to synthesize a help URL.
   ///
@@ -72,11 +67,11 @@ abstract class Screen {
   /// Builds the body to display for this tab.
   Widget build(BuildContext context);
 
-  /// Build a widget to display in the statys line.
+  /// Build a widget to display in the status line.
   ///
-  /// See also [providesStatus].
+  /// If this method returns `null`, then no page specific status is displayed.
   Widget buildStatus(BuildContext context, TextTheme textTheme) {
-    throw UnimplementedError();
+    return null;
   }
 }
 

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -32,19 +32,19 @@ abstract class Screen {
   final Key tabKey;
 
   /// Whether this screen provides a screen specific status.
-  /// 
+  ///
   /// See also [buildStatus].
   bool get providesStatus => false;
 
   /// Whether this screen should display the isolate selector in the status
   /// line.
-  /// 
+  ///
   /// Some screens act on all isolates; for these screens, displaying a
   /// selector doesn't make sense.
   bool get usesIsolateSelector => false;
 
   /// The id to use to synthesize a help URL.
-  /// 
+  ///
   /// If the screen does not have a custom documentation page, this property
   /// should return `null`.
   String get docPageId => null;
@@ -73,7 +73,7 @@ abstract class Screen {
   Widget build(BuildContext context);
 
   /// Build a widget to display in the statys line.
-  /// 
+  ///
   /// See also [providesStatus].
   Widget buildStatus(BuildContext context, TextTheme textTheme) {
     throw UnimplementedError();

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -31,6 +31,24 @@ abstract class Screen {
   /// testing).
   final Key tabKey;
 
+  /// Whether this screen provides a screen specific status.
+  /// 
+  /// See also [buildStatus].
+  bool get providesStatus => false;
+
+  /// Whether this screen should display the isolate selector in the status
+  /// line.
+  /// 
+  /// Some screens act on all isolates; for these screens, displaying a
+  /// selector doesn't make sense.
+  bool get usesIsolateSelector => false;
+
+  /// The id to use to synthesize a help URL.
+  /// 
+  /// If the screen does not have a custom documentation page, this property
+  /// should return `null`.
+  String get docPageId => null;
+
   /// Builds the tab to show for this screen in the [DevToolsScaffold]'s main
   /// navbar.
   ///
@@ -53,6 +71,13 @@ abstract class Screen {
 
   /// Builds the body to display for this tab.
   Widget build(BuildContext context);
+
+  /// Build a widget to display in the statys line.
+  /// 
+  /// See also [providesStatus].
+  Widget buildStatus(BuildContext context, TextTheme textTheme) {
+    throw UnimplementedError();
+  }
 }
 
 enum DevToolsScreenType {

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -95,10 +95,7 @@ class StatusLine extends StatelessWidget {
     if (docPageId != null) {
       return InkWell(
         onTap: () async {
-          // TODO(devoncarew): Shorten these urls to something like
-          // 'https://flutter.dev/devtools/$docPageId'.
-          final url =
-              'https://flutter.dev/docs/development/tools/devtools/$docPageId';
+          final url = 'https://flutter.dev/devtools/$docPageId';
           if (await url_launcher.canLaunch(url)) {
             await url_launcher.launch(url);
           } else {
@@ -106,7 +103,7 @@ class StatusLine extends StatelessWidget {
           }
         },
         child: Text(
-          'flutter.dev/docs/development/tools/devtools/$docPageId',
+          'flutter.dev/devtools/$docPageId',
           style: textTheme.bodyText2.copyWith(
             decoration: TextDecoration.underline,
           ),

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -2,9 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/flutter/common_widgets.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/material.dart';
-
-import '../../devtools.dart' as devtools;
+import 'package:vm_service/vm_service.dart';
 
 /// The status line widget displayed at the bottom of DevTools.
 class StatusLine extends StatelessWidget {
@@ -18,10 +19,91 @@ class StatusLine extends StatelessWidget {
     return Container(
       height: 24.0,
       alignment: Alignment.centerLeft,
-      child: Text(
-        'DevTools ${devtools.version}',
-        style: textTheme.bodyText2,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: <Widget>[
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerLeft,
+              child: buildIsolateSelector(textTheme),
+            ),
+          ),
+          BulletSpacer(),
+          Expanded(
+            child: Align(
+              alignment: Alignment.center,
+              child: buildPageStatus(textTheme),
+            ),
+          ),
+          BulletSpacer(),
+          Expanded(
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: buildConnectionStatus(textTheme),
+            ),
+          ),
+        ],
       ),
+    );
+  }
+
+  Widget buildIsolateSelector(TextTheme textTheme) {
+    // TODO: isolate selector
+
+    // TODO: only applies to certain pages
+
+    // todo: listen to more changes
+
+    return StreamBuilder(
+      initialData: serviceManager.isolateManager.selectedIsolate,
+      stream: serviceManager.isolateManager.onSelectedIsolateChanged,
+      builder: (BuildContext context, AsyncSnapshot<IsolateRef> snapshot) {
+        final vmService = serviceManager.service;
+
+        return Text(
+          '${snapshot.data?.id}',
+          style: textTheme.bodyText2,
+          overflow: TextOverflow.clip,
+        );
+      },
+    );
+  }
+
+  Widget buildPageStatus(TextTheme textTheme) {
+    // TODO: show page status for the current page
+
+    return Text(
+      'todo: page status',
+      style: textTheme.bodyText2,
+    );
+  }
+
+  Widget buildConnectionStatus(TextTheme textTheme) {
+    // TODO: show connection status
+
+    return StreamBuilder(
+      initialData: serviceManager.service != null,
+      stream: serviceManager.onStateChange,
+      builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
+        if (snapshot.data) {
+          final vmService = serviceManager.service;
+          final uri = vmService.connectedUri;
+
+          // todo: include flutter, dart vm, flutter web, web, ...
+
+          return Text(
+            'Connected to ${uri.host}:${uri.port}',
+            style: textTheme.bodyText2,
+            overflow: TextOverflow.clip,
+            //maxLines: 1,
+          );
+        } else {
+          return Text(
+            'No client connection',
+            style: textTheme.bodyText2,
+          );
+        }
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -12,6 +12,7 @@ import 'package:vm_service/vm_service.dart';
 import '../../devtools.dart' as devtools;
 import '../globals.dart';
 import '../service_manager.dart';
+import '../utils.dart';
 import 'common_widgets.dart';
 import 'notifications.dart';
 import 'screen.dart';
@@ -32,51 +33,48 @@ class StatusLine extends StatelessWidget {
     final List<Widget> children = [];
 
     // Have an area for page specific help (always docked to the left).
-    children.addAll([
-      Expanded(
-        child: Align(
-          alignment: Alignment.centerLeft,
-          child: buildHelpUrlStatus(context, currentScreen, textTheme),
-        ),
+    children.add(Expanded(
+      child: Align(
+        alignment: Alignment.centerLeft,
+        child: buildHelpUrlStatus(context, currentScreen, textTheme),
       ),
-      BulletSpacer(),
-    ]);
+    ));
+    children.add(BulletSpacer());
 
     // Optionally display page specific status.
-    if (currentScreen != null && currentScreen.providesStatus) {
-      children.addAll([
-        Expanded(
+    if (currentScreen != null) {
+      final Widget pageStatus =
+          buildPageStatus(context, currentScreen, textTheme);
+
+      if (pageStatus != null) {
+        children.add(Expanded(
           child: Align(
             alignment: Alignment.center,
             child: buildPageStatus(context, currentScreen, textTheme),
           ),
-        ),
-        BulletSpacer(),
-      ]);
+        ));
+        children.add(BulletSpacer());
+      }
     }
 
     // Optionally display an isolate selector.
-    if (currentScreen != null && currentScreen.usesIsolateSelector) {
-      children.addAll([
-        Expanded(
-          child: Align(
-            alignment: Alignment.center,
-            child: buildIsolateSelector(context, textTheme),
-          ),
+    if (currentScreen != null && currentScreen.showIsolateSelector) {
+      children.add(Expanded(
+        child: Align(
+          alignment: Alignment.center,
+          child: buildIsolateSelector(context, textTheme),
         ),
-        BulletSpacer(),
-      ]);
+      ));
+      children.add(BulletSpacer());
     }
 
     // Always display connection status (docked to the right).
-    children.addAll([
-      Expanded(
-        child: Align(
-          alignment: Alignment.centerRight,
-          child: buildConnectionStatus(textTheme),
-        ),
+    children.add(Expanded(
+      child: Align(
+        alignment: Alignment.centerRight,
+        child: buildConnectionStatus(textTheme),
       ),
-    ]);
+    ));
 
     return Container(
       height: statusLineHeight,
@@ -116,7 +114,7 @@ class StatusLine extends StatelessWidget {
       );
     } else {
       // Use a placeholder for pages with no explicit documentation.
-      return Text('DevTools ${devtools.version}');
+      return const Text('DevTools ${devtools.version}');
     }
   }
 
@@ -200,27 +198,4 @@ class StatusLine extends StatelessWidget {
       },
     );
   }
-}
-
-Stream combineStreams(Stream a, Stream b, Stream c) {
-  StreamController controller;
-
-  StreamSubscription asub;
-  StreamSubscription bsub;
-  StreamSubscription csub;
-
-  controller = StreamController(
-    onListen: () {
-      asub = a.listen(controller.add);
-      bsub = b.listen(controller.add);
-      csub = c.listen(controller.add);
-    },
-    onCancel: () {
-      asub?.cancel();
-      bsub?.cancel();
-      csub?.cancel();
-    },
-  );
-
-  return controller.stream;
 }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -2,97 +2,191 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/flutter/common_widgets.dart';
-import 'package:devtools_app/src/globals.dart';
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:vm_service/vm_service.dart';
 
+import '../../devtools.dart' as devtools;
+import '../globals.dart';
+import '../service_manager.dart';
+import 'common_widgets.dart';
+import 'notifications.dart';
+import 'screen.dart';
+
+const statusLineHeight = 24.0;
+
 /// The status line widget displayed at the bottom of DevTools.
+///
+/// This displays information global to the application, as well as gives pages
+/// a mechanism to display page-specific information.
 class StatusLine extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    // TODO(devoncarew): Break this into an isolates area, a connection status
-    // area, a page specific area, and a documentation link area.
-
     final textTheme = Theme.of(context).textTheme;
 
+    final Screen currentScreen = Provider.of<Screen>(context);
+
+    final List<Widget> children = [];
+
+    // Have an area for page specific help (always docked to the left).
+    children.addAll([
+      Expanded(
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: buildHelpUrlStatus(context, currentScreen, textTheme),
+        ),
+      ),
+      BulletSpacer(),
+    ]);
+
+    // Optionally display page specific status.
+    if (currentScreen != null && currentScreen.providesStatus) {
+      children.addAll([
+        Expanded(
+          child: Align(
+            alignment: Alignment.center,
+            child: buildPageStatus(context, currentScreen, textTheme),
+          ),
+        ),
+        BulletSpacer(),
+      ]);
+    }
+
+    // Optionally display an isolate selector.
+    if (currentScreen != null && currentScreen.usesIsolateSelector) {
+      children.addAll([
+        Expanded(
+          child: Align(
+            alignment: Alignment.center,
+            child: buildIsolateSelector(context, textTheme),
+          ),
+        ),
+        BulletSpacer(),
+      ]);
+    }
+
+    // Always display connection status (docked to the right).
+    children.addAll([
+      Expanded(
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: buildConnectionStatus(textTheme),
+        ),
+      ),
+    ]);
+
     return Container(
-      height: 24.0,
+      height: statusLineHeight,
       alignment: Alignment.centerLeft,
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: <Widget>[
-          Expanded(
-            child: Align(
-              alignment: Alignment.centerLeft,
-              child: buildIsolateSelector(textTheme),
-            ),
-          ),
-          BulletSpacer(),
-          Expanded(
-            child: Align(
-              alignment: Alignment.center,
-              child: buildPageStatus(textTheme),
-            ),
-          ),
-          BulletSpacer(),
-          Expanded(
-            child: Align(
-              alignment: Alignment.centerRight,
-              child: buildConnectionStatus(textTheme),
-            ),
-          ),
-        ],
+        children: children,
       ),
     );
   }
 
-  Widget buildIsolateSelector(TextTheme textTheme) {
-    // TODO: isolate selector
+  Widget buildHelpUrlStatus(
+    BuildContext context,
+    Screen currentScreen,
+    TextTheme textTheme,
+  ) {
+    final String docPageId = currentScreen.docPageId;
+    if (docPageId != null) {
+      return InkWell(
+        onTap: () async {
+          // TODO(devoncarew): Shorten these urls to something like
+          // 'https://flutter.dev/devtools/$docPageId'.
+          final url =
+              'https://flutter.dev/docs/development/tools/devtools/$docPageId';
+          if (await url_launcher.canLaunch(url)) {
+            await url_launcher.launch(url);
+          } else {
+            Notifications.of(context).push('Unable to open $url.');
+          }
+        },
+        child: Text(
+          'flutter.dev/docs/development/tools/devtools/$docPageId',
+          style: textTheme.bodyText2.copyWith(
+            decoration: TextDecoration.underline,
+          ),
+        ),
+      );
+    } else {
+      // Use a placeholder for pages with no explicit documentation.
+      return Text('DevTools ${devtools.version}');
+    }
+  }
 
-    // TODO: only applies to certain pages
+  Widget buildPageStatus(
+      BuildContext context, Screen currentScreen, TextTheme textTheme) {
+    return currentScreen.buildStatus(context, textTheme);
+  }
 
-    // todo: listen to more changes
+  Widget buildIsolateSelector(BuildContext context, TextTheme textTheme) {
+    final IsolateManager isolateManager = serviceManager.isolateManager;
 
-    return StreamBuilder(
-      initialData: serviceManager.isolateManager.selectedIsolate,
-      stream: serviceManager.isolateManager.onSelectedIsolateChanged,
+    // Listen to all isolate existence changes.
+    final Stream changeStream = combineStreams(
+      isolateManager.onSelectedIsolateChanged,
+      isolateManager.onIsolateCreated,
+      isolateManager.onIsolateExited,
+    );
+
+    return StreamBuilder<IsolateRef>(
+      initialData: isolateManager.selectedIsolate,
+      stream: changeStream.map((event) => isolateManager.selectedIsolate),
       builder: (BuildContext context, AsyncSnapshot<IsolateRef> snapshot) {
-        final vmService = serviceManager.service;
+        final List<IsolateRef> isolates = isolateManager.isolates;
 
-        return Text(
-          '${snapshot.data?.id}',
-          style: textTheme.bodyText2,
-          overflow: TextOverflow.clip,
+        // When we have two or more isolates with the same name, append dome
+        // disambiguating information.
+        String disambiguatedName(IsolateRef ref) {
+          String name = ref.name;
+          if (isolates.where((e) => e.name == ref.name).length >= 2) {
+            name = '$name (${ref.number})';
+          }
+          return 'isolate: $name';
+        }
+
+        return DropdownButton<IsolateRef>(
+          value: snapshot.data,
+          onChanged: (IsolateRef ref) {
+            isolateManager.selectIsolate(ref?.id);
+          },
+          isDense: true,
+          items: isolates.map((IsolateRef ref) {
+            return DropdownMenuItem<IsolateRef>(
+              value: ref,
+              child: Text(disambiguatedName(ref), style: textTheme.bodyText2),
+            );
+          }).toList(),
         );
       },
     );
   }
 
-  Widget buildPageStatus(TextTheme textTheme) {
-    // TODO: show page status for the current page
-
-    return Text(
-      'todo: page status',
-      style: textTheme.bodyText2,
-    );
-  }
-
   Widget buildConnectionStatus(TextTheme textTheme) {
-    // TODO: show connection status
-
     return StreamBuilder(
       initialData: serviceManager.service != null,
       stream: serviceManager.onStateChange,
       builder: (BuildContext context, AsyncSnapshot<bool> snapshot) {
         if (snapshot.data) {
-          final vmService = serviceManager.service;
-          final uri = vmService.connectedUri;
+          final app = serviceManager.connectedApp;
 
-          // todo: include flutter, dart vm, flutter web, web, ...
+          String description;
+          if (!app.isRunningOnDartVM) {
+            description = 'web app';
+          } else {
+            final VM vm = serviceManager.vm;
+            description =
+                '${vm.targetCPU}-${vm.architectureBits} ${vm.operatingSystem}';
+          }
 
           return Text(
-            'Connected to ${uri.host}:${uri.port}',
+            'Connected ($description)',
             style: textTheme.bodyText2,
             overflow: TextOverflow.clip,
             //maxLines: 1,
@@ -106,4 +200,27 @@ class StatusLine extends StatelessWidget {
       },
     );
   }
+}
+
+Stream combineStreams(Stream a, Stream b, Stream c) {
+  StreamController controller;
+
+  StreamSubscription asub;
+  StreamSubscription bsub;
+  StreamSubscription csub;
+
+  controller = StreamController(
+    onListen: () {
+      asub = a.listen(controller.add);
+      bsub = b.listen(controller.add);
+      csub = c.listen(controller.add);
+    },
+    onCancel: () {
+      asub?.cancel();
+      bsub?.cancel();
+      csub?.cancel();
+    },
+  );
+
+  return controller.stream;
 }

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -21,6 +21,9 @@ class InfoScreen extends Screen {
         );
 
   @override
+  bool get usesIsolateSelector => true;
+
+  @override
   Widget build(BuildContext context) => InfoScreenBody();
 
   /// The key to identify the flutter version view.

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -21,7 +21,7 @@ class InfoScreen extends Screen {
         );
 
   @override
-  bool get usesIsolateSelector => true;
+  bool get showIsolateSelector => true;
 
   @override
   Widget build(BuildContext context) => InfoScreenBody();

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -30,6 +30,9 @@ class InspectorScreen extends Screen {
         );
 
   @override
+  String get docPageId => 'inspector';
+
+  @override
   Widget build(BuildContext context) => const InspectorScreenBody();
 }
 

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -34,8 +34,27 @@ class LoggingScreen extends Screen {
         );
 
   @override
+  bool get providesStatus => true;
+
+  @override
+  String get docPageId => 'logging';
+
+  @override
   Widget build(BuildContext context) {
     return LoggingScreenBody();
+  }
+
+  @override
+  Widget buildStatus(BuildContext context, TextTheme textTheme) {
+    final LoggingController controller = Controllers.of(context).logging;
+
+    return StreamBuilder<String>(
+      initialData: controller.statusText,
+      stream: controller.onLogStatusChanged,
+      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+        return Text(snapshot.data ?? '');
+      },
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -34,9 +34,6 @@ class LoggingScreen extends Screen {
         );
 
   @override
-  bool get providesStatus => true;
-
-  @override
   String get docPageId => 'logging';
 
   @override

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -67,7 +67,7 @@ class LoggingDetailsController {
   /// Callback to execute to show the inspector.
   final VoidCallback onShowInspector;
 
-  /// Callback to executue to show the data from the details tree in the view.
+  /// Callback to execute to show the data from the details tree in the view.
   final OnShowDetails onShowDetails;
 
   /// Callback to create an inspectorTree for the logging view of the correct
@@ -164,6 +164,7 @@ class LoggingController {
       _handleConnectionStart(serviceManager.service);
     }
     _listen(serviceManager.onConnectionClosed, _handleConnectionStop);
+    _handleBusEvents();
   }
 
   LoggingDetailsController detailsController;
@@ -190,24 +191,6 @@ class LoggingController {
     _listen(_loggingTableModel.onRowsChanged, (_) {
       _updateStatus();
     });
-
-    // TODO(jacobr): expose the messageBus for use by vm tests.
-    if (messageBus != null) {
-      _listen(messageBus.onEvent(type: 'reload.end'), (BusEvent event) {
-        log(LogData(
-          'hot.reload',
-          event.data,
-          DateTime.now().millisecondsSinceEpoch,
-        ));
-      });
-      _listen(messageBus.onEvent(type: 'restart.end'), (BusEvent event) {
-        log(LogData(
-          'hot.restart',
-          event.data,
-          DateTime.now().millisecondsSinceEpoch,
-        ));
-      });
-    }
   }
 
   /// Callback returning whether the logging screen is visible.
@@ -215,6 +198,14 @@ class LoggingController {
 
   /// Callbacks to apply changes in the controller to other views.
   final OnLogCountStatusChanged onLogCountStatusChanged;
+
+  final StreamController<String> _logStatusController =
+      StreamController.broadcast();
+
+  /// A stream of events for the textual description of the log contents.
+  ///
+  /// See also [statusText].
+  Stream get onLogStatusChanged => _logStatusController.stream;
 
   /// This is specifiable in the constructor for testing.
   @visibleForTesting
@@ -262,19 +253,36 @@ class LoggingController {
     _cachedFilteredData = null;
 
     onLogsUpdated.notify();
+    _updateStatus();
   }
 
   /// ObjectGroup for Flutter (null for non-Flutter apps).
   ObjectGroup objectGroup;
 
-  void _updateStatus() {
-    final int count = _loggingTableModel.rowCount;
-    final String label = count >= kMaxLogItemsLowerBound
-        ? '${nf.format(kMaxLogItemsLowerBound)}+'
-        : nf.format(count);
+  String get statusText {
+    final int totalCount = data.length;
+    final int showingCount = filteredData.length;
 
-    // TODO(devoncarew): Nobody is currently listening for this event.
-    onLogCountStatusChanged('$label events');
+    String label;
+
+    if (totalCount == showingCount) {
+      label = nf.format(totalCount);
+    } else {
+      label = 'showing ${nf.format(showingCount)} of '
+          '${nf.format(totalCount)}';
+    }
+
+    label = '$label ${pluralize('event', totalCount)}';
+
+    return label;
+  }
+
+  void _updateStatus() {
+    final label = statusText;
+    _logStatusController.add(label);
+
+    // TODO(devoncarew): The Flutter web version does not listen for this event.
+    onLogCountStatusChanged(label);
   }
 
   void clear() {
@@ -282,6 +290,7 @@ class LoggingController {
     _cachedFilteredData = null;
     detailsController?.setData(null);
     _loggingTableModel?.setRows(data);
+    _updateStatus();
   }
 
   void _handleConnectionStart(VmServiceWrapper service) async {
@@ -554,6 +563,7 @@ class LoggingController {
     }
 
     onLogsUpdated.notify();
+    _updateStatus();
   }
 
   void entering() {
@@ -589,6 +599,26 @@ class LoggingController {
       subscription.cancel();
     }
     _subscriptions.clear();
+  }
+
+  void _handleBusEvents() {
+    // TODO(jacobr): expose the messageBus for use by vm tests.
+    if (messageBus != null) {
+      _listen(messageBus.onEvent(type: 'reload.end'), (BusEvent event) {
+        log(LogData(
+          'hot.reload',
+          event.data,
+          DateTime.now().millisecondsSinceEpoch,
+        ));
+      });
+      _listen(messageBus.onEvent(type: 'restart.end'), (BusEvent event) {
+        log(LogData(
+          'hot.restart',
+          event.data,
+          DateTime.now().millisecondsSinceEpoch,
+        ));
+      });
+    }
   }
 }
 

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -605,18 +605,22 @@ class LoggingController {
     // TODO(jacobr): expose the messageBus for use by vm tests.
     if (messageBus != null) {
       _listen(messageBus.onEvent(type: 'reload.end'), (BusEvent event) {
-        log(LogData(
-          'hot.reload',
-          event.data,
-          DateTime.now().millisecondsSinceEpoch,
-        ));
+        log(
+          LogData(
+            'hot.reload',
+            event.data,
+            DateTime.now().millisecondsSinceEpoch,
+          ),
+        );
       });
       _listen(messageBus.onEvent(type: 'restart.end'), (BusEvent event) {
-        log(LogData(
-          'hot.restart',
-          event.data,
-          DateTime.now().millisecondsSinceEpoch,
-        ));
+        log(
+          LogData(
+            'hot.restart',
+            event.data,
+            DateTime.now().millisecondsSinceEpoch,
+          ),
+        );
       });
     }
   }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -54,6 +54,9 @@ class MemoryScreen extends Screen {
   static const memorySourceMenuItemPrefix = 'Source: ';
 
   @override
+  String get docPageId => 'memory';
+
+  @override
   Widget build(BuildContext context) => const MemoryBody();
 }
 

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -36,6 +36,9 @@ class PerformanceScreen extends Screen {
   static const recordingStatusKey = Key('Recording Status');
 
   @override
+  String get docPageId => 'performance';
+
+  @override
   Widget build(BuildContext context) => PerformanceScreenBody();
 }
 

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -46,12 +46,13 @@ const flutterVersion = RegisteredServiceDescription._(
 
 /// Flutter memory service registered by Flutter Tools.
 ///
-/// We call this service to get version information about the Flutter Android memory info
-/// using Android's ADB.
+/// We call this service to get version information about the Flutter Android
+/// memory info using Android's ADB.
 const flutterMemory = RegisteredServiceDescription._(
   service: 'flutterMemoryInfo',
   title: 'Flutter Memory Info',
-  // TODO(terry): Better icon - package or memory looking for now snapshop is memory.
+  // TODO(terry): Better icon - package or memory looking for now snapshot is
+  // memory.
   icon: FlutterIcons.snapshot,
 );
 

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -52,6 +52,9 @@ class TimelineScreen extends Screen {
   static const stopRecordingButtonKey = Key('Stop Recording Button');
 
   @override
+  String get docPageId => 'timeline';
+
+  @override
   Widget build(BuildContext context) => TimelineScreenBody();
 }
 

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -210,6 +210,7 @@ Future<void> _wrapReloadCall(
   } catch (_) {
     final String message = 'error performing $name';
     messageBus.addEvent(BusEvent('$name.end', data: message));
+    rethrow;
   }
 }
 

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -203,21 +203,13 @@ Future<void> _wrapReloadCall(
     await reloadCall();
     timer.stop();
     // 'restarted in 1.6s'
-    final String message = '${name}ed in ${_renderDuration(timer.elapsed)}';
+    final String message = '${name}ed in ${renderDuration(timer.elapsed)}';
     messageBus.addEvent(BusEvent('$name.end', data: message));
     // TODO(devoncarew): Add analytics.
     //ga.select(ga.devToolsMain, ga.hotRestart, timer.elapsed.inMilliseconds);
   } catch (_) {
     final String message = 'error performing $name';
     messageBus.addEvent(BusEvent('$name.end', data: message));
-  }
-}
-
-String _renderDuration(Duration duration) {
-  if (duration.inMilliseconds < 1000) {
-    return '${nf.format(duration.inMilliseconds)}ms';
-  } else {
-    return '${(duration.inMilliseconds / 1000).toStringAsFixed(1)}s';
   }
 }
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -70,6 +70,16 @@ String msText(
       '${includeUnit ? ' ms' : ''}';
 }
 
+/// Render the given [Duration] to text using either seconds or milliseconds as
+/// the units, depending on the value of the duration.
+String renderDuration(Duration duration) {
+  if (duration.inMilliseconds < 1000) {
+    return '${nf.format(duration.inMilliseconds)}ms';
+  } else {
+    return '${(duration.inMilliseconds / 1000).toStringAsFixed(1)}s';
+  }
+}
+
 T nullSafeMin<T extends num>(T a, T b) {
   if (a == null || b == null) {
     return a ?? b;
@@ -188,6 +198,31 @@ String getSimpleStackFrameName(String name) {
     return newName;
   }
   return newName.split('&').last;
+}
+
+/// Return a Stream that fires events whenever any of the three given parameter
+/// streams fire.
+Stream combineStreams(Stream a, Stream b, Stream c) {
+  StreamController controller;
+
+  StreamSubscription asub;
+  StreamSubscription bsub;
+  StreamSubscription csub;
+
+  controller = StreamController(
+    onListen: () {
+      asub = a.listen(controller.add);
+      bsub = b.listen(controller.add);
+      csub = c.listen(controller.add);
+    },
+    onCancel: () {
+      asub?.cancel();
+      bsub?.cancel();
+      csub?.cancel();
+    },
+  );
+
+  return controller.stream;
 }
 
 class Property<T> {
@@ -551,6 +586,7 @@ class Range {
 
   final double begin;
   final double end;
+
   double get size => end - begin;
 
   @override

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -167,6 +167,8 @@ String longestFittingSubstring(
 bool isLetter(int codeUnit) =>
     (codeUnit >= 65 && codeUnit <= 90) || (codeUnit >= 97 && codeUnit <= 122);
 
+String pluralize(String word, int count) => count == 1 ? word : '${word}s';
+
 /// Returns a simplified version of a StackFrame name.
 ///
 /// Given an input such as

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   platform_detect: ^1.3.5
+  provider: ^4.0.0
   url_launcher: ^5.0.0
   vm_service: ^4.0.0
   # We would use local dependencies for these packages if pub publish allowed it.

--- a/packages/devtools_app/test/flutter/scaffold_test.dart
+++ b/packages/devtools_app/test/flutter/scaffold_test.dart
@@ -4,13 +4,25 @@
 
 import 'package:devtools_app/src/flutter/scaffold.dart';
 import 'package:devtools_app/src/flutter/screen.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
+import '../support/mocks.dart';
 import 'wrappers.dart';
 
 void main() {
   group('DevToolsScaffold widget', () {
+    MockServiceManager mockServiceManager;
+
+    setUp(() {
+      mockServiceManager = MockServiceManager();
+      when(mockServiceManager.service).thenReturn(null);
+      setGlobal(ServiceConnectionManager, mockServiceManager);
+    });
+
     testWidgetsWithWindowSize(
         'displays in narrow mode without error', const Size(800.0, 1200.0),
         (WidgetTester tester) async {

--- a/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:devtools_app/src/core/message_bus.dart';
 import 'package:devtools_app/src/flutter/notifications.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_extensions.dart';
@@ -42,7 +43,7 @@ void main() {
       });
     });
 
-    testWidgets('performs a hot reload when pressed',
+    testWidgetsWithContext('performs a hot reload when pressed',
         (WidgetTester tester) async {
       registerServiceExtension(mockServiceManager, hotReload);
       final button = HotReloadButton();
@@ -55,6 +56,8 @@ void main() {
       await tester.tap(find.byWidget(button));
       await tester.pumpAndSettle();
       expect(reloads, 1);
+    }, context: {
+      MessageBus: MessageBus(),
     });
 
     testWidgets(
@@ -87,7 +90,7 @@ void main() {
       });
     });
 
-    testWidgets('performs a hot restart when pressed',
+    testWidgetsWithContext('performs a hot restart when pressed',
         (WidgetTester tester) async {
       registerServiceExtension(mockServiceManager, hotRestart);
       final button = HotRestartButton();
@@ -100,6 +103,8 @@ void main() {
       await tester.tap(find.byWidget(button));
       await tester.pumpAndSettle();
       expect(restarts, 1);
+    }, context: {
+      MessageBus: MessageBus(),
     });
 
     testWidgets(

--- a/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/flutter/service_extension_widgets_test.dart
@@ -26,10 +26,7 @@ void main() {
     mockServiceManager = MockServiceManager();
     when(mockServiceManager.serviceExtensionManager)
         .thenReturn(FakeServiceExtensionManager());
-    setGlobal(
-      ServiceConnectionManager,
-      mockServiceManager,
-    );
+    setGlobal(ServiceConnectionManager, mockServiceManager);
   });
 
   group('Hot Reload Button', () {

--- a/packages/devtools_app/test/flutter/wrappers.dart
+++ b/packages/devtools_app/test/flutter/wrappers.dart
@@ -5,6 +5,7 @@
 import 'package:devtools_app/src/flutter/controllers.dart';
 import 'package:devtools_app/src/flutter/notifications.dart';
 import 'package:devtools_app/src/flutter/theme.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/memory/flutter/memory_controller.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
@@ -51,6 +52,33 @@ Widget wrapWithControllers(
       ),
     ),
   );
+}
+
+/// Call [testWidgets], allowing the test to set specific values for app globals
+/// ([MessageBus], ...).
+@isTest
+void testWidgetsWithContext(
+  String description,
+  WidgetTesterCallback callback, {
+  Map<Type, dynamic> context = const {},
+}) {
+  testWidgets(description, (WidgetTester widgetTester) async {
+    // set up the context
+    final Map<Type, dynamic> oldValues = {};
+    for (Type type in context.keys) {
+      oldValues[type] = globals[type];
+      setGlobal(type, context[type]);
+    }
+
+    try {
+      await callback(widgetTester);
+    } finally {
+      // restore previous global values
+      for (Type type in oldValues.keys) {
+        setGlobal(type, oldValues[type]);
+      }
+    }
+  });
 }
 
 /// Runs a test with the size of the app window under test to [windowSize].

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -298,6 +298,20 @@ void main() {
       expect(getSimpleStackFrameName(name), equals(name));
     });
 
+    group('pluralize', () {
+      test('zero', () {
+        expect(pluralize('cat', 0), 'cats');
+      });
+
+      test('one', () {
+        expect(pluralize('cat', 1), 'cat');
+      });
+
+      test('many', () {
+        expect(pluralize('cat', 2), 'cats');
+      });
+    });
+
     group('safeDivide', () {
       test('divides a finite result correctly', () {
         expect(safeDivide(2.0, 1.0), 2.0);


### PR DESCRIPTION
Various improvements to the status line:
- added 4 sections to the status line: a page aware help url, an optional per-page status, an optional isolate selector, and connection status
- added the use of `package:provider` in order to make the current screen available to widgets further down the app (like the status line)
- have screens report whether they have a screen specific help url; whether that screen needs an isolate selector, and whether that screen has page specific status
- have the logging page implement page specific status (to show the total number of items, and the filtered count if there's a filter)
- move the `Debug` banner so that it doesn't draw over the status line

<img width="1160" alt="Screen Shot 2020-03-17 at 9 45 08 AM" src="https://user-images.githubusercontent.com/1269969/76885302-413c0380-683c-11ea-826f-faeab641fbff.png">

<img width="1161" alt="Screen Shot 2020-03-17 at 9 44 58 AM" src="https://user-images.githubusercontent.com/1269969/76885316-46994e00-683c-11ea-859c-8dc4d3459fc8.png">

<img width="1164" alt="Screen Shot 2020-03-17 at 9 44 51 AM" src="https://user-images.githubusercontent.com/1269969/76885326-4c8f2f00-683c-11ea-8a9c-e273168c3112.png">
