### PR TITLE
Autofocus "Pause" button in debugger pane

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -34,6 +34,7 @@ class DebuggingControls extends StatelessWidget {
                     DebuggerButton(
                       title: 'Pause',
                       icon: Icons.pause,
+                      autofocus: true,
                       onPressed: isPaused ? null : controller.pause,
                     ),
                     _LeftBorder(
@@ -188,17 +189,20 @@ class DebuggerButton extends StatelessWidget {
     @required this.title,
     @required this.icon,
     @required this.onPressed,
+    this.autofocus = false,
   });
 
   final String title;
   final IconData icon;
   final VoidCallback onPressed;
+  final bool autofocus;
 
   @override
   Widget build(BuildContext context) {
     return ActionButton(
       tooltip: title,
       child: OutlineButton(
+        autofocus: autofocus,
         borderSide: BorderSide.none,
         shape: const ContinuousRectangleBorder(),
         onPressed: onPressed,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -175,31 +175,28 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         actions: <Type, Action<Intent>>{
           FilterLibraryIntent: FilterLibraryAction(),
         },
-        child: Focus(
-          autofocus: true,
-          child: Split(
-            axis: Axis.horizontal,
-            initialFractions: const [0.25, 0.75],
-            children: [
-              OutlineDecoration(child: debuggerPanes()),
-              Column(
-                children: [
-                  DebuggingControls(controller: controller),
-                  const SizedBox(height: denseRowSpacing),
-                  Expanded(
-                    child: Split(
-                      axis: Axis.vertical,
-                      initialFractions: const [0.74, 0.26],
-                      children: [
-                        codeArea,
-                        Console(controller: controller),
-                      ],
-                    ),
+        child: Split(
+          axis: Axis.horizontal,
+          initialFractions: const [0.25, 0.75],
+          children: [
+            OutlineDecoration(child: debuggerPanes()),
+            Column(
+              children: [
+                DebuggingControls(controller: controller),
+                const SizedBox(height: denseRowSpacing),
+                Expanded(
+                  child: Split(
+                    axis: Axis.vertical,
+                    initialFractions: const [0.74, 0.26],
+                    children: [
+                      codeArea,
+                      Console(controller: controller),
+                    ],
                   ),
-                ],
-              ),
-            ],
-          ),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );


### PR DESCRIPTION
Previously we focussed the whole screen in order to activate the
shortcuts. But now that https://github.com/flutter/flutter/issues/56493 is resolved we can focus an individual element which makes more sense and simplifies the widget hierarchy
slightly.

This implements a suggestion in #1899 that couldn't be implemented
because of the bug.

after:
<img width="912" alt="debugger_focus_after" src="https://user-images.githubusercontent.com/3227/81612915-6c515800-9392-11ea-8487-4ba92106d86b.png">

before:
<img width="912" alt="debugger_focus_before" src="https://user-images.githubusercontent.com/3227/81612922-6f4c4880-9392-11ea-81cb-6a5d9bec6255.png">
