### PR TITLE
Remove dart:html from build_release.sh

### DIFF
--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -80,32 +80,11 @@ Future<shelf.Handler> defaultHandler(
     debugProxyHandler = proxyHandler(Uri.parse('http://localhost:$webPort/'));
   }
 
-  // The packages folder is renamed in the pub package so this handler serves
-  // out of the `pack` folder.
-  Handler packHandler;
-  if (!debugMode) {
-    final packFolder = path.join(packageDir, 'build', 'pack');
-    if (Directory(packFolder).existsSync()) {
-      packHandler = createStaticHandler(
-        packFolder,
-        defaultDocument: 'index.html',
-      );
-    }
-  }
-
   final sseHandler = SseHandler(Uri.parse('/api/sse'))
     ..connections.rest.listen(clients.acceptClient);
 
   // Make a handler that delegates based on path.
   final handler = (shelf.Request request) {
-    if (!debugMode) {
-      if (packHandler != null && request.url.path.startsWith('packages/')) {
-        // request.change here will strip the `packages` prefix from the path
-        // so it's relative to packHandler's root.
-        return packHandler(request.change(path: 'packages'));
-      }
-    }
-
     if (request.url.path.startsWith('api/sse')) {
       return sseHandler.handler(request);
     }

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -11,23 +11,8 @@ pushd packages/devtools_app
 rm -rf build
 rm -rf ../devtools/build
 flutter pub get
-flutter pub run build_runner build -o web:build --release
-mv ./build/packages ./build/pack
 
-# move release to the devtools package from the devtools_app package for deployment
-mv build ../devtools
-
-# Build the flutter release of the app as well.
-
-rm -rf build
 flutter build web --dart-define=FLUTTER_WEB_USE_SKIA=true --no-tree-shake-icons
-mkdir build/web/flutter
-mv build/web/main.* build/web/flutter/
-
-sed 's|main.dart.js|flutter\/main.dart.js|' build/web/index.html > build/web/tmp.html
-sed 's|<head>|<head><style>.legacy-dart {visibility: hidden;}</style>|' build/web/tmp.html > build/web/flutter.html
-rm build/web/index.html build/web/tmp.html
-
-mv build/web/* ../devtools/build/
+mv build/web ../devtools/build
 
 popd


### PR DESCRIPTION
I *think* this is all correct. We no longer need to build the dart:html version, nor do we need to do gymnastics to put the Flutter version in a folder and change its index to flutter.html.

With this change, running the "Run Server with Release Build" launch config from VS Code seems to work as expected.