### PR TITLE
add a SettingsController

### DIFF
--- a/packages/devtools_app/lib/html_main.dart
+++ b/packages/devtools_app/lib/html_main.dart
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-
 import 'dart:html';
+
 import 'package:pedantic/pedantic.dart';
 import 'package:platform_detect/platform_detect.dart';
 
@@ -20,7 +20,7 @@ void main() {
       // Initialize the core framework.
       FrameworkCore.init(window.location.toString());
 
-      // Hookup for possbile analytic collection.
+      // Hookup for possible analytic collection.
       ga.exposeGaDevToolsEnabledToJs();
 
       if (ga.isGtagsReset()) {

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -277,10 +277,6 @@ class SettingsDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final preferences = DevToolsApp.of(context).preferences;
 
-    void _toggleTheme() {
-      preferences.darkModeTheme.value = !preferences.darkModeTheme.value;
-    }
-
     return AlertDialog(
       actions: [
         DialogCloseButton(),
@@ -291,7 +287,9 @@ class SettingsDialog extends StatelessWidget {
         children: [
           ..._header(Theme.of(context).textTheme, 'Settings'),
           InkWell(
-            onTap: _toggleTheme,
+            onTap: () {
+              preferences.toggleDarkModeTheme(!preferences.darkModeTheme.value);
+            },
             child: Row(
               children: [
                 ValueListenableBuilder(
@@ -300,7 +298,7 @@ class SettingsDialog extends StatelessWidget {
                     return Checkbox(
                       value: value,
                       onChanged: (bool value) {
-                        preferences.darkModeTheme.value = value;
+                        preferences.toggleDarkModeTheme(value);
                       },
                     );
                   },

--- a/packages/devtools_app/lib/src/flutter/controllers.dart
+++ b/packages/devtools_app/lib/src/flutter/controllers.dart
@@ -73,8 +73,7 @@ class ProvidedControllers implements DisposableController {
 ///
 /// See [Controllers.of] for how to retrieve a [ProvidedControllers] instance.
 class Controllers extends StatefulWidget {
-  const Controllers({Key key, Widget child})
-      : this._(key: key, child: child, overrideProviders: null);
+  const Controllers({Key key, Widget child}) : this._(key: key, child: child);
 
   @visibleForTesting
   const Controllers.overridden({Key key, this.child, this.overrideProviders});

--- a/packages/devtools_app/lib/src/flutter/preferences.dart
+++ b/packages/devtools_app/lib/src/flutter/preferences.dart
@@ -1,0 +1,56 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import '../ui/theme.dart' as devtools_theme;
+
+// TODO(devoncarew): This controller is currently backed by a global in
+// devtools_theme. A future refactor will instead provide a backing store on
+// disk.
+
+/// A controller for global application preferences.
+class PreferencesController {
+  PreferencesController() {
+    // TODO(devoncarew): Enable when we have storage backed settings.
+    //if (storage == null) {
+    //  // This can happen when running tests.
+    //  log('PreferencesController: storage not initialized');
+    //  return;
+    //}
+
+    // TODO(devoncarew): Enable when we have storage backed settings.
+    // Get the current values and listen for and write back changes.
+    //storage.getValue('ui.darkMode').then((String value) {
+    //  darkModeTheme.value = value == null || value == 'true';
+    //  darkModeTheme.addListener(() {
+    //    setTheme(darkTheme: darkModeTheme.value);
+    //    storage.setValue('ui.darkMode', '${darkModeTheme.value}');
+    //  });
+    //});
+
+    darkModeTheme.addListener(() {
+      // ignore: deprecated_member_use_from_same_package
+      devtools_theme.setDarkTheme(darkModeTheme.value);
+    });
+
+    // TODO(devoncarew): Enable when we have storage backed settings.
+    //storage.getValue('analytics.enabled').then((String value) {
+    //  analyticsEnabled.value = value == 'true';
+    //  analyticsEnabled.addListener(() {
+    //    storage.setValue('analytics.enabled', '${analyticsEnabled.value}');
+    //  });
+    //});
+  }
+
+  final ValueNotifier<bool> darkModeTheme =
+      ValueNotifier(devtools_theme.isDarkTheme);
+
+  // TODO(devoncarew): Enable when we have storage backed settings.
+  final ValueNotifier<bool> analyticsEnabled = ValueNotifier(false);
+
+  void dispose() {
+    // Nothing to do here.
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/preferences.dart
+++ b/packages/devtools_app/lib/src/flutter/preferences.dart
@@ -13,6 +13,15 @@ import '../ui/theme.dart' as devtools_theme;
 /// A controller for global application preferences.
 class PreferencesController {
   PreferencesController() {
+    _init();
+  }
+
+  final ValueNotifier<bool> _darkModeTheme =
+      ValueNotifier(devtools_theme.isDarkTheme);
+
+  ValueListenable get darkModeTheme => _darkModeTheme;
+
+  void _init() {
     // TODO(devoncarew): Enable when we have storage backed settings.
     //if (storage == null) {
     //  // This can happen when running tests.
@@ -30,27 +39,14 @@ class PreferencesController {
     //  });
     //});
 
-    darkModeTheme.addListener(() {
+    _darkModeTheme.addListener(() {
       // ignore: deprecated_member_use_from_same_package
-      devtools_theme.setDarkTheme(darkModeTheme.value);
+      devtools_theme.setDarkTheme(_darkModeTheme.value);
     });
-
-    // TODO(devoncarew): Enable when we have storage backed settings.
-    //storage.getValue('analytics.enabled').then((String value) {
-    //  analyticsEnabled.value = value == 'true';
-    //  analyticsEnabled.addListener(() {
-    //    storage.setValue('analytics.enabled', '${analyticsEnabled.value}');
-    //  });
-    //});
   }
 
-  final ValueNotifier<bool> darkModeTheme =
-      ValueNotifier(devtools_theme.isDarkTheme);
-
-  // TODO(devoncarew): Enable when we have storage backed settings.
-  final ValueNotifier<bool> analyticsEnabled = ValueNotifier(false);
-
-  void dispose() {
-    // Nothing to do here.
+  /// Change the value for the dark mode setting.
+  void toggleDarkModeTheme(bool useDarkMode) {
+    _darkModeTheme.value = useDarkMode;
   }
 }

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -12,7 +12,7 @@ import '../core/message_bus.dart';
 import '../globals.dart';
 import '../service.dart';
 import '../service_manager.dart';
-import '../ui/theme.dart' as theme;
+import '../ui/theme.dart';
 import '../vm_service_wrapper.dart';
 
 typedef ErrorReporter = void Function(String title, dynamic error);
@@ -22,8 +22,10 @@ class FrameworkCore {
     // Print the version number at startup.
     log('DevTools version ${devtools.version}.');
 
-    final uri = Uri.parse(url);
-    theme.initializeTheme(uri.queryParameters['theme']);
+    // ignore: deprecated_member_use_from_same_package
+    final theme = Uri.parse(url).queryParameters['theme'];
+    // ignore: deprecated_member_use_from_same_package
+    setDarkTheme(theme == 'dark');
 
     _setGlobals();
   }

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -5,6 +5,8 @@
 import 'fake_flutter/fake_flutter.dart';
 import 'flutter_html_shim.dart';
 
+bool _isDarkTheme = false;
+
 /// Whether the application is running with a light or dark theme.
 ///
 /// All Dart code that behaves differently depending on whether the current
@@ -12,20 +14,14 @@ import 'flutter_html_shim.dart';
 ///
 /// Generally Dart code should use [ThemedColor] everywhere colors are used so
 /// that code can be written without directly depending on [isDarkTheme].
-bool get isDarkTheme => _isDarkTheme;
-bool _isDarkTheme = false;
-
-/// Change the value for the current theme.
 ///
-/// Note: this does not rebuild the widget hierarchy.
-set useDarkTheme(bool value) {
-  _isDarkTheme = value;
+/// This getter will be deprecated - prefer using the SettingsController class.
+bool get isDarkTheme => _isDarkTheme;
 
-  clearColorCache();
-}
+@Deprecated('Prefer using the SettingsController')
+void setDarkTheme(bool dark) {
+  _isDarkTheme = dark;
 
-void initializeTheme(String theme) {
-  _isDarkTheme = theme == 'dark';
   clearColorCache();
 }
 

--- a/packages/devtools_app/test/flutter/navigation_test.dart
+++ b/packages/devtools_app/test/flutter/navigation_test.dart
@@ -111,7 +111,8 @@ void main() {
       testWidgets('Builds with global dark mode when dark mode is on',
           (WidgetTester tester) async {
         String generatedRoute;
-        initializeTheme('dark');
+        // ignore: deprecated_member_use_from_same_package
+        setDarkTheme(true);
         await tester.pumpWidget(unnamedRouteApp((context) {
           generatedRoute =
               routeNameWithQueryParams(context, '/home', {'foo': 'baz'});
@@ -119,7 +120,8 @@ void main() {
         await tester.pumpAndSettle();
         expect(generatedRoute, '/home?foo=baz&theme=dark');
         // Teardown the global theme change
-        initializeTheme('light');
+        // ignore: deprecated_member_use_from_same_package
+        setDarkTheme(false);
       });
 
       testWidgets('Builds with global light mode when dark mode is off',

--- a/packages/devtools_app/test/flutter/preferences_controller_test.dart
+++ b/packages/devtools_app/test/flutter/preferences_controller_test.dart
@@ -17,7 +17,7 @@ void main() {
       expect(controller.darkModeTheme.value, isNotNull);
     });
 
-    test('changes value', () {
+    test('toggleDarkModeTheme', () {
       bool valueChanged = false;
       final originalValue = controller.darkModeTheme.value;
 
@@ -25,7 +25,7 @@ void main() {
         valueChanged = true;
       });
 
-      controller.darkModeTheme.value = !controller.darkModeTheme.value;
+      controller.toggleDarkModeTheme(!controller.darkModeTheme.value);
       expect(valueChanged, isTrue);
       expect(controller.darkModeTheme.value, isNot(originalValue));
     });

--- a/packages/devtools_app/test/flutter/preferences_controller_test.dart
+++ b/packages/devtools_app/test/flutter/preferences_controller_test.dart
@@ -1,0 +1,33 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/preferences.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('PreferencesController', () {
+    PreferencesController controller;
+
+    setUp(() {
+      controller = PreferencesController();
+    });
+
+    test('has value', () {
+      expect(controller.darkModeTheme.value, isNotNull);
+    });
+
+    test('changes value', () {
+      bool valueChanged = false;
+      final originalValue = controller.darkModeTheme.value;
+
+      controller.darkModeTheme.addListener(() {
+        valueChanged = true;
+      });
+
+      controller.darkModeTheme.value = !controller.darkModeTheme.value;
+      expect(valueChanged, isTrue);
+      expect(controller.darkModeTheme.value, isNot(originalValue));
+    });
+  });
+}

--- a/packages/devtools_app/test/ui/theme_test.dart
+++ b/packages/devtools_app/test/ui/theme_test.dart
@@ -13,7 +13,8 @@ void main() {
   const Color customColor = ThemedColor(customLight, customDark);
 
   test('light theme', () {
-    initializeTheme('light');
+    // ignore: deprecated_member_use_from_same_package
+    setDarkTheme(false);
     expect(defaultBackground.red, equals(255));
     expect(defaultBackground.green, equals(255));
     expect(defaultBackground.blue, equals(255));
@@ -35,7 +36,8 @@ void main() {
   });
 
   test('dark theme', () {
-    initializeTheme('dark');
+    // ignore: deprecated_member_use_from_same_package
+    setDarkTheme(true);
     expect(defaultBackground.red, equals(0));
     expect(defaultBackground.green, equals(0));
     expect(defaultBackground.blue, equals(0));


### PR DESCRIPTION
- add a SettingsController; use that in the app to control the current theme (and address a todo)

In a future refactor, this controller will be backed by storage on disk, and changes will propagate via the SSE connection to the devtools server. The theme variable in the url is now used for initial setup of the theme value, but the SettingsController's value is used after that. 

Pulled out of https://github.com/flutter/devtools/pull/1787 to make that PR smaller.
