### PR TITLE
Initial support for running integration tests using Flutter web version

### DIFF
--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -15,9 +15,11 @@ import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
 import '../support/chrome.dart';
 import '../support/cli_test_driver.dart';
 import '../support/utils.dart';
-import 'integration_test.dart';
 
 const bool verboseTesting = false;
+final bool testInReleaseMode = Platform.environment['WEBDEV_RELEASE'] == 'true';
+final bool testFlutterWebVersion =
+    Platform.environment['DEVTOOLS_FLUTTER_WEB'] == 'true';
 
 WebdevFixture webdevFixture;
 BrowserManager browserManager;

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+import 'dart:io';
 
 import 'package:devtools_testing/support/file_utils.dart';
 import 'package:test/test.dart';
@@ -16,10 +17,11 @@ void main() {
   group('integration', () {
     setUpAll(() async {
       compensateForFlutterTestDirectoryBug();
-      webdevFixture = await WebdevFixture.serve(
-          flutter: testFlutterWebVersion,
-          release: testInReleaseMode,
-          verbose: true);
+      final bool testInReleaseMode =
+          Platform.environment['WEBDEV_RELEASE'] == 'true';
+
+      webdevFixture =
+          await WebdevFixture.serve(release: testInReleaseMode, verbose: true);
       browserManager = await BrowserManager.create();
     });
 

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -13,15 +13,18 @@ import 'debugger.dart';
 import 'integration.dart';
 import 'logging.dart';
 
+final bool testInReleaseMode = Platform.environment['WEBDEV_RELEASE'] == 'true';
+final bool testFlutterWebVersion =
+    Platform.environment['TEST_FLUTTER_WEB'] == 'true';
+
 void main() {
   group('integration', () {
     setUpAll(() async {
       compensateForFlutterTestDirectoryBug();
-      final bool testInReleaseMode =
-          Platform.environment['WEBDEV_RELEASE'] == 'true';
-
-      webdevFixture =
-          await WebdevFixture.serve(release: testInReleaseMode, verbose: true);
+      webdevFixture = await WebdevFixture.serve(
+          flutter: testFlutterWebVersion,
+          release: testInReleaseMode,
+          verbose: true);
       browserManager = await BrowserManager.create();
     });
 

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:io';
 
 import 'package:devtools_testing/support/file_utils.dart';
 import 'package:test/test.dart';
@@ -12,10 +11,6 @@ import 'app.dart';
 import 'debugger.dart';
 import 'integration.dart';
 import 'logging.dart';
-
-final bool testInReleaseMode = Platform.environment['WEBDEV_RELEASE'] == 'true';
-final bool testFlutterWebVersion =
-    Platform.environment['TEST_FLUTTER_WEB'] == 'true';
 
 void main() {
   group('integration', () {

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -17,7 +17,6 @@ import '../support/chrome.dart';
 import '../support/cli_test_driver.dart';
 import '../support/devtools_server_driver.dart';
 import 'integration.dart';
-import 'integration_test.dart';
 
 CliAppFixture appFixture;
 DevToolsServerDriver server;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -17,6 +17,7 @@ import '../support/chrome.dart';
 import '../support/cli_test_driver.dart';
 import '../support/devtools_server_driver.dart';
 import 'integration.dart';
+import 'integration_test.dart';
 
 CliAppFixture appFixture;
 DevToolsServerDriver server;
@@ -30,29 +31,33 @@ final Map<String, String> registeredServices = {};
 final List<int> browserPids = [];
 
 void main() {
-  final bool testInReleaseMode =
-      Platform.environment['WEBDEV_RELEASE'] == 'true';
-
   setUpAll(() async {
     // Clear the existing build directory.
     if (Directory('build').existsSync()) {
       Directory('build').deleteSync(recursive: true);
     }
     // Build the app, as the server can't start without the build output.
-    await WebdevFixture.build(release: testInReleaseMode, verbose: true);
+    await WebdevFixture.build(
+        release: testInReleaseMode,
+        flutter: testFlutterWebVersion,
+        verbose: true);
 
-    if (!Directory('build/packages').existsSync()) {
-      fail('Build failed');
+    if (!testFlutterWebVersion) {
+      if (!Directory('build/packages').existsSync()) {
+        fail('Build failed');
+      }
+
+      Directory('build/packages').renameSync('build/pack');
     }
 
-    Directory('build/packages').renameSync('build/pack');
     // The devtools package build directory needs to reflect the latest
     // devtools_app package contents.
     if (Directory('../devtools/build').existsSync()) {
       Directory('../devtools/build').deleteSync(recursive: true);
     }
 
-    Directory('build').renameSync('../devtools/build');
+    Directory(testFlutterWebVersion ? 'build/web' : 'build')
+        .renameSync('../devtools/build');
   });
 
   setUp(() async {

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -30,6 +30,11 @@ final Map<String, String> registeredServices = {};
 final List<int> browserPids = [];
 
 void main() {
+  final bool testInReleaseMode =
+      Platform.environment['WEBDEV_RELEASE'] == 'true';
+  final bool testFlutterWebVersion =
+      Platform.environment['DEVTOOLS_FLUTTER_WEB'] == 'true';
+
   setUpAll(() async {
     // Clear the existing build directory.
     if (Directory('build').existsSync()) {

--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -84,10 +84,13 @@ Future<shelf.Handler> defaultHandler(
   // out of the `pack` folder.
   Handler packHandler;
   if (!debugMode) {
-    packHandler = createStaticHandler(
-      path.join(packageDir, 'build', 'pack'),
-      defaultDocument: 'index.html',
-    );
+    final packFolder = path.join(packageDir, 'build', 'pack');
+    if (Directory(packFolder).existsSync()) {
+      packHandler = createStaticHandler(
+        packFolder,
+        defaultDocument: 'index.html',
+      );
+    }
   }
 
   final sseHandler = SseHandler(Uri.parse('/api/sse'))
@@ -96,7 +99,7 @@ Future<shelf.Handler> defaultHandler(
   // Make a handler that delegates based on path.
   final handler = (shelf.Request request) {
     if (!debugMode) {
-      if (request.url.path.startsWith('packages/')) {
+      if (packHandler != null && request.url.path.startsWith('packages/')) {
         // request.change here will strip the `packages` prefix from the path
         // so it's relative to packHandler's root.
         return packHandler(request.change(path: 'packages'));

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -745,16 +745,7 @@ Future<Map<String, dynamic>> launchDevTools(
   uriParams['uri'] = vmServiceUri.toString();
 
   final devToolsUri = Uri.parse(devToolsUrl);
-  final uriToLaunch = devToolsUri.replace(
-    // If path is empty, we generate 'http://foo:8000?uri=' (missing `/`) and
-    // ChromeOS fails to detect that it's a port that's tunneled, and will
-    // quietly replace the IP with "penguin.linux.test". This is not valid
-    // for us since the server isn't bound to the containers IP (it's bound
-    // to the containers loopback IP).
-    path: devToolsUri.path.isEmpty ? '/' : devToolsUri.path,
-    queryParameters: uriParams,
-    fragment: page,
-  );
+  final uriToLaunch = _buildUriToLaunch(uriParams, page, devToolsUri);
 
   // TODO(dantup): When ChromeOS has support for tunneling all ports we
   // can change this to always use the native browser for ChromeOS
@@ -786,6 +777,40 @@ Future<Map<String, dynamic>> launchDevTools(
       pid: browserPid,
       machineMode: machineMode);
   return {'reused': false, 'notified': false, 'pid': browserPid};
+}
+
+String _buildUriToLaunch(
+    Map<String, dynamic> uriParams, page, Uri devToolsUri) {
+  // TEMP: When `TEST_FLUTTER_WEB=true` construct the URL in the correct format
+  // for the Flutter version of the web app.
+  final useFlutterVersion = Platform.environment['TEST_FLUTTER_WEB'] == 'true';
+
+  if (useFlutterVersion) {
+    final queryStringNameValues = [];
+    uriParams.forEach((key, value) => queryStringNameValues.add(
+        '${Uri.encodeQueryComponent(key)}=${Uri.encodeQueryComponent(value)}'));
+    if (page != null) {
+      queryStringNameValues.add('page=${Uri.encodeQueryComponent(page)}');
+    }
+    return devToolsUri
+        .replace(
+            path: '${devToolsUri.path.isEmpty ? '/' : devToolsUri.path}',
+            fragment: '?${queryStringNameValues.join('&')}')
+        .toString();
+  } else {
+    return devToolsUri
+        .replace(
+          // If path is empty, we generate 'http://foo:8000?uri=' (missing `/`) and
+          // ChromeOS fails to detect that it's a port that's tunneled, and will
+          // quietly replace the IP with "penguin.linux.test". This is not valid
+          // for us since the server isn't bound to the containers IP (it's bound
+          // to the containers loopback IP).
+          path: '${devToolsUri.path.isEmpty ? '/' : devToolsUri.path}',
+          queryParameters: uriParams,
+          fragment: page,
+        )
+        .toString();
+  }
 }
 
 /// Prints a launch event to stdout so consumers of the DevTools server

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -781,9 +781,10 @@ Future<Map<String, dynamic>> launchDevTools(
 
 String _buildUriToLaunch(
     Map<String, dynamic> uriParams, page, Uri devToolsUri) {
-  // TEMP: When `TEST_FLUTTER_WEB=true` construct the URL in the correct format
+  // TEMP: When `DEVTOOLS_FLUTTER_WEB=true` construct the URL in the correct format
   // for the Flutter version of the web app.
-  final useFlutterVersion = Platform.environment['TEST_FLUTTER_WEB'] == 'true';
+  final useFlutterVersion =
+      Platform.environment['DEVTOOLS_FLUTTER_WEB'] == 'true';
 
   if (useFlutterVersion) {
     final queryStringNameValues = [];


### PR DESCRIPTION
This makes it possible to run integration tests using `flutter` instead of `pub build_runner` (spoiler: they don't pass) by setting an env variable `DEVTOOLS_FLUTTER_WEB`. This will cause the tests to build using Flutter, and the server to build the URI in a format for launching the Flutter version. Some of this conditional code can be dropped with the dart:html version.

Right now, most of these tests fail, because they rely on sending messages to the app using `HtmlApp` which is only set up in the HTML version. @devoncarew not sure what the plan is here - should that be fixed up to work with the Flutter version, or should the tests work differently?

The tests in `server_test.dart` don't need that model though, so almost pass (working on another PR for that).

It won't be possible to enable these tests on Travis until we fix them (most of the time out, so even having them as allowed failures may significantly increase the run duration), but this makes it easier to work on them locally:

```
WEBDEV_RELEASE=true TEST_FLUTTER_WEB=true flutter test -j1 test/integration_tests
```