### PR TITLE
virtualize debugger lists; show execution point

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -14,6 +14,7 @@ class BreakpointPicker extends StatelessWidget {
   const BreakpointPicker(
       {Key key, @required this.breakpoints, @required this.controller})
       : super(key: key);
+
   final List<Breakpoint> breakpoints;
   final DebuggerController controller;
 

--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/theme.dart';
 import 'codeview.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
@@ -39,11 +40,12 @@ class BreakpointPicker extends StatelessWidget {
           child: SizedBox(
             width: MediaQuery.of(context).size.width,
             child: ListView.builder(
+              itemCount: breakpoints.length,
+              itemExtent: defaultListItemHeight,
               itemBuilder: (context, index) => SizedBox(
                 height: CodeView.rowHeight,
                 child: Text(textFor(breakpoints[index])),
               ),
-              itemCount: breakpoints.length,
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -96,6 +96,7 @@ class _CodeViewState extends State<CodeView> {
 
     if (pausedPositions.isNotEmpty) {
       final lineIndex = pausedPositions.first - 1;
+      // Back up 10 lines so the execution point isn't right at the top.
       final scrollPosition = (lineIndex - 10) * CodeView.rowHeight;
       verticalController.animateTo(
         math.max(0, scrollPosition),
@@ -144,7 +145,7 @@ class _CodeViewState extends State<CodeView> {
                 controller: gutterController,
                 itemExtent: CodeView.rowHeight,
                 itemCount: lines.length,
-                itemBuilder: (BuildContext context, int index) {
+                itemBuilder: (context, index) {
                   final lineNum = index + 1;
                   return GutterRow(
                     lineNumber: lineNum,
@@ -171,7 +172,7 @@ class _CodeViewState extends State<CodeView> {
                     controller: textController,
                     itemExtent: CodeView.rowHeight,
                     itemCount: lines.length,
-                    itemBuilder: (BuildContext context, int index) {
+                    itemBuilder: (context, index) {
                       final lineNum = index + 1;
                       return ScriptRow(
                         lineContents: lines[index],

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -15,7 +15,7 @@ Widget densePadding(Widget child) {
 }
 
 /// Create a header area for a debugger component.
-/// 
+///
 /// Either one of [text] or [child] must be supplied.
 Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
   assert(text != null || child != null);

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -4,9 +4,38 @@
 
 import 'package:flutter/material.dart';
 
+import '../../flutter/theme.dart';
+import 'debugger_screen.dart';
+
 Widget densePadding(Widget child) {
   return Padding(
     padding: const EdgeInsets.all(2.0),
     child: child,
+  );
+}
+
+/// Create a header area for a debugger component.
+/// 
+/// Either one of [text] or [child] must be supplied.
+Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
+  assert(text != null || child != null);
+  assert(text == null || child == null);
+
+  return Container(
+    decoration: BoxDecoration(
+      border: Border(
+        bottom: BorderSide(color: theme.focusColor),
+      ),
+      color: titleSolidBackgroundColor,
+    ),
+    padding: const EdgeInsets.only(left: defaultSpacing),
+    alignment: Alignment.centerLeft,
+    height: DebuggerScreen.debuggerPaneHeaderHeight,
+    child: child != null
+        ? child
+        : Text(
+            text,
+            style: theme.textTheme.subtitle2,
+          ),
   );
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -1,0 +1,45 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '../../flutter/common_widgets.dart';
+import '../../flutter/theme.dart';
+import 'debugger_screen.dart';
+
+class Console extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return OutlinedBorder(
+      child: Column(
+        children: [
+          buildTitle('Console', theme),
+          const Expanded(
+            child: Center(child: Text('todo:')),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Container buildTitle(String title, ThemeData theme) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: theme.focusColor),
+        ),
+        color: titleSolidBackgroundColor,
+      ),
+      padding: const EdgeInsets.only(left: defaultSpacing),
+      alignment: Alignment.centerLeft,
+      height: DebuggerScreen.debuggerPaneHeaderHeight,
+      child: Text(
+        title,
+        style: theme.textTheme.subtitle2,
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -5,8 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../flutter/common_widgets.dart';
-import '../../flutter/theme.dart';
-import 'debugger_screen.dart';
+import 'common.dart';
 
 class Console extends StatelessWidget {
   @override
@@ -16,29 +15,11 @@ class Console extends StatelessWidget {
     return OutlinedBorder(
       child: Column(
         children: [
-          buildTitle('Console', theme),
+          debuggerSectionTitle(theme, text: 'Console'),
           const Expanded(
             child: Center(child: Text('todo:')),
           ),
         ],
-      ),
-    );
-  }
-
-  Container buildTitle(String title, ThemeData theme) {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(
-          bottom: BorderSide(color: theme.focusColor),
-        ),
-        color: titleSolidBackgroundColor,
-      ),
-      padding: const EdgeInsets.only(left: defaultSpacing),
-      alignment: Alignment.centerLeft,
-      height: DebuggerScreen.debuggerPaneHeaderHeight,
-      child: Text(
-        title,
-        style: theme.textTheme.subtitle2,
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -17,6 +17,7 @@ import '../../globals.dart';
 import '../../ui/flutter/label.dart';
 import 'breakpoints.dart';
 import 'codeview.dart';
+import 'common.dart';
 import 'console.dart';
 import 'debugger_controller.dart';
 import 'scripts.dart';
@@ -177,7 +178,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                     OutlinedBorder(
                       child: Column(
                         children: [
-                          buildScriptTitle(theme),
+                          debuggerSectionTitle(theme,
+                              text: script == null ? ' ' : '${script.uri}'),
                           Expanded(
                             child: CodeView(
                               script: script,
@@ -200,24 +202,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     );
   }
 
-  Container buildScriptTitle(ThemeData theme) {
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(
-          bottom: BorderSide(color: theme.focusColor),
-        ),
-        color: titleSolidBackgroundColor,
-      ),
-      padding: const EdgeInsets.only(left: defaultSpacing),
-      alignment: Alignment.centerLeft,
-      height: DebuggerScreen.debuggerPaneHeaderHeight,
-      child: Text(
-        script == null ? ' ' : '${script.uri}',
-        style: theme.textTheme.subtitle2,
-      ),
-    );
-  }
-
   Widget debuggerPanes() {
     return LayoutBuilder(
       builder: (context, constraints) {
@@ -226,7 +210,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           initialFractions: const [0.25, 0.25, 0.25, 0.25],
           minSizes: const [0.0, 0.0, 0.0, 0.0],
           headers: [
-            _debuggerPaneHeader(callStackTitle),
+            _debuggerPaneHeader(callStackTitle, needsTopBorder: false),
             _debuggerPaneHeader(variablesTitle),
             _debuggerPaneHeader(breakpointsTitle),
             _debuggerPaneHeader(librariesTitle),
@@ -249,7 +233,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     );
   }
 
-  FlexSplitColumnHeader _debuggerPaneHeader(String title) {
+  FlexSplitColumnHeader _debuggerPaneHeader(
+    String title, {
+    bool needsTopBorder = true,
+  }) {
     final theme = Theme.of(context);
 
     return FlexSplitColumnHeader(
@@ -257,6 +244,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       child: Container(
         decoration: BoxDecoration(
           border: Border(
+            top: needsTopBorder
+                ? BorderSide(color: theme.focusColor)
+                : BorderSide.none,
             bottom: BorderSide(color: theme.focusColor),
           ),
           color: titleSolidBackgroundColor,
@@ -291,7 +281,7 @@ class DebuggingControls extends StatelessWidget {
             children: [
               OutlinedBorder(
                 child: Row(
-                  children: <Widget>[
+                  children: [
                     MaterialButton(
                       onPressed: isPaused ? null : controller.pause,
                       child: const MaterialIconLabel(
@@ -312,7 +302,7 @@ class DebuggingControls extends StatelessWidget {
               const SizedBox(width: denseSpacing),
               OutlinedBorder(
                 child: Row(
-                  children: <Widget>[
+                  children: [
                     MaterialButton(
                       onPressed: isPaused ? controller.stepIn : null,
                       child: const MaterialIconLabel(

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -17,6 +17,7 @@ import '../../globals.dart';
 import '../../ui/flutter/label.dart';
 import 'breakpoints.dart';
 import 'codeview.dart';
+import 'console.dart';
 import 'debugger_controller.dart';
 import 'scripts.dart';
 
@@ -27,6 +28,8 @@ class DebuggerScreen extends Screen {
           title: 'Debugger',
           icon: Octicons.bug,
         );
+
+  static const debuggerPaneHeaderHeight = 36.0;
 
   @override
   String get docPageId => 'debugger';
@@ -55,8 +58,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   static const variablesTitle = 'Variables';
   static const breakpointsTitle = 'Breakpoints';
   static const librariesTitle = 'Libraries';
-
-  static const debuggerPaneHeaderHeight = 36.0;
 
   DebuggerController controller;
   ScriptRef loadingScript;
@@ -152,6 +153,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final loading = loadingScript != null && script == null;
 
     return Split(
       axis: Axis.horizontal,
@@ -166,27 +168,16 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             DebuggingControls(controller: controller),
             const SizedBox(height: denseRowSpacing),
             Expanded(
-              child: loadingScript != null && script == null
-                  ? const Center(child: CircularProgressIndicator())
-                  : OutlinedBorder(
+              child: Split(
+                axis: Axis.vertical,
+                initialFractions: const [0.75, 0.25],
+                children: [
+                  if (loading) const Center(child: CircularProgressIndicator()),
+                  if (!loading)
+                    OutlinedBorder(
                       child: Column(
                         children: [
-                          Container(
-                            decoration: BoxDecoration(
-                              border: Border(
-                                bottom: BorderSide(color: theme.focusColor),
-                              ),
-                              color: titleSolidBackgroundColor,
-                            ),
-                            padding:
-                                const EdgeInsets.only(left: defaultSpacing),
-                            alignment: Alignment.centerLeft,
-                            height: debuggerPaneHeaderHeight,
-                            child: Text(
-                              script == null ? ' ' : '${script.uri}',
-                              style: theme.textTheme.subtitle2,
-                            ),
-                          ),
+                          buildScriptTitle(theme),
                           Expanded(
                             child: CodeView(
                               script: script,
@@ -199,10 +190,31 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                         ],
                       ),
                     ),
+                  Console(),
+                ],
+              ),
             ),
           ],
         ),
       ],
+    );
+  }
+
+  Container buildScriptTitle(ThemeData theme) {
+    return Container(
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(color: theme.focusColor),
+        ),
+        color: titleSolidBackgroundColor,
+      ),
+      padding: const EdgeInsets.only(left: defaultSpacing),
+      alignment: Alignment.centerLeft,
+      height: DebuggerScreen.debuggerPaneHeaderHeight,
+      child: Text(
+        script == null ? ' ' : '${script.uri}',
+        style: theme.textTheme.subtitle2,
+      ),
     );
   }
 
@@ -241,7 +253,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     final theme = Theme.of(context);
 
     return FlexSplitColumnHeader(
-      height: debuggerPaneHeaderHeight,
+      height: DebuggerScreen.debuggerPaneHeaderHeight,
       child: Container(
         decoration: BoxDecoration(
           border: Border(
@@ -251,7 +263,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         ),
         padding: const EdgeInsets.only(left: defaultSpacing),
         alignment: Alignment.centerLeft,
-        height: debuggerPaneHeaderHeight,
+        height: DebuggerScreen.debuggerPaneHeaderHeight,
         child: Text(
           title,
           style: Theme.of(context).textTheme.subtitle2,
@@ -269,52 +281,60 @@ class DebuggingControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO(devoncarew): Change to using two sets of ToggleButtons.
-
     return ValueListenableBuilder(
       valueListenable: controller.isPaused,
       builder: (context, isPaused, child) {
         return SizedBox(
-          height: DebuggerScreenBodyState.debuggerPaneHeaderHeight,
+          height: DebuggerScreen.debuggerPaneHeaderHeight,
           child: ListView(
             scrollDirection: Axis.horizontal,
             children: [
-              // todo: create a group
-              MaterialButton(
-                onPressed: isPaused ? null : controller.pause,
-                child: const MaterialIconLabel(
-                  Icons.pause,
-                  'Pause',
+              OutlinedBorder(
+                child: Row(
+                  children: <Widget>[
+                    MaterialButton(
+                      onPressed: isPaused ? null : controller.pause,
+                      child: const MaterialIconLabel(
+                        Icons.pause,
+                        'Pause',
+                      ),
+                    ),
+                    MaterialButton(
+                      onPressed: isPaused ? controller.resume : null,
+                      child: const MaterialIconLabel(
+                        Icons.play_arrow,
+                        'Resume',
+                      ),
+                    ),
+                  ],
                 ),
               ),
-              MaterialButton(
-                onPressed: isPaused ? controller.resume : null,
-                child: const MaterialIconLabel(
-                  Icons.play_arrow,
-                  'Resume',
-                ),
-              ),
-              const SizedBox(width: defaultSpacing),
-              // todo: create a group
-              MaterialButton(
-                onPressed: isPaused ? controller.stepIn : null,
-                child: const MaterialIconLabel(
-                  Icons.keyboard_arrow_down,
-                  'Step In',
-                ),
-              ),
-              MaterialButton(
-                onPressed: isPaused ? controller.stepOver : null,
-                child: const MaterialIconLabel(
-                  Icons.keyboard_arrow_right,
-                  'Step Over',
-                ),
-              ),
-              MaterialButton(
-                onPressed: isPaused ? controller.stepOut : null,
-                child: const MaterialIconLabel(
-                  Icons.keyboard_arrow_up,
-                  'Step Out',
+              const SizedBox(width: denseSpacing),
+              OutlinedBorder(
+                child: Row(
+                  children: <Widget>[
+                    MaterialButton(
+                      onPressed: isPaused ? controller.stepIn : null,
+                      child: const MaterialIconLabel(
+                        Icons.keyboard_arrow_down,
+                        'Step In',
+                      ),
+                    ),
+                    MaterialButton(
+                      onPressed: isPaused ? controller.stepOver : null,
+                      child: const MaterialIconLabel(
+                        Icons.keyboard_arrow_right,
+                        'Step Over',
+                      ),
+                    ),
+                    MaterialButton(
+                      onPressed: isPaused ? controller.stepOut : null,
+                      child: const MaterialIconLabel(
+                        Icons.keyboard_arrow_up,
+                        'Step Out',
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/theme.dart';
 import 'common.dart';
 
 /// Picker that takes a [ScriptList] and allows selection of one of the scripts
@@ -32,12 +33,14 @@ class ScriptPickerState extends State<ScriptPicker> {
   @override
   void initState() {
     super.initState();
+
     if (_isNotLoaded) initFilter();
   }
 
   @override
   void didUpdateWidget(ScriptPicker oldWidget) {
     super.didUpdateWidget(oldWidget);
+
     if (_isNotLoaded) {
       initFilter();
     } else if (oldWidget.scripts != widget.scripts) {
@@ -46,7 +49,8 @@ class ScriptPickerState extends State<ScriptPicker> {
   }
 
   void initFilter() {
-    // Make an educated guess as to the main package to slim down the initial list of scripts we show.
+    // Make an educated guess as to the main package to slim down the initial
+    // list of scripts we show.
     if (widget.scripts?.scripts != null) {
       final mainFile = widget.scripts.scripts
           .firstWhere((ref) => ref.uri.contains('main.dart'));
@@ -107,6 +111,7 @@ class ScriptPickerState extends State<ScriptPicker> {
           ),
           controller: filterController,
           onChanged: updateFilter,
+          style: Theme.of(context).textTheme.bodyText2,
         ),
         Expanded(
           child: densePadding(
@@ -116,9 +121,9 @@ class ScriptPickerState extends State<ScriptPicker> {
                 child: SizedBox(
                   width: MediaQuery.of(context).size.width,
                   child: ListView.builder(
-                    itemBuilder: (context, index) => _buildScript(items[index]),
                     itemCount: items.length,
-                    itemExtent: 32.0,
+                    itemExtent: defaultListItemHeight,
+                    itemBuilder: (context, index) => _buildScript(items[index]),
                   ),
                 ),
               ),

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -49,6 +49,8 @@ const defaultSpacing = 16.0;
 const denseSpacing = 8.0;
 const denseRowSpacing = 6.0;
 
+const defaultListItemHeight = 28.0;
+
 /// Branded grey color.
 ///
 /// Source: https://drive.google.com/open?id=1QBhMJqXyRt-CpRsHR6yw2LAfQtiNat4g

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -38,5 +38,25 @@ void main() {
       expect(find.byType(DebuggerScreenBody), findsNothing);
       expect(find.byType(DisabledForProfileBuildMessage), findsOneWidget);
     });
+
+    testWidgets('has Console area', (WidgetTester tester) async {
+      final debuggerController = MockDebuggerController();
+      when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
+      when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      await tester.pumpWidget(wrapWithControllers(
+        Builder(builder: screen.build),
+        debugger: debuggerController,
+      ));
+
+      expect(find.text('Console'), findsOneWidget);
+
+      expect(
+        find.descendant(
+          of: find.byType(DebuggerScreenBody),
+          matching: find.text('todo:'),
+        ),
+        findsOneWidget,
+      );
+    });
   });
 }

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -50,13 +50,7 @@ void main() {
 
       expect(find.text('Console'), findsOneWidget);
 
-      expect(
-        find.descendant(
-          of: find.byType(DebuggerScreenBody),
-          matching: find.text('todo:'),
-        ),
-        findsOneWidget,
-      );
+      expect(find.text('todo:'), findsOneWidget);
     });
   });
 }

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -139,6 +139,11 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   }
 
   @override
+  Future<ScriptList> getScripts(String isolateId) {
+    return Future.value(ScriptList(scripts: []));
+  }
+
+  @override
   Future<Success> setFlag(String name, String value) {
     final List<Flag> flags = _flags['flags'];
     final existingFlag =


### PR DESCRIPTION
Various debugger improvements:
- virtualized the source lines list and the line numbers list
- made the source text display in a more condensed format
- fixed the scroll-to-line for the code view
- added a placeholder for a `Console` area
- added a test to make sure the console area displays
- normalized our list heights
- changed the look of the debugger buttons slightly to better match buttons in other pages (some more work to be done here)

@kenzieschmoll 
