### PR TITLE
some tweaks to the debugger's console actions

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -97,9 +97,10 @@ class Console extends StatelessWidget {
     return Stack(
       children: [
         _ConsoleOutput(lines: lines),
-        _ConsoleControls(
-          controls: controls,
-        ),
+        if (controls.isNotEmpty)
+          _ConsoleControls(
+            controls: controls,
+          ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -58,24 +58,26 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
 
   @override
   Widget build(BuildContext context) {
-    return Console(
-      lines: _lines,
-      controls: [
-        // TODO(ditman) Extract these IconButtons to common_widgets.dart
-        IconButton(
-          icon: const Icon(Icons.content_copy, size: actionsIconSize),
-          onPressed:
-              _lines.isEmpty ? null : () => copyToClipboard(_lines, context),
-          tooltip: 'Copy to clipboard',
-          key: DebuggerConsole.copyToClipboardButtonKey,
-        ),
-        IconButton(
-          icon: const Icon(Icons.delete, size: actionsIconSize),
-          onPressed: _lines.isEmpty ? null : widget.controller.clearStdio,
-          tooltip: 'Clear console output',
-          key: DebuggerConsole.clearStdioButtonKey,
-        ),
-      ],
+    return Material(
+      child: Console(
+        lines: _lines,
+        controls: [
+          // TODO(ditman) Extract these IconButtons to common_widgets.dart
+          IconButton(
+            icon: const Icon(Icons.content_copy, size: actionsIconSize),
+            onPressed:
+                _lines.isEmpty ? null : () => copyToClipboard(_lines, context),
+            tooltip: 'Copy to clipboard',
+            key: DebuggerConsole.copyToClipboardButtonKey,
+          ),
+          IconButton(
+            icon: const Icon(Icons.delete, size: actionsIconSize),
+            onPressed: _lines.isEmpty ? null : widget.controller.clearStdio,
+            tooltip: 'Clear console output',
+            key: DebuggerConsole.clearStdioButtonKey,
+          ),
+        ],
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -61,29 +61,28 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
     return Console(
       lines: _lines,
       controls: [
-        if (_lines.isNotEmpty) ...[
-          // TODO(ditman) Extract these IconButtons to common_widgets.dart
-          IconButton(
-            icon: const Icon(Icons.content_copy),
-            onPressed: () => copyToClipboard(_lines, context),
-            tooltip: 'Copy to clipboard',
-            key: DebuggerConsole.copyToClipboardButtonKey,
-          ),
-          IconButton(
-            icon: const Icon(Icons.delete),
-            onPressed: widget.controller.clearStdio,
-            tooltip: 'Clear console output',
-            key: DebuggerConsole.clearStdioButtonKey,
-          ),
-        ],
+        // TODO(ditman) Extract these IconButtons to common_widgets.dart
+        IconButton(
+          icon: const Icon(Icons.content_copy, size: actionsIconSize),
+          onPressed:
+              _lines.isEmpty ? null : () => copyToClipboard(_lines, context),
+          tooltip: 'Copy to clipboard',
+          key: DebuggerConsole.copyToClipboardButtonKey,
+        ),
+        IconButton(
+          icon: const Icon(Icons.delete, size: actionsIconSize),
+          onPressed: _lines.isEmpty ? null : widget.controller.clearStdio,
+          tooltip: 'Clear console output',
+          key: DebuggerConsole.clearStdioButtonKey,
+        ),
       ],
     );
   }
 }
 
-/// Renders a ConsoleOutput widget with ConsoleControls overlaid on the top-right corner.
-///
-/// TODO(ditman): Reuse this in `logging/flutter/logging_screen.dart`?
+/// Renders a ConsoleOutput widget with ConsoleControls overlaid on the
+/// top-right corner.
+// TODO(ditman): Reuse this in `logging/flutter/logging_screen.dart`?
 class Console extends StatelessWidget {
   const Console({
     this.controls = const <Widget>[],
@@ -98,17 +97,16 @@ class Console extends StatelessWidget {
     return Stack(
       children: [
         _ConsoleOutput(lines: lines),
-        if (controls.isNotEmpty) ...[
-          _ConsoleControls(
-            controls: controls,
-          ),
-        ],
+        _ConsoleControls(
+          controls: controls,
+        ),
       ],
     );
   }
 }
 
-/// Renders a top-right aligned ButtonBar wrapping a List of IconButtons (`controls`).
+/// Renders a top-right aligned ButtonBar wrapping a List of IconButtons
+/// (`controls`).
 class _ConsoleControls extends StatelessWidget {
   const _ConsoleControls({
     this.controls,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -127,6 +127,7 @@ class DebuggerController extends DisposableController
   }
 
   final _stdio = ValueNotifier<List<String>>([]);
+  bool _stdioTrailingNewline = false;
 
   /// Return the stdout and stderr emitted from the application.
   ///
@@ -149,13 +150,20 @@ class DebuggerController extends DisposableController
     var lines = _stdio.value.toList();
     final newLines = text.split('\n');
 
-    if (lines.isNotEmpty && !lines.last.endsWith('\n')) {
+    if (lines.isNotEmpty && !_stdioTrailingNewline) {
       lines[lines.length - 1] = '${lines[lines.length - 1]}${newLines.first}';
       if (newLines.length > 1) {
         lines.addAll(newLines.sublist(1));
       }
     } else {
       lines.addAll(newLines);
+    }
+
+    _stdioTrailingNewline = text.endsWith('\n');
+
+    // Don't report trailing blank lines.
+    if (lines.isNotEmpty && lines.last.isEmpty) {
+      lines = lines.sublist(0, lines.length - 1);
     }
 
     // For performance reasons, we drop older lines in batches, so the lines

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -238,7 +238,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           ActionButton(
             child: FlatButton(
               padding: EdgeInsets.zero,
-              child: const Icon(Icons.delete, size: 24.0),
+              child: const Icon(Icons.delete, size: actionsIconSize),
               onPressed:
                   breakpoints.isNotEmpty ? controller.clearBreakpoints : null,
             ),

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -2,10 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:ansi_up/ansi_up.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
-import 'package:ansi_up/ansi_up.dart';
 
 import '../utils.dart';
 import 'notifications.dart';
@@ -24,9 +24,14 @@ Future<void> copyToClipboard(List<String> lines, BuildContext context) async {
     text: lines.join('\n'),
   ));
 
-  final numLines = lines.length;
+  var numLines = lines.length;
+  // Adjust line count if there's a trailing empty line.
+  if (numLines > 0 && lines.last.trim().isEmpty) {
+    numLines--;
+  }
+
   Notifications.of(context)?.push(
-    'Copied $numLines ${pluralize("line", numLines)}.',
+    'Copied $numLines ${pluralize('line', numLines)}.',
   );
 }
 

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -24,12 +24,7 @@ Future<void> copyToClipboard(List<String> lines, BuildContext context) async {
     text: lines.join('\n'),
   ));
 
-  var numLines = lines.length;
-  // Adjust line count if there's a trailing empty line.
-  if (numLines > 0 && lines.last.trim().isEmpty) {
-    numLines--;
-  }
-
+  final numLines = lines.length;
   Notifications.of(context)?.push(
     'Copied $numLines ${pluralize('line', numLines)}.',
   );

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -114,7 +114,7 @@ void main() {
     });
 
     group('ConsoleControls', () {
-      testWidgets('Console Controls are rendered disables when stdio is empty',
+      testWidgets('Console Controls are rendered disabled when stdio is empty',
           (WidgetTester tester) async {
         when(debuggerController.stdio).thenReturn(ValueNotifier([]));
 

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -114,15 +114,20 @@ void main() {
     });
 
     group('ConsoleControls', () {
-      testWidgets('Console Controls are not rendered when stdio is empty',
+      testWidgets('Console Controls are rendered disables when stdio is empty',
           (WidgetTester tester) async {
         when(debuggerController.stdio).thenReturn(ValueNotifier([]));
 
         await pumpDebuggerScreen(tester, debuggerController);
 
-        expect(find.byKey(DebuggerConsole.clearStdioButtonKey), findsNothing);
-        expect(
-            find.byKey(DebuggerConsole.copyToClipboardButtonKey), findsNothing);
+        expect(find.byKey(DebuggerConsole.clearStdioButtonKey), findsOneWidget);
+        expect(find.byKey(DebuggerConsole.copyToClipboardButtonKey),
+            findsOneWidget);
+
+        final clearStdioElement =
+            find.byKey(DebuggerConsole.clearStdioButtonKey).evaluate().first;
+        final clearStdioButton = clearStdioElement.widget as IconButton;
+        expect(clearStdioButton.onPressed, isNull);
       });
 
       testWidgets('Tapping the Console Clear button clears stdio.',


### PR DESCRIPTION
Some tweaks to the debugger's console actions:
- use a const for the icon size (from theme.dart, `actionsIconSize`)
- have the actions always visible - even if they don't apply at the time - but disabled when necessary
- a slight tweak to the 'copied n lines text'; it looked strange when there were 3 lines in the console (w/ a 4th empty newline), but the copied text said 'copied 4 lines'

cc @ditman 