### PR TITLE
Add Ctrl+P shortcut to filter libraries

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -116,6 +116,11 @@ class DebuggerController extends DisposableController
     _librariesVisible.value = !_librariesVisible.value;
   }
 
+  /// Make the 'Libraries' view on the right-hand side of the screen visible.
+  void openLibrariesView() {
+    _librariesVisible.value = true;
+  }
+
   final _stdio = ValueNotifier<List<String>>([]);
 
   /// Return the stdout and stderr emitted from the application.

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -250,23 +250,22 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   }
 }
 
-class FilterLibraryIntent extends RequestFocusIntent {
+class FilterLibraryIntent extends Intent {
   const FilterLibraryIntent(
-    FocusNode focusNode,
+    this.focusNode,
     this.debuggerController,
   )   : assert(debuggerController != null),
-        super(focusNode);
+        assert(focusNode != null);
 
+  final FocusNode focusNode;
   final DebuggerController debuggerController;
 }
 
-class FilterLibraryAction extends RequestFocusAction {
+class FilterLibraryAction extends Action<FilterLibraryIntent> {
   @override
   void invoke(FilterLibraryIntent intent) {
-    debugPrint('invoking filter action');
-    super.invoke(intent);
-    // TODO: open, don't toggle
-    intent.debuggerController.toggleLibrariesVisible();
+    intent.debuggerController.openLibrariesView();
+    intent.focusNode.requestFocus();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart' hide Stack;
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -69,6 +70,13 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   static const breakpointsTitle = 'Breakpoints';
 
   DebuggerController controller;
+  FocusNode _libraryFilterFocusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _libraryFilterFocusNode = FocusNode();
+  }
 
   @override
   void didChangeDependencies() {
@@ -77,6 +85,12 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     final newController = Provider.of<DebuggerController>(context);
     if (newController == controller) return;
     controller = newController;
+  }
+
+  @override
+  void dispose() {
+    _libraryFilterFocusNode.dispose();
+    super.dispose();
   }
 
   void _onLocationSelected(ScriptLocation location) {
@@ -137,6 +151,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                     scripts: controller.sortedScripts.value,
                     classes: controller.sortedClasses.value,
                     onSelected: _onLocationSelected,
+                    libraryFilterFocusNode: _libraryFilterFocusNode,
                   );
                 },
               ),
@@ -148,28 +163,42 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       },
     );
 
-    return Split(
-      axis: Axis.horizontal,
-      initialFractions: const [0.25, 0.75],
-      children: [
-        OutlinedBorder(child: debuggerPanes()),
-        Column(
-          children: [
-            DebuggingControls(controller: controller),
-            const SizedBox(height: denseRowSpacing),
-            Expanded(
-              child: Split(
-                axis: Axis.vertical,
-                initialFractions: const [0.74, 0.26],
+    return Shortcuts(
+      shortcuts: <LogicalKeySet, Intent>{
+        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyP):
+            FilterLibraryIntent(_libraryFilterFocusNode, controller),
+      },
+      child: Actions(
+        actions: <Type, Action<Intent>>{
+          FilterLibraryIntent: FilterLibraryAction(),
+        },
+        child: Focus(
+          autofocus: true,
+          child: Split(
+            axis: Axis.horizontal,
+            initialFractions: const [0.25, 0.75],
+            children: [
+              OutlinedBorder(child: debuggerPanes()),
+              Column(
                 children: [
-                  codeArea,
-                  Console(controller: controller),
+                  DebuggingControls(controller: controller),
+                  const SizedBox(height: denseRowSpacing),
+                  Expanded(
+                    child: Split(
+                      axis: Axis.vertical,
+                      initialFractions: const [0.74, 0.26],
+                      children: [
+                        codeArea,
+                        Console(controller: controller),
+                      ],
+                    ),
+                  ),
                 ],
               ),
-            ),
-          ],
+            ],
+          ),
         ),
-      ],
+      ),
     );
   }
 
@@ -218,6 +247,26 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         ]);
       },
     );
+  }
+}
+
+class FilterLibraryIntent extends RequestFocusIntent {
+  const FilterLibraryIntent(
+    FocusNode focusNode,
+    this.debuggerController,
+  )   : assert(debuggerController != null),
+        super(focusNode);
+
+  final DebuggerController debuggerController;
+}
+
+class FilterLibraryAction extends RequestFocusAction {
+  @override
+  void invoke(FilterLibraryIntent intent) {
+    debugPrint('invoking filter action');
+    super.invoke(intent);
+    // TODO: open, don't toggle
+    intent.debuggerController.toggleLibrariesVisible();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -133,6 +133,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       valueListenable: controller.librariesVisible,
       builder: (context, visible, _) {
         if (visible) {
+          // Focus the filter textfield when the ScriptPicker opens
+          _libraryFilterFocusNode.requestFocus();
+
           // TODO(devoncarew): Animate this opening and closing.
           return Split(
             axis: Axis.horizontal,

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -24,12 +24,14 @@ class ScriptPicker extends StatefulWidget {
     @required this.scripts,
     @required this.classes,
     @required this.onSelected,
+    this.libraryFilterFocusNode,
   }) : super(key: key);
 
   final DebuggerController controller;
   final List<ScriptRef> scripts;
   final List<ClassRef> classes;
   final void Function(ScriptLocation scriptRef) onSelected;
+  final FocusNode libraryFilterFocusNode;
 
   @override
   ScriptPickerState createState() => ScriptPickerState();
@@ -88,12 +90,13 @@ class ScriptPickerState extends State<ScriptPicker> {
                 height: 36.0,
                 child: TextField(
                   decoration: const InputDecoration(
-                    labelText: 'Filter',
+                    labelText: 'Filter (Ctrl + P)',
                     border: OutlineInputBorder(),
                   ),
                   controller: _filterController,
                   onChanged: (value) => updateFilter(),
                   style: Theme.of(context).textTheme.bodyText2,
+                  focusNode: widget.libraryFilterFocusNode,
                 ),
               ),
             ),

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -253,8 +253,10 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         Container(
           padding: DevToolsScaffold.appPadding,
           alignment: Alignment.topLeft,
-          child: BannerMessages(
-            screen: screen,
+          child: FocusScope(
+            child: BannerMessages(
+              screen: screen,
+            ),
           ),
         ),
     ];


### PR DESCRIPTION
In the spirit of the Chrome devtools "sources" panel, we'll use Ctrl+P to
search libraries and classes in the debugger view. Fixes #1294