### PR TITLE
update the UI and data structures after a reload / restart

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -290,15 +290,21 @@ class DebuggerController extends DisposableController
 
         break;
       case EventKind.kBreakpointRemoved:
-        // todo: update _selectedBreakpoint if necessary
+        final breakpoint = event.breakpoint;
+
+        // Update _selectedBreakpoint if necessary.
+        if (_selectedBreakpoint.value?.breakpoint == breakpoint) {
+          _selectedBreakpoint.value = null;
+        }
+
         _breakpoints.value = [
           for (var b in _breakpoints.value)
-            if (b != event.breakpoint) b
+            if (b != breakpoint) b
         ];
 
         _breakpointsWithLocation.value = [
           for (var b in _breakpointsWithLocation.value)
-            if (b.breakpoint != event.breakpoint) b
+            if (b.breakpoint != breakpoint) b
         ];
 
         break;

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -134,14 +134,9 @@ class StatusLine extends StatelessWidget {
       builder: (BuildContext context, AsyncSnapshot<IsolateRef> snapshot) {
         final List<IsolateRef> isolates = isolateManager.isolates;
 
-        // When we have two or more isolates with the same name, append some
-        // disambiguating information.
-        String disambiguatedName(IsolateRef ref) {
-          String name = ref.name;
-          if (isolates.where((e) => e.name == ref.name).length >= 2) {
-            name = '$name (${ref.number})';
-          }
-          return 'isolate: $name';
+        String isolateName(IsolateRef ref) {
+          final name = ref.name;
+          return 'Isolate $name #${isolateManager.isolateIndex(ref)}';
         }
 
         return DropdownButtonHideUnderline(
@@ -154,7 +149,7 @@ class StatusLine extends StatelessWidget {
             items: isolates.map((IsolateRef ref) {
               return DropdownMenuItem<IsolateRef>(
                 value: ref,
-                child: Text(disambiguatedName(ref), style: textTheme.bodyText2),
+                child: Text(isolateName(ref), style: textTheme.bodyText2),
               );
             }).toList(),
           ),

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -75,6 +75,7 @@ class MemoryTracker {
     final VM vm = await service.getVM();
 
     // TODO(terry): Need to handle a possible Sentinel being returned.
+    // TODO(devoncarew): Switch to using vmService.getMemoryUsage().
     final List<Isolate> isolates =
         await Future.wait(vm.isolates.map((IsolateRef ref) async {
       try {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -387,15 +387,9 @@ class IsolateManager {
   /// Return a unique, monotonically increasing number for this Isolate.
   int isolateIndex(IsolateRef isolateRef) {
     if (!_isolateIndexMap.containsKey(isolateRef.id)) {
-      _assignIsolateIndex(isolateRef);
-    }
-    return _isolateIndexMap[isolateRef.id];
-  }
-
-  void _assignIsolateIndex(IsolateRef isolateRef) {
-    if (!_isolateIndexMap.containsKey(isolateRef.id)) {
       _isolateIndexMap[isolateRef.id] = ++_lastIsolateIndex;
     }
+    return _isolateIndexMap[isolateRef.id];
   }
 
   void selectIsolate(String isolateRefId) {
@@ -407,7 +401,7 @@ class IsolateManager {
 
   Future<void> _initIsolates(List<IsolateRef> isolates) async {
     _isolates = isolates;
-    _isolates.forEach(_assignIsolateIndex);
+    _isolates.forEach(isolateIndex);
 
     await _initSelectedIsolate(isolates);
 
@@ -424,7 +418,7 @@ class IsolateManager {
   Future<void> _handleIsolateEvent(Event event) async {
     if (event.kind == EventKind.kIsolateStart) {
       _isolates.add(event.isolate);
-      _assignIsolateIndex(event.isolate);
+      isolateIndex(event.isolate);
       _isolateCreatedController.add(event.isolate);
       if (_selectedIsolate == null) {
         await _setSelectedIsolate(event.isolate);

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -232,6 +232,8 @@ class ServiceConnectionManager {
 
     serviceTrafficLogger?.dispose();
 
+    _isolateManager._handleVmServiceClosed();
+
     _stateController.add(false);
     _connectionClosedController.add(null);
   }
@@ -341,6 +343,9 @@ class IsolateManager {
 
   var selectedIsolateAvailable = Completer<void>();
 
+  int _lastIsolateIndex = 0;
+  final Map<String, int> _isolateIndexMap = {};
+
   List<LibraryRef> selectedIsolateLibraries;
 
   List<IsolateRef> get isolates => List<IsolateRef>.unmodifiable(_isolates);
@@ -354,6 +359,20 @@ class IsolateManager {
 
   Stream<IsolateRef> get onIsolateExited => _isolateExitedController.stream;
 
+  /// Return a unique, monotonically increasing number for this Isolate.
+  int isolateIndex(IsolateRef isolateRef) {
+    if (!_isolateIndexMap.containsKey(isolateRef.id)) {
+      _assignIsolateIndex(isolateRef);
+    }
+    return _isolateIndexMap[isolateRef.id];
+  }
+
+  void _assignIsolateIndex(IsolateRef isolateRef) {
+    if (!_isolateIndexMap.containsKey(isolateRef.id)) {
+      _isolateIndexMap[isolateRef.id] = ++_lastIsolateIndex;
+    }
+  }
+
   void selectIsolate(String isolateRefId) {
     final IsolateRef ref = _isolates.firstWhere(
         (IsolateRef ref) => ref.id == isolateRefId,
@@ -363,6 +382,7 @@ class IsolateManager {
 
   Future<void> _initIsolates(List<IsolateRef> isolates) async {
     _isolates = isolates;
+    _isolates.forEach(_assignIsolateIndex);
 
     await _initSelectedIsolate(isolates);
 
@@ -377,13 +397,14 @@ class IsolateManager {
   }
 
   Future<void> _handleIsolateEvent(Event event) async {
-    if (event.kind == 'IsolateStart') {
+    if (event.kind == EventKind.kIsolateStart) {
       _isolates.add(event.isolate);
+      _assignIsolateIndex(event.isolate);
       _isolateCreatedController.add(event.isolate);
       if (_selectedIsolate == null) {
         await _setSelectedIsolate(event.isolate);
       }
-    } else if (event.kind == 'ServiceExtensionAdded') {
+    } else if (event.kind == EventKind.kServiceExtensionAdded) {
       // On hot restart, service extensions are added from here.
       await _serviceExtensionManager
           ._maybeAddServiceExtension(event.extensionRPC);
@@ -392,7 +413,7 @@ class IsolateManager {
       if (_selectedIsolate == null && _isFlutterExtension(event.extensionRPC)) {
         await _setSelectedIsolate(event.isolate);
       }
-    } else if (event.kind == 'IsolateExit') {
+    } else if (event.kind == EventKind.kIsolateExit) {
       _isolates.remove(event.isolate);
       _isolateExitedController.add(event.isolate);
       if (_selectedIsolate == event.isolate) {
@@ -443,8 +464,12 @@ class IsolateManager {
     }
 
     // Store the library uris for the selected isolate.
-    final Isolate isolate = await _service.getIsolate(ref.id);
-    selectedIsolateLibraries = isolate.libraries;
+    if (ref == null) {
+      selectedIsolateLibraries = [];
+    } else {
+      final Isolate isolate = await _service.getIsolate(ref.id);
+      selectedIsolateLibraries = isolate.libraries;
+    }
 
     _selectedIsolate = ref;
     if (!selectedIsolateAvailable.isCompleted) {
@@ -459,6 +484,13 @@ class IsolateManager {
       onData(_selectedIsolate);
     }
     return _selectedIsolateController.stream.listen(onData);
+  }
+
+  void _handleVmServiceClosed() {
+    _lastIsolateIndex = 0;
+    _setSelectedIsolate(null);
+    _isolateIndexMap.clear();
+    _isolates.clear();
   }
 }
 


### PR DESCRIPTION
Update the UI and data structures after a reload / restart:
- listen for `IsolateReload` events and update the appropriate data structures
- change how we report isolate names, so there's a visual change in the UI when we change isolates on a restart

