### PR TITLE
improve breakpoint resolution code

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/breakpoints.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
@@ -110,7 +109,7 @@ class _BreakpointPickerState extends State<BreakpointPicker> {
 class BreakpointsCountBadge extends StatelessWidget {
   const BreakpointsCountBadge({@required this.breakpoints});
 
-  final List<Breakpoint> breakpoints;
+  final List<BreakpointAndSourcePosition> breakpoints;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -32,7 +32,7 @@ class CodeView extends StatefulWidget {
   static const assumedCharacterWidth = 16.0;
 
   final DebuggerController controller;
-  final Map<int, Breakpoint> lineNumberToBreakpoint;
+  final Map<int, BreakpointAndSourcePosition> lineNumberToBreakpoint;
   final Script script;
   final vm.Stack stack;
   final void Function(Script script, int line) onSelected;
@@ -63,14 +63,6 @@ class _CodeViewState extends State<CodeView> {
   }
 
   @override
-  void dispose() {
-    super.dispose();
-
-    gutterController.dispose();
-    textController.dispose();
-  }
-
-  @override
   void didUpdateWidget(CodeView oldWidget) {
     super.didUpdateWidget(oldWidget);
 
@@ -81,6 +73,14 @@ class _CodeViewState extends State<CodeView> {
     if (widget.stack != oldWidget.stack) {
       _updatePausedPositions();
     }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+
+    gutterController.dispose();
+    textController.dispose();
   }
 
   void _updateLines() {
@@ -189,7 +189,6 @@ class _CodeViewState extends State<CodeView> {
                   final lineNum = index + 1;
                   return ScriptRow(
                     lineContents: lines[index],
-                    onPressed: () => _onPressed(lineNum),
                     isPausedHere: pausedPositions.contains(lineNum),
                   );
                 },
@@ -284,12 +283,10 @@ class ScriptRow extends StatelessWidget {
   const ScriptRow({
     Key key,
     @required this.lineContents,
-    @required this.onPressed,
     @required this.isPausedHere,
   }) : super(key: key);
 
   final String lineContents;
-  final VoidCallback onPressed;
   final bool isPausedHere;
 
   @override
@@ -299,18 +296,15 @@ class ScriptRow extends StatelessWidget {
     final regularStyle = TextStyle(color: theme.textTheme.bodyText2.color);
     final selectedStyle = TextStyle(color: theme.textSelectionColor);
 
-    return InkWell(
-      onTap: onPressed,
-      child: Container(
-        alignment: Alignment.centerLeft,
-        height: CodeView.rowHeight,
-        color: isPausedHere ? theme.selectedRowColor : null,
-        child: Text(
-          lineContents,
-          maxLines: 1,
-          overflow: TextOverflow.ellipsis,
-          style: isPausedHere ? selectedStyle : regularStyle,
-        ),
+    return Container(
+      alignment: Alignment.centerLeft,
+      height: CodeView.rowHeight,
+      color: isPausedHere ? theme.selectedRowColor : null,
+      child: Text(
+        lineContents,
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        style: isPausedHere ? selectedStyle : regularStyle,
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -108,8 +108,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (bp.script != null) {
       await controller.selectScript(bp.script);
     } else if (bp.scriptUri != null) {
-      await controller
-          .selectScript(controller.getScriptRefFromUri(bp.scriptUri));
+      await controller.selectScript(controller.scriptRefForUri(bp.scriptUri));
     }
   }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -88,7 +88,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
     addAutoDisposeListener(controller.currentStack);
     addAutoDisposeListener(controller.sortedScripts);
-    addAutoDisposeListener(controller.breakpoints);
+    addAutoDisposeListener(controller.breakpointsWithLocation);
   }
 
   Future<void> _onScriptSelected(ScriptRef ref) async {
@@ -105,22 +105,29 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     }
 
     // TODO(devoncarew): Change the line selection in the code view as well.
-    await controller.selectScript(bp.script);
+    if (bp.script != null) {
+      await controller.selectScript(bp.script);
+    } else if (bp.scriptUri != null) {
+      await controller
+          .selectScript(controller.getScriptRefFromUri(bp.scriptUri));
+    }
   }
 
-  Map<int, Breakpoint> _breakpointsForLines() {
+  Map<int, BreakpointAndSourcePosition> _breakpointsForLines() {
     if (script == null) return {};
+
     return {
-      for (var b in controller.breakpoints.value
-          .where((b) => b != null && b.location.script?.id == script.id))
-        controller.lineNumber(script, b.location): b,
+      for (var b in controller.breakpointsWithLocation.value.where((b) {
+        return b.script?.id == script.id || b.scriptUri == script.uri;
+      }))
+        b.line: b,
     };
   }
 
   Future<void> toggleBreakpoint(Script script, int line) async {
     final breakpoints = _breakpointsForLines();
     if (breakpoints.containsKey(line)) {
-      await controller.removeBreakpoint(breakpoints[line]);
+      await controller.removeBreakpoint(breakpoints[line].breakpoint);
     } else {
       try {
         await controller.addBreakpoint(script.id, line);
@@ -192,7 +199,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             _debuggerPaneHeader(
               breakpointsTitle,
               rightChild: BreakpointsCountBadge(
-                breakpoints: controller.breakpoints.value,
+                breakpoints: controller.breakpointsWithLocation.value,
               ),
             ),
             _debuggerPaneHeader(

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -106,7 +106,7 @@ void main() {
       ];
 
       final breakpointsWithLocation = [
-        BreakpointAndSourcePosition(
+        BreakpointAndSourcePosition.create(
           breakpoints.first,
           SourcePosition(line: 10, column: 1),
         )


### PR DESCRIPTION
improve breakpoint resolution code:
- improve our wrapper around breakpoints that are resolved and ones that aren't (clients of the API can mostly use the typed wrappers now, instead of the `dynamic` location field)
- fix issues with jumping to locations of breakpoints for file that haven't yet been executed
- fix issues for setting breakpoints in scripts that are part files
