### PR TITLE
Add keyboard navigation to move the selected row up and down for #1795.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -218,8 +218,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   int selectedNodeIndex;
   List<double> columnWidths;
   List<bool> rootsExpanded;
-
-  final focusNode = FocusNode();
+  FocusNode focusNode = FocusNode();
 
   @override
   void initState() {

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -535,8 +535,6 @@ void main() {
       await tester.pumpWidget(wrap(table));
       await tester.pumpAndSettle();
 
-      final fooFinder = find.byKey(const Key('Foo'));
-
       final TreeTableState state = tester.state(find.byWidget(table));
       state.focusNode.requestFocus();
       await tester.pumpAndSettle();

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -537,22 +537,22 @@ void main() {
 
       final fooFinder = find.byKey(const Key('Foo'));
 
-      await tester.tap(fooFinder);
-      await tester.pumpAndSettle();
       final TreeTableState state = tester.state(find.byWidget(table));
-
-      expect(state.selectedNode, equals(data.root));
-
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      state.focusNode.requestFocus();
       await tester.pumpAndSettle();
 
-      expect(state.selectedNode, equals(data.children[1]));
+      expect(state.selectedNode, equals(null));
+
+      // the root is selected by default when there is no selection. Pressing
+      // arrowDown should take us to the first child, Bar
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.pumpAndSettle();
+      expect(state.selectedNode, equals(data.children[0]));
 
       await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pumpAndSettle();
 
-      expect(state.selectedNode, equals(data.children[0]));
+      expect(state.selectedNode, equals(data.root));
     });
 
     testWidgets('properly colors rows with alternating colors',

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -1,7 +1,6 @@
 import 'package:devtools_app/src/flutter/table.dart';
 import 'package:devtools_app/src/table_data.dart';
 import 'package:devtools_app/src/trees.dart';
-//import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart' hide TableRow;
 import 'package:flutter/services.dart';
@@ -544,13 +543,13 @@ void main() {
 
       expect(state.selectedNode, equals(data.root));
 
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
       await tester.pumpAndSettle();
 
       expect(state.selectedNode, equals(data.children[1]));
 
-      await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowUp);
+      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
       await tester.pumpAndSettle();
 
       expect(state.selectedNode, equals(data.children[0]));


### PR DESCRIPTION
Add arrow up/down key navigation for the TreeTable.

In order to plumb together all the needed objects, it adds a focusNode parameter to _Table and also a handleKeyEvent callback with the layout constraints and scrollController.