### PR TITLE
Add support for selecting an initial page using the querystring

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -127,6 +127,7 @@ class DevToolsAppState extends State<DevToolsApp> {
             url: params['uri'],
             builder: (_) => _providedControllers(
               child: DevToolsScaffold(
+                initialPage: params['page'],
                 tabs: _visibleScreens(),
                 actions: [
                   HotReloadButton(),

--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -31,6 +31,7 @@ class DevToolsScaffold extends StatefulWidget {
   const DevToolsScaffold({
     Key key,
     @required this.tabs,
+    this.initialPage,
     this.actions,
   })  : assert(tabs != null),
         super(key: key);
@@ -61,6 +62,9 @@ class DevToolsScaffold extends StatefulWidget {
 
   /// All of the [Screen]s that it's possible to navigate to from this Scaffold.
   final List<Screen> tabs;
+
+  /// The initial page to render.
+  final String initialPage;
 
   /// Actions that it's possible to perform in this Scaffold.
   ///
@@ -159,6 +163,14 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     _tabController?.dispose();
     _tabController = TabController(length: widget.tabs.length, vsync: this);
 
+    if (widget.initialPage != null) {
+      final initialIndex = widget.tabs
+          .indexWhere((screen) => screen.screenId == widget.initialPage);
+      if (initialIndex != -1) {
+        _tabController.index = initialIndex;
+      }
+    }
+
     _currentScreen.value = widget.tabs[_tabController.index];
     _tabController.addListener(() {
       final screen = widget.tabs[_tabController.index];
@@ -171,6 +183,9 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         frameworkController.notifyPageChange(screen?.screenId);
       }
     });
+
+    // Broadcast the initial page.
+    frameworkController.notifyPageChange(_currentScreen.value.screenId);
   }
 
   /// Switch to the given page ID. This request usually comes from the server API
@@ -179,9 +194,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   void _showPageById(String pageId) {
     final existingTabIndex = _tabController.index;
 
-    final screen = widget.tabs
-        .firstWhere((screen) => screen.screenId == pageId, orElse: () => null);
-    final newIndex = screen == null ? -1 : widget.tabs.indexOf(screen);
+    final newIndex =
+        widget.tabs.indexWhere((screen) => screen.screenId == pageId);
 
     if (newIndex != -1 && newIndex != existingTabIndex) {
       _tabController.animateTo(newIndex);
@@ -194,8 +208,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   /// Note that this currently works very well, but it doesn't integrate with
   /// the browser's history yet.
   void _pushScreenToLocalPageRoute(int newIndex) {
-    final previousTabIndex = _tabController.previousIndex;
-    if (newIndex != previousTabIndex) {
+    if (_tabController.indexIsChanging) {
+      final previousTabIndex = _tabController.previousIndex;
       ModalRoute.of(context).addLocalHistoryEntry(LocalHistoryEntry(
         onRemove: () {
           if (widget.tabs.length >= previousTabIndex) {

--- a/packages/devtools_app/test/flutter/scaffold_test.dart
+++ b/packages/devtools_app/test/flutter/scaffold_test.dart
@@ -84,13 +84,26 @@ void main() {
       expect(find.byKey(k1), findsOneWidget);
       expect(find.byKey(k2), findsNothing);
     });
+
+    testWidgets('displays the requested initial page',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(
+        DevToolsScaffold(
+          tabs: const [screen1, screen2],
+          initialPage: screen2.screenId,
+        ),
+      ));
+
+      expect(find.byKey(k1), findsNothing);
+      expect(find.byKey(k2), findsOneWidget);
+    });
   });
 }
 
 class _TestScreen extends Screen {
   const _TestScreen(this.name, this.key, {Key tabKey})
       : super(
-          'testScreen',
+          'testScreen$name',
           title: name,
           icon: Icons.computer,
           tabKey: tabKey,


### PR DESCRIPTION
This adds support for `page=foo` on the query string to load as the initial page (and broadcasts the initial page to the server).

However, it's slightly weird that it stays in the URL even when you move to other pages. I can fix that by changing the `addLocalHistoryEntry` code to instead push real routes (this would mean the `page=` in the querystring updates as you move around - and we could probably move that to be part of the route so it'll become `/inspector?uri=xxx` -> `/memory?uri=xxx`) - however, that seems to mess with the animations when you move between tabs because it's now loading whole new routes.

I can't find any way to update the browsers address bar (like pushing a named route) without us getting full page transitions. I think we need something like [`pushState`](https://developer.mozilla.org/en-US/docs/Web/API/History/pushState) that lets us manipulate the URL without actually changing anything else. Named routes trigger Flutter to do work we don't want, and `addLocalHistoryEntry` doesn't allow us to update the URL (maybe it should, and that would be the nicest fix?).

Ideas welcome!