### PR TITLE
show VM classes in the Libraries view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -9,6 +9,7 @@ import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
 import '../../ui/flutter/label.dart';
 import 'debugger_controller.dart';
+import 'scripts.dart';
 
 class DebuggingControls extends StatelessWidget {
   const DebuggingControls({Key key, @required this.controller})
@@ -92,7 +93,7 @@ class DebuggingControls extends StatelessWidget {
                       color: visible ? Theme.of(context).highlightColor : null,
                       child: DebuggerButton(
                         title: 'Libraries',
-                        icon: Icons.insert_chart,
+                        icon: libraryIcon,
                         onPressed: controller.toggleLibrariesVisible,
                       ),
                     ),

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -53,17 +53,15 @@ class DebuggerController extends DisposableController
 
   ValueListenable<Stack> get currentStack => _currentStack;
 
-  final _scriptList = ValueNotifier<ScriptList>(null);
-
-  /// Return the [ScriptList] active in the current isolate.
-  ///
-  /// See also [sortedScripts].
-  ValueListenable<ScriptList> get scriptList => _scriptList;
-
   final _sortedScripts = ValueNotifier<List<ScriptRef>>([]);
 
   /// Return the sorted list of ScriptRefs active in the current isolate.
   ValueListenable<List<ScriptRef>> get sortedScripts => _sortedScripts;
+
+  final _sortedClasses = ValueNotifier<List<ClassRef>>([]);
+
+  /// Return the sorted list of ClassRefs active in the current isolate.
+  ValueListenable<List<ClassRef>> get sortedClasses => _sortedClasses;
 
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
 
@@ -313,11 +311,11 @@ class DebuggerController extends DisposableController
     _reportedException = null;
   }
 
-  /// Get the populated [Instance] object, given an [InstanceRef].
+  /// Get the populated [Obj] object, given an [ObjRef].
   ///
-  /// The return value can be one of [Instance] or [Sentinel].
-  Future<Object> getInstance(InstanceRef instanceRef) {
-    return _service.getObject(isolateRef.id, instanceRef.id);
+  /// The return value can be one of [Obj] or [Sentinel].
+  Future<Obj> getObject(ObjRef objRef) {
+    return _service.getObject(isolateRef.id, objRef.id);
   }
 
   Future<Script> getScript(ScriptRef scriptRef) async {
@@ -341,11 +339,11 @@ class DebuggerController extends DisposableController
   }
 
   Future<void> _populateScripts(Isolate isolate) async {
-    _scriptList.value = await _service.getScripts(isolateRef.id);
+    final scriptList = await _service.getScripts(isolateRef.id);
 
     // TODO(devoncarew): Follow up to see why we need to filter out non-unique
     // items here.
-    final scriptRefs = Set.of(_scriptList.value.scripts).toList();
+    final scriptRefs = Set.of(scriptList.scripts).toList();
     scriptRefs.sort((a, b) {
       // We sort uppercase so that items like dart:foo sort before items like
       // dart:_foo.
@@ -353,14 +351,38 @@ class DebuggerController extends DisposableController
     });
     _sortedScripts.value = scriptRefs;
 
+    // TODO(devoncarew): Switch to calling the typed method once it's in the VM
+    // service protocol library.
+    // ignore: unawaited_futures
+    _service
+        .callMethod('getClassList', isolateId: isolateRef.id)
+        .then((Response response) {
+      final List classes = response.json['classes'];
+      final List<ClassRef> classRefs = classes
+          .map((json) => ClassRef.parse(json))
+          .cast<ClassRef>()
+          .where((c) => c.name != null && c.name.isNotEmpty)
+          .toList();
+
+      classRefs.sort((ClassRef a, ClassRef b) {
+        // We sort uppercase so that items like Foo sort before items like _Foo.
+        return a.name.toUpperCase().compareTo(b.name.toUpperCase());
+      });
+
+      _sortedClasses.value = classRefs;
+    }).catchError((e) {
+      // Fail gracefully - not all clients support getClassList().
+    });
+
     for (var scriptRef in scriptRefs) {
       _uriToScriptMap[scriptRef.uri] = scriptRef;
     }
 
     // Update the selected script.
-    final mainScriptRef = _scriptList.value.scripts.firstWhere((ref) {
+    final mainScriptRef = scriptRefs.firstWhere((ref) {
       return ref.uri == isolate.rootLib.uri;
     }, orElse: () => null);
+
     await selectScript(mainScriptRef);
   }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -10,6 +10,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../auto_dispose.dart';
 import '../../globals.dart';
+import '../../vm_service_wrapper.dart';
 import 'debugger_model.dart';
 
 // TODO(devoncarew): Add some delayed resume value notifiers (to be used to
@@ -369,11 +370,9 @@ class DebuggerController extends DisposableController
     });
     _sortedScripts.value = scriptRefs;
 
-    // TODO(devoncarew): Switch to calling the typed method once it's in the VM
-    // service protocol library.
     // ignore: unawaited_futures
-    _service
-        .callMethod('getClassList', isolateId: isolateRef.id)
+    (_service as VmServiceWrapper)
+        .getClassList(isolateRef.id)
         .then((Response response) {
       final List classes = response.json['classes'];
       final List<ClassRef> classRefs = classes

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -85,10 +85,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     });
 
     addAutoDisposeListener(controller.currentStack);
-    addAutoDisposeListener(controller.sortedScripts);
     addAutoDisposeListener(controller.breakpointsWithLocation);
   }
 
+  // TODO(devoncarew): Support a SourceLocation as well.
   Future<void> _onScriptSelected(ScriptRef ref) async {
     if (ref == null) return;
 
@@ -117,8 +117,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         // ignore errors setting breakpoints
       }
     }
-    // The controller's breakpoints value listener will update us at this point
-    // to rebuild.
   }
 
   @override
@@ -143,10 +141,14 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       ),
     );
 
-    final codeArea = ValueListenableBuilder(
-      valueListenable: controller.librariesVisible,
-      builder: (context, visible, _) {
-        if (visible) {
+    final codeArea = AnimatedBuilder(
+      animation: Listenable.merge([
+        controller.librariesVisible,
+        controller.sortedScripts,
+        controller.sortedClasses,
+      ]),
+      builder: (_, __) {
+        if (controller.librariesVisible.value) {
           // TODO(devoncarew): Animate this opening and closing.
           return Split(
             axis: Axis.horizontal,
@@ -156,7 +158,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
               ScriptPicker(
                 controller: controller,
                 scripts: controller.sortedScripts.value,
-                selected: script,
+                classes: controller.sortedClasses.value,
                 onSelected: _onScriptSelected,
               ),
             ],

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -125,13 +125,15 @@ class ScriptPickerState extends State<ScriptPicker> {
     } else if (ref is ClassRef) {
       text = ref.name;
       icon = classIcon;
+    } else {
+      assert(false, 'unexpected object reference: ${ref.type}');
     }
 
     return Material(
       child: InkWell(
         onTap: () => _handleSelected(ref),
         child: Container(
-          padding: const EdgeInsets.all(4.0),
+          padding: const EdgeInsets.all(densePadding),
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.center,
             children: [
@@ -159,15 +161,14 @@ class ScriptPickerState extends State<ScriptPicker> {
   void _updateFiltered() {
     final filterText = _filterController.text.trim().toLowerCase();
 
-    _items = [];
-    _items.addAll(widget.scripts);
-    _items.addAll(widget.classes);
+    _items = [...widget.scripts, ...widget.classes];
 
-    _filteredItems = [];
-    _filteredItems.addAll(widget.scripts
-        .where((ref) => ref.uri.toLowerCase().contains(filterText)));
-    _filteredItems.addAll(widget.classes
-        .where((ref) => ref.name.toLowerCase().contains(filterText)));
+    _filteredItems = [
+      ...widget.scripts
+          .where((ref) => ref.uri.toLowerCase().contains(filterText)),
+      ...widget.classes
+          .where((ref) => ref.name.toLowerCase().contains(filterText)),
+    ];
   }
 
   void _handleSelected(ObjRef ref) {
@@ -179,6 +180,8 @@ class ScriptPickerState extends State<ScriptPicker> {
         final Class clas = obj;
         widget.onSelected(clas.location.script);
       });
+    } else {
+      assert(false, 'unexpected object reference: ${ref.type}');
     }
   }
 }

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -373,6 +373,13 @@ class VmServiceWrapper implements VmService {
     return _trackFuture('getScripts', _vmService.getScripts(isolateId));
   }
 
+  // TODO(devoncarew): Switch to calling the typed method once it's in the VM
+  // service protocol library.
+  Future<Response> getClassList(String isolateId) {
+    // This returns a list of ClassRef in a 'classes' field.
+    return callMethod('getClassList', isolateId: isolateId);
+  }
+
   @override
   Future<SourceReport> getSourceReport(
     String isolateId,

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -46,9 +46,8 @@ void main() {
           .thenReturn(ValueNotifier([]));
       when(debuggerController.librariesVisible)
           .thenReturn(ValueNotifier(false));
-      when(debuggerController.scriptList)
-          .thenReturn(ValueNotifier(ScriptList(scripts: [])));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
+      when(debuggerController.sortedClasses).thenReturn(ValueNotifier([]));
       when(debuggerController.selectedBreakpoint)
           .thenReturn(ValueNotifier(null));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
@@ -85,31 +84,30 @@ void main() {
     testWidgets('Libraries hidden', (WidgetTester tester) async {
       final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
 
-      when(debuggerController.scriptList)
-          .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
 
       // Libraries view is hidden
       when(debuggerController.librariesVisible)
           .thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('Libraries'), findsNothing);
+      expect(find.text('Libraries and Classes'), findsNothing);
     });
 
     testWidgets('Libraries visible', (WidgetTester tester) async {
       final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
+      final classes = [ClassRef(name: 'Foo')];
 
-      when(debuggerController.scriptList)
-          .thenReturn(ValueNotifier(ScriptList(scripts: scripts)));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(debuggerController.sortedClasses).thenReturn(ValueNotifier(classes));
 
       // Libraries view is shown
       when(debuggerController.librariesVisible).thenReturn(ValueNotifier(true));
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('Libraries'), findsOneWidget);
+      expect(find.text('Libraries and Classes'), findsOneWidget);
 
-      // test for items in the libraries list
+      // test for items in the libraries and classes list
       expect(find.text(scripts.first.uri), findsOneWidget);
+      expect(find.text(classes.first.name), findsOneWidget);
     });
 
     testWidgets('Breakpoints show items', (WidgetTester tester) async {
@@ -136,8 +134,6 @@ void main() {
       when(debuggerController.breakpointsWithLocation)
           .thenReturn(ValueNotifier(breakpointsWithLocation));
 
-      when(debuggerController.scriptList)
-          .thenReturn(ValueNotifier(ScriptList(scripts: [])));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.currentStack).thenReturn(ValueNotifier(null));
       when(debuggerController.stdio).thenReturn(ValueNotifier([]));


### PR DESCRIPTION
- show VM classes in the Libraries view

This will allow users to jump to classes (and navigate their app) more easily.

The `getClassList` is an undocumented call (currently used by the Observatory). If we find it useful, we should ask the package:dwds authors to add support for it.

<img width="330" alt="Screen Shot 2020-04-23 at 12 57 43 PM" src="https://user-images.githubusercontent.com/1269969/80144003-9b7a6380-8562-11ea-8091-e1a09af9cbcc.png">

<img width="359" alt="Screen Shot 2020-04-23 at 12 57 51 PM" src="https://user-images.githubusercontent.com/1269969/80144017-a0d7ae00-8562-11ea-8192-9cee788320b8.png">
