### PR TITLE
Manage selected breakpoint in debugger_controller.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -75,6 +75,11 @@ class DebuggerController extends DisposableController
   ValueListenable<List<BreakpointAndSourcePosition>>
       get breakpointsWithLocation => _breakpointsWithLocation;
 
+  final _selectedBreakpoint = ValueNotifier<BreakpointAndSourcePosition>(null);
+
+  ValueListenable<BreakpointAndSourcePosition> get selectedBreakpoint =>
+      _selectedBreakpoint;
+
   final _exceptionPauseMode =
       ValueNotifier<String>(ExceptionPauseMode.kUnhandled);
 
@@ -387,6 +392,10 @@ class DebuggerController extends DisposableController
     } else {
       return BreakpointAndSourcePosition.create(breakpoint);
     }
+  }
+
+  void selectBreakpoint(BreakpointAndSourcePosition bp) {
+    _selectedBreakpoint.value = bp;
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -66,7 +66,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
   DebuggerController controller;
   Script script;
-  BreakpointAndSourcePosition selectedBreakpoint;
 
   @override
   void didChangeDependencies() {
@@ -95,21 +94,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (ref == null) return;
 
     await controller.selectScript(ref);
-  }
-
-  Future<void> _onBreakpointSelected(BreakpointAndSourcePosition bp) async {
-    if (bp != selectedBreakpoint) {
-      setState(() {
-        selectedBreakpoint = bp;
-      });
-    }
-
-    // TODO(devoncarew): Change the line selection in the code view as well.
-    if (bp.script != null) {
-      await controller.selectScript(bp.script);
-    } else if (bp.scriptUri != null) {
-      await controller.selectScript(controller.scriptRefForUri(bp.scriptUri));
-    }
   }
 
   Map<int, BreakpointAndSourcePosition> _breakpointsForLines() {
@@ -211,11 +195,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           children: [
             const Center(child: Text('TODO: call stack')),
             const Center(child: Text('TODO: variables')),
-            BreakpointPicker(
-              controller: controller,
-              selected: selectedBreakpoint,
-              onSelected: _onBreakpointSelected,
-            ),
+            const BreakpointPicker(),
             ScriptPicker(
               scripts: controller.sortedScripts.value,
               selected: script,

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -47,6 +47,8 @@ void main() {
       when(debuggerController.scriptList)
           .thenReturn(ValueNotifier(ScriptList(scripts: [])));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
+      when(debuggerController.selectedBreakpoint)
+          .thenReturn(ValueNotifier(null));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       when(debuggerController.stdio).thenReturn(ValueNotifier(['']));
       when(debuggerController.currentScript).thenReturn(ValueNotifier(null));

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -78,7 +78,7 @@ void main() {
 
       expect(find.text('Console'), findsOneWidget);
 
-      // test for stdio output
+      // test for stdio output.
       expect(find.text('test stdio'), findsOneWidget);
     });
 


### PR DESCRIPTION
- Use value listenables to manage UI state in breakpoints.dart
- get controller from Provider.of
- avoid rebuilding the entire Debugger screen when the selected breakpoint changes 