### PR TITLE
fix an issue with the theme of BulletSpacer

### DIFF
--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -292,11 +292,17 @@ class BulletSpacer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final textStyle = (useAccentColor
-            ? Theme.of(context).accentTextTheme
-            : Theme.of(context).textTheme)
-        .bodyText2;
-    final mutedColor = textStyle.color.withAlpha(0x90);
+    final ThemeData theme = Theme.of(context);
+
+    TextTheme textTheme;
+    if (useAccentColor) {
+      textTheme = theme.appBarTheme.textTheme ?? theme.primaryTextTheme;
+    } else {
+      textTheme = theme.textTheme;
+    }
+
+    final textStyle = textTheme.bodyText2;
+    final mutedColor = textStyle?.color?.withAlpha(0x90);
 
     return Container(
       width: DevToolsScaffold.actionWidgetSize / 2,
@@ -304,7 +310,7 @@ class BulletSpacer extends StatelessWidget {
       alignment: Alignment.center,
       child: Text(
         '•',
-        style: textStyle.copyWith(color: mutedColor),
+        style: textStyle?.copyWith(color: mutedColor),
       ),
     );
   }


### PR DESCRIPTION
- fix an issue with the theme of BulletSpacer

BulletSpacer didn't have the correct foreground color for dart themes when used in an AppBar. Now all four situations (status line, app bar, dart theme, light theme) look correct.

Some extra null aware operations seem to be necessary as during theme changes (dark => light, light => dark), some values can be null that normally aren't.