### PR TITLE
Use FlexSplitColumn for debugger panes.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/common_widgets.dart';
+import '../../flutter/flex_split_column.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
+import '../../flutter/theme.dart';
 import '../../globals.dart';
 
 class DebuggerScreen extends Screen {
@@ -41,6 +43,12 @@ class DebuggerScreenBody extends StatefulWidget {
 }
 
 class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
+  static const callStackTitle = 'Call Stack';
+  static const variablesTitle = 'Variables';
+  static const breakpointsTitle = 'Breakpoints';
+  static const librariesTitle = 'Libraries';
+  static const debuggerPaneHeaderHeight = 60.0;
+
   ScriptRef loadingScript;
   Script script;
   ScriptList scriptList;
@@ -82,13 +90,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
       initialFractions: const [0.25, 0.75],
       // TODO(https://github.com/flutter/devtools/issues/1648): Debug panes.
       children: [
-        OutlinedBorder(
-          child: ScriptPicker(
-            scripts: scriptList,
-            onSelected: onScriptSelected,
-            selected: loadingScript,
-          ),
-        ),
+        OutlinedBorder(child: debuggerPanes()),
         // TODO(https://github.com/flutter/devtools/issues/1648): Debug controls.
         OutlinedBorder(
           child: loadingScript != null && script == null
@@ -98,6 +100,60 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
                 ),
         ),
       ],
+    );
+  }
+
+  Widget debuggerPanes() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final paneWidth = constraints.maxWidth;
+        return FlexSplitColumn(
+          totalHeight: constraints.maxHeight,
+          initialFractions: const [0.25, 0.25, 0.25, 0.25],
+          minSizes: const [0.0, 0.0, 0.0, 0.0],
+          headers: [
+            _debuggerPaneHeader(callStackTitle, paneWidth),
+            _debuggerPaneHeader(variablesTitle, paneWidth),
+            _debuggerPaneHeader(breakpointsTitle, paneWidth),
+            _debuggerPaneHeader(librariesTitle, paneWidth),
+          ],
+          children: [
+            const Center(child: Text('TODO: call stack')),
+            const Center(child: Text('TODO: variables')),
+            const Center(child: Text('TODO: breakpoints')),
+            ScriptPicker(
+              scripts: scriptList,
+              onSelected: onScriptSelected,
+              selected: loadingScript,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  FlexSplitColumnHeader _debuggerPaneHeader(
+    String title,
+    double debuggerPaneWidth,
+  ) {
+    return FlexSplitColumnHeader(
+      height: debuggerPaneHeaderHeight,
+      width: debuggerPaneWidth,
+      child: Container(
+        decoration: BoxDecoration(
+          border: Border(
+            bottom: BorderSide(color: Theme.of(context).focusColor),
+          ),
+          color: Theme.of(context).primaryColor,
+        ),
+        padding: EdgeInsets.only(left: defaultSpacing),
+        alignment: Alignment.centerLeft,
+        height: debuggerPaneHeaderHeight,
+        child: Text(
+          title,
+          style: Theme.of(context).textTheme.headline6,
+        ),
+      ),
     );
   }
 }
@@ -181,29 +237,36 @@ class ScriptPickerState extends State<ScriptPicker> {
       return const Center(child: CircularProgressIndicator());
     }
     final items = _filtered;
-    return Column(
-      mainAxisSize: MainAxisSize.max,
-      children: [
-        TextField(
-          controller: filterController,
-          onChanged: updateFilter,
-        ),
-        Expanded(
-          child: Scrollbar(
-            child: SingleChildScrollView(
-              scrollDirection: Axis.horizontal,
-              child: SizedBox(
-                width: MediaQuery.of(context).size.width,
-                child: ListView.builder(
-                  itemBuilder: (context, index) => _buildScript(items[index]),
-                  itemCount: items.length,
-                  itemExtent: 32.0,
+    return Padding(
+      padding: const EdgeInsets.only(left: denseSpacing),
+      child: Column(
+        mainAxisSize: MainAxisSize.max,
+        children: [
+          TextField(
+            decoration: const InputDecoration(
+              labelText: 'Filter',
+              border: UnderlineInputBorder(),
+            ),
+            controller: filterController,
+            onChanged: updateFilter,
+          ),
+          Expanded(
+            child: Scrollbar(
+              child: SingleChildScrollView(
+                scrollDirection: Axis.horizontal,
+                child: SizedBox(
+                  width: MediaQuery.of(context).size.width,
+                  child: ListView.builder(
+                    itemBuilder: (context, index) => _buildScript(items[index]),
+                    itemCount: items.length,
+                    itemExtent: 32.0,
+                  ),
                 ),
               ),
             ),
           ),
-        ),
-      ],
+        ],
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -106,16 +106,15 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
   Widget debuggerPanes() {
     return LayoutBuilder(
       builder: (context, constraints) {
-        final paneWidth = constraints.maxWidth;
         return FlexSplitColumn(
           totalHeight: constraints.maxHeight,
           initialFractions: const [0.25, 0.25, 0.25, 0.25],
           minSizes: const [0.0, 0.0, 0.0, 0.0],
           headers: [
-            _debuggerPaneHeader(callStackTitle, paneWidth),
-            _debuggerPaneHeader(variablesTitle, paneWidth),
-            _debuggerPaneHeader(breakpointsTitle, paneWidth),
-            _debuggerPaneHeader(librariesTitle, paneWidth),
+            _debuggerPaneHeader(callStackTitle),
+            _debuggerPaneHeader(variablesTitle),
+            _debuggerPaneHeader(breakpointsTitle),
+            _debuggerPaneHeader(librariesTitle),
           ],
           children: [
             const Center(child: Text('TODO: call stack')),
@@ -132,13 +131,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
     );
   }
 
-  FlexSplitColumnHeader _debuggerPaneHeader(
-    String title,
-    double debuggerPaneWidth,
-  ) {
+  FlexSplitColumnHeader _debuggerPaneHeader(String title) {
     return FlexSplitColumnHeader(
       height: debuggerPaneHeaderHeight,
-      width: debuggerPaneWidth,
       child: Container(
         decoration: BoxDecoration(
           border: Border(
@@ -146,7 +141,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody> {
           ),
           color: Theme.of(context).primaryColor,
         ),
-        padding: EdgeInsets.only(left: defaultSpacing),
+        padding: const EdgeInsets.only(left: defaultSpacing),
         alignment: Alignment.centerLeft,
         height: debuggerPaneHeaderHeight,
         child: Text(

--- a/packages/devtools_app/lib/src/flutter/flex_split_column.dart
+++ b/packages/devtools_app/lib/src/flutter/flex_split_column.dart
@@ -1,0 +1,132 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:flutter/material.dart';
+
+import 'split.dart';
+
+class FlexSplitColumn extends StatelessWidget {
+  FlexSplitColumn({
+    Key key,
+    @required this.totalHeight,
+    @required this.headers,
+    @required List<Widget> children,
+    @required List<double> initialFractions,
+    List<double> minSizes,
+  })  : assert(children != null && children.length >= 2),
+        assert(initialFractions != null && initialFractions.length >= 2),
+        assert(children.length == initialFractions.length),
+        adjustedChildren = adjustChildren(children, headers),
+        adjustedInitialFractions =
+            adjustInitialFractions(initialFractions, headers, totalHeight),
+        adjustedMinSizes = adjustMinSizes(minSizes, headers),
+        super(key: key) {
+    if (minSizes != null) {
+      assert(minSizes.length == children.length);
+    }
+  }
+
+  /// The headers that will be laid out above each corresponding child in
+  /// [children].
+  ///
+  /// All headers but the first will be passed into [Split.splitters] when
+  /// creating the [Split] widget in `build`. Instead of being passed into
+  /// [Split.splitters], it will be combined with the first child in [children]
+  /// to create the first child we will pass into [Split.children].
+  ///
+  /// We do this because the first header will not actually be a splitter as
+  /// there is not any content above it for it to split.
+  ///
+  /// We adjust other values [adjustedChildren], [adjustedInitialFractions], and
+  /// [adjustedMinSizes] to account for the first header. We do this adjustment
+  /// here so that the creators of [FlexSplitColumn] can be unaware of
+  /// the under-the-hood calculations necessary to achieve the UI requirements
+  /// specified by [initialFractions] and [minSizes].
+  final List<FlexSplitColumnHeader> headers;
+
+  /// The children that will be laid out below each corresponding header in
+  /// [headers].
+  ///
+  /// All [children] except the first will be passed into [Split.children]
+  /// unmodified. We need to adjust the first child from [children] to account
+  /// for the first header (see above).
+  final List<Widget> adjustedChildren;
+
+  /// The fraction of the layout to allocate to each child in [children].
+  ///
+  /// We need to adjust the values given by [initialFractions] to account for
+  /// the first header (see above).
+  final List<double> adjustedInitialFractions;
+
+  /// The minimum size each child is allowed to be.
+  final List<double> adjustedMinSizes;
+
+  /// The total height of the column, including all [headers] and [children].
+  final double totalHeight;
+
+  @visibleForTesting
+  static List<Widget> adjustChildren(
+    List<Widget> children,
+    List<FlexSplitColumnHeader> headers,
+  ) {
+    return [
+      Column(
+        children: [
+          headers[0],
+          Expanded(child: children[0]),
+        ],
+      ),
+      ...children.sublist(1),
+    ];
+  }
+
+  @visibleForTesting
+  static List<double> adjustInitialFractions(
+    List<double> initialFractions,
+    List<FlexSplitColumnHeader> headers,
+    double totalHeight,
+  ) {
+    final intendedContentHeight = totalHeight -
+        headers.map((header) => header.height).reduce((a, b) => a + b);
+    final intendedChildHeights = List<double>.generate(initialFractions.length,
+        (i) => intendedContentHeight * initialFractions[i]);
+    final trueContentHeight = intendedContentHeight + headers[0].height;
+    return List<double>.generate(initialFractions.length, (i) {
+      if (i == 0) {
+        return (intendedChildHeights[i] + headers[0].height) /
+            trueContentHeight;
+      }
+      return intendedChildHeights[i] / trueContentHeight;
+    });
+  }
+
+  @visibleForTesting
+  static List<double> adjustMinSizes(
+    List<double> minSizes,
+    List<FlexSplitColumnHeader> headers,
+  ) {
+    return [
+      minSizes[0] + headers[0].height,
+      ...minSizes.sublist(1),
+    ];
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Split(
+      axis: Axis.vertical,
+      children: adjustedChildren,
+      initialFractions: adjustedInitialFractions,
+      minSizes: adjustedMinSizes,
+      splitters: headers.sublist(1),
+    );
+  }
+}
+
+class FlexSplitColumnHeader extends SizedBox {
+  const FlexSplitColumnHeader({
+    @required double width,
+    @required double height,
+    @required Widget child,
+  }) : super(width: width, height: height, child: child);
+}

--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -31,7 +31,7 @@ class Split extends StatefulWidget {
         assert(initialFractions != null && initialFractions.length >= 2),
         assert(children.length == initialFractions.length),
         super(key: key) {
-    _verifyFractionsSum(initialFractions);
+    _verifyFractionsSumTo1(initialFractions);
     if (minSizes != null) {
       assert(minSizes.length == children.length);
     }
@@ -75,8 +75,7 @@ class Split extends StatefulWidget {
   @visibleForTesting
   Key dividerKey(int index) => Key('$this dividerKey $index');
 
-  /// The default size of the divider between children in logical pixels (dp,
-  /// not px).
+  /// The default size of the divider between children.
   static const double defaultSplitterSize = 10.0;
 
   static Axis axisFor(BuildContext context, double horizontalAspectRatio) {
@@ -194,7 +193,7 @@ class _SplitState extends State<Split> {
           updateSpacingBeforeSplitterIndex(-appliedDelta);
         }
       });
-      _verifyFractionsSum(fractions);
+      _verifyFractionsSumTo1(fractions);
     }
 
     final children = <Widget>[];
@@ -285,7 +284,7 @@ class _SplitState extends State<Split> {
   }
 }
 
-void _verifyFractionsSum(List<double> fractions) {
+void _verifyFractionsSumTo1(List<double> fractions) {
   var sumFractions = 0.0;
   for (var fraction in fractions) {
     sumFractions += fraction;

--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
+import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -25,19 +25,18 @@ class Split extends StatefulWidget {
     @required this.children,
     @required this.initialFractions,
     this.minSizes,
+    this.splitters,
   })  : assert(axis != null),
         assert(children != null && children.length >= 2),
         assert(initialFractions != null && initialFractions.length >= 2),
         assert(children.length == initialFractions.length),
         super(key: key) {
-    var sumFractions = 0.0;
-    for (var fraction in initialFractions) {
-      sumFractions += fraction;
-    }
-    assert((1.0 - sumFractions).abs() < defaultEpsilon);
-
+    _verifyFractionsSum(initialFractions);
     if (minSizes != null) {
       assert(minSizes.length == children.length);
+    }
+    if (splitters != null) {
+      assert(splitters.length == children.length - 1);
     }
   }
 
@@ -64,6 +63,11 @@ class Split extends StatefulWidget {
   /// The minimum size each child is allowed to be.
   final List<double> minSizes;
 
+  /// Splitter widgets to divide [children].
+  ///
+  /// If this is null, a default splitter will be used to divide [children].
+  final List<SizedBox> splitters;
+
   /// The key passed to the divider between children[index] and
   /// children[index + 1].
   ///
@@ -71,8 +75,9 @@ class Split extends StatefulWidget {
   @visibleForTesting
   Key dividerKey(int index) => Key('$this dividerKey $index');
 
-  /// The size of the divider between children in logical pixels (dp, not px).
-  static const double dividerMainAxisSize = 10.0;
+  /// The default size of the divider between children in logical pixels (dp,
+  /// not px).
+  static const double defaultSplitterSize = 10.0;
 
   static Axis axisFor(BuildContext context, double horizontalAspectRatio) {
     final screenSize = MediaQuery.of(context).size;
@@ -105,16 +110,13 @@ class _SplitState extends State<Split> {
     final width = constraints.maxWidth;
     final height = constraints.maxHeight;
     final axisSize = isHorizontal ? width : height;
-    final crossAxisSize = isHorizontal ? height : width;
-    final numDividers = widget.children.length - 1;
 
     // Size calculation helpers.
     double _minSizeForIndex(int index) =>
         widget.minSizes != null ? widget.minSizes[index] : 0.0;
 
     double _minFractionForIndex(int index) =>
-        _minSizeForIndex(index) /
-        (axisSize - numDividers * Split.dividerMainAxisSize);
+        _minSizeForIndex(index) / (axisSize - _totalSplitterSize());
 
     void _clampFraction(int index) {
       fractions[index] =
@@ -122,8 +124,7 @@ class _SplitState extends State<Split> {
     }
 
     double _sizeForIndex(int index) {
-      final size = (axisSize - numDividers * Split.dividerMainAxisSize) *
-          fractions[index];
+      final size = (axisSize - _totalSplitterSize()) * fractions[index];
       assert(size >= _minSizeForIndex(index));
       return size;
     }
@@ -146,7 +147,7 @@ class _SplitState extends State<Split> {
           final minFractionForIndex = _minFractionForIndex(index);
           if (fractions[index] >= minFractionForIndex) {
             _clampFraction(index);
-            return delta;
+            return startingDelta;
           }
           delta = fractions[index] - minFractionForIndex;
           _clampFraction(index);
@@ -167,7 +168,7 @@ class _SplitState extends State<Split> {
           final minFractionForIndex = _minFractionForIndex(index);
           if (fractions[index] >= minFractionForIndex) {
             _clampFraction(index);
-            return delta;
+            return startingDelta;
           }
           delta = fractions[index] - minFractionForIndex;
           _clampFraction(index);
@@ -193,37 +194,8 @@ class _SplitState extends State<Split> {
           updateSpacingBeforeSplitterIndex(-appliedDelta);
         }
       });
+      _verifyFractionsSum(fractions);
     }
-
-    // TODO(https://github.com/flutter/flutter/issues/43747): use an icon.
-    // The material icon for a drag handle is not currently available.
-    // For now, draw an indicator that is 3 lines running in the direction
-    // of the main axis, like a hamburger menu.
-    // TODO(https://github.com/flutter/devtools/issues/1265): update mouse
-    // to indicate that this is resizable.
-    final dragIndicator = Flex(
-      direction: isHorizontal ? Axis.vertical : Axis.horizontal,
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        for (var i = 0; i < min(crossAxisSize / 6.0, 3).floor(); i++)
-          Padding(
-            padding: EdgeInsets.symmetric(
-              vertical: isHorizontal ? 2.0 : 0.0,
-              horizontal: isHorizontal ? 0.0 : 2.0,
-            ),
-            child: DecoratedBox(
-              decoration: BoxDecoration(
-                color: Theme.of(context).dividerColor,
-                borderRadius: BorderRadius.circular(Split.dividerMainAxisSize),
-              ),
-              child: SizedBox(
-                height: isHorizontal ? 2.0 : Split.dividerMainAxisSize - 2.0,
-                width: isHorizontal ? Split.dividerMainAxisSize - 2.0 : 2.0,
-              ),
-            ),
-          ),
-      ],
-    );
 
     final children = <Widget>[];
     for (int i = 0; i < widget.children.length; i++) {
@@ -245,16 +217,81 @@ class _SplitState extends State<Split> {
             // the drag bar. There still appears to be a few frame lag before the
             // drag action triggers which is't ideal but isn't a launch blocker.
             dragStartBehavior: DragStartBehavior.down,
-            child: SizedBox(
-              width: isHorizontal ? Split.dividerMainAxisSize : width,
-              height: isHorizontal ? height : Split.dividerMainAxisSize,
-              child: Center(
-                child: dragIndicator,
-              ),
-            ),
+            child: widget.splitters != null
+                ? widget.splitters[i]
+                : _defaultSplitter(layoutHeight: height, layoutWidth: width),
           ),
       ]);
     }
     return Flex(direction: widget.axis, children: children);
   }
+
+  double _totalSplitterSize() {
+    final numSplitters = widget.children.length - 1;
+    if (widget.splitters == null) {
+      return numSplitters * Split.defaultSplitterSize;
+    } else {
+      var totalSize = 0.0;
+      for (var splitter in widget.splitters) {
+        totalSize += isHorizontal ? splitter.width : splitter.height;
+      }
+      return totalSize;
+    }
+  }
+
+  Widget _defaultSplitter({
+    @required double layoutWidth,
+    @required double layoutHeight,
+  }) {
+    final crossAxisSize = isHorizontal ? layoutHeight : layoutWidth;
+
+    // TODO(https://github.com/flutter/flutter/issues/43747): use an icon.
+    // The material icon for a drag handle is not currently available.
+    // For now, draw an indicator that is 3 lines running in the direction
+    // of the main axis, like a hamburger menu.
+    // TODO(https://github.com/flutter/devtools/issues/1265): update mouse
+    // to indicate that this is resizable.
+    final defaultDragIndicator = Flex(
+      direction: isHorizontal ? Axis.vertical : Axis.horizontal,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        for (var i = 0; i < math.min(crossAxisSize / 6.0, 3).floor(); i++)
+          Padding(
+            padding: EdgeInsets.symmetric(
+              vertical: isHorizontal ? 2.0 : 0.0,
+              horizontal: isHorizontal ? 0.0 : 2.0,
+            ),
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color: Theme.of(context).dividerColor,
+                borderRadius: BorderRadius.circular(Split.defaultSplitterSize),
+              ),
+              child: SizedBox(
+                height: isHorizontal ? 2.0 : Split.defaultSplitterSize - 2.0,
+                width: isHorizontal ? Split.defaultSplitterSize - 2.0 : 2.0,
+              ),
+            ),
+          ),
+      ],
+    );
+
+    return SizedBox(
+      width: isHorizontal ? Split.defaultSplitterSize : layoutWidth,
+      height: isHorizontal ? layoutHeight : Split.defaultSplitterSize,
+      child: Center(
+        child: defaultDragIndicator,
+      ),
+    );
+  }
+}
+
+void _verifyFractionsSum(List<double> fractions) {
+  var sumFractions = 0.0;
+  for (var fraction in fractions) {
+    sumFractions += fraction;
+  }
+  assert(
+    (1.0 - sumFractions).abs() < defaultEpsilon,
+    'Fractions should sum to 1.0, but instead sum to $sumFractions:\n$fractions',
+  );
 }

--- a/packages/devtools_app/test/flutter/flex_split_column_test.dart
+++ b/packages/devtools_app/test/flutter/flex_split_column_test.dart
@@ -15,21 +15,18 @@ void main() {
     const children = [SizedBox(), SizedBox(), SizedBox(), SizedBox()];
     const firstHeaderKey = Key('first header');
     const headers = [
-      FlexSplitColumnHeader(
-        height: 50.0,
-        width: 50.0,
-        child: SizedBox(key: firstHeaderKey),
-      ),
-      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
-      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
-      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
+      FlexSplitColumnHeader(height: 50.0, child: SizedBox(key: firstHeaderKey)),
+      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
+      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
+      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
     ];
     const initialFractions = [0.25, 0.25, 0.25, 0.25];
     const minSizes = [10.0, 10.0, 10.0, 10.0];
     const totalHeight = 1200.0;
 
-    test('adjustInitialFractions', () {
-      final adjustedFractions = FlexSplitColumn.adjustInitialFractions(
+    test('modifyInitialFractionsToIncludeFirstHeader', () {
+      final adjustedFractions =
+          FlexSplitColumn.modifyInitialFractionsToIncludeFirstHeader(
         initialFractions,
         headers,
         totalHeight,
@@ -48,8 +45,9 @@ void main() {
       );
     });
 
-    test('adjustInitialFractions', () {
-      final adjustedFractions = FlexSplitColumn.adjustMinSizes(
+    test('modifyMinSizesToIncludeFirstHeader', () {
+      final adjustedFractions =
+          FlexSplitColumn.modifyMinSizesToIncludeFirstHeader(
         minSizes,
         headers,
       );
@@ -57,15 +55,16 @@ void main() {
           isTrue);
     });
 
-    testWidgets('adjustInitialChildren', (WidgetTester tester) async {
+    testWidgets('buildChildrenWithFirstHeader', (WidgetTester tester) async {
       await tester.pumpWidget(Column(children: children));
       expect(find.byKey(firstHeaderKey), findsNothing);
 
       // Wrap each child in a container so we can build the elements in a
       // arbitrary column to check for [firstHeaderKey].
-      final adjustedChildren = FlexSplitColumn.adjustChildren(children, headers)
-          .map((child) => Container(height: 100.0, child: child))
-          .toList();
+      final adjustedChildren =
+          FlexSplitColumn.buildChildrenWithFirstHeader(children, headers)
+              .map((child) => Container(height: 100.0, child: child))
+              .toList();
       await tester.pumpWidget(Column(children: adjustedChildren));
       expect(find.byKey(firstHeaderKey), findsOneWidget);
     });

--- a/packages/devtools_app/test/flutter/flex_split_column_test.dart
+++ b/packages/devtools_app/test/flutter/flex_split_column_test.dart
@@ -1,0 +1,73 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+import 'package:devtools_app/src/flutter/flex_split_column.dart';
+import 'package:devtools_app/src/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('FlexSplitColumn', () {
+    // The UI of the FlexSplitColumn widget is well tested in [split_test.dart].
+    // These tests test the data transformations that take place upon
+    // constructing [FlexSplitColumn].
+
+    const children = [SizedBox(), SizedBox(), SizedBox(), SizedBox()];
+    const firstHeaderKey = Key('first header');
+    const headers = [
+      FlexSplitColumnHeader(
+        height: 50.0,
+        width: 50.0,
+        child: SizedBox(key: firstHeaderKey),
+      ),
+      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
+      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
+      FlexSplitColumnHeader(height: 50.0, width: 50.0, child: SizedBox()),
+    ];
+    const initialFractions = [0.25, 0.25, 0.25, 0.25];
+    const minSizes = [10.0, 10.0, 10.0, 10.0];
+    const totalHeight = 1200.0;
+
+    test('adjustInitialFractions', () {
+      final adjustedFractions = FlexSplitColumn.adjustInitialFractions(
+        initialFractions,
+        headers,
+        totalHeight,
+      );
+      expect(
+        collectionEquals(
+          adjustedFractions,
+          [
+            0.2857142857142857,
+            0.23809523809523808,
+            0.23809523809523808,
+            0.23809523809523808
+          ],
+        ),
+        isTrue,
+      );
+    });
+
+    test('adjustInitialFractions', () {
+      final adjustedFractions = FlexSplitColumn.adjustMinSizes(
+        minSizes,
+        headers,
+      );
+      expect(collectionEquals(adjustedFractions, [60.0, 10.0, 10.0, 10.0]),
+          isTrue);
+    });
+
+    testWidgets('adjustInitialChildren', (WidgetTester tester) async {
+      await tester.pumpWidget(Column(children: children));
+      expect(find.byKey(firstHeaderKey), findsNothing);
+
+      // Wrap each child in a container so we can build the elements in a
+      // arbitrary column to check for [firstHeaderKey].
+      final adjustedChildren = FlexSplitColumn.adjustChildren(children, headers)
+          .map((child) => Container(height: 100.0, child: child))
+          .toList();
+      await tester.pumpWidget(Column(children: adjustedChildren));
+      expect(find.byKey(firstHeaderKey), findsOneWidget);
+    });
+  });
+}

--- a/packages/devtools_app/test/flutter/split_test.dart
+++ b/packages/devtools_app/test/flutter/split_test.dart
@@ -105,6 +105,22 @@ void main() {
             tester.element(find.byKey(_k3)).size, const Size(312, 600));
       });
 
+      testWidgets('with custom splitters', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.horizontal,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+          splitters: [_mediumSplitter, _largeSplitter],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(148, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(296, 600));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(296, 600));
+      });
+
       testWidgets('with initialFraction rounding errors',
           (WidgetTester tester) async {
         const oneThird = 0.333333;
@@ -198,6 +214,22 @@ void main() {
             tester.element(find.byKey(_k2)).size, const Size(800, 232));
         expectEqualSizes(
             tester.element(find.byKey(_k3)).size, const Size(800, 232));
+      });
+
+      testWidgets('with custom splitters', (WidgetTester tester) async {
+        final split = buildSplit(
+          Axis.vertical,
+          children: [_w1, _w2, _w3],
+          initialFractions: [0.2, 0.4, 0.4],
+          splitters: [_mediumSplitter, _largeSplitter],
+        );
+        await tester.pumpWidget(wrap(split));
+        expectEqualSizes(
+            tester.element(find.byKey(_k1)).size, const Size(800, 108));
+        expectEqualSizes(
+            tester.element(find.byKey(_k2)).size, const Size(800, 216));
+        expectEqualSizes(
+            tester.element(find.byKey(_k3)).size, const Size(800, 216));
       });
 
       testWidgets('with initialFraction rounding errors',
@@ -634,11 +666,14 @@ const _k3 = Key('child 3');
 const _w1 = Text('content1', key: _k1);
 const _w2 = Text('content2', key: _k2);
 const _w3 = Text('content3', key: _k3);
+const _mediumSplitter = SizedBox(height: 20, width: 20);
+const _largeSplitter = SizedBox(height: 40, width: 40);
 Split buildSplit(
   Axis axis, {
   @required List<double> initialFractions,
   List<Widget> children,
   List<double> minSizes,
+  List<SizedBox> splitters,
 }) {
   children ??= const [_w1, _w2];
   return Split(
@@ -646,6 +681,7 @@ Split buildSplit(
     children: children,
     initialFractions: initialFractions,
     minSizes: minSizes,
+    splitters: splitters,
   );
 }
 


### PR DESCRIPTION
This CL:
- Creates the `FlexSplitColumn` widget, which builds a `Split` widget with custom splitters and minor fraction and size transformations. Functionality explained in comments of respective class members.
- Adds functionality to specify custom splitter widgets in `Split`
- Uses `FlexSplitColumn` for the debugger panes so that the section headers are now the "splitter" widgets that respond to dragging and resizing.

![debugger_panes](https://user-images.githubusercontent.com/43759233/78193573-b1977700-742f-11ea-8b4e-25ce547c7348.gif)
