### PR TITLE
Track PIDs of browsers spawned during tests and clean them up

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -24,6 +24,9 @@ final StreamController<Map<String, dynamic>> eventController =
     StreamController.broadcast();
 Stream<Map<String, dynamic>> get events => eventController.stream;
 final Map<String, String> registeredServices = {};
+// A list of PIDs for Chrome instances spawned by tests that should be
+// cleaned up.
+final List<int> browserPids = [];
 
 void main() {
   final bool testInReleaseMode =
@@ -75,6 +78,9 @@ void main() {
   });
 
   tearDown(() async {
+    browserPids
+      ..forEach(Process.killPid)
+      ..clear();
     server?.kill();
     await appFixture?.teardown();
   });
@@ -394,6 +400,10 @@ Future<Map<String, dynamic>> _sendLaunchDevToolsRequest({
     });
   }
   final response = await launchEvent;
+  final pid = response['params']['pid'];
+  if (pid != null) {
+    browserPids.add(pid);
+  }
   return response['params'];
 }
 

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -71,6 +71,8 @@ to `launchDevTools`. `params` contains the following fields:
 - `reused` - whether an existing DevTools instance was reused (otherwise a new
   browser was launched)
 - `notified` - whether or not a notification was shown
+- `pid` - the pid of the launched instance of Chrome (omitted if Chrome was not
+  not launched or an existing Chrome instance was reused)
 -->
 
 ### Requests


### PR DESCRIPTION
I've noticed a few recent builds have been flaky (failing to connect to Chrome debug ports), especially since #1826 (which made more Chrome tests run). I think this may be related to the server spawning instances of Chrome, but not terminating them.

I'm not sure we want to automatically terminate them when the server quits (the user may have opened new tabs and be doing things in them), so I've added the `pid` to the return package so the client (or in this case, the tests) can decide whether to clean them up.

Running this locally prevents Chrome processes being left around after the tests.