### PR TITLE
have the debugger page contribute a status line item

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -48,6 +48,8 @@ class DebuggerController extends DisposableController
 
   Event _lastEvent;
 
+  Event get lastEvent => _lastEvent;
+
   final _currentScript = ValueNotifier<Script>(null);
 
   ValueListenable<Script> get currentScript => _currentScript;
@@ -397,7 +399,7 @@ class SourcePosition {
   final int column;
 
   @override
-  String toString() => '$line $column';
+  String toString() => '$line:$column';
 }
 
 /// A tuple of a breakpoint and a source position.

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -388,13 +388,19 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
   }
 
   void _updateStatus() async {
+    final status = await _computeStatus();
+    if (status != _status) {
+      setState(() {
+        _status = status;
+      });
+    }
+  }
+
+  Future<String> _computeStatus() async {
     final paused = widget.controller.isPaused.value;
 
     if (!paused) {
-      setState(() {
-        _status = 'running';
-      });
-      return;
+      return 'running';
     }
 
     final event = widget.controller.lastEvent;
@@ -403,10 +409,7 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
         event.kind == EventKind.kPauseException ? ' on exception' : '';
 
     if (frame == null) {
-      setState(() {
-        _status = 'paused$reason';
-      });
-      return;
+      return 'paused$reason';
     }
 
     final fileName = ' at ' + frame.location.script.uri.split('/').last;
@@ -414,8 +417,6 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
     final pos =
         widget.controller.calculatePosition(script, frame.location.tokenPos);
 
-    setState(() {
-      _status = 'paused$reason$fileName $pos';
-    });
+    return 'paused$reason$fileName $pos';
   }
 }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -39,7 +39,19 @@ class StatusLine extends StatelessWidget {
         child: buildHelpUrlStatus(context, currentScreen, textTheme),
       ),
     ));
+
     children.add(const BulletSpacer());
+
+    // Optionally display an isolate selector.
+    if (currentScreen != null && currentScreen.showIsolateSelector) {
+      children.add(Expanded(
+        child: Align(
+          child: buildIsolateSelector(context, textTheme),
+        ),
+      ));
+
+      children.add(const BulletSpacer());
+    }
 
     // Optionally display page specific status.
     if (currentScreen != null) {
@@ -52,18 +64,9 @@ class StatusLine extends StatelessWidget {
             child: buildPageStatus(context, currentScreen, textTheme),
           ),
         ));
+
         children.add(const BulletSpacer());
       }
-    }
-
-    // Optionally display an isolate selector.
-    if (currentScreen != null && currentScreen.showIsolateSelector) {
-      children.add(Expanded(
-        child: Align(
-          child: buildIsolateSelector(context, textTheme),
-        ),
-      ));
-      children.add(const BulletSpacer());
     }
 
     // Always display connection status (docked to the right).


### PR DESCRIPTION
have the debugger page contribute a status line item:
- contribute a debugger status line item showing `running` or `paused at ...`
- reorder the position of the isolate selector and the page specific status in the app's status line

<img width="820" alt="Screen Shot 2020-04-18 at 7 22 16 PM" src="https://user-images.githubusercontent.com/1269969/79677874-6957b300-81aa-11ea-94bd-c7ea912100b1.png">
