### PR TITLE
logging view UI work and improved filtering

### DIFF
--- a/packages/devtools_app/lib/src/core/filtering.dart
+++ b/packages/devtools_app/lib/src/core/filtering.dart
@@ -1,0 +1,60 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+typedef Matcher = bool Function(String text);
+
+/// Create a query a text based filter.
+/// 
+/// The search terms can be positive terms (the query items must contain the
+/// term) or negative terms (the query items must not contain the term).
+///
+/// The filter text `'foo'` would match all items that contain the word `foo`.
+/// `'-bar'` would exclude all items that contain `bar`.
+class Filter {
+  Filter._(this.items);
+
+  static Filter compile(String text) {
+    if (text == null) {
+      return Filter._(const []);
+    }
+
+    text = text.toLowerCase().trim().replaceAll(RegExp(r'\s+'), ' ');
+    final terms = text.split(' ');
+
+    return Filter._(terms.map((term) {
+      if (term.startsWith(r'\-')) {
+        return FilterItem(term.substring(1));
+      } else if (term.startsWith('-')) {
+        return FilterItem(term.substring(1), true);
+      } else {
+        return FilterItem(term);
+      }
+    }).toList());
+  }
+
+  final List<FilterItem> items;
+
+  bool matches(Matcher matcher) {
+    for (FilterItem item in items) {
+      final match = matcher(item.text);
+
+      if (item.positive && !match) {
+        return false;
+      } else if (item.negative && match) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+class FilterItem {
+  FilterItem(this.text, [this.negative = false]);
+
+  final String text;
+  final bool negative;
+
+  bool get positive => !negative;
+}

--- a/packages/devtools_app/lib/src/core/filtering.dart
+++ b/packages/devtools_app/lib/src/core/filtering.dart
@@ -26,7 +26,7 @@ class Filter {
       if (term.startsWith(r'\-')) {
         return FilterItem(term.substring(1));
       } else if (term.startsWith('-')) {
-        return FilterItem(term.substring(1), true);
+        return FilterItem(term.substring(1), negative: true);
       } else {
         return FilterItem(term);
       }
@@ -51,7 +51,7 @@ class Filter {
 }
 
 class FilterItem {
-  FilterItem(this.text, [this.negative = false]);
+  FilterItem(this.text, {this.negative = false});
 
   final String text;
   final bool negative;

--- a/packages/devtools_app/lib/src/core/filtering.dart
+++ b/packages/devtools_app/lib/src/core/filtering.dart
@@ -5,7 +5,7 @@
 typedef Matcher = bool Function(String text);
 
 /// Create a query a text based filter.
-/// 
+///
 /// The search terms can be positive terms (the query items must contain the
 /// term) or negative terms (the query items must not contain the term).
 ///
@@ -22,7 +22,7 @@ class Filter {
     text = text.toLowerCase().trim().replaceAll(RegExp(r'\s+'), ' ');
     final terms = text.split(' ');
 
-    return Filter._(terms.map((term) {
+    return Filter._(terms.where((term) => term != '-').map((term) {
       if (term.startsWith(r'\-')) {
         return FilterItem(term.substring(1));
       } else if (term.startsWith('-')) {

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -118,7 +118,6 @@ class _LoggingScreenState extends State<LoggingScreenBody>
             height: 36.0,
             child: TextField(
               controller: filterController,
-              maxLines: 1,
               decoration: const InputDecoration(
                 isDense: true,
                 border: OutlineInputBorder(),

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -118,10 +118,14 @@ class _LoggingScreenState extends State<LoggingScreenBody>
             height: 36.0,
             child: TextField(
               controller: filterController,
+              maxLines: 1,
               decoration: const InputDecoration(
                 isDense: true,
                 border: OutlineInputBorder(),
-                labelText: 'Search',
+                labelText: 'Filter',
+                // TODO(devoncarew): Include hint text (this currently has an
+                // issue w/ sizing of the search field's contents).
+                //hintText: 'term -term',
               ),
             ),
           ),
@@ -134,11 +138,15 @@ class _LoggingScreenState extends State<LoggingScreenBody>
           axis: Axis.vertical,
           initialFractions: const [0.78, 0.22],
           children: [
-            LogsTable(
-              data: controller.filteredData,
-              onItemSelected: _select,
+            OutlinedBorder(
+              child: LogsTable(
+                data: controller.filteredData,
+                onItemSelected: _select,
+              ),
             ),
-            LogDetails(log: selected),
+            OutlinedBorder(
+              child: LogDetails(log: selected),
+            ),
           ],
         ),
       ),
@@ -185,6 +193,7 @@ class LogsTable extends StatelessWidget {
 
 class LogDetails extends StatefulWidget {
   const LogDetails({Key key, @required this.log}) : super(key: key);
+
   final LogData log;
 
   @override
@@ -193,40 +202,19 @@ class LogDetails extends StatefulWidget {
 
 class _LogDetailsState extends State<LogDetails>
     with SingleTickerProviderStateMixin {
-  AnimationController crossFade;
-
   @override
   void initState() {
     super.initState();
 
-    crossFade = defaultAnimationController(this)
-      ..addStatusListener((status) {
-        if (status == AnimationStatus.completed) {
-          setState(() {
-            _oldLog = widget.log;
-            crossFade.value = 0.0;
-          });
-        }
-      });
-
-    // We'll use a linear curve for this animation, so no curve needed.
     _computeLogDetails();
-  }
-
-  @override
-  void dispose() {
-    crossFade.dispose();
-    super.dispose();
   }
 
   @override
   void didUpdateWidget(LogDetails oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.log != oldWidget.log) {
-      _oldLog = oldWidget.log;
-      crossFade.forward();
+      _computeLogDetails();
     }
-    _computeLogDetails();
   }
 
   Future<void> _computeLogDetails() async {
@@ -236,8 +224,6 @@ class _LogDetailsState extends State<LogDetails>
     }
   }
 
-  LogData _oldLog;
-
   bool showInspector(LogData log) => log != null && log.node != null;
 
   bool showSimple(LogData log) =>
@@ -245,26 +231,9 @@ class _LogDetailsState extends State<LogDetails>
 
   @override
   Widget build(BuildContext context) {
-    return AnimatedBuilder(
-      animation: crossFade,
-      builder: (context, _) {
-        return Container(
-          color: Theme.of(context).cardColor,
-          child: Stack(
-            fit: StackFit.expand,
-            children: [
-              Opacity(
-                opacity: crossFade.value,
-                child: _buildContent(context, widget.log),
-              ),
-              Opacity(
-                opacity: 1 - crossFade.value,
-                child: _buildContent(context, _oldLog),
-              ),
-            ],
-          ),
-        );
-      },
+    return Container(
+      color: Theme.of(context).cardColor,
+      child: _buildContent(context, widget.log),
     );
   }
 
@@ -278,7 +247,7 @@ class _LogDetailsState extends State<LogDetails>
     return const SizedBox();
   }
 
-  // TODO(https://github.com/flutter/devtools/issues/1370): implement this.
+  // TODO(#1370): implement this.
   Widget _buildInspector(BuildContext context, LogData log) => const SizedBox();
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
@@ -309,7 +278,7 @@ class _KindColumn extends LogKindColumn implements ColumnRenderer<LogData> {
   String getValue(LogData dataObject) => dataObject.kind;
 
   @override
-  double get fixedWidthPx => 140;
+  double get fixedWidthPx => 145;
 
   @override
   Widget build(BuildContext context, LogData item) {

--- a/packages/devtools_app/test/core/filtering_test.dart
+++ b/packages/devtools_app/test/core/filtering_test.dart
@@ -61,7 +61,6 @@ void defineTests() {
 
 List<String> applyFilter(Filter filter, List<String> items) {
   return items.where((element) {
-    final m = filter.matches((String text) => element.contains(text));
-    return m;
+    return filter.matches((String text) => element.contains(text));
   }).toList();
 }

--- a/packages/devtools_app/test/core/filtering_test.dart
+++ b/packages/devtools_app/test/core/filtering_test.dart
@@ -23,6 +23,16 @@ void defineTests() {
       expect(filter.items, hasLength(2));
       expect(filter.items[0].negative, false);
       expect(filter.items[1].negative, true);
+
+      // ignore empty terms
+      filter = Filter.compile('foo');
+      expect(filter.items, hasLength(1));
+
+      filter = Filter.compile('foo ');
+      expect(filter.items, hasLength(1));
+
+      filter = Filter.compile('foo -');
+      expect(filter.items, hasLength(1));
     });
 
     test('matches', () async {

--- a/packages/devtools_app/test/core/filtering_test.dart
+++ b/packages/devtools_app/test/core/filtering_test.dart
@@ -1,0 +1,57 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/core/filtering.dart';
+import 'package:test/test.dart';
+
+void main() {
+  defineTests();
+}
+
+void defineTests() {
+  group('Filter', () {
+    test('compile', () async {
+      var filter = Filter.compile('foo bar');
+      expect(filter.items, hasLength(2));
+      expect(filter.items[0].text, 'foo');
+      expect(filter.items[1].negative, false);
+      expect(filter.items[1].text, 'bar');
+      expect(filter.items[1].negative, false);
+
+      filter = Filter.compile('foo -bar');
+      expect(filter.items, hasLength(2));
+      expect(filter.items[0].negative, false);
+      expect(filter.items[1].negative, true);
+    });
+
+    test('matches', () async {
+      final items = ['foo', 'bar', 'baz'];
+
+      // positive filter
+      var filter = Filter.compile('foo');
+      expect(applyFilter(filter, items), ['foo']);
+
+      // negative filter
+      filter = Filter.compile('-bar');
+      expect(applyFilter(filter, items), ['foo', 'baz']);
+
+      // escaped dash
+      filter = Filter.compile(r'\-bar');
+      expect(applyFilter(filter, ['foo', r'\-bar', 'baz']), [r'\-bar']);
+
+      // positive and negative filter
+      filter = Filter.compile('foo -bar');
+      expect(applyFilter(filter, items), ['foo']);
+      expect(
+          applyFilter(filter, ['foo', 'foofoo', 'foobar']), ['foo', 'foofoo']);
+    });
+  });
+}
+
+List<String> applyFilter(Filter filter, List<String> items) {
+  return items.where((element) {
+    final m = filter.matches((String text) => element.contains(text));
+    return m;
+  }).toList();
+}

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -138,10 +138,9 @@ void main() {
         await tester.pumpAndSettle();
         expect(
           find.text('log event 996'),
-          findsNWidgets(3),
-          reason: 'The log details should be visible both in the table and '
-              'the details section. The details view will have two text '
-              'widgets to support its cross-fade animation.',
+          findsNWidgets(2),
+          reason: 'The log details should be visible both in the table and the '
+              'details section.',
         );
       });
 
@@ -170,12 +169,7 @@ void main() {
         );
 
         await tester.pumpAndSettle();
-        expect(
-          find.text(nonJsonOutput),
-          findsNWidgets(2),
-          reason:
-              'The fade transition between details views will have two text widgets.',
-        );
+        expect(find.text(nonJsonOutput), findsOneWidget);
       });
 
       testWidgets('can show details of json log data',
@@ -205,12 +199,7 @@ void main() {
         );
 
         await tester.pumpAndSettle();
-        expect(
-          findJson,
-          findsNWidgets(2),
-          reason:
-              'The fade transition between details views will have two text widgets.',
-        );
+        expect(findJson, findsOneWidget);
       });
     });
   });


### PR DESCRIPTION
- tweak the UI of the logging view to better match the look of other pages
- remove an opacity animation from the logging pages detail area - overall I don't think this animation helped the page
- add more sophisticated filtering to the page - support negative filter terms (`foo` matches all items w/ 'foo`; `-bar` matches all items that do not contain 'bar')

<img width="297" alt="Screen Shot 2020-04-19 at 6 25 47 PM" src="https://user-images.githubusercontent.com/1269969/79705649-404b2700-826b-11ea-8181-e9cebce58bd7.png">
