### PR TITLE
allow DevTools to re-connect to a new app after closing a previous app

### DIFF
--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -60,7 +60,7 @@ class ConnectedApp {
   bool get isDartCliAppNow => isRunningOnDartVM && !isFlutterAppNow;
 
   Future<bool> _connectedToProfileBuild() async {
-    assert(serviceManager.serviceAvailable.isCompleted);
+    assert(serviceManager.isServiceAvailable);
     // Only flutter apps have profile and non-profile builds. If this changes in
     // the future (flutter web), we can modify this check.
     if (!isRunningOnDartVM || !await isFlutterApp) return false;

--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -160,7 +160,7 @@ class DevToolsAppState extends State<DevToolsApp> {
     final visibleScreens = <Screen>[];
     for (var screen in _screens) {
       if (screen.conditionalLibrary != null) {
-        if (serviceManager.serviceAvailable.isCompleted &&
+        if (serviceManager.isServiceAvailable &&
             serviceManager
                 .isolateManager.selectedIsolateAvailable.isCompleted &&
             serviceManager.libraryUriAvailableNow(screen.conditionalLibrary)) {

--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -94,7 +94,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
         html.window.location.href = href;
       });
 
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
     await addScreens();
     screensReady.complete();
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -212,7 +212,7 @@ class MemoryBodyState extends State<MemoryBody> {
   }
 
   void _updateListeningState() async {
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
 
     if (controller != null && controller.hasStarted) return;
 

--- a/packages/devtools_app/lib/src/memory/html_memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/html_memory_screen.dart
@@ -1012,7 +1012,7 @@ class HtmlMemoryScreen extends HtmlScreen with HtmlSetStateMixin {
   }
 
   void _updateListeningState() async {
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
 
     final bool shouldBeRunning = isCurrentScreen;
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -47,7 +47,7 @@ class ServiceConnectionManager {
 
   Completer<VmService> _serviceAvailable = Completer();
 
-  Future get onServiceAvailable => _serviceAvailable.future;
+  Future<VmService> get onServiceAvailable => _serviceAvailable.future;
 
   bool get isServiceAvailable => _serviceAvailable.isCompleted;
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -45,14 +45,18 @@ class ServiceConnectionManager {
   final StreamController<VmServiceWrapper> _connectionAvailableController =
       StreamController<VmServiceWrapper>.broadcast();
 
-  final serviceAvailable = Completer<void>();
+  Completer<VmService> _serviceAvailable = Completer();
+
+  Future get onServiceAvailable => _serviceAvailable.future;
+
+  bool get isServiceAvailable => _serviceAvailable.isCompleted;
 
   VmServiceCapabilities _serviceCapabilities;
   VmServiceTrafficLogger serviceTrafficLogger;
 
   Future<VmServiceCapabilities> get serviceCapabilities async {
     if (_serviceCapabilities == null) {
-      await serviceAvailable.future;
+      await _serviceAvailable.future;
       final version = await service.getVersion();
       _serviceCapabilities = VmServiceCapabilities(version);
     }
@@ -138,7 +142,7 @@ class ServiceConnectionManager {
       serviceTrafficLogger = VmServiceTrafficLogger(service);
     }
 
-    serviceAvailable.complete();
+    _serviceAvailable.complete(service);
 
     connectedApp = ConnectedApp();
     serviceExtensionManager.connectedApp = connectedApp;
@@ -217,11 +221,14 @@ class ServiceConnectionManager {
   }
 
   void vmServiceClosed() {
+    _serviceAvailable = Completer();
+
     service = null;
     vm = null;
     sdkVersion = null;
     connectedApp = null;
     serviceExtensionManager.connectedApp = null;
+    serviceExtensionManager.resetAvailableExtensions();
 
     serviceTrafficLogger?.dispose();
 
@@ -304,7 +311,7 @@ class ServiceConnectionManager {
   }
 
   bool libraryUriAvailableNow(String uri) {
-    assert(serviceAvailable.isCompleted);
+    assert(_serviceAvailable.isCompleted);
     assert(isolateManager.selectedIsolateAvailable.isCompleted);
     return isolateManager.selectedIsolateLibraries
         .map((ref) => ref.uri)
@@ -313,7 +320,7 @@ class ServiceConnectionManager {
   }
 
   Future<bool> libraryUriAvailable(String uri) async {
-    assert(serviceAvailable.isCompleted);
+    assert(_serviceAvailable.isCompleted);
     await isolateManager.selectedIsolateAvailable.future;
     return libraryUriAvailableNow(uri);
   }

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_service.dart
@@ -70,7 +70,7 @@ class TimelineService {
           )
         : TimelineData();
 
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
     await allowedError(
         serviceManager.service.setVMTimelineFlags(['GC', 'Dart', 'Embedder']));
     await allowedError(serviceManager.service.clearVMTimeline());
@@ -146,13 +146,13 @@ class TimelineService {
   Future<void> updateListeningState(bool isCurrentScreen) async {
     final bool shouldBeRunning =
         timelineController.recording.value && !offlineMode && isCurrentScreen;
-    final bool isRunning = serviceManager.serviceAvailable.isCompleted &&
+    final bool isRunning = serviceManager.isServiceAvailable &&
         timelineController.recording.value &&
         (await serviceManager.service.getVMTimelineFlags())
             .recordedStreams
             .isNotEmpty;
 
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
     if (shouldBeRunning) {
       await startTimeline();
     } else if (shouldBeRunning && !isRunning) {

--- a/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
+++ b/packages/devtools_app/lib/src/timeline/html_timeline_service.dart
@@ -85,7 +85,7 @@ class TimelineService {
     }
     timelineController.fullTimeline.data = FullTimelineData();
 
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
     await allowedError(
         serviceManager.service.setVMTimelineFlags(['GC', 'Dart', 'Embedder']));
     await allowedError(serviceManager.service.clearVMTimeline());
@@ -166,7 +166,7 @@ class TimelineService {
                 timelineController.fullTimeline.recordingNotifier.value) &&
             !offlineMode &&
             isCurrentScreen;
-    final bool isRunning = serviceManager.serviceAvailable.isCompleted &&
+    final bool isRunning = serviceManager.isServiceAvailable &&
         (!timelineController.frameBasedTimeline.pausedNotifier.value ||
             timelineController.fullTimeline.recordingNotifier.value) &&
         (await serviceManager.service.getVMTimelineFlags())
@@ -184,7 +184,7 @@ class TimelineService {
   }) async {
     // TODO(kenz): instead of awaiting here, should we check that
     // serviceManager.connectedApp != null?
-    await serviceManager.serviceAvailable.future;
+    await serviceManager.onServiceAvailable;
     if (shouldBeRunning) {
       await startTimeline();
     } else if (shouldBeRunning && !isRunning) {

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -45,10 +45,10 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   final VmServiceWrapper service;
 
   @override
-  Future get onServiceAvailable => Future.value(service);
+  Future<VmService> get onServiceAvailable => Future.value(service);
 
   @override
-  bool get isServiceAvailable => true;
+  bool get isServiceAvailable => hasConnection;
 
   @override
   final ConnectedApp connectedApp = MockConnectedApp();

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -38,13 +38,17 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
             : MockVmService() {
     _flagManager.service = service;
   }
+
   static final _flagManager = VmFlagManager();
 
   @override
   final VmServiceWrapper service;
 
-//  @override
-//  final Completer serviceAvailable = Completer()..complete();
+  @override
+  Future get onServiceAvailable => Future.value(service);
+
+  @override
+  bool get isServiceAvailable => true;
 
   @override
   final ConnectedApp connectedApp = MockConnectedApp();

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -43,8 +43,8 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   @override
   final VmServiceWrapper service;
 
-  @override
-  final Completer serviceAvailable = Completer()..complete();
+//  @override
+//  final Completer serviceAvailable = Completer()..complete();
 
   @override
   final ConnectedApp connectedApp = MockConnectedApp();

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -45,7 +45,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   final VmServiceWrapper service;
 
   @override
-  Future<VmService> get onServiceAvailable => Future.value(service);
+  Future<VmService> onServiceAvailable = Future.value();
 
   @override
   bool get isServiceAvailable => hasConnection;


### PR DESCRIPTION
- allow DevTools to re-connect to a new app after closing a previous app
- fix https://github.com/flutter/devtools/issues/1889 (related to https://github.com/flutter/devtools/issues/1897)

This does some surgery on the `ServiceConnectionManager` class to make one Completer private, and ensure that we reset some minimal state between connections.
