### PR TITLE
improve the editor gutter display

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -11,6 +11,9 @@ import '../../utils.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
 
+const executableLineRadius = 1.5;
+const breakpointRadius = 6.0;
+
 class BreakpointPicker extends StatefulWidget {
   const BreakpointPicker({
     Key key,
@@ -57,16 +60,27 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
       color: isSelected ? theme.selectedRowColor : null,
       child: InkWell(
         onTap: () => widget.onSelected(bp),
-        child: densePadding(
-          Row(
+        child: Padding(
+          padding: const EdgeInsets.all(borderPadding),
+          child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
+              Padding(
+                padding: const EdgeInsets.only(
+                  left: borderPadding,
+                  right: borderPadding * 2,
+                ),
+                child: createCircleWidget(
+                  breakpointRadius,
+                  (isSelected ? selectedStyle : regularStyle).color,
+                ),
+              ),
               Flexible(
                 child: RichText(
                   maxLines: 1,
                   overflow: TextOverflow.ellipsis,
                   text: TextSpan(
-                    text: '● ${_descriptionFor(bp)}',
+                    text: _descriptionFor(bp),
                     style: isSelected ? selectedStyle : regularStyle,
                     children: [
                       TextSpan(

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -10,6 +10,8 @@ import 'package:vm_service/vm_service.dart' as vm show Stack;
 
 import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/theme.dart';
+import 'breakpoints.dart';
+import 'common.dart';
 import 'debugger_controller.dart';
 
 // TODO(kenz): consider moving lines / pausedPositions calculations to the
@@ -220,6 +222,9 @@ class GutterRow extends StatelessWidget {
     final foregroundColor = theme.textTheme.bodyText2.color;
     final subtleColor = theme.unselectedWidgetColor;
 
+    const bpBoxSize = 12.0;
+    const executionPointIndent = 8.0;
+
     return InkWell(
       onTap: onPressed,
       child: Container(
@@ -234,13 +239,15 @@ class GutterRow extends StatelessWidget {
               Align(
                 alignment: Alignment.centerLeft,
                 child: SizedBox(
-                  width: 12,
-                  height: 12,
+                  width: bpBoxSize,
+                  height: bpBoxSize,
                   child: Stack(
                     alignment: AlignmentDirectional.center,
                     children: [
-                      if (isExecutable) _createCircle(1.5, subtleColor),
-                      if (isBreakpoint) _createCircle(6.0, foregroundColor),
+                      if (isExecutable)
+                        createCircleWidget(executableLineRadius, subtleColor),
+                      if (isBreakpoint)
+                        createCircleWidget(breakpointRadius, foregroundColor),
                     ],
                   ),
                 ),
@@ -248,7 +255,7 @@ class GutterRow extends StatelessWidget {
             Text('$lineNumber', textAlign: TextAlign.end),
             if (isPausedHere)
               const Padding(
-                padding: EdgeInsets.only(left: 8.0),
+                padding: EdgeInsets.only(left: executionPointIndent),
                 child: Align(
                   alignment: Alignment.centerLeft,
                   child: Icon(Icons.play_arrow, size: defaultIconSize),
@@ -257,14 +264,6 @@ class GutterRow extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-
-  Widget _createCircle(double radius, Color color) {
-    return Container(
-      width: radius,
-      height: radius,
-      decoration: BoxDecoration(color: color, shape: BoxShape.circle),
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -7,13 +7,6 @@ import 'package:flutter/material.dart';
 import '../../flutter/theme.dart';
 import 'debugger_screen.dart';
 
-Widget densePadding(Widget child) {
-  return Padding(
-    padding: const EdgeInsets.all(2.0),
-    child: child,
-  );
-}
-
 /// Create a header area for a debugger component.
 ///
 /// Either one of [text] or [child] must be supplied.
@@ -32,5 +25,13 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
     alignment: Alignment.centerLeft,
     height: DebuggerScreen.debuggerPaneHeaderHeight,
     child: child != null ? child : Text(text, style: theme.textTheme.subtitle2),
+  );
+}
+
+Widget createCircleWidget(double radius, Color color) {
+  return Container(
+    width: radius,
+    height: radius,
+    decoration: BoxDecoration(color: color, shape: BoxShape.circle),
   );
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -124,7 +124,11 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (breakpoints.containsKey(line)) {
       await controller.removeBreakpoint(breakpoints[line]);
     } else {
-      await controller.addBreakpoint(script.id, line);
+      try {
+        await controller.addBreakpoint(script.id, line);
+      } catch (_) {
+        // ignore errors setting breakpoints
+      }
     }
     // The controller's breakpoints value listener will update us at this point
     // to rebuild.

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -49,6 +49,9 @@ const defaultSpacing = 16.0;
 const denseSpacing = 8.0;
 const denseRowSpacing = 6.0;
 
+const borderPadding = 2.0;
+const densePadding = 4.0;
+
 const defaultListItemHeight = 28.0;
 
 /// Branded grey color.

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -129,7 +129,7 @@ void main() {
       expect(
         find.byWidgetPredicate((Widget widget) =>
             widget is RichText &&
-            widget.text.toPlainText().contains('● script.dart:10')),
+            widget.text.toPlainText().contains('script.dart:10')),
         findsOneWidget,
       );
     });


### PR DESCRIPTION
Improve the editor gutter display:
- use a Stack to better position breakpoints, the execution point, and line numbers in the editor's gutter
- also display a decoration for lines that are executable but that don't currently have a breakpoints
- change to displaying breakpoints with a Container and a decoration (instead of a bullet unicode char) in order to better center the decoration

<img width="237" alt="Screen Shot 2020-04-17 at 2 46 23 PM" src="https://user-images.githubusercontent.com/1269969/79616946-279c0f00-80bb-11ea-808c-5396b90f87d7.png">

<img width="227" alt="Screen Shot 2020-04-17 at 2 48 43 PM" src="https://user-images.githubusercontent.com/1269969/79616953-2c60c300-80bb-11ea-9f94-722b5635262a.png">
