### PR TITLE
log all service protocol traffic

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -71,6 +71,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
     final newController = Controllers.of(context).debugger;
     if (newController == controller) return;
+
+    // Remove our listeners to the old controller.
+    cancel();
+
     controller = newController;
 
     // TODO(devoncarew): We need to be more precise about the changes we listen

--- a/packages/devtools_app/lib/src/flutter/controllers.dart
+++ b/packages/devtools_app/lib/src/flutter/controllers.dart
@@ -146,6 +146,13 @@ class _ControllersState extends State<Controllers> {
   @override
   void didUpdateWidget(Controllers oldWidget) {
     super.didUpdateWidget(oldWidget);
+
+    // TODO(#1732): We create controllers twice - here, and in initState().
+    // Additionally, when creating new controllers in didUpdateWidget, we never
+    // dispose of the old controllers. For places like the debugger page, this
+    // means that we send many more requests to the VM for the same data than we
+    // need to.
+
     _initializeProviderData();
   }
 
@@ -157,6 +164,8 @@ class _ControllersState extends State<Controllers> {
         'Attempted to build overridden providers, but got a null value.',
       );
     } else {
+      // TODO(#1732): Don't re-create controllers on each hot reload, or,
+      // dispose of the old controllers here.
       data = ProvidedControllers.defaults();
     }
   }


### PR DESCRIPTION
- add a `debugLogServiceProtocolEvents` const to the debugger controller; when this is turned on, we log all service protocol traffic to the Logging page. This can be used to audit our service protocol traffic, and be better aware when we're making expensive calls

@jacob314, this shows up some issues wrt our controller lifetimes. It looks like we're creating controllers twice at app startup, and then once each time we hot reload, likely w/o disposing of the old controllers. I'm not sure why we re-create controllers on hot reload. I wasn't successful in untangling exactly what's going on. It has the effect of us sending a lot more traffic over the service protocol (requesting objects, the list of scripts, ...) than we need to.

@grouma - this should be useful in auditing our protocol traffic, reducing expensive calls, and delaying some calls until they're necessary.
