### PR TITLE
fix an issue where we tried to initiate a connection twice

### DIFF
--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -8,6 +8,7 @@ import 'package:pedantic/pedantic.dart';
 
 import '../../src/framework/framework_core.dart';
 import '../url_utils.dart';
+import '../utils.dart';
 import 'common_widgets.dart';
 import 'navigation.dart';
 import 'notifications.dart';
@@ -81,13 +82,15 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
   }
 
   Widget _buildTextInput() {
+    final CallbackDwell connectDebounce = CallbackDwell(_connect);
+
     return Row(
       mainAxisAlignment: MainAxisAlignment.start,
       children: [
         SizedBox(
           width: 350.0,
           child: TextField(
-            onSubmitted: _connect,
+            onSubmitted: (str) => connectDebounce.invoke(),
             autofocus: true,
             decoration: const InputDecoration(
               isDense: true,
@@ -107,13 +110,13 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
         ),
         RaisedButton(
           child: const Text('Connect'),
-          onPressed: _connect,
+          onPressed: connectDebounce.invoke,
         ),
       ],
     );
   }
 
-  Future<void> _connect([_]) async {
+  Future<void> _connect() async {
     final uri = normalizeVmServiceUri(controller.text);
     final connected = await FrameworkCore.initVmService(
       '',

--- a/packages/devtools_app/lib/src/flutter/initializer.dart
+++ b/packages/devtools_app/lib/src/flutter/initializer.dart
@@ -81,6 +81,7 @@ class _InitializerState extends State<Initializer>
         _navigateToConnectPage();
       }),
     );
+
     if (widget.url != null) {
       _attemptUrlConnection();
     } else {

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -39,13 +39,13 @@ class FrameworkCore {
     Uri explicitUri,
     @required ErrorReporter errorReporter,
   }) async {
-    final Uri uri = explicitUri ?? _getUriFromQuerystring(url);
     if (serviceManager.hasConnection) {
       // TODO(https://github.com/flutter/devtools/issues/1568): why do we call
       // this multiple times?
       return true;
     }
 
+    final Uri uri = explicitUri ?? _getUriFromQuerystring(url);
     if (uri != null) {
       final finishedCompleter = Completer<void>();
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -614,4 +614,30 @@ extension SortDirectionExtension on SortDirection {
   }
 }
 
+/// A small double value, used to ensure that comparisons between double are
+/// valid.
 const defaultEpsilon = 1 / 1000;
+
+/// Have a quiet period after a callback to ensure that rapid invocations of a
+/// callback only result in one call.
+class CallbackDwell {
+  CallbackDwell(
+    this.callback, {
+    this.dwell = const Duration(milliseconds: 250),
+  });
+
+  final VoidCallback callback;
+  final Duration dwell;
+
+  Timer _timer;
+
+  void invoke() {
+    if (_timer == null) {
+      _timer = Timer(dwell, () {
+        _timer = null;
+      });
+
+      callback();
+    }
+  }
+}


### PR DESCRIPTION
- fix an issue where we tried to initiate a connection twice

When using an `onSubmitted` on the `TextField`, both the callback for the onSubmitted and for the `RaisedButton`'s onPressed are called. This makes sure that we only try and initiate a connection once.

This would show up as an error after connection - displayed as a 'Completer already completed' error.