### PR TITLE
Debugger state management cleanup

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -5,15 +5,14 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/theme.dart';
 import 'codeview.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
 
 class BreakpointPicker extends StatelessWidget {
-  const BreakpointPicker(
-      {Key key, @required this.breakpoints, @required this.controller})
+  const BreakpointPicker({Key key, @required this.controller})
       : super(key: key);
-  final List<Breakpoint> breakpoints;
   final DebuggerController controller;
 
   String textFor(Breakpoint breakpoint) {
@@ -38,12 +37,18 @@ class BreakpointPicker extends StatelessWidget {
           scrollDirection: Axis.horizontal,
           child: SizedBox(
             width: MediaQuery.of(context).size.width,
-            child: ListView.builder(
-              itemBuilder: (context, index) => SizedBox(
-                height: CodeView.rowHeight,
-                child: Text(textFor(breakpoints[index])),
-              ),
-              itemCount: breakpoints.length,
+            child: ValueListenableBuilder(
+              valueListenable: controller.breakpoints,
+              builder: (context, breakpoints, _) {
+                return ListView.builder(
+                  itemCount: breakpoints.length,
+                  itemExtent: defaultListItemHeight,
+                  itemBuilder: (context, index) => SizedBox(
+                    height: CodeView.rowHeight,
+                    child: Text(textFor(breakpoints[index])),
+                  ),
+                );
+              },
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -11,6 +11,8 @@ import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/theme.dart';
 import 'debugger_controller.dart';
 
+// TODO(kenz): consider moving lines / pausedPositions calculations to the
+// controller.
 class CodeView extends StatefulWidget {
   const CodeView({
     Key key,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -9,25 +9,19 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../auto_dispose.dart';
 import '../../globals.dart';
+import 'debugger_service.dart';
 
 /// Responsible for managing the debug state of the app.
 class DebuggerController extends DisposableController
     with AutoDisposeControllerMixin {
   DebuggerController() {
     switchToIsolate(serviceManager.isolateManager.selectedIsolate);
-    autoDispose(serviceManager.isolateManager.onSelectedIsolateChanged
-        .listen(switchToIsolate));
-
-    autoDispose(_service.onDebugEvent.listen(_handleIsolateEvent));
+    autoDispose(
+        debuggerService.onSelectedIsolateChanged.listen(switchToIsolate));
+    autoDispose(debuggerService.onDebugEvent.listen(_handleIsolateEvent));
   }
 
-  // TODO(djshuckerow): Separate the controller from a debugging service object
-  // such that the controller does not need to know about VmService.
-  VmService get _service => serviceManager.service;
-  InstanceRef get reportedException => _reportedException;
-
-  IsolateRef isolateRef;
-  List<ScriptRef> scripts;
+  final debuggerService = DebuggerService();
 
   final _scriptCache = <String, Script>{};
 
@@ -51,17 +45,32 @@ class DebuggerController extends DisposableController
 
   Event lastEvent;
 
+  final _currentScript = ValueNotifier<Script>(null);
+  ValueListenable<Script> get currentScript => _currentScript;
+
+  final _currentStack = ValueNotifier<Stack>(null);
+  ValueListenable<Stack> get currentStack => _currentStack;
+
+  final _scriptList = ValueNotifier<ScriptList>(null);
+  ValueListenable<ScriptList> get scriptList => _scriptList;
+
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
   ValueListenable<List<Breakpoint>> get breakpoints => _breakpoints;
 
   final _exceptionPauseMode = ValueNotifier<String>(null);
   ValueListenable<String> get exceptionPauseMode => _exceptionPauseMode;
 
+  IsolateRef isolateRef;
+
+  List<ScriptRef> scripts;
+
+  InstanceRef get reportedException => _reportedException;
   InstanceRef _reportedException;
 
   String commonScriptPrefix;
-  LibraryRef _rootLib;
+
   LibraryRef get rootLib => _rootLib;
+  LibraryRef _rootLib;
   set rootLib(LibraryRef rootLib) {
     _rootLib = rootLib;
 
@@ -100,6 +109,7 @@ class DebuggerController extends DisposableController
     isolateRef = ref;
 
     _isPaused.value = false;
+    await _pause(false);
 
     _clearCaches();
 
@@ -108,14 +118,13 @@ class DebuggerController extends DisposableController
       return;
     }
 
-    final result = await _service.getIsolate(isolateRef.id);
-    final Isolate isolate = result;
+    final isolate = await debuggerService.getIsolate(isolateRef.id);
 
     if (isolate.pauseEvent != null &&
         isolate.pauseEvent.kind != EventKind.kResume) {
       lastEvent = isolate.pauseEvent;
       _reportedException = isolate.pauseEvent.exception;
-      _isPaused.value = true;
+      await _pause(true);
     }
 
     _breakpoints.value = isolate.breakpoints;
@@ -123,27 +132,25 @@ class DebuggerController extends DisposableController
     _exceptionPauseMode.value = isolate.exceptionPauseMode;
   }
 
-  Future<Success> pause() => _service.pause(isolateRef.id);
+  Future<Success> pause() => debuggerService.pause(isolateRef.id);
 
-  Future<Success> resume() => _service.resume(isolateRef.id);
+  Future<Success> resume() => debuggerService.resume(isolateRef.id);
 
   Future<Success> stepOver() {
     // Handle async suspensions; issue StepOption.kOverAsyncSuspension.
     final useAsyncStepping = lastEvent?.atAsyncSuspension ?? false;
-    return _service.resume(
+    return debuggerService.resume(
       isolateRef.id,
       step:
           useAsyncStepping ? StepOption.kOverAsyncSuspension : StepOption.kOver,
     );
   }
 
-  Future<Success> stepIn() {
-    return _service.resume(isolateRef.id, step: StepOption.kInto);
-  }
+  Future<Success> stepIn() =>
+      debuggerService.resume(isolateRef.id, step: StepOption.kInto);
 
-  Future<Success> stepOut() {
-    return _service.resume(isolateRef.id, step: StepOption.kOut);
-  }
+  Future<Success> stepOut() =>
+      debuggerService.resume(isolateRef.id, step: StepOption.kOut);
 
   Future<void> clearBreakpoints() async {
     final breakpoints = _breakpoints.value.toList();
@@ -152,33 +159,26 @@ class DebuggerController extends DisposableController
     });
   }
 
-  Future<void> addBreakpoint(String scriptId, int line) {
-    return _service.addBreakpoint(isolateRef.id, scriptId, line);
-  }
+  Future<void> addBreakpoint(String scriptId, int line) =>
+      debuggerService.addBreakpoint(isolateRef.id, scriptId, line);
 
   Future<void> addBreakpointByPathFragment(String path, int line) async {
     final ref =
         scripts.firstWhere((ref) => ref.uri.endsWith(path), orElse: () => null);
     if (ref != null) {
-      return _service.addBreakpoint(isolateRef.id, ref.id, line);
+      return addBreakpoint(ref.id, line);
     }
   }
 
-  Future<void> removeBreakpoint(Breakpoint breakpoint) {
-    return _service.removeBreakpoint(isolateRef.id, breakpoint.id);
-  }
+  Future<void> removeBreakpoint(Breakpoint breakpoint) =>
+      debuggerService.removeBreakpoint(isolateRef.id, breakpoint.id);
 
-  Future<void> setExceptionPauseMode(String mode) {
-    return _service.setExceptionPauseMode(isolateRef.id, mode);
-  }
+  Future<void> setExceptionPauseMode(String mode) =>
+      debuggerService.setExceptionPauseMode(isolateRef.id, mode);
 
-  Future<Stack> getStack() async {
-    final stack = await _service.getStack(isolateRef.id);
-    if (stack is Sentinel) return null;
-    return stack;
-  }
+  Future<Stack> getStack() => debuggerService.getStack(isolateRef.id);
 
-  void _handleIsolateEvent(Event event) {
+  void _handleIsolateEvent(Event event) async {
     if (event.isolate.id != isolateRef.id) return;
 
     _hasFrames.value = event.topFrame != null;
@@ -186,7 +186,7 @@ class DebuggerController extends DisposableController
 
     switch (event.kind) {
       case EventKind.kResume:
-        _isPaused.value = false;
+        await _pause(false);
         _reportedException = null;
         break;
       case EventKind.kPauseStart:
@@ -196,7 +196,7 @@ class DebuggerController extends DisposableController
       case EventKind.kPauseException:
       case EventKind.kPausePostRequest:
         _reportedException = event.exception;
-        _isPaused.value = true;
+        await _pause(true);
         break;
       // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'
       // that knows how to notify when performing a list edit operation.
@@ -217,6 +217,17 @@ class DebuggerController extends DisposableController
     }
   }
 
+  Future<void> _pause(bool pause) async {
+    _isPaused.value = pause;
+    _currentStack.value = await getStack();
+    if (_currentStack.value != null && _currentStack.value.frames.isNotEmpty) {
+      // TODO(https://github.com/flutter/devtools/issues/1648): Allow choice of
+      // the scripts on the stack.
+      _currentScript.value =
+          await getScript(_currentStack.value.frames.first.location.script);
+    }
+  }
+
   void _clearCaches() {
     _scriptCache.clear();
     lastEvent = null;
@@ -227,16 +238,25 @@ class DebuggerController extends DisposableController
   ///
   /// The return value can be one of [Instance] or [Sentinel].
   Future<Object> getInstance(InstanceRef instanceRef) {
-    return _service.getObject(isolateRef.id, instanceRef.id);
+    return debuggerService.getObject(isolateRef.id, instanceRef.id);
   }
 
   Future<Script> getScript(ScriptRef scriptRef) async {
     if (!_scriptCache.containsKey(scriptRef.id)) {
       _scriptCache[scriptRef.id] =
-          await _service.getObject(isolateRef.id, scriptRef.id);
+          await debuggerService.getScript(isolateRef.id, scriptRef.id);
     }
-
     return _scriptCache[scriptRef.id];
+  }
+
+  Future<void> selectScript(ScriptRef ref) async {
+    if (ref == null) return;
+    _currentScript.value =
+        await debuggerService.getScript(isolateRef.id, ref.id);
+  }
+
+  Future<void> getScripts() async {
+    _scriptList.value = await debuggerService.getScripts(isolateRef.id);
   }
 
   SourcePosition calculatePosition(Script script, int tokenPos) {
@@ -291,10 +311,6 @@ class DebuggerController extends DisposableController
     } else {
       return uri.substring(commonScriptPrefix.length);
     }
-  }
-
-  void updateFrom(Isolate isolate) {
-    _breakpoints.value = isolate.breakpoints;
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -63,9 +63,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   DebuggerController controller;
   ScriptRef loadingScript;
   Script script;
-  ScriptList scriptList;
-  Stack stack;
-  List<Breakpoint> breakpoints;
 
   @override
   void didChangeDependencies() {
@@ -80,22 +77,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         script = controller.currentScript.value;
       });
     });
-    addAutoDisposeListener(controller.currentStack, () {
-      setState(() {
-        stack = controller.currentStack.value;
-      });
-    });
-    addAutoDisposeListener(controller.scriptList, () {
-      setState(() {
-        scriptList = controller.scriptList.value;
-      });
-    });
-    breakpoints = controller.breakpoints.value;
-    addAutoDisposeListener(controller.breakpoints, () {
-      setState(() {
-        breakpoints = controller.breakpoints.value;
-      });
-    });
+    addAutoDisposeListener(controller.currentStack);
+    addAutoDisposeListener(controller.scriptList);
+    addAutoDisposeListener(controller.breakpoints);
 
     controller.getScripts();
   }
@@ -111,10 +95,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
   Map<int, Breakpoint> _breakpointsForLines() {
     if (script == null) return {};
-    final bps = breakpoints
-        .where((b) => b != null && b.location.script.id == script.id);
     return {
-      for (var b in bps) controller.lineNumber(script, b.location): b,
+      for (var b in controller.breakpoints.value
+          .where((b) => b != null && b.location.script.id == script.id))
+        controller.lineNumber(script, b.location): b,
     };
   }
 
@@ -161,7 +145,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                           Expanded(
                             child: CodeView(
                               script: script,
-                              stack: stack,
+                              stack: controller.currentStack.value,
                               controller: controller,
                               lineNumberToBreakpoint: _breakpointsForLines(),
                               onSelected: toggleBreakpoint,
@@ -198,7 +182,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             const Center(child: Text('TODO: variables')),
             BreakpointPicker(controller: controller),
             ScriptPicker(
-              scripts: scriptList,
+              scripts: controller.scriptList.value,
               onSelected: _onScriptSelected,
               selected: loadingScript,
             ),

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_service.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_service.dart
@@ -1,0 +1,40 @@
+import 'package:vm_service/vm_service.dart';
+
+import '../../globals.dart';
+
+class DebuggerService {
+  Stream<Event> get onDebugEvent => serviceManager.service.onDebugEvent;
+
+  Stream<IsolateRef> get onSelectedIsolateChanged =>
+      serviceManager.isolateManager.onSelectedIsolateChanged;
+
+  Future<Success> pause(String isolateId) =>
+      serviceManager.service.pause(isolateId);
+
+  Future<Success> resume(String isolateId, {String step}) =>
+      serviceManager.service.resume(isolateId, step: step);
+
+  Future<void> addBreakpoint(String isolateId, String scriptId, int line) =>
+      serviceManager.service.addBreakpoint(isolateId, scriptId, line);
+
+  Future<void> removeBreakpoint(String isolateId, String breakpointId) =>
+      serviceManager.service.removeBreakpoint(isolateId, breakpointId);
+
+  Future<void> setExceptionPauseMode(String isolateId, String mode) =>
+      serviceManager.service.setExceptionPauseMode(isolateId, mode);
+
+  Future<Stack> getStack(String isolateId) =>
+      serviceManager.service.getStack(isolateId);
+
+  Future<Isolate> getIsolate(String isolateId) =>
+      serviceManager.service.getIsolate(isolateId);
+
+  Future<Script> getScript(String isolateId, String scriptId) =>
+      getObject(isolateId, scriptId);
+
+  Future<ScriptList> getScripts(String isolateId) =>
+      serviceManager.service.getScripts(isolateId);
+
+  Future<Obj> getObject(String isolateId, String objectId) =>
+      serviceManager.service.getObject(isolateId, objectId);
+}

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -51,7 +51,7 @@ class ScriptPickerState extends State<ScriptPicker> {
   void initFilter() {
     // Make an educated guess as to the main package to slim down the initial
     // list of scripts we show.
-    if (widget.scripts?.scripts != null) {
+    if ((widget.scripts?.scripts ?? []).isNotEmpty) {
       final mainFile = widget.scripts.scripts
           .firstWhere((ref) => ref.uri.contains('main.dart'));
       filterController.text = mainFile.uri.split('/').first;

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -5,17 +5,18 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/theme.dart';
 import 'common.dart';
 
 /// Picker that takes a [ScriptList] and allows selection of one of the scripts
 /// inside.
 class ScriptPicker extends StatefulWidget {
-  const ScriptPicker(
-      {Key key,
-      @required this.scripts,
-      @required this.onSelected,
-      @required this.selected})
-      : super(key: key);
+  const ScriptPicker({
+    Key key,
+    @required this.scripts,
+    @required this.onSelected,
+    @required this.selected,
+  }) : super(key: key);
 
   final ScriptList scripts;
   final void Function(ScriptRef scriptRef) onSelected;
@@ -116,9 +117,9 @@ class ScriptPickerState extends State<ScriptPicker> {
                 child: SizedBox(
                   width: MediaQuery.of(context).size.width,
                   child: ListView.builder(
-                    itemBuilder: (context, index) => _buildScript(items[index]),
                     itemCount: items.length,
-                    itemExtent: 32.0,
+                    itemExtent: defaultListItemHeight,
+                    itemBuilder: (context, index) => _buildScript(items[index]),
                   ),
                 ),
               ),

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -49,6 +49,8 @@ const defaultSpacing = 16.0;
 const denseSpacing = 8.0;
 const denseRowSpacing = 6.0;
 
+const defaultListItemHeight = 28.0;
+
 /// Branded grey color.
 ///
 /// Source: https://drive.google.com/open?id=1QBhMJqXyRt-CpRsHR6yw2LAfQtiNat4g

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../support/mocks.dart';
 import 'wrappers.dart';
@@ -43,6 +44,9 @@ void main() {
       final debuggerController = MockDebuggerController();
       when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      when(debuggerController.scriptList)
+          .thenReturn(ValueNotifier(ScriptList(scripts: [])));
+      when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -19,11 +19,11 @@ import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/stream_value_listenable.dart';
 import 'package:devtools_app/src/timeline/flutter/timeline_controller.dart';
-import 'package:devtools_app/src/ui/fake_flutter/fake_flutter.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:devtools_app/src/vm_service_wrapper.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
+import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
@@ -141,6 +141,11 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   @override
   Future<ScriptList> getScripts(String isolateId) {
     return Future.value(ScriptList(scripts: []));
+  }
+
+  @override
+  Future<Stack> getStack(String isolateId) {
+    return Future.value(Stack(frames: [], messages: []));
   }
 
   @override


### PR DESCRIPTION
- Moves business logic into controller from screen
- Use ValueListenable pattern to update UI
- Add `debugger_service.dart` file to interact with vm_service (follows pattern used in the rest of DevTools)