### PR TITLE
Add a flag to allow DevTools to be embedded

### DIFF
--- a/packages/devtools_app/lib/html_main.dart
+++ b/packages/devtools_app/lib/html_main.dart
@@ -32,7 +32,12 @@ void main() {
 
       // TODO(terry): Eventually remove the below line localStorage clear().
       /// Nothing is now stored in Chrome's local store - remove old stuff.
-      window.localStorage.clear();
+      try {
+        window.localStorage.clear();
+        // ignore: empty_catches
+      } catch (e) {
+        // window.localStorage will throw permissions errors when embedded.
+      }
 
       // Show the opt-in dialog for collection analytics?
       try {

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -48,6 +48,7 @@ class DevToolsServerDriver {
   static Future<DevToolsServerDriver> create({
     int port = 0,
     int tryPorts,
+    List<String> additionalArgs = const [],
   }) async {
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
@@ -56,6 +57,7 @@ class DevToolsServerDriver {
       '--machine',
       '--port',
       '$port',
+      ...additionalArgs
     ];
 
     if (tryPorts != null) {

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -28,6 +28,7 @@ const protocolVersion = '1.1.0';
 const argHelp = 'help';
 const argVmUri = 'vm-uri';
 const argEnableNotifications = 'enable-notifications';
+const argAllowEmbedding = 'allow-embedding';
 const argHeadlessMode = 'headless';
 const argDebugMode = 'debug';
 const argLaunchBrowser = 'launch-browser';
@@ -94,6 +95,12 @@ final argParser = ArgParser()
         'Requests notification permissions immediately when a client connects back to the server.',
   )
   ..addFlag(
+    argAllowEmbedding,
+    hide: true,
+    negatable: false,
+    help: 'Allow embedding DevTools inside an iframe.',
+  )
+  ..addFlag(
     argHeadlessMode,
     hide: true,
     negatable: false,
@@ -127,6 +134,7 @@ Future<HttpServer> serveDevToolsWithArgs(
   final bool machineMode = args[argMachine];
   final bool launchBrowser = args[argLaunchBrowser];
   final bool enableNotifications = args[argEnableNotifications];
+  final bool allowEmbedding = args[argAllowEmbedding];
   final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
   final bool headlessMode = args[argHeadlessMode];
   final bool debugMode = args[argDebugMode];
@@ -144,6 +152,7 @@ Future<HttpServer> serveDevToolsWithArgs(
     debugMode: debugMode,
     launchBrowser: launchBrowser,
     enableNotifications: enableNotifications,
+    allowEmbedding: allowEmbedding,
     port: port,
     headlessMode: headlessMode,
     numPortsToTry: numPortsToTry,
@@ -166,6 +175,7 @@ Future<HttpServer> serveDevTools({
   bool debugMode = false,
   bool launchBrowser = false,
   bool enableNotifications = false,
+  bool allowEmbedding = false,
   bool headlessMode = false,
   bool verboseMode = false,
   String hostname = 'localhost',
@@ -217,6 +227,9 @@ Future<HttpServer> serveDevTools({
     throw ex;
   }
 
+  if (allowEmbedding) {
+    server.defaultResponseHeaders.remove('x-frame-options', 'SAMEORIGIN');
+  }
   shelf.serveRequests(server, handler);
 
   final devToolsUrl = 'http://${server.address.host}:${server.port}';


### PR DESCRIPTION
This adds a flag `--allow-embedding` that will suppress the `x-frame-options` header (adding by Shelf by default) to allow this to be embedded (for ex. inside VS Code).