### PR TITLE
various tweaks to the memory page

### DIFF
--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -205,9 +205,6 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
   @override
   Widget build(BuildContext context) {
-    if (memoryTimeline.liveData.isEmpty)
-      return const Center(child: Text('No data'));
-
     controller.memoryTimeline.image = _img;
 
     // Compute number of stops for the timeline slider.
@@ -227,12 +224,10 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
       mainAxisSize: MainAxisSize.max,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        const Padding(
-          padding: edgeSpacing,
-          child: Text('Flutter Framework Heap'),
-        ),
         Expanded(
-          child: LineChart(dartChartController),
+          child: memoryTimeline.liveData.isEmpty
+              ? const SizedBox()
+              : LineChart(dartChartController),
         ),
         Row(
           children: [
@@ -247,13 +242,8 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
           ],
         ),
         controller.isAndroidChartVisible
-            ? Expanded(
-                child: LineChart(androidChartController),
-              )
-            : const Padding(
-                padding: edgeSpacing,
-                child: Text(''),
-              ),
+            ? Expanded(child: LineChart(androidChartController))
+            : const SizedBox(),
       ],
     );
   }
@@ -278,8 +268,8 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
           ..setValueFormatter(LargeValueFormatter())
           ..drawGridLines = true
           ..granularityEnabled = true
-          ..setStartAtZero(
-              true) // Set to baseline min and auto track max axis range.
+          // Set to baseline min and auto track max axis range.
+          ..setStartAtZero(true)
           ..textColor = defaultForeground;
       },
       axisRightSettingFunction: (axisRight, controller) {

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -361,8 +361,6 @@ class MemoryController extends DisposableController
 
   bool hasStopped;
 
-  VM _vm;
-
   void _handleIsolateChanged() {
     // TODO(terry): Need an event on the controller for this too?
   }
@@ -447,13 +445,8 @@ class MemoryController extends DisposableController
     }).toList();
   }
 
-  void ensureVM() async {
-    _vm ??= await serviceManager.service.getVM();
-  }
-
   bool get isConnectedDeviceAndroid {
-    ensureVM();
-    return (_vm?.operatingSystem) == 'android';
+    return serviceManager.vm.operatingSystem == 'android';
   }
 
   Future<List<InstanceSummary>> getInstances(

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -247,16 +247,16 @@ class MemoryController extends DisposableController
     processDataset(args);
   }
 
-  bool _paused = false;
+  final _paused = ValueNotifier<bool>(false);
 
-  bool get paused => _paused;
+  ValueListenable<bool> get paused => _paused;
 
   void pauseLiveFeed() {
-    _paused = true;
+    _paused.value = true;
   }
 
   void resumeLiveFeed() {
-    _paused = false;
+    _paused.value = false;
   }
 
   bool _androidChartVisible = false;
@@ -985,7 +985,7 @@ class MemoryTimeline {
             liveData[startingIndex].timestamp.toInt()));
         final endDT = mFormat.format(DateTime.fromMillisecondsSinceEpoch(
             liveData[endingIndex].timestamp.toInt()));
-        print('Time range Live data start: $startDT, end: $endDT');
+        log('Time range Live data start: $startDT, end: $endDT');
       }
 
       return args;
@@ -1032,7 +1032,7 @@ class MemoryTimeline {
           data[startingIndex].timestamp.toInt()));
       final endDT = mFormat.format(DateTime.fromMillisecondsSinceEpoch(
           data[endingIndex].timestamp.toInt()));
-      print('Recompute Time range Offline data start: $startDT, end: $endDT');
+      log('Recompute Time range Offline data start: $startDT, end: $endDT');
     }
   }
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_protocol.dart
@@ -17,7 +17,7 @@ import 'memory_controller.dart';
 class MemoryTracker {
   MemoryTracker(this.service, this.memoryController);
 
-  static const Duration _updateDelay = Duration(milliseconds: 1000);
+  static const Duration _updateDelay = Duration(milliseconds: 500);
 
   VmServiceWrapper service;
 

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -119,6 +119,7 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             _buildPrimaryStateControls(),
+            const Expanded(child: SizedBox(width: denseSpacing)),
             _buildMemoryControls(),
           ],
         ),
@@ -243,68 +244,54 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
   }
 
   Widget _buildPrimaryStateControls() {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6),
-      // Add a semi-transparent background to the
-      // expand and collapse buttons so they don't interfere
-      // too badly with the tree content when the tree
-      // is narrow.
-      color: Theme.of(context).scaffoldBackgroundColor.withAlpha(200),
-      child: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          ValueListenableBuilder(
-            valueListenable: controller.paused,
-            builder: (context, paused, _) {
-              return OutlineButton(
-                key: MemoryScreen.pauseButtonKey,
-                onPressed: paused ? null : controller.pauseLiveFeed,
-                child: Label(
-                  pauseIcon,
-                  'Pause',
-                  minIncludeTextWidth: _primaryControlsMinVerboseWidth,
-                ),
-              );
-            },
-          ),
-          const SizedBox(width: denseSpacing),
-          ValueListenableBuilder(
-            valueListenable: controller.paused,
-            builder: (context, paused, _) {
-              return OutlineButton(
-                key: MemoryScreen.resumeButtonKey,
-                onPressed: paused ? controller.resumeLiveFeed : null,
-                child: Label(
-                  playIcon,
-                  'Resume',
-                  minIncludeTextWidth: _primaryControlsMinVerboseWidth,
-                ),
-              );
-            },
-          ),
-          const SizedBox(width: defaultSpacing),
-          OutlineButton(
-              key: MemoryScreen.clearButtonKey,
-              // TODO(terry): Button needs to be Delete for offline data.
-              onPressed: controller.memorySource == MemoryController.liveFeed
-                  ? _clearTimeline
-                  : null,
+    return ValueListenableBuilder(
+      valueListenable: controller.paused,
+      builder: (context, paused, _) {
+        return Row(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            OutlineButton(
+              key: MemoryScreen.pauseButtonKey,
+              onPressed: paused ? null : controller.pauseLiveFeed,
               child: Label(
-                clearIcon,
-                'Clear',
+                pauseIcon,
+                'Pause',
                 minIncludeTextWidth: _primaryControlsMinVerboseWidth,
-              )),
-          const SizedBox(width: defaultSpacing),
-          _intervalDropdown(),
-        ],
-      ),
+              ),
+            ),
+            const SizedBox(width: denseSpacing),
+            OutlineButton(
+              key: MemoryScreen.resumeButtonKey,
+              onPressed: paused ? controller.resumeLiveFeed : null,
+              child: Label(
+                playIcon,
+                'Resume',
+                minIncludeTextWidth: _primaryControlsMinVerboseWidth,
+              ),
+            ),
+            const SizedBox(width: defaultSpacing),
+            OutlineButton(
+                key: MemoryScreen.clearButtonKey,
+                // TODO(terry): Button needs to be Delete for offline data.
+                onPressed: controller.memorySource == MemoryController.liveFeed
+                    ? _clearTimeline
+                    : null,
+                child: Label(
+                  clearIcon,
+                  'Clear',
+                  minIncludeTextWidth: _primaryControlsMinVerboseWidth,
+                )),
+            const SizedBox(width: defaultSpacing),
+            _intervalDropdown(),
+          ],
+        );
+      },
     );
   }
 
   Widget _buildMemoryControls() {
     return Row(
-      mainAxisSize: MainAxisSize.min,
-      mainAxisAlignment: MainAxisAlignment.end,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         _memorySourceDropdown(),
         const SizedBox(width: defaultSpacing),

--- a/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_screen.dart
@@ -19,6 +19,9 @@ import 'memory_chart.dart';
 import 'memory_controller.dart';
 import 'memory_heap_tree_view.dart';
 
+/// Width of application when memory buttons loose their text.
+const _primaryControlsMinVerboseWidth = 1100.0;
+
 class MemoryScreen extends Screen {
   const MemoryScreen() : super(id, title: 'Memory', icon: Octicons.package);
 
@@ -169,11 +172,9 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
       iconSize: 20,
       style: const TextStyle(fontWeight: FontWeight.w100),
       onChanged: (String newValue) {
-        setState(
-          () {
-            controller.displayInterval = newValue;
-          },
-        );
+        setState(() {
+          controller.displayInterval = newValue;
+        });
       },
       items: _displayTypes,
     );
@@ -241,9 +242,6 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
 */
   }
 
-  /// Width of application when primary buttons loose their text.
-  static const double _primaryControlsMinVerboseWidth = 1300;
-
   Widget _buildPrimaryStateControls() {
     return Container(
       padding: const EdgeInsets.symmetric(horizontal: 6),
@@ -255,23 +253,34 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
       child: Row(
         crossAxisAlignment: CrossAxisAlignment.center,
         children: [
-          OutlineButton(
-            key: MemoryScreen.pauseButtonKey,
-            onPressed: controller.paused ? null : _pauseLiveTimeline,
-            child: Label(
-              pauseIcon,
-              'Pause',
-              minIncludeTextWidth: _primaryControlsMinVerboseWidth,
-            ),
+          ValueListenableBuilder(
+            valueListenable: controller.paused,
+            builder: (context, paused, _) {
+              return OutlineButton(
+                key: MemoryScreen.pauseButtonKey,
+                onPressed: paused ? null : controller.pauseLiveFeed,
+                child: Label(
+                  pauseIcon,
+                  'Pause',
+                  minIncludeTextWidth: _primaryControlsMinVerboseWidth,
+                ),
+              );
+            },
           ),
-          OutlineButton(
-            key: MemoryScreen.resumeButtonKey,
-            onPressed: controller.paused ? _resumeLiveTimeline : null,
-            child: Label(
-              playIcon,
-              'Resume',
-              minIncludeTextWidth: _primaryControlsMinVerboseWidth,
-            ),
+          const SizedBox(width: denseSpacing),
+          ValueListenableBuilder(
+            valueListenable: controller.paused,
+            builder: (context, paused, _) {
+              return OutlineButton(
+                key: MemoryScreen.resumeButtonKey,
+                onPressed: paused ? controller.resumeLiveFeed : null,
+                child: Label(
+                  playIcon,
+                  'Resume',
+                  minIncludeTextWidth: _primaryControlsMinVerboseWidth,
+                ),
+              );
+            },
           ),
           const SizedBox(width: defaultSpacing),
           OutlineButton(
@@ -292,55 +301,44 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
     );
   }
 
-  /// Width of application when memory buttons loose their text.
-  static const double _memoryControlsMinVerboseWidth = 1100;
-
   Widget _buildMemoryControls() {
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 6),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        mainAxisAlignment: MainAxisAlignment.end,
-        children: [
-          _memorySourceDropdown(),
-          const SizedBox(width: defaultSpacing),
-          Flexible(
-            child: OutlineButton(
-              key: MemoryScreen.resetButtonKey,
-              onPressed: _reset,
-              child: Label(
-                memoryReset,
-                'Reset',
-                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
-              ),
-            ),
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      mainAxisAlignment: MainAxisAlignment.end,
+      children: [
+        _memorySourceDropdown(),
+        const SizedBox(width: defaultSpacing),
+        OutlineButton(
+          key: MemoryScreen.resetButtonKey,
+          onPressed: _reset,
+          child: Label(
+            memoryReset,
+            'Reset',
+            minIncludeTextWidth: _primaryControlsMinVerboseWidth,
           ),
-          Flexible(
-            child: OutlineButton(
-              key: MemoryScreen.gcButtonKey,
-              onPressed: _gc,
-              child: Label(
-                memoryGC,
-                'GC',
-                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
-              ),
-            ),
+        ),
+        const SizedBox(width: denseSpacing),
+        OutlineButton(
+          key: MemoryScreen.gcButtonKey,
+          onPressed: _gc,
+          child: Label(
+            memoryGC,
+            'GC',
+            minIncludeTextWidth: _primaryControlsMinVerboseWidth,
           ),
-          const SizedBox(width: defaultSpacing),
-          Flexible(
-            child: OutlineButton(
-              key: MemoryScreen.exportButtonKey,
-              onPressed:
-                  controller.offline ? null : controller.memoryLog.exportMemory,
-              child: Label(
-                exportIcon,
-                'Export',
-                minIncludeTextWidth: _memoryControlsMinVerboseWidth,
-              ),
-            ),
+        ),
+        const SizedBox(width: defaultSpacing),
+        OutlineButton(
+          key: MemoryScreen.exportButtonKey,
+          onPressed:
+              controller.offline ? null : controller.memoryLog.exportMemory,
+          child: Label(
+            exportIcon,
+            'Export',
+            minIncludeTextWidth: _primaryControlsMinVerboseWidth,
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 
@@ -348,18 +346,6 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
 
   void _clearTimeline() {
     controller.memoryTimeline.reset();
-  }
-
-  void _pauseLiveTimeline() {
-    // TODO(terry): Implement real pause when connected to live feed.
-    controller.pauseLiveFeed();
-    setState(() {});
-  }
-
-  void _resumeLiveTimeline() {
-    // TODO(terry): Implement real resume when connected to live feed.
-    controller.resumeLiveFeed();
-    setState(() {});
   }
 
   void _reset() async {

--- a/packages/devtools_app/test/flutter/memory_screen_test.dart
+++ b/packages/devtools_app/test/flutter/memory_screen_test.dart
@@ -6,10 +6,10 @@
 import 'package:devtools_app/src/flutter/common_widgets.dart';
 import 'package:devtools_app/src/flutter/split.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/memory/flutter/memory_chart.dart';
-import 'package:devtools_app/src/memory/flutter/memory_screen.dart';
 import 'package:devtools_app/src/memory/flutter/memory_controller.dart';
+import 'package:devtools_app/src/memory/flutter/memory_screen.dart';
+import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/fake_flutter/_real_flutter.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -44,6 +44,7 @@ void main() {
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)
           .thenReturn(false);
+      when(fakeServiceManager.vm.operatingSystem).thenReturn('iOS');
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -41,6 +41,8 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
 
   static final _flagManager = VmFlagManager();
 
+  final MockVM _mockVM = MockVM();
+
   @override
   final VmServiceWrapper service;
 
@@ -67,6 +69,9 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
 
   @override
   final IsolateManager isolateManager = FakeIsolateManager();
+
+  @override
+  VM get vm => _mockVM;
 
   @override
   final VmFlagManager vmFlagManager = _flagManager;
@@ -295,6 +300,8 @@ class MockTimelineController extends Mock implements TimelineController {}
 class MockPerformanceController extends Mock implements PerformanceController {}
 
 class MockDebuggerController extends Mock implements DebuggerController {}
+
+class MockVM extends Mock implements VM {}
 
 /// Fake that simplifies writing UI tests that depend on the
 /// ServiceExtensionManager.


### PR DESCRIPTION
Various tweaks to the memory page:
- hook up the pause and resume buttons for the live memory feed (and, use a ValueNotifier in the memory controller)
- additional padding between some of the buttons
- reduce some vertical spacing in the memory screen to give more room to the charts
- have the button labels show up even for more narrow page layouts

@terrylucas 

<img width="1519" alt="Screen Shot 2020-05-06 at 8 02 31 AM" src="https://user-images.githubusercontent.com/1269969/81195320-7af2d600-8f72-11ea-8e75-890cc9f4c25f.png">
