### PR TITLE
minor UI tweaks to the network page

### DIFF
--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
@@ -71,6 +71,7 @@ class HttpRequestInspector extends StatelessWidget {
     );
 
     return Card(
+      margin: EdgeInsets.zero,
       color: Theme.of(context).canvasColor,
       child: Container(
         decoration: BoxDecoration(

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -8,6 +8,7 @@ import 'package:flutter/rendering.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';
+import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../http/http_request_data.dart';
 import '../network_controller.dart';
@@ -95,7 +96,7 @@ class NetworkScreenBodyState extends State<NetworkScreenBody> {
           includeTextWidth: includeTextWidth,
           onPressed: networkController.pauseRecording,
         ),
-        const SizedBox(width: 8.0),
+        const SizedBox(width: denseSpacing),
         clearButton(
           key: NetworkScreen.clearButtonKey,
           onPressed: () {
@@ -226,6 +227,7 @@ class NetworkScreenBodyState extends State<NetworkScreenBody> {
             return Column(
               children: [
                 _buildHttpProfilerControlRow(isRecording),
+                const SizedBox(height: denseRowSpacing),
                 _buildHttpProfilerBody(isRecording),
               ],
             );


### PR DESCRIPTION
Some minor UI tweaks to the network page for similarity with our other pages.

We may want to move away from using `PaginatedDataTable` to display the data - it's hard to get rid of the (small) padding around the Card that that widget uses. Also, I don't think we need the  pagination support that widget provides - we can just scroll for however long the list is.

cc @bkonyi 
