### PR TITLE
Fix timeline breakage caused by change of flutter event name.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
@@ -253,8 +253,8 @@ class TimelineController implements DisposableController {
     // TODO(kenz): once each trace event has a ui/gpu distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
     final uiThreadId =
-        _threadIdForEvents([uiEventName, uiEventNameOld], traceEvents);
-    final gpuThreadId = _threadIdForEvents([gpuEventName], traceEvents);
+        _threadIdForEvents({uiEventName, uiEventNameOld}, traceEvents);
+    final gpuThreadId = _threadIdForEvents({gpuEventName}, traceEvents);
 
     offlineTimelineData = offlineData.shallowClone();
     data = offlineData.shallowClone();
@@ -277,20 +277,13 @@ class TimelineController implements DisposableController {
   }
 
   int _threadIdForEvents(
-    List<String> targetEventNames,
+    Set<String> targetEventNames,
     List<TraceEventWrapper> traceEvents,
   ) {
     const invalidThreadId = -1;
     return traceEvents
             .firstWhere(
-              (trace) {
-                for (final target in targetEventNames) {
-                  if (trace.event.name == target) {
-                    return true;
-                  }
-                }
-                return false;
-              },
+              (trace) => targetEventNames.contains(trace.event.name),
               orElse: () => null,
             )
             ?.event

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_controller.dart
@@ -252,8 +252,9 @@ class TimelineController implements DisposableController {
 
     // TODO(kenz): once each trace event has a ui/gpu distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
-    final uiThreadId = _threadIdForEvent(uiEventName, traceEvents);
-    final gpuThreadId = _threadIdForEvent(gpuEventName, traceEvents);
+    final uiThreadId =
+        _threadIdForEvents([uiEventName, uiEventNameOld], traceEvents);
+    final gpuThreadId = _threadIdForEvents([gpuEventName], traceEvents);
 
     offlineTimelineData = offlineData.shallowClone();
     data = offlineData.shallowClone();
@@ -275,14 +276,23 @@ class TimelineController implements DisposableController {
     _loadOfflineDataController.add(offlineTimelineData);
   }
 
-  int _threadIdForEvent(
-    String targetEventName,
+  int _threadIdForEvents(
+    List<String> targetEventNames,
     List<TraceEventWrapper> traceEvents,
   ) {
     const invalidThreadId = -1;
     return traceEvents
-            .firstWhere((trace) => trace.event.name == targetEventName,
-                orElse: () => null)
+            .firstWhere(
+              (trace) {
+                for (final target in targetEventNames) {
+                  if (trace.event.name == target) {
+                    return true;
+                  }
+                }
+                return false;
+              },
+              orElse: () => null,
+            )
             ?.event
             ?.threadId ??
         invalidThreadId;

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_processor.dart
@@ -40,7 +40,11 @@ StringBuffer debugFrameTracking = StringBuffer();
 
 const String gpuEventName = 'GPURasterizer::Draw';
 
-const String uiEventName = 'VSYNC';
+// For older versions of Flutter, the starting event for the UI portion of a
+// Flutter frame was 'VSYNC'. We need to check for both so that we can still
+// support users on older versions of Flutter.
+const String uiEventNameOld = 'VSYNC';
+const String uiEventName = 'VsyncProcessCallback';
 
 const String messageLoopFlushTasks = 'MessageLoop::FlushTasks';
 

--- a/packages/devtools_app/lib/src/timeline/html_timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_controller.dart
@@ -151,8 +151,9 @@ class TimelineController implements DisposableController {
 
     // TODO(kenz): once each trace event has a ui/gpu distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
-    final uiThreadId = _threadIdForEvent(uiEventName, traceEvents);
-    final gpuThreadId = _threadIdForEvent(gpuEventName, traceEvents);
+    final uiThreadId =
+        _threadIdForEvents([uiEventName, uiEventNameOld], traceEvents);
+    final gpuThreadId = _threadIdForEvents([gpuEventName], traceEvents);
 
     _timelineModeNotifier.value = offlineData.timelineMode;
     offlineTimelineData = offlineData.shallowClone();
@@ -184,14 +185,23 @@ class TimelineController implements DisposableController {
     }
   }
 
-  int _threadIdForEvent(
-    String targetEventName,
+  int _threadIdForEvents(
+    List<String> targetEventNames,
     List<TraceEventWrapper> traceEvents,
   ) {
     const invalidThreadId = -1;
     return traceEvents
-            .firstWhere((trace) => trace.event.name == targetEventName,
-                orElse: () => null)
+            .firstWhere(
+              (trace) {
+                for (final target in targetEventNames) {
+                  if (trace.event.name == target) {
+                    return true;
+                  }
+                }
+                return false;
+              },
+              orElse: () => null,
+            )
             ?.event
             ?.threadId ??
         invalidThreadId;

--- a/packages/devtools_app/lib/src/timeline/html_timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_controller.dart
@@ -152,8 +152,8 @@ class TimelineController implements DisposableController {
     // TODO(kenz): once each trace event has a ui/gpu distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
     final uiThreadId =
-        _threadIdForEvents([uiEventName, uiEventNameOld], traceEvents);
-    final gpuThreadId = _threadIdForEvents([gpuEventName], traceEvents);
+        _threadIdForEvents({uiEventName, uiEventNameOld}, traceEvents);
+    final gpuThreadId = _threadIdForEvents({gpuEventName}, traceEvents);
 
     _timelineModeNotifier.value = offlineData.timelineMode;
     offlineTimelineData = offlineData.shallowClone();
@@ -186,20 +186,13 @@ class TimelineController implements DisposableController {
   }
 
   int _threadIdForEvents(
-    List<String> targetEventNames,
+    Set<String> targetEventNames,
     List<TraceEventWrapper> traceEvents,
   ) {
     const invalidThreadId = -1;
     return traceEvents
             .firstWhere(
-              (trace) {
-                for (final target in targetEventNames) {
-                  if (trace.event.name == target) {
-                    return true;
-                  }
-                }
-                return false;
-              },
+              (trace) => targetEventNames.contains(trace.event.name),
               orElse: () => null,
             )
             ?.event

--- a/packages/devtools_app/lib/src/timeline/html_timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_processor.dart
@@ -52,7 +52,11 @@ const Duration traceEventDelay = Duration(milliseconds: 1000);
 
 const String gpuEventName = 'GPURasterizer::Draw';
 
-const String uiEventName = 'VSYNC';
+// For older versions of Flutter, the starting event for the UI portion of a
+// Flutter frame was 'VSYNC'. We need to check for both so that we can still
+// support users on older versions of Flutter.
+const String uiEventNameOld = 'VSYNC';
+const String uiEventName = 'VsyncProcessCallback';
 
 /// Protocol for processing trace events and composing them into
 /// [SyncTimelineEvents] and [TimelineFrames].
@@ -252,6 +256,7 @@ class FrameBasedTimelineProcessor extends TimelineProcessor {
     final current = currentEventNodes[event.type.index];
     if (current == null &&
         !(event.name.contains(uiEventName) ||
+            event.name.contains(uiEventNameOld) ||
             event.name.contains(gpuEventName))) {
       return;
     }


### PR DESCRIPTION
The event that parented the UI portion of a Flutter frame used to be 'VSYNC'. Once I upgraded my Flutter checkout, the event was named 'VsyncProcessCallback'. In the few places of the Timeline that we depend on this, we now check for the old name 'VSYNC' and the new name 'VsyncProcessCallback'.

There's an open issue to try to get tests in the engine that keep these event names stable: https://github.com/flutter/flutter/issues/27609

