### PR TITLE
lint for relative imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -43,7 +43,7 @@ linter:
     - avoid_null_checks_in_equality_operators
     # - avoid_positional_boolean_parameters # not yet tested
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
-    - avoid_relative_lib_imports
+    #- avoid_relative_lib_imports
     - avoid_renaming_method_parameters
     - avoid_return_types_on_setters
     # - avoid_returning_null # we do this commonly


### PR DESCRIPTION
- lint for relative imports

Ensure we consistently use relative imports (before, we'd have the lints for both `avoid_relative_lib_imports` and `prefer_relative_imports` enabled, which is definitely a confusing situation).