### PR TITLE
Add arrow left/right navigation to tree table

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -1,5 +1,4 @@
 import 'dart:math';
-import 'dart:ui';
 
 import 'package:flutter/material.dart' hide TableRow;
 import 'package:flutter/services.dart';
@@ -457,26 +456,28 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       _moveSelection(ScrollKind.down, scrollController, constraints.maxHeight);
     } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
       _moveSelection(ScrollKind.up, scrollController, constraints.maxHeight);
-    }
-
-    // On left arrow collapse the row if it is expanded. If it is not, move
-    // selection to its parent.
-    else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      // On left arrow collapse the row if it is expanded. If it is not, move
+      // selection to its parent.
       if (selectedNode.isExpanded) {
         _toggleNode(selectedNode);
       } else {
         _moveSelection(
-            ScrollKind.parent, scrollController, constraints.maxHeight);
+          ScrollKind.parent,
+          scrollController,
+          constraints.maxHeight,
+        );
       }
-    }
-
-    // On right arrow expand the row if possible, otherwise move selection down.
-    else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+      // On right arrow expand the row if possible, otherwise move selection down.
       if (!selectedNode.isExpanded) {
         _toggleNode(selectedNode);
       } else {
         _moveSelection(
-            ScrollKind.down, scrollController, constraints.maxHeight);
+          ScrollKind.down,
+          scrollController,
+          constraints.maxHeight,
+        );
       }
     }
   }
@@ -497,15 +498,16 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     final lastItemIndex = firstItemIndex + minCompleteItemsInView - 1;
     int newSelectedNodeIndex;
 
-    if (scrollKind == ScrollKind.down) {
-      // move selection down if there is a next node.
-      newSelectedNodeIndex = min(selectedNodeIndex + 1, items.length - 1);
-    } else if (scrollKind == ScrollKind.up) {
-      // move selection up if there is a previous node.
-      newSelectedNodeIndex = max(selectedNodeIndex - 1, 0);
-    } else if (scrollKind == ScrollKind.parent) {
-      // move selection to parent
-      newSelectedNodeIndex = items.indexOf(selectedNode.parent);
+    switch (scrollKind) {
+      case ScrollKind.down:
+        newSelectedNodeIndex = min(selectedNodeIndex + 1, items.length - 1);
+        break;
+      case ScrollKind.up:
+        newSelectedNodeIndex = max(selectedNodeIndex - 1, 0);
+        break;
+      case ScrollKind.parent:
+        newSelectedNodeIndex = items.indexOf(selectedNode.parent);
+        break;
     }
 
     final newSelectedNode = items[newSelectedNodeIndex];

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -1,4 +1,5 @@
 import 'dart:math';
+import 'dart:ui';
 
 import 'package:flutter/material.dart' hide TableRow;
 import 'package:flutter/services.dart';
@@ -22,6 +23,8 @@ typedef IndexedScrollableWidgetBuilder = Widget Function(
 
 typedef TableKeyEventHandler = void Function(RawKeyEvent event,
     ScrollController scrollController, BoxConstraints constraints);
+
+enum ScrollKind { up, down, parent }
 
 /// A table that displays in a collection of [data], based on a collection of
 /// [ColumnData].
@@ -273,10 +276,14 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
 
   void _onItemPressed(T node, int nodeIndex) {
     /// Rebuilds the table whenever the tree structure has been updated
-    setState(() {
-      selectedNode = node;
-      selectedNodeIndex = nodeIndex;
+    selectedNode = node;
+    selectedNodeIndex = nodeIndex;
 
+    _toggleNode(node);
+  }
+
+  void _toggleNode(T node) {
+    setState(() {
       if (!node.isExpandable) return;
       animatingNode = node;
       List<T> nodeChildren;
@@ -446,15 +453,36 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     }
     assert(selectedNode == items[selectedNodeIndex]);
 
-    if (event.logicalKey == LogicalKeyboardKey.arrowDown ||
-        event.logicalKey == LogicalKeyboardKey.arrowUp) {
-      _moveSelection(event.logicalKey, scrollController, constraints.maxHeight);
+    if (event.logicalKey == LogicalKeyboardKey.arrowDown) {
+      _moveSelection(ScrollKind.down, scrollController, constraints.maxHeight);
+    } else if (event.logicalKey == LogicalKeyboardKey.arrowUp) {
+      _moveSelection(ScrollKind.up, scrollController, constraints.maxHeight);
     }
-    // TODO(gmoothart): Add expand/collapse with left/right keys
+
+    // On left arrow collapse the row if it is expanded. If it is not, move
+    // selection to its parent.
+    else if (event.logicalKey == LogicalKeyboardKey.arrowLeft) {
+      if (selectedNode.isExpanded) {
+        _toggleNode(selectedNode);
+      } else {
+        _moveSelection(
+            ScrollKind.parent, scrollController, constraints.maxHeight);
+      }
+    }
+
+    // On right arrow expand the row if possible, otherwise move selection down.
+    else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
+      if (!selectedNode.isExpanded) {
+        _toggleNode(selectedNode);
+      } else {
+        _moveSelection(
+            ScrollKind.down, scrollController, constraints.maxHeight);
+      }
+    }
   }
 
   void _moveSelection(
-    LogicalKeyboardKey key,
+    ScrollKind scrollKind,
     ScrollController scrollController,
     double viewportHeight,
   ) {
@@ -462,20 +490,22 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     final firstItemIndex =
         (scrollController.offset / _Table.defaultRowHeight).ceil();
 
+    // '-1' in the following calculations is needed because the header row
+    // occupies space in the viewport so we must subtract it out.
     final minCompleteItemsInView =
         (viewportHeight / _Table.defaultRowHeight).floor() - 1;
     final lastItemIndex = firstItemIndex + minCompleteItemsInView - 1;
     int newSelectedNodeIndex;
 
-    if (key == LogicalKeyboardKey.arrowDown) {
-      // move selection down if there is a node lower down.
+    if (scrollKind == ScrollKind.down) {
+      // move selection down if there is a next node.
       newSelectedNodeIndex = min(selectedNodeIndex + 1, items.length - 1);
-    } else if (key == LogicalKeyboardKey.arrowUp) {
-      // move selection up if there is a node lower down.
+    } else if (scrollKind == ScrollKind.up) {
+      // move selection up if there is a previous node.
       newSelectedNodeIndex = max(selectedNodeIndex - 1, 0);
-    } else {
-      // Nowhere to move
-      return;
+    } else if (scrollKind == ScrollKind.parent) {
+      // move selection to parent
+      newSelectedNodeIndex = items.indexOf(selectedNode.parent);
     }
 
     final newSelectedNode = items[newSelectedNodeIndex];
@@ -484,10 +514,10 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
 
     if (isBelowViewport) {
       // Scroll so selected row is the last full item displayed in the viewport.
-      // To do this we need to be showing the (minCompleteItemsInView - 1)
+      // To do this we need to be showing the (minCompleteItemsInView + 1)
       // previous item  at the top.
       scrollController.animateTo(
-        (newSelectedNodeIndex - minCompleteItemsInView - 1) *
+        (newSelectedNodeIndex - minCompleteItemsInView + 1) *
             _Table.defaultRowHeight,
         duration: defaultDuration,
         curve: defaultCurve,


### PR DESCRIPTION
Left key collapses the current node or selects the node's parent.
Right key expands the current node, or selects its first child.

Also fixed a math error in scrolling and added comments plus general
cleanup.

Fixes  #1769