### PR TITLE
Support Uris on querystring

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -37,7 +37,6 @@ import 'theme.dart';
 import 'utils.dart';
 
 const homeRoute = '/';
-const connectRoute = '/connect';
 const snapshotRoute = '/snapshot';
 
 /// Top-level configuration for the app.
@@ -85,7 +84,7 @@ class DevToolsAppState extends State<DevToolsApp> {
   /// Generates routes, separating the path from URL query parameters.
   Route _generateRoute(RouteSettings settings) {
     final uri = Uri.parse(settings.name);
-    final path = uri.path.isEmpty ? connectRoute : uri.path;
+    final path = uri.path.isEmpty ? homeRoute : uri.path;
     final args = settings.arguments;
 
     // Provide the appropriate page route.
@@ -122,7 +121,9 @@ class DevToolsAppState extends State<DevToolsApp> {
   /// The routes that the app exposes.
   Map<String, UrlParametersBuilder> get routes {
     return _routes ??= {
-      homeRoute: (_, params, __) => Initializer(
+      homeRoute: (_, params, __) {
+        if (params['uri']?.isNotEmpty ?? false) {
+          return Initializer(
             url: params['uri'],
             builder: (_) => _providedControllers(
               child: DevToolsScaffold(
@@ -135,9 +136,11 @@ class DevToolsAppState extends State<DevToolsApp> {
                 ],
               ),
             ),
-          ),
-      connectRoute: (_, __, ___) =>
-          DevToolsScaffold.withChild(child: ConnectScreenBody()),
+          );
+        } else {
+          return DevToolsScaffold.withChild(child: ConnectScreenBody());
+        }
+      },
       snapshotRoute: (_, __, args) {
         return DevToolsScaffold.withChild(
           child: _providedControllers(

--- a/packages/devtools_app/lib/src/flutter/connect_screen.dart
+++ b/packages/devtools_app/lib/src/flutter/connect_screen.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:pedantic/pedantic.dart';
 
 import '../../src/framework/framework_core.dart';
+import '../globals.dart';
 import '../url_utils.dart';
 import '../utils.dart';
 import 'common_widgets.dart';
@@ -109,6 +110,13 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
   }
 
   Future<void> _connect() async {
+    if (controller.text?.isEmpty ?? true) {
+      Notifications.of(context).push(
+        'Please enter a VM Service URL.',
+      );
+      return;
+    }
+
     final uri = normalizeVmServiceUri(controller.text);
     final connected = await FrameworkCore.initVmService(
       '',
@@ -118,13 +126,14 @@ class _ConnectScreenBodyState extends State<ConnectScreenBody> {
       },
     );
     if (connected) {
+      final connectedUri = serviceManager.service.connectedUri;
       unawaited(
-        Navigator.popAndPushNamed(
+        Navigator.pushNamed(
           context,
-          routeNameWithQueryParams(context, '/', {'uri': '$uri'}),
+          routeNameWithQueryParams(context, '/', {'uri': '$connectedUri'}),
         ),
       );
-      final shortUri = uri.replace(path: '');
+      final shortUri = connectedUri.replace(path: '');
       Notifications.of(context).push(
         'Successfully connected to $shortUri.',
       );

--- a/packages/devtools_app/lib/src/flutter/initializer.dart
+++ b/packages/devtools_app/lib/src/flutter/initializer.dart
@@ -68,11 +68,6 @@ class _InitializerState extends State<Initializer>
     // If we become disconnected, attempt to reconnect.
     autoDispose(
       serviceManager.onStateChange.where((connected) => !connected).listen((_) {
-        // Generally, empty setState calls in Flutter should be avoided.
-        // However, serviceManager is an implicit part of this state.
-        // This setState call is alerting a change in the serviceManager's
-        // state.
-        setState(() {});
         // TODO(https://github.com/flutter/devtools/issues/1285): On losing
         // the connection, only provide an option to reconnect; don't
         // immediately go to the connection page.
@@ -114,7 +109,7 @@ class _InitializerState extends State<Initializer>
       if (!_checkLoaded() && ModalRoute.of(context).isCurrent) {
         // If this route is on top and the app is not connected, then we navigate
         // back to the connect page.
-        Navigator.of(context).pop();
+        Navigator.of(context).popUntil(ModalRoute.withName('/'));
       }
     });
   }

--- a/packages/devtools_app/lib/src/flutter/initializer.dart
+++ b/packages/devtools_app/lib/src/flutter/initializer.dart
@@ -11,9 +11,7 @@ import '../framework/framework_core.dart';
 import '../globals.dart';
 import '../inspector/flutter_widget.dart';
 import '../url_utils.dart';
-import 'app.dart';
 import 'auto_dispose_mixin.dart';
-import 'navigation.dart';
 import 'notifications.dart';
 
 /// Widget that requires business logic to be loaded before building its
@@ -26,7 +24,7 @@ import 'notifications.dart';
 /// connected. As we require additional services to be available, add them
 /// here.
 class Initializer extends StatefulWidget {
-  const Initializer({Key key, this.url, @required this.builder})
+  const Initializer({Key key, @required this.url, @required this.builder})
       : assert(builder != null),
         super(key: key);
 
@@ -67,8 +65,9 @@ class _InitializerState extends State<Initializer>
       });
     });
 
+    // If we become disconnected, attempt to reconnect.
     autoDispose(
-      serviceManager.onStateChange.listen((_) {
+      serviceManager.onStateChange.where((connected) => !connected).listen((_) {
         // Generally, empty setState calls in Flutter should be avoided.
         // However, serviceManager is an implicit part of this state.
         // This setState call is alerting a change in the serviceManager's
@@ -77,19 +76,25 @@ class _InitializerState extends State<Initializer>
         // TODO(https://github.com/flutter/devtools/issues/1285): On losing
         // the connection, only provide an option to reconnect; don't
         // immediately go to the connection page.
-        // If we've become disconnected, attempt to reconnect.
-        _navigateToConnectPage();
+        _attemptUrlConnection();
       }),
     );
+    // Trigger a rebuild when the connection becomes available. This is done
+    // by onConnectionAvailable and not onStateChange because we also need
+    // to have queried what type of app this is before we load the UI.
+    autoDispose(
+      serviceManager.onConnectionAvailable.listen((_) => setState(() {})),
+    );
 
-    if (widget.url != null) {
-      _attemptUrlConnection();
-    } else {
-      _navigateToConnectPage();
-    }
+    _attemptUrlConnection();
   }
 
   Future<void> _attemptUrlConnection() async {
+    if (widget.url == null) {
+      _navigateBackToConnectPage();
+      return;
+    }
+
     final uri = normalizeVmServiceUri(widget.url);
     final connected = await FrameworkCore.initVmService(
       '',
@@ -97,21 +102,19 @@ class _InitializerState extends State<Initializer>
       errorReporter: (message, error) =>
           Notifications.of(context).push('$message, $error'),
     );
+
     if (!connected) {
-      _navigateToConnectPage();
+      _navigateBackToConnectPage();
     }
   }
 
-  /// Loads the /connect page if the [service.serviceManager] is not currently connected.
-  void _navigateToConnectPage() {
+  /// Goes back to the connect page if the [service.serviceManager] is not currently connected.
+  void _navigateBackToConnectPage() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!_checkLoaded() && ModalRoute.of(context).isCurrent) {
-        // If this route is on top and the app is not loaded, then we navigate to
-        // the /connect page to get a VM Service connection for serviceManager.
-        // When it completes, the serviceManager will notify this instance.
-        Navigator.of(context).pushNamed(
-          routeNameWithQueryParams(context, connectRoute),
-        );
+        // If this route is on top and the app is not connected, then we navigate
+        // back to the connect page.
+        Navigator.of(context).pop();
       }
     });
   }

--- a/packages/devtools_app/test/flutter/initializer_test.dart
+++ b/packages/devtools_app/test/flutter/initializer_test.dart
@@ -29,16 +29,21 @@ void main() {
       );
 
       app = MaterialApp(
+        // This test uses a fake route of /init for the initializer but
+        // in the real app it's loaded based on whether there's a ?uri= on
+        // the querystring, with / loading the connect dialog.
+        initialRoute: '/init',
         routes: {
-          '/connect': (_) => const SizedBox(key: connectKey),
-          '/': (_) => Initializer(
+          '/': (_) => const SizedBox(key: connectKey),
+          '/init': (_) => Initializer(
+                url: null,
                 builder: (_) => const SizedBox(key: initializedKey),
               ),
         },
       );
     });
 
-    testWidgets('navigates to the connection page when uninitialized',
+    testWidgets('navigates back to the connection page when uninitialized',
         (WidgetTester tester) async {
       setGlobal(
         ServiceConnectionManager,


### PR DESCRIPTION
This adds support for ?uri= on the querystring to allow hard-refreshing and direct launching from VS Code.

The original issue is that code handling `/` would loading the `Initializer` which would push the `/connect` route if it was not able to connect. However, loading `/?uri=foo` would trigger two routes, `/` and `/?uri=foo` which resulted in us both pushing `/connect` and trying to handle the connection.

This removes the `/connect` route and instead conditional handles a single home route based on whether it has `?uri=`. The route `/` will just load the connection form, and then `/?uri=` will load the `Initializer`. If the `Initializer` decides to navigate back to the connection screen, it'll do that by popping itself off rather than pushing a new route.

This is my first foray into Routing, so don't assume I know what I'm doing - if anything looks weird or not best practice, do point it out 😄