### PR TITLE
on page entry select the main isolate script

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -76,16 +76,16 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     // TODO(devoncarew): We need to be more precise about the changes we listen
     // to. These coarse listeners are causing us to rebuild much more of the UI
     // than we need to.
+    script = controller.currentScript.value;
     addAutoDisposeListener(controller.currentScript, () {
       setState(() {
         script = controller.currentScript.value;
       });
     });
+
     addAutoDisposeListener(controller.currentStack);
     addAutoDisposeListener(controller.sortedScripts);
     addAutoDisposeListener(controller.breakpoints);
-
-    controller.getScripts();
   }
 
   Future<void> _onScriptSelected(ScriptRef ref) async {

--- a/packages/devtools_app/test/flutter/controllers_test.dart
+++ b/packages/devtools_app/test/flutter/controllers_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-
 import 'package:devtools_app/src/flutter/controllers.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -188,6 +187,7 @@ class _TestProvidedControllers extends Fake implements ProvidedControllers {
   _TestProvidedControllers() {
     _disposed[this] = false;
   }
+
   @override
   void dispose() {
     _disposed[this] = true;
@@ -207,6 +207,7 @@ class _TestDependent extends StatefulWidget {
 class _TestDependentState extends State<_TestDependent> {
   int notifications = 0;
   _TestProvidedControllers controllers;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -52,6 +52,8 @@ void main() {
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       when(debuggerController.stdio).thenReturn(ValueNotifier(['test stdio']));
+      when(debuggerController.currentScript).thenReturn(ValueNotifier(null));
+
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,
@@ -76,6 +78,8 @@ void main() {
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       when(debuggerController.stdio).thenReturn(ValueNotifier([]));
+      when(debuggerController.currentScript).thenReturn(ValueNotifier(null));
+
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,
@@ -118,6 +122,8 @@ void main() {
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       when(debuggerController.stdio).thenReturn(ValueNotifier([]));
+      when(debuggerController.currentScript).thenReturn(ValueNotifier(null));
+
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,


### PR DESCRIPTION
- on page entry select the main isolate script
- remove some unused code from the debugger controller

This means that the code view comes up populated by default, generally with the `main.dart` from the running application.