### PR TITLE
move the Libraries view to the RHS, and have it toggleable

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -76,7 +76,9 @@ class DebuggingControls extends StatelessWidget {
                 child: Center(
                   child: Padding(
                     padding: const EdgeInsets.only(
-                        left: defaultSpacing, right: borderPadding),
+                      left: defaultSpacing,
+                      right: borderPadding,
+                    ),
                     child: BreakOnExceptionsControl(controller: controller),
                   ),
                 ),
@@ -84,16 +86,14 @@ class DebuggingControls extends StatelessWidget {
               const Expanded(child: SizedBox(width: denseSpacing)),
               ValueListenableBuilder(
                 valueListenable: controller.librariesVisible,
-                builder: (BuildContext context, value, Widget child) {
+                builder: (context, visible, _) {
                   return RoundedOutlinedBorder(
                     child: Container(
-                      color: controller.librariesVisible.value
-                          ? Theme.of(context).highlightColor
-                          : null,
+                      color: visible ? Theme.of(context).highlightColor : null,
                       child: DebuggerButton(
                         title: 'Libraries',
                         icon: Icons.insert_chart,
-                        onPressed: () => controller.toggleLibrariesVisible(),
+                        onPressed: controller.toggleLibrariesVisible,
                       ),
                     ),
                   );

--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -71,16 +71,34 @@ class DebuggingControls extends StatelessWidget {
                   ],
                 ),
               ),
-              const Expanded(child: SizedBox(width: denseSpacing)),
+              const SizedBox(width: denseSpacing),
               RoundedOutlinedBorder(
                 child: Center(
                   child: Padding(
                     padding: const EdgeInsets.only(
-                        left: denseSpacing, right: borderPadding),
+                        left: defaultSpacing, right: borderPadding),
                     child: BreakOnExceptionsControl(controller: controller),
                   ),
                 ),
               ),
+              const Expanded(child: SizedBox(width: denseSpacing)),
+              ValueListenableBuilder(
+                valueListenable: controller.librariesVisible,
+                builder: (BuildContext context, value, Widget child) {
+                  return RoundedOutlinedBorder(
+                    child: Container(
+                      color: controller.librariesVisible.value
+                          ? Theme.of(context).highlightColor
+                          : null,
+                      child: DebuggerButton(
+                        title: 'Libraries',
+                        icon: Icons.insert_chart,
+                        onPressed: () => controller.toggleLibrariesVisible(),
+                      ),
+                    ),
+                  );
+                },
+              )
             ],
           ),
         );
@@ -138,17 +156,17 @@ class ExceptionMode {
   static final modes = [
     ExceptionMode(
       ExceptionPauseMode.kNone,
-      'Ignore exceptions',
+      'Ignore',
       "Don't stop on exceptions",
     ),
     ExceptionMode(
       ExceptionPauseMode.kUnhandled,
-      'Stop on uncaught',
+      'Uncaught',
       'Stop on uncaught exceptions',
     ),
     ExceptionMode(
       ExceptionPauseMode.kAll,
-      'Stop on exceptions',
+      'All',
       'Stop on all exceptions',
     ),
   ];

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -80,7 +80,7 @@ class DebuggerController extends DisposableController
 
   ValueListenable<String> get exceptionPauseMode => _exceptionPauseMode;
 
-  final ValueNotifier<bool> _librariesVisible = ValueNotifier(false);
+  final _librariesVisible = ValueNotifier(false);
 
   ValueListenable<bool> get librariesVisible => _librariesVisible;
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -77,6 +77,15 @@ class DebuggerController extends DisposableController
 
   ValueListenable<String> get exceptionPauseMode => _exceptionPauseMode;
 
+  final ValueNotifier<bool> _librariesVisible = ValueNotifier(false);
+
+  ValueListenable<bool> get librariesVisible => _librariesVisible;
+
+  /// todo: doc
+  void toggleLibrariesVisible() {
+    _librariesVisible.value = !_librariesVisible.value;
+  }
+
   final _stdio = ValueNotifier<List<String>>([]);
 
   /// Return the stdout and stderr emitted from the application.
@@ -308,6 +317,11 @@ class DebuggerController extends DisposableController
           await _service.getObject(isolateRef.id, scriptRef.id);
     }
     return _scriptCache[scriptRef.id];
+  }
+
+  ScriptRef getScriptRefFromUri(String uri) {
+    return _sortedScripts.value
+        .firstWhere((ref) => ref.uri == uri, orElse: () => null);
   }
 
   Future<void> selectScript(ScriptRef ref) async {

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -81,7 +81,8 @@ class DebuggerController extends DisposableController
 
   ValueListenable<bool> get librariesVisible => _librariesVisible;
 
-  /// todo: doc
+  /// Make the 'Libraries' view on the right-hand side of the screen visible or
+  /// hidden.
   void toggleLibrariesVisible() {
     _librariesVisible.value = !_librariesVisible.value;
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -161,8 +161,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
     final codeArea = ValueListenableBuilder(
       valueListenable: controller.librariesVisible,
-      builder: (context, value, _) {
-        if (value) {
+      builder: (context, visible, _) {
+        if (visible) {
           // TODO(devoncarew): Animate this opening and closing.
           return Split(
             axis: Axis.horizontal,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -104,7 +104,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     }
 
     // TODO(devoncarew): Change the line selection in the code view as well.
-        await controller.selectScript(bp.script);
+    await controller.selectScript(bp.script);
   }
 
   Map<int, Breakpoint> _breakpointsForLines() {

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -62,7 +62,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   static const callStackTitle = 'Call Stack';
   static const variablesTitle = 'Variables';
   static const breakpointsTitle = 'Breakpoints';
-  static const librariesTitle = 'Libraries';
 
   DebuggerController controller;
   Script script;
@@ -105,7 +104,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     }
 
     // TODO(devoncarew): Change the line selection in the code view as well.
-    await controller.selectScript(bp.script);
+        await controller.selectScript(bp.script);
   }
 
   Map<int, Breakpoint> _breakpointsForLines() {
@@ -136,6 +135,48 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
+    final codeWidget = OutlinedBorder(
+      child: Column(
+        children: [
+          debuggerSectionTitle(theme,
+              text: script == null ? ' ' : '${script.uri}'),
+          Expanded(
+            child: CodeView(
+              script: script,
+              stack: controller.currentStack.value,
+              controller: controller,
+              lineNumberToBreakpoint: _breakpointsForLines(),
+              onSelected: toggleBreakpoint,
+            ),
+          ),
+        ],
+      ),
+    );
+
+    final codeArea = ValueListenableBuilder(
+      valueListenable: controller.librariesVisible,
+      builder: (context, value, _) {
+        if (value) {
+          // TODO(devoncarew): Animate this opening and closing.
+          return Split(
+            axis: Axis.horizontal,
+            initialFractions: const [0.70, 0.30],
+            children: [
+              codeWidget,
+              ScriptPicker(
+                controller: controller,
+                scripts: controller.sortedScripts.value,
+                selected: script,
+                onSelected: _onScriptSelected,
+              ),
+            ],
+          );
+        } else {
+          return codeWidget;
+        }
+      },
+    );
+
     return Split(
       axis: Axis.horizontal,
       initialFractions: const [0.25, 0.75],
@@ -148,28 +189,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             Expanded(
               child: Split(
                 axis: Axis.vertical,
-                initialFractions: const [0.75, 0.25],
+                initialFractions: const [0.74, 0.26],
                 children: [
-                  OutlinedBorder(
-                    child: Column(
-                      children: [
-                        debuggerSectionTitle(theme,
-                            text: script == null ? ' ' : '${script.uri}'),
-                        Expanded(
-                          child: CodeView(
-                            script: script,
-                            stack: controller.currentStack.value,
-                            controller: controller,
-                            lineNumberToBreakpoint: _breakpointsForLines(),
-                            onSelected: toggleBreakpoint,
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                  Console(
-                    controller: controller,
-                  ),
+                  codeArea,
+                  Console(controller: controller),
                 ],
               ),
             ),
@@ -184,21 +207,16 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       builder: (context, constraints) {
         return FlexSplitColumn(
           totalHeight: constraints.maxHeight,
-          initialFractions: const [0.20, 0.20, 0.20, 0.40],
-          minSizes: const [0.0, 0.0, 0.0, 0.0],
+          initialFractions: const [0.38, 0.38, 0.24],
+          minSizes: const [0.0, 0.0, 0.0],
           headers: [
-            _debuggerPaneHeader(callStackTitle, needsTopBorder: false),
-            _debuggerPaneHeader(variablesTitle),
-            _debuggerPaneHeader(
+            debuggerPaneHeader(context, callStackTitle, needsTopBorder: false),
+            debuggerPaneHeader(context, variablesTitle),
+            debuggerPaneHeader(
+              context,
               breakpointsTitle,
               rightChild: BreakpointsCountBadge(
                 breakpoints: controller.breakpoints.value,
-              ),
-            ),
-            _debuggerPaneHeader(
-              librariesTitle,
-              rightChild: ScriptCountBadge(
-                scripts: controller.sortedScripts.value,
               ),
             ),
           ],
@@ -210,53 +228,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
               selected: selectedBreakpoint,
               onSelected: _onBreakpointSelected,
             ),
-            ScriptPicker(
-              scripts: controller.sortedScripts.value,
-              selected: script,
-              onSelected: _onScriptSelected,
-            ),
           ],
         );
       },
-    );
-  }
-
-  FlexSplitColumnHeader _debuggerPaneHeader(
-    String title, {
-    bool needsTopBorder = true,
-    Widget rightChild,
-  }) {
-    final theme = Theme.of(context);
-
-    return FlexSplitColumnHeader(
-      height: DebuggerScreen.debuggerPaneHeaderHeight,
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border(
-            top: needsTopBorder
-                ? BorderSide(color: theme.focusColor)
-                : BorderSide.none,
-            bottom: BorderSide(color: theme.focusColor),
-          ),
-          color: titleSolidBackgroundColor,
-        ),
-        padding: const EdgeInsets.only(left: defaultSpacing, right: 4.0),
-        alignment: Alignment.centerLeft,
-        height: DebuggerScreen.debuggerPaneHeaderHeight,
-        child: Row(
-          children: [
-            Expanded(
-              child: Text(
-                title,
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
-                style: Theme.of(context).textTheme.subtitle2,
-              ),
-            ),
-            if (rightChild != null) rightChild,
-          ],
-        ),
-      ),
     );
   }
 }
@@ -335,4 +309,44 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
 
     return 'paused$reason$fileName $pos';
   }
+}
+
+FlexSplitColumnHeader debuggerPaneHeader(
+  BuildContext context,
+  String title, {
+  bool needsTopBorder = true,
+  Widget rightChild,
+}) {
+  final theme = Theme.of(context);
+
+  return FlexSplitColumnHeader(
+    height: DebuggerScreen.debuggerPaneHeaderHeight,
+    child: Container(
+      decoration: BoxDecoration(
+        border: Border(
+          top: needsTopBorder
+              ? BorderSide(color: theme.focusColor)
+              : BorderSide.none,
+          bottom: BorderSide(color: theme.focusColor),
+        ),
+        color: titleSolidBackgroundColor,
+      ),
+      padding: const EdgeInsets.only(left: defaultSpacing, right: 4.0),
+      alignment: Alignment.centerLeft,
+      height: DebuggerScreen.debuggerPaneHeaderHeight,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.subtitle2,
+            ),
+          ),
+          if (rightChild != null) rightChild,
+        ],
+      ),
+    ),
+  );
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -100,9 +100,8 @@ class ScriptPickerState extends State<ScriptPicker> {
               child: ListView.builder(
                 itemCount: _filteredScripts.length,
                 itemExtent: defaultListItemHeight,
-                itemBuilder: (context, index) {
-                  return _buildScript(_filteredScripts[index]);
-                },
+                itemBuilder: (context, index) =>
+                    _buildScript(_filteredScripts[index]),
               ),
             ),
         ],

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -44,6 +44,8 @@ void main() {
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
       when(debuggerController.breakpointsWithLocation)
           .thenReturn(ValueNotifier([]));
+      when(debuggerController.librariesVisible)
+          .thenReturn(ValueNotifier(false));
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: [])));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
@@ -78,15 +80,29 @@ void main() {
       expect(find.text('test stdio'), findsOneWidget);
     });
 
-    testWidgets('Scripts show items', (WidgetTester tester) async {
+    testWidgets('Libraries hidden', (WidgetTester tester) async {
       final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
 
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
 
+      // Libraries view is hidden
+      when(debuggerController.librariesVisible).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
+      expect(find.text('Libraries'), findsNothing);
+    });
 
+    testWidgets('Libraries visible', (WidgetTester tester) async {
+      final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
+
+      when(debuggerController.scriptList)
+          .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
+      when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+
+      // Libraries view is shown
+      when(debuggerController.librariesVisible).thenReturn(ValueNotifier(true));
+      await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Libraries'), findsOneWidget);
 
       // test for items in the libraries list
@@ -193,7 +209,7 @@ void main() {
         Builder(builder: screen.build),
         debugger: debuggerController,
       ));
-      expect(find.text('Ignore exceptions'), findsOneWidget);
+      expect(find.text('Ignore'), findsOneWidget);
     });
   });
 }

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -88,7 +88,8 @@ void main() {
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
 
       // Libraries view is hidden
-      when(debuggerController.librariesVisible).thenReturn(ValueNotifier(false));
+      when(debuggerController.librariesVisible)
+          .thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Libraries'), findsNothing);
     });


### PR DESCRIPTION
- move the Libraries view to the RHS, and have it toggleable

This frees up more vertical space on the left for the frames, variables, and breakpoints, and gives more vertical space to the scripts when that view is open.

Closed (the default):

<img width="427" alt="Screen Shot 2020-04-21 at 2 17 47 PM" src="https://user-images.githubusercontent.com/1269969/79920737-a065d880-83e5-11ea-9f44-7f61152769db.png">

and open:

<img width="443" alt="Screen Shot 2020-04-21 at 2 17 55 PM" src="https://user-images.githubusercontent.com/1269969/79915160-524bd780-83db-11ea-9134-6c1b56c2febe.png">

<img width="369" alt="Screen Shot 2020-04-21 at 2 18 21 PM" src="https://user-images.githubusercontent.com/1269969/80000356-e5375100-8471-11ea-9ccd-cea82b7a0cc5.png">
