### PR TITLE
show the device as busy during reload calls

### DIFF
--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -183,9 +183,27 @@ class StatusLine extends StatelessWidget {
           // TODO(devoncarew): Add an interactive dialog to the device status
           // line.
 
+          final color = Theme.of(context).textTheme.bodyText2.color;
+
           return Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
+              ValueListenableBuilder<bool>(
+                valueListenable: serviceManager.deviceBusy,
+                builder: (context, isBusy, _) {
+                  return SizedBox(
+                    width: smallProgressSize,
+                    height: smallProgressSize,
+                    child: isBusy
+                        ? CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(color),
+                          )
+                        : const SizedBox(),
+                  );
+                },
+              ),
+              const SizedBox(width: denseSpacing),
               Text(
                 'Device: $description',
                 style: textTheme.bodyText2,

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -188,7 +188,7 @@ class StatusLine extends StatelessWidget {
           return Row(
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
-              ValueListenableBuilder<bool>(
+              ValueListenableBuilder(
                 valueListenable: serviceManager.deviceBusy,
                 builder: (context, isBusy, _) {
                   return SizedBox(

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -53,6 +53,8 @@ const denseRowSpacing = 6.0;
 const borderPadding = 2.0;
 const densePadding = 4.0;
 
+const smallProgressSize = 12.0;
+
 const defaultListItemHeight = 28.0;
 
 /// Branded grey color.

--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -57,8 +57,8 @@ class NetworkScreen extends Screen {
                 Text('${nf.format(count)} ${pluralize('request', count)}'),
                 const SizedBox(width: denseSpacing),
                 SizedBox(
-                  width: 12,
-                  height: 12,
+                  width: smallProgressSize,
+                  height: smallProgressSize,
                   child: recording
                       ? CircularProgressIndicator(
                           strokeWidth: 2,

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -97,6 +97,18 @@ class ServiceConnectionManager {
   Stream<void> get onConnectionClosed => _connectionClosedController.stream;
   final _connectionClosedController = StreamController<void>.broadcast();
 
+  final ValueNotifier<bool> _deviceBusy = ValueNotifier<bool>(false);
+
+  /// Whether the device is currently busy - performing a long-lived, blocking
+  /// operation.
+  ValueListenable<bool> get deviceBusy => _deviceBusy;
+
+  /// Set whether the device is currently busy - performing a long-lived,
+  /// blocking operation.
+  void setDeviceBusy(bool isBusy) {
+    _deviceBusy.value = isBusy;
+  }
+
   /// Call a service that is registered by exactly one client.
   Future<Response> callService(
     String name, {
@@ -146,6 +158,8 @@ class ServiceConnectionManager {
 
     connectedApp = ConnectedApp();
     serviceExtensionManager.connectedApp = connectedApp;
+
+    setDeviceBusy(false);
 
     unawaited(onClosed.then((_) => vmServiceClosed()));
 
@@ -231,6 +245,8 @@ class ServiceConnectionManager {
     serviceExtensionManager.resetAvailableExtensions();
 
     serviceTrafficLogger?.dispose();
+
+    setDeviceBusy(false);
 
     _stateController.add(false);
     _connectionClosedController.add(null);

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -109,6 +109,16 @@ class ServiceConnectionManager {
     _deviceBusy.value = isBusy;
   }
 
+  /// Set the device as busy during the duration of the given async task.
+  Future<T> runDeviceBusyTask<T>(Future<T> task) async {
+    try {
+      setDeviceBusy(true);
+      return await task;
+    } finally {
+      setDeviceBusy(false);
+    }
+  }
+
   /// Call a service that is registered by exactly one client.
   Future<Response> callService(
     String name, {

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -174,8 +174,11 @@ class HotReloadButton extends StatelessWidget {
       tooltip: 'Hot reload',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotReload,
-        action: () =>
+        action: () {
+          return serviceManager.runDeviceBusyTask(
             _wrapReloadCall('reload', serviceManager.performHotReload),
+          );
+        },
         completedText: 'Hot reload completed.',
         describeError: (error) => 'Unable to hot reload the app: $error',
       ),
@@ -193,8 +196,11 @@ class HotRestartButton extends StatelessWidget {
       tooltip: 'Hot restart',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotRestart,
-        action: () =>
+        action: () {
+          return serviceManager.runDeviceBusyTask(
             _wrapReloadCall('restart', serviceManager.performHotRestart),
+          );
+        },
         completedText: 'Hot restart completed.',
         describeError: (error) => 'Unable to hot restart the app: $error',
       ),
@@ -207,7 +213,6 @@ Future<void> _wrapReloadCall(
   Future<void> Function() reloadCall,
 ) async {
   try {
-    serviceManager.setDeviceBusy(true);
     final Stopwatch timer = Stopwatch()..start();
     messageBus.addEvent(BusEvent('$name.start'));
     await reloadCall();
@@ -221,8 +226,6 @@ Future<void> _wrapReloadCall(
     final String message = 'error performing $name';
     messageBus.addEvent(BusEvent('$name.end', data: message));
     rethrow;
-  } finally {
-    serviceManager.setDeviceBusy(false);
   }
 }
 

--- a/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/flutter/service_extension_widgets.dart
@@ -6,10 +6,12 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../../config_specific/logger/logger.dart';
 import '../../core/message_bus.dart';
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/notifications.dart';
+import '../../flutter/scaffold.dart';
 import '../../flutter/theme.dart';
 import '../../globals.dart';
 import '../../service_extensions.dart';
@@ -166,13 +168,14 @@ class _ServiceExtensionButtonGroupState
 class HotReloadButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    // TODO(devoncarew): Show as disabled when reload service calls are in progress.
+
     return ActionButton(
       tooltip: 'Hot reload',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotReload,
         action: () =>
             _wrapReloadCall('reload', serviceManager.performHotReload),
-        inProgressText: 'Performing hot reload',
         completedText: 'Hot reload completed.',
         describeError: (error) => 'Unable to hot reload the app: $error',
       ),
@@ -184,13 +187,14 @@ class HotReloadButton extends StatelessWidget {
 class HotRestartButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
+    // TODO(devoncarew): Show as disabled when reload service calls are in progress.
+
     return ActionButton(
       tooltip: 'Hot restart',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotRestart,
         action: () =>
             _wrapReloadCall('restart', serviceManager.performHotRestart),
-        inProgressText: 'Performing hot restart',
         completedText: 'Hot restart completed.',
         describeError: (error) => 'Unable to hot restart the app: $error',
       ),
@@ -203,6 +207,7 @@ Future<void> _wrapReloadCall(
   Future<void> Function() reloadCall,
 ) async {
   try {
+    serviceManager.setDeviceBusy(true);
     final Stopwatch timer = Stopwatch()..start();
     messageBus.addEvent(BusEvent('$name.start'));
     await reloadCall();
@@ -216,24 +221,22 @@ Future<void> _wrapReloadCall(
     final String message = 'error performing $name';
     messageBus.addEvent(BusEvent('$name.end', data: message));
     rethrow;
+  } finally {
+    serviceManager.setDeviceBusy(false);
   }
 }
 
 /// Button that when clicked invokes a VM Service , such as hot reload or hot
 /// restart.
 ///
-/// This button will attempt to register to the given service description,
+/// This button will attempt to register to the given service description.
 class _RegisteredServiceExtensionButton extends _ServiceExtensionWidget {
   const _RegisteredServiceExtensionButton._({
     @required this.serviceDescription,
     @required this.action,
-    @required String inProgressText,
     @required String completedText,
     @required String Function(dynamic error) describeError,
-  }) : super(
-            inProgressText: inProgressText,
-            completedText: completedText,
-            describeError: describeError);
+  }) : super(completedText: completedText, describeError: describeError);
 
   /// The service to subscribe to.
   final RegisteredServiceDescription serviceDescription;
@@ -273,7 +276,10 @@ class _RegisteredServiceExtensionButtonState
     return InkWell(
       onTap: () => invokeAndCatchErrors(widget.action),
       child: Container(
-        constraints: const BoxConstraints.tightFor(width: 48.0, height: 48.0),
+        constraints: const BoxConstraints.tightFor(
+          width: DevToolsScaffold.actionWidgetSize,
+          height: DevToolsScaffold.actionWidgetSize,
+        ),
         alignment: Alignment.center,
         // TODO(djshuckerow): Just make these icons the right size to fit this
         // box. The current size is a little tiny by comparison to our other
@@ -308,7 +314,6 @@ class _ServiceExtensionToggle extends _ServiceExtensionWidget {
           key: key,
           // Don't show messages on success or when this toggle is in progress.
           completedText: null,
-          inProgressText: null,
           describeError: describeError,
         );
   final ToggleableServiceExtensionDescription service;
@@ -378,17 +383,9 @@ class _ServiceExtensionToggleState extends State<_ServiceExtensionToggle>
 /// Widget that knows how to talk to a service extension and surface the relevant errors.
 abstract class _ServiceExtensionWidget extends StatefulWidget {
   const _ServiceExtensionWidget(
-      {Key key,
-      @required this.inProgressText,
-      @required this.completedText,
-      @required this.describeError})
+      {Key key, @required this.completedText, @required this.describeError})
       : assert(describeError != null),
         super(key: key);
-
-  /// The text to show when the action is in progress.
-  ///
-  /// This will be shown in a [SnackBar] when completed.
-  final String inProgressText;
 
   /// The text to show when the action is completed.
   ///
@@ -404,8 +401,8 @@ abstract class _ServiceExtensionWidget extends StatefulWidget {
   _ServiceExtensionMixin<_ServiceExtensionWidget> createState();
 }
 
-/// State mixin that manages calling an async service extension
-/// and reporting errors consistently.
+/// State mixin that manages calling an async service extension and reports
+/// errors.
 mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
   /// Whether an action is currently in progress.
   ///
@@ -425,19 +422,15 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
       disabled = true;
     });
 
-    if (widget.inProgressText != null) {
-      // TODO(devoncarew): Display this 'starting work' message in the status
-      // bar.
-
-    }
-
     try {
       await action();
 
       if (widget.completedText != null) {
         Notifications.of(context).push(widget.completedText);
       }
-    } catch (e) {
+    } catch (e, st) {
+      log('$e\n$st');
+
       Notifications.of(context).push(widget.describeError(e));
     } finally {
       setState(() {


### PR DESCRIPTION
Show the device as busy during reload calls:
- add an `deviceBusy` ValueNotifier in the service connection manager
- when the device is busy, display a small indefinite progress widget near the device name
- have the reload and restart operations mark the device as busy

This gives the user more of an indication when longer term work is happening.

If we want to generalize this past this one use case, we could introduce the notion of a 'Jobs' abstraction. This would be longer lived tasks, with names and a manager class, that we could use to surface info about the jobs to the user.

- https://www.eclipse.org/articles/Article-Concurrency/jobs-api.html
- https://github.com/googlearchive/chromedeveditor/blob/master/ide/web/lib/jobs.dart

