### PR TITLE
Use light grey color for debugger pane headers in light theme.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math' as math;
 
-import 'package:devtools_app/src/ui/theme.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:vm_service/vm_service.dart';
 
@@ -19,6 +18,7 @@ import '../../flutter/split.dart';
 import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../ui/flutter/label.dart';
+import '../../ui/theme.dart';
 import 'debugger_controller.dart';
 
 class DebuggerScreen extends Screen {

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -4,6 +4,7 @@
 
 import 'dart:math' as math;
 
+import 'package:devtools_app/src/ui/theme.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:vm_service/vm_service.dart';
 
@@ -209,14 +210,15 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   }
 
   FlexSplitColumnHeader _debuggerPaneHeader(String title) {
+    final theme = Theme.of(context);
     return FlexSplitColumnHeader(
       height: debuggerPaneHeaderHeight,
       child: Container(
         decoration: BoxDecoration(
           border: Border(
-            bottom: BorderSide(color: Theme.of(context).focusColor),
+            bottom: BorderSide(color: theme.focusColor),
           ),
-          color: Theme.of(context).primaryColor,
+          color: ThemedColor(devtoolsGrey[50], theme.primaryColor),
         ),
         padding: const EdgeInsets.only(left: defaultSpacing),
         alignment: Alignment.centerLeft,


### PR DESCRIPTION
Before:
![Screen Shot 2020-04-10 at 8 38 46 AM](https://user-images.githubusercontent.com/43759233/79003113-bda5c780-7b06-11ea-83e8-97ef0ffa7aa4.png)

After:
![Screen Shot 2020-04-10 at 8 36 29 AM](https://user-images.githubusercontent.com/43759233/79003127-c5656c00-7b06-11ea-9ce1-ec58b97af2ba.png)

