### PR TITLE
minor tweaks to the variables view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_model.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart' hide Stack;
 import 'package:vm_service/vm_service.dart';
 
 import '../../trees.dart';
+import '../../utils.dart';
 
 /// A tuple of a script and an optional location.
 class ScriptLocation {
@@ -204,12 +205,13 @@ class Variable extends TreeNode<Variable> {
     final value = this.value;
 
     String valueStr;
+
     if (value is InstanceRef) {
       if (value.valueAsString == null) {
         valueStr = value.classRef.name;
       } else {
         valueStr = value.valueAsString;
-        if (value.valueAsStringIsTruncated) {
+        if (value.valueAsStringIsTruncated == true) {
           valueStr += '...';
         }
         if (value.kind == InstanceKind.kString) {
@@ -218,12 +220,12 @@ class Variable extends TreeNode<Variable> {
       }
 
       if (value.kind == InstanceKind.kList) {
-        valueStr = '[${value.length}] $valueStr';
+        valueStr = '$valueStr (${_itemCount(value.length)})';
       } else if (value.kind == InstanceKind.kMap) {
-        valueStr = '{ ${value.length} } $valueStr';
+        valueStr = '$valueStr (${_itemCount(value.length)})';
       } else if (value.kind != null && value.kind.endsWith('List')) {
         // Uint8List, Uint16List, ...
-        valueStr = '[${value.length}] $valueStr';
+        valueStr = '$valueStr (${_itemCount(value.length)})';
       }
     } else if (value is Sentinel) {
       valueStr = value.valueAsString;
@@ -234,6 +236,10 @@ class Variable extends TreeNode<Variable> {
     }
 
     return valueStr;
+  }
+
+  String _itemCount(int count) {
+    return '${nf.format(count)} ${pluralize('item', count)}';
   }
 
   @override

--- a/packages/devtools_app/lib/src/flutter/tree.dart
+++ b/packages/devtools_app/lib/src/flutter/tree.dart
@@ -114,10 +114,10 @@ class _TreeViewItemState<T extends TreeNode<T>> extends State<TreeViewItem<T>>
                       turns: expandArrowAnimation,
                       child: const Icon(
                         Icons.arrow_drop_down,
-                        size: actionsIconSize,
+                        size: defaultIconSize,
                       ),
                     )
-                  : const SizedBox(width: defaultSpacing),
+                  : const SizedBox(width: defaultIconSize),
               Expanded(child: widget.display),
             ]),
       ),

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -374,7 +374,7 @@ void main() {
 
       final listFinder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&
-          widget.text.toPlainText().contains('Root 1 [2] _GrowableList'));
+          widget.text.toPlainText().contains('Root 1 _GrowableList (2 items)'));
       final listChild1Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText && widget.text.toPlainText().contains('0: 3'));
       final listChild2Finder = find.byWidgetPredicate((Widget widget) =>
@@ -384,7 +384,7 @@ void main() {
           widget is RichText &&
           widget.text
               .toPlainText()
-              .contains('Root 2 { 2 } _InternalLinkedHashmap'));
+              .contains('Root 2 _InternalLinkedHashmap (2 items)'));
       final mapElement1Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&
           widget.text.toPlainText().contains("['key1'] 1.0"));


### PR DESCRIPTION
minor tweaks to the variables view:
- use a consistent indent for both items that are and aren't expandable
- display the length of lists and maps at the end of the description (the `[length]` format was nice and terse, but was a little confusing to read with `[0]`, `[1]`, ... expanded subitems
- `valueAsStringIsTruncated` might be null, so guard against that
