### PR TITLE
Make TreeTable column headers not focusable

### DIFF
--- a/packages/devtools_app/lib/src/flutter/table.dart
+++ b/packages/devtools_app/lib/src/flutter/table.dart
@@ -840,6 +840,7 @@ class _TableRowState<T> extends State<TableRow<T>>
         color: widget.backgroundColor ?? Theme.of(context).canvasColor,
         child: widget.onPressed != null
             ? InkWell(
+                canRequestFocus: false,
                 key: contentKey,
                 onTap: () => widget.onPressed(widget.node),
                 child: row,
@@ -906,6 +907,7 @@ class _TableRowState<T> extends State<TableRow<T>>
       if (node == null) {
         final isSortColumn = column.title == widget.sortColumn.title;
         content = InkWell(
+          canRequestFocus: false,
           onTap: () => _handleSortChange(column),
           child: Row(
             mainAxisAlignment: _mainAxisAlignmentFor(column),


### PR DESCRIPTION
This fixes a usability issue with treetable arrow-key navigation. We
don't want focus going to the column headers and scrolling vertically.

Before:
![focus_before](https://user-images.githubusercontent.com/3227/81343018-123a5500-9069-11ea-81bc-f4547ee8db04.gif)

After:
![focus_after](https://user-images.githubusercontent.com/3227/81343046-1cf4ea00-9069-11ea-81f6-216f50df113f.gif)

