### PR TITLE
improve the look of the scripts view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -245,6 +245,8 @@ class ScriptRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // TODO(#1648): Implement syntax highlighting.
+
     return InkWell(
       onTap: onPressed,
       child: Container(

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -163,6 +163,8 @@ class _CodeViewState extends State<CodeView> {
               child: SingleChildScrollView(
                 controller: _horizontalController,
                 scrollDirection: Axis.horizontal,
+                // TODO: Improve our sizing here - currently we do
+                // CodeView.assumedCharacterWidth * max line width
                 child: SizedBox(
                   width: CodeView.assumedCharacterWidth *
                       lines

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -111,6 +111,8 @@ class _CodeViewState extends State<CodeView> {
 
   @override
   Widget build(BuildContext context) {
+    // TODO(#1648): Implement syntax highlighting.
+
     if (widget.script == null) {
       return Center(
         child: Text(
@@ -245,8 +247,6 @@ class ScriptRow extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // TODO(#1648): Implement syntax highlighting.
-
     return InkWell(
       onTap: onPressed,
       child: Container(

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -14,26 +14,6 @@ Widget densePadding(Widget child) {
   );
 }
 
-class Badge extends StatelessWidget {
-  const Badge({@required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    // TODO(devoncarew): We'll likely want a badge implementation that's
-    // separate from [Chip].
-
-    return SizedBox(
-      child: Chip(
-        label: child,
-        visualDensity: VisualDensity.compact,
-        padding: const EdgeInsets.symmetric(vertical: -4.0),
-      ),
-    );
-  }
-}
-
 /// Create a header area for a debugger component.
 ///
 /// Either one of [text] or [child] must be supplied.

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -14,6 +14,21 @@ Widget densePadding(Widget child) {
   );
 }
 
+class Badge extends StatelessWidget {
+  const Badge({@required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return Chip(
+      label: child,
+      visualDensity: VisualDensity.compact,
+      backgroundColor: Theme.of(context).accentColor,
+    );
+  }
+}
+
 /// Create a header area for a debugger component.
 ///
 /// Either one of [text] or [child] must be supplied.
@@ -31,11 +46,6 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
     padding: const EdgeInsets.only(left: defaultSpacing),
     alignment: Alignment.centerLeft,
     height: DebuggerScreen.debuggerPaneHeaderHeight,
-    child: child != null
-        ? child
-        : Text(
-            text,
-            style: theme.textTheme.subtitle2,
-          ),
+    child: child != null ? child : Text(text, style: theme.textTheme.subtitle2),
   );
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -72,6 +72,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (newController == controller) return;
     controller = newController;
 
+    // TODO(all): We need to be more precise about the changes we listen to.
+    // These coarse listeners are causing us to rebuild much more of the UI than
+    // we need to.
     addAutoDisposeListener(controller.currentScript, () {
       setState(() {
         script = controller.currentScript.value;

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -220,7 +220,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         alignment: Alignment.centerLeft,
         height: DebuggerScreen.debuggerPaneHeaderHeight,
         child: Row(
-          children: <Widget>[
+          children: [
             Expanded(
               child: Text(
                 title,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -213,7 +213,12 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             _debuggerPaneHeader(callStackTitle, needsTopBorder: false),
             _debuggerPaneHeader(variablesTitle),
             _debuggerPaneHeader(breakpointsTitle),
-            _debuggerPaneHeader(librariesTitle),
+            _debuggerPaneHeader(
+              librariesTitle,
+              rightChild: const Badge(
+                child: Text('123'),
+              ),
+            ),
           ],
           children: [
             const Center(child: Text('TODO: call stack')),
@@ -224,8 +229,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             ),
             ScriptPicker(
               scripts: scriptList,
-              onSelected: onScriptSelected,
               selected: loadingScript,
+              onSelected: onScriptSelected,
             ),
           ],
         );
@@ -236,6 +241,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   FlexSplitColumnHeader _debuggerPaneHeader(
     String title, {
     bool needsTopBorder = true,
+    Widget rightChild,
   }) {
     final theme = Theme.of(context);
 
@@ -251,12 +257,19 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           ),
           color: titleSolidBackgroundColor,
         ),
-        padding: const EdgeInsets.only(left: defaultSpacing),
+        padding: const EdgeInsets.only(left: defaultSpacing, right: 4.0),
         alignment: Alignment.centerLeft,
         height: DebuggerScreen.debuggerPaneHeaderHeight,
-        child: Text(
-          title,
-          style: Theme.of(context).textTheme.subtitle2,
+        child: Row(
+          children: <Widget>[
+            Expanded(
+              child: Text(
+                title,
+                style: Theme.of(context).textTheme.subtitle2,
+              ),
+            ),
+            if (rightChild != null) rightChild,
+          ],
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -5,9 +5,9 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
 import '../../utils.dart';
-import 'common.dart';
 
 // TODO(devoncarew): Show the filtered count in the scripts header.
 
@@ -30,7 +30,7 @@ class ScriptPicker extends StatefulWidget {
 }
 
 class ScriptPickerState extends State<ScriptPicker> {
-  final TextEditingController _filterController = TextEditingController();
+  final _filterController = TextEditingController();
   List<ScriptRef> _filteredScripts = [];
 
   @override

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -316,6 +316,27 @@ class BulletSpacer extends StatelessWidget {
   }
 }
 
+/// A small element containing some accessory information, often a numeric
+/// value.
+class Badge extends StatelessWidget {
+  const Badge({@required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(devoncarew): We'll likely want a badge implementation that's
+    // separate from Chip.
+
+    return SizedBox(
+      child: Chip(
+        label: child,
+        visualDensity: VisualDensity.compact,
+      ),
+    );
+  }
+}
+
 /// A widget, commonly used for icon buttons, that provides a tooltip with a
 /// common delay before the tooltip is shown.
 class ActionButton extends StatelessWidget {

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -57,5 +57,26 @@ void main() {
 
       expect(find.text('todo:'), findsOneWidget);
     });
+
+    testWidgets('Scripts show items', (WidgetTester tester) async {
+      final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
+
+      final debuggerController = MockDebuggerController();
+      when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
+      when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      when(debuggerController.scriptList)
+          .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
+      when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
+      await tester.pumpWidget(wrapWithControllers(
+        Builder(builder: screen.build),
+        debugger: debuggerController,
+      ));
+
+      expect(find.text('Libraries'), findsOneWidget);
+
+      // test for items in the libraries list
+      expect(find.text(scripts.first.uri), findsOneWidget);
+    });
   });
 }

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -46,6 +46,7 @@ void main() {
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: [])));
+      when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),


### PR DESCRIPTION
Improve the look of the scripts view:
- give slightly more room to the scripts view
- don't use horizontal scrolling, but allow horizontal overflow
- make the filter area slightly smaller
- add a badge for the script count in the script area header
- sort the scripts in the debugger controller
- make similar horizontal scrolling changes to the code area
- general work towards https://github.com/flutter/devtools/issues/1648

<img width="328" alt="Screen Shot 2020-04-14 at 4 16 49 PM" src="https://user-images.githubusercontent.com/1269969/79283285-3b056b00-7e6c-11ea-9bb3-18fd66b4509d.png">

Some future improvements are to make the badge slightly smaller (perhaps use https://pub.dev/packages/badges ?), and to remove the dedicated filter area and move it to the script area header.
