### PR TITLE
UI tweaks to the network page

### DIFF
--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -101,11 +101,13 @@ StatelessWidget clearButton({
 /// * `recording`: Whether recording is in progress.
 /// * `includeTextWidth`: The minimum width the button can be before the text is
 ///    omitted.
+/// * `labelOverride`: Optional alternative text to use for the button.
 /// * `onPressed`: The callback to be called upon pressing the button.
 StatelessWidget recordButton({
   Key key,
   @required bool recording,
   double includeTextWidth,
+  String labelOverride,
   @required VoidCallback onPressed,
 }) {
   return OutlineButton(
@@ -113,7 +115,7 @@ StatelessWidget recordButton({
     onPressed: recording ? null : onPressed,
     child: MaterialIconLabel(
       Icons.fiber_manual_record,
-      'Record',
+      labelOverride ?? 'Record',
       includeTextWidth: includeTextWidth,
     ),
   );
@@ -142,13 +144,13 @@ StatelessWidget stopRecordingButton({
   );
 }
 
-/// Button to pause recording data.
+/// Button to stop recording data.
 ///
 /// * `recording`: Whether recording is in progress.
 /// * `includeTextWidth`: The minimum width the button can be before the text is
 ///    omitted.
 /// * `onPressed`: The callback to be called upon pressing the button.
-StatelessWidget pauseButton({
+StatelessWidget stopButton({
   Key key,
   @required bool paused,
   double includeTextWidth,
@@ -158,8 +160,8 @@ StatelessWidget pauseButton({
     key: key,
     onPressed: paused ? null : onPressed,
     child: MaterialIconLabel(
-      Icons.pause,
-      'Pause',
+      Icons.stop,
+      'Stop',
       includeTextWidth: includeTextWidth,
     ),
   );

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -14,6 +14,12 @@ import 'theme.dart';
 // TODO(devoncarew): We need to render the selected row with a different
 // background color.
 
+/// The maximum height to allow for rows in the table.
+///
+/// When rows in the table expand or collapse, they will animate between a
+/// height of 0 and a height of [defaultRowHeight].
+const defaultRowHeight = 32.0;
+
 typedef IndexedScrollableWidgetBuilder = Widget Function(
   BuildContext,
   LinkedScrollControllerGroup linkedScrollControllerGroup,
@@ -488,13 +494,12 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     double viewportHeight,
   ) {
     // get the index of the first item fully visible in the viewport
-    final firstItemIndex =
-        (scrollController.offset / _Table.defaultRowHeight).ceil();
+    final firstItemIndex = (scrollController.offset / defaultRowHeight).ceil();
 
     // '-1' in the following calculations is needed because the header row
     // occupies space in the viewport so we must subtract it out.
     final minCompleteItemsInView =
-        (viewportHeight / _Table.defaultRowHeight).floor() - 1;
+        (viewportHeight / defaultRowHeight).floor() - 1;
     final lastItemIndex = firstItemIndex + minCompleteItemsInView - 1;
     int newSelectedNodeIndex;
 
@@ -519,14 +524,13 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       // To do this we need to be showing the (minCompleteItemsInView + 1)
       // previous item  at the top.
       scrollController.animateTo(
-        (newSelectedNodeIndex - minCompleteItemsInView + 1) *
-            _Table.defaultRowHeight,
+        (newSelectedNodeIndex - minCompleteItemsInView + 1) * defaultRowHeight,
         duration: defaultDuration,
         curve: defaultCurve,
       );
     } else if (isAboveViewport) {
       scrollController.animateTo(
-        newSelectedNodeIndex * _Table.defaultRowHeight,
+        newSelectedNodeIndex * defaultRowHeight,
         duration: defaultDuration,
         curve: defaultCurve,
       );
@@ -573,12 +577,6 @@ class _Table<T> extends StatefulWidget {
 
   /// The width to assume for columns that don't specify a width.
   static const defaultColumnWidth = 500.0;
-
-  /// The maximum height to allow for rows in the table.
-  ///
-  /// When rows in the table expand or collapse, they will animate between
-  /// a height of 0 and a height of [defaultRowHeight].
-  static const defaultRowHeight = 32.0;
 
   @override
   _TableState<T> createState() => _TableState<T>();
@@ -840,7 +838,7 @@ class _TableRowState<T> extends State<TableRow<T>>
     final row = tableRowFor(context);
 
     final box = SizedBox(
-      height: _Table.defaultRowHeight,
+      height: defaultRowHeight,
       child: Material(
         color: widget.backgroundColor ?? Theme.of(context).canvasColor,
         child: widget.onPressed != null
@@ -863,10 +861,10 @@ class _TableRowState<T> extends State<TableRow<T>>
             box,
             for (var c in widget.expansionChildren)
               SizedBox(
-                height: _Table.defaultRowHeight * expandCurve.value,
+                height: defaultRowHeight * expandCurve.value,
                 child: OverflowBox(
                   minHeight: 0.0,
-                  maxHeight: _Table.defaultRowHeight,
+                  maxHeight: defaultRowHeight,
                   alignment: Alignment.topCenter,
                   child: c,
                 ),
@@ -922,7 +920,7 @@ class _TableRowState<T> extends State<TableRow<T>>
                       : Icons.expand_more,
                   size: defaultIconSize,
                 ),
-              const SizedBox(height: _Table.defaultRowHeight, width: 4.0),
+              const SizedBox(height: defaultRowHeight, width: 4.0),
               Text(
                 column.title,
                 overflow: TextOverflow.ellipsis,

--- a/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
+++ b/packages/devtools_app/lib/src/network/flutter/http_request_inspector.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../flutter/common_widgets.dart';
 import '../../http/http_request_data.dart';
 import 'http_request_inspector_views.dart';
 
@@ -73,12 +74,7 @@ class HttpRequestInspector extends StatelessWidget {
     return Card(
       margin: EdgeInsets.zero,
       color: Theme.of(context).canvasColor,
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(
-            color: Theme.of(context).focusColor,
-          ),
-        ),
+      child: RoundedOutlinedBorder(
         child: (data == null)
             ? Center(
                 child: Text(

--- a/packages/devtools_app/lib/src/network/flutter/network_model.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_model.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 import '../../http/http_request_data.dart';
+import '../../utils.dart';
 
 class HttpRequestDataTableSource extends DataTableSource {
   @visibleForTesting
@@ -36,10 +37,7 @@ class HttpRequestDataTableSource extends DataTableSource {
   int get selectedRowCount => _currentSelection.value == null ? 0 : 1;
 
   void sort(Function getField, bool ascending) {
-    _data.sort((
-      HttpRequestData a,
-      HttpRequestData b,
-    ) {
+    _data.sort((HttpRequestData a, HttpRequestData b) {
       if (!ascending) {
         final tmp = a;
         a = b;
@@ -86,15 +84,15 @@ class HttpRequestDataTableSource extends DataTableSource {
 
   @visibleForTesting
   String formatDuration(Duration duration) {
-    final numFormat = NumberFormat.decimalPattern();
     return (duration == null)
         ? 'In Progress'
-        : numFormat.format(duration.inMilliseconds);
+        : nf.format(duration.inMilliseconds);
   }
 
   @visibleForTesting
-  String formatRequestTime(DateTime requestTime) =>
-      DateFormat.Hms().add_yMd().format(requestTime);
+  String formatRequestTime(DateTime requestTime) {
+    return DateFormat.Hms().add_yMd().format(requestTime);
+  }
 
   @override
   DataRow getRow(int index) {
@@ -102,7 +100,6 @@ class HttpRequestDataTableSource extends DataTableSource {
     final status = (data.status == null) ? '--' : data.status.toString();
     final TextStyle statusColor = getStatusColor(data.status);
 
-    // TODO(bkonyi): is this the number format we want?
     final durationMs = formatDuration(data.duration);
     final requestTime = formatRequestTime(data.requestTime);
 

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -197,7 +197,7 @@ class NetworkController {
   /// Pauses the output of HTTP request information to the timeline.
   ///
   /// May result in some incomplete timeline events.
-  Future<void> pauseRecording() async =>
+  Future<void> stopRecording() async =>
       await _toggleHttpTimelineRecording(false);
 
   /// Checks to see if HTTP requests are currently being output. If so, recording

--- a/packages/devtools_app/test/flutter/network_profiler_test.dart
+++ b/packages/devtools_app/test/flutter/network_profiler_test.dart
@@ -5,12 +5,12 @@
 @TestOn('vm')
 import 'package:devtools_app/src/flutter/split.dart';
 import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/http/http.dart';
+import 'package:devtools_app/src/http/http_request_data.dart';
 import 'package:devtools_app/src/network/flutter/http_request_inspector.dart';
 import 'package:devtools_app/src/network/flutter/http_request_inspector_views.dart';
 import 'package:devtools_app/src/network/flutter/network_model.dart';
 import 'package:devtools_app/src/network/flutter/network_screen.dart';
-import 'package:devtools_app/src/http/http.dart';
-import 'package:devtools_app/src/http/http_request_data.dart';
 import 'package:devtools_app/src/network/network_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
@@ -105,13 +105,11 @@ void main() {
         findsOneWidget,
       );
 
-      // Start recording but don't advance the clock in order to check the
-      // loading spinner is displayed before requests are populated.
+      // Start recording.
       await tester.tap(find.byKey(NetworkScreen.recordButtonKey));
       await tester.pump();
 
       expect(splitFinder, findsOneWidget);
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
 
       // Advance the clock to populate the HTTP requests table.
       await tester.pump(const Duration(seconds: 1));

--- a/packages/devtools_app/test/flutter/network_profiler_test.dart
+++ b/packages/devtools_app/test/flutter/network_profiler_test.dart
@@ -81,7 +81,7 @@ void main() {
       expect(controller.recordingNotifier.value, true);
 
       // Stop recording.
-      await tester.tap(find.byKey(NetworkScreen.pauseButtonKey));
+      await tester.tap(find.byKey(NetworkScreen.stopButtonKey));
       await tester.pump();
 
       // Check that we've stopped polling.
@@ -97,9 +97,9 @@ void main() {
       // We're not recording; only expect the instructions and buttons to be
       // visible.
       expect(splitFinder, findsNothing);
-      expect(find.byKey(NetworkScreen.clearButtonKey), findsOneWidget);
       expect(find.byKey(NetworkScreen.recordButtonKey), findsOneWidget);
-      expect(find.byKey(NetworkScreen.pauseButtonKey), findsOneWidget);
+      expect(find.byKey(NetworkScreen.stopButtonKey), findsOneWidget);
+      expect(find.byKey(NetworkScreen.clearButtonKey), findsOneWidget);
       expect(
         find.byKey(NetworkScreen.recordingInstructionsKey),
         findsOneWidget,
@@ -285,7 +285,7 @@ void main() {
       await loadRequestsAndCheck(tester);
 
       // Stop the profiler.
-      await tester.tap(find.byKey(NetworkScreen.pauseButtonKey));
+      await tester.tap(find.byKey(NetworkScreen.stopButtonKey));
       await tester.pumpAndSettle();
 
       // Clear the results.

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -59,7 +59,7 @@ void main() {
           expect(notifier.value, false);
           expect(controller.isPolling, false);
         },
-        callback: () async => await controller.pauseRecording(),
+        callback: () async => await controller.stopRecording(),
       );
 
       await addListenerScope(


### PR DESCRIPTION
UI tweaks to the network page:
- add a status line contribution for the network page
- make the network page table look slightly more similar to our std table (in terms of padding and row height)
- rename some of the network page's buttons

<img width="1469" alt="Screen Shot 2020-04-25 at 5 16 22 AM" src="https://user-images.githubusercontent.com/1269969/80287439-7f073400-86e6-11ea-9b7e-b6a0d5cb1362.png">
