### PR TITLE
address an exception when reparenting widgets

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -69,9 +69,6 @@ class _CodeViewState extends State<CodeView> {
 
     if (widget.script != oldWidget.script) {
       _updateLines();
-    }
-
-    if (widget.stack != oldWidget.stack) {
       _updatePausedPositions();
     }
   }
@@ -85,31 +82,27 @@ class _CodeViewState extends State<CodeView> {
   }
 
   void _updateLines() {
-    setState(() {
-      lines = widget.script?.source?.split('\n') ?? [];
+    lines = widget.script?.source?.split('\n') ?? [];
 
-      executableLines = {};
+    executableLines = {};
 
-      // TODO(devoncarew): Improve this with SourceReportRange.possibleBreakpoints.
-      // (see getSourceReport('PossibleBreakpoints').
-      // Recalculate the executable lines.
-      if (widget.script?.tokenPosTable != null) {
-        for (var encodedInfo in widget.script.tokenPosTable) {
-          executableLines.add(encodedInfo[0]);
-        }
+    // TODO(devoncarew): Improve this with SourceReportRange.possibleBreakpoints.
+    // (see getSourceReport('PossibleBreakpoints').
+    // Recalculate the executable lines.
+    if (widget.script?.tokenPosTable != null) {
+      for (var encodedInfo in widget.script.tokenPosTable) {
+        executableLines.add(encodedInfo[0]);
       }
-    });
+    }
   }
 
   void _updatePausedPositions() {
-    setState(() {
-      final framesInScript = (widget.stack?.frames ?? [])
-          .where((frame) => frame.location.script.id == widget.script?.id);
-      pausedPositions = [
-        for (var frame in framesInScript)
-          widget.controller.lineNumber(widget.script, frame.location)
-      ];
-    });
+    final framesInScript = (widget.stack?.frames ?? [])
+        .where((frame) => frame.location.script.id == widget.script?.id);
+    pausedPositions = [
+      for (var frame in framesInScript)
+        widget.controller.lineNumber(widget.script, frame.location)
+    ];
 
     if (pausedPositions.isNotEmpty) {
       final position = verticalController.position;

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -55,6 +55,8 @@ class DebuggerScreen extends Screen {
 class DebuggerScreenBody extends StatefulWidget {
   const DebuggerScreenBody();
 
+  static final codeViewKey = GlobalKey(debugLabel: 'codeViewKey');
+
   @override
   DebuggerScreenBodyState createState() => DebuggerScreenBodyState();
 }
@@ -132,6 +134,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
               text: script == null ? ' ' : '${script.uri}'),
           Expanded(
             child: CodeView(
+              key: DebuggerScreenBody.codeViewKey,
               script: script,
               stack: controller.callStack.value,
               controller: controller,


### PR DESCRIPTION
- address an exception when reparenting widgets
- use a global key to have the code area remember its scroll position even when the parent widgets change (we add and remove a Split widget above it)

```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following assertion was thrown building Expanded(flex: 1):
LinkedScrollControllerGroup does not have any scroll controllers attached.
'package:devtools_app/src/flutter/flutter_widgets/linked_scroll_controller.dart':
Failed assertion: line 45 pos 7: '_attachedControllers.isNotEmpty'

The relevant error-causing widget was: 
  Expanded devtools/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart:133:11
When the exception was thrown, this was the stack: 
#2      LinkedScrollControllerGroup.position (package:devtools_app/src/flutter/flutter_widgets/linked_scroll_controller.dart:45:7)
#3      _CodeViewState._updatePausedPositions (package:devtools_app/src/debugger/flutter/codeview.dart:115:43)
#4      _CodeViewState.initState (package:devtools_app/src/debugger/flutter/codeview.dart:63:5)
#5      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4644:58)
#6      ComponentElement.mount (package:flutter/src/widgets/framework.dart:4480:5)
...
════════════════════════════════════════════════════════════════════════════════════════════════════
```
