### PR TITLE
Fix timeline for upstream thread name change.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
@@ -119,11 +119,15 @@ class TimelineService {
       // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
       if (name.contains('.ui')) uiThreadName = name;
 
-      // Android: "1.gpu (12651)"
-      // iOS: "io.flutter.1.gpu (12651)"
-      // Linux, Windows, Dream (g3): "io.flutter.gpu (12651)"
+      // Android: "1.raster (12651)"
+      // iOS: "io.flutter.1.raster (12651)"
+      // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
       // MacOS: Does not exist
-      if (name.contains('.gpu')) gpuThreadName = name;
+      // Also look for .gpu here for older versions of Flutter.
+      // TODO(kenz): remove check for .gpu name in April 2021.
+      if (name.contains('.raster') || name.contains('.gpu')) {
+        gpuThreadName = name;
+      }
 
       // Android: "1.platform (22585)"
       // iOS: "io.flutter.1.platform (22585)"


### PR DESCRIPTION
Same change for Flutter app landed in https://github.com/flutter/devtools/pull/1821. This PR applies the same change to the html app. 

Fixes https://github.com/flutter/devtools/issues/1879