### PR TITLE
rename OutlinedBorder to OutlineDecoration

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -221,7 +221,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
 
     _updateScrollPosition(animate: false);
 
-    return OutlinedBorder(
+    return OutlineDecoration(
       child: Column(
         children: [
           debuggerSectionTitle(theme, text: scriptRef?.uri ?? ' '),

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -38,7 +38,7 @@ class _ConsoleState extends State<Console> {
     final textStyle =
         theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
 
-    return OutlinedBorder(
+    return OutlineDecoration(
       child: Padding(
         padding: const EdgeInsets.all(denseSpacing),
         child: ValueListenableBuilder<List<String>>(

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -181,7 +181,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             axis: Axis.horizontal,
             initialFractions: const [0.25, 0.75],
             children: [
-              OutlinedBorder(child: debuggerPanes()),
+              OutlineDecoration(child: debuggerPanes()),
               Column(
                 children: [
                   DebuggingControls(controller: controller),

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -66,7 +66,7 @@ class ScriptPickerState extends State<ScriptPicker> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    return OutlinedBorder(
+    return OutlineDecoration(
       child: Column(
         children: [
           debuggerPaneHeader(

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -426,8 +426,8 @@ class ToggleButton extends StatelessWidget {
   }
 }
 
-class OutlinedBorder extends StatelessWidget {
-  const OutlinedBorder({Key key, this.child}) : super(key: key);
+class OutlineDecoration extends StatelessWidget {
+  const OutlineDecoration({Key key, this.child}) : super(key: key);
 
   final Widget child;
 

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -136,13 +136,13 @@ class _LoggingScreenState extends State<LoggingScreenBody>
           axis: Axis.vertical,
           initialFractions: const [0.78, 0.22],
           children: [
-            OutlinedBorder(
+            OutlineDecoration(
               child: LogsTable(
                 data: controller.filteredData,
                 onItemSelected: _select,
               ),
             ),
-            OutlinedBorder(
+            OutlineDecoration(
               child: LogDetails(log: selected),
             ),
           ],


### PR DESCRIPTION
- rename `OutlinedBorder` to `OutlineDecoration` to avoid a conflict with a new widget in flutter master
