### PR TITLE
make the banner close buttons slightly smaller

### DIFF
--- a/packages/devtools_app/lib/src/flutter/banner_messages.dart
+++ b/packages/devtools_app/lib/src/flutter/banner_messages.dart
@@ -210,6 +210,7 @@ class BannerMessage extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(defaultSpacing),
         child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
           children: <Widget>[
             Expanded(
               child: RichText(

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -481,8 +481,8 @@ class CircularIconButton extends StatelessWidget {
       elevation: 0.0,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       constraints: const BoxConstraints.tightFor(
-        width: buttonMinWidth,
-        height: buttonMinWidth,
+        width: 24.0,
+        height: 24.0,
       ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20.0),
@@ -494,6 +494,7 @@ class CircularIconButton extends StatelessWidget {
       onPressed: onPressed,
       child: Icon(
         icon,
+        size: defaultIconSize,
         color: foregroundColor,
       ),
     );


### PR DESCRIPTION
- make the banner close buttons slightly smaller

<img width="231" alt="Screen Shot 2020-03-31 at 9 09 43 AM" src="https://user-images.githubusercontent.com/1269969/78049336-cc82c200-732f-11ea-97b5-1ff7ae8afb6f.png">

<img width="164" alt="Screen Shot 2020-03-31 at 9 09 55 AM" src="https://user-images.githubusercontent.com/1269969/78049354-d1e00c80-732f-11ea-8ba6-b98978d2de48.png">

<img width="1273" alt="Screen Shot 2020-03-31 at 9 13 09 AM" src="https://user-images.githubusercontent.com/1269969/78049388-dc9aa180-732f-11ea-875c-e9c0efe46793.png">

@kenzieschmoll 