### PR TITLE
clean up around the use of the theme setting

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_desktop.dart
+++ b/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_desktop.dart
@@ -20,10 +20,7 @@ Future<String> initializePlatform() async {
 
   setGlobal(Storage, FlutterDesktopStorage());
 
-  // TODO(jacobr): we don't yet have a direct analog to the URL on flutter
-  // desktop. Hard code to the dark theme as the majority of users are on the
-  // dark theme.
-  return '/?theme=dark';
+  return '';
 }
 
 class FlutterDesktopStorage implements Storage {

--- a/packages/devtools_app/lib/src/debugger/console_area.dart
+++ b/packages/devtools_app/lib/src/debugger/console_area.dart
@@ -20,6 +20,7 @@ class ConsoleArea implements CoreElementView {
       ..flex();
     _editor = CodeMirror.fromElement(_container.element, options: options);
     _editor.setReadOnly(true);
+    // ignore: deprecated_member_use_from_same_package
     if (isDarkTheme) {
       _editor.setTheme('darcula');
     }

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -12,7 +12,6 @@ import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/flutter_widgets/linked_scroll_controller.dart';
 import '../../flutter/theme.dart';
-import '../../ui/theme.dart';
 import '../../utils.dart';
 import 'breakpoints.dart';
 import 'common.dart';
@@ -157,7 +156,6 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
 
     if (!verticalController.hasAttachedControllers) {
       // TODO(devoncarew): I'm uncertain why this occurs.
-      // todo: ???
       log('LinkedScrollControllerGroup has no attached controllers');
       return;
     }
@@ -349,9 +347,10 @@ class GutterItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final darkTheme = theme.brightness == Brightness.dark;
 
     final foregroundColor =
-        isDarkTheme ? theme.textTheme.bodyText2.color : theme.primaryColor;
+        darkTheme ? theme.textTheme.bodyText2.color : theme.primaryColor;
     final subtleColor = theme.unselectedWidgetColor;
 
     const bpBoxSize = 12.0;
@@ -362,7 +361,7 @@ class GutterItem extends StatelessWidget {
       child: Container(
         height: CodeView.rowHeight,
         padding: const EdgeInsets.only(right: 4.0),
-        decoration: BoxDecoration(color: titleSolidBackgroundColor),
+        decoration: BoxDecoration(color: titleSolidBackgroundColor(theme)),
         child: Stack(
           alignment: AlignmentDirectional.centerStart,
           fit: StackFit.expand,
@@ -447,13 +446,14 @@ class LineItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final darkTheme = theme.brightness == Brightness.dark;
 
     Widget child;
     if (pausedFrame != null) {
       final column = pausedFrame.column;
 
       final foregroundColor =
-          isDarkTheme ? theme.textTheme.bodyText2.color : theme.primaryColor;
+          darkTheme ? theme.textTheme.bodyText2.color : theme.primaryColor;
 
       // The following constants are tweaked for using the
       // 'Icons.label_important' icon.
@@ -496,7 +496,7 @@ class LineItem extends StatelessWidget {
     }
 
     final backgroundColor = pausedFrame != null
-        ? (isDarkTheme
+        ? (darkTheme
             ? theme.canvasColor.brighten()
             : theme.canvasColor.darken())
         : null;

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -347,10 +347,10 @@ class GutterItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final darkTheme = theme.brightness == Brightness.dark;
 
-    final foregroundColor =
-        darkTheme ? theme.textTheme.bodyText2.color : theme.primaryColor;
+    final foregroundColor = theme.isDarkTheme
+        ? theme.textTheme.bodyText2.color
+        : theme.primaryColor;
     final subtleColor = theme.unselectedWidgetColor;
 
     const bpBoxSize = 12.0;

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -19,7 +19,7 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
       border: Border(
         bottom: BorderSide(color: theme.focusColor),
       ),
-      color: titleSolidBackgroundColor,
+      color: titleSolidBackgroundColor(theme),
     ),
     padding: const EdgeInsets.only(left: defaultSpacing),
     alignment: Alignment.centerLeft,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -298,7 +298,7 @@ FlexSplitColumnHeader debuggerPaneHeader(
               : BorderSide.none,
           bottom: BorderSide(color: theme.focusColor),
         ),
-        color: titleSolidBackgroundColor,
+        color: titleSolidBackgroundColor(theme),
       ),
       padding: const EdgeInsets.only(left: defaultSpacing, right: 4.0),
       alignment: Alignment.centerLeft,

--- a/packages/devtools_app/lib/src/debugger/html_debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/html_debugger_screen.dart
@@ -443,6 +443,7 @@ class HtmlDebuggerScreen extends HtmlScreen {
     final codeMirror =
         CodeMirror.fromElement(_sourceArea.element, options: options);
     codeMirror.setReadOnly(true);
+    // ignore: deprecated_member_use_from_same_package
     if (isDarkTheme) {
       codeMirror.setTheme('darcula');
     }

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -632,3 +632,9 @@ extension ColorExtension on Color {
     );
   }
 }
+
+/// Utility extension methods to the [ThemeData] class.
+extension ThemeDataExtension on ThemeData {
+  /// Returns whether we are currently using a dark theme.
+  bool get isDarkTheme => brightness == Brightness.dark;
+}

--- a/packages/devtools_app/lib/src/flutter/navigation.dart
+++ b/packages/devtools_app/lib/src/flutter/navigation.dart
@@ -56,4 +56,5 @@ String routeNameWithQueryParams(BuildContext context, String routeName,
 ///
 /// ModalRoute.of`(innerContext)` returns the unnamed page route.
 String get _inferThemeParameter =>
+    // ignore: deprecated_member_use_from_same_package
     devtools_theme.isDarkTheme ? '/unnamedRoute?theme=dark' : '/unnamedRoute';

--- a/packages/devtools_app/lib/src/flutter/preferences.dart
+++ b/packages/devtools_app/lib/src/flutter/preferences.dart
@@ -8,10 +8,6 @@ import '../config_specific/logger/logger.dart';
 import '../globals.dart';
 import '../ui/theme.dart' as devtools_theme;
 
-// TODO(devoncarew): This controller is currently backed by a global in
-// devtools_theme. A future refactor will instead provide a backing store on
-// disk.
-
 /// A controller for global application preferences.
 class PreferencesController {
   PreferencesController() {
@@ -19,6 +15,7 @@ class PreferencesController {
   }
 
   final ValueNotifier<bool> _darkModeTheme =
+      // ignore: deprecated_member_use_from_same_package
       ValueNotifier(devtools_theme.isDarkTheme);
 
   ValueListenable get darkModeTheme => _darkModeTheme;

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -5,10 +5,9 @@ import 'package:flutter/services.dart';
 
 import '../table_data.dart';
 import '../trees.dart';
-import '../ui/theme.dart';
 import '../utils.dart';
 import 'collapsible_mixin.dart';
-import 'common_widgets.dart' show ScrollControllerAutoScroll;
+import 'common_widgets.dart' show ColorExtension, ScrollControllerAutoScroll;
 import 'flutter_widgets/linked_scroll_controller.dart';
 import 'theme.dart';
 
@@ -788,8 +787,14 @@ class TableRow<T> extends StatefulWidget {
   /// Gets a color to use for this row at a given index.
   static Color colorFor(BuildContext context, int index) {
     final theme = Theme.of(context);
-    final alternateColor = ThemedColor(devtoolsGrey[50], devtoolsGrey[900]);
-    return index % 2 == 0 ? alternateColor : theme.canvasColor;
+    final color = theme.canvasColor;
+
+    if (index % 2 == 0) {
+      return color;
+    } else {
+      final darkTheme = theme.brightness == Brightness.dark;
+      return darkTheme ? color.brighten() : color.darken();
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -3,6 +3,7 @@ import 'dart:math';
 import 'package:flutter/material.dart' hide TableRow;
 import 'package:flutter/services.dart';
 
+import '../flutter/common_widgets.dart';
 import '../table_data.dart';
 import '../trees.dart';
 import '../utils.dart';
@@ -792,8 +793,7 @@ class TableRow<T> extends StatefulWidget {
     if (index % 2 == 0) {
       return color;
     } else {
-      final darkTheme = theme.brightness == Brightness.dark;
-      return darkTheme ? color.brighten() : color.darken();
+      return theme.isDarkTheme ? color.brighten() : color.darken();
     }
   }
 

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:mp_chart/mp/core/adapter_android_mp.dart';
 
+import '../flutter/common_widgets.dart';
 import '../ui/theme.dart';
 
 /// Constructs the light or dark theme for the app.
@@ -146,10 +147,7 @@ CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
 
 Color titleSolidBackgroundColor(ThemeData theme) {
-  // ThemedColor(devtoolsGrey[50], devtoolsGrey[900])
-
-  final darkTheme = theme.brightness == Brightness.dark;
-  return darkTheme ? devtoolsGrey[900] : devtoolsGrey[50];
+  return theme.isDarkTheme ? devtoolsGrey[900] : devtoolsGrey[50];
 }
 
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -145,8 +145,12 @@ const defaultCurve = Curves.easeInOutCubic;
 CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
 
-final titleSolidBackgroundColor =
-    ThemedColor(devtoolsGrey[50], devtoolsGrey[900]);
+Color titleSolidBackgroundColor(ThemeData theme) {
+  // ThemedColor(devtoolsGrey[50], devtoolsGrey[900])
+
+  final darkTheme = theme.brightness == Brightness.dark;
+  return darkTheme ? devtoolsGrey[900] : devtoolsGrey[50];
+}
 
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);
 

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -13,7 +13,6 @@ import '../framework_controller.dart';
 import '../globals.dart';
 import '../service.dart';
 import '../service_manager.dart';
-import '../ui/theme.dart';
 import '../vm_service_wrapper.dart';
 
 typedef ErrorReporter = void Function(String title, dynamic error);
@@ -28,10 +27,6 @@ class FrameworkCore {
   static void init({String url}) {
     // Print the version number at startup.
     log('DevTools version ${devtools.version}.');
-
-    final theme = url == null ? null : Uri.parse(url).queryParameters['theme'];
-    // ignore: deprecated_member_use_from_same_package
-    setTheme(darkTheme: theme == 'dark');
   }
 
   /// Returns true if we're able to connect to a device and false otherwise.

--- a/packages/devtools_app/lib/src/ui/html_icon_renderer.dart
+++ b/packages/devtools_app/lib/src/ui/html_icon_renderer.dart
@@ -96,6 +96,7 @@ class _UrlIconRenderer extends HtmlIconRenderer<UrlIcon> {
       ..width = '${icon.iconWidth}px'
       ..height = '${icon.iconHeight}px'
       ..backgroundImage = 'url($src)';
+    // ignore: deprecated_member_use_from_same_package
     if (icon.invertDark && isDarkTheme) {
       element.style.filter = 'invert(1)';
     }

--- a/packages/devtools_app/lib/src/ui/theme.dart
+++ b/packages/devtools_app/lib/src/ui/theme.dart
@@ -7,7 +7,7 @@ import 'package:meta/meta.dart';
 import 'fake_flutter/fake_flutter.dart';
 import 'flutter_html_shim.dart';
 
-bool _isDarkTheme = false;
+bool _isDarkTheme = true;
 
 /// Whether the application is running with a light or dark theme.
 ///
@@ -18,6 +18,7 @@ bool _isDarkTheme = false;
 /// that code can be written without directly depending on [isDarkTheme].
 ///
 /// This getter will be deprecated - prefer using the SettingsController class.
+@Deprecated('Prefer using the SettingsController')
 bool get isDarkTheme => _isDarkTheme;
 
 @Deprecated('Prefer using the SettingsController')
@@ -69,6 +70,7 @@ class ThemedColor implements Color {
   final Color _light;
   final Color _dark;
 
+  // ignore: deprecated_member_use_from_same_package
   Color get _current => isDarkTheme ? _dark : _light;
 
   @override

--- a/packages/devtools_app/test/flutter/table_test.dart
+++ b/packages/devtools_app/test/flutter/table_test.dart
@@ -586,8 +586,8 @@ void main() {
       final crackleFinder = find.byKey(const Key('Crackle'));
 
       // Expected values returned through accessing Color.value property.
-      const color1Value = 4293585900;
-      const color2Value = 4294638330;
+      const color1Value = 4294638330;
+      const color2Value = 4293848814;
       const rowSelectedColorValue = 4278285762;
 
       await tester.pumpWidget(wrap(table));


### PR DESCRIPTION
Clean up around the use of the theme setting:
- just use the theme setting to control the light/dark theme (no longer use the url)
- in some places, query the `theme.brightness` theme field to know whether we're in light or dark theme (instead of querying the global var)
- convert the `titleSolidBackgroundColor` global final field to a function; we'd had issues w/ some colors not updating on theme changes, I think possibly due to the framework making copies of colors? i.e., not expecting colors to be not be immutable (a `ThemedColor` can return different values when called two separate times)

