### PR TITLE
Use a Focus widget to capture input to TreeTable

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -27,7 +27,7 @@ typedef IndexedScrollableWidgetBuilder = Widget Function(
   int index,
 );
 
-typedef TableKeyEventHandler = void Function(RawKeyEvent event,
+typedef TableKeyEventHandler = bool Function(RawKeyEvent event,
     ScrollController scrollController, BoxConstraints constraints);
 
 enum ScrollKind { up, down, parent }
@@ -122,7 +122,6 @@ class FlatTableState<T> extends State<FlatTable<T>>
       sortColumn: widget.sortColumn,
       sortDirection: widget.sortDirection,
       onSortChanged: _sortDataAndUpdate,
-      focusNode: FocusNode(),
     );
   }
 
@@ -224,7 +223,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   int selectedNodeIndex;
   List<double> columnWidths;
   List<bool> rootsExpanded;
-  FocusNode focusNode = FocusNode();
+  FocusNode focusNode;
 
   @override
   void initState() {
@@ -233,12 +232,13 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     rootsExpanded =
         List.generate(dataRoots.length, (index) => dataRoots[index].isExpanded);
     _updateItems();
+    focusNode = FocusNode();
   }
 
   @override
   void didUpdateWidget(TreeTable oldWidget) {
     super.didUpdateWidget(oldWidget);
-    FocusScope.of(context).requestFocus(focusNode);
+    focusNode.requestFocus();
 
     if (widget.sortColumn != oldWidget.sortColumn ||
         widget.sortDirection != oldWidget.sortDirection ||
@@ -258,6 +258,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   @override
   void dispose() {
     super.dispose();
+    focusNode.dispose();
   }
 
   void _updateItems() {
@@ -434,12 +435,12 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       ..forEach(_sort);
   }
 
-  void _handleKeyEvent(
+  bool _handleKeyEvent(
     RawKeyEvent event,
     ScrollController scrollController,
     BoxConstraints constraints,
   ) {
-    if (event is! RawKeyDownEvent) return;
+    if (event is! RawKeyDownEvent) return false;
 
     // Exit early if we aren't handling the key
     if (![
@@ -447,7 +448,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       LogicalKeyboardKey.arrowUp,
       LogicalKeyboardKey.arrowLeft,
       LogicalKeyboardKey.arrowRight
-    ].contains(event.logicalKey)) return;
+    ].contains(event.logicalKey)) return false;
 
     // If there is no selected node, choose the first one.
     if (selectedNode == null) {
@@ -474,7 +475,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       }
     } else if (event.logicalKey == LogicalKeyboardKey.arrowRight) {
       // On right arrow expand the row if possible, otherwise move selection down.
-      if (!selectedNode.isExpanded) {
+      if (selectedNode.isExpandable && !selectedNode.isExpanded) {
         _toggleNode(selectedNode);
       } else {
         _moveSelection(
@@ -484,6 +485,8 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
         );
       }
     }
+
+    return true;
   }
 
   void _moveSelection(
@@ -509,7 +512,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
         newSelectedNodeIndex = max(selectedNodeIndex - 1, 0);
         break;
       case ScrollKind.parent:
-        newSelectedNodeIndex = items.indexOf(selectedNode.parent);
+        newSelectedNodeIndex = max(items.indexOf(selectedNode.parent), 0);
         break;
     }
 
@@ -556,7 +559,7 @@ class _Table<T> extends StatefulWidget {
     @required this.sortColumn,
     @required this.sortDirection,
     @required this.onSortChanged,
-    @required this.focusNode,
+    this.focusNode,
     this.handleKeyEvent,
     this.autoScrollContent = false,
   }) : super(key: key);
@@ -650,14 +653,14 @@ class _TableState<T> extends State<_Table<T>> {
             ),
             Expanded(
               child: Scrollbar(
-                child: RawKeyboardListener(
-                  onKey: (event) => widget.handleKeyEvent != null
+                child: Focus(
+                  onKey: (_, event) => widget.handleKeyEvent != null
                       ? widget.handleKeyEvent(
                           event,
                           scrollController,
                           constraints,
                         )
-                      : null,
+                      : false,
                   focusNode: widget.focusNode,
                   child: ListView.custom(
                     controller: scrollController,

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -223,7 +223,9 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   int selectedNodeIndex;
   List<double> columnWidths;
   List<bool> rootsExpanded;
-  FocusNode focusNode;
+  FocusNode _focusNode;
+
+  FocusNode get focusNode => _focusNode;
 
   @override
   void initState() {
@@ -232,13 +234,12 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     rootsExpanded =
         List.generate(dataRoots.length, (index) => dataRoots[index].isExpanded);
     _updateItems();
-    focusNode = FocusNode();
+    _focusNode = FocusNode();
   }
 
   @override
   void didUpdateWidget(TreeTable oldWidget) {
     super.didUpdateWidget(oldWidget);
-    focusNode.requestFocus();
 
     if (widget.sortColumn != oldWidget.sortColumn ||
         widget.sortDirection != oldWidget.sortDirection ||
@@ -258,7 +259,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   @override
   void dispose() {
     super.dispose();
-    focusNode.dispose();
+    _focusNode.dispose();
   }
 
   void _updateItems() {
@@ -380,7 +381,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       sortColumn: widget.sortColumn,
       sortDirection: widget.sortDirection,
       onSortChanged: _sortDataAndUpdate,
-      focusNode: focusNode,
+      focusNode: _focusNode,
       handleKeyEvent: _handleKeyEvent,
     );
   }
@@ -653,18 +654,23 @@ class _TableState<T> extends State<_Table<T>> {
             ),
             Expanded(
               child: Scrollbar(
-                child: Focus(
-                  onKey: (_, event) => widget.handleKeyEvent != null
-                      ? widget.handleKeyEvent(
-                          event,
-                          scrollController,
-                          constraints,
-                        )
-                      : false,
-                  focusNode: widget.focusNode,
-                  child: ListView.custom(
-                    controller: scrollController,
-                    childrenDelegate: itemDelegate,
+                child: GestureDetector(
+                  behavior: HitTestBehavior.translucent,
+                  onTapDown: (a) => widget.focusNode.requestFocus(),
+                  child: Focus(
+                    autofocus: true,
+                    onKey: (_, event) => widget.handleKeyEvent != null
+                        ? widget.handleKeyEvent(
+                            event,
+                            scrollController,
+                            constraints,
+                          )
+                        : false,
+                    focusNode: widget.focusNode,
+                    child: ListView.custom(
+                      controller: scrollController,
+                      childrenDelegate: itemDelegate,
+                    ),
                   ),
                 ),
               ),

--- a/packages/devtools_app/lib/src/trees.dart
+++ b/packages/devtools_app/lib/src/trees.dart
@@ -88,6 +88,9 @@ class TreeNode<T extends TreeNode<T>> {
   bool get isExpanded => _isExpanded;
   bool _isExpanded = false;
 
+  // TODO(gmoothart): expand does not check isExpandable, which can lead to
+  // inconsistent state, particular in combination with expandCascading. We
+  // should clean this up.
   void expand() {
     _isExpanded = true;
   }

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -512,45 +512,86 @@ void main() {
       expect(tree.children[2].name, equals('Baz'));
     });
 
-    testWidgets('selection changes with arrow keys',
-        (WidgetTester tester) async {
-      final data = TestData('Foo', 0)
-        ..children.addAll([
+    group('keyboard navigation', () {
+      TestData data;
+      TreeTable<TestData> table;
+
+      setUp(() {
+        data = TestData('Foo', 0);
+        data.addAllChildren([
           TestData('Bar', 1),
           TestData('Crackle', 5),
-        ])
-        ..expandCascading();
-      final table = TreeTable<TestData>(
-        columns: [
-          _NumberColumn(),
-          treeColumn,
-        ],
-        dataRoots: [data],
-        treeColumn: treeColumn,
-        keyFactory: (d) => Key(d.name),
-        sortColumn: treeColumn,
-        sortDirection: SortDirection.ascending,
-      );
+        ]);
 
-      await tester.pumpWidget(wrap(table));
-      await tester.pumpAndSettle();
+        table = TreeTable<TestData>(
+          columns: [
+            _NumberColumn(),
+            treeColumn,
+          ],
+          dataRoots: [data],
+          treeColumn: treeColumn,
+          keyFactory: (d) => Key(d.name),
+          sortColumn: treeColumn,
+          sortDirection: SortDirection.ascending,
+        );
+      });
 
-      final TreeTableState state = tester.state(find.byWidget(table));
-      state.focusNode.requestFocus();
-      await tester.pumpAndSettle();
+      testWidgets('selection changes with up/down arrow keys',
+          (WidgetTester tester) async {
+        data.expand();
+        await tester.pumpWidget(wrap(table));
+        await tester.pumpAndSettle();
 
-      expect(state.selectedNode, equals(null));
+        final TreeTableState state = tester.state(find.byWidget(table));
+        state.focusNode.requestFocus();
+        await tester.pumpAndSettle();
 
-      // the root is selected by default when there is no selection. Pressing
-      // arrowDown should take us to the first child, Bar
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-      await tester.pumpAndSettle();
-      expect(state.selectedNode, equals(data.children[0]));
+        expect(state.selectedNode, equals(null));
 
-      await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
-      await tester.pumpAndSettle();
+        // the root is selected by default when there is no selection. Pressing
+        // arrowDown should take us to the first child, Bar
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+        await tester.pumpAndSettle();
+        expect(state.selectedNode, equals(data.children[0]));
 
-      expect(state.selectedNode, equals(data.root));
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+        await tester.pumpAndSettle();
+
+        expect(state.selectedNode, equals(data.root));
+      });
+
+      testWidgets('selection changes with left/right arrow keys',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(wrap(table));
+        await tester.pumpAndSettle();
+
+        final TreeTableState state = tester.state(find.byWidget(table));
+        state.focusNode.requestFocus();
+        await tester.pumpAndSettle();
+
+        // left arrow on collapsed node with no parent should succeed but have
+        // no effect.
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pumpAndSettle();
+
+        expect(state.selectedNode, equals(data.root));
+        expect(state.selectedNode.isExpanded, isFalse);
+
+        // Expand root and navigate down twice
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowRight);
+        await tester.pumpAndSettle();
+
+        expect(state.selectedNode, equals(data.root.children[1]));
+
+        // Back to parent
+        await tester.sendKeyEvent(LogicalKeyboardKey.arrowLeft);
+        await tester.pumpAndSettle();
+
+        expect(state.selectedNode, equals(data.root));
+        expect(state.selectedNode.isExpanded, isTrue);
+      });
     });
 
     testWidgets('properly colors rows with alternating colors',


### PR DESCRIPTION
Based on code review from #1856. Also improved test coverage and fixed a
few boundary condition bugs caught by better tests.