### PR TITLE
Rename uses of 'gpu' to 'raster'.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flutter/flame_chart.dart
@@ -851,7 +851,7 @@ class FlameChartNode<T> {
   }
 
   Rect zoomedRect(double zoom, double chartStartInset) {
-    // If a node is not selectable (e.g. section labels "UI", "GPU", etc.), it
+    // If a node is not selectable (e.g. section labels "UI", "Raster", etc.), it
     // will not be zoomed, so return the original rect.
     if (!selectable) return rect;
 
@@ -877,13 +877,14 @@ mixin FlameChartColorMixin {
     return color;
   }
 
-  int _gpuColorOffset = 0;
-  Color nextGpuColor({bool resetOffset = false}) {
+  int _rasterColorOffset = 0;
+  Color nextRasterColor({bool resetOffset = false}) {
     if (resetOffset) {
-      _gpuColorOffset = 0;
+      _rasterColorOffset = 0;
     }
-    final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
-    _gpuColorOffset++;
+    final color =
+        rasterColorPalette[_rasterColorOffset % rasterColorPalette.length];
+    _rasterColorOffset++;
     return color;
   }
 
@@ -923,7 +924,7 @@ mixin FlameChartColorMixin {
   void resetColorOffsets() {
     _asyncColorOffset = 0;
     _uiColorOffset = 0;
-    _gpuColorOffset = 0;
+    _rasterColorOffset = 0;
     _unknownColorOffset = 0;
     _selectedColorOffset = 0;
   }

--- a/packages/devtools_app/lib/src/inspector/flutter/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/layout_explorer/flex/flex.dart
@@ -24,7 +24,8 @@ import 'overflow_indicator_painter.dart';
 import 'utils.dart';
 
 const widthIndicatorColor = ThemedColor(Color(0xFF000099), mainUiColorDark);
-const heightIndicatorColor = ThemedColor(mainGpuColorDark, Color(0xFF27AAE1));
+const heightIndicatorColor =
+    ThemedColor(mainRasterColorDark, Color(0xFF27AAE1));
 const margin = 8.0;
 
 const arrowHeadSize = 8.0;

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -723,10 +723,6 @@ typedef SelectionCallback = void Function(int timestamp);
 
 typedef SelectSampleCallback = HeapSample Function(int timestamp);
 
-/// Selection of a point in the Bar chart displays the data point values
-/// UI duration and GPU duration. Also, highlight the selected stacked bar.
-/// Uses marker/highlight mechanism which lags because it uses onTapUp maybe
-/// onTapDown would be less laggy.
 class SelectedDataPoint extends LineChartMarker {
   SelectedDataPoint(
     this.type, {

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -47,7 +47,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     implements OnChartValueSelectedListener {
   static const maxFrames = 150;
 
-  /// Datapoint entry for each frame duration (UI/GPU) for stacked bars.
+  /// Datapoint entry for each frame duration (UI/Raster) for stacked bars.
   final _frameDurations = <BarEntry>[];
 
   /// Set of all duration information (the data, colors, etc).
@@ -182,7 +182,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
 
     // Create heap used dataset.
     frameDurationsSet = BarDataSet(_frameDurations, 'Durations')
-      ..setColors1([mainGpuColor, mainUiColor])
+      ..setColors1([mainRasterColor, mainUiColor])
       ..setDrawValues(false);
 
     // Create a data object with all the data sets - stacked bar.
@@ -196,19 +196,19 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     return BarEntry.fromListYVals(x: 0.0, vals: [0.0, 0.0]);
   }
 
-  // TODO(terry): Consider grouped bars (UI/GPU) not stacked.
+  // TODO(terry): Consider grouped bars (UI/Raster) not stacked.
   BarEntry createBarEntry(TimelineFrame frame, int index) {
-    if (frame.uiDurationMs + frame.gpuDurationMs > 250) {
+    if (frame.uiDurationMs + frame.rasterDurationMs > 250) {
       // Constrain the y-axis so outliers don't blow the barchart scale.
       // TODO(terry): Need to have a max where the hover value shows the real #s but the chart just looks pinned to the top.
       _chartController.axisLeft?.setAxisMaximum(250);
     }
 
-    // TODO(terry): Structured class item 0 is GPU, item 1 is UI if not stacked.
+    // TODO(terry): Structured class item 0 is Raster, item 1 is UI if not stacked.
     final entry = BarEntry.fromListYVals(
       x: index.toDouble(),
       vals: [
-        frame.gpuDurationMs.toDouble(),
+        frame.rasterDurationMs.toDouble(),
         frame.uiDurationMs.toDouble(),
       ],
     );
@@ -250,7 +250,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     final yValues = (e as BarEntry).yVals;
     print(
       'onValueSelected - Frame Index = ${e.x}, '
-      'GPU = ${yValues[0]}, UI = ${yValues[1]}',
+      'Raster = ${yValues[0]}, UI = ${yValues[1]}',
     );
   }
 }
@@ -263,7 +263,7 @@ class YAxisUnitFormatter extends ValueFormatter {
 typedef SelectionCallback = void Function(int frameIndex);
 
 /// Selection of a point in the Bar chart displays the data point values
-/// UI duration and GPU duration. Also, highlight the selected stacked bar.
+/// UI duration and Raster duration. Also, highlight the selected stacked bar.
 /// Uses marker/highlight mechanism which lags because it uses onTapUp maybe
 /// onTapDown would be less laggy.
 ///
@@ -307,12 +307,12 @@ class SelectedDataPoint extends LineChartMarker {
     final yValues = (_entry as BarEntry).yVals;
 
     final num uiDuration = yValues[1];
-    final num gpuDuration = yValues[0];
+    final num rasterDuration = yValues[0];
 
     final TextPainter painter = PainterUtils.create(
       null,
       'UI  = ${_formatter.getFormattedValue1(uiDuration)}\n'
-      'GPU = ${_formatter.getFormattedValue1(gpuDuration)}',
+      'Raster = ${_formatter.getFormattedValue1(rasterDuration)}',
       textColor,
       fontSize,
     )..textAlign = TextAlign.left;

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
@@ -191,10 +191,10 @@ class TimelineController implements DisposableController {
       frame.uiEventFlow.format(buf, '  ');
       buf.writeln('\nUI trace for frame ${frame.id}');
       frame.uiEventFlow.writeTraceToBuffer(buf);
-      buf.writeln('\nGPU timeline event frame ${frame.id}:');
-      frame.gpuEventFlow.format(buf, '  ');
-      buf.writeln('\nGPU trace for frame ${frame.id}');
-      frame.gpuEventFlow.writeTraceToBuffer(buf);
+      buf.writeln('\Raster timeline event frame ${frame.id}:');
+      frame.rasterEventFlow.format(buf, '  ');
+      buf.writeln('\nRaster trace for frame ${frame.id}');
+      frame.rasterEventFlow.writeTraceToBuffer(buf);
       log(buf.toString());
     }
   }
@@ -250,10 +250,10 @@ class TimelineController implements DisposableController {
         )
     ];
 
-    // TODO(kenz): once each trace event has a ui/gpu distinction bit added to
+    // TODO(kenz): once each trace event has a ui/raster distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
     final uiThreadId = _threadIdForEvent(uiEventName, traceEvents);
-    final gpuThreadId = _threadIdForEvent(gpuEventName, traceEvents);
+    final rasterThreadId = _threadIdForEvent(rasterEventName, traceEvents);
 
     offlineTimelineData = offlineData.shallowClone();
     data = offlineData.shallowClone();
@@ -261,7 +261,7 @@ class TimelineController implements DisposableController {
     // Process offline data.
     processor.primeThreadIds(
       uiThreadId: uiThreadId,
-      gpuThreadId: gpuThreadId,
+      rasterThreadId: rasterThreadId,
     );
     await processTraceEvents(traceEvents, 0);
     if (data.cpuProfileData != null) {

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -174,14 +174,14 @@ class TimelineFlameChartState
         backgroundColor = nextAsyncColor(resetOffset: event.isRoot);
       } else if (event.isUiEvent) {
         backgroundColor = nextUiColor(resetOffset: event.isRoot);
-      } else if (event.isGpuEvent) {
-        backgroundColor = nextGpuColor(resetOffset: event.isRoot);
+      } else if (event.isRasterEvent) {
+        backgroundColor = nextRasterColor(resetOffset: event.isRoot);
       } else {
         backgroundColor = nextUnknownColor(resetOffset: event.isRoot);
       }
 
       Color textColor;
-      if (event.isGpuEvent) {
+      if (event.isRasterEvent) {
         textColor = ThemedColor.fromSingleColor(contrastForegroundWhite);
       } else {
         textColor = ThemedColor.fromSingleColor(Colors.black);
@@ -239,8 +239,8 @@ class TimelineFlameChartState
         case TimelineData.uiKey:
           sectionLabelBackgroundColor = mainUiColor;
           break;
-        case TimelineData.gpuKey:
-          sectionLabelBackgroundColor = mainGpuColor;
+        case TimelineData.rasterKey:
+          sectionLabelBackgroundColor = mainRasterColor;
           break;
         case TimelineData.unknownKey:
           sectionLabelBackgroundColor = mainUnknownColor;

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
@@ -88,14 +88,14 @@ class TimelineService {
       return event.name == 'thread_name';
     }).toList();
 
-    // TODO(kenz): Remove this logic once ui/gpu distinction changes are
+    // TODO(kenz): Remove this logic once ui/raster distinction changes are
     // available in the engine.
     int uiThreadId;
-    int gpuThreadId;
+    int rasterThreadId;
     final threadIdsByName = <String, int>{};
 
     String uiThreadName;
-    String gpuThreadName;
+    String rasterThreadName;
     String platformThreadName;
     for (TraceEvent event in events) {
       final name = event.args['name'];
@@ -109,7 +109,7 @@ class TimelineService {
       // iOS: "io.flutter.1.gpu (12651)"
       // Linux, Windows, Dream (g3): "io.flutter.gpu (12651)"
       // MacOS: Does not exist
-      if (name.contains('.gpu')) gpuThreadName = name;
+      if (name.contains('.gpu')) rasterThreadName = name;
 
       // Android: "1.platform (22585)"
       // iOS: "io.flutter.1.platform (22585)"
@@ -123,22 +123,22 @@ class TimelineService {
     }
 
     // MacOS and Flutter apps with platform views do not have a .gpu thread.
-    // In these cases, the "GPU" events will come on the .platform thread
+    // In these cases, the "Raster" events will come on the .platform thread
     // instead.
-    if (gpuThreadName != null) {
-      gpuThreadId = threadIdsByName[gpuThreadName];
+    if (rasterThreadName != null) {
+      rasterThreadId = threadIdsByName[rasterThreadName];
     } else {
-      gpuThreadId = threadIdsByName[platformThreadName];
+      rasterThreadId = threadIdsByName[platformThreadName];
     }
 
-    if (uiThreadId == null || gpuThreadId == null) {
+    if (uiThreadId == null || rasterThreadId == null) {
       timelineController.logNonFatalError(
-          'Could not find UI thread and / or GPU thread from names: '
+          'Could not find UI thread and / or Raster thread from names: '
           '${threadIdsByName.keys}');
     }
 
     timelineController.processor
-        .primeThreadIds(uiThreadId: uiThreadId, gpuThreadId: gpuThreadId);
+        .primeThreadIds(uiThreadId: uiThreadId, rasterThreadId: rasterThreadId);
   }
 
   Future<void> updateListeningState(bool isCurrentScreen) async {

--- a/packages/devtools_app/lib/src/timeline/html_event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/html_event_details.dart
@@ -176,7 +176,7 @@ class HtmlEventDetails extends CoreElement {
     } else if (event.isUiEvent) {
       return mainUiColor;
     } else if (event.isGpuEvent) {
-      return mainGpuColor;
+      return mainRasterColor;
     } else {
       return _defaultTitleBackground;
     }

--- a/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
@@ -207,7 +207,7 @@ class PlotlyDivGraph extends CoreElement {
       // TODO(terry): HACK - Ignore the event.
       log(
         'Ignored onFrameAdded - bad data.\n [uiDuration: '
-        '${frame.uiDuration}, gpuDuration: ${frame.gpuDuration}',
+        '${frame.uiDuration}, gpuDuration: ${frame.rasterDuration}',
         LogLevel.warning,
       );
     }

--- a/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_frames_bar_chart.dart
@@ -191,7 +191,7 @@ class PlotlyDivGraph extends CoreElement {
 
   // Add current frame data to chunks of data for later plotting.
   void processNextFrame() async {
-    final frame =
+    final TimelineFrame frame =
         timelineController.frameBasedTimeline.frameAddedNotifier.value;
     if (frame == null) return;
 
@@ -207,7 +207,7 @@ class PlotlyDivGraph extends CoreElement {
       // TODO(terry): HACK - Ignore the event.
       log(
         'Ignored onFrameAdded - bad data.\n [uiDuration: '
-        '${frame.uiDuration}, gpuDuration: ${frame.rasterDuration}',
+        '${frame.uiDuration}, gpuDuration: ${frame.gpuDuration}',
         LogLevel.warning,
       );
     }

--- a/packages/devtools_app/lib/src/timeline/html_frames_bar_plotly.dart
+++ b/packages/devtools_app/lib/src/timeline/html_frames_bar_plotly.dart
@@ -174,7 +174,7 @@ class FramesBarPlotly {
           ),
         ),
         marker: Marker(
-          color: colorToCss(mainGpuColor),
+          color: colorToCss(mainRasterColor),
         ),
         width: [0],
       ),
@@ -188,16 +188,16 @@ class FramesBarPlotly {
         x: [xCoordNotUsed],
         hoverinfo: 'y+name',
         hoverlabel: HoverLabel(
-          bgcolor: colorToCss(selectedGpuColor),
+          bgcolor: colorToCss(selectedRasterColor),
           font: Font(
             color: colorToCss(hoverTextColor),
           ),
-          bordercolor: colorToCss(selectedGpuColor),
+          bordercolor: colorToCss(selectedRasterColor),
         ),
         showlegend: false,
         type: 'bar',
         marker: Marker(
-          color: colorToCss(selectedGpuColor),
+          color: colorToCss(selectedRasterColor),
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/timeline/html_timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_flame_chart.dart
@@ -37,7 +37,7 @@ class FrameBasedTimelineFlameChartCanvas
   @override
   void initUiElements() {
     super.initUiElements();
-    expandRows(data.uiEventFlow.depth + data.rasterEventFlow.depth);
+    expandRows(data.uiEventFlow.depth + data.gpuEventFlow.depth);
 
     final int frameStartOffset = data.time.start.inMicroseconds;
     double getTopForRow(int row) {
@@ -108,7 +108,7 @@ class FrameBasedTimelineFlameChartCanvas
     }
 
     createChartNodes(data.uiEventFlow, 0);
-    createChartNodes(data.rasterEventFlow, gpuSectionStartRow);
+    createChartNodes(data.gpuEventFlow, gpuSectionStartRow);
   }
 
   @override

--- a/packages/devtools_app/lib/src/timeline/html_timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_flame_chart.dart
@@ -37,7 +37,7 @@ class FrameBasedTimelineFlameChartCanvas
   @override
   void initUiElements() {
     super.initUiElements();
-    expandRows(data.uiEventFlow.depth + data.gpuEventFlow.depth);
+    expandRows(data.uiEventFlow.depth + data.rasterEventFlow.depth);
 
     final int frameStartOffset = data.time.start.inMicroseconds;
     double getTopForRow(int row) {
@@ -65,7 +65,7 @@ class FrameBasedTimelineFlameChartCanvas
     // Add GPU section label.
     final gpuSectionLabel = sectionLabel(
       'GPU',
-      mainGpuColor,
+      mainRasterColor,
       top: getTopForRow(gpuSectionStartRow),
       width: 42.0,
     );
@@ -108,7 +108,7 @@ class FrameBasedTimelineFlameChartCanvas
     }
 
     createChartNodes(data.uiEventFlow, 0);
-    createChartNodes(data.gpuEventFlow, gpuSectionStartRow);
+    createChartNodes(data.rasterEventFlow, gpuSectionStartRow);
   }
 
   @override
@@ -288,7 +288,7 @@ class FullTimelineFlameChartCanvas extends FlameChartCanvas<FullTimelineData> {
           sectionLabelBackgroundColor = mainUiColor;
           break;
         case FullTimelineData.gpuKey:
-          sectionLabelBackgroundColor = mainGpuColor;
+          sectionLabelBackgroundColor = mainRasterColor;
           break;
         case FullTimelineData.unknownKey:
           sectionLabelBackgroundColor = mainUnknownColor;
@@ -532,7 +532,7 @@ Color _nextUiColor() {
 int _gpuColorOffset = 0;
 
 Color _nextGpuColor() {
-  final color = gpuColorPalette[_gpuColorOffset % gpuColorPalette.length];
+  final color = rasterColorPalette[_gpuColorOffset % rasterColorPalette.length];
   _gpuColorOffset++;
   return color;
 }

--- a/packages/devtools_app/lib/src/timeline/html_timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_model.dart
@@ -550,7 +550,7 @@ class TimelineFrame {
   TimelineEvent get uiEventFlow => eventFlows[TimelineEventType.ui.index];
 
   /// Flow of events describing the GPU work for the frame.
-  TimelineEvent get gpuEventFlow => eventFlows[TimelineEventType.gpu.index];
+  TimelineEvent get gpuEventFlow => eventFlows[TimelineEventType.raster.index];
 
   /// Whether the frame is ready for the timeline.
   ///
@@ -596,7 +596,7 @@ class TimelineFrame {
     if (type == TimelineEventType.ui) {
       time.start = event?.time?.start;
     }
-    if (type == TimelineEventType.gpu) {
+    if (type == TimelineEventType.raster) {
       time.end = event?.time?.end;
     }
     eventFlows[type.index] = event;
@@ -605,7 +605,7 @@ class TimelineFrame {
 
   TimelineEvent findTimelineEvent(TimelineEvent event) {
     if (event.type == TimelineEventType.ui ||
-        event.type == TimelineEventType.gpu) {
+        event.type == TimelineEventType.raster) {
       return eventFlows[event.type.index].firstChildWithCondition(
           (e) => e.name == event.name && e.time == event.time);
     }
@@ -658,7 +658,7 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
 
   bool get isUiEvent => type == TimelineEventType.ui;
 
-  bool get isGpuEvent => type == TimelineEventType.gpu;
+  bool get isGpuEvent => type == TimelineEventType.raster;
 
   bool get isAsyncEvent => type == TimelineEventType.async;
 

--- a/packages/devtools_app/lib/src/timeline/html_timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_processor.dart
@@ -576,7 +576,7 @@ class FrameBasedTimelineProcessor extends TimelineProcessor {
         // events, or c) parent multiple event flows - none of which we want.
         event.name != 'MessageLoop::RunExpiredTasks' &&
         // Only process events from the UI or GPU thread.
-        (event.isGpuEvent || event.isUiEvent);
+        (event.isRasterEvent || event.isUiEvent);
   }
 
   @override
@@ -1011,7 +1011,7 @@ abstract class TimelineProcessor {
     } else if (event.threadId == uiThreadId) {
       return TimelineEventType.ui;
     } else if (event.threadId == gpuThreadId) {
-      return TimelineEventType.gpu;
+      return TimelineEventType.raster;
     } else {
       return TimelineEventType.unknown;
     }

--- a/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_screen.dart
@@ -688,10 +688,11 @@ class HtmlTimelineScreen extends HtmlScreen {
             timelineProtocol.currentEventNodes[TimelineEventType.ui.index]
                 .format(buf, '   ');
           }
-          if (timelineProtocol.currentEventNodes[TimelineEventType.gpu.index] !=
+          if (timelineProtocol
+                  .currentEventNodes[TimelineEventType.raster.index] !=
               null) {
             buf.writeln('\n Current GPU event node:');
-            timelineProtocol.currentEventNodes[TimelineEventType.gpu.index]
+            timelineProtocol.currentEventNodes[TimelineEventType.raster.index]
                 .format(buf, '   ');
           }
           if (timelineProtocol.heaps[TimelineEventType.ui.index].isNotEmpty) {
@@ -702,10 +703,11 @@ class HtmlTimelineScreen extends HtmlScreen {
               buf.writeln(wrapper.event.json.toString());
             }
           }
-          if (timelineProtocol.heaps[TimelineEventType.gpu.index].isNotEmpty) {
+          if (timelineProtocol
+              .heaps[TimelineEventType.raster.index].isNotEmpty) {
             buf.writeln('\nGPU heap');
             for (TraceEventWrapper wrapper in timelineProtocol
-                .heaps[TimelineEventType.gpu.index]
+                .heaps[TimelineEventType.raster.index]
                 .toList()) {
               buf.writeln(wrapper.event.json.toString());
             }

--- a/packages/devtools_app/lib/src/trace_event.dart
+++ b/packages/devtools_app/lib/src/trace_event.dart
@@ -104,8 +104,8 @@ class TraceEvent {
     if (_type == null) {
       if (args[typeKey] == 'ui') {
         _type = TimelineEventType.ui;
-      } else if (args[typeKey] == 'gpu') {
-        _type = TimelineEventType.gpu;
+      } else if (args[typeKey] == 'raster') {
+        _type = TimelineEventType.raster;
       } else {
         _type = TimelineEventType.unknown;
       }
@@ -117,7 +117,7 @@ class TraceEvent {
 
   bool get isUiEvent => type == TimelineEventType.ui;
 
-  bool get isGpuEvent => type == TimelineEventType.gpu;
+  bool get isRasterEvent => type == TimelineEventType.raster;
 
   @override
   String toString() => '$type event [$idKey: $id] [$phaseKey: $phase] '
@@ -151,7 +151,7 @@ class TraceEventWrapper implements Comparable<TraceEventWrapper> {
 
 enum TimelineEventType {
   ui,
-  gpu,
+  raster,
   async,
   unknown,
 }

--- a/packages/devtools_app/lib/src/trace_event.dart
+++ b/packages/devtools_app/lib/src/trace_event.dart
@@ -100,18 +100,7 @@ class TraceEvent {
 
   TimelineEventType _type;
 
-  TimelineEventType get type {
-    if (_type == null) {
-      if (args[typeKey] == 'ui') {
-        _type = TimelineEventType.ui;
-      } else if (args[typeKey] == 'raster') {
-        _type = TimelineEventType.raster;
-      } else {
-        _type = TimelineEventType.unknown;
-      }
-    }
-    return _type;
-  }
+  TimelineEventType get type => _type ??= TimelineEventType.unknown;
 
   set type(TimelineEventType t) => _type = t;
 

--- a/packages/devtools_app/lib/src/ui/analytics.dart
+++ b/packages/devtools_app/lib/src/ui/analytics.dart
@@ -84,7 +84,7 @@ class GtagEventDevTools extends GtagEvent {
     String ide_launched, // dimension7 Devtools launched (CLI, VSCode, Android)
     String flutter_client_id, // dimension8 Flutter tool client_id (~/.flutter).
 
-    int gpu_duration,
+    int raster_duration,
     int ui_duration,
   });
 
@@ -124,7 +124,7 @@ class GtagEventDevTools extends GtagEvent {
   external String get flutter_client_id;
 
   // Custom metrics:
-  external int get gpu_duration;
+  external int get raster_duration;
 
   external int get ui_duration;
 }
@@ -471,7 +471,7 @@ void select(
 void selectFrame(
   String screenName,
   String selectedItem, [
-  int gpuDuration, // Custom metric
+  int rasterDuration, // Custom metric
   int uiDuration, // Custom metric
 ]) {
   GTag.event(
@@ -479,7 +479,7 @@ void selectFrame(
     GtagEventDevTools(
       event_category: selectEvent,
       event_label: selectedItem,
-      gpu_duration: gpuDuration,
+      raster_duration: rasterDuration,
       ui_duration: uiDuration,
       user_app: userAppType,
       user_build: userBuildType,

--- a/packages/devtools_app/lib/src/ui/analytics_constants.dart
+++ b/packages/devtools_app/lib/src/ui/analytics_constants.dart
@@ -49,7 +49,7 @@ const String showOnDeviceInspector = 'showInspector';
 
 // Timeline UX actions:
 const String timelineFrame = 'frame'; // Frame selected in frame chart
-const String timelineFlameGpu = 'flameGPU'; // Selected a GPU flame
+const String timelineFlameRaster = 'flameRaster'; // Selected a Raster flame
 const String timelineFlameUi = 'flameUI'; // Selected a UI flame
 
 // Memory UX actions:

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -13,29 +13,29 @@ import 'theme.dart';
 /// Light mode is Light Blue 50 palette and Dark mode is Blue 50 palette.
 /// https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
 const mainUiColor = ThemedColor(mainUiColorLight, mainUiColorDark);
-const mainGpuColor = ThemedColor(mainGpuColorLight, mainGpuColorDark);
+const mainRasterColor = ThemedColor(mainRasterColorLight, mainRasterColorDark);
 final mainUnknownColor = ThemedColor.fromSingleColor(const Color(0xFFCAB8E9));
 final mainAsyncColor = ThemedColor.fromSingleColor(const Color(0xFF80CBC4));
 
 const mainUiColorLight = Color(0xFF81D4FA); // Light Blue 50 - 200
-const mainGpuColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
+const mainRasterColorLight = Color(0xFF0288D1); // Light Blue 50 - 700
 
 const mainUiColorSelectedLight = Color(0xFFD4D7DA); // Lighter grey.
-const mainGpuColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
+const mainRasterColorSelectedLight = Color(0xFFB5B5B5); // Darker grey.
 
 const mainUiColorDark = Color(0xFF9EBEF9); // Blue 200 Material Dark
-const mainGpuColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
+const mainRasterColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
 
 const mainUiColorSelectedDark = Colors.white;
-const mainGpuColorSelectedDark = Color(0xFFC9C9C9); // Grey.
+const mainRasterColorSelectedDark = Color(0xFFC9C9C9); // Grey.
 
 const Color selectedUiColor = ThemedColor(
   mainUiColorSelectedLight,
   mainUiColorSelectedDark,
 );
-const Color selectedGpuColor = ThemedColor(
-  mainGpuColorSelectedLight,
-  mainGpuColorSelectedDark,
+const Color selectedRasterColor = ThemedColor(
+  mainRasterColorSelectedLight,
+  mainRasterColorSelectedDark,
 );
 
 // Light Blue 50: 200-400 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
@@ -48,8 +48,8 @@ final uiColorPalette = [
 
 // Light Blue 50: 700-900 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
 // Blue Material Dark: 500-700 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
-final gpuColorPalette = [
-  const ThemedColor(mainGpuColorLight, mainGpuColorDark),
+final rasterColorPalette = [
+  const ThemedColor(mainRasterColorLight, mainRasterColorDark),
   const ThemedColor(Color(0xFF0277BD), Color(0xFF1966D2)),
   const ThemedColor(Color(0xFF01579B), Color(0xFF1859BD)),
 ];

--- a/packages/devtools_app/test/flutter/event_details_test.dart
+++ b/packages/devtools_app/test/flutter/event_details_test.dart
@@ -48,8 +48,8 @@ void main() {
       expect(find.text(EventDetails.instructions), findsNothing);
     });
 
-    testWidgets('builds for GPU event', (WidgetTester tester) async {
-      await pumpEventDetails(goldenGpuTimelineEvent, tester);
+    testWidgets('builds for Raster event', (WidgetTester tester) async {
+      await pumpEventDetails(goldenRasterTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsNothing);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
       expect(find.byType(EventSummary), findsOneWidget);
@@ -122,7 +122,7 @@ void main() {
     });
 
     testWidgets('event with args', (WidgetTester tester) async {
-      eventSummary = EventSummary(goldenGpuTimelineEvent);
+      eventSummary = EventSummary(goldenRasterTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
       expect(find.text('Time'), findsOneWidget);

--- a/packages/devtools_app/test/flutter/timeline_model_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_model_test.dart
@@ -23,7 +23,7 @@ void main() {
         timelineEvents: [
           goldenAsyncTimelineEvent,
           goldenUiTimelineEvent,
-          goldenGpuTimelineEvent,
+          goldenRasterTimelineEvent,
           unknownEvent,
         ],
       );
@@ -76,7 +76,7 @@ void main() {
         timelineEvents: [
           goldenAsyncTimelineEvent,
           goldenUiTimelineEvent,
-          goldenGpuTimelineEvent,
+          goldenRasterTimelineEvent,
           unknownEvent,
         ],
       )
@@ -112,7 +112,7 @@ void main() {
         equals(1),
       );
       expect(
-        timelineData.eventGroups[TimelineData.gpuKey].rows[0].events.length,
+        timelineData.eventGroups[TimelineData.rasterKey].rows[0].events.length,
         equals(1),
       );
       expect(
@@ -123,8 +123,8 @@ void main() {
     });
 
     test('event bucket compare', () {
-      expect(TimelineData.eventGroupComparator('UI', 'GPU'), equals(-1));
-      expect(TimelineData.eventGroupComparator('GPU', 'UI'), equals(1));
+      expect(TimelineData.eventGroupComparator('UI', 'Raster'), equals(-1));
+      expect(TimelineData.eventGroupComparator('Raster', 'UI'), equals(1));
       expect(TimelineData.eventGroupComparator('UI', 'UI'), equals(0));
       expect(TimelineData.eventGroupComparator('UI', 'Async'), equals(1));
       expect(TimelineData.eventGroupComparator('A', 'B'), equals(-1));

--- a/packages/devtools_app/test/timeline_processor_test.dart
+++ b/packages/devtools_app/test/timeline_processor_test.dart
@@ -150,7 +150,7 @@ void main() {
 
       frame
         ..setEventFlow(null, type: TimelineEventType.ui)
-        ..setEventFlow(gpuEvent, type: TimelineEventType.gpu);
+        ..setEventFlow(gpuEvent, type: TimelineEventType.raster);
       expect(processor.eventOccursWithinFrameBounds(uiEvent, frame), isFalse);
     });
 
@@ -353,7 +353,7 @@ void main() {
       );
       expect(
         processor.inferEventType(gpuRasterizerDrawTrace.event),
-        equals(TimelineEventType.gpu),
+        equals(TimelineEventType.raster),
       );
       expect(
         processor.inferEventType(unknownEventBeginTrace.event),

--- a/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
@@ -77,7 +77,8 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
         isTrue,
       );
       expect(timelineController.processor.uiThreadId, equals(testUiThreadId));
-      expect(timelineController.processor.gpuThreadId, equals(testGpuThreadId));
+      expect(timelineController.processor.rasterThreadId,
+          equals(testRasterThreadId));
 
       await env.tearDownEnvironment();
     });

--- a/packages/devtools_testing/lib/support/flutter/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/flutter/timeline_test_data.dart
@@ -14,7 +14,7 @@ import '../cpu_profile_test_data.dart';
 import 'test_utils.dart';
 
 const testUiThreadId = 1;
-const testGpuThreadId = 2;
+const testRasterThreadId = 2;
 const testUnknownThreadId = 3;
 
 final frameStartEvent = testTraceEventWrapper({
@@ -31,7 +31,7 @@ final frameStartEvent = testTraceEventWrapper({
 final frameEndEvent = testTraceEventWrapper({
   'name': 'PipelineItem',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 118039679872,
   'ph': 'f',
@@ -42,11 +42,11 @@ final frameEndEvent = testTraceEventWrapper({
 
 final testFrame0 = TimelineFrame('id_0')
   ..setEventFlow(goldenUiTimelineEvent)
-  ..setEventFlow(goldenGpuTimelineEvent);
+  ..setEventFlow(goldenRasterTimelineEvent);
 
 final testFrame1 = TimelineFrame('id_1')
   ..setEventFlow(goldenUiTimelineEvent)
-  ..setEventFlow(goldenGpuTimelineEvent);
+  ..setEventFlow(goldenRasterTimelineEvent);
 
 // Mark: UI golden data.
 // None of the following data should be modified. If you have a need to modify
@@ -372,26 +372,26 @@ final endEngineBeginFrameTrace = testTraceEventWrapper({
   'args': {}
 });
 
-// Mark: GPU golden data. This data is abbreviated in comparison to the UI
+// Mark: Raster golden data. This data is abbreviated in comparison to the UI
 // golden data. We do not need both data sets to be complete for testing.
 // None of the following data should be modified. If you have a need to modify
 // any of the below events for a test, make a copy and modify the copy.
 final gpuRasterizerDrawEvent = testSyncTimelineEvent(gpuRasterizerDrawTrace)
-  ..type = TimelineEventType.gpu
+  ..type = TimelineEventType.raster
   ..addEndEvent(endGpuRasterizerDrawTrace);
 
 final pipelineConsumeEvent = testSyncTimelineEvent(pipelineConsumeTrace)
-  ..type = TimelineEventType.gpu
+  ..type = TimelineEventType.raster
   ..addEndEvent(endPipelineConsumeTrace);
 
-final goldenGpuTimelineEvent = gpuRasterizerDrawEvent
+final goldenRasterTimelineEvent = gpuRasterizerDrawEvent
   ..addChild(pipelineConsumeEvent);
 
-const goldenGpuString =
+const goldenRasterString =
     '  GPURasterizer::Draw [118039651469 μs - 118039679873 μs]\n'
     '    PipelineConsume [118039651470 μs - 118039679870 μs]\n';
 
-final goldenGpuTraceEvents = [
+final goldenRasterTraceEvents = [
   gpuRasterizerDrawTrace,
   pipelineConsumeTrace,
   endPipelineConsumeTrace,
@@ -401,7 +401,7 @@ final goldenGpuTraceEvents = [
 final gpuRasterizerDrawTrace = testTraceEventWrapper({
   'name': 'GPURasterizer::Draw',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 118039651469,
   'ph': 'B',
@@ -412,7 +412,7 @@ final gpuRasterizerDrawTrace = testTraceEventWrapper({
 final pipelineConsumeTrace = testTraceEventWrapper({
   'name': 'PipelineConsume',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 118039651470,
   'ph': 'B',
@@ -421,7 +421,7 @@ final pipelineConsumeTrace = testTraceEventWrapper({
 final endPipelineConsumeTrace = testTraceEventWrapper({
   'name': 'PipelineConsume',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 118039679870,
   'ph': 'E',
@@ -430,7 +430,7 @@ final endPipelineConsumeTrace = testTraceEventWrapper({
 final endGpuRasterizerDrawTrace = testTraceEventWrapper({
   'name': 'GPURasterizer::Draw',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 118039679873,
   'ph': 'E',
@@ -944,7 +944,7 @@ final unknownEventEndTrace = testTraceEventWrapper({
 // Mark: OfflineTimelineData.
 final goldenTraceEventsJson = List.from(
     goldenUiTraceEvents.map((trace) => trace.json).toList()
-      ..addAll(goldenGpuTraceEvents.map((trace) => trace.json).toList()));
+      ..addAll(goldenRasterTraceEvents.map((trace) => trace.json).toList()));
 
 final offlineTimelineDataJson = {
   TimelineData.traceEventsKey: goldenTraceEventsJson,
@@ -959,7 +959,7 @@ final offlineTimelineDataJson = {
 final transformLayerStart1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039651669,
   'tts': 733287,
@@ -969,7 +969,7 @@ final transformLayerStart1 = testTraceEventWrapper({
 final transformLayerStart2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039651869,
   'tts': 733289,
@@ -979,7 +979,7 @@ final transformLayerStart2 = testTraceEventWrapper({
 final transformLayerEnd2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,
@@ -989,7 +989,7 @@ final transformLayerEnd2 = testTraceEventWrapper({
 final transformLayerEnd1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -968,7 +968,7 @@ final offlineFullTimelineDataJson = {
 final transformLayerStart1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testRasterThreadId,
+  'tid': testGpuThreadId,
   'pid': 22283,
   'ts': 118039651669,
   'tts': 733287,
@@ -978,7 +978,7 @@ final transformLayerStart1 = testTraceEventWrapper({
 final transformLayerStart2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testRasterThreadId,
+  'tid': testGpuThreadId,
   'pid': 22283,
   'ts': 118039651869,
   'tts': 733289,
@@ -988,7 +988,7 @@ final transformLayerStart2 = testTraceEventWrapper({
 final transformLayerEnd2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testRasterThreadId,
+  'tid': testGpuThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,
@@ -998,7 +998,7 @@ final transformLayerEnd2 = testTraceEventWrapper({
 final transformLayerEnd1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testRasterThreadId,
+  'tid': testGpuThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,

--- a/packages/devtools_testing/lib/support/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/timeline_test_data.dart
@@ -377,11 +377,11 @@ final endEngineBeginFrameTrace = testTraceEventWrapper({
 // None of the following data should be modified. If you have a need to modify
 // any of the below events for a test, make a copy and modify the copy.
 final gpuRasterizerDrawEvent = testSyncTimelineEvent(gpuRasterizerDrawTrace)
-  ..type = TimelineEventType.gpu
+  ..type = TimelineEventType.raster
   ..addEndEvent(endGpuRasterizerDrawTrace);
 
 final pipelineConsumeEvent = testSyncTimelineEvent(pipelineConsumeTrace)
-  ..type = TimelineEventType.gpu
+  ..type = TimelineEventType.raster
   ..addEndEvent(endPipelineConsumeTrace);
 
 final goldenGpuTimelineEvent = gpuRasterizerDrawEvent
@@ -968,7 +968,7 @@ final offlineFullTimelineDataJson = {
 final transformLayerStart1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039651669,
   'tts': 733287,
@@ -978,7 +978,7 @@ final transformLayerStart1 = testTraceEventWrapper({
 final transformLayerStart2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039651869,
   'tts': 733289,
@@ -988,7 +988,7 @@ final transformLayerStart2 = testTraceEventWrapper({
 final transformLayerEnd2 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,
@@ -998,7 +998,7 @@ final transformLayerEnd2 = testTraceEventWrapper({
 final transformLayerEnd1 = testTraceEventWrapper({
   'name': 'TransformLayer::Preroll',
   'cat': 'Embedder',
-  'tid': testGpuThreadId,
+  'tid': testRasterThreadId,
   'pid': 22283,
   'ts': 118039679673,
   'tts': 733656,

--- a/packages/devtools_testing/lib/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/timeline_controller_test.dart
@@ -83,7 +83,7 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       );
       expect(
         timelineController.frameBasedTimeline.processor.gpuThreadId,
-        equals(testGpuThreadId),
+        equals(testRasterThreadId),
       );
 
       // Full timeline.
@@ -107,7 +107,7 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       );
       expect(
         timelineController.fullTimeline.processor.gpuThreadId,
-        equals(testGpuThreadId),
+        equals(testRasterThreadId),
       );
 
       await env.tearDownEnvironment();

--- a/packages/devtools_testing/lib/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/timeline_controller_test.dart
@@ -83,7 +83,7 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       );
       expect(
         timelineController.frameBasedTimeline.processor.gpuThreadId,
-        equals(testRasterThreadId),
+        equals(testGpuThreadId),
       );
 
       // Full timeline.
@@ -107,7 +107,7 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       );
       expect(
         timelineController.fullTimeline.processor.gpuThreadId,
-        equals(testRasterThreadId),
+        equals(testGpuThreadId),
       );
 
       await env.tearDownEnvironment();


### PR DESCRIPTION
Per, https://github.com/flutter/flutter/issues/29443, this CL updates the DevTools UI and code to use 'raster' instead of 'gpu'. This CL just includes renames, and leaves the html code alone where possible since we will be deleting it soon.