### PR TITLE
[Logging] Use reusable Console widget in Log Details

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -56,7 +56,7 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
       lines: _lines,
       controls: [
         CopyToClipboardControl(
-          data: disabled ? null : _lines.join('\n'),
+          dataProvider: disabled ? null : () => _lines.join('\n'),
           successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
           buttonKey: DebuggerConsole.copyToClipboardButtonKey,
         ),

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -9,12 +9,6 @@ import '../../flutter/console.dart';
 import '../../utils.dart';
 import 'debugger_controller.dart';
 
-// TODO(devoncarew): Allow scrolling horizontally as well.
-
-// TODO(devoncarew): Show some small UI indicator when we receive stdout/stderr.
-
-// TODO(devoncarew): Support hyperlinking to stack traces.
-
 /// Display the stdout and stderr output from the process under debug.
 class DebuggerConsole extends StatefulWidget {
   const DebuggerConsole({

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -5,10 +5,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import '../../flutter/common_widgets.dart';
-import '../../flutter/theme.dart';
-import '../../flutter/utils.dart';
-import 'codeview.dart';
+import '../../flutter/console.dart';
+import '../../utils.dart';
 import 'debugger_controller.dart';
 
 // TODO(devoncarew): Allow scrolling horizontally as well.
@@ -58,132 +56,23 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
 
   @override
   Widget build(BuildContext context) {
+    final numLines = _lines.length;
+    final disabled = numLines == 0;
     return Material(
       child: Console(
         lines: _lines,
         controls: [
-          // TODO(ditman) Extract these IconButtons to common_widgets.dart
-          IconButton(
-            icon: const Icon(Icons.content_copy, size: actionsIconSize),
-            onPressed:
-                _lines.isEmpty ? null : () => copyToClipboard(_lines, context),
-            tooltip: 'Copy to clipboard',
-            key: DebuggerConsole.copyToClipboardButtonKey,
+          CopyToClipboardControl(
+            data: disabled ? null : _lines.join('\n'),
+            successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
+            buttonKey: DebuggerConsole.copyToClipboardButtonKey,
           ),
-          IconButton(
-            icon: const Icon(Icons.delete, size: actionsIconSize),
-            onPressed: _lines.isEmpty ? null : widget.controller.clearStdio,
+          DeleteControl(
+            onPressed: disabled ? null : widget.controller.clearStdio,
             tooltip: 'Clear console output',
-            key: DebuggerConsole.clearStdioButtonKey,
+            buttonKey: DebuggerConsole.clearStdioButtonKey,
           ),
         ],
-      ),
-    );
-  }
-}
-
-/// Renders a ConsoleOutput widget with ConsoleControls overlaid on the
-/// top-right corner.
-// TODO(ditman): Reuse this in `logging/flutter/logging_screen.dart`?
-class Console extends StatelessWidget {
-  const Console({
-    this.controls = const <Widget>[],
-    this.lines = const <String>[],
-  }) : super();
-
-  final List<Widget> controls;
-  final List<String> lines;
-
-  @override
-  Widget build(BuildContext context) {
-    return Stack(
-      children: [
-        _ConsoleOutput(lines: lines),
-        if (controls.isNotEmpty)
-          _ConsoleControls(
-            controls: controls,
-          ),
-      ],
-    );
-  }
-}
-
-/// Renders a top-right aligned ButtonBar wrapping a List of IconButtons
-/// (`controls`).
-class _ConsoleControls extends StatelessWidget {
-  const _ConsoleControls({
-    this.controls,
-  }) : super();
-
-  final List<Widget> controls;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      alignment: Alignment.topRight,
-      child: ButtonBar(
-        buttonPadding: EdgeInsets.zero,
-        alignment: MainAxisAlignment.end,
-        children: controls,
-      ),
-    );
-  }
-}
-
-/// Renders a widget with the output of the console.
-///
-/// This is a ListView of text lines, with a monospace font and a border.
-class _ConsoleOutput extends StatefulWidget {
-  const _ConsoleOutput({
-    Key key,
-    this.lines,
-  }) : super(key: key);
-
-  final List<String> lines;
-
-  @override
-  _ConsoleOutputState createState() => _ConsoleOutputState();
-}
-
-class _ConsoleOutputState extends State<_ConsoleOutput> {
-  // The scroll controller must survive ConsoleOutput re-renders
-  // to work as intended, so it must be part of the "state".
-  final ScrollController _scroll = ScrollController();
-
-  // Whenever the widget updates, refresh the scroll position if needed.
-  @override
-  void didUpdateWidget(oldWidget) {
-    if (_scroll.hasClients && _scroll.atScrollBottom) {
-      _scroll.autoScrollToBottom();
-    }
-    super.didUpdateWidget(oldWidget);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final textStyle =
-        theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
-
-    return OutlineDecoration(
-      child: Scrollbar(
-        child: ListView.builder(
-          padding: const EdgeInsets.all(denseSpacing),
-          itemCount: widget.lines.length,
-          itemExtent: CodeView.rowHeight,
-          controller: _scroll,
-          itemBuilder: (context, index) {
-            return RichText(
-              text: TextSpan(
-                children: processAnsiTerminalCodes(
-                  widget.lines[index],
-                  textStyle,
-                ),
-              ),
-              maxLines: 1,
-            );
-          },
-        ),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -58,22 +58,20 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
   Widget build(BuildContext context) {
     final numLines = _lines.length;
     final disabled = numLines == 0;
-    return Material(
-      child: Console(
-        lines: _lines,
-        controls: [
-          CopyToClipboardControl(
-            data: disabled ? null : _lines.join('\n'),
-            successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
-            buttonKey: DebuggerConsole.copyToClipboardButtonKey,
-          ),
-          DeleteControl(
-            onPressed: disabled ? null : widget.controller.clearStdio,
-            tooltip: 'Clear console output',
-            buttonKey: DebuggerConsole.clearStdioButtonKey,
-          ),
-        ],
-      ),
+    return Console(
+      lines: _lines,
+      controls: [
+        CopyToClipboardControl(
+          data: disabled ? null : _lines.join('\n'),
+          successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
+          buttonKey: DebuggerConsole.copyToClipboardButtonKey,
+        ),
+        DeleteControl(
+          onPressed: disabled ? null : widget.controller.clearStdio,
+          tooltip: 'Clear console output',
+          buttonKey: DebuggerConsole.clearStdioButtonKey,
+        ),
+      ],
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -34,15 +34,16 @@ class Console extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Material(
-        child: Stack(
-      children: [
-        _ConsoleOutput(lines: lines),
-        if (controls.isNotEmpty)
-          _ConsoleControls(
-            controls: controls,
-          ),
-      ],
-    ));
+      child: Stack(
+        children: [
+          _ConsoleOutput(lines: lines),
+          if (controls.isNotEmpty)
+            _ConsoleControls(
+              controls: controls,
+            ),
+        ],
+      ),
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -127,14 +127,15 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
 // CONTROLS
 
 /// A pre-configured IconButton that fits the ux of the Console widget.
-/// 
+///
 /// The customizations are:
 ///  * Icon size: [actionsIconSize]
 ///  * Do not show [tooltip] if the button is disabled
 ///  * [VisualDensity.compact]
 class ConsoleControl extends StatelessWidget {
-  const ConsoleControl({this.icon, this.tooltip, this.onPressed, this.buttonKey});
-  
+  const ConsoleControl(
+      {this.icon, this.tooltip, this.onPressed, this.buttonKey});
+
   final IconData icon;
   final String tooltip;
   final VoidCallback onPressed;
@@ -154,11 +155,15 @@ class ConsoleControl extends StatelessWidget {
 }
 
 /// A Console Control to "delete" the contents of the console.
-/// 
+///
 /// This just preconfigures a ConsoleControl with the `delete` icon,
 /// and the `onPressed` function passed from the outside.
 class DeleteControl extends StatelessWidget {
-  const DeleteControl({this.onPressed, this.tooltip = 'Clear contents', this.buttonKey,});
+  const DeleteControl({
+    this.onPressed,
+    this.tooltip = 'Clear contents',
+    this.buttonKey,
+  });
 
   final VoidCallback onPressed;
   final String tooltip;
@@ -176,11 +181,15 @@ class DeleteControl extends StatelessWidget {
 }
 
 /// A Console Control that copies `data` to the clipboard.
-/// 
+///
 /// If it succeeds, it displays a notification with `successMessage`.
 class CopyToClipboardControl extends StatelessWidget {
-
-  const CopyToClipboardControl({this.data, this.successMessage = 'Copied to clipboard.', this.tooltip = 'Copy to clipboard', this.buttonKey,});
+  const CopyToClipboardControl({
+    this.data,
+    this.successMessage = 'Copied to clipboard.',
+    this.tooltip = 'Copy to clipboard',
+    this.buttonKey,
+  });
 
   final String data;
   final String successMessage;
@@ -193,7 +202,9 @@ class CopyToClipboardControl extends StatelessWidget {
     return ConsoleControl(
       icon: Icons.content_copy,
       tooltip: tooltip,
-      onPressed: disabled ? null : () => copyToClipboard(data, successMessage, context),
+      onPressed: disabled
+          ? null
+          : () => copyToClipboard(data, successMessage, context),
       buttonKey: buttonKey,
     );
   }

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -1,0 +1,199 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../debugger/flutter/codeview.dart';
+
+import './common_widgets.dart';
+import './theme.dart';
+import './utils.dart';
+
+// TODO(devoncarew): Allow scrolling horizontally as well.
+
+// TODO(devoncarew): Show some small UI indicator when we receive stdout/stderr.
+
+// TODO(devoncarew): Support hyperlinking to stack traces.
+
+/// Renders a ConsoleOutput widget with ConsoleControls overlaid on the
+/// top-right corner.
+class Console extends StatelessWidget {
+  const Console({
+    this.controls = const <Widget>[],
+    this.lines = const <String>[],
+  }) : super();
+
+  final List<Widget> controls;
+  final List<String> lines;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: [
+        _ConsoleOutput(lines: lines),
+        if (controls.isNotEmpty)
+          _ConsoleControls(
+            controls: controls,
+          ),
+      ],
+    );
+  }
+}
+
+/// Renders a top-right aligned ButtonBar wrapping a List of IconButtons
+/// (`controls`).
+class _ConsoleControls extends StatelessWidget {
+  const _ConsoleControls({
+    this.controls,
+  }) : super();
+
+  final List<Widget> controls;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.topRight,
+      child: ButtonBar(
+        buttonPadding: EdgeInsets.zero,
+        alignment: MainAxisAlignment.end,
+        children: controls,
+      ),
+    );
+  }
+}
+
+/// Renders a widget with the output of the console.
+///
+/// This is a ListView of text lines, with a monospace font and a border.
+class _ConsoleOutput extends StatefulWidget {
+  const _ConsoleOutput({
+    Key key,
+    this.lines,
+  }) : super(key: key);
+
+  final List<String> lines;
+
+  @override
+  _ConsoleOutputState createState() => _ConsoleOutputState();
+}
+
+class _ConsoleOutputState extends State<_ConsoleOutput> {
+  // The scroll controller must survive ConsoleOutput re-renders
+  // to work as intended, so it must be part of the "state".
+  final ScrollController _scroll = ScrollController();
+
+  // Whenever the widget updates, refresh the scroll position if needed.
+  @override
+  void didUpdateWidget(oldWidget) {
+    if (_scroll.hasClients && _scroll.atScrollBottom) {
+      _scroll.autoScrollToBottom();
+    }
+    super.didUpdateWidget(oldWidget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle =
+        theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
+
+    return OutlineDecoration(
+      child: Scrollbar(
+        child: ListView.builder(
+          padding: const EdgeInsets.all(denseSpacing),
+          itemCount: widget.lines.length,
+          itemExtent: CodeView.rowHeight, // TODO: Get from theme?
+          controller: _scroll,
+          itemBuilder: (context, index) {
+            return RichText(
+              text: TextSpan(
+                children: processAnsiTerminalCodes(
+                  widget.lines[index],
+                  textStyle,
+                ),
+              ),
+              maxLines: 1,
+            );
+          },
+        ),
+      ),
+    );
+  }
+}
+
+// CONTROLS
+
+/// A pre-configured IconButton that fits the ux of the Console widget.
+/// 
+/// The customizations are:
+///  * Icon size: [actionsIconSize]
+///  * Do not show [tooltip] if the button is disabled
+///  * [VisualDensity.compact]
+class ConsoleControl extends StatelessWidget {
+  const ConsoleControl({this.icon, this.tooltip, this.onPressed, this.buttonKey});
+  
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+  final Key buttonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final disabled = onPressed == null;
+    return IconButton(
+      icon: Icon(icon, size: actionsIconSize),
+      onPressed: onPressed,
+      tooltip: disabled ? null : tooltip,
+      visualDensity: VisualDensity.compact,
+      key: buttonKey,
+    );
+  }
+}
+
+/// A Console Control to "delete" the contents of the console.
+/// 
+/// This just preconfigures a ConsoleControl with the `delete` icon,
+/// and the `onPressed` function passed from the outside.
+class DeleteControl extends StatelessWidget {
+  const DeleteControl({this.onPressed, this.tooltip = 'Clear contents', this.buttonKey,});
+
+  final VoidCallback onPressed;
+  final String tooltip;
+  final Key buttonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return ConsoleControl(
+      icon: Icons.delete,
+      tooltip: tooltip,
+      onPressed: onPressed,
+      buttonKey: buttonKey,
+    );
+  }
+}
+
+/// A Console Control that copies `data` to the clipboard.
+/// 
+/// If it succeeds, it displays a notification with `successMessage`.
+class CopyToClipboardControl extends StatelessWidget {
+
+  const CopyToClipboardControl({this.data, this.successMessage = 'Copied to clipboard.', this.tooltip = 'Copy to clipboard', this.buttonKey,});
+
+  final String data;
+  final String successMessage;
+  final String tooltip;
+  final Key buttonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final disabled = data == null || data.isEmpty;
+    return ConsoleControl(
+      icon: Icons.content_copy,
+      tooltip: tooltip,
+      onPressed: disabled ? null : () => copyToClipboard(data, successMessage, context),
+      buttonKey: buttonKey,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -28,6 +28,9 @@ class Console extends StatelessWidget {
   final List<Widget> controls;
   final List<String> lines;
 
+  @visibleForTesting
+  String get textContent => lines.join('\n');
+
   @override
   Widget build(BuildContext context) {
     return Material(

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -188,31 +188,34 @@ class DeleteControl extends StatelessWidget {
   }
 }
 
+/// The type of data provider function used by the CopyToClipboard Control.
+typedef ClipboardDataProvider = String Function();
+
 /// A Console Control that copies `data` to the clipboard.
 ///
 /// If it succeeds, it displays a notification with `successMessage`.
 class CopyToClipboardControl extends StatelessWidget {
   const CopyToClipboardControl({
-    this.data,
+    this.dataProvider,
     this.successMessage = 'Copied to clipboard.',
     this.tooltip = 'Copy to clipboard',
     this.buttonKey,
   });
 
-  final String data;
+  final ClipboardDataProvider dataProvider;
   final String successMessage;
   final String tooltip;
   final Key buttonKey;
 
   @override
   Widget build(BuildContext context) {
-    final disabled = data == null || data.isEmpty;
+    final disabled = dataProvider == null;
     return ConsoleControl(
       icon: Icons.content_copy,
       tooltip: tooltip,
       onPressed: disabled
           ? null
-          : () => copyToClipboard(data, successMessage, context),
+          : () => copyToClipboard(dataProvider(), successMessage, context),
       buttonKey: buttonKey,
     );
   }

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -137,8 +137,12 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
 ///  * Do not show [tooltip] if the button is disabled
 ///  * [VisualDensity.compact]
 class ConsoleControl extends StatelessWidget {
-  const ConsoleControl(
-      {this.icon, this.tooltip, this.onPressed, this.buttonKey});
+  const ConsoleControl({
+    this.icon,
+    this.tooltip,
+    this.onPressed,
+    this.buttonKey,
+  });
 
   final IconData icon;
   final String tooltip;

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -30,7 +30,8 @@ class Console extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Stack(
+    return Material(
+        child: Stack(
       children: [
         _ConsoleOutput(lines: lines),
         if (controls.isNotEmpty)
@@ -38,7 +39,7 @@ class Console extends StatelessWidget {
             controls: controls,
           ),
       ],
-    );
+    ));
   }
 }
 
@@ -103,7 +104,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
       child: Scrollbar(
         child: ListView.builder(
           padding: const EdgeInsets.all(denseSpacing),
-          itemCount: widget.lines.length,
+          itemCount: widget.lines?.length ?? 0,
           itemExtent: CodeView.rowHeight, // TODO: Get from theme?
           controller: _scroll,
           itemBuilder: (context, index) {

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -21,7 +21,10 @@ Future<void> launchUrl(String url, BuildContext context) async {
 ///
 /// Shows a `successMessage` [Notification] on the passed in `context`.
 Future<void> copyToClipboard(
-    String data, String successMessage, BuildContext context) async {
+  String data,
+  String successMessage,
+  BuildContext context,
+) async {
   await Clipboard.setData(ClipboardData(
     text: data,
   ));

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 
-import '../utils.dart';
 import 'notifications.dart';
 
 Future<void> launchUrl(String url, BuildContext context) async {
@@ -18,7 +17,9 @@ Future<void> launchUrl(String url, BuildContext context) async {
   }
 }
 
-/// Attempts to copy a bunch of `lines` to the clipboard.
+/// Attempts to copy a String of `data` to the clipboard.
+///
+/// Shows a `successMessage` [Notification] on the passed in `context`.
 Future<void> copyToClipboard(
     String data, String successMessage, BuildContext context) async {
   await Clipboard.setData(ClipboardData(

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -19,7 +19,8 @@ Future<void> launchUrl(String url, BuildContext context) async {
 }
 
 /// Attempts to copy a bunch of `lines` to the clipboard.
-Future<void> copyToClipboard(String data, String successMessage, BuildContext context) async {
+Future<void> copyToClipboard(
+    String data, String successMessage, BuildContext context) async {
   await Clipboard.setData(ClipboardData(
     text: data,
   ));

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -19,15 +19,14 @@ Future<void> launchUrl(String url, BuildContext context) async {
 }
 
 /// Attempts to copy a bunch of `lines` to the clipboard.
-Future<void> copyToClipboard(List<String> lines, BuildContext context) async {
+Future<void> copyToClipboard(String data, String successMessage, BuildContext context) async {
   await Clipboard.setData(ClipboardData(
-    text: lines.join('\n'),
+    text: data,
   ));
 
-  final numLines = lines.length;
-  Notifications.of(context)?.push(
-    'Copied $numLines ${pluralize('line', numLines)}.',
-  );
+  if (successMessage != null) {
+    Notifications.of(context)?.push(successMessage);
+  }
 }
 
 List<TextSpan> processAnsiTerminalCodes(String input, TextStyle defaultStyle) {

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -197,6 +197,9 @@ class LogDetails extends StatefulWidget {
 
   @override
   _LogDetailsState createState() => _LogDetailsState();
+
+  static const copyToClipboardButtonKey =
+      Key('log_details_copy_to_clipboard_button');
 }
 
 class _LogDetailsState extends State<LogDetails>
@@ -259,6 +262,7 @@ class _LogDetailsState extends State<LogDetails>
       controls: [
         CopyToClipboardControl(
           data: log?.prettyPrinted,
+          buttonKey: LogDetails.copyToClipboardButtonKey,
         )
       ],
     );

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -261,7 +261,7 @@ class _LogDetailsState extends State<LogDetails>
         CopyToClipboardControl(
           dataProvider: disabled ? null : () => log?.prettyPrinted,
           buttonKey: LogDetails.copyToClipboardButtonKey,
-        )
+        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -143,9 +143,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
                 onItemSelected: _select,
               ),
             ),
-            OutlineDecoration(
-              child: LogDetails(log: selected),
-            ),
+            LogDetails(log: selected),
           ],
         ),
       ),

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -4,12 +4,12 @@
 
 import 'dart:convert';
 
-import 'package:devtools_app/src/flutter/console.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
+import '../../flutter/console.dart';
 import '../../flutter/octicons.dart';
 import '../../flutter/screen.dart';
 import '../../flutter/split.dart';

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -243,9 +243,8 @@ class _LogDetailsState extends State<LogDetails>
       return Stack(
         children: [
           _buildSimpleLog(context, log),
-          if (log != null && log.needsComputing) ...[
+          if (log != null && log.needsComputing)
             const Center(child: CircularProgressIndicator()),
-          ],
         ],
       );
     }
@@ -255,11 +254,12 @@ class _LogDetailsState extends State<LogDetails>
   Widget _buildInspector(BuildContext context, LogData log) => const SizedBox();
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
+    final disabled = log?.details == null || log.details.isEmpty;
     return Console(
       lines: log?.prettyPrinted?.split('\n'),
       controls: [
         CopyToClipboardControl(
-          data: log?.prettyPrinted,
+          dataProvider: disabled ? null : () => log?.prettyPrinted,
           buttonKey: LogDetails.copyToClipboardButtonKey,
         )
       ],

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -4,6 +4,7 @@
 
 import 'dart:convert';
 
+import 'package:devtools_app/src/flutter/console.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -230,38 +231,36 @@ class _LogDetailsState extends State<LogDetails>
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Theme.of(context).cardColor,
       child: _buildContent(context, widget.log),
     );
   }
 
   Widget _buildContent(BuildContext context, LogData log) {
-    if (log == null) return const SizedBox();
-    if (log.needsComputing) {
-      return const Center(child: CircularProgressIndicator());
+    if (showInspector(log)) {
+      return _buildInspector(context, log);
+    } else {
+      return Stack(
+        children: [
+          _buildSimpleLog(context, log),
+          if (log != null && log.needsComputing) ...[
+            const Center(child: CircularProgressIndicator()),
+          ],
+        ],
+      );
     }
-    if (showInspector(log)) return _buildInspector(context, log);
-    if (showSimple(log)) return _buildSimpleLog(context, log);
-    return const SizedBox();
   }
 
   // TODO(#1370): implement this.
   Widget _buildInspector(BuildContext context, LogData log) => const SizedBox();
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
-    final RichText richText = RichText(
-      text: TextSpan(
-        children: processAnsiTerminalCodes(
-          log.prettyPrinted,
-          fixedFontStyle(context),
-        ),
-      ),
-    );
-
-    return Scrollbar(
-      child: SingleChildScrollView(
-        child: richText,
-      ),
+    return Console(
+      lines: log?.prettyPrinted?.split('\n'),
+      controls: [
+        CopyToClipboardControl(
+          data: log?.prettyPrinted,
+        )
+      ],
     );
   }
 }

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -154,6 +154,45 @@ void main() {
         await tester.pumpAndSettle();
       });
 
+      testWidgets('Copy to clipboard button enables/disables correctly',
+          (WidgetTester tester) async {
+        await pumpLoggingScreen(tester);
+
+        // Locates the copy to clipboard button's IconButton.
+        final copyButton = () => find
+            .byKey(LogDetails.copyToClipboardButtonKey)
+            .evaluate()
+            .first
+            .widget as IconButton;
+
+        expect(
+          copyButton().onPressed,
+          isNull,
+          reason:
+              'Copy to clipboard button should be disabled when no logs are selected',
+        );
+
+        await tester.tap(find.byKey(ValueKey(fakeLogData[5])));
+        await tester.pumpAndSettle();
+
+        expect(
+          copyButton().onPressed,
+          isNotNull,
+          reason:
+              'Copy to clipboard button should be enabled when a log with content is selected',
+        );
+
+        await tester.tap(find.byKey(ValueKey(fakeLogData[7])));
+        await tester.pumpAndSettle();
+
+        expect(
+          copyButton().onPressed,
+          isNull,
+          reason:
+              'Copy to clipboard button should be disabled when the log details are null',
+        );
+      });
+
       testWidgets('can compute details of non-json log data',
           (WidgetTester tester) async {
         const index = 8;

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 
 import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/src/flutter/common_widgets.dart';
+import 'package:devtools_app/src/flutter/console.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/logging/flutter/logging_screen.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
@@ -178,10 +179,9 @@ void main() {
           (WidgetTester tester) async {
         const index = 9;
         bool containsJson(Widget widget) {
-          if (widget is! RichText) return false;
-          final richText = widget as RichText;
-          return richText.text.toPlainText().contains('{') &&
-              richText.text.toPlainText().contains('}');
+          if (widget is! Console) return false;
+          final content = (widget as Console).textContent.trim();
+          return content.startsWith('{') && content.endsWith('}');
         }
 
         final findJson = find.descendant(


### PR DESCRIPTION
Reuse the Console widget from the Debugger panel in the Logging panel.

* Extract the Console widget and the Control buttons to a separate, common, file.
* Modify the Debugger and Logging panels to use the same widget.
* Tests.

Fixes https://github.com/flutter/devtools/issues/1753 (or mitigates it, since this doesn't add selectability to the details, only the copy to clipboard functionality)

This is what it looks like:

![console-in-logging-panel](https://user-images.githubusercontent.com/1255594/82388374-583ed380-99ee-11ea-9a4c-8f9771aeac6f.png)
