### PR TITLE
various UI tweaks

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -127,7 +127,7 @@ class DevToolsAppState extends State<DevToolsApp> {
               HotReloadButton(),
               HotRestartButton(),
               OpenSettingsAction(),
-              DevToolsInfoAction(),
+              OpenAboutAction(),
             ],
           ),
         ),
@@ -181,7 +181,7 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
   }
 }
 
-class DevToolsInfoAction extends StatelessWidget {
+class OpenAboutAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ActionButton(
@@ -190,7 +190,7 @@ class DevToolsInfoAction extends StatelessWidget {
         onTap: () async {
           unawaited(showDialog(
             context: context,
-            builder: (context) => DevToolsInfoDialog(),
+            builder: (context) => DevToolsAboutDialog(),
           ));
         },
         child: Container(
@@ -240,7 +240,7 @@ List<Widget> _header(TextTheme textTheme, String title) {
   ];
 }
 
-class DevToolsInfoDialog extends StatelessWidget {
+class DevToolsAboutDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
@@ -254,7 +254,7 @@ class DevToolsInfoDialog extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           ..._header(textTheme, 'About DevTools'),
-          _devtoolsInfo(context),
+          _aboutDevTools(context),
           const SizedBox(height: defaultSpacing),
           ..._header(textTheme, 'Feedback'),
           Wrap(
@@ -269,7 +269,7 @@ class DevToolsInfoDialog extends StatelessWidget {
     );
   }
 
-  Widget _devtoolsInfo(BuildContext context) {
+  Widget _aboutDevTools(BuildContext context) {
     return const SelectableText('DevTools version ${devtools.version}');
   }
 

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -126,8 +126,8 @@ class DevToolsAppState extends State<DevToolsApp> {
             actions: [
               HotReloadButton(),
               HotRestartButton(),
-              DevToolsInfoAction(),
               OpenSettingsAction(),
+              DevToolsInfoAction(),
             ],
           ),
         ),
@@ -185,7 +185,7 @@ class DevToolsInfoAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ActionButton(
-      tooltip: 'Info',
+      tooltip: 'About DevTools',
       child: InkWell(
         onTap: () async {
           unawaited(showDialog(
@@ -198,7 +198,7 @@ class DevToolsInfoAction extends StatelessWidget {
           height: DevToolsScaffold.actionWidgetSize,
           alignment: Alignment.center,
           child: Icon(
-            Icons.info,
+            Icons.info_outline,
             size: actionsIconSize,
           ),
         ),
@@ -233,6 +233,13 @@ class OpenSettingsAction extends StatelessWidget {
   }
 }
 
+List<Widget> _header(TextTheme textTheme, String title) {
+  return [
+    Text(title, style: textTheme.headline6),
+    const PaddedDivider(padding: EdgeInsets.only(bottom: denseRowSpacing)),
+  ];
+}
+
 class DevToolsInfoDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -246,7 +253,7 @@ class DevToolsInfoDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          ..._header(textTheme, 'DevTools'),
+          ..._header(textTheme, 'About DevTools'),
           _devtoolsInfo(context),
           const SizedBox(height: defaultSpacing),
           ..._header(textTheme, 'Feedback'),
@@ -260,13 +267,6 @@ class DevToolsInfoDialog extends StatelessWidget {
         ],
       ),
     );
-  }
-
-  List<Widget> _header(TextTheme textTheme, String title) {
-    return [
-      Text(title, style: textTheme.headline6),
-      const PaddedDivider(padding: EdgeInsets.only(bottom: denseRowSpacing)),
-    ];
   }
 
   Widget _devtoolsInfo(BuildContext context) {
@@ -326,14 +326,14 @@ class _SettingsDialogState extends State<SettingsDialog> {
     }
 
     return AlertDialog(
-      title: const Text('Settings'),
       actions: [
         DialogCloseButton(),
       ],
       content: Column(
         mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          // Theme setting
+          ..._header(Theme.of(context).textTheme, 'Settings'),
           InkWell(
             onTap: _toggleTheme,
             child: Row(

--- a/packages/devtools_app/lib/src/flutter/banner_messages.dart
+++ b/packages/devtools_app/lib/src/flutter/banner_messages.dart
@@ -207,6 +207,7 @@ class BannerMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Card(
       color: backgroundColor,
+      margin: const EdgeInsets.only(bottom: denseRowSpacing),
       child: Padding(
         padding: const EdgeInsets.all(defaultSpacing),
         child: Row(

--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -131,7 +131,8 @@ class NotificationsState extends State<_NotificationsProvider>
     return Align(
       alignment: Alignment.bottomRight,
       child: Padding(
-        // Clear the status line.
+        // Position the notifications in the lower right of the app window, and
+        // high enough up that we don't obscure the status line.
         padding: const EdgeInsets.only(
           right: defaultSpacing,
           bottom: status_line.statusLineHeight + defaultSpacing,

--- a/packages/devtools_app/lib/src/flutter/notifications.dart
+++ b/packages/devtools_app/lib/src/flutter/notifications.dart
@@ -8,8 +8,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'common_widgets.dart';
+import 'status_line.dart' as status_line;
+import 'theme.dart';
 
-const _notificationHeight = 160.0;
+const _notificationHeight = 175.0;
 final _notificationWidth = _notificationHeight * goldenRatio;
 
 /// Interface for pushing notifications in the app.
@@ -128,14 +130,21 @@ class NotificationsState extends State<_NotificationsProvider>
   Widget _buildOverlay(BuildContext context) {
     return Align(
       alignment: Alignment.bottomRight,
-      child: SizedBox(
-        width: _notificationWidth,
-        child: SingleChildScrollView(
-          reverse: true,
-          child: Column(
-            verticalDirection: VerticalDirection.down,
-            mainAxisSize: MainAxisSize.min,
-            children: _notifications,
+      child: Padding(
+        // Clear the status line.
+        padding: const EdgeInsets.only(
+          right: defaultSpacing,
+          bottom: status_line.statusLineHeight + defaultSpacing,
+        ),
+        child: SizedBox(
+          width: _notificationWidth,
+          child: SingleChildScrollView(
+            reverse: true,
+            child: Column(
+              verticalDirection: VerticalDirection.down,
+              mainAxisSize: MainAxisSize.min,
+              children: _notifications,
+            ),
           ),
         ),
       ),

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -175,11 +175,28 @@ class StatusLine extends StatelessWidget {
                 '${vm.targetCPU}-${vm.architectureBits} ${vm.operatingSystem}';
           }
 
-          return Text(
-            'Connected ($description)',
-            style: textTheme.bodyText2,
-            overflow: TextOverflow.clip,
-            //maxLines: 1,
+          // TODO(devoncarew): Add an interactive dialog to the device status
+          // line.
+
+          return Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: <Widget>[
+              Text(
+                'Device: ',
+                style: textTheme.bodyText2,
+                overflow: TextOverflow.clip,
+              ),
+              Text(
+                description,
+                style: textTheme.bodyText2,
+                overflow: TextOverflow.clip,
+              ),
+              const SizedBox(width: 2.0),
+              Icon(
+                Icons.phone_android,
+                size: defaultIconSize,
+              ),
+            ],
           );
         } else {
           return Text(

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -180,14 +180,9 @@ class StatusLine extends StatelessWidget {
 
           return Row(
             mainAxisAlignment: MainAxisAlignment.end,
-            children: <Widget>[
+            children: [
               Text(
-                'Device: ',
-                style: textTheme.bodyText2,
-                overflow: TextOverflow.clip,
-              ),
-              Text(
-                description,
+                'Device: $description',
                 style: textTheme.bodyText2,
                 overflow: TextOverflow.clip,
               ),

--- a/packages/devtools_app/test/flutter/about_dialog_test.dart
+++ b/packages/devtools_app/test/flutter/about_dialog_test.dart
@@ -10,11 +10,11 @@ import '../support/utils.dart';
 import 'wrappers.dart';
 
 void main() {
-  DevToolsInfoDialog aboutDialog;
+  DevToolsAboutDialog aboutDialog;
 
-  group('Info Dialog', () {
+  group('About Dialog', () {
     setUp(() {
-      aboutDialog = DevToolsInfoDialog();
+      aboutDialog = DevToolsAboutDialog();
     });
 
     testWidgets('builds dialog', (WidgetTester tester) async {

--- a/packages/devtools_app/test/flutter/info_dialog_test.dart
+++ b/packages/devtools_app/test/flutter/info_dialog_test.dart
@@ -19,12 +19,12 @@ void main() {
 
     testWidgets('builds dialog', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(aboutDialog));
-      expect(find.text('DevTools'), findsOneWidget);
+      expect(find.text('About DevTools'), findsOneWidget);
     });
 
     testWidgets('DevTools section', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(aboutDialog));
-      expect(find.text('DevTools'), findsOneWidget);
+      expect(find.text('About DevTools'), findsOneWidget);
       expect(findSubstring(aboutDialog, devtools.version), findsOneWidget);
     });
 


### PR DESCRIPTION
Various UI tweaks:
- tweak the padding around our connection warning messages (profile mode and debug mode)
- reorder the info button and settings buttons
- rename the info button to an about button
- unify the look of the about and settings dialogs
- have the 'connected' notifications just take up one line if the message is short
- adjust the location of the notifications so they don't obscure the status line
- add a mobile device icon to the status line

<img width="240" alt="Screen Shot 2020-04-02 at 8 06 55 AM" src="https://user-images.githubusercontent.com/1269969/78270422-a8ee8180-74bf-11ea-9a9a-d3ecc33f8237.png">

<img width="422" alt="Screen Shot 2020-04-02 at 8 38 07 AM" src="https://user-images.githubusercontent.com/1269969/78270441-adb33580-74bf-11ea-911c-c20b7a77e3e2.png">
