### PR TITLE
Implement scroll-to-zoom and alt+scroll for flame charts

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -1,10 +1,12 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:async';
 import 'dart:math' as math;
 import 'dart:ui';
 
 import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -15,7 +17,6 @@ import '../../flutter/extent_delegate_list.dart';
 import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/theme.dart';
 import '../../ui/colors.dart';
-import '../../ui/fake_flutter/_real_flutter.dart';
 import '../../utils.dart';
 
 const double rowPadding = 2.0;
@@ -46,9 +47,16 @@ abstract class FlameChart<T, V> extends StatefulWidget {
   });
   static const minZoomLevel = 1.0;
   static const maxZoomLevel = 32000.0;
+  static const zoomMultiplier = 0.003;
   static const minScrollOffset = 0.0;
   static const rowOffsetForBottomPadding = 1;
   static const rowOffsetForSectionSpacer = 1;
+
+  /// Maximum scroll delta allowed for scroll wheel based zooming.
+  ///
+  /// This isn't really needed but is a reasonable for safety in case we
+  /// aren't handling some mouse based scroll wheel behavior well, etc.
+  static const double maxScrollWheelDelta = 20.0;
 
   final T data;
 
@@ -90,6 +98,8 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
   double mouseHoverX;
 
   ScrollController verticalScrollController;
+
+  FixedExtentDelegate verticalExtentDelegate;
 
   LinkedScrollControllerGroup linkedHorizontalScrollControllerGroup;
 
@@ -164,6 +174,12 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       upperBound: FlameChart.maxZoomLevel,
       vsync: this,
     )..addListener(_handleZoomControllerValueUpdate);
+
+    verticalExtentDelegate = FixedExtentDelegate(
+      computeExtent: (index) =>
+          rows[index].nodes.isEmpty ? sectionSpacing : rowHeightWithPadding,
+      computeLength: () => rows.length,
+    );
   }
 
   @override
@@ -174,6 +190,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       verticalScrollController.jumpTo(FlameChart.minScrollOffset);
       previousZoom = FlameChart.minZoomLevel;
       zoomController.reset();
+      verticalExtentDelegate.recompute();
     }
     FocusScope.of(context).requestFocus(focusNode);
     super.didUpdateWidget(oldWidget);
@@ -197,45 +214,45 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       child: RawKeyboardListener(
         focusNode: focusNode,
         onKey: (event) => _handleKeyEvent(event),
-        child: Listener(
-          behavior: HitTestBehavior.opaque,
-          onPointerSignal: (event) => _handlePointerSignal(event),
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              final customPaints = buildCustomPaints(constraints);
-              final flameChart = _buildFlameChart(constraints);
-              return customPaints.isNotEmpty
-                  ? Stack(
-                      children: [
-                        flameChart,
-                        ...customPaints,
-                      ],
-                    )
-                  : flameChart;
-            },
-          ),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            final customPaints = buildCustomPaints(constraints);
+            final flameChart = _buildFlameChart(constraints);
+            return customPaints.isNotEmpty
+                ? Stack(
+                    children: [
+                      flameChart,
+                      ...customPaints,
+                    ],
+                  )
+                : flameChart;
+          },
         ),
       ),
     );
   }
 
   Widget _buildFlameChart(BoxConstraints constraints) {
-    return ListView.builder(
+    return ExtentDelegateListView(
       controller: verticalScrollController,
-      addAutomaticKeepAlives: false,
-      itemCount: rows.length,
-      itemBuilder: (context, index) {
-        // TODO(kenz): investigate if we are building too many
-        // ScrollingFlameChartRow widgets on zoom / pan.
-        return ScrollingFlameChartRow<V>(
-          linkedScrollControllerGroup: linkedHorizontalScrollControllerGroup,
-          nodes: rows[index].nodes,
-          width: math.max(constraints.maxWidth, widthWithZoom),
-          startInset: widget.startInset,
-          selected: widget.selected,
-          zoom: zoomController.value,
-        );
-      },
+      extentDelegate: verticalExtentDelegate,
+      customPointerSignalHandler: _handlePointerSignal,
+      childrenDelegate: SliverChildBuilderDelegate(
+        (context, index) {
+          // TODO(kenz): investigate if we are building too many
+          // ScrollingFlameChartRow widgets on zoom / pan.
+          return ScrollingFlameChartRow<V>(
+            linkedScrollControllerGroup: linkedHorizontalScrollControllerGroup,
+            nodes: rows[index].nodes,
+            width: math.max(constraints.maxWidth, widthWithZoom),
+            startInset: widget.startInset,
+            selected: widget.selected,
+            zoom: zoomController.value,
+          );
+        },
+        childCount: rows.length,
+        addAutomaticKeepAlives: false,
+      ),
     );
   }
 
@@ -286,10 +303,10 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
         zoomTo(math.max(FlameChart.minZoomLevel,
             zoomController.value - keyboardZoomOutUnit));
       } else if (keyLabel == 'a') {
-        scrollTo(
+        horizontallyScrollTo(
             linkedHorizontalScrollControllerGroup.offset - keyboardScrollUnit);
       } else if (keyLabel == 'd') {
-        scrollTo(
+        horizontallyScrollTo(
             linkedHorizontalScrollControllerGroup.offset + keyboardScrollUnit);
       }
     }
@@ -297,12 +314,38 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
 
   void _handlePointerSignal(PointerSignalEvent event) {
     if (event is PointerScrollEvent) {
-      if (_shiftKeyPressed) {
-        // TODO(kenz): scroll vertical list regularly / zoom. See
-        // https://github.com/flutter/devtools/issues/1600.
+      final deltaX = event.scrollDelta.dx;
+      double deltaY = event.scrollDelta.dy;
+      // TODO(kenz): shift + scroll with a mouse wheel does not register as a
+      // vertical scroll event, so we will not vertical scroll in this case (see
+      // https://github.com/flutter/flutter/issues/52767). Hopefully we can get
+      // around this if https://github.com/flutter/flutter/issues/52762 is
+      // fixed.
+      if (deltaY.abs() >= deltaX.abs()) {
+        if (_shiftKeyPressed) {
+          verticalScrollController
+              .jumpTo(verticalScrollController.offset + deltaY);
+        } else {
+          deltaY = deltaY.clamp(
+            -FlameChart.maxScrollWheelDelta,
+            FlameChart.maxScrollWheelDelta,
+          );
+          final currentZoom = zoomController.value;
+          // TODO(kenz): if https://github.com/flutter/flutter/issues/52762 is,
+          // resolved, consider adjusting the multiplier based on the scroll device
+          // kind (mouse or track pad).
+          final multiplier = FlameChart.zoomMultiplier * currentZoom;
+          final newZoomLevel = (currentZoom + deltaY * multiplier).clamp(
+            FlameChart.minZoomLevel,
+            FlameChart.maxZoomLevel,
+          );
+          zoomTo(newZoomLevel, jump: true);
+        }
       } else {
-        // TODO(kenz): scroll vertical list regularly / zoom. See
-        // https://github.com/flutter/devtools/issues/1600.
+        horizontallyScrollTo(
+          linkedHorizontalScrollControllerGroup.offset + deltaX,
+          jump: true,
+        );
       }
     }
   }
@@ -333,22 +376,34 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     });
   }
 
-  Future<void> zoomTo(double zoom, {double forceMouseX}) async {
+  Future<void> zoomTo(
+    double zoom, {
+    double forceMouseX,
+    bool jump = false,
+  }) async {
     if (forceMouseX != null) {
       mouseHoverX = forceMouseX;
     }
     await zoomController.animateTo(
       zoom.clamp(FlameChart.minZoomLevel, FlameChart.maxZoomLevel),
-      duration: shortDuration,
+      duration: jump ? Duration.zero : shortDuration,
     );
   }
 
-  Future<void> scrollTo(double offset) async {
-    await linkedHorizontalScrollControllerGroup.animateTo(
-      offset.clamp(FlameChart.minScrollOffset, maxScrollOffset),
-      curve: defaultCurve,
-      duration: shortDuration,
-    );
+  FutureOr<void> horizontallyScrollTo(
+    double offset, {
+    bool jump = false,
+  }) async {
+    final target = offset.clamp(FlameChart.minScrollOffset, maxScrollOffset);
+    if (jump) {
+      linkedHorizontalScrollControllerGroup.jumpTo(target);
+    } else {
+      await linkedHorizontalScrollControllerGroup.animateTo(
+        target,
+        curve: defaultCurve,
+        duration: shortDuration,
+      );
+    }
   }
 }
 
@@ -458,6 +513,8 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
             controller: scrollController,
             scrollDirection: Axis.horizontal,
             extentDelegate: extentDelegate,
+            // Horizontal scrolling is handled in FlameChartState.
+            physics: const NeverScrollableScrollPhysics(),
             childrenDelegate: SliverChildBuilderDelegate(
               (context, index) => _buildFlameChartNode(index),
               childCount: nodes.length,
@@ -719,7 +776,7 @@ class FlameChartNode<T> {
 
   static const _selectedNodeColor = lightSelection;
   static const _alternateTextColor = Colors.black;
-  static const _minWidthForText = 22.0;
+  static const _minWidthForText = 30.0;
 
   final Key key;
   final Rect rect;

--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -504,6 +504,8 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
             childrenDelegate: SliverChildBuilderDelegate(
               (context, index) => _buildFlameChartNode(index),
               childCount: nodes.length,
+              addRepaintBoundaries: false,
+              addAutomaticKeepAlives: false,
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
@@ -1,0 +1,874 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+
+/// A [ScrollView] that uses a single child layout model and allows for custom
+/// handling of [PointerSignalEvent]s.
+///
+/// This class is copied from the Flutter framework [BoxScrollView] and
+/// overrides [ScrollView.build] to use [CustomPointerScrollable] in place of
+/// [Scrollable].
+abstract class CustomPointerScrollView extends ScrollView {
+  /// Creates a [ScrollView] uses a single child layout model.
+  ///
+  /// If the [primary] argument is true, the [controller] must be null.
+  const CustomPointerScrollView({
+    Key key,
+    Axis scrollDirection = Axis.vertical,
+    bool reverse = false,
+    ScrollController controller,
+    bool primary,
+    ScrollPhysics physics,
+    bool shrinkWrap = false,
+    this.padding,
+    double cacheExtent,
+    int semanticChildCount,
+    DragStartBehavior dragStartBehavior = DragStartBehavior.start,
+    this.customPointerSignalHandler,
+  }) : super(
+          key: key,
+          scrollDirection: scrollDirection,
+          reverse: reverse,
+          controller: controller,
+          primary: primary,
+          physics: physics,
+          shrinkWrap: shrinkWrap,
+          cacheExtent: cacheExtent,
+          semanticChildCount: semanticChildCount,
+          dragStartBehavior: dragStartBehavior,
+        );
+
+  /// The amount of space by which to inset the children.
+  final EdgeInsetsGeometry padding;
+
+  final void Function(PointerSignalEvent event) customPointerSignalHandler;
+
+  @override
+  List<Widget> buildSlivers(BuildContext context) {
+    Widget sliver = buildChildLayout(context);
+    EdgeInsetsGeometry effectivePadding = padding;
+    if (padding == null) {
+      final MediaQueryData mediaQuery = MediaQuery.of(context, nullOk: true);
+      if (mediaQuery != null) {
+        // Automatically pad sliver with padding from MediaQuery.
+        final EdgeInsets mediaQueryHorizontalPadding =
+            mediaQuery.padding.copyWith(top: 0.0, bottom: 0.0);
+        final EdgeInsets mediaQueryVerticalPadding =
+            mediaQuery.padding.copyWith(left: 0.0, right: 0.0);
+        // Consume the main axis padding with SliverPadding.
+        effectivePadding = scrollDirection == Axis.vertical
+            ? mediaQueryVerticalPadding
+            : mediaQueryHorizontalPadding;
+        // Leave behind the cross axis padding.
+        sliver = MediaQuery(
+          data: mediaQuery.copyWith(
+            padding: scrollDirection == Axis.vertical
+                ? mediaQueryHorizontalPadding
+                : mediaQueryVerticalPadding,
+          ),
+          child: sliver,
+        );
+      }
+    }
+
+    if (effectivePadding != null)
+      sliver = SliverPadding(padding: effectivePadding, sliver: sliver);
+    return <Widget>[sliver];
+  }
+
+  /// Subclasses should override this method to build the layout model.
+  @protected
+  Widget buildChildLayout(BuildContext context);
+
+  @override
+  Widget build(BuildContext context) {
+    final List<Widget> slivers = buildSlivers(context);
+    final AxisDirection axisDirection = getDirection(context);
+
+    final ScrollController scrollController =
+        primary ? PrimaryScrollController.of(context) : controller;
+    final CustomPointerScrollable scrollable = CustomPointerScrollable(
+      dragStartBehavior: dragStartBehavior,
+      axisDirection: axisDirection,
+      controller: scrollController,
+      physics: physics,
+      semanticChildCount: semanticChildCount,
+      viewportBuilder: (BuildContext context, ViewportOffset offset) {
+        return buildViewport(context, offset, axisDirection, slivers);
+      },
+      customPointerSignalHandler: customPointerSignalHandler,
+    );
+    return primary && scrollController != null
+        ? PrimaryScrollController.none(child: scrollable)
+        : scrollable;
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
+        defaultValue: null));
+  }
+}
+
+/// A widget that scrolls and allows custom pointer signal event handling.
+///
+/// This widget is a copy of [Scrollable] with additional support for custom
+/// pointer signal event handling via [customPointerSignalHandler].
+class CustomPointerScrollable extends StatefulWidget {
+  const CustomPointerScrollable({
+    Key key,
+    this.axisDirection = AxisDirection.down,
+    this.controller,
+    this.physics,
+    @required this.viewportBuilder,
+    this.incrementCalculator,
+    this.excludeFromSemantics = false,
+    this.semanticChildCount,
+    this.dragStartBehavior = DragStartBehavior.start,
+    this.customPointerSignalHandler,
+  })  : assert(axisDirection != null),
+        assert(dragStartBehavior != null),
+        assert(viewportBuilder != null),
+        assert(excludeFromSemantics != null),
+        assert(semanticChildCount == null || semanticChildCount >= 0),
+        super(key: key);
+
+  /// The direction in which this widget scrolls.
+  ///
+  /// For example, if the [axisDirection] is [AxisDirection.down], increasing
+  /// the scroll position will cause content below the bottom of the viewport to
+  /// become visible through the viewport. Similarly, if [axisDirection] is
+  /// [AxisDirection.right], increasing the scroll position will cause content
+  /// beyond the right edge of the viewport to become visible through the
+  /// viewport.
+  ///
+  /// Defaults to [AxisDirection.down].
+  final AxisDirection axisDirection;
+
+  /// An object that can be used to control the position to which this widget is
+  /// scrolled.
+  ///
+  /// A [ScrollController] serves several purposes. It can be used to control
+  /// the initial scroll position (see [ScrollController.initialScrollOffset]).
+  /// It can be used to control whether the scroll view should automatically
+  /// save and restore its scroll position in the [PageStorage] (see
+  /// [ScrollController.keepScrollOffset]). It can be used to read the current
+  /// scroll position (see [ScrollController.offset]), or change it (see
+  /// [ScrollController.animateTo]).
+  ///
+  /// See also:
+  ///
+  ///  * [ensureVisible], which animates the scroll position to reveal a given
+  ///    [BuildContext].
+  final ScrollController controller;
+
+  /// How the widgets should respond to user input.
+  ///
+  /// For example, determines how the widget continues to animate after the
+  /// user stops dragging the scroll view.
+  ///
+  /// Defaults to matching platform conventions via the physics provided from
+  /// the ambient [ScrollConfiguration].
+  ///
+  /// The physics can be changed dynamically, but new physics will only take
+  /// effect if the _class_ of the provided object changes. Merely constructing
+  /// a new instance with a different configuration is insufficient to cause the
+  /// physics to be reapplied. (This is because the final object used is
+  /// generated dynamically, which can be relatively expensive, and it would be
+  /// inefficient to speculatively create this object each frame to see if the
+  /// physics should be updated.)
+  ///
+  /// See also:
+  ///
+  ///  * [AlwaysScrollableScrollPhysics], which can be used to indicate that the
+  ///    scrollable should react to scroll requests (and possible overscroll)
+  ///    even if the scrollable's contents fit without scrolling being necessary.
+  final ScrollPhysics physics;
+
+  /// Builds the viewport through which the scrollable content is displayed.
+  ///
+  /// A typical viewport uses the given [ViewportOffset] to determine which part
+  /// of its content is actually visible through the viewport.
+  ///
+  /// See also:
+  ///
+  ///  * [Viewport], which is a viewport that displays a list of slivers.
+  ///  * [ShrinkWrappingViewport], which is a viewport that displays a list of
+  ///    slivers and sizes itself based on the size of the slivers.
+  final ViewportBuilder viewportBuilder;
+
+  /// An optional function that will be called to calculate the distance to
+  /// scroll when the scrollable is asked to scroll via the keyboard using a
+  /// [ScrollAction].
+  ///
+  /// If not supplied, the [Scrollable] will scroll a default amount when a
+  /// keyboard navigation key is pressed (e.g. pageUp/pageDown, control-upArrow,
+  /// etc.), or otherwise invoked by a [ScrollAction].
+  ///
+  /// If [incrementCalculator] is null, the default for
+  /// [ScrollIncrementType.page] is 80% of the size of the scroll window, and
+  /// for [ScrollIncrementType.line], 50 logical pixels.
+  final ScrollIncrementCalculator incrementCalculator;
+
+  /// Whether the scroll actions introduced by this [Scrollable] are exposed
+  /// in the semantics tree.
+  ///
+  /// Text fields with an overflow are usually scrollable to make sure that the
+  /// user can get to the beginning/end of the entered text. However, these
+  /// scrolling actions are generally not exposed to the semantics layer.
+  ///
+  /// See also:
+  ///
+  ///  * [GestureDetector.excludeFromSemantics], which is used to accomplish the
+  ///    exclusion.
+  final bool excludeFromSemantics;
+
+  /// The number of children that will contribute semantic information.
+  ///
+  /// The value will be null if the number of children is unknown or unbounded.
+  ///
+  /// Some subtypes of [ScrollView] can infer this value automatically. For
+  /// example [ListView] will use the number of widgets in the child list,
+  /// while the [new ListView.separated] constructor will use half that amount.
+  ///
+  /// For [CustomScrollView] and other types which do not receive a builder
+  /// or list of widgets, the child count must be explicitly provided.
+  ///
+  /// See also:
+  ///
+  ///  * [CustomScrollView], for an explanation of scroll semantics.
+  ///  * [SemanticsConfiguration.scrollChildCount], the corresponding semantics property.
+  final int semanticChildCount;
+
+  // TODO(jslavitz): Set the DragStartBehavior default to be start across all widgets.
+  /// {@template flutter.widgets.scrollable.dragStartBehavior}
+  /// Determines the way that drag start behavior is handled.
+  ///
+  /// If set to [DragStartBehavior.start], scrolling drag behavior will
+  /// begin upon the detection of a drag gesture. If set to
+  /// [DragStartBehavior.down] it will begin when a down event is first detected.
+  ///
+  /// In general, setting this to [DragStartBehavior.start] will make drag
+  /// animation smoother and setting it to [DragStartBehavior.down] will make
+  /// drag behavior feel slightly more reactive.
+  ///
+  /// By default, the drag start behavior is [DragStartBehavior.start].
+  ///
+  /// See also:
+  ///
+  ///  * [DragGestureRecognizer.dragStartBehavior], which gives an example for
+  ///    the different behaviors.
+  ///
+  /// {@endtemplate}
+  final DragStartBehavior dragStartBehavior;
+
+  /// The axis along which the scroll view scrolls.
+  ///
+  /// Determined by the [axisDirection].
+  Axis get axis => axisDirectionToAxis(axisDirection);
+
+  final void Function(PointerSignalEvent event) customPointerSignalHandler;
+
+  @override
+  _CustomPointerScrollableState createState() =>
+      _CustomPointerScrollableState();
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(EnumProperty<AxisDirection>('axisDirection', axisDirection));
+    properties.add(DiagnosticsProperty<ScrollPhysics>('physics', physics));
+  }
+
+  /// The state from the closest instance of this class that encloses the given context.
+  ///
+  /// Typical usage is as follows:
+  ///
+  /// ```dart
+  /// ScrollableState scrollable = Scrollable.of(context);
+  /// ```
+  ///
+  /// Calling this method will create a dependency on the closest [Scrollable]
+  /// in the [context], if there is one.
+  static _CustomPointerScrollableState of(BuildContext context) {
+    final _ScrollableScope widget =
+        context.dependOnInheritedWidgetOfExactType<_ScrollableScope>();
+    return widget?.scrollable;
+  }
+
+  /// Provides a heuristic to determine if expensive frame-bound tasks should be
+  /// deferred for the [context] at a specific point in time.
+  ///
+  /// Calling this method does _not_ create a dependency on any other widget.
+  /// This also means that the value returned is only good for the point in time
+  /// when it is called, and callers will not get updated if the value changes.
+  ///
+  /// The heuristic used is determined by the [physics] of this [Scrollable]
+  /// via [ScrollPhysics.recommendDeferredScrolling]. That method is called with
+  /// the current [activity]'s [ScrollActivity.velocity].
+  ///
+  /// If there is no [Scrollable] in the widget tree above the [context], this
+  /// method returns false.
+  static bool recommendDeferredLoadingForContext(BuildContext context) {
+    final _ScrollableScope widget = context
+        .getElementForInheritedWidgetOfExactType<_ScrollableScope>()
+        ?.widget as _ScrollableScope;
+    if (widget == null) {
+      return false;
+    }
+    return widget.position.recommendDeferredLoading(context);
+  }
+
+  /// Scrolls the scrollables that enclose the given context so as to make the
+  /// given context visible.
+  static Future<void> ensureVisible(
+    BuildContext context, {
+    double alignment = 0.0,
+    Duration duration = Duration.zero,
+    Curve curve = Curves.ease,
+    ScrollPositionAlignmentPolicy alignmentPolicy =
+        ScrollPositionAlignmentPolicy.explicit,
+  }) {
+    final List<Future<void>> futures = <Future<void>>[];
+
+    ScrollableState scrollable = Scrollable.of(context);
+    while (scrollable != null) {
+      futures.add(scrollable.position.ensureVisible(
+        context.findRenderObject(),
+        alignment: alignment,
+        duration: duration,
+        curve: curve,
+        alignmentPolicy: alignmentPolicy,
+      ));
+      context = scrollable.context;
+      scrollable = Scrollable.of(context);
+    }
+
+    if (futures.isEmpty || duration == Duration.zero)
+      return Future<void>.value();
+    if (futures.length == 1) return futures.single;
+    return Future.wait<void>(futures).then<void>((List<void> _) => null);
+  }
+}
+
+/// State object for [CustomPointerScrollable].
+///
+/// This state object is a copy of [ScrollableState] and replaces the handler
+/// [ScrollableState._receivedPointerSignal] with
+/// [CustomPointerScrollable.customPointerSignalHandler] when non-null.
+class _CustomPointerScrollableState extends State<CustomPointerScrollable>
+    with TickerProviderStateMixin
+    implements ScrollContext {
+  /// The manager for this [Scrollable] widget's viewport position.
+  ///
+  /// To control what kind of [ScrollPosition] is created for a [Scrollable],
+  /// provide it with custom [ScrollController] that creates the appropriate
+  /// [ScrollPosition] in its [ScrollController.createScrollPosition] method.
+  ScrollPosition get position => _position;
+  ScrollPosition _position;
+
+  @override
+  AxisDirection get axisDirection => widget.axisDirection;
+
+  ScrollBehavior _configuration;
+  ScrollPhysics _physics;
+
+  // Only call this from places that will definitely trigger a rebuild.
+  void _updatePosition() {
+    _configuration = ScrollConfiguration.of(context);
+    _physics = _configuration.getScrollPhysics(context);
+    if (widget.physics != null) _physics = widget.physics.applyTo(_physics);
+    final ScrollController controller = widget.controller;
+    final ScrollPosition oldPosition = position;
+    if (oldPosition != null) {
+      controller?.detach(oldPosition);
+      // It's important that we not dispose the old position until after the
+      // viewport has had a chance to unregister its listeners from the old
+      // position. So, schedule a microtask to do it.
+      scheduleMicrotask(oldPosition.dispose);
+    }
+
+    _position = controller?.createScrollPosition(_physics, this, oldPosition) ??
+        ScrollPositionWithSingleContext(
+            physics: _physics, context: this, oldPosition: oldPosition);
+    assert(position != null);
+    controller?.attach(position);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _updatePosition();
+  }
+
+  bool _shouldUpdatePosition(CustomPointerScrollable oldWidget) {
+    ScrollPhysics newPhysics = widget.physics;
+    ScrollPhysics oldPhysics = oldWidget.physics;
+    do {
+      if (newPhysics?.runtimeType != oldPhysics?.runtimeType) return true;
+      newPhysics = newPhysics?.parent;
+      oldPhysics = oldPhysics?.parent;
+    } while (newPhysics != null || oldPhysics != null);
+
+    return widget.controller?.runtimeType != oldWidget.controller?.runtimeType;
+  }
+
+  @override
+  void didUpdateWidget(CustomPointerScrollable oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.controller != oldWidget.controller) {
+      oldWidget.controller?.detach(position);
+      widget.controller?.attach(position);
+    }
+
+    if (_shouldUpdatePosition(oldWidget)) _updatePosition();
+  }
+
+  @override
+  void dispose() {
+    widget.controller?.detach(position);
+    position.dispose();
+    super.dispose();
+  }
+
+  // SEMANTICS
+
+  final GlobalKey _scrollSemanticsKey = GlobalKey();
+
+  @override
+  @protected
+  void setSemanticsActions(Set<SemanticsAction> actions) {
+    if (_gestureDetectorKey.currentState != null)
+      _gestureDetectorKey.currentState.replaceSemanticsActions(actions);
+  }
+
+  // GESTURE RECOGNITION AND POINTER IGNORING
+
+  final GlobalKey<RawGestureDetectorState> _gestureDetectorKey =
+      GlobalKey<RawGestureDetectorState>();
+  final GlobalKey _ignorePointerKey = GlobalKey();
+
+  // This field is set during layout, and then reused until the next time it is set.
+  Map<Type, GestureRecognizerFactory> _gestureRecognizers =
+      const <Type, GestureRecognizerFactory>{};
+  bool _shouldIgnorePointer = false;
+
+  bool _lastCanDrag;
+  Axis _lastAxisDirection;
+
+  @override
+  @protected
+  void setCanDrag(bool canDrag) {
+    if (canDrag == _lastCanDrag &&
+        (!canDrag || widget.axis == _lastAxisDirection)) return;
+    if (!canDrag) {
+      _gestureRecognizers = const <Type, GestureRecognizerFactory>{};
+    } else {
+      switch (widget.axis) {
+        case Axis.vertical:
+          _gestureRecognizers = <Type, GestureRecognizerFactory>{
+            VerticalDragGestureRecognizer: GestureRecognizerFactoryWithHandlers<
+                VerticalDragGestureRecognizer>(
+              () => VerticalDragGestureRecognizer(),
+              (VerticalDragGestureRecognizer instance) {
+                instance
+                  ..onDown = _handleDragDown
+                  ..onStart = _handleDragStart
+                  ..onUpdate = _handleDragUpdate
+                  ..onEnd = _handleDragEnd
+                  ..onCancel = _handleDragCancel
+                  ..minFlingDistance = _physics?.minFlingDistance
+                  ..minFlingVelocity = _physics?.minFlingVelocity
+                  ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..dragStartBehavior = widget.dragStartBehavior;
+              },
+            ),
+          };
+          break;
+        case Axis.horizontal:
+          _gestureRecognizers = <Type, GestureRecognizerFactory>{
+            HorizontalDragGestureRecognizer:
+                GestureRecognizerFactoryWithHandlers<
+                    HorizontalDragGestureRecognizer>(
+              () => HorizontalDragGestureRecognizer(),
+              (HorizontalDragGestureRecognizer instance) {
+                instance
+                  ..onDown = _handleDragDown
+                  ..onStart = _handleDragStart
+                  ..onUpdate = _handleDragUpdate
+                  ..onEnd = _handleDragEnd
+                  ..onCancel = _handleDragCancel
+                  ..minFlingDistance = _physics?.minFlingDistance
+                  ..minFlingVelocity = _physics?.minFlingVelocity
+                  ..maxFlingVelocity = _physics?.maxFlingVelocity
+                  ..dragStartBehavior = widget.dragStartBehavior;
+              },
+            ),
+          };
+          break;
+      }
+    }
+    _lastCanDrag = canDrag;
+    _lastAxisDirection = widget.axis;
+    if (_gestureDetectorKey.currentState != null)
+      _gestureDetectorKey.currentState
+          .replaceGestureRecognizers(_gestureRecognizers);
+  }
+
+  @override
+  TickerProvider get vsync => this;
+
+  @override
+  @protected
+  void setIgnorePointer(bool value) {
+    if (_shouldIgnorePointer == value) return;
+    _shouldIgnorePointer = value;
+    if (_ignorePointerKey.currentContext != null) {
+      final RenderIgnorePointer renderBox = _ignorePointerKey.currentContext
+          .findRenderObject() as RenderIgnorePointer;
+      renderBox.ignoring = _shouldIgnorePointer;
+    }
+  }
+
+  @override
+  BuildContext get notificationContext => _gestureDetectorKey.currentContext;
+
+  @override
+  BuildContext get storageContext => context;
+
+  // TOUCH HANDLERS
+
+  Drag _drag;
+  ScrollHoldController _hold;
+
+  void _handleDragDown(DragDownDetails details) {
+    assert(_drag == null);
+    assert(_hold == null);
+    _hold = position.hold(_disposeHold);
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    // It's possible for _hold to become null between _handleDragDown and
+    // _handleDragStart, for example if some user code calls jumpTo or otherwise
+    // triggers a new activity to begin.
+    assert(_drag == null);
+    _drag = position.drag(details, _disposeDrag);
+    assert(_drag != null);
+    assert(_hold == null);
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _drag?.update(details);
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _drag?.end(details);
+    assert(_drag == null);
+  }
+
+  void _handleDragCancel() {
+    // _hold might be null if the drag started.
+    // _drag might be null if the drag activity ended and called _disposeDrag.
+    assert(_hold == null || _drag == null);
+    _hold?.cancel();
+    _drag?.cancel();
+    assert(_hold == null);
+    assert(_drag == null);
+  }
+
+  void _disposeHold() {
+    _hold = null;
+  }
+
+  void _disposeDrag() {
+    _drag = null;
+  }
+
+  // SCROLL WHEEL
+
+  // Returns the offset that should result from applying [event] to the current
+  // position, taking min/max scroll extent into account.
+  double _targetScrollOffsetForPointerScroll(PointerScrollEvent event) {
+    double delta = widget.axis == Axis.horizontal
+        ? event.scrollDelta.dx
+        : event.scrollDelta.dy;
+
+    if (axisDirectionIsReversed(widget.axisDirection)) {
+      delta *= -1;
+    }
+
+    return math.min(math.max(position.pixels + delta, position.minScrollExtent),
+        position.maxScrollExtent);
+  }
+
+  void _receivedPointerSignal(PointerSignalEvent event) {
+    if (event is PointerScrollEvent && position != null) {
+      final double targetScrollOffset =
+          _targetScrollOffsetForPointerScroll(event);
+      // Only express interest in the event if it would actually result in a scroll.
+      if (targetScrollOffset != position.pixels) {
+        GestureBinding.instance.pointerSignalResolver
+            .register(event, _handlePointerScroll);
+      }
+    }
+  }
+
+  void _handlePointerScroll(PointerEvent event) {
+    assert(event is PointerScrollEvent);
+    if (_physics != null && !_physics.shouldAcceptUserOffset(position)) {
+      return;
+    }
+    final double targetScrollOffset =
+        _targetScrollOffsetForPointerScroll(event as PointerScrollEvent);
+    if (targetScrollOffset != position.pixels) {
+      position.jumpTo(targetScrollOffset);
+    }
+  }
+
+  // DESCRIPTION
+
+  @override
+  Widget build(BuildContext context) {
+    assert(position != null);
+    // _ScrollableScope must be placed above the BuildContext returned by notificationContext
+    // so that we can get this ScrollableState by doing the following:
+    //
+    // ScrollNotification notification;
+    // Scrollable.of(notification.context)
+    //
+    // Since notificationContext is pointing to _gestureDetectorKey.context, _ScrollableScope
+    // must be placed above the widget using it: RawGestureDetector
+    Widget result = _ScrollableScope(
+      scrollable: this,
+      position: position,
+      // TODO(ianh): Having all these global keys is sad.
+      child: Listener(
+        behavior: HitTestBehavior.opaque,
+        onPointerSignal:
+            widget.customPointerSignalHandler ?? _receivedPointerSignal,
+        child: RawGestureDetector(
+          key: _gestureDetectorKey,
+          gestures: _gestureRecognizers,
+          excludeFromSemantics: widget.excludeFromSemantics,
+          child: Semantics(
+            explicitChildNodes: !widget.excludeFromSemantics,
+            child: IgnorePointer(
+              key: _ignorePointerKey,
+              ignoring: _shouldIgnorePointer,
+              ignoringSemantics: false,
+              child: widget.viewportBuilder(context, position),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (!widget.excludeFromSemantics) {
+      result = _ScrollSemantics(
+        key: _scrollSemanticsKey,
+        child: result,
+        position: position,
+        allowImplicitScrolling: widget?.physics?.allowImplicitScrolling ??
+            _physics.allowImplicitScrolling,
+        semanticChildCount: widget.semanticChildCount,
+      );
+    }
+
+    return _configuration.buildViewportChrome(
+        context, result, widget.axisDirection);
+  }
+
+  @override
+  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
+    super.debugFillProperties(properties);
+    properties.add(DiagnosticsProperty<ScrollPosition>('position', position));
+  }
+}
+
+// The following classes were copied from the Flutter framework, with the
+// exception that some types had to be replaced to use these classes with
+// [CustomPointerScrollable]. See flutter/lib/src/widgets/scrollable.dart for
+// original classes.
+
+// Enable Scrollable.of() to work as if ScrollableState was an inherited widget.
+// ScrollableState.build() always rebuilds its _ScrollableScope.
+class _ScrollableScope extends InheritedWidget {
+  const _ScrollableScope({
+    Key key,
+    @required this.scrollable,
+    @required this.position,
+    @required Widget child,
+  })  : assert(scrollable != null),
+        assert(child != null),
+        super(key: key, child: child);
+
+  final _CustomPointerScrollableState scrollable;
+  final ScrollPosition position;
+
+  @override
+  bool updateShouldNotify(_ScrollableScope old) {
+    return position != old.position;
+  }
+}
+
+/// With [_ScrollSemantics] certain child [SemanticsNode]s can be
+/// excluded from the scrollable area for semantics purposes.
+///
+/// Nodes, that are to be excluded, have to be tagged with
+/// [RenderViewport.excludeFromScrolling] and the [RenderAbstractViewport] in
+/// use has to add the [RenderViewport.useTwoPaneSemantics] tag to its
+/// [SemanticsConfiguration] by overriding
+/// [RenderObject.describeSemanticsConfiguration].
+///
+/// If the tag [RenderViewport.useTwoPaneSemantics] is present on the viewport,
+/// two semantics nodes will be used to represent the [Scrollable]: The outer
+/// node will contain all children, that are excluded from scrolling. The inner
+/// node, which is annotated with the scrolling actions, will house the
+/// scrollable children.
+class _ScrollSemantics extends SingleChildRenderObjectWidget {
+  const _ScrollSemantics({
+    Key key,
+    @required this.position,
+    @required this.allowImplicitScrolling,
+    @required this.semanticChildCount,
+    Widget child,
+  })  : assert(position != null),
+        assert(semanticChildCount == null || semanticChildCount >= 0),
+        super(key: key, child: child);
+
+  final ScrollPosition position;
+  final bool allowImplicitScrolling;
+  final int semanticChildCount;
+
+  @override
+  _RenderScrollSemantics createRenderObject(BuildContext context) {
+    return _RenderScrollSemantics(
+      position: position,
+      allowImplicitScrolling: allowImplicitScrolling,
+      semanticChildCount: semanticChildCount,
+    );
+  }
+
+  @override
+  void updateRenderObject(
+      BuildContext context, _RenderScrollSemantics renderObject) {
+    renderObject
+      ..allowImplicitScrolling = allowImplicitScrolling
+      ..position = position
+      ..semanticChildCount = semanticChildCount;
+  }
+}
+
+class _RenderScrollSemantics extends RenderProxyBox {
+  _RenderScrollSemantics({
+    @required ScrollPosition position,
+    @required bool allowImplicitScrolling,
+    @required int semanticChildCount,
+    RenderBox child,
+  })  : _position = position,
+        _allowImplicitScrolling = allowImplicitScrolling,
+        _semanticChildCount = semanticChildCount,
+        assert(position != null),
+        super(child) {
+    position.addListener(markNeedsSemanticsUpdate);
+  }
+
+  /// Whether this render object is excluded from the semantic tree.
+  ScrollPosition get position => _position;
+  ScrollPosition _position;
+  set position(ScrollPosition value) {
+    assert(value != null);
+    if (value == _position) return;
+    _position.removeListener(markNeedsSemanticsUpdate);
+    _position = value;
+    _position.addListener(markNeedsSemanticsUpdate);
+    markNeedsSemanticsUpdate();
+  }
+
+  /// Whether this node can be scrolled implicitly.
+  bool get allowImplicitScrolling => _allowImplicitScrolling;
+  bool _allowImplicitScrolling;
+  set allowImplicitScrolling(bool value) {
+    if (value == _allowImplicitScrolling) return;
+    _allowImplicitScrolling = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  int get semanticChildCount => _semanticChildCount;
+  int _semanticChildCount;
+  set semanticChildCount(int value) {
+    if (value == semanticChildCount) return;
+    _semanticChildCount = value;
+    markNeedsSemanticsUpdate();
+  }
+
+  @override
+  void describeSemanticsConfiguration(SemanticsConfiguration config) {
+    super.describeSemanticsConfiguration(config);
+    config.isSemanticBoundary = true;
+    if (position.haveDimensions) {
+      config
+        ..hasImplicitScrolling = allowImplicitScrolling
+        ..scrollPosition = _position.pixels
+        ..scrollExtentMax = _position.maxScrollExtent
+        ..scrollExtentMin = _position.minScrollExtent
+        ..scrollChildCount = semanticChildCount;
+    }
+  }
+
+  SemanticsNode _innerNode;
+
+  @override
+  void assembleSemanticsNode(SemanticsNode node, SemanticsConfiguration config,
+      Iterable<SemanticsNode> children) {
+    if (children.isEmpty ||
+        !children.first.isTagged(RenderViewport.useTwoPaneSemantics)) {
+      super.assembleSemanticsNode(node, config, children);
+      return;
+    }
+
+    _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
+    _innerNode
+      ..isMergedIntoParent = node.isPartOfNodeMerging
+      ..rect = Offset.zero & node.rect.size;
+
+    int firstVisibleIndex;
+    final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode];
+    final List<SemanticsNode> included = <SemanticsNode>[];
+    for (final SemanticsNode child in children) {
+      assert(child.isTagged(RenderViewport.useTwoPaneSemantics));
+      if (child.isTagged(RenderViewport.excludeFromScrolling)) {
+        excluded.add(child);
+      } else {
+        if (!child.hasFlag(SemanticsFlag.isHidden))
+          firstVisibleIndex ??= child.indexInParent;
+        included.add(child);
+      }
+    }
+    config.scrollIndex = firstVisibleIndex;
+    node.updateWith(config: null, childrenInInversePaintOrder: excluded);
+    _innerNode.updateWith(
+        config: config, childrenInInversePaintOrder: included);
+  }
+
+  @override
+  void clearSemantics() {
+    super.clearSemantics();
+    _innerNode = null;
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
@@ -614,12 +614,12 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
       position: position,
       // TODO(ianh): Having all these global keys is sad.
       child: Listener(
-        behavior: HitTestBehavior.opaque,
         onPointerSignal:
             widget.customPointerSignalHandler ?? _receivedPointerSignal,
         child: RawGestureDetector(
           key: _gestureDetectorKey,
           gestures: _gestureRecognizers,
+          behavior: HitTestBehavior.opaque,
           excludeFromSemantics: widget.excludeFromSemantics,
           child: Semantics(
             explicitChildNodes: !widget.excludeFromSemantics,
@@ -656,10 +656,9 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
   }
 }
 
-// The following classes were copied from the Flutter framework, with the
-// exception that some types had to be replaced to use these classes with
-// [CustomPointerScrollable]. See flutter/lib/src/widgets/scrollable.dart for
-// original classes.
+// The following classes were copied from the Flutter framework with minor
+// changes to use with [CustomPointerScrollable] instead of [Scrollable]. See
+// flutter/lib/src/widgets/scrollable.dart for original classes.
 
 // Enable Scrollable.of() to work as if _CustomPointerScrollableState was an
 // inherited widget. _CustomPointerScrollableState.build() always rebuilds its

--- a/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
@@ -249,7 +249,7 @@ class CustomPointerScrollable extends StatefulWidget {
   /// Typical usage is as follows:
   ///
   /// ```dart
-  /// ScrollableState scrollable = Scrollable.of(context);
+  /// _CustomPointerScrollableState scrollable = Scrollable.of(context);
   /// ```
   ///
   /// Calling this method will create a dependency on the closest [Scrollable]
@@ -295,7 +295,8 @@ class CustomPointerScrollable extends StatefulWidget {
   }) {
     final List<Future<void>> futures = <Future<void>>[];
 
-    ScrollableState scrollable = Scrollable.of(context);
+    _CustomPointerScrollableState scrollable =
+        CustomPointerScrollable.of(context);
     while (scrollable != null) {
       futures.add(scrollable.position.ensureVisible(
         context.findRenderObject(),
@@ -305,7 +306,7 @@ class CustomPointerScrollable extends StatefulWidget {
         alignmentPolicy: alignmentPolicy,
       ));
       context = scrollable.context;
-      scrollable = Scrollable.of(context);
+      scrollable = CustomPointerScrollable.of(context);
     }
 
     if (futures.isEmpty || duration == Duration.zero)
@@ -599,11 +600,12 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
   @override
   Widget build(BuildContext context) {
     assert(position != null);
-    // _ScrollableScope must be placed above the BuildContext returned by notificationContext
-    // so that we can get this ScrollableState by doing the following:
+    // _ScrollableScope must be placed above the BuildContext returned by
+    // notificationContext so that we can get this _CustomPointerScrollableState
+    // by doing the following:
     //
     // ScrollNotification notification;
-    // Scrollable.of(notification.context)
+    // CustomPointerScrollable.of(notification.context)
     //
     // Since notificationContext is pointing to _gestureDetectorKey.context, _ScrollableScope
     // must be placed above the widget using it: RawGestureDetector
@@ -659,8 +661,9 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
 // [CustomPointerScrollable]. See flutter/lib/src/widgets/scrollable.dart for
 // original classes.
 
-// Enable Scrollable.of() to work as if ScrollableState was an inherited widget.
-// ScrollableState.build() always rebuilds its _ScrollableScope.
+// Enable Scrollable.of() to work as if _CustomPointerScrollableState was an
+// inherited widget. _CustomPointerScrollableState.build() always rebuilds its
+// _ScrollableScope.
 class _ScrollableScope extends InheritedWidget {
   const _ScrollableScope({
     Key key,

--- a/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/flutter/custom_pointer_scroll_view.dart
@@ -17,7 +17,7 @@ import 'package:flutter/widgets.dart';
 /// This class is copied from the Flutter framework [BoxScrollView] and
 /// overrides [ScrollView.build] to use [CustomPointerScrollable] in place of
 /// [Scrollable].
-abstract class CustomPointerScrollView extends ScrollView {
+abstract class CustomPointerScrollView extends BoxScrollView {
   /// Creates a [ScrollView] uses a single child layout model.
   ///
   /// If the [primary] argument is true, the [controller] must be null.
@@ -29,7 +29,7 @@ abstract class CustomPointerScrollView extends ScrollView {
     bool primary,
     ScrollPhysics physics,
     bool shrinkWrap = false,
-    this.padding,
+    EdgeInsetsGeometry padding,
     double cacheExtent,
     int semanticChildCount,
     DragStartBehavior dragStartBehavior = DragStartBehavior.start,
@@ -39,6 +39,7 @@ abstract class CustomPointerScrollView extends ScrollView {
           scrollDirection: scrollDirection,
           reverse: reverse,
           controller: controller,
+          padding: padding,
           primary: primary,
           physics: physics,
           shrinkWrap: shrinkWrap,
@@ -47,47 +48,7 @@ abstract class CustomPointerScrollView extends ScrollView {
           dragStartBehavior: dragStartBehavior,
         );
 
-  /// The amount of space by which to inset the children.
-  final EdgeInsetsGeometry padding;
-
   final void Function(PointerSignalEvent event) customPointerSignalHandler;
-
-  @override
-  List<Widget> buildSlivers(BuildContext context) {
-    Widget sliver = buildChildLayout(context);
-    EdgeInsetsGeometry effectivePadding = padding;
-    if (padding == null) {
-      final MediaQueryData mediaQuery = MediaQuery.of(context, nullOk: true);
-      if (mediaQuery != null) {
-        // Automatically pad sliver with padding from MediaQuery.
-        final EdgeInsets mediaQueryHorizontalPadding =
-            mediaQuery.padding.copyWith(top: 0.0, bottom: 0.0);
-        final EdgeInsets mediaQueryVerticalPadding =
-            mediaQuery.padding.copyWith(left: 0.0, right: 0.0);
-        // Consume the main axis padding with SliverPadding.
-        effectivePadding = scrollDirection == Axis.vertical
-            ? mediaQueryVerticalPadding
-            : mediaQueryHorizontalPadding;
-        // Leave behind the cross axis padding.
-        sliver = MediaQuery(
-          data: mediaQuery.copyWith(
-            padding: scrollDirection == Axis.vertical
-                ? mediaQueryHorizontalPadding
-                : mediaQueryVerticalPadding,
-          ),
-          child: sliver,
-        );
-      }
-    }
-
-    if (effectivePadding != null)
-      sliver = SliverPadding(padding: effectivePadding, sliver: sliver);
-    return <Widget>[sliver];
-  }
-
-  /// Subclasses should override this method to build the layout model.
-  @protected
-  Widget buildChildLayout(BuildContext context);
 
   @override
   Widget build(BuildContext context) {
@@ -110,13 +71,6 @@ abstract class CustomPointerScrollView extends ScrollView {
     return primary && scrollController != null
         ? PrimaryScrollController.none(child: scrollable)
         : scrollable;
-  }
-
-  @override
-  void debugFillProperties(DiagnosticPropertiesBuilder properties) {
-    super.debugFillProperties(properties);
-    properties.add(DiagnosticsProperty<EdgeInsetsGeometry>('padding', padding,
-        defaultValue: null));
   }
 }
 

--- a/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/flutter/extent_delegate_list.dart
@@ -1,9 +1,15 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart' as collection;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+
+import 'custom_pointer_scroll_view.dart';
 
 /// Base class for delegate providing extent information for items in a list.
 abstract class ExtentDelegate {
@@ -127,7 +133,7 @@ class FixedExtentDelegate extends ExtentDelegate {
 /// itemExtent as only items visible on screen need to be built and laid out.
 /// This class is more robust than ListView for cases where ListView items off
 /// screen need to be animated.
-class ExtentDelegateListView extends BoxScrollView {
+class ExtentDelegateListView extends CustomPointerScrollView {
   const ExtentDelegateListView({
     Key key,
     Axis scrollDirection = Axis.vertical,
@@ -140,6 +146,7 @@ class ExtentDelegateListView extends BoxScrollView {
     @required this.childrenDelegate,
     @required this.extentDelegate,
     int semanticChildCount,
+    Function(PointerSignalEvent event) customPointerSignalHandler,
   })  : assert(childrenDelegate != null),
         super(
           key: key,
@@ -151,6 +158,7 @@ class ExtentDelegateListView extends BoxScrollView {
           shrinkWrap: shrinkWrap,
           padding: padding,
           semanticChildCount: semanticChildCount,
+          customPointerSignalHandler: customPointerSignalHandler,
         );
 
   /// A delegate that provides the children for the [ExtentDelegateListView].

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -136,7 +136,7 @@ class TimelineFlameChartState
       final offset = contentWidthWithZoom * ratio +
           widget.startInset -
           widget.totalStartingWidth * 0.1;
-      await scrollTo(offset);
+      await horizontallyScrollTo(offset);
     }
   }
 
@@ -628,7 +628,7 @@ class TimelineGridPainter extends CustomPainter {
         origin,
         origin,
         constraints.maxWidth,
-        rowHeight,
+        math.min(constraints.maxHeight, rowHeight),
       ),
       Paint()..color = chartBackgroundColor,
     );

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -136,7 +136,7 @@ class TimelineFlameChartState
       final offset = contentWidthWithZoom * ratio +
           widget.startInset -
           widget.totalStartingWidth * 0.1;
-      await horizontallyScrollTo(offset);
+      await scrollToX(offset);
     }
   }
 

--- a/packages/devtools_app/test/flutter/extent_delegate_list_view_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_list_view_test.dart
@@ -1,0 +1,103 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/extent_delegate_list.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ExtentDelegateListView', () {
+    final children = [1.0, 2.0, 3.0, 4.0];
+
+    Future<void> pumpList(
+      WidgetTester tester,
+      ExtentDelegateListView listView,
+    ) async {
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: listView,
+      ));
+    }
+
+    testWidgets('builds successfully', (tester) async {
+      await pumpList(
+        tester,
+        ExtentDelegateListView(
+          controller: ScrollController(),
+          extentDelegate: FixedExtentDelegate(
+            computeLength: () => children.length,
+            computeExtent: (index) => children[index],
+          ),
+          childrenDelegate: SliverChildBuilderDelegate(
+            (context, index) => Text('${children[index]}'),
+            childCount: children.length,
+          ),
+        ),
+      );
+
+      for (final child in children) {
+        expect(find.text('$child'), findsOneWidget);
+      }
+    });
+
+    testWidgets('builds successfully with customPointerSignalHandler',
+        (tester) async {
+      int pointerSignalEventCount = 0;
+      void _handlePointerSignal(PointerSignalEvent event) {
+        pointerSignalEventCount++;
+      }
+
+      await pumpList(
+        tester,
+        ExtentDelegateListView(
+          controller: ScrollController(),
+          extentDelegate: FixedExtentDelegate(
+            computeLength: () => children.length,
+            computeExtent: (index) => children[index],
+          ),
+          childrenDelegate: SliverChildBuilderDelegate(
+            (context, index) => Text('${children[index]}'),
+            childCount: children.length,
+          ),
+          customPointerSignalHandler: _handlePointerSignal,
+        ),
+      );
+
+      final scrollEventLocation =
+          tester.getCenter(find.byType(ExtentDelegateListView));
+      final testPointer = TestPointer(1, PointerDeviceKind.mouse);
+      // Create a hover event so that |testPointer| has a location when
+      // generating the scroll.
+      testPointer.hover(scrollEventLocation);
+      final result = tester.hitTestOnBinding(scrollEventLocation);
+
+      await tester.sendEventToBinding(
+        testPointer.scroll(const Offset(0.0, 10.0)),
+        result,
+      );
+      expect(pointerSignalEventCount, equals(1));
+    });
+
+    testWidgets('throws for null childrenDelegate', (tester) async {
+      expect(
+        () async {
+          await pumpList(
+            tester,
+            ExtentDelegateListView(
+              controller: ScrollController(),
+              extentDelegate: FixedExtentDelegate(
+                computeLength: () => children.length,
+                computeExtent: (index) => children[index],
+              ),
+              childrenDelegate: null,
+            ),
+          );
+        },
+        throwsAssertionError,
+      );
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/extent_delegate_test.dart
+++ b/packages/devtools_app/test/flutter/extent_delegate_test.dart
@@ -77,7 +77,7 @@ class TestRenderSliverBoxChildManager extends RenderSliverBoxChildManager {
 }
 
 void main() {
-  group('RenderSliverFixedExtentList', () {
+  group('RenderSliverFixedExtentDelgate', () {
     group('extentDelegate', () {
       test('itemExtent', () {
         final extents = [100.0, 200.0, 50.0, 100.0];


### PR DESCRIPTION
- Scroll zooms the flame chart in / out
- alt + scroll vertically scrolls the chart up / down

Since ListView does not support custom PointerSignalEvent handling (see https://github.com/flutter/flutter/issues/35723), we needed to create a custom implementation of ListView to do this. I modified `ExtentDelegateListView` to include this behavior.

New classes:
`CustomPointerScrollView` - extension of `BoxScrollView` (see comments for changes)
`CustomPointerScrollable` - copy of `Scrollable` (see comments for changes)
`_CustomPointerScrollableState` - copy of `ScrollableState` (see comments for changes)

Fixes https://github.com/flutter/devtools/issues/1600