### PR TITLE
[Debugger] Added "Copy to Clipboard" and "Clear" to stdio console.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -62,6 +62,7 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
       lines: _lines,
       controls: [
         if (_lines.isNotEmpty) ...[
+          // TODO(ditman) Extract these IconButtons to common_widgets.dart
           IconButton(
             icon: const Icon(Icons.content_copy),
             onPressed: () => copyToClipboard(_lines, context),

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -29,7 +29,8 @@ class DebuggerConsole extends StatefulWidget {
   @override
   _DebuggerConsoleState createState() => _DebuggerConsoleState();
 
-  static const copyToClipboardButtonKey = Key('debugger_console_copy_to_clipboard_button');
+  static const copyToClipboardButtonKey =
+      Key('debugger_console_copy_to_clipboard_button');
   static const clearStdioButtonKey = Key('debugger_console_clear_stdio_button');
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -33,8 +33,6 @@ class Console extends StatefulWidget {
 }
 
 class _ConsoleState extends State<Console> {
-  bool canDelete = false;
-
   @override
   Widget build(BuildContext context) {
     return Stack(

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -137,7 +137,7 @@ class DebuggerController extends DisposableController
   InstanceRef get reportedException => _reportedException;
   InstanceRef _reportedException;
 
-  /// Clears the contents of stdio
+  /// Clears the contents of stdio.
   void clearStdio() {
     _stdio.value = [];
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -137,6 +137,11 @@ class DebuggerController extends DisposableController
   InstanceRef get reportedException => _reportedException;
   InstanceRef _reportedException;
 
+  /// Clears the contents of stdio
+  void clearStdio() {
+    _stdio.value = [];
+  }
+
   /// Append to the stdout / stderr buffer.
   void appendStdio(String text) {
     const int kMaxLogItemsLowerBound = 5000;

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -190,7 +190,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                     initialFractions: const [0.74, 0.26],
                     children: [
                       codeArea,
-                      Console(controller: controller),
+                      DebuggerConsole(controller: controller),
                     ],
                   ),
                 ),

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -2,10 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:ansi_up/ansi_up.dart';
 
+import '../utils.dart';
 import 'notifications.dart';
 
 Future<void> launchUrl(String url, BuildContext context) async {
@@ -14,6 +16,18 @@ Future<void> launchUrl(String url, BuildContext context) async {
   } else {
     Notifications.of(context).push('Unable to open $url.');
   }
+}
+
+/// Attempts to copy a bunch of `lines` to the clipboard.
+Future<void> copyToClipboard(List<String> lines, BuildContext context) async {
+  await Clipboard.setData(ClipboardData(
+    text: lines.join('\n'),
+  ));
+
+  final numLines = lines.length;
+  Notifications.of(context)?.push(
+    'Copied $numLines ${pluralize("line", numLines)}.',
+  );
 }
 
 List<TextSpan> processAnsiTerminalCodes(String input, TextStyle defaultStyle) {

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -177,7 +177,13 @@ String longestFittingSubstring(
 bool isLetter(int codeUnit) =>
     (codeUnit >= 65 && codeUnit <= 90) || (codeUnit >= 97 && codeUnit <= 122);
 
-String pluralize(String word, int count) => count == 1 ? word : '${word}s';
+/// Pluralizes a word, following english rules (1, many).
+///
+/// Pass a custom named `plural` for irregular plurals:
+/// `pluralize('index', count, plural: 'indices')`
+/// So it returns `indices` and not `indexs`.
+String pluralize(String word, int count, {String plural}) =>
+    count == 1 ? word : (plural ?? '${word}s');
 
 /// Returns a simplified version of a StackFrame name.
 ///

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -122,7 +122,8 @@ void main() {
         await pumpDebuggerScreen(tester, debuggerController);
 
         expect(find.byKey(DebuggerConsole.clearStdioButtonKey), findsNothing);
-        expect(find.byKey(DebuggerConsole.copyToClipboardButtonKey), findsNothing);
+        expect(
+            find.byKey(DebuggerConsole.copyToClipboardButtonKey), findsNothing);
       });
 
       testWidgets('Tapping the Console Clear button clears stdio.',
@@ -172,7 +173,8 @@ void main() {
 
           await pumpDebuggerScreen(tester, debuggerController);
 
-          final copyButton = find.byKey(DebuggerConsole.copyToClipboardButtonKey);
+          final copyButton =
+              find.byKey(DebuggerConsole.copyToClipboardButtonKey);
           expect(copyButton, findsOneWidget);
 
           expect(_clipboardContents, isEmpty);

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:ansicolor/ansicolor.dart';
+import 'package:devtools_app/src/debugger/flutter/console.dart';
 import 'package:devtools_app/src/debugger/flutter/controls.dart';
 import 'package:devtools_app/src/debugger/flutter/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/flutter/debugger_model.dart';
@@ -120,8 +121,8 @@ void main() {
 
         await pumpDebuggerScreen(tester, debuggerController);
 
-        expect(find.byTooltip('Clear console output.'), findsNothing);
-        expect(find.byTooltip('Copy to clipboard.'), findsNothing);
+        expect(find.byKey(DebuggerConsole.clearStdioButtonKey), findsNothing);
+        expect(find.byKey(DebuggerConsole.copyToClipboardButtonKey), findsNothing);
       });
 
       testWidgets('Tapping the Console Clear button clears stdio.',
@@ -131,7 +132,7 @@ void main() {
 
         await pumpDebuggerScreen(tester, debuggerController);
 
-        final clearButton = find.byTooltip('Clear console output.');
+        final clearButton = find.byKey(DebuggerConsole.clearStdioButtonKey);
         expect(clearButton, findsOneWidget);
 
         await tester.tap(clearButton);
@@ -171,14 +172,13 @@ void main() {
 
           await pumpDebuggerScreen(tester, debuggerController);
 
-          final copyButton = find.byTooltip('Copy to clipboard.');
+          final copyButton = find.byKey(DebuggerConsole.copyToClipboardButtonKey);
           expect(copyButton, findsOneWidget);
 
           expect(_clipboardContents, isEmpty);
 
           await tester.tap(copyButton);
 
-          expect(_clipboardContents, isNotEmpty);
           expect(_clipboardContents, equals(_expected));
         });
       });

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -308,6 +308,11 @@ void main() {
       test('many', () {
         expect(pluralize('cat', 2), 'cats');
       });
+
+      test('irregular plurals', () {
+        expect(pluralize('index', 1, plural: 'indices'), 'index');
+        expect(pluralize('index', 2, plural: 'indices'), 'indices');
+      });
     });
 
     group('safeDivide', () {


### PR DESCRIPTION
Added a couple of IconButtons to Copy to Clipboard and Clear the stdio output in the Debugger panel. (Those only show when there's *something* in `stdio`).

<img width="1277" alt="Screen Shot 2020-05-13 at 12 22 28 PM" src="https://user-images.githubusercontent.com/1255594/81867449-912a0480-9525-11ea-8904-1d0ea0bb725f.png">

Added a few unit tests for the logic.