### PR TITLE
Consolidate Screen and ConditionalScreen classes.

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -5,17 +5,39 @@
 import 'package:flutter/material.dart';
 
 import 'src/config_specific/flutter/framework_initialize/framework_initialize.dart';
+import 'src/debugger/flutter/debugger_screen.dart';
 import 'src/flutter/app.dart';
 import 'src/flutter/screen.dart';
+import 'src/info/flutter/info_screen.dart';
+import 'src/inspector/flutter/inspector_screen.dart';
+import 'src/logging/flutter/logging_screen.dart';
+import 'src/memory/flutter/memory_screen.dart';
+import 'src/network/flutter/network_screen.dart';
+import 'src/performance/flutter/performance_screen.dart';
+import 'src/timeline/flutter/timeline_screen.dart';
+
+// TODO(bkonyi): remove this bool when page is ready.
+const showNetworkPage = false;
 
 void main() {
-  // TODO(kenz): add some conditional screens.
-  const conditionalScreens = <ConditionalScreen>[];
+  // Conditional screens can be added to this list, and they will automatically
+  // be shown or hidden based on the [conditionalLibrary] provided.
+  const screens = <Screen>[
+    InspectorScreen(),
+    TimelineScreen(),
+    MemoryScreen(),
+    PerformanceScreen(),
+    DebuggerScreen(),
+    if (showNetworkPage) NetworkScreen(),
+    LoggingScreen(),
+    InfoScreen(),
+  ];
 
   initializeFramework();
 
   // Now run the app.
   runApp(
-    const DevToolsApp(conditionalScreens),
+    const DevToolsApp(screens),
   );
 }
+

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -40,4 +40,3 @@ void main() {
     const DevToolsApp(screens),
   );
 }
-

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -23,7 +23,7 @@ import 'utils.dart';
 /// Top-level configuration for the app.
 @immutable
 class DevToolsApp extends StatefulWidget {
-  const DevToolsApp([this.screens]);
+  const DevToolsApp(this.screens);
 
   final List<Screen> screens;
 

--- a/packages/devtools_app/lib/src/flutter/screen.dart
+++ b/packages/devtools_app/lib/src/flutter/screen.dart
@@ -19,7 +19,13 @@ import 'theme.dart';
 /// Defines a page shown in the DevTools [TabBar].
 @immutable
 abstract class Screen {
-  const Screen(this.type, {this.title, this.icon, this.tabKey});
+  const Screen(
+    this.type, {
+    this.title,
+    this.icon,
+    this.tabKey,
+    this.conditionalLibrary,
+  });
 
   final DevToolsScreenType type;
 
@@ -31,6 +37,16 @@ abstract class Screen {
   /// An optional key to use when creating the Tab widget (for use during
   /// testing).
   final Key tabKey;
+
+  /// Library uri that determines whether to include this screen in DevTools.
+  ///
+  /// This can either be a full library uri or it can be a prefix. If null, this
+  /// screen will be shown unconditionally.
+  ///
+  /// Examples:
+  ///  * 'package:provider/provider.dart'
+  ///  * 'package:provider/'
+  final String conditionalLibrary;
 
   /// Whether this screen should display the isolate selector in the status
   /// line.
@@ -74,58 +90,6 @@ abstract class Screen {
   Widget buildStatus(BuildContext context, TextTheme textTheme) {
     return null;
   }
-}
-
-/// Defines a page shown in the DevTools [TabBar] if [conditionalLibrary] is
-/// present in the connected application.
-///
-/// If [conditionalLibrary] is not present, the screen will be hidden from the
-/// [TabBar], not just disabled like other DevTools [Screen]s.
-///
-/// ```dart
-/// class PackageProviderScreen extends ConditionalScreen {
-///   const PackageProviderScreen()
-///       : super(
-///           conditionalLibrary: 'package:provider',
-///           screenType: const DevToolsScreenType(
-//              'packageProvider',
-//              createOverride: _create,
-//            ),
-///           title: 'Provider',
-///           icon: Icons.palette,
-///         );
-///
-///   static PackageProviderScreen _create() => const PackageProviderScreen();
-///
-///   @override
-///   Widget build(BuildContext context) {
-///     return const Center(child: Text('Package provider tools'));
-///   }
-/// }
-/// ```
-/// {@end-tool}
-abstract class ConditionalScreen extends Screen {
-  const ConditionalScreen({
-    @required this.conditionalLibrary,
-    @required DevToolsScreenType screenType,
-    String title,
-    IconData icon,
-    Key tabKey,
-  }) : super(
-          screenType,
-          title: title,
-          icon: icon,
-          tabKey: tabKey,
-        );
-
-  /// Library uri that determines whether to include this screen in DevTools.
-  ///
-  /// This can either be a full library uri or it can be a prefix.
-  ///
-  /// Examples:
-  ///  * 'package:provider/provider.dart'
-  ///  * 'package:provider/'
-  final String conditionalLibrary;
 }
 
 class DevToolsScreenType {

--- a/packages/devtools_app/test/flutter/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/flutter/integration/dart_cli_profile_test.dart
@@ -52,7 +52,7 @@ Future<void> main() async {
       FrameworkCore.init('');
       final app = DefaultAssetBundle(
         bundle: _DiskAssetBundle(),
-        child: const DevToolsApp(),
+        child: const DevToolsApp([]),
       );
       await tester.pumpWidget(app);
       await tester.pumpAndSettle();


### PR DESCRIPTION
This CL also pulls screen definition out into `main.dart` so that conditional screens can be ordered in a more flexible manner.