### PR TITLE
various debugger UI improvements

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_state.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_state.dart
@@ -22,10 +22,12 @@ class DebuggerState {
   final Map<String, Script> _scriptCache = <String, Script>{};
 
   final _isPaused = ValueNotifier<bool>(false);
+
   ValueListenable<bool> get isPaused => _isPaused;
 
   final _hasFrames = ValueNotifier<bool>(false);
   ValueNotifier<bool> _supportsStepping;
+
   ValueListenable<bool> get supportsStepping {
     return _supportsStepping ??= () {
       final notifier = ValueNotifier<bool>(_isPaused.value && _hasFrames.value);
@@ -42,9 +44,11 @@ class DebuggerState {
   Event lastEvent;
 
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
+
   ValueListenable<List<Breakpoint>> get breakpoints => _breakpoints;
 
   final _exceptionPauseMode = ValueNotifier<String>(null);
+
   ValueListenable<String> get exceptionPauseMode => _exceptionPauseMode;
 
   InstanceRef _reportedException;

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -18,7 +18,6 @@ import '../../flutter/split.dart';
 import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../ui/flutter/label.dart';
-import '../../ui/theme.dart';
 import 'debugger_controller.dart';
 
 class DebuggerScreen extends Screen {
@@ -173,16 +172,13 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                   ? const Center(child: CircularProgressIndicator())
                   : OutlinedBorder(
                       child: Column(
-                        children: <Widget>[
+                        children: [
                           Container(
                             decoration: BoxDecoration(
                               border: Border(
                                 bottom: BorderSide(color: theme.focusColor),
                               ),
-                              color: ThemedColor(
-                                devtoolsGrey[50],
-                                theme.primaryColor,
-                              ),
+                              color: titleSolidBackgroundColor,
                             ),
                             padding:
                                 const EdgeInsets.only(left: defaultSpacing),
@@ -253,7 +249,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           border: Border(
             bottom: BorderSide(color: theme.focusColor),
           ),
-          color: ThemedColor(devtoolsGrey[50], theme.primaryColor),
+          color: titleSolidBackgroundColor,
         ),
         padding: const EdgeInsets.only(left: defaultSpacing),
         alignment: Alignment.centerLeft,
@@ -372,6 +368,12 @@ class ScriptPickerState extends State<ScriptPicker> {
 
   Widget _buildScript(ScriptRef ref) {
     final selectedColor = Theme.of(context).selectedRowColor;
+
+    TextStyle style;
+    if (ref == widget.selected) {
+      style = TextStyle(color: Theme.of(context).textSelectionColor);
+    }
+
     return Material(
       color: ref == widget.selected ? selectedColor : null,
       child: InkWell(
@@ -379,7 +381,10 @@ class ScriptPickerState extends State<ScriptPicker> {
         child: Container(
           padding: const EdgeInsets.all(4.0),
           alignment: Alignment.centerLeft,
-          child: Text('${ref?.uri?.split('/')?.last} (${ref?.uri})'),
+          child: Text(
+            '${ref?.uri?.split('/')?.last} (${ref?.uri})',
+            style: style,
+          ),
         ),
       ),
     );
@@ -438,6 +443,7 @@ class DebuggingControls extends StatelessWidget {
       valueListenable: controller.isPaused,
       builder: (context, isPaused, child) {
         return SizedBox(
+          // Increase the height by one to accommodate for the bottom border.
           height: DebuggerScreenBodyState.debuggerPaneHeaderHeight + 1.0,
           child: ListView(
             scrollDirection: Axis.horizontal,
@@ -682,18 +688,15 @@ class GutterRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final background = ThemedColor(devtoolsGrey[50], theme.primaryColor);
-
     return InkWell(
       onTap: onPressed,
       child: Container(
         height: _CodeViewState.rowHeight,
         padding: const EdgeInsets.only(left: 2.0, right: 4.0),
         alignment: Alignment.centerRight,
-        decoration: BoxDecoration(color: background),
+        decoration: BoxDecoration(color: titleSolidBackgroundColor),
         child: Row(
-          children: <Widget>[
+          children: [
             if (isBreakpoint) const Text('●'),
             Expanded(
               child: Text(
@@ -722,13 +725,21 @@ class ScriptRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    TextStyle style;
+    if (isPausedHere) {
+      style = TextStyle(color: Theme.of(context).textSelectionColor);
+    }
+
     return InkWell(
       onTap: onPressed,
       child: Container(
         alignment: Alignment.centerLeft,
         height: _CodeViewState.rowHeight,
         color: isPausedHere ? Theme.of(context).selectedRowColor : null,
-        child: Text(lineContents),
+        child: Text(
+          lineContents,
+          style: style,
+        ),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -369,11 +369,6 @@ class ScriptPickerState extends State<ScriptPicker> {
   Widget _buildScript(ScriptRef ref) {
     final selectedColor = Theme.of(context).selectedRowColor;
 
-    TextStyle style;
-    if (ref == widget.selected) {
-      style = TextStyle(color: Theme.of(context).textSelectionColor);
-    }
-
     return Material(
       color: ref == widget.selected ? selectedColor : null,
       child: InkWell(
@@ -383,7 +378,9 @@ class ScriptPickerState extends State<ScriptPicker> {
           alignment: Alignment.centerLeft,
           child: Text(
             '${ref?.uri?.split('/')?.last} (${ref?.uri})',
-            style: style,
+            style: ref == widget.selected
+                ? TextStyle(color: Theme.of(context).textSelectionColor)
+                : null,
           ),
         ),
       ),
@@ -649,6 +646,9 @@ class _CodeViewState extends State<CodeView> {
                   child: ListView(
                     controller: textController,
                     children: [
+                      // Note: below, lineNum is the 1-based line number (the
+                      // user facing one, and the one that the VM uses);
+                      // lineNum - 1 is the index into the lines array.
                       // TODO(devoncarew): We need to virtualize this.
                       for (var lineNum = 1; lineNum <= lines.length; lineNum++)
                         ScriptRow(
@@ -725,11 +725,6 @@ class ScriptRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    TextStyle style;
-    if (isPausedHere) {
-      style = TextStyle(color: Theme.of(context).textSelectionColor);
-    }
-
     return InkWell(
       onTap: onPressed,
       child: Container(
@@ -738,7 +733,9 @@ class ScriptRow extends StatelessWidget {
         color: isPausedHere ? Theme.of(context).selectedRowColor : null,
         child: Text(
           lineContents,
-          style: style,
+          style: isPausedHere
+              ? TextStyle(color: Theme.of(context).textSelectionColor)
+              : null,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -388,6 +388,7 @@ class ToggleButton extends StatelessWidget {
 
 class OutlinedBorder extends StatelessWidget {
   const OutlinedBorder({Key key, this.child}) : super(key: key);
+
   final Widget child;
 
   @override

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -134,6 +134,9 @@ const defaultCurve = Curves.easeInOutCubic;
 CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
 
+final titleSolidBackgroundColor =
+    ThemedColor(devtoolsGrey[50], devtoolsGrey[900]);
+
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);
 
 final chartLightTypeFace = TypeFace(

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -35,6 +35,9 @@ ThemeData _lightTheme() {
     primaryColorLight: devtoolsBlue[400],
     indicatorColor: Colors.yellowAccent[400],
     accentColor: devtoolsBlue[400],
+    backgroundColor: devtoolsGrey[600],
+    toggleableActiveColor: devtoolsBlue[400],
+    selectedRowColor: devtoolsBlue[600],
     buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth),
   );
 }

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -546,7 +546,7 @@ void main() {
       // Expected values returned through accessing Color.value property.
       const color1Value = 4293585900;
       const color2Value = 4294638330;
-      const rowSelectedColorValue = 4294309365;
+      const rowSelectedColorValue = 4278285762;
 
       await tester.pumpWidget(wrap(table));
       await tester.pumpAndSettle();
@@ -649,6 +649,7 @@ void main() {
 
 class TestData extends TreeNode<TestData> {
   TestData(this.name, this.number);
+
   final String name;
   final int number;
 


### PR DESCRIPTION
Various debugger UI improvements:
- render source view text with less line height
- make the debugger panel titles more compact
- address an issue where the state was not updated when the app resumed from pause
- address an issue where the debugger UI was 1 line based, but the VM uses 1-based line numbers
- various padding and layout tweaks
- address issues in the light theme in how selected lines were rendered
- display breakpoints as bullet chars (instead of border decorations around the line numbers)

<img width="1380" alt="Screen Shot 2020-04-12 at 5 49 14 AM" src="https://user-images.githubusercontent.com/1269969/79069999-71ce5c00-7c87-11ea-97f8-b9f9ac087a5b.png">

<img width="332" alt="Screen Shot 2020-04-12 at 5 49 25 AM" src="https://user-images.githubusercontent.com/1269969/79070002-7a269700-7c87-11ea-838d-4a3320ca8c94.png">

<img width="496" alt="Screen Shot 2020-04-12 at 5 49 38 AM" src="https://user-images.githubusercontent.com/1269969/79070008-7f83e180-7c87-11ea-8afe-7b8444fccc00.png">
