### PR TITLE
Add launch config to run integration tests in release mode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -40,6 +40,23 @@
 			"type": "dart",
 			"request": "launch",
 			"program": "${file}"
+		},
+		{
+			// This templated launch config will show up in CodeLens to make it
+			// easier to run tests in release mode from the editor.
+			"name": "${debugType} (release)",
+			"type": "dart",
+			"request": "launch",
+			"templateFor": "packages/devtools_app/test/integration_tests",
+			"template": [
+				"run-test",
+				"run-test-file",
+				"debug-test",
+				"debug-test-file"
+			],
+			"env": {
+				"WEBDEV_RELEASE": true,
+			}
 		}
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -42,18 +42,19 @@
 			"program": "${file}"
 		},
 		{
-			// This templated launch config will show up in CodeLens to make it
-			// easier to run tests in release mode from the editor.
-			"name": "${debugType} (release)",
+			"name": "Current File (WEBDEV_RELEASE=true)",
 			"type": "dart",
 			"request": "launch",
-			"templateFor": "packages/devtools_app/test/integration_tests",
-			"template": [
-				"run-test",
-				"run-test-file",
-				"debug-test",
-				"debug-test-file"
-			],
+			"codeLens": {
+				"for": [
+					"run-test",
+					"run-test-file",
+					"debug-test",
+					"debug-test-file",
+				],
+				"path": "packages/devtools_app/test/integration_tests",
+				"title": "${debugType} (release)"
+			},
 			"env": {
 				"WEBDEV_RELEASE": true,
 			}


### PR DESCRIPTION
This injects some extra CodeLens links in the integration tests to make it easy to run+debug the integration tests in release mode (the same as the dart2js bot on Travis):

<img width="495" alt="Screenshot 2020-05-18 at 18 04 19" src="https://user-images.githubusercontent.com/1078012/82240470-629b9780-9932-11ea-8795-7f795e3525f9.png">

Note: Requires v3.11.0 of Dart-Code (which isn't released yet).