### PR TITLE
improvements to the breakpoints view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -65,12 +65,14 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
                     ? TextStyle(color: Theme.of(context).textSelectionColor)
                     : null,
               ),
-              Text(
-                ' (${bp.scriptUri})',
-                overflow: TextOverflow.ellipsis,
-                style: bp.id == widget.selected?.id
-                    ? TextStyle(color: Theme.of(context).textSelectionColor)
-                    : subtleStyle,
+              Flexible(
+                child: Text(
+                  ' (${bp.scriptUri})',
+                  overflow: TextOverflow.ellipsis,
+                  style: bp.id == widget.selected?.id
+                      ? TextStyle(color: Theme.of(context).textSelectionColor)
+                      : subtleStyle,
+                ),
               ),
             ],
           ),

--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -5,16 +5,23 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
 import '../../utils.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
 
 class BreakpointPicker extends StatefulWidget {
-  const BreakpointPicker({Key key, @required this.controller})
-      : super(key: key);
+  const BreakpointPicker({
+    Key key,
+    @required this.controller,
+    @required this.selected,
+    @required this.onSelected,
+  }) : super(key: key);
 
   final DebuggerController controller;
+  final BreakpointAndSourcePosition selected;
+  final void Function(BreakpointAndSourcePosition breakpoint) onSelected;
 
   @override
   _BreakpointPickerState createState() => _BreakpointPickerState();
@@ -42,20 +49,28 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
         TextStyle(color: Theme.of(context).unselectedWidgetColor);
 
     return Material(
+      color: bp.id == widget.selected?.id
+          ? Theme.of(context).selectedRowColor
+          : null,
       child: InkWell(
-        // todo:
-        onTap: () => print(bp),
+        onTap: () => widget.onSelected(bp),
         child: densePadding(
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              const Text('● '),
-              Text(_descriptionFor(bp)),
-              Expanded(
-                child: Text(
-                  ' (${bp.scriptUri})',
-                  style: subtleStyle,
-                ),
+              Text(
+                '● ${_descriptionFor(bp)}',
+                overflow: TextOverflow.ellipsis,
+                style: bp.id == widget.selected?.id
+                    ? TextStyle(color: Theme.of(context).textSelectionColor)
+                    : null,
+              ),
+              Text(
+                ' (${bp.scriptUri})',
+                overflow: TextOverflow.ellipsis,
+                style: bp.id == widget.selected?.id
+                    ? TextStyle(color: Theme.of(context).textSelectionColor)
+                    : subtleStyle,
               ),
             ],
           ),
@@ -84,23 +99,6 @@ class BreakpointsCountBadge extends StatelessWidget {
     return Badge(
       child: Text(
         '${nf.format(breakpoints.length)}',
-      ),
-    );
-  }
-}
-
-class Badge extends StatelessWidget {
-  const Badge({@required this.child});
-
-  final Widget child;
-
-  @override
-  Widget build(BuildContext context) {
-    return SizedBox(
-      child: Chip(
-        label: child,
-        visualDensity: VisualDensity.compact,
-        padding: const EdgeInsets.symmetric(vertical: -4.0),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -45,33 +45,37 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
   }
 
   Widget buildBreakpoint(BuildContext context, BreakpointAndSourcePosition bp) {
+    final regularStyle =
+        TextStyle(color: Theme.of(context).textTheme.bodyText2.color);
     final subtleStyle =
         TextStyle(color: Theme.of(context).unselectedWidgetColor);
+    final selectedStyle =
+        TextStyle(color: Theme.of(context).textSelectionColor);
+
+    final isSelected = bp.id == widget.selected?.id;
 
     return Material(
-      color: bp.id == widget.selected?.id
-          ? Theme.of(context).selectedRowColor
-          : null,
+      color: isSelected ? Theme.of(context).selectedRowColor : null,
       child: InkWell(
         onTap: () => widget.onSelected(bp),
         child: densePadding(
           Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
-              Text(
-                '● ${_descriptionFor(bp)}',
-                overflow: TextOverflow.ellipsis,
-                style: bp.id == widget.selected?.id
-                    ? TextStyle(color: Theme.of(context).textSelectionColor)
-                    : null,
-              ),
               Flexible(
-                child: Text(
-                  ' (${bp.scriptUri})',
+                child: RichText(
+                  maxLines: 1,
                   overflow: TextOverflow.ellipsis,
-                  style: bp.id == widget.selected?.id
-                      ? TextStyle(color: Theme.of(context).textSelectionColor)
-                      : subtleStyle,
+                  text: TextSpan(
+                    text: '● ${_descriptionFor(bp)}',
+                    style: isSelected ? selectedStyle : regularStyle,
+                    children: [
+                      TextSpan(
+                        text: ' (${bp.scriptUri})',
+                        style: isSelected ? selectedStyle : subtleStyle,
+                      ),
+                    ],
+                  ),
                 ),
               ),
             ],

--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -45,17 +45,16 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
   }
 
   Widget buildBreakpoint(BuildContext context, BreakpointAndSourcePosition bp) {
-    final regularStyle =
-        TextStyle(color: Theme.of(context).textTheme.bodyText2.color);
-    final subtleStyle =
-        TextStyle(color: Theme.of(context).unselectedWidgetColor);
-    final selectedStyle =
-        TextStyle(color: Theme.of(context).textSelectionColor);
+    final theme = Theme.of(context);
+
+    final regularStyle = TextStyle(color: theme.textTheme.bodyText2.color);
+    final subtleStyle = TextStyle(color: theme.unselectedWidgetColor);
+    final selectedStyle = TextStyle(color: theme.textSelectionColor);
 
     final isSelected = bp.id == widget.selected?.id;
 
     return Material(
-      color: isSelected ? Theme.of(context).selectedRowColor : null,
+      color: isSelected ? theme.selectedRowColor : null,
       child: InkWell(
         onTap: () => widget.onSelected(bp),
         child: densePadding(

--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -6,53 +6,101 @@ import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/theme.dart';
-import 'codeview.dart';
+import '../../utils.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
 
-class BreakpointPicker extends StatelessWidget {
+class BreakpointPicker extends StatefulWidget {
   const BreakpointPicker({Key key, @required this.controller})
       : super(key: key);
 
   final DebuggerController controller;
 
-  String textFor(Breakpoint breakpoint) {
-    if (breakpoint.resolved) {
-      final location = breakpoint.location as SourceLocation;
-      // TODO(djshuckerow): Resolve the scripts in the background and
-      // switch from token position to line numbers.
-      return '${location.script.uri.split('/').last} Position '
-          '${location.tokenPos} (${location.script.uri})';
-    } else {
-      final location = breakpoint.location as UnresolvedSourceLocation;
-      return '${location.script.uri.split('/').last} Position '
-          '${location.line} (${location.script.uri})';
-    }
+  @override
+  _BreakpointPickerState createState() => _BreakpointPickerState();
+}
+
+class _BreakpointPickerState extends State<BreakpointPicker> {
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<List<BreakpointAndSourcePosition>>(
+      valueListenable: widget.controller.breakpointsWithLocation,
+      builder: (context, breakpoints, _) {
+        return ListView.builder(
+          itemCount: breakpoints.length,
+          itemExtent: defaultListItemHeight,
+          itemBuilder: (context, index) {
+            return buildBreakpoint(context, breakpoints[index]);
+          },
+        );
+      },
+    );
   }
+
+  Widget buildBreakpoint(BuildContext context, BreakpointAndSourcePosition bp) {
+    final subtleStyle =
+        TextStyle(color: Theme.of(context).unselectedWidgetColor);
+
+    return Material(
+      child: InkWell(
+        // todo:
+        onTap: () => print(bp),
+        child: densePadding(
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              const Text('● '),
+              Text(_descriptionFor(bp)),
+              Expanded(
+                child: Text(
+                  ' (${bp.scriptUri})',
+                  style: subtleStyle,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _descriptionFor(BreakpointAndSourcePosition breakpoint) {
+    final fileName = breakpoint.scriptUri.split('/').last;
+    final line = breakpoint.line;
+
+    return breakpoint.resolved
+        ? '$fileName:$line:${breakpoint.column}'
+        : '$fileName:$line';
+  }
+}
+
+class BreakpointsCountBadge extends StatelessWidget {
+  const BreakpointsCountBadge({@required this.breakpoints});
+
+  final List<Breakpoint> breakpoints;
 
   @override
   Widget build(BuildContext context) {
-    return densePadding(
-      Scrollbar(
-        child: SingleChildScrollView(
-          scrollDirection: Axis.horizontal,
-          child: SizedBox(
-            width: MediaQuery.of(context).size.width,
-            child: ValueListenableBuilder(
-              valueListenable: controller.breakpoints,
-              builder: (context, breakpoints, _) {
-                return ListView.builder(
-                  itemCount: breakpoints.length,
-                  itemExtent: defaultListItemHeight,
-                  itemBuilder: (context, index) => SizedBox(
-                    height: CodeView.rowHeight,
-                    child: Text(textFor(breakpoints[index])),
-                  ),
-                );
-              },
-            ),
-          ),
-        ),
+    return Badge(
+      child: Text(
+        '${nf.format(breakpoints.length)}',
+      ),
+    );
+  }
+}
+
+class Badge extends StatelessWidget {
+  const Badge({@required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      child: Chip(
+        label: child,
+        visualDensity: VisualDensity.compact,
+        padding: const EdgeInsets.symmetric(vertical: -4.0),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -150,12 +150,15 @@ class DebuggerController extends DisposableController
     }
 
     _breakpoints.value = isolate.breakpoints;
+
     // Build _breakpointsWithLocation from _breakpoints.
-    // ignore: unawaited_futures
-    Future.wait(_breakpoints.value.map(_createBreakpointWithLocation))
-        .then((list) {
-      _breakpointsWithLocation.value = list.toList()..sort();
-    });
+    if (breakpoints.value != null) {
+      // ignore: unawaited_futures
+      Future.wait(breakpoints.value.map(_createBreakpointWithLocation))
+          .then((list) {
+        _breakpointsWithLocation.value = list.toList()..sort();
+      });
+    }
 
     _exceptionPauseMode.value = isolate.exceptionPauseMode;
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -246,10 +246,11 @@ class DebuggerController extends DisposableController
         // ignore: unawaited_futures
         _createBreakpointWithLocation(event.breakpoint).then((bp) {
           final list = _breakpointsWithLocation.value.toList();
-          list
-            ..remove(bp)
-            ..add(bp)
-            ..sort();
+          // Remote the bp with the older, unresolved information from the list.
+          list.removeWhere((breakpoint) => bp.breakpoint.id == bp.id);
+          // Add the bp with the newer, resolved information.
+          list.add(bp);
+          list.sort();
           _breakpointsWithLocation.value = list;
         });
 
@@ -379,7 +380,7 @@ class DebuggerController extends DisposableController
     if (breakpoint.resolved) {
       final bp = BreakpointAndSourcePosition(breakpoint);
       return getScript(bp.script).then((Script script) {
-        final SourcePosition pos = calculatePosition(script, bp.tokenPos);
+        final pos = calculatePosition(script, bp.tokenPos);
         return BreakpointAndSourcePosition(breakpoint, pos);
       });
     } else {

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -114,7 +114,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (script == null) return {};
     return {
       for (var b in controller.breakpoints.value
-          .where((b) => b != null && b.location.script.id == script.id))
+          .where((b) => b != null && b.location.script?.id == script.id))
         controller.lineNumber(script, b.location): b,
     };
   }
@@ -248,6 +248,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             Expanded(
               child: Text(
                 title,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
                 style: Theme.of(context).textTheme.subtitle2,
               ),
             ),

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -63,6 +63,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   DebuggerController controller;
   ScriptRef loadingScript;
   Script script;
+  BreakpointAndSourcePosition selectedBreakpoint;
 
   @override
   void didChangeDependencies() {
@@ -72,9 +73,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (newController == controller) return;
     controller = newController;
 
-    // TODO(all): We need to be more precise about the changes we listen to.
-    // These coarse listeners are causing us to rebuild much more of the UI than
-    // we need to.
+    // TODO(devoncarew): We need to be more precise about the changes we listen
+    // to. These coarse listeners are causing us to rebuild much more of the UI
+    // than we need to.
     addAutoDisposeListener(controller.currentScript, () {
       setState(() {
         script = controller.currentScript.value;
@@ -96,6 +97,17 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     });
 
     await controller.selectScript(ref);
+  }
+
+  Future<void> _onBreakpointSelected(BreakpointAndSourcePosition bp) async {
+    if (bp != selectedBreakpoint) {
+      setState(() {
+        selectedBreakpoint = bp;
+      });
+    }
+
+    // TODO(devoncarew): Change the line selection in the code view as well.
+    await controller.selectScript(bp.script);
   }
 
   Map<int, Breakpoint> _breakpointsForLines() {
@@ -177,7 +189,12 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           headers: [
             _debuggerPaneHeader(callStackTitle, needsTopBorder: false),
             _debuggerPaneHeader(variablesTitle),
-            _debuggerPaneHeader(breakpointsTitle),
+            _debuggerPaneHeader(
+              breakpointsTitle,
+              rightChild: BreakpointsCountBadge(
+                breakpoints: controller.breakpoints.value,
+              ),
+            ),
             _debuggerPaneHeader(
               librariesTitle,
               rightChild: ScriptCountBadge(
@@ -188,7 +205,11 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           children: [
             const Center(child: Text('TODO: call stack')),
             const Center(child: Text('TODO: variables')),
-            BreakpointPicker(controller: controller),
+            BreakpointPicker(
+              controller: controller,
+              selected: selectedBreakpoint,
+              onSelected: _onBreakpointSelected,
+            ),
             ScriptPicker(
               scripts: controller.sortedScripts.value,
               selected: loadingScript,

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -94,7 +94,9 @@ void main() {
 
       final breakpointsWithLocation = [
         BreakpointAndSourcePosition(
-            breakpoints.first, SourcePosition(line: 10, column: 1))
+          breakpoints.first,
+          SourcePosition(line: 10, column: 1),
+        )
       ];
 
       final debuggerController = MockDebuggerController();
@@ -116,7 +118,12 @@ void main() {
       expect(find.text('Breakpoints'), findsOneWidget);
 
       // test for items in the breakpoint list
-      expect(find.text('script.dart 10'), findsOneWidget);
+      expect(
+        find.byWidgetPredicate((Widget widget) =>
+            widget is RichText &&
+            widget.text.toPlainText().contains('● script.dart:10')),
+        findsOneWidget,
+      );
     });
   });
 }

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -45,6 +45,8 @@ void main() {
       final debuggerController = MockDebuggerController();
       when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      when(debuggerController.breakpointsWithLocation)
+          .thenReturn(ValueNotifier([]));
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: [])));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
@@ -65,6 +67,8 @@ void main() {
       final debuggerController = MockDebuggerController();
       when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      when(debuggerController.breakpointsWithLocation)
+          .thenReturn(ValueNotifier([]));
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/debugger/flutter/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/flutter/debugger_screen.dart';
 import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
@@ -77,6 +78,45 @@ void main() {
 
       // test for items in the libraries list
       expect(find.text(scripts.first.uri), findsOneWidget);
+    });
+
+    testWidgets('Breakpoints show items', (WidgetTester tester) async {
+      final breakpoints = [
+        Breakpoint(
+          breakpointNumber: 1,
+          resolved: false,
+          location: UnresolvedSourceLocation(
+            scriptUri: 'package:/test/script.dart',
+            line: 10,
+          ),
+        )
+      ];
+
+      final breakpointsWithLocation = [
+        BreakpointAndSourcePosition(
+            breakpoints.first, SourcePosition(line: 10, column: 1))
+      ];
+
+      final debuggerController = MockDebuggerController();
+      when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
+      when(debuggerController.breakpoints)
+          .thenReturn(ValueNotifier(breakpoints));
+      when(debuggerController.breakpointsWithLocation)
+          .thenReturn(ValueNotifier(breakpointsWithLocation));
+
+      when(debuggerController.scriptList)
+          .thenReturn(ValueNotifier(ScriptList(scripts: [])));
+      when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
+      when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
+      await tester.pumpWidget(wrapWithControllers(
+        Builder(builder: screen.build),
+        debugger: debuggerController,
+      ));
+
+      expect(find.text('Breakpoints'), findsOneWidget);
+
+      // test for items in the breakpoint list
+      expect(find.text('script.dart 10'), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
Various improvements to the breakpoints view:
- improve the look of the breakpoints list
- add an additional way to represent breakpoints - a breakpoint and a resolved source location. This allows us to collect some async information to associate with the breakpoint, and fire an event when all the info is collected and ready for display
- add a new ValueNotifier to the debugger controller - the list of resolved breakpoints and locations; `breakpointsWithLocation`
- add a total breakpoint count to the header of the breakpoints view
- have a notion of a selected breakpoint
- on breakpoint selection, open the associated script

Now ready for review -
