### PR TITLE
Fix timeline for change in Flutter engine thread name.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
@@ -105,11 +105,14 @@ class TimelineService {
       // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
       if (name.contains('.ui')) uiThreadName = name;
 
-      // Android: "1.gpu (12651)"
-      // iOS: "io.flutter.1.gpu (12651)"
-      // Linux, Windows, Dream (g3): "io.flutter.gpu (12651)"
+      // Android: "1.raster (12651)"
+      // iOS: "io.flutter.1.raster (12651)"
+      // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
       // MacOS: Does not exist
-      if (name.contains('.gpu')) rasterThreadName = name;
+      // Also look for .gpu here for older versions of Flutter.
+      if (name.contains('.raster') || name.contains('.gpu')) {
+        rasterThreadName = name;
+      }
 
       // Android: "1.platform (22585)"
       // iOS: "io.flutter.1.platform (22585)"

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
@@ -110,6 +110,7 @@ class TimelineService {
       // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
       // MacOS: Does not exist
       // Also look for .gpu here for older versions of Flutter.
+      // TODO(kenz): remove check for .gpu name in April 2021.
       if (name.contains('.raster') || name.contains('.gpu')) {
         rasterThreadName = name;
       }


### PR DESCRIPTION
The engine thread names have changed from .gpu to .raster.