### PR TITLE
fix how we parse errors in vm_service_logger.dart

### DIFF
--- a/packages/devtools_app/lib/src/logging/vm_service_logger.dart
+++ b/packages/devtools_app/lib/src/logging/vm_service_logger.dart
@@ -46,7 +46,8 @@ class VmServiceTrafficLogger {
       if (m['result'] != null) {
         details = m['result']['type'];
       } else {
-        details = m['error'] ?? '';
+        final Map error = m['error'];
+        details = error == null ? '' : '$error';
       }
     } else if (details == 'streamNotify') {
       details = '';


### PR DESCRIPTION
- fix how we parse errors in vm_service_logger.dart
