### PR TITLE
Modify initial inspector split ratio.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -153,7 +153,7 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
         Expanded(
           child: Split(
             axis: splitAxis,
-            initialFractions: const [0.40, 0.60],
+            initialFractions: const [0.33, 0.67],
             children: [
               summaryTree,
               InspectorDetailsTabController(


### PR DESCRIPTION
Change ratio to 1/3 and 2/3 to start. Addresses part of https://github.com/flutter/devtools/issues/1984.