### PR TITLE
Disable DevTools pages based on the connected app type.

### DIFF
--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -61,7 +61,7 @@ class ConnectedApp {
 
     await serviceManager.serviceExtensionManager.extensionStatesUpdated.future;
 
-    // The debugAllowBanner extension is only available in debug builds.
+    // The debugAllowBanner extension is only available in debug builds
     final hasDebugExtension = serviceManager.serviceExtensionManager
         .isServiceExtensionAvailable(extensions.debugAllowBanner.extension);
     return !hasDebugExtension;

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -16,7 +16,7 @@ class ConnectedApp {
   bool get appTypeKnown => _appTypeKnown;
   bool _appTypeKnown = false;
 
-  FutureOr<bool> get isFlutterApp async {
+  Future<bool> get isFlutterApp async {
     _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
     _updateAppTypeKnown();
     return _isFlutterApp;
@@ -29,7 +29,7 @@ class ConnectedApp {
 
   bool _isFlutterApp;
 
-  FutureOr<bool> get isProfileBuild async {
+  Future<bool> get isProfileBuild async {
     _isProfileBuild ??= await _connectedToProfileBuild();
     _updateAppTypeKnown();
     return _isProfileBuild;
@@ -42,7 +42,7 @@ class ConnectedApp {
 
   bool _isProfileBuild;
 
-  FutureOr<bool> get isDartWebApp async {
+  Future<bool> get isDartWebApp async {
     _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
     _updateAppTypeKnown();
     return _isDartWebApp;
@@ -63,7 +63,7 @@ class ConnectedApp {
 
   bool get isRunningOnDartVM => serviceManager.vm.name != 'ChromeDebugProxy';
 
-  FutureOr<bool> get isDartCliApp async =>
+  Future<bool> get isDartCliApp async =>
       isRunningOnDartVM && !(await isFlutterApp);
 
   bool get isDartCliAppRaw => isRunningOnDartVM && !isFlutterAppRaw;

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -13,60 +13,45 @@ const dartHtmlLibraryUri = 'dart:html';
 class ConnectedApp {
   ConnectedApp();
 
-  bool get appTypeKnown => _appTypeKnown;
-  bool _appTypeKnown = false;
+  bool get appTypeKnown =>
+      _isFlutterApp != null && _isProfileBuild != null && _isDartWebApp != null;
 
-  Future<bool> get isFlutterApp async {
-    _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
-    _updateAppTypeKnown();
-    return _isFlutterApp;
-  }
+  Future<bool> get isFlutterApp async =>
+      _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
 
-  bool get isFlutterAppRaw {
+  bool get isFlutterAppNow {
     assert(_isFlutterApp != null);
     return _isFlutterApp;
   }
 
   bool _isFlutterApp;
 
-  Future<bool> get isProfileBuild async {
-    _isProfileBuild ??= await _connectedToProfileBuild();
-    _updateAppTypeKnown();
-    return _isProfileBuild;
-  }
+  Future<bool> get isProfileBuild async =>
+      _isProfileBuild ??= await _connectedToProfileBuild();
 
-  bool get isProfileBuildRaw {
+  bool get isProfileBuildNow {
     assert(_isProfileBuild != null);
     return _isProfileBuild;
   }
 
   bool _isProfileBuild;
 
-  Future<bool> get isDartWebApp async {
-    _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
-    _updateAppTypeKnown();
-    return _isDartWebApp;
-  }
+  Future<bool> get isDartWebApp async =>
+      _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
 
-  bool get isDartWebAppRaw {
+  bool get isDartWebAppNow {
     assert(_isDartWebApp != null);
     return _isDartWebApp;
   }
 
   bool _isDartWebApp;
 
-  void _updateAppTypeKnown() {
-    _appTypeKnown = _isFlutterApp != null &&
-        _isProfileBuild != null &&
-        _isDartWebApp != null;
-  }
-
   bool get isRunningOnDartVM => serviceManager.vm.name != 'ChromeDebugProxy';
 
   Future<bool> get isDartCliApp async =>
       isRunningOnDartVM && !(await isFlutterApp);
 
-  bool get isDartCliAppRaw => isRunningOnDartVM && !isFlutterAppRaw;
+  bool get isDartCliAppNow => isRunningOnDartVM && !isFlutterAppNow;
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
@@ -92,9 +77,6 @@ class ConnectedApp {
   }
 
   Future<void> initializeValues() async {
-    await isFlutterApp;
-    await isProfileBuild;
-    await isDartWebApp;
-    _appTypeKnown = true;
+    await Future.wait([isFlutterApp, isProfileBuild, isDartWebApp]);
   }
 }

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -46,6 +46,8 @@ class ConnectedApp {
 
   bool _isDartWebApp;
 
+  bool get isFlutterWebAppNow => isFlutterAppNow && isDartWebAppNow;
+
   bool get isRunningOnDartVM => serviceManager.vm.name != 'ChromeDebugProxy';
 
   Future<bool> get isDartCliApp async =>

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -8,35 +8,65 @@ import 'globals.dart';
 import 'service_extensions.dart' as extensions;
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
-const flutterWebLibraryUri = 'package:flutter_web/src/widgets/binding.dart';
 const dartHtmlLibraryUri = 'dart:html';
 
 class ConnectedApp {
   ConnectedApp();
 
-  Future<bool> get isFlutterApp async =>
-      _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
+  bool get appTypeKnown => _appTypeKnown;
+  bool _appTypeKnown = false;
+
+  FutureOr<bool> get isFlutterApp async {
+    _isFlutterApp ??= await _libraryUriAvailable(flutterLibraryUri);
+    _updateAppTypeKnown();
+    return _isFlutterApp;
+  }
+
+  bool get isFlutterAppRaw {
+    assert(_isFlutterApp != null);
+    return _isFlutterApp;
+  }
+
   bool _isFlutterApp;
 
-  Future<bool> get isPackageFlutterWeb async =>
-      _isPackageFlutterWeb ??= await _libraryUriAvailable(flutterWebLibraryUri);
-  bool _isPackageFlutterWeb;
+  FutureOr<bool> get isProfileBuild async {
+    _isProfileBuild ??= await _connectedToProfileBuild();
+    _updateAppTypeKnown();
+    return _isProfileBuild;
+  }
 
-  Future<bool> get isProfileBuild async =>
-      _isProfileBuild ??= await _connectedToProfileBuild();
+  bool get isProfileBuildRaw {
+    assert(_isProfileBuild != null);
+    return _isProfileBuild;
+  }
+
   bool _isProfileBuild;
 
-  Future<bool> get isAnyFlutterApp async =>
-      await isFlutterApp || await isPackageFlutterWeb;
+  FutureOr<bool> get isDartWebApp async {
+    _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
+    _updateAppTypeKnown();
+    return _isDartWebApp;
+  }
 
-  Future<bool> get isDartWebApp async =>
-      _isDartWebApp ??= await _libraryUriAvailable(dartHtmlLibraryUri);
+  bool get isDartWebAppRaw {
+    assert(_isDartWebApp != null);
+    return _isDartWebApp;
+  }
+
   bool _isDartWebApp;
+
+  void _updateAppTypeKnown() {
+    _appTypeKnown = _isFlutterApp != null &&
+        _isProfileBuild != null &&
+        _isDartWebApp != null;
+  }
 
   bool get isRunningOnDartVM => serviceManager.vm.name != 'ChromeDebugProxy';
 
-  Future<bool> get isDartCliApp async =>
+  FutureOr<bool> get isDartCliApp async =>
       isRunningOnDartVM && !(await isFlutterApp);
+
+  bool get isDartCliAppRaw => isRunningOnDartVM && !isFlutterAppRaw;
 
   Future<bool> _connectedToProfileBuild() async {
     assert(serviceManager.serviceAvailable.isCompleted);
@@ -55,10 +85,16 @@ class ConnectedApp {
   Future<bool> _libraryUriAvailable(String uri) async {
     assert(serviceManager.serviceAvailable.isCompleted);
     await serviceManager.isolateManager.selectedIsolateAvailable.future;
-
     return serviceManager.isolateManager.selectedIsolateLibraries
         .map((ref) => ref.uri)
         .toList()
         .any((u) => u.startsWith(uri));
+  }
+
+  Future<void> initializeValues() async {
+    await isFlutterApp;
+    await isProfileBuild;
+    await isDartWebApp;
+    _appTypeKnown = true;
   }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -29,7 +29,7 @@ class DebuggerScreen extends Screen {
   Widget build(BuildContext context) {
     return !serviceManager.connectedApp.isProfileBuildNow
         ? const DebuggerScreenBody()
-        : const DisabledForProfileModeMessage();
+        : const DisabledForProfileBuildMessage();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -27,11 +27,18 @@ class DebuggerScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return DebuggerScreenBody();
+    return enabled()
+        ? const DebuggerScreenBody()
+        : const DisabledForProfileModeMessage();
   }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isProfileBuildRaw;
 }
 
 class DebuggerScreenBody extends StatefulWidget {
+  const DebuggerScreenBody();
+
   @override
   DebuggerScreenBodyState createState() => DebuggerScreenBodyState();
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -27,7 +27,7 @@ class DebuggerScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isProfileBuildRaw
+    return !serviceManager.connectedApp.isProfileBuildNow
         ? const DebuggerScreenBody()
         : const DisabledForProfileModeMessage();
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -27,13 +27,10 @@ class DebuggerScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled()
+    return !serviceManager.connectedApp.isProfileBuildRaw
         ? const DebuggerScreenBody()
         : const DisabledForProfileModeMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isProfileBuildRaw;
 }
 
 class DebuggerScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -101,12 +101,7 @@ class DevToolsAppState extends State<DevToolsApp> {
       settings: settings,
       builder: (BuildContext context) {
         return DevToolsScaffold.withChild(
-          child: Center(
-            child: Text(
-              'Sorry, $uri was not found.',
-              style: Theme.of(context).textTheme.headline4,
-            ),
-          ),
+          child: CenteredMessage('Sorry, $uri was not found.'),
         );
       },
     );

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -392,3 +392,57 @@ class OutlinedBorder extends StatelessWidget {
 ///
 /// Makes for nice-looking rectangles.
 final goldenRatio = 1 + sqrt(5) / 2;
+
+class DisabledForProfileModeMessage extends StatelessWidget {
+  const DisabledForProfileModeMessage();
+
+  static const message =
+      'This screen is disabled because you are running a profile build of your '
+      'application.';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CenteredMessage(message);
+  }
+}
+
+class DisabledForWebAppMessage extends StatelessWidget {
+  const DisabledForWebAppMessage();
+
+  static const message =
+      'This screen is disabled because you are connected to a web application.';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CenteredMessage(message);
+  }
+}
+
+class DisabledForNonFlutterAppMessage extends StatelessWidget {
+  const DisabledForNonFlutterAppMessage();
+
+  static const message =
+      'This screen is disabled because you are not running a Flutter '
+      'application.';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CenteredMessage(message);
+  }
+}
+
+class CenteredMessage extends StatelessWidget {
+  const CenteredMessage(this.message);
+
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Text(
+        message,
+        style: Theme.of(context).textTheme.headline6,
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -393,8 +393,8 @@ class OutlinedBorder extends StatelessWidget {
 /// Makes for nice-looking rectangles.
 final goldenRatio = 1 + sqrt(5) / 2;
 
-class DisabledForProfileModeMessage extends StatelessWidget {
-  const DisabledForProfileModeMessage();
+class DisabledForProfileBuildMessage extends StatelessWidget {
+  const DisabledForProfileBuildMessage();
 
   static const message =
       'This screen is disabled because you are running a profile build of your '
@@ -411,6 +411,19 @@ class DisabledForWebAppMessage extends StatelessWidget {
 
   static const message =
       'This screen is disabled because you are connected to a web application.';
+
+  @override
+  Widget build(BuildContext context) {
+    return const CenteredMessage(message);
+  }
+}
+
+class DisabledForFlutterWebProfileBuildMessage extends StatelessWidget {
+  const DisabledForFlutterWebProfileBuildMessage();
+
+  static const message =
+      'This screen is disabled because you are connected to a profile build of '
+      'your Flutter Web application.';
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -71,7 +71,8 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
             const Padding(padding: EdgeInsets.only(top: 20.0)),
             _buildTextInput(),
             const PaddedDivider(padding: EdgeInsets.symmetric(vertical: 10.0)),
-            // TODO(https://github.com/flutter/devtools/issues/1111): support drag-and-drop of snapshot files here.
+            // TODO(https://github.com/flutter/devtools/issues/1111): support
+            // drag-and-drop of snapshot files here.
           ],
         ),
       ],

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -74,6 +74,9 @@ abstract class Screen {
   Widget buildStatus(BuildContext context, TextTheme textTheme) {
     return null;
   }
+
+  /// Whether the screen is enabled.
+  bool enabled() => true;
 }
 
 enum DevToolsScreenType {

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -74,9 +74,6 @@ abstract class Screen {
   Widget buildStatus(BuildContext context, TextTheme textTheme) {
     return null;
   }
-
-  /// Whether the screen is enabled.
-  bool enabled() => true;
 }
 
 enum DevToolsScreenType {

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -27,7 +27,7 @@ class InfoScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppRaw
+    return !serviceManager.connectedApp.isDartWebAppNow
         ? const InfoScreenBody()
         : const DisabledForWebAppMessage();
   }

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -10,6 +10,7 @@ import '../../flutter/common_widgets.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/theme.dart';
+import '../../globals.dart';
 import '../../version.dart';
 import '../info_controller.dart';
 
@@ -25,7 +26,14 @@ class InfoScreen extends Screen {
   bool get showIsolateSelector => true;
 
   @override
-  Widget build(BuildContext context) => InfoScreenBody();
+  Widget build(BuildContext context) {
+    return enabled()
+        ? const InfoScreenBody()
+        : const DisabledForWebAppMessage();
+  }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 
   /// The key to identify the flutter version view.
   @visibleForTesting
@@ -37,6 +45,8 @@ class InfoScreen extends Screen {
 }
 
 class InfoScreenBody extends StatefulWidget {
+  const InfoScreenBody();
+
   @override
   _InfoScreenBodyState createState() => _InfoScreenBodyState();
 }

--- a/packages/devtools_app/lib/src/info/flutter/info_screen.dart
+++ b/packages/devtools_app/lib/src/info/flutter/info_screen.dart
@@ -27,13 +27,10 @@ class InfoScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled()
+    return !serviceManager.connectedApp.isDartWebAppRaw
         ? const InfoScreenBody()
         : const DisabledForWebAppMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 
   /// The key to identify the flutter version view.
   @visibleForTesting

--- a/packages/devtools_app/lib/src/info/info_controller.dart
+++ b/packages/devtools_app/lib/src/info/info_controller.dart
@@ -44,7 +44,7 @@ class InfoController extends DisposableController
   }
 
   Future<void> _listenForFlutterVersionChanges() async {
-    if (await serviceManager.connectedApp.isAnyFlutterApp) {
+    if (await serviceManager.connectedApp.isFlutterApp) {
       final flutterVersionServiceListenable = serviceManager
           .registeredServiceListenable(registrations.flutterVersion.service);
       addAutoDisposeListener(flutterVersionServiceListenable, () async {

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -7,6 +7,7 @@ import 'package:vm_service/vm_service.dart' hide Stack;
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/blocking_action_mixin.dart';
+import '../../flutter/common_widgets.dart';
 import '../../flutter/initializer.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
@@ -33,7 +34,22 @@ class InspectorScreen extends Screen {
   String get docPageId => 'inspector';
 
   @override
-  Widget build(BuildContext context) => const InspectorScreenBody();
+  Widget build(BuildContext context) {
+    if (!enabled()) {
+      if (!serviceManager.connectedApp.isFlutterAppRaw) {
+        return const DisabledForNonFlutterAppMessage();
+      }
+      if (serviceManager.connectedApp.isProfileBuildRaw) {
+        return const DisabledForProfileModeMessage();
+      }
+    }
+    return const InspectorScreenBody();
+  }
+
+  @override
+  bool enabled() =>
+      serviceManager.connectedApp.isFlutterAppRaw &&
+      !serviceManager.connectedApp.isProfileBuildRaw;
 }
 
 class InspectorScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -36,8 +36,8 @@ class InspectorScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    final isFlutterApp = serviceManager.connectedApp.isFlutterAppRaw;
-    final isProfileBuild = serviceManager.connectedApp.isProfileBuildRaw;
+    final isFlutterApp = serviceManager.connectedApp.isFlutterAppNow;
+    final isProfileBuild = serviceManager.connectedApp.isProfileBuildNow;
     if (!isFlutterApp || isProfileBuild) {
       return !isFlutterApp
           ? const DisabledForNonFlutterAppMessage()

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -41,7 +41,7 @@ class InspectorScreen extends Screen {
     if (!isFlutterApp || isProfileBuild) {
       return !isFlutterApp
           ? const DisabledForNonFlutterAppMessage()
-          : const DisabledForProfileModeMessage();
+          : const DisabledForProfileBuildMessage();
     }
     return const InspectorScreenBody();
   }

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -35,21 +35,15 @@ class InspectorScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    if (!enabled()) {
-      if (!serviceManager.connectedApp.isFlutterAppRaw) {
-        return const DisabledForNonFlutterAppMessage();
-      }
-      if (serviceManager.connectedApp.isProfileBuildRaw) {
-        return const DisabledForProfileModeMessage();
-      }
+    final isFlutterApp = serviceManager.connectedApp.isFlutterAppRaw;
+    final isProfileBuild = serviceManager.connectedApp.isProfileBuildRaw;
+    if (!isFlutterApp || isProfileBuild) {
+      return !isFlutterApp
+          ? const DisabledForNonFlutterAppMessage()
+          : const DisabledForProfileModeMessage();
     }
     return const InspectorScreenBody();
   }
-
-  @override
-  bool enabled() =>
-      serviceManager.connectedApp.isFlutterAppRaw &&
-      !serviceManager.connectedApp.isProfileBuildRaw;
 }
 
 class InspectorScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -14,6 +14,7 @@ import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
 import '../../flutter/table.dart';
 import '../../flutter/theme.dart';
+import '../../globals.dart';
 import '../../table_data.dart';
 import '../../ui/flutter/service_extension_widgets.dart';
 import '../../utils.dart';
@@ -40,7 +41,10 @@ class LoggingScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return LoggingScreenBody();
+    return !(serviceManager.connectedApp.isFlutterWebAppNow &&
+            serviceManager.connectedApp.isProfileBuildNow)
+        ? const LoggingScreenBody()
+        : const DisabledForFlutterWebProfileBuildMessage();
   }
 
   @override
@@ -58,6 +62,8 @@ class LoggingScreen extends Screen {
 }
 
 class LoggingScreenBody extends StatefulWidget {
+  const LoggingScreenBody();
+
   @override
   _LoggingScreenState createState() => _LoggingScreenState();
 }

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../flutter/common_widgets.dart';
 import '../../flutter/controllers.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
@@ -58,7 +59,12 @@ class MemoryScreen extends Screen {
   String get docPageId => 'memory';
 
   @override
-  Widget build(BuildContext context) => const MemoryBody();
+  Widget build(BuildContext context) {
+    return enabled() ? const MemoryBody() : const DisabledForWebAppMessage();
+  }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class MemoryBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -60,11 +60,10 @@ class MemoryScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled() ? const MemoryBody() : const DisabledForWebAppMessage();
+    return !serviceManager.connectedApp.isDartWebAppRaw
+        ? const MemoryBody()
+        : const DisabledForWebAppMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class MemoryBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -60,7 +60,7 @@ class MemoryScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppRaw
+    return !serviceManager.connectedApp.isDartWebAppNow
         ? const MemoryBody()
         : const DisabledForWebAppMessage();
   }

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -33,13 +33,10 @@ class NetworkScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled()
+    return !serviceManager.connectedApp.isDartWebAppRaw
         ? const NetworkScreenBody()
         : const DisabledForWebAppMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class NetworkScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
+import '../../globals.dart';
 import '../../http/http_request_data.dart';
 import '../network_controller.dart';
 import 'http_request_inspector.dart';
@@ -31,7 +32,14 @@ class NetworkScreen extends Screen {
   static const recordingInstructionsKey = Key('Recording Instructions');
 
   @override
-  Widget build(BuildContext context) => const NetworkScreenBody();
+  Widget build(BuildContext context) {
+    return enabled()
+        ? const NetworkScreenBody()
+        : const DisabledForWebAppMessage();
+  }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class NetworkScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -33,7 +33,7 @@ class NetworkScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppRaw
+    return !serviceManager.connectedApp.isDartWebAppNow
         ? const NetworkScreenBody()
         : const DisabledForWebAppMessage();
   }

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -41,7 +41,7 @@ class PerformanceScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppRaw
+    return !serviceManager.connectedApp.isDartWebAppNow
         ? const PerformanceScreenBody()
         : const DisabledForWebAppMessage();
   }

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -10,6 +10,7 @@ import '../../flutter/common_widgets.dart';
 import '../../flutter/controllers.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
+import '../../globals.dart';
 import '../../performance/performance_controller.dart';
 import '../../profiler/cpu_profile_controller.dart';
 import '../../profiler/cpu_profile_model.dart';
@@ -39,10 +40,19 @@ class PerformanceScreen extends Screen {
   String get docPageId => 'performance';
 
   @override
-  Widget build(BuildContext context) => PerformanceScreenBody();
+  Widget build(BuildContext context) {
+    return enabled()
+        ? const PerformanceScreenBody()
+        : const DisabledForWebAppMessage();
+  }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class PerformanceScreenBody extends StatefulWidget {
+  const PerformanceScreenBody();
+
   @override
   _PerformanceScreenBodyState createState() => _PerformanceScreenBodyState();
 }

--- a/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/flutter/performance_screen.dart
@@ -41,13 +41,10 @@ class PerformanceScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled()
+    return !serviceManager.connectedApp.isDartWebAppRaw
         ? const PerformanceScreenBody()
         : const DisabledForWebAppMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class PerformanceScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -73,7 +73,8 @@ class ServiceConnectionManager {
   VM vm;
   String sdkVersion;
 
-  bool get hasConnection => service != null;
+  bool get hasConnection =>
+      service != null && connectedApp != null && connectedApp.appTypeKnown;
 
   Stream<bool> get onStateChange => _stateController.stream;
   final _stateController = StreamController<bool>.broadcast();
@@ -199,6 +200,8 @@ class ServiceConnectionManager {
         }
       }
     }));
+
+    await connectedApp.initializeValues();
   }
 
   void vmServiceClosed() {
@@ -243,7 +246,7 @@ class ServiceConnectionManager {
   }
 
   Future<double> getDisplayRefreshRate() async {
-    if (connectedApp == null || !await connectedApp.isAnyFlutterApp) {
+    if (connectedApp == null || !await connectedApp.isFlutterApp) {
       return null;
     }
 
@@ -519,7 +522,7 @@ class ServiceExtensionManager {
     }
     final Isolate isolate = await _service.getIsolate(isolateRef.id);
     if (isolate.extensionRPCs != null) {
-      if (await connectedApp.isAnyFlutterApp) {
+      if (await connectedApp.isFlutterApp) {
         for (String extension in isolate.extensionRPCs) {
           await _maybeAddServiceExtension(extension);
         }

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -164,7 +164,6 @@ class ServiceConnectionManager {
     _vmFlagManager.service = service;
 
     _stateController.add(true);
-    _connectionAvailableController.add(service);
 
     await _isolateManager._initIsolates(vm.isolates);
     service.onIsolateEvent.listen(_isolateManager._handleIsolateEvent);
@@ -202,6 +201,7 @@ class ServiceConnectionManager {
     }));
 
     await connectedApp.initializeValues();
+    _connectionAvailableController.add(service);
   }
 
   void vmServiceClosed() {

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -57,7 +57,7 @@ class TimelineScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppRaw
+    return !serviceManager.connectedApp.isDartWebAppNow
         ? const TimelineScreenBody()
         : const DisabledForWebAppMessage();
   }
@@ -129,7 +129,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
       children: [
         _timelineControls(),
         const SizedBox(height: denseRowSpacing),
-        if (serviceManager.connectedApp.isFlutterAppRaw)
+        if (serviceManager.connectedApp.isFlutterAppNow)
           const FlutterFramesChart(),
         Expanded(
           child: Split(
@@ -194,7 +194,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
       children: [
         ProfileGranularityDropdown(),
         const SizedBox(width: defaultSpacing),
-        if (!serviceManager.connectedApp.isDartCliAppRaw)
+        if (!serviceManager.connectedApp.isDartCliAppNow)
           ServiceExtensionButtonGroup(
             minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
             extensions: [performanceOverlay, profileWidgetBuilds],

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -56,13 +56,10 @@ class TimelineScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return enabled()
+    return !serviceManager.connectedApp.isDartWebAppRaw
         ? const TimelineScreenBody()
         : const DisabledForWebAppMessage();
   }
-
-  @override
-  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class TimelineScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -55,10 +55,19 @@ class TimelineScreen extends Screen {
   String get docPageId => 'timeline';
 
   @override
-  Widget build(BuildContext context) => TimelineScreenBody();
+  Widget build(BuildContext context) {
+    return enabled()
+        ? const TimelineScreenBody()
+        : const DisabledForWebAppMessage();
+  }
+
+  @override
+  bool enabled() => !serviceManager.connectedApp.isDartWebAppRaw;
 }
 
 class TimelineScreenBody extends StatefulWidget {
+  const TimelineScreenBody();
+
   @override
   TimelineScreenBodyState createState() => TimelineScreenBodyState();
 }
@@ -121,9 +130,8 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
     return Column(
       children: [
         _timelineControls(),
-        // TODO(kenz): hide the bar chart if the connected app is not a Flutter
-        // app.
-        const FlutterFramesChart(),
+        if (serviceManager.connectedApp.isFlutterAppRaw)
+          const FlutterFramesChart(),
         Expanded(
           child: Split(
             axis: Axis.vertical,
@@ -191,11 +199,11 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
           padding: const EdgeInsets.symmetric(horizontal: 8.0),
           child: ProfileGranularityDropdown(),
         ),
-        // TODO(kenz): don't show these buttons if connected to a Dart VM app.
-        ServiceExtensionButtonGroup(
-          minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
-          extensions: [performanceOverlay, profileWidgetBuilds],
-        ),
+        if (!serviceManager.connectedApp.isDartCliAppRaw)
+          ServiceExtensionButtonGroup(
+            minIncludeTextWidth: _secondaryControlsMinIncludeTextWidth,
+            extensions: [performanceOverlay, profileWidgetBuilds],
+          ),
         // TODO(kenz): hide or disable button if http timeline logging is not
         // available.
         _logNetworkTrafficButton(),

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
@@ -66,7 +66,7 @@ class TimelineService {
   }
 
   Future<void> startTimeline() async {
-    timelineController.data = await serviceManager.connectedApp.isAnyFlutterApp
+    timelineController.data = await serviceManager.connectedApp.isFlutterApp
         ? TimelineData(
             displayRefreshRate: await serviceManager.getDisplayRefreshRate(),
           )

--- a/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
@@ -80,7 +80,7 @@ class TimelineService {
   }
 
   Future<void> startTimeline() async {
-    if (await serviceManager.connectedApp.isAnyFlutterApp) {
+    if (await serviceManager.connectedApp.isFlutterApp) {
       timelineController.frameBasedTimeline.data = FrameBasedTimelineData(
           displayRefreshRate: await serviceManager.getDisplayRefreshRate());
     }

--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -595,7 +595,6 @@ Future<void> computeUserApplicationCustomGTagData() async {
   final isFlutter = await serviceManager.connectedApp.isFlutterApp;
   final isWebApp = await serviceManager.connectedApp.isDartWebApp;
   final isProfile = await serviceManager.connectedApp.isProfileBuild;
-  final isAnyFlutterApp = await serviceManager.connectedApp.isAnyFlutterApp;
 
   if (isFlutter) {
     userPlatformType = (await serviceManager.service.isProtocolVersionSupported(
@@ -604,13 +603,11 @@ Future<void> computeUserApplicationCustomGTagData() async {
         : 'unknown';
   }
 
-  if (isAnyFlutterApp) {
-    if (isFlutter) {
-      userAppType = appTypeFlutter;
-    }
-    if (isWebApp) {
-      userAppType = appTypeWeb;
-    }
+  if (isFlutter) {
+    userAppType = appTypeFlutter;
+  }
+  if (isWebApp) {
+    userAppType = appTypeWeb;
   }
   userBuildType = isProfile ? buildTypeProfile : buildTypeDebug;
 

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -21,7 +21,7 @@ void main() {
   group('DebuggerScreen', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const DebuggerScreen();
     });
@@ -33,7 +33,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for profile mode',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(DebuggerScreenBody), findsNothing);
       expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -36,7 +36,7 @@ void main() {
       when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(DebuggerScreenBody), findsNothing);
-      expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);
+      expect(find.byType(DisabledForProfileBuildMessage), findsOneWidget);
     });
   });
 }

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/debugger/flutter/debugger_screen.dart';
+import 'package:devtools_app/src/flutter/common_widgets.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../support/mocks.dart';
+import 'wrappers.dart';
+
+void main() {
+  DebuggerScreen screen;
+  FakeServiceManager fakeServiceManager;
+
+  group('DebuggerScreen', () {
+    setUp(() async {
+      fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      screen = const DebuggerScreen();
+    });
+
+    testWidgets('builds its tab', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
+      expect(find.text('Debugger'), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for profile mode',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(DebuggerScreenBody), findsNothing);
+      expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/info_screen_test.dart
+++ b/packages/devtools_app/test/flutter/info_screen_test.dart
@@ -19,7 +19,7 @@ void main() {
   group('Info Screen', () {
     setUp(() {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       setGlobal(
         ServiceConnectionManager,
         fakeServiceManager,
@@ -36,7 +36,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for web app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InfoScreenBody), findsNothing);
       expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
@@ -52,7 +52,7 @@ void main() {
     testWidgets('builds with no data', (WidgetTester tester) async {
       setGlobal(ServiceConnectionManager, FakeServiceManager());
       when(serviceManager.service.getFlagList()).thenAnswer((_) => null);
-      when(serviceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(serviceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       mockIsFlutterApp(serviceManager.connectedApp);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InfoScreenBody), findsOneWidget);

--- a/packages/devtools_app/test/flutter/info_screen_test.dart
+++ b/packages/devtools_app/test/flutter/info_screen_test.dart
@@ -20,12 +20,8 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
-      setGlobal(
-        ServiceConnectionManager,
-        fakeServiceManager,
-      );
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
       mockIsFlutterApp(serviceManager.connectedApp);
-
       screen = const InfoScreen();
     });
 

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -32,8 +32,8 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       fakeExtensionManager = fakeServiceManager.serviceExtensionManager;
-      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
 
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       mockIsFlutterApp(serviceManager.connectedApp);
@@ -91,8 +91,8 @@ void main() {
 
     testWidgets('builds disabled message when disabled for non-flutter app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(false);
-      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsNothing);
       expect(find.byType(DisabledForNonFlutterAppMessage), findsOneWidget);
@@ -100,8 +100,8 @@ void main() {
 
     testWidgets('builds disabled message when disabled for profile mode',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsNothing);
       expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:devtools_app/src/inspector/flutter/inspector_screen.dart';
@@ -31,6 +32,8 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       fakeExtensionManager = fakeServiceManager.serviceExtensionManager;
+      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
 
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       mockIsFlutterApp(serviceManager.connectedApp);
@@ -84,6 +87,24 @@ void main() {
       // await setWindowSize(const Size(1000.0, 1200.0));
       // Verify that description text is no-longer shown.
       // expect(find.text(extensions.debugPaint.description), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for non-flutter app',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(false);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(InspectorScreenBody), findsNothing);
+      expect(find.byType(DisabledForNonFlutterAppMessage), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for profile mode',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isProfileBuildRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(InspectorScreenBody), findsNothing);
+      expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/flutter/inspector_screen_test.dart
+++ b/packages/devtools_app/test/flutter/inspector_screen_test.dart
@@ -104,7 +104,7 @@ void main() {
       when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(InspectorScreenBody), findsNothing);
-      expect(find.byType(DisabledForProfileModeMessage), findsOneWidget);
+      expect(find.byType(DisabledForProfileBuildMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-
+import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/flutter/split.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -41,6 +41,7 @@ void main() {
     setUp(() async {
       await ensureInspectorDependencies();
       fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
@@ -50,6 +51,14 @@ void main() {
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
       expect(find.text('Memory'), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for web app',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(MemoryBody), findsNothing);
+      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('builds proper content for state', windowSize,

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -41,7 +41,7 @@ void main() {
     setUp(() async {
       await ensureInspectorDependencies();
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
@@ -55,7 +55,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for web app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(MemoryBody), findsNothing);
       expect(find.byType(DisabledForWebAppMessage), findsOneWidget);

--- a/packages/devtools_app/test/flutter/network_screen_test.dart
+++ b/packages/devtools_app/test/flutter/network_screen_test.dart
@@ -21,7 +21,7 @@ void main() {
   group('NetworkScreen', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const NetworkScreen();
     });
@@ -33,7 +33,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for web app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(NetworkScreenBody), findsNothing);
       expect(find.byType(DisabledForWebAppMessage), findsOneWidget);

--- a/packages/devtools_app/test/flutter/network_screen_test.dart
+++ b/packages/devtools_app/test/flutter/network_screen_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/common_widgets.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/network/flutter/network_screen.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import '../support/mocks.dart';
+import 'wrappers.dart';
+
+void main() {
+  NetworkScreen screen;
+  FakeServiceManager fakeServiceManager;
+
+  group('NetworkScreen', () {
+    setUp(() async {
+      fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      screen = const NetworkScreen();
+    });
+
+    testWidgets('builds its tab', (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
+      expect(find.text('Network'), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for web app',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(NetworkScreenBody), findsNothing);
+      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/performance_screen_test.dart
+++ b/packages/devtools_app/test/flutter/performance_screen_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/flutter/performance_screen.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
@@ -12,6 +13,7 @@ import 'package:devtools_app/src/ui/flutter/vm_flag_widgets.dart';
 import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 import '../support/mocks.dart';
 import 'wrappers.dart';
@@ -20,9 +22,10 @@ void main() {
   PerformanceScreen screen;
   FakeServiceManager fakeServiceManager;
 
-  group('TimelineScreen', () {
+  group('PerformanceScreen', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const PerformanceScreen();
     });
@@ -51,13 +54,21 @@ void main() {
       expect(find.text('Performance'), findsOneWidget);
     });
 
+    testWidgets('builds disabled message when disabled for web app',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(PerformanceScreenBody), findsNothing);
+      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
+    });
+
     const windowSize = Size(1000.0, 1000.0);
 
     testWidgetsWithWindowSize(
       'builds proper content for recording state',
       windowSize,
       (WidgetTester tester) async {
-        final perfScreenBody = PerformanceScreenBody();
+        const perfScreenBody = PerformanceScreenBody();
         await tester.pumpWidget(wrapWithControllers(
           perfScreenBody,
           performance: PerformanceController(),
@@ -91,7 +102,7 @@ void main() {
     testWidgetsWithWindowSize('builds for disabled profiler', windowSize,
         (WidgetTester tester) async {
       await serviceManager.service.setFlag(vm_flags.profiler, 'false');
-      final perfScreenBody = PerformanceScreenBody();
+      const perfScreenBody = PerformanceScreenBody();
       await tester.pumpWidget(wrapWithControllers(
         perfScreenBody,
         performance: PerformanceController(),

--- a/packages/devtools_app/test/flutter/performance_screen_test.dart
+++ b/packages/devtools_app/test/flutter/performance_screen_test.dart
@@ -25,7 +25,7 @@ void main() {
   group('PerformanceScreen', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const PerformanceScreen();
     });
@@ -56,7 +56,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for web app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(PerformanceScreenBody), findsNothing);
       expect(find.byType(DisabledForWebAppMessage), findsOneWidget);

--- a/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
@@ -22,6 +22,9 @@ void main() {
   group('TimelineFlameChart', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartCliAppRaw).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));

--- a/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
@@ -22,9 +22,9 @@ void main() {
   group('TimelineFlameChart', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
-      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isDartCliAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));

--- a/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_flame_chart_test.dart
@@ -44,7 +44,7 @@ void main() {
         ..data = data
         ..selectFrame(testFrame1);
       await tester.pumpWidget(wrapWithControllers(
-        TimelineScreenBody(),
+        const TimelineScreenBody(),
         timeline: controllerWithData,
       ));
       expect(find.byType(TimelineFlameChart), findsOneWidget);
@@ -55,7 +55,7 @@ void main() {
         (WidgetTester tester) async {
       // Set a wide enough screen width that we do not run into overflow.
       await tester.pumpWidget(wrapWithControllers(
-        TimelineScreenBody(),
+        const TimelineScreenBody(),
         timeline: TimelineController(),
       ));
       expect(find.byType(TimelineFlameChart), findsNothing);

--- a/packages/devtools_app/test/flutter/timeline_screen_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_screen_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/flutter/split.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -31,7 +32,7 @@ void main() {
   }) async {
     // Set a wide enough screen width that we do not run into overflow.
     await tester.pumpWidget(wrapWithControllers(
-      TimelineScreenBody(),
+      const TimelineScreenBody(),
       timeline: controller = timelineController ?? TimelineController(),
     ));
     expect(find.byType(TimelineScreenBody), findsOneWidget);
@@ -61,6 +62,9 @@ void main() {
     setUp(() async {
       await ensureInspectorDependencies();
       fakeServiceManager = FakeServiceManager(useFakeService: true);
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartCliAppRaw).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
@@ -73,6 +77,14 @@ void main() {
         timeline: TimelineController(),
       ));
       expect(find.text('Timeline'), findsOneWidget);
+    });
+
+    testWidgets('builds disabled message when disabled for web app',
+        (WidgetTester tester) async {
+      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
+      expect(find.byType(TimelineScreenBody), findsNothing);
+      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('builds initial content', windowSize,

--- a/packages/devtools_app/test/flutter/timeline_screen_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_screen_test.dart
@@ -62,9 +62,9 @@ void main() {
     setUp(() async {
       await ensureInspectorDependencies();
       fakeServiceManager = FakeServiceManager(useFakeService: true);
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(false);
-      when(fakeServiceManager.connectedApp.isFlutterAppRaw).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isDartCliAppRaw).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
+      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
@@ -81,7 +81,7 @@ void main() {
 
     testWidgets('builds disabled message when disabled for web app',
         (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppRaw).thenReturn(true);
+      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
       await tester.pumpWidget(wrap(Builder(builder: screen.build)));
       expect(find.byType(TimelineScreenBody), findsNothing);
       expect(find.byType(DisabledForWebAppMessage), findsOneWidget);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -550,5 +550,5 @@ Future<void> ensureInspectorDependencies() async {
 }
 
 void mockIsFlutterApp(MockConnectedApp connectedApp) {
-  when(connectedApp.isAnyFlutterApp).thenAnswer((_) => Future.value(true));
+  when(connectedApp.isFlutterApp).thenAnswer((_) => Future.value(true));
 }


### PR DESCRIPTION
When the page is not supported for the connected app, we show a full screen message explaining why the page is disabled.

![Screen Shot 2020-03-20 at 10 40 00 AM](https://user-images.githubusercontent.com/43759233/77198781-e527e800-6aa4-11ea-9b02-5de05e71165e.png)

Fixes https://github.com/flutter/devtools/issues/1669
