### PR TITLE
Add selected row to TreeTableState

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -209,6 +209,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   List<T> animatingChildren = [];
   Set<T> animatingChildrenSet = {};
   T animatingNode;
+  T selectedNode;
   List<double> columnWidths;
   List<bool> rootsExpanded;
 
@@ -263,8 +264,10 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
 
   void _onItemPressed(T node) {
     /// Rebuilds the table whenever the tree structure has been updated
-    if (!node.isExpandable) return;
     setState(() {
+      selectedNode = node;
+
+      if (!node.isExpandable) return;
       animatingNode = node;
       List<T> nodeChildren;
       if (node.isExpanded) {
@@ -365,12 +368,15 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     int index,
   ) {
     Widget rowForNode(T node) {
+      final isNodeSelected = selectedNode == node;
       return TableRow<T>(
         key: widget.keyFactory(node),
         linkedScrollControllerGroup: linkedScrollControllerGroup,
         node: node,
         onPressed: _onItemPressed,
-        backgroundColor: TableRow.colorFor(context, index),
+        backgroundColor: isNodeSelected
+            ? Theme.of(context).selectedRowColor
+            : TableRow.colorFor(context, index),
         columns: widget.columns,
         columnWidths: columnWidths,
         expandableColumn: widget.treeColumn,

--- a/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,8 +5,10 @@
 import FlutterMacOS
 import Foundation
 
+import path_provider_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -546,6 +546,7 @@ void main() {
       // Expected values returned through accessing Color.value property.
       const color1Value = 4293585900;
       const color2Value = 4294638330;
+      const rowSelectedColorValue = 4294309365;
 
       await tester.pumpWidget(wrap(table));
       await tester.pumpAndSettle();
@@ -584,7 +585,8 @@ void main() {
       crackleRow = tester.widget(crackleFinder);
 
       expect(fooRow.backgroundColor.value, equals(color1Value));
-      expect(barRow.backgroundColor.value, equals(color2Value));
+      // [barRow] has the rowSelected color after being tapped.
+      expect(barRow.backgroundColor.value, equals(rowSelectedColorValue));
       // [crackleRow] has a different background color after collapsing previous
       // row (Bar).
       expect(crackleRow.backgroundColor.value, equals(color1Value));


### PR DESCRIPTION
TreeTableState now maintains a selected row (currently, the last row to
be clicked on) and draws it in selectedRowColor.

Selection is needed to implement arrow key traversal in #1769