### PR TITLE
Remove some legacy checks that would prevent tests running

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -181,11 +181,7 @@ void main() {
     );
   }, timeout: const Timeout.factor(10));
 
-  // TODO(dantup): We can't run tests using the stdin API for devTools.launch unless
-  // we're running with a new server version. This check can be removed (and always use
-  // both) after the next server release (after the PR lands).
-  for (final bool useVmService
-      in serverDevToolsLaunchViaStdin ? [true, false] : [true]) {
+  for (final bool useVmService in [true, false]) {
     group('Server (${useVmService ? 'VM Service' : 'API'})', () {
       test(
           'DevTools connects back to server API and registers that it is connected',

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -10,10 +10,6 @@ import 'chrome.dart';
 
 const verbose = true;
 
-// TODO(dantup): Remove this when the live Pub version supports devTools.launch.
-final bool serverDevToolsLaunchViaStdin =
-    Platform.environment['USE_LOCAL_DEPENDENCIES'] == 'true';
-
 class DevToolsServerDriver {
   DevToolsServerDriver._(this._process, this._stdin, Stream<String> _stdout,
       Stream<String> _stderr)


### PR DESCRIPTION
This was simplified in #1721, so this check is no longer required (but because the variable was removed, it also meant these tests were not running). This removes the condition and always runs the test in both modes since the tests always run using the local dependencies.