### PR TITLE
some UI / padding changes to the inspector page

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -12,6 +12,7 @@ import 'common_widgets.dart';
 import 'navigation.dart';
 import 'notifications.dart';
 import 'screen.dart';
+import 'theme.dart';
 
 /// The screen in the app responsible for connecting to the Dart VM.
 ///
@@ -63,7 +64,7 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
               'Connect to a Running App',
               style: textTheme.bodyText1,
             ),
-            const SizedBox(height: 6.0),
+            const SizedBox(height: denseRowSpacing),
             Text(
               'Enter a URL to a running Dart or Flutter application',
               style: textTheme.caption,

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -43,6 +43,8 @@ const buttonMinWidth = 36.0;
 const defaultIconSize = 16.0;
 const actionsIconSize = 20.0;
 const defaultSpacing = 16.0;
+const denseSpacing = 8.0;
+const denseRowSpacing = 6.0;
 
 /// Branded grey color.
 ///

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -11,6 +11,7 @@ import '../../flutter/initializer.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
+import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../service_extensions.dart' as extensions;
 import '../../ui/flutter/label.dart';
@@ -89,14 +90,20 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    final summaryTree = InspectorTree(
-      controller: summaryTreeController,
-      isSummaryTree: true,
+    final summaryTree = Container(
+      decoration: BoxDecoration(
+        border: Border.all(color: Theme.of(context).focusColor),
+      ),
+      child: InspectorTree(
+        controller: summaryTreeController,
+        isSummaryTree: true,
+      ),
     );
     final detailsTree = InspectorTree(
       controller: detailsTreeController,
       isSummaryTree: false,
     );
+
     final splitAxis = Split.axisFor(context, 0.85);
     return Column(
       children: <Widget>[
@@ -118,18 +125,25 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
                 );
               },
             ),
-            OutlineButton(
-              onPressed: _refreshInspector,
-              child: Label(
-                FlutterIcons.refresh,
-                'Refresh Tree',
-                minIncludeTextWidth: 750,
+            const SizedBox(width: denseSpacing),
+            Container(
+              // This value sizes the refresh OutlineButton to the same height
+              // as the ServiceExtensionButtonGroup ToggleButtons.
+              height: 33.0,
+              child: OutlineButton(
+                onPressed: _refreshInspector,
+                child: Label(
+                  FlutterIcons.refresh,
+                  'Refresh Tree',
+                  minIncludeTextWidth: 750,
+                ),
               ),
             ),
             const Spacer(),
             Row(children: getServiceExtensionWidgets()),
           ],
         ),
+        const SizedBox(height: denseRowSpacing),
         Expanded(
           child: Split(
             axis: splitAxis,
@@ -153,10 +167,12 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         minIncludeTextWidth: 1050,
         extensions: [extensions.slowAnimations],
       ),
+      const SizedBox(width: denseSpacing),
       ServiceExtensionButtonGroup(
         minIncludeTextWidth: 1050,
         extensions: [extensions.debugPaint, extensions.debugPaintBaselines],
       ),
+      const SizedBox(width: denseSpacing),
       ServiceExtensionButtonGroup(
         minIncludeTextWidth: 1250,
         extensions: [extensions.repaintRainbow, extensions.debugAllowBanner],

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -108,7 +108,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
     return Column(
       children: <Widget>[
         Row(
-          crossAxisAlignment: CrossAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             ValueListenableBuilder(
               valueListenable: serviceManager.serviceExtensionManager
@@ -127,9 +127,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
             ),
             const SizedBox(width: denseSpacing),
             Container(
-              // This value sizes the refresh OutlineButton to the same height
-              // as the ServiceExtensionButtonGroup ToggleButtons.
-              height: 33.0,
+              height: Theme.of(context).buttonTheme.height,
               child: OutlineButton(
                 onPressed: _refreshInspector,
                 child: Label(

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -837,7 +837,7 @@ class InspectorController extends DisposableController
     );
   }
 
-  void collapseDetailsToSelected() {
+  Future<void> collapseDetailsToSelected() async {
     details.inspectorTree.collapseToSelected();
     details.animateTo(details.inspectorTree.selection);
   }

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
+import '../../flutter/common_widgets.dart';
 import '../../flutter/controllers.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
@@ -104,10 +105,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
       Row(
         mainAxisAlignment: MainAxisAlignment.start,
         children: [
-          RaisedButton(
-            child: const Text('Clear logs'),
-            onPressed: _clearLogs,
-          ),
+          clearButton(onPressed: _clearLogs),
           const Spacer(),
           Container(
             width: 200.0,
@@ -160,6 +158,7 @@ class LogsTable extends StatelessWidget {
   final ColumnData<LogData> when = _WhenColumn();
   final ColumnData<LogData> kind = _KindColumn();
   final ColumnData<LogData> message = _MessageColumn((message) => message);
+
   List<ColumnData<LogData>> get columns => [when, kind, message];
 
   @override

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -14,6 +14,7 @@ import '../../flutter/notifications.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
+import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../service_extensions.dart';
 import '../../ui/flutter/label.dart';
@@ -121,6 +122,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     return Column(
       children: [
         _timelineControls(),
+        const SizedBox(height: denseRowSpacing),
         // TODO(kenz): hide the bar chart if the connected app is not a Flutter
         // app.
         const FlutterFramesChart(),
@@ -142,17 +144,14 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
         controller.exitOfflineMode();
       });
     });
-    return Padding(
-      padding: const EdgeInsets.symmetric(vertical: 8.0),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-        children: offlineMode
-            ? [_exitOfflineButton]
-            : [
-                _buildPrimaryStateControls(),
-                _buildSecondaryControls(),
-              ],
-      ),
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: offlineMode
+          ? [_exitOfflineButton]
+          : [
+              _buildPrimaryStateControls(),
+              _buildSecondaryControls(),
+            ],
     );
   }
 
@@ -165,13 +164,14 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
           minIncludeTextWidth: _primaryControlsMinIncludeTextWidth,
           onPressed: _startRecording,
         ),
+        const SizedBox(width: denseSpacing),
         stopRecordingButton(
           key: TimelineScreen.stopRecordingButtonKey,
           recording: recording,
           minIncludeTextWidth: _primaryControlsMinIncludeTextWidth,
           onPressed: _stopRecording,
         ),
-        const SizedBox(width: 8.0),
+        const SizedBox(width: defaultSpacing),
         clearButton(
           key: TimelineScreen.clearButtonKey,
           minIncludeTextWidth: _primaryControlsMinIncludeTextWidth,
@@ -187,10 +187,8 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 8.0),
-          child: ProfileGranularityDropdown(),
-        ),
+        ProfileGranularityDropdown(),
+        const SizedBox(width: defaultSpacing),
         // TODO(kenz): don't show these buttons if connected to a Dart VM app.
         ServiceExtensionButtonGroup(
           minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
@@ -199,13 +197,16 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
         // TODO(kenz): hide or disable button if http timeline logging is not
         // available.
         _logNetworkTrafficButton(),
-        const SizedBox(width: 8.0),
-        OutlineButton(
-          onPressed: _exportTimeline,
-          child: MaterialIconLabel(
-            Icons.file_download,
-            'Export',
-            minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
+        const SizedBox(width: defaultSpacing),
+        Container(
+          height: Theme.of(context).buttonTheme.height,
+          child: OutlineButton(
+            onPressed: _exportTimeline,
+            child: MaterialIconLabel(
+              Icons.file_download,
+              'Export',
+              minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
+            ),
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -104,17 +104,14 @@ class _ServiceExtensionButtonGroupState
     // TODO(jacobr): respect _available better by displaying whether individual
     // widgets are available (not currently supported by ToggleButtons).
     final available = _extensionStates.any((e) => e.isAvailable);
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 8.0),
-      child: ToggleButtons(
-        constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
-        children: <Widget>[
-          for (var extensionState in _extensionStates)
-            _buildExtension(extensionState)
-        ],
-        isSelected: [for (var e in _extensionStates) e.isSelected],
-        onPressed: available ? _onPressed : null,
-      ),
+    return ToggleButtons(
+      constraints: const BoxConstraints(minWidth: 32.0, minHeight: 32.0),
+      children: <Widget>[
+        for (var extensionState in _extensionStates)
+          _buildExtension(extensionState)
+      ],
+      isSelected: [for (var e in _extensionStates) e.isSelected],
+      onPressed: available ? _onPressed : null,
     );
   }
 

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -54,7 +54,7 @@ void main() {
       expect(find.byType(LoggingScreenBody), findsOneWidget);
       expect(find.byType(LogsTable), findsOneWidget);
       expect(find.byType(LogDetails), findsOneWidget);
-      expect(find.text('Clear logs'), findsOneWidget);
+      expect(find.text('Clear'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
       expect(find.byType(StructuredErrorsToggle), findsOneWidget);
     });
@@ -62,7 +62,7 @@ void main() {
     testWidgets('can clear logs', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       verifyNever(mockLoggingController.clear());
-      await tester.tap(find.text('Clear logs'));
+      await tester.tap(find.text('Clear'));
       verify(mockLoggingController.clear()).called(1);
     });
 


### PR DESCRIPTION
some UI / padding changes to the inspector page:
- draw a border around the inspector master portion of the page (to match the inspector details portion)
- change the padding around the buttons at the top of the inspector page, to line up visually with the border around the master area
- convert some double literals to constant theme values
- use our common 'clear' button in the logging page
- fix a type system assignment error when calling the `collapseDetailsToSelected()` method

<img width="283" alt="Screen Shot 2020-03-19 at 7 23 18 PM" src="https://user-images.githubusercontent.com/1269969/77177454-c1ec4100-6a82-11ea-98ad-8a28f6a2aabd.png">
