### PR TITLE
Protect against NPE caused by null `devtoolsServer`

### DIFF
--- a/packages/devtools_app/lib/src/main.dart
+++ b/packages/devtools_app/lib/src/main.dart
@@ -176,7 +176,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
 
     // If we showed a notification for DevTools and the user manually clicked
     // into the window instead, we should hide the notification automatically.
-    html.window.onFocus.listen((_) => devToolsServer.dismissNotifications());
+    html.window.onFocus.listen((_) => devToolsServer?.dismissNotifications());
 
     // TODO(dantup): As a workaround for not being able to reconnect DevTools to
     // a new VM yet (https://github.com/flutter/devtools/issues/989) we reload
@@ -187,7 +187,7 @@ class HtmlPerfToolFramework extends HtmlFramework {
       final newParams = Map.of(uri.queryParameters)..remove('notify');
       html.window.history.pushState(
           null, null, uri.replace(queryParameters: newParams).toString());
-      unawaited(devToolsServer.notify());
+      unawaited(devToolsServer?.notify());
     }
 
     // Handle onShowPageId.


### PR DESCRIPTION
@DanTup we were seeing exceptions in g3 because `devToolsServer` was null ("devtools server not available (204)" printed to console in this case).

This will fix the NPE but do we expect `devToolsServer to be null?