### PR TITLE
Log isolate events

### DIFF
--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -628,6 +628,13 @@ class LoggingController {
         );
       });
 
+      // Listen for debugger events.
+      _listen(
+        messageBus.onEvent().where((event) =>
+            event.type == 'debugger' || event.type.startsWith('debugger.')),
+        _handleDebuggerEvent,
+      );
+
       // Listen for DevTools internal events.
       _listen(
         messageBus
@@ -636,6 +643,24 @@ class LoggingController {
         _handleDevToolsEvent,
       );
     }
+  }
+
+  void _handleDebuggerEvent(BusEvent event) {
+    final Event debuggerEvent = event.data;
+
+    // Filter ServiceExtensionAdded events as they're pretty noisy.
+    if (debuggerEvent.kind == EventKind.kServiceExtensionAdded) {
+      return;
+    }
+
+    log(
+      LogData(
+        event.type,
+        jsonEncode(debuggerEvent.json),
+        debuggerEvent.timestamp,
+        summary: '${debuggerEvent.kind} ${debuggerEvent.isolate.id}',
+      ),
+    );
   }
 
   void _handleDevToolsEvent(BusEvent event) {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -11,7 +11,9 @@ import 'package:vm_service/vm_service.dart' hide Error;
 
 import 'config_specific/logger/logger.dart';
 import 'connected_app.dart';
+import 'core/message_bus.dart';
 import 'eval_on_dart_library.dart';
+import 'globals.dart';
 import 'logging/vm_service_logger.dart';
 import 'service_extensions.dart' as extensions;
 import 'service_registrations.dart' as registrations;
@@ -377,6 +379,8 @@ class IsolateManager {
   }
 
   Future<void> _handleIsolateEvent(Event event) async {
+    _sendToMessageBus(event);
+
     if (event.kind == 'IsolateStart') {
       _isolates.add(event.isolate);
       _isolateCreatedController.add(event.isolate);
@@ -404,6 +408,13 @@ class IsolateManager {
         _serviceExtensionManager.resetAvailableExtensions();
       }
     }
+  }
+
+  void _sendToMessageBus(Event event) {
+    messageBus.addEvent(BusEvent(
+      'debugger',
+      data: event,
+    ));
   }
 
   bool _isFlutterExtension(String extensionName) {


### PR DESCRIPTION
Log isolate events:
- send debugger isolate events to the message bus
- display those events in the logging page

The isolate events are a good way of letting the user know when something interesting happens in their application - an isolate starts, gets reloaded, or terminates.
