### PR TITLE
Refactor splitter to allow for N children and explicit minimum sizes.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -79,23 +79,25 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
   Widget build(BuildContext context) {
     return Split(
       axis: Axis.horizontal,
-      initialFirstFraction: 0.25,
+      initialFractions: const [0.25, 0.75],
       // TODO(https://github.com/flutter/devtools/issues/1648): Debug panes.
-      firstChild: OutlinedBorder(
-        child: ScriptPicker(
-          scripts: scriptList,
-          onSelected: onScriptSelected,
-          selected: loadingScript,
+      children: [
+        OutlinedBorder(
+          child: ScriptPicker(
+            scripts: scriptList,
+            onSelected: onScriptSelected,
+            selected: loadingScript,
+          ),
         ),
-      ),
-      // TODO(https://github.com/flutter/devtools/issues/1648): Debug controls.
-      secondChild: OutlinedBorder(
-        child: loadingScript != null && script == null
-            ? const Center(child: CircularProgressIndicator())
-            : CodeView(
-                script: script,
-              ),
-      ),
+        // TODO(https://github.com/flutter/devtools/issues/1648): Debug controls.
+        OutlinedBorder(
+          child: loadingScript != null && script == null
+              ? const Center(child: CircularProgressIndicator())
+              : CodeView(
+                  script: script,
+                ),
+        ),
+      ],
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -4,10 +4,10 @@
 
 import 'dart:math';
 
-import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart';
+
+import '../utils.dart';
 
 /// A widget that takes a list of children, lays them out along [axis], and
 /// allows the user to resize them.

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -155,14 +155,16 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         Expanded(
           child: Split(
             axis: splitAxis,
-            initialFirstFraction: 0.40,
-            firstChild: summaryTree,
-            secondChild: InspectorDetailsTabController(
-              detailsTree: detailsTree,
-              controller: inspectorController,
-              actionButtons: _expandCollapseButtons(),
-              layoutExplorerSupported: _layoutExplorerSupported,
-            ),
+            initialFractions: const [0.40, 0.60],
+            children: [
+              summaryTree,
+              InspectorDetailsTabController(
+                detailsTree: detailsTree,
+                controller: inspectorController,
+                actionButtons: _expandCollapseButtons(),
+                layoutExplorerSupported: _layoutExplorerSupported,
+              ),
+            ],
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -132,12 +132,14 @@ class _LoggingScreenState extends State<LoggingScreenBody>
       Expanded(
         child: Split(
           axis: Axis.vertical,
-          firstChild: LogsTable(
-            data: controller.filteredData,
-            onItemSelected: _select,
-          ),
-          secondChild: LogDetails(log: selected),
-          initialFirstFraction: 0.78,
+          initialFractions: const [0.78, 0.22],
+          children: [
+            LogsTable(
+              data: controller.filteredData,
+              onItemSelected: _select,
+            ),
+            LogDetails(log: selected),
+          ],
         ),
       ),
     ]);

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -115,9 +115,11 @@ class MemoryBodyState extends State<MemoryBody> {
         Expanded(
           child: Split(
             axis: Axis.vertical,
-            firstChild: _memoryChart,
-            secondChild: const Text('Memory Panel TBD capacity'),
-            initialFirstFraction: 0.40,
+            initialFractions: const [0.40, 0.60],
+            children: [
+              _memoryChart,
+              const Text('Memory Panel TBD capacity'),
+            ],
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -201,18 +201,18 @@ class NetworkScreenBodyState extends State<NetworkScreenBody> {
                   ),
                 )
               : Split(
-                  initialFirstFraction: 0.5,
+                  initialFractions: const [0.5, 0.5],
                   axis: Axis.horizontal,
-                  firstChild: (_dataTableSource.rowCount == 0)
-                      ? Container(
-                          alignment: Alignment.center,
-                          child: const CircularProgressIndicator(),
-                        )
-                      : _buildHttpRequestTable(),
-                  // Only show the data page when there's data to display.
-                  secondChild: HttpRequestInspector(
-                    data,
-                  ),
+                  children: [
+                    (_dataTableSource.rowCount == 0)
+                        ? Container(
+                            alignment: Alignment.center,
+                            child: const CircularProgressIndicator(),
+                          )
+                        : _buildHttpRequestTable(),
+                    // Only show the data page when there's data to display.
+                    HttpRequestInspector(data),
+                  ],
                 ),
         );
       },

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -137,9 +137,11 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
         Expanded(
           child: Split(
             axis: Axis.vertical,
-            firstChild: _buildFlameChartSection(selectedEvent),
-            secondChild: EventDetails(selectedEvent),
-            initialFirstFraction: 0.6,
+            initialFractions: const [0.6, 0.4],
+            children: [
+              _buildFlameChartSection(selectedEvent),
+              EventDetails(selectedEvent),
+            ],
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -613,3 +613,5 @@ extension SortDirectionExtension on SortDirection {
         : SortDirection.ascending;
   }
 }
+
+const defaultEpsilon = 1 / 1000;

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -92,7 +92,7 @@ void main() {
       splitFinder = find.byType(Split);
       expect(splitFinder, findsOneWidget);
       final Split splitter = tester.widget(splitFinder);
-      expect(splitter.initialFirstFraction, equals(0.40));
+      expect(splitter.initialFractions[0], equals(0.40));
 
       // Check memory sources available.
       await tester.tap(find.byKey(MemoryScreen.dropdownSourceMenuButtonKey));

--- a/packages/devtools_app/test/flutter/split_test.dart
+++ b/packages/devtools_app/test/flutter/split_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/flutter/split.dart';
+import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -103,6 +104,23 @@ void main() {
         expectEqualSizes(
             tester.element(find.byKey(_k3)).size, const Size(312, 600));
       });
+
+      testWidgets('with initialFraction rounding errors',
+          (WidgetTester tester) async {
+        const oneThird = 0.333333;
+        final split = buildSplit(
+          Axis.horizontal,
+          children: [_w1, _w2, _w3],
+          initialFractions: [oneThird, oneThird, oneThird],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(260, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(260, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(260, 600));
+      });
     });
 
     group('builds vertical layout', () {
@@ -180,6 +198,23 @@ void main() {
             tester.element(find.byKey(_k2)).size, const Size(800, 232));
         expectEqualSizes(
             tester.element(find.byKey(_k3)).size, const Size(800, 232));
+      });
+
+      testWidgets('with initialFraction rounding errors',
+          (WidgetTester tester) async {
+        const oneThird = 0.333333;
+        final split = buildSplit(
+          Axis.vertical,
+          children: [_w1, _w2, _w3],
+          initialFractions: [oneThird, oneThird, oneThird],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 193.3333));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 193.3333));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(800, 193.3333));
       });
     });
 
@@ -615,14 +650,13 @@ Split buildSplit(
 }
 
 void expectEqualSizes(Size a, Size b) {
-  const epsilon = 1 / 1000000;
   expect(
-    (a.width - b.width).abs() < epsilon,
+    (a.width - b.width).abs() < defaultEpsilon,
     isTrue,
     reason: 'Widths unequal:\nExpected ${b.width}\nActual: ${a.width}',
   );
   expect(
-    (a.height - b.height).abs() < epsilon,
+    (a.height - b.height).abs() < defaultEpsilon,
     isTrue,
     reason: 'Heights unequal:\nExpected ${b.height}\nActual: ${a.height}',
   );

--- a/packages/devtools_app/test/flutter/split_test.dart
+++ b/packages/devtools_app/test/flutter/split_test.dart
@@ -13,243 +13,511 @@ void main() {
   group('Split', () {
     group('builds horizontal layout', () {
       testWidgets('with 25% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.25);
+        final split = buildSplit(
+          Axis.horizontal,
+          initialFractions: [0.25, 0.75],
+        );
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(195, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(595, 600));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(197.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(592.5, 600));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(10, 600));
       });
 
       testWidgets('with 50% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.50);
+        final split = buildSplit(
+          Axis.horizontal,
+          initialFractions: [0.50, 0.50],
+        );
         await tester.pumpWidget(wrap(split));
-        expect(tester.element(find.byKey(_w1)).size, const Size(395, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(395, 600));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(395, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(395, 600));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(10, 600));
       });
 
       testWidgets('with 75% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.75);
+        final split = buildSplit(
+          Axis.horizontal,
+          initialFractions: [0.75, 0.25],
+        );
         await tester.pumpWidget(wrap(split));
-        expect(tester.element(find.byKey(_w1)).size, const Size(595, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(195, 600));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(592.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(197.5, 600));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(10, 600));
       });
 
       testWidgets('with 0% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.0);
+        final split = buildSplit(Axis.horizontal, initialFractions: [0.0, 1.0]);
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(0, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(790, 600));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(790, 600));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(10, 600));
       });
 
       testWidgets('with 100% space to first child',
           (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 1.0);
+        final split = buildSplit(
+          Axis.horizontal,
+          initialFractions: [1.0, 0.0],
+        );
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(790, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(0, 600));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(790, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(0, 600));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(10, 600));
+      });
+
+      testWidgets('with n children', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.horizontal,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(156, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(312, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
       });
     });
 
     group('builds vertical layout', () {
       testWidgets('with 25% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.25);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.25, 0.75]);
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 145));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 445));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 147.5));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 442.5));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(800, 10));
       });
 
       testWidgets('with 50% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.5);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.5, 0.5]);
         await tester.pumpWidget(wrap(split));
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 295));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 295));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 295));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 295));
       });
 
       testWidgets('with 75% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.75);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.75, 0.25]);
         await tester.pumpWidget(wrap(split));
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 445));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 145));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 442.5));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 147.5));
       });
 
       testWidgets('with 0% space to first child', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.0);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.0, 1.0]);
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 0));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 590));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 590));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(800, 10));
       });
 
       testWidgets('with 100% space to first child',
           (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 1.0);
+        final split = buildSplit(Axis.vertical, initialFractions: [1.0, 0.0]);
         await tester.pumpWidget(wrap(split));
-        expect(find.byKey(_w1), findsOneWidget);
-        expect(find.byKey(_w2), findsOneWidget);
-        expect(find.byKey(split.dividerKey), findsOneWidget);
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 590));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 0));
-        expect(tester.element(find.byKey(split.dividerKey)).size,
+        expect(find.byKey(_k1), findsOneWidget);
+        expect(find.byKey(_k2), findsOneWidget);
+        expect(find.byKey(split.dividerKey(0)), findsOneWidget);
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 590));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 0));
+        expectEqualSizes(tester.element(find.byKey(split.dividerKey(0))).size,
             const Size(800, 10));
+      });
+
+      testWidgets('with n children', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.vertical,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 116));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 232));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(800, 232));
       });
     });
 
     group('drags properly', () {
       testWidgets('with horizontal layout', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.5);
+        final split = buildSplit(Axis.horizontal, initialFractions: [0.5, 0.5]);
         await tester.pumpWidget(wrap(split));
 
         // We start at 0.5 size.
-        expect(tester.element(find.byKey(_w1)).size, const Size(395, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(395, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(395, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(395, 600));
 
         // Drag to 0.75 first child size.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(200, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(200, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(595, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(195, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(592.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(197.5, 600));
 
         // Drag to 0.25 first child size.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(-400, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-400, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(195, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(595, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(197.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(592.5, 600));
 
         // Drag past the right end of the widget.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(600, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(600, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(790, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(790, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(0, 600));
 
         // Make sure we can't overdrag.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(200, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(200, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(790, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(790, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(0, 600));
 
         // Drag back past the left end of the widget.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(-800, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-800, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(0, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(790, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(790, 600));
 
         // Make sure we can't overdrag.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(-200, 0));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-200, 0));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(0, 600));
-        expect(tester.element(find.byKey(_w2)).size, const Size(790, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(790, 600));
       });
 
       testWidgets('with vertical layout', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.5);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.5, 0.5]);
         await tester.pumpWidget(wrap(split));
 
         // We start at 0.5 size.
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 295));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 295));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 295));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 295));
 
         // Drag to 0.75 first child size.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, 150));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, 150));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 445));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 145));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 442.5));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 147.5));
 
         // Drag to 0.25 first child size.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, -300));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, -300));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 145));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 445));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 147.5));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 442.5));
 
         // Drag past the right end of the widget.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, 450));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, 450));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 590));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 590));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 0));
 
         // Make sure we can't overdrag.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, 200));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, 200));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 590));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 590));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 0));
 
         // Drag back past the left end of the widget.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, -600));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, -600));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 0));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 590));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 590));
 
         // Make sure we can't overdrag.
-        await tester.drag(find.byKey(split.dividerKey), const Offset(0, -200));
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(0, -200));
         await tester.pumpAndSettle();
-        expect(tester.element(find.byKey(_w1)).size, const Size(800, 0));
-        expect(tester.element(find.byKey(_w2)).size, const Size(800, 590));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 590));
+      });
+
+      testWidgets('with n children', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.horizontal,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+        );
+        await tester.pumpWidget(wrap(split));
+
+        // We start at initial size.
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(156, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(312, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
+
+        // Drag first splitter to 0.1 first child size.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-80, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(78, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(390, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
+
+        // Drag first splitter to the left end of the widget.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-80, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(468, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
+
+        // Make sure we can't overdrag.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-200, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(468, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
+
+        // Drag first splitter to second splitter.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(480, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(468, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(312, 600));
+
+        // Drag second splitter past first splitter.
+        await tester.drag(
+            find.byKey(split.dividerKey(1)), const Offset(-100, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(370.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(0, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(409.5, 600));
+
+        // Drag second splitter to the right end of the widget.
+        await tester.drag(
+            find.byKey(split.dividerKey(1)), const Offset(420, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(370.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(409.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(0, 600));
+
+        // Make sure we can't overdrag.
+        await tester.drag(
+            find.byKey(split.dividerKey(1)), const Offset(200, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(370.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(409.5, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(0, 600));
       });
     });
 
     group('resizes contents', () {
       testWidgets('in a horizontal layout', (WidgetTester tester) async {
-        final split = buildSplit(Axis.horizontal, initialFirstFraction: 0.0);
+        final split = buildSplit(Axis.horizontal, initialFractions: [0.0, 1.0]);
         await tester.pumpWidget(wrap(
           Center(
             child: SizedBox(width: 300.0, height: 300.0, child: split),
           ),
         ));
-        expect(tester.element(find.byKey(_w1)).size, const Size(0, 300));
-        expect(tester.element(find.byKey(_w2)).size, const Size(290, 300));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 300));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(290, 300));
 
         await tester.pumpWidget(wrap(
           Center(
             child: SizedBox(width: 200.0, height: 200.0, child: split),
           ),
         ));
-        expect(tester.element(find.byKey(_w1)).size, const Size(0, 200));
-        expect(tester.element(find.byKey(_w2)).size, const Size(190, 200));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(0, 200));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(190, 200));
+      });
+
+      testWidgets('in a horizontal layout with n children',
+          (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.horizontal,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+        );
+        await tester.pumpWidget(wrap(
+          Center(
+            child: SizedBox(width: 400.0, height: 400.0, child: split),
+          ),
+        ));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(76, 400));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(152, 400));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(152, 400));
+
+        await tester.pumpWidget(wrap(
+          Center(
+            child: SizedBox(width: 200.0, height: 200.0, child: split),
+          ),
+        ));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(36, 200));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(72, 200));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(72, 200));
       });
 
       testWidgets('in a vertical layout', (WidgetTester tester) async {
-        final split = buildSplit(Axis.vertical, initialFirstFraction: 0.0);
+        final split = buildSplit(Axis.vertical, initialFractions: [0.0, 1.0]);
         await tester.pumpWidget(wrap(
           Center(
             child: SizedBox(width: 300.0, height: 300.0, child: split),
           ),
         ));
-        expect(tester.element(find.byKey(_w1)).size, const Size(300, 0));
-        expect(tester.element(find.byKey(_w2)).size, const Size(300, 290));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(300, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(300, 290));
 
         await tester.pumpWidget(wrap(
           Center(
             child: SizedBox(width: 200.0, height: 200.0, child: split),
           ),
         ));
-        expect(tester.element(find.byKey(_w1)).size, const Size(200, 0));
-        expect(tester.element(find.byKey(_w2)).size, const Size(200, 190));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(200, 0));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(200, 190));
+      });
+
+      testWidgets('in a vertical layout with n children',
+          (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.vertical,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+        );
+        await tester.pumpWidget(wrap(
+          Center(
+            child: SizedBox(width: 400.0, height: 400.0, child: split),
+          ),
+        ));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(400, 76));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(400, 152));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(400, 152));
+
+        await tester.pumpWidget(wrap(
+          Center(
+            child: SizedBox(width: 200.0, height: 200.0, child: split),
+          ),
+        ));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(200, 36));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(200, 72));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(200, 72));
       });
     });
 
@@ -276,15 +544,35 @@ void main() {
   });
 }
 
-const _w1 = Key('child 1');
-const _w2 = Key('child 2');
-Split buildSplit(Axis axis, {@required double initialFirstFraction}) {
-  const w1 = Text('content1', key: _w1);
-  const w2 = Text('content2', key: _w2);
+const _k1 = Key('child 1');
+const _k2 = Key('child 2');
+const _k3 = Key('child 3');
+const _w1 = Text('content1', key: _k1);
+const _w2 = Text('content2', key: _k2);
+const _w3 = Text('content3', key: _k3);
+Split buildSplit(
+  Axis axis, {
+  @required List<double> initialFractions,
+  List<Widget> children,
+}) {
+  children ??= const [_w1, _w2];
   return Split(
     axis: axis,
-    firstChild: w1,
-    secondChild: w2,
-    initialFirstFraction: initialFirstFraction,
+    children: children,
+    initialFractions: initialFractions,
+  );
+}
+
+void expectEqualSizes(Size a, Size b) {
+  const epsilon = 1 / 1000000;
+  expect(
+    (a.width - b.width).abs() < epsilon,
+    isTrue,
+    reason: 'Widths unequal:\nExpected ${b.width}\nActual: ${a.width}',
+  );
+  expect(
+    (a.height - b.height).abs() < epsilon,
+    isTrue,
+    reason: 'Heights unequal:\nExpected ${b.height}\nActual: ${a.height}',
   );
 }

--- a/packages/devtools_app/test/flutter/split_test.dart
+++ b/packages/devtools_app/test/flutter/split_test.dart
@@ -407,6 +407,55 @@ void main() {
         expectEqualSizes(
             tester.element(find.byKey(_k3)).size, const Size(0, 600));
       });
+
+      testWidgets('with minSizes', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.horizontal,
+          initialFractions: [0.5, 0.5],
+          minSizes: [100.0, 100.0],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(395, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(395, 600));
+
+        // Drag splitter to the left end of the widget.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-300, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(100, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(690, 600));
+
+        // Make sure we can't overdrag.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(-200, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(100, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(690, 600));
+
+        // Drag splitter to the right end of the widget.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(597.5, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(690, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(100, 600));
+
+        // Make sure we can't overdrag.
+        await tester.drag(
+            find.byKey(split.dividerKey(0)), const Offset(200, 0));
+        await tester.pumpAndSettle();
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(690, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(100, 600));
+      });
     });
 
     group('resizes contents', () {
@@ -554,12 +603,14 @@ Split buildSplit(
   Axis axis, {
   @required List<double> initialFractions,
   List<Widget> children,
+  List<double> minSizes,
 }) {
   children ??= const [_w1, _w2];
   return Split(
     axis: axis,
     children: children,
     initialFractions: initialFractions,
+    minSizes: minSizes,
   );
 }
 

--- a/packages/devtools_app/test/flutter/timeline_screen_test.dart
+++ b/packages/devtools_app/test/flutter/timeline_screen_test.dart
@@ -106,7 +106,7 @@ void main() {
       final splitFinder = find.byType(Split);
       expect(splitFinder, findsOneWidget);
       final Split splitter = tester.widget(splitFinder);
-      expect(splitter.initialFirstFraction, equals(0.6));
+      expect(splitter.initialFractions[0], equals(0.6));
     });
 
     testWidgetsWithWindowSize('starts and stops recording', windowSize,


### PR DESCRIPTION
N split:
![n_splitter](https://user-images.githubusercontent.com/43759233/78063239-c0552f80-7344-11ea-9451-3380a1d85479.gif)
N split with minimum sizes:
![splitter_with_min_size](https://user-images.githubusercontent.com/43759233/78070049-fcda5880-734f-11ea-9bf7-e772d65b61df.gif)
