### PR TITLE
Add DebuggerController to provided controllers.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -9,6 +9,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
+import '../../flutter/controllers.dart';
 import '../../flutter/flex_split_column.dart';
 import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/octicons.dart';
@@ -65,8 +66,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   @override
   void initState() {
     super.initState();
-    // TODO(djshuckerow): promote this controller to app-level Controllers.
-    controller = DebuggerController();
+    final newController = Controllers.of(context).debugger;
+    if (newController == controller) return;
+    controller = newController;
     addAutoDisposeListener(controller.isPaused, _onPaused);
     addAutoDisposeListener(controller.breakpoints);
     // TODO(djshuckerow): Make the loading process disposable.

--- a/packages/devtools_app/lib/src/flutter/controllers.dart
+++ b/packages/devtools_app/lib/src/flutter/controllers.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../auto_dispose.dart';
+import '../debugger/flutter/debugger_controller.dart';
 import '../globals.dart';
 import '../logging/logging_controller.dart';
 import '../memory/flutter/memory_controller.dart';
@@ -26,11 +27,13 @@ class ProvidedControllers implements DisposableController {
     @required this.timeline,
     @required this.memory,
     @required this.performance,
+    @required this.debugger,
     @required this.bannerMessages,
   })  : assert(logging != null),
         assert(timeline != null),
         assert(memory != null),
         assert(performance != null),
+        assert(debugger != null),
         assert(bannerMessages != null);
 
   /// Builds the default providers for the app.
@@ -47,6 +50,7 @@ class ProvidedControllers implements DisposableController {
       timeline: TimelineController(),
       memory: MemoryController(),
       performance: PerformanceController(),
+      debugger: DebuggerController(),
       bannerMessages: BannerMessagesController(),
     );
   }
@@ -55,6 +59,7 @@ class ProvidedControllers implements DisposableController {
   final TimelineController timeline;
   final MemoryController memory;
   final PerformanceController performance;
+  final DebuggerController debugger;
   final BannerMessagesController bannerMessages;
 
   @override
@@ -63,6 +68,7 @@ class ProvidedControllers implements DisposableController {
     timeline.dispose();
     memory.dispose();
     performance.dispose();
+    debugger.dispose();
   }
 }
 

--- a/packages/devtools_app/test/flutter/wrappers.dart
+++ b/packages/devtools_app/test/flutter/wrappers.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/debugger/flutter/debugger_controller.dart';
 import 'package:devtools_app/src/flutter/banner_messages.dart';
 import 'package:devtools_app/src/flutter/controllers.dart';
 import 'package:devtools_app/src/flutter/notifications.dart';
@@ -37,6 +38,7 @@ Widget wrapWithControllers(
   MemoryController memory,
   TimelineController timeline,
   PerformanceController performance,
+  DebuggerController debugger,
   BannerMessagesController bannerMessages,
 }) {
   return MaterialApp(
@@ -49,6 +51,7 @@ Widget wrapWithControllers(
             memory: memory ?? MockFlutterMemoryController(),
             timeline: timeline ?? MockTimelineController(),
             performance: performance ?? MockPerformanceController(),
+            debugger: debugger ?? MockDebuggerController(),
             bannerMessages: bannerMessages ?? MockBannerMessagesController(),
           );
         },

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:devtools_app/src/connected_app.dart';
+import 'package:devtools_app/src/debugger/flutter/debugger_controller.dart';
 import 'package:devtools_app/src/flutter/banner_messages.dart';
 import 'package:devtools_app/src/flutter/initializer.dart' as initializer;
 import 'package:devtools_app/src/logging/logging_controller.dart';
@@ -265,6 +266,8 @@ class MockFlutterMemoryController extends Mock
 class MockTimelineController extends Mock implements TimelineController {}
 
 class MockPerformanceController extends Mock implements PerformanceController {}
+
+class MockDebuggerController extends Mock implements DebuggerController {}
 
 /// Fake that simplifies writing UI tests that depend on the
 /// ServiceExtensionManager.

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -134,6 +134,11 @@ class FakeVmService extends Fake implements VmServiceWrapper {
       );
 
   @override
+  Future<Isolate> getIsolate(String isolateId) {
+    return Future.value(MockIsolate());
+  }
+
+  @override
   Future<Success> setFlag(String name, String value) {
     final List<Flag> flags = _flags['flags'];
     final existingFlag =
@@ -240,16 +245,24 @@ class FakeVmService extends Fake implements VmServiceWrapper {
 
   @override
   Stream<Event> get onExtensionEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onDebugEvent => const Stream.empty();
 }
 
 class FakeIsolateManager extends Fake implements IsolateManager {
   @override
   IsolateRef get selectedIsolate => IsolateRef.parse({'id': 'fake_isolate_id'});
+
+  @override
+  Stream<IsolateRef> get onSelectedIsolateChanged => const Stream.empty();
 }
 
 class MockServiceManager extends Mock implements ServiceConnectionManager {}
 
 class MockVmService extends Mock implements VmServiceWrapper {}
+
+class MockIsolate extends Mock implements Isolate {}
 
 class MockConnectedApp extends Mock implements ConnectedApp {}
 


### PR DESCRIPTION
DebuggerController can now be accessed via `Controller.of(context)`, like other controllers in DevTools.