### PR TITLE
Fix CPU profiler bug where we were unintentionally mutating data.

### DIFF
--- a/packages/devtools_app/lib/src/profiler/flutter/cpu_profile_call_tree.dart
+++ b/packages/devtools_app/lib/src/profiler/flutter/cpu_profile_call_tree.dart
@@ -46,7 +46,7 @@ class CpuCallTreeTable extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return TreeTable<CpuStackFrame>(
-      dataRoots: [data.cpuProfileRoot],
+      dataRoots: [data.cpuProfileRoot.deepCopy()],
       columns: columns,
       treeColumn: treeColumn,
       keyFactory: (frame) => PageStorageKey<String>(frame.id),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1910.

We need to make a deep copy so that, when we change sort order in the Call Tree, we do not affect the data the flame chart is using to do layout.