### PR TITLE
add a settings dialog

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -189,9 +189,8 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
 class ReportBugAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: 'Report an issue',
-      waitDuration: tooltipWait,
+    return ActionButton(
+      tooltip: 'Report an issue',
       child: InkWell(
         onTap: () async {
           // TODO(devoncarew): Support analytics.
@@ -222,9 +221,8 @@ class ReportBugAction extends StatelessWidget {
 class OpenSettingsAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: 'Settings',
-      waitDuration: tooltipWait,
+    return ActionButton(
+      tooltip: 'Settings',
       child: InkWell(
         onTap: () async {
           unawaited(showDialog(
@@ -249,6 +247,11 @@ class OpenSettingsAction extends StatelessWidget {
 // TODO(devoncarew): Add an analytics setting.
 
 // TODO(devoncarew): Convert the SettingsDialog over to using a controller?
+// Add a settings controller to Controllers that Widgets can access via
+// Controllers.of(context); the SettingsController could manage setting states
+// (where setting values are ValueNotifiers) and have methods to modify them.
+// Widgets (like below) can then just grab the active SettingsController from
+// Controller.of(context).settings and listening to its notifiers.
 
 class SettingsDialog extends StatefulWidget {
   const SettingsDialog({
@@ -265,7 +268,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
     void _toggleTheme([bool value]) {
       value ??= !devtools_theme.isDarkTheme;
       setState(() {
-        devtools_theme.useDartTheme = value;
+        devtools_theme.useDarkTheme = value;
 
         DevToolsApp.of(context).updateTheme();
       });

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -286,10 +286,17 @@ Widget exitOfflineButton(FutureOr<void> Function() onPressed) {
 /// Display a single bullet character in order to act as a stylized spacer
 /// component.
 class BulletSpacer extends StatelessWidget {
+  const BulletSpacer({this.useAccentColor = false});
+
+  final bool useAccentColor;
+
   @override
   Widget build(BuildContext context) {
-    final textStyle = Theme.of(context).primaryTextTheme.bodyText1;
-    final mutedColor = textStyle.color.withAlpha(0xB2); // 70% alpha
+    final textStyle = (useAccentColor
+            ? Theme.of(context).accentTextTheme
+            : Theme.of(context).textTheme)
+        .bodyText2;
+    final mutedColor = textStyle.color.withAlpha(0x90);
 
     return Container(
       width: DevToolsScaffold.actionWidgetSize / 2,

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -13,7 +13,7 @@ import '../ui/flutter/label.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
-const tooltipWait = Duration(milliseconds: 500);
+const Duration tooltipWait = Duration(milliseconds: 500);
 
 /// Convenience [Divider] with [Padding] that provides a good divider in forms.
 class PaddedDivider extends StatelessWidget {
@@ -306,6 +306,27 @@ class BulletSpacer extends StatelessWidget {
         '•',
         style: textStyle.copyWith(color: mutedColor),
       ),
+    );
+  }
+}
+
+/// A widget, commonly used for icon buttons, that provides a tooltip with a
+/// common delay before the tooltip is shown.
+class ActionButton extends StatelessWidget {
+  const ActionButton({
+    @required this.tooltip,
+    @required this.child,
+  });
+
+  final String tooltip;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Tooltip(
+      message: tooltip,
+      waitDuration: tooltipWait,
+      child: child,
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -13,7 +13,7 @@ import '../ui/flutter/label.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
-const Duration tooltipWait = Duration(milliseconds: 500);
+const tooltipWait = Duration(milliseconds: 500);
 
 /// Convenience [Divider] with [Padding] that provides a good divider in forms.
 class PaddedDivider extends StatelessWidget {

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -43,7 +43,7 @@ class DevToolsScaffold extends StatefulWidget {
   static const Key fullWidthKey = Key('Full-width Scaffold');
 
   /// The width at or below which we treat the scaffold as narrow-width.
-  static const double narrowWidthThreshold = 1060.0;
+  static const double narrowWidthThreshold = 1100.0;
 
   /// The size that all actions on this widget are expected to have.
   static const double actionWidgetSize = 48.0;
@@ -200,7 +200,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         ),
     ];
 
-    return ValueListenableProvider<Screen>.value(
+    return ValueListenableProvider.value(
       value: _currentScreen,
       child: DragAndDrop(
         handleDrop: _importController.importData,

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -39,7 +39,7 @@ class StatusLine extends StatelessWidget {
         child: buildHelpUrlStatus(context, currentScreen, textTheme),
       ),
     ));
-    children.add(BulletSpacer());
+    children.add(const BulletSpacer());
 
     // Optionally display page specific status.
     if (currentScreen != null) {
@@ -53,7 +53,7 @@ class StatusLine extends StatelessWidget {
             child: buildPageStatus(context, currentScreen, textTheme),
           ),
         ));
-        children.add(BulletSpacer());
+        children.add(const BulletSpacer());
       }
     }
 
@@ -65,7 +65,7 @@ class StatusLine extends StatelessWidget {
           child: buildIsolateSelector(context, textTheme),
         ),
       ));
-      children.add(BulletSpacer());
+      children.add(const BulletSpacer());
     }
 
     // Always display connection status (docked to the right).

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -15,30 +15,33 @@ ThemeData themeFor({@required bool isDarkTheme}) {
 ThemeData _darkTheme() {
   final theme = ThemeData.dark();
   return theme.copyWith(
-      primaryColor: devtoolsGrey[900],
-      primaryColorDark: devtoolsBlue[700],
-      primaryColorLight: devtoolsBlue[400],
-      indicatorColor: devtoolsBlue[400],
-      accentColor: devtoolsBlue[400],
-      backgroundColor: devtoolsGrey[600],
-      toggleableActiveColor: devtoolsBlue[400],
-      selectedRowColor: devtoolsGrey[600],
-      buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth));
+    primaryColor: devtoolsGrey[900],
+    primaryColorDark: devtoolsBlue[700],
+    primaryColorLight: devtoolsBlue[400],
+    indicatorColor: devtoolsBlue[400],
+    accentColor: devtoolsBlue[400],
+    backgroundColor: devtoolsGrey[600],
+    toggleableActiveColor: devtoolsBlue[400],
+    selectedRowColor: devtoolsGrey[600],
+    buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth),
+  );
 }
 
 ThemeData _lightTheme() {
   final theme = ThemeData.light();
   return theme.copyWith(
-      primaryColor: devtoolsBlue[600],
-      primaryColorDark: devtoolsBlue[700],
-      primaryColorLight: devtoolsBlue[400],
-      indicatorColor: Colors.yellowAccent[400],
-      accentColor: devtoolsBlue[400],
-      buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth));
+    primaryColor: devtoolsBlue[600],
+    primaryColorDark: devtoolsBlue[700],
+    primaryColorLight: devtoolsBlue[400],
+    indicatorColor: Colors.yellowAccent[400],
+    accentColor: devtoolsBlue[400],
+    buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth),
+  );
 }
 
 const buttonMinWidth = 36.0;
 const defaultIconSize = 16.0;
+const actionsIconSize = 20.0;
 const defaultSpacing = 16.0;
 
 /// Branded grey color.

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -169,9 +169,8 @@ class _ServiceExtensionButtonGroupState
 class HotReloadButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: 'Hot reload',
-      waitDuration: tooltipWait,
+    return ActionButton(
+      tooltip: 'Hot reload',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotReload,
         action: () =>
@@ -188,9 +187,8 @@ class HotReloadButton extends StatelessWidget {
 class HotRestartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return Tooltip(
-      message: 'Hot restart',
-      waitDuration: tooltipWait,
+    return ActionButton(
+      tooltip: 'Hot restart',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotRestart,
         action: () =>

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -169,12 +169,17 @@ class _ServiceExtensionButtonGroupState
 class HotReloadButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return _RegisteredServiceExtensionButton._(
-      serviceDescription: hotReload,
-      action: () => _wrapReloadCall('reload', serviceManager.performHotReload),
-      inProgressText: 'Performing hot reload',
-      completedText: 'Hot reload completed.',
-      describeError: (error) => 'Unable to hot reload the app: $error',
+    return Tooltip(
+      message: 'Hot reload',
+      waitDuration: tooltipWait,
+      child: _RegisteredServiceExtensionButton._(
+        serviceDescription: hotReload,
+        action: () =>
+            _wrapReloadCall('reload', serviceManager.performHotReload),
+        inProgressText: 'Performing hot reload',
+        completedText: 'Hot reload completed.',
+        describeError: (error) => 'Unable to hot reload the app: $error',
+      ),
     );
   }
 }
@@ -183,13 +188,17 @@ class HotReloadButton extends StatelessWidget {
 class HotRestartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return _RegisteredServiceExtensionButton._(
-      serviceDescription: hotRestart,
-      action: () =>
-          _wrapReloadCall('restart', serviceManager.performHotRestart),
-      inProgressText: 'Performing hot restart',
-      completedText: 'Hot restart completed.',
-      describeError: (error) => 'Unable to hot restart the app: $error',
+    return Tooltip(
+      message: 'Hot restart',
+      waitDuration: tooltipWait,
+      child: _RegisteredServiceExtensionButton._(
+        serviceDescription: hotRestart,
+        action: () =>
+            _wrapReloadCall('restart', serviceManager.performHotRestart),
+        inProgressText: 'Performing hot restart',
+        completedText: 'Hot restart completed.',
+        describeError: (error) => 'Unable to hot restart the app: $error',
+      ),
     );
   }
 }
@@ -337,7 +346,7 @@ class _ServiceExtensionToggleState extends State<_ServiceExtensionToggle>
       message: value
           ? widget.service.enabledTooltip
           : widget.service.disabledTooltip,
-      waitDuration: const Duration(seconds: 1),
+      waitDuration: tooltipWait,
       child: InkWell(
         onTap: _onClick,
         child: Row(

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -16,7 +16,7 @@ bool get isDarkTheme => _isDarkTheme;
 bool _isDarkTheme = false;
 
 /// Change the value for the current theme.
-/// 
+///
 /// Note: this does not rebuild the widget hierarchy.
 set useDartTheme(bool value) {
   _isDarkTheme = value;

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -18,7 +18,7 @@ bool _isDarkTheme = false;
 /// Change the value for the current theme.
 ///
 /// Note: this does not rebuild the widget hierarchy.
-set useDartTheme(bool value) {
+set useDarkTheme(bool value) {
   _isDarkTheme = value;
 
   clearColorCache();

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -9,10 +9,20 @@ import 'flutter_html_shim.dart';
 ///
 /// All Dart code that behaves differently depending on whether the current
 /// theme is dark or light should use this flag.
+///
 /// Generally Dart code should use [ThemedColor] everywhere colors are used so
 /// that code can be written without directly depending on [isDarkTheme].
 bool get isDarkTheme => _isDarkTheme;
 bool _isDarkTheme = false;
+
+/// Change the value for the current theme.
+/// 
+/// Note: this does not rebuild the widget hierarchy.
+set useDartTheme(bool value) {
+  _isDarkTheme = value;
+
+  clearColorCache();
+}
 
 void initializeTheme(String theme) {
   _isDarkTheme = theme == 'dark';


### PR DESCRIPTION
Add a settings dialog:
- add a 'Settings' button to the main toolbar
- add Tooltips for the actions on the toolbar
- have the settings button open a dialog
- populate the dialog with one item - a checkbox to control the current theme
- use the `tooltipWait` duration constant for all action tooltips
- improve how `BulletSpacer` looks for both themes

For future work, we'll need to persist the user's selection to disk, possibly stop reading the theme from the url, perhaps switch to a more industrial strength mechanism for setting and notifying on settings changes, and add more settings - specifically, to configure sending analytics.

<img width="389" alt="Screen Shot 2020-03-18 at 10 46 14 AM" src="https://user-images.githubusercontent.com/1269969/77000117-0c4faf80-6915-11ea-8c13-6782fe6aad6a.png">

<img width="390" alt="Screen Shot 2020-03-18 at 12 20 51 PM" src="https://user-images.githubusercontent.com/1269969/77000130-11146380-6915-11ea-8cae-568ea0a98990.png">
