### PR TITLE
set a max limit for caching the compiled devtools resources

### DIFF
--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -47,7 +47,6 @@ Future<shelf.Handler> defaultHandler(
   Handler debugProxyHandler;
   if (debugMode) {
     // Start up a flutter run -d web-server instance.
-
     const webPort = 9101;
 
     // ignore: unawaited_futures

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -130,10 +130,7 @@ final argParser = ArgParser()
 /// Wraps [serveDevTools] `arguments` parsed, as from the command line.
 ///
 /// For more information on `handler`, see [serveDevTools].
-Future<HttpServer> serveDevToolsWithArgs(
-  List<String> arguments, {
-  shelf.Handler handler,
-}) async {
+Future<HttpServer> serveDevToolsWithArgs(List<String> arguments) async {
   final args = argParser.parse(arguments);
 
   final help = args[argHelp];
@@ -163,7 +160,6 @@ Future<HttpServer> serveDevToolsWithArgs(
     port: port,
     headlessMode: headlessMode,
     numPortsToTry: numPortsToTry,
-    handler: handler,
     serviceProtocolUri: vmUri,
     profileFilename: profileAbsoluteFilename,
     verboseMode: verboseMode,
@@ -189,7 +185,6 @@ Future<HttpServer> serveDevTools({
   String hostname = 'localhost',
   int port = 0,
   int numPortsToTry = 1,
-  shelf.Handler handler,
   String serviceProtocolUri = '',
   String profileFilename = '',
 }) async {
@@ -216,7 +211,7 @@ Future<HttpServer> serveDevTools({
 
   clients = ClientManager(enableNotifications);
 
-  handler ??= await defaultHandler(clients, debugMode: debugMode);
+  final handler = await defaultHandler(clients, debugMode: debugMode);
 
   HttpServer server;
   SocketException ex;
@@ -238,6 +233,9 @@ Future<HttpServer> serveDevTools({
   if (allowEmbedding) {
     server.defaultResponseHeaders.remove('x-frame-options', 'SAMEORIGIN');
   }
+  // Ensure browsers don't cache older versions of the app.
+  server.defaultResponseHeaders
+      .add(HttpHeaders.cacheControlHeader, 'max-age=900');
   shelf.serveRequests(server, handler);
 
   final devToolsUrl = 'http://${server.address.host}:${server.port}';


### PR DESCRIPTION
- set a max limit for caching the compiled devtools resources served from the devtools server
- fix https://github.com/flutter/devtools/issues/1944
