### PR TITLE
Only show hot restart and hot reload buttons for Flutter apps.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -131,8 +131,10 @@ class DevToolsAppState extends State<DevToolsApp> {
                 initialPage: params['page'],
                 tabs: _visibleScreens(),
                 actions: [
-                  HotReloadButton(),
-                  HotRestartButton(),
+                  if (serviceManager.connectedApp.isFlutterAppNow) ...[
+                    HotReloadButton(),
+                    HotRestartButton(),
+                  ],
                   OpenSettingsAction(),
                   OpenAboutAction(),
                 ],


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1756