### PR TITLE
log service protocol traffic to the message bus

### DIFF
--- a/packages/devtools_app/lib/src/logging/vm_service.dart
+++ b/packages/devtools_app/lib/src/logging/vm_service.dart
@@ -1,0 +1,76 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:vm_service/vm_service.dart';
+
+import '../core/message_bus.dart';
+import '../globals.dart';
+
+/// A class which listens for all traffic over the VM service protocol and logs
+/// the traffic to the message bus.
+///
+/// The messages are then available in the Logging page. This class is typically
+/// only used during development by engineers working on DevTools.
+class VmServiceTrafficLogger {
+  VmServiceTrafficLogger(VmService service) {
+    _sendSub = service.onSend.listen(_logServiceProtocolCalls);
+    _receiveSub = service.onReceive.listen(_logServiceProtocolResponses);
+  }
+
+  StreamSubscription _sendSub;
+  StreamSubscription _receiveSub;
+
+  void _logServiceProtocolCalls(String message) {
+    final Map m = jsonDecode(message);
+
+    final String method = m['method'];
+    final String id = m['id'];
+
+    messageBus.addEvent(BusEvent(
+      'devtools.debugger',
+      data: '⇨ #$id $method()\n$message',
+    ));
+  }
+
+  void _logServiceProtocolResponses(String message) {
+    final Map m = jsonDecode(message);
+
+    String details = m['method'];
+    if (details == null) {
+      if (m['result'] != null) {
+        details = m['result']['type'];
+      } else {
+        details = m['error'] ?? '';
+      }
+    } else if (details == 'streamNotify') {
+      details = '';
+    }
+
+    final String id = m['id'];
+    var streamId = '';
+    var kind = '';
+
+    if (m['params'] != null) {
+      final Map p = m['params'];
+      streamId = p['streamId'];
+
+      if (p['event'] != null) {
+        kind = p['event']['extensionKind'] ?? p['event']['kind'];
+      }
+    }
+
+    messageBus.addEvent(BusEvent(
+      'devtools.debugger',
+      data: '  ⇦ ${id == null ? '' : '#$id '}$details$streamId $kind\n$message',
+    ));
+  }
+
+  void dispose() {
+    _sendSub?.cancel();
+    _receiveSub?.cancel();
+  }
+}

--- a/packages/devtools_app/lib/src/logging/vm_service_logger.dart
+++ b/packages/devtools_app/lib/src/logging/vm_service_logger.dart
@@ -21,6 +21,8 @@ class VmServiceTrafficLogger {
     _receiveSub = service.onReceive.listen(_logServiceProtocolResponses);
   }
 
+  static const eventName = 'devtools.service';
+
   StreamSubscription _sendSub;
   StreamSubscription _receiveSub;
 
@@ -31,7 +33,7 @@ class VmServiceTrafficLogger {
     final String id = m['id'];
 
     messageBus.addEvent(BusEvent(
-      'devtools.debugger',
+      eventName,
       data: '⇨ #$id $method()\n$message',
     ));
   }
@@ -64,7 +66,7 @@ class VmServiceTrafficLogger {
     }
 
     messageBus.addEvent(BusEvent(
-      'devtools.debugger',
+      eventName,
       data: '  ⇦ ${id == null ? '' : '#$id '}$details$streamId $kind\n$message',
     ));
   }

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -12,7 +12,7 @@ import 'package:vm_service/vm_service.dart' hide Error;
 import 'config_specific/logger/logger.dart';
 import 'connected_app.dart';
 import 'eval_on_dart_library.dart';
-import 'logging/vm_service.dart';
+import 'logging/vm_service_logger.dart';
 import 'service_extensions.dart' as extensions;
 import 'service_registrations.dart' as registrations;
 import 'stream_value_listenable.dart';

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -24,7 +24,7 @@ import 'vm_service_wrapper.dart';
 /// Used to debug service protocol traffic. All requests to to the VM service
 /// connection are logged to the Logging page, as well as all responses and
 /// events from the service protocol device.
-const debugLogServiceProtocolEvents = true;
+const debugLogServiceProtocolEvents = false;
 
 // TODO(kenz): add an offline service manager implementation.
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -12,12 +12,19 @@ import 'package:vm_service/vm_service.dart' hide Error;
 import 'config_specific/logger/logger.dart';
 import 'connected_app.dart';
 import 'eval_on_dart_library.dart';
+import 'logging/vm_service.dart';
 import 'service_extensions.dart' as extensions;
 import 'service_registrations.dart' as registrations;
 import 'stream_value_listenable.dart';
 import 'ui/fake_flutter/fake_flutter.dart';
 import 'utils.dart';
 import 'vm_service_wrapper.dart';
+
+// Note: don't check this in enabled.
+/// Used to debug service protocol traffic. All requests to to the VM service
+/// connection are logged to the Logging page, as well as all responses and
+/// events from the service protocol device.
+const debugLogServiceProtocolEvents = true;
 
 // TODO(kenz): add an offline service manager implementation.
 
@@ -41,6 +48,7 @@ class ServiceConnectionManager {
   final serviceAvailable = Completer<void>();
 
   VmServiceCapabilities _serviceCapabilities;
+  VmServiceTrafficLogger serviceTrafficLogger;
 
   Future<VmServiceCapabilities> get serviceCapabilities async {
     if (_serviceCapabilities == null) {
@@ -126,6 +134,10 @@ class ServiceConnectionManager {
 
     this.service = service;
 
+    if (debugLogServiceProtocolEvents) {
+      serviceTrafficLogger = VmServiceTrafficLogger(service);
+    }
+
     serviceAvailable.complete();
 
     connectedApp = ConnectedApp();
@@ -210,6 +222,8 @@ class ServiceConnectionManager {
     sdkVersion = null;
     connectedApp = null;
     serviceExtensionManager.connectedApp = null;
+
+    serviceTrafficLogger?.dispose();
 
     _stateController.add(false);
     _connectionClosedController.add(null);
@@ -833,6 +847,7 @@ class ServiceExtensionState {
 class VmFlagManager {
   VmServiceWrapper get service => _service;
   VmServiceWrapper _service;
+
   set service(VmServiceWrapper service) {
     _service = service;
     // Upon setting the vm service, get initial values for vm flags.


### PR DESCRIPTION
- log service protocol traffic to the message bus
- the logs are then available to view in the Logging page
- redux of https://github.com/flutter/devtools/pull/1842

The logging can be enabled by setting `debugLogServiceProtocolEvents` to true.

<img width="1397" alt="Screen Shot 2020-04-21 at 8 52 43 PM" src="https://user-images.githubusercontent.com/1269969/79994497-eb75ff00-846a-11ea-889a-8859d276eed9.png">
