### PR TITLE
Move querystring values over to URL fragment

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -27,8 +27,10 @@
             window.location.href = '/unsupported-browser.html';
         }
 
-        // Handle legacy dart:html app URLs by moving query strings over to
-        // fragments.
+        // Handle URLs that pass all variables directly on a querystring without
+        // the fragment (for ex. VS Code while it has some encoding bugs preventing
+        // building the correct URLs using fragments
+        // https://github.com/microsoft/vscode/issues/85930).
         if (window.location.search && window.location.search.length > 1) {
           // Ensure each component is encoded, because if the URI contains / slashes
           // Flutter will split on them and try to push multiple routes.

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -26,6 +26,16 @@
         if (!supportsES6Classes()) {
             window.location.href = '/unsupported-browser.html';
         }
+
+        // Handle legacy dart:html app URLs by moving query strings over to
+        // fragments.
+        if (window.location.search && window.location.search.length > 1) {
+          // Ensure each component is encoded, because if the URI contains / slashes
+          // Flutter will split on them and try to push multiple routes.
+          const params = new URLSearchParams(unescape(window.location.search));
+          params.forEach(function(v, k) { params.set(k, encodeURIComponent(v)) });
+          window.location.replace(window.location.origin + '/#/?' + params.toString());
+        }
     </script>
 </head>
 


### PR DESCRIPTION
This fixes #1990, though it doesn't feel particularly elegant. The details of why we need something like this are in #1990 (in short it's to work around a VS Code URL encoding bug that isn't likely to be fixed before we ship the Flutter version of DevTools ☹️).

Another option could be to have a separate HTML page with this JS in it, and launch that from VS Code to keep the index.html clean (though this won't maintain backwards compatibility with older versions of the extension).

