### PR TITLE
Remove unnecessary Containers (and enable lint)

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -54,6 +54,7 @@ linter:
     - avoid_slow_async_io
     # - avoid_types_as_parameter_names # https://github.com/dart-lang/linter/pull/954/files
     # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    - avoid_unnecessary_containers
     # - avoid_unused_constructor_parameters # https://github.com/dart-lang/linter/pull/847
     - await_only_futures
     - camel_case_types

--- a/case_study/memory_leak/lib/tabs/http_data.dart
+++ b/case_study/memory_leak/lib/tabs/http_data.dart
@@ -106,29 +106,27 @@ class MyGetHttpDataState extends State<MyGetHttpData> {
       body: ListView.builder(
           itemCount: data == null ? 0 : data.length,
           itemBuilder: (BuildContext context, int index) {
-            return Container(
-              child: Center(
-                  child: Column(
-                // Stretch the cards in horizontal axis
-                crossAxisAlignment: CrossAxisAlignment.stretch,
-                children: <Widget>[
-                  Card(
-                    child: Container(
-                      child: Text(
-                        // Read the name field value and set it in the Text widget
-                        api?.display(data, index),
+            return Center(
+                child: Column(
+              // Stretch the cards in horizontal axis
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: <Widget>[
+                Card(
+                  child: Container(
+                    child: Text(
+                      // Read the name field value and set it in the Text widget
+                      api?.display(data, index),
 
-                        // set some style to text
-                        style: TextStyle(
-                            fontSize: 20.0, color: Colors.lightBlueAccent),
-                      ),
-                      // added padding
-                      padding: const EdgeInsets.all(15.0),
+                      // set some style to text
+                      style: TextStyle(
+                          fontSize: 20.0, color: Colors.lightBlueAccent),
                     ),
-                  )
-                ],
-              )),
-            );
+                    // added padding
+                    padding: const EdgeInsets.all(15.0),
+                  ),
+                )
+              ],
+            ));
           }),
     );
   }

--- a/case_study/memory_leak/lib/tabs/http_data.dart
+++ b/case_study/memory_leak/lib/tabs/http_data.dart
@@ -110,7 +110,7 @@ class MyGetHttpDataState extends State<MyGetHttpData> {
                 child: Column(
               // Stretch the cards in horizontal axis
               crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: <Widget>[
+              children: [
                 Card(
                   child: Container(
                     child: Text(

--- a/packages/devtools_app/lib/src/inspector/flutter/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/layout_explorer/flex/flex.dart
@@ -681,13 +681,11 @@ class _FlexLayoutExplorerWidgetState extends State<FlexLayoutExplorerWidget>
                   children: [
                     Expanded(
                       flex: 2,
-                      child: Container(
-                        child: Text(
-                          describeEnum(alignment),
-                          style: TextStyle(color: color),
-                          textAlign: TextAlign.center,
-                          overflow: TextOverflow.ellipsis,
-                        ),
+                      child: Text(
+                        describeEnum(alignment),
+                        style: TextStyle(color: color),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
                       ),
                     ),
                     Flexible(
@@ -714,13 +712,11 @@ class _FlexLayoutExplorerWidgetState extends State<FlexLayoutExplorerWidget>
                     crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Expanded(
-                        child: Container(
-                          child: Text(
-                            describeEnum(alignment),
-                            style: TextStyle(color: color),
-                            textAlign: TextAlign.center,
-                            overflow: TextOverflow.ellipsis,
-                          ),
+                        child: Text(
+                          describeEnum(alignment),
+                          style: TextStyle(color: color),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
                         ),
                       ),
                       Flexible(

--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
@@ -51,10 +51,8 @@ class HttpRequestInspector extends StatelessWidget {
           Row(
             children: [
               Flexible(
-                child: Container(
-                  child: TabBar(
-                    tabs: tabs,
-                  ),
+                child: TabBar(
+                  tabs: tabs,
                 ),
               ),
             ],

--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector_views.dart
@@ -246,38 +246,36 @@ class HttpRequestCookiesView extends StatelessWidget {
   Widget build(BuildContext context) {
     final requestCookies = data.requestCookies;
     final responseCookies = data.responseCookies;
-    return Container(
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          return Column(
-            children: [
-              if (responseCookies.isNotEmpty)
-                _buildCookiesTable(
-                  context,
-                  'Response Cookies',
-                  responseCookies,
-                  constraints,
-                  responseCookiesKey,
-                ),
-              // Add padding between the cookie tables if displaying both
-              // response and request cookies.
-              if (responseCookies.isNotEmpty && requestCookies.isNotEmpty)
-                const Padding(
-                  padding: EdgeInsets.only(bottom: 24.0),
-                ),
-              if (requestCookies.isNotEmpty)
-                _buildCookiesTable(
-                  context,
-                  'Request Cookies',
-                  requestCookies,
-                  constraints,
-                  requestCookiesKey,
-                  requestCookies: true,
-                ),
-            ],
-          );
-        },
-      ),
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return Column(
+          children: [
+            if (responseCookies.isNotEmpty)
+              _buildCookiesTable(
+                context,
+                'Response Cookies',
+                responseCookies,
+                constraints,
+                responseCookiesKey,
+              ),
+            // Add padding between the cookie tables if displaying both
+            // response and request cookies.
+            if (responseCookies.isNotEmpty && requestCookies.isNotEmpty)
+              const Padding(
+                padding: EdgeInsets.only(bottom: 24.0),
+              ),
+            if (requestCookies.isNotEmpty)
+              _buildCookiesTable(
+                context,
+                'Request Cookies',
+                requestCookies,
+                constraints,
+                requestCookiesKey,
+                requestCookies: true,
+              ),
+          ],
+        );
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -187,17 +187,15 @@ class NetworkScreenBodyState extends State<NetworkScreenBody> {
       builder: (context, HttpRequestData data, widget) {
         return Expanded(
           child: (!isRecording && _dataTableSource.rowCount == 0)
-              ? Container(
-                  child: Center(
-                    child: recordingInfo(
-                      instructionsKey: NetworkScreen.recordingInstructionsKey,
-                      recording: isRecording,
-                      // TODO(kenz): create a processing notifier if necessary
-                      // for this data.
-                      processing: false,
-                      recordedObject: 'HTTP requests',
-                      isPause: true,
-                    ),
+              ? Center(
+                  child: recordingInfo(
+                    instructionsKey: NetworkScreen.recordingInstructionsKey,
+                    recording: isRecording,
+                    // TODO(kenz): create a processing notifier if necessary
+                    // for this data.
+                    processing: false,
+                    recordedObject: 'HTTP requests',
+                    isPause: true,
                   ),
                 )
               : Split(

--- a/packages/devtools_app/test/flutter/flame_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flame_chart_test.dart
@@ -30,11 +30,9 @@ void main() {
     );
 
     Future<void> pumpFlameChart(WidgetTester tester) async {
-      await tester.pumpWidget(Container(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: flameChart,
-        ),
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: flameChart,
       ));
     }
 
@@ -173,18 +171,16 @@ void main() {
       WidgetTester tester,
       ScrollingFlameChartRow row,
     ) async {
-      await tester.pumpWidget(Container(
-        child: Directionality(
-          textDirection: TextDirection.ltr,
-          child: Overlay(
-            initialEntries: [
-              OverlayEntry(
-                builder: (context) {
-                  return currentRow = row;
-                },
-              ),
-            ],
-          ),
+      await tester.pumpWidget(Directionality(
+        textDirection: TextDirection.ltr,
+        child: Overlay(
+          initialEntries: [
+            OverlayEntry(
+              builder: (context) {
+                return currentRow = row;
+              },
+            ),
+          ],
         ),
       ));
     }


### PR DESCRIPTION
Follow-up from https://github.com/flutter/devtools/pull/1764#pullrequestreview-381500325.

Removes unneeded `Container` widgets and enables the corresponding lint.


/cc @jacob314 @kenzieschmoll @devoncarew 