### PR TITLE
improved feedback when stepping

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/call_stack.dart
@@ -8,6 +8,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
+import '../../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
@@ -140,5 +141,16 @@ class _CallStackState extends State<CallStack> {
     }
     final file = uri.split('/').last;
     return frame.line == null ? ' $file' : ' $file:${frame.line}';
+  }
+}
+
+class CallStackCountBadge extends StatelessWidget {
+  const CallStackCountBadge({@required this.stackFrames});
+
+  final List<StackFrameAndSourcePosition> stackFrames;
+
+  @override
+  Widget build(BuildContext context) {
+    return Badge('${nf.format(stackFrames.length)}');
   }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -173,7 +173,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
       if (animate) {
         verticalController.animateTo(
           scrollPosition,
-          duration: rapidDuration,
+          duration: longDuration,
           curve: defaultCurve,
         );
       } else {

--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -21,88 +21,97 @@ class DebuggingControls extends StatelessWidget {
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: controller.isPaused,
-      builder: (context, isPaused, child) {
-        final canStep = isPaused && controller.hasFrames.value;
+      builder: (context, isPaused, _) {
+        return ValueListenableBuilder(
+          valueListenable: controller.maybeResuming,
+          builder: (context, maybeResuming, Widget _) {
+            final canStep =
+                isPaused && !maybeResuming && controller.hasFrames.value;
 
-        return SizedBox(
-          height: Theme.of(context).buttonTheme.height,
-          child: Row(
-            children: [
-              RoundedOutlinedBorder(
-                child: Row(
-                  children: [
-                    DebuggerButton(
-                      title: 'Pause',
-                      icon: Icons.pause,
-                      autofocus: true,
-                      onPressed: isPaused ? null : controller.pause,
+            return SizedBox(
+              height: Theme.of(context).buttonTheme.height,
+              child: Row(
+                children: [
+                  RoundedOutlinedBorder(
+                    child: Row(
+                      children: [
+                        DebuggerButton(
+                          title: 'Pause',
+                          icon: Icons.pause,
+                          autofocus: true,
+                          onPressed: isPaused ? null : controller.pause,
+                        ),
+                        _LeftBorder(
+                          child: DebuggerButton(
+                            title: 'Resume',
+                            icon: Icons.play_arrow,
+                            onPressed: (isPaused && !maybeResuming)
+                                ? controller.resume
+                                : null,
+                          ),
+                        ),
+                      ],
                     ),
-                    _LeftBorder(
-                      child: DebuggerButton(
-                        title: 'Resume',
-                        icon: Icons.play_arrow,
-                        onPressed: isPaused ? controller.resume : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: denseSpacing),
-              RoundedOutlinedBorder(
-                child: Row(
-                  children: [
-                    DebuggerButton(
-                      title: 'Step In',
-                      icon: Icons.keyboard_arrow_down,
-                      onPressed: canStep ? controller.stepIn : null,
-                    ),
-                    _LeftBorder(
-                      child: DebuggerButton(
-                        title: 'Step Over',
-                        icon: Icons.keyboard_arrow_right,
-                        onPressed: canStep ? controller.stepOver : null,
-                      ),
-                    ),
-                    _LeftBorder(
-                      child: DebuggerButton(
-                        title: 'Step Out',
-                        icon: Icons.keyboard_arrow_up,
-                        onPressed: canStep ? controller.stepOut : null,
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              const SizedBox(width: denseSpacing),
-              RoundedOutlinedBorder(
-                child: Center(
-                  child: Padding(
-                    padding: const EdgeInsets.only(
-                      left: defaultSpacing,
-                      right: borderPadding,
-                    ),
-                    child: BreakOnExceptionsControl(controller: controller),
                   ),
-                ),
-              ),
-              const Expanded(child: SizedBox(width: denseSpacing)),
-              ValueListenableBuilder(
-                valueListenable: controller.librariesVisible,
-                builder: (context, visible, _) {
-                  return RoundedOutlinedBorder(
-                    child: Container(
-                      color: visible ? Theme.of(context).highlightColor : null,
-                      child: DebuggerButton(
-                        title: 'Libraries',
-                        icon: libraryIcon,
-                        onPressed: controller.toggleLibrariesVisible,
+                  const SizedBox(width: denseSpacing),
+                  RoundedOutlinedBorder(
+                    child: Row(
+                      children: [
+                        DebuggerButton(
+                          title: 'Step In',
+                          icon: Icons.keyboard_arrow_down,
+                          onPressed: canStep ? controller.stepIn : null,
+                        ),
+                        _LeftBorder(
+                          child: DebuggerButton(
+                            title: 'Step Over',
+                            icon: Icons.keyboard_arrow_right,
+                            onPressed: canStep ? controller.stepOver : null,
+                          ),
+                        ),
+                        _LeftBorder(
+                          child: DebuggerButton(
+                            title: 'Step Out',
+                            icon: Icons.keyboard_arrow_up,
+                            onPressed: canStep ? controller.stepOut : null,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: denseSpacing),
+                  RoundedOutlinedBorder(
+                    child: Center(
+                      child: Padding(
+                        padding: const EdgeInsets.only(
+                          left: defaultSpacing,
+                          right: borderPadding,
+                        ),
+                        child: BreakOnExceptionsControl(controller: controller),
                       ),
                     ),
-                  );
-                },
-              )
-            ],
-          ),
+                  ),
+                  const Expanded(child: SizedBox(width: denseSpacing)),
+                  ValueListenableBuilder(
+                    valueListenable: controller.librariesVisible,
+                    builder: (context, visible, _) {
+                      return RoundedOutlinedBorder(
+                        child: Container(
+                          color:
+                              visible ? Theme.of(context).highlightColor : null,
+                          child: DebuggerButton(
+                            title: 'Libraries',
+                            icon: libraryIcon,
+                            onPressed: controller.toggleLibrariesVisible,
+                          ),
+                        ),
+                      );
+                    },
+                  )
+                ],
+              ),
+            );
+          },
         );
       },
     );

--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -23,10 +23,10 @@ class DebuggingControls extends StatelessWidget {
       valueListenable: controller.isPaused,
       builder: (context, isPaused, _) {
         return ValueListenableBuilder(
-          valueListenable: controller.maybeResuming,
-          builder: (context, maybeResuming, Widget _) {
+          valueListenable: controller.resuming,
+          builder: (context, resuming, Widget _) {
             final canStep =
-                isPaused && !maybeResuming && controller.hasFrames.value;
+                isPaused && !resuming && controller.hasFrames.value;
 
             return SizedBox(
               height: Theme.of(context).buttonTheme.height,
@@ -45,7 +45,7 @@ class DebuggingControls extends StatelessWidget {
                           child: DebuggerButton(
                             title: 'Resume',
                             icon: Icons.play_arrow,
-                            onPressed: (isPaused && !maybeResuming)
+                            onPressed: (isPaused && !resuming)
                                 ? controller.resume
                                 : null,
                           ),

--- a/packages/devtools_app/lib/src/debugger/flutter/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/controls.dart
@@ -25,8 +25,7 @@ class DebuggingControls extends StatelessWidget {
         return ValueListenableBuilder(
           valueListenable: controller.resuming,
           builder: (context, resuming, Widget _) {
-            final canStep =
-                isPaused && !resuming && controller.hasFrames.value;
+            final canStep = isPaused && !resuming && controller.hasFrames.value;
 
             return SizedBox(
               height: Theme.of(context).buttonTheme.height,

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -20,7 +20,7 @@ import 'debugger_model.dart';
 // help debounce stepping operations).
 
 // Make sure this a checked in with `mute: true`.
-final _log = TimingLogger('debugger', mute: false);
+final _log = TimingLogger('debugger', mute: true);
 
 /// Responsible for managing the debug state of the app.
 class DebuggerController extends DisposableController

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -27,6 +27,10 @@ import 'debugger_model.dart';
 import 'scripts.dart';
 import 'variables.dart';
 
+// This is currently a dev-time flag as the overall call depth may not be that
+// interesting to users.
+const bool showCallStackCount = true;
+
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
       : super('debugger', title: 'Debugger', icon: Octicons.bug);
@@ -210,7 +214,12 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           initialFractions: const [0.38, 0.38, 0.24],
           minSizes: const [0.0, 0.0, 0.0],
           headers: [
-            debuggerPaneHeader(context, callStackTitle, needsTopBorder: false),
+            debuggerPaneHeader(
+              context,
+              callStackTitle,
+              needsTopBorder: false,
+              rightChild: showCallStackCount ? _callStackRightChild() : null,
+            ),
             debuggerPaneHeader(context, variablesTitle),
             debuggerPaneHeader(
               context,
@@ -225,6 +234,15 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             BreakpointPicker(),
           ],
         );
+      },
+    );
+  }
+
+  Widget _callStackRightChild() {
+    return ValueListenableBuilder(
+      valueListenable: controller.stackFramesWithLocation,
+      builder: (context, stackFrames, _) {
+        return CallStackCountBadge(stackFrames: stackFrames);
       },
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -29,7 +29,7 @@ import 'variables.dart';
 
 // This is currently a dev-time flag as the overall call depth may not be that
 // interesting to users.
-const bool showCallStackCount = false;
+const bool debugShowCallStackCount = false;
 
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
@@ -218,7 +218,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
               context,
               callStackTitle,
               needsTopBorder: false,
-              rightChild: showCallStackCount ? _callStackRightChild() : null,
+              rightChild:
+                  // ignore: avoid_redundant_argument_values
+                  debugShowCallStackCount ? _callStackRightChild() : null,
             ),
             debuggerPaneHeader(context, variablesTitle),
             debuggerPaneHeader(

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -29,7 +29,7 @@ import 'variables.dart';
 
 // This is currently a dev-time flag as the overall call depth may not be that
 // interesting to users.
-const bool showCallStackCount = true;
+const bool showCallStackCount = false;
 
 class DebuggerScreen extends Screen {
   const DebuggerScreen()

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -651,3 +651,28 @@ class CallbackDwell {
     }
   }
 }
+
+/// A dev time class to help trace DevTools application events.
+class DebugTimingLogger {
+  DebugTimingLogger(this.name, {this.mute});
+
+  final String name;
+  final bool mute;
+
+  Stopwatch _timer;
+
+  void log(String message) {
+    if (mute) return;
+
+    if (_timer != null) {
+      _timer.stop();
+      print('[$name}]   ${_timer.elapsedMilliseconds}ms');
+      _timer.reset();
+    }
+
+    _timer ??= Stopwatch();
+    _timer.start();
+
+    print('[$name] $message');
+  }
+}

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -44,6 +44,7 @@ void main() {
 
       debuggerController = MockDebuggerController();
       when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
+      when(debuggerController.resuming).thenReturn(ValueNotifier(false));
       when(debuggerController.hasFrames).thenReturn(ValueNotifier(false));
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
       when(debuggerController.breakpointsWithLocation)


### PR DESCRIPTION
- when stepping, show the stepping controls as disabled until we get an indication that the app has resumed (this provides better feedback that hitting the step button did something)
- slow animations down for scrolling the editor when stepping
- add some dev time flags to help diagnose where we're spending time when stepping (to help diagnose slow package:dwds stepping)

I have a `ValueListenableBuilder` in a `ValueListenableBuilder` in this PR, which is correct I guess, but it would be nice if there was a technique that involved less widget nesting.

