### PR TITLE
Remove VS Code tasks/launch config for old DDC builds

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,0 @@
-{
-	"recommendations": [
-		"msjsdiag.debugger-for-chrome"
-	],
-	"unwantedRecommendations": []
-}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,14 +15,6 @@
 			]
 		},
 		{
-			"type": "chrome",
-			"request": "launch",
-			"name": "Serve DDC app",
-			"url": "http://localhost:8080",
-			"webRoot": "${workspaceFolder}/packages/devtools_app/web",
-			"preLaunchTask": "Serve DDC"
-		},
-		{
 			"type": "dart",
 			"request": "launch",
 			"name": "Run Server with Release Build",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,26 +2,6 @@
 	"version": "2.0.0",
 	"tasks": [
 		{
-			"label": "Serve DDC",
-			"type": "shell",
-			"options": {
-				"cwd": "${workspaceFolder}/packages/devtools_app",
-			},
-			"command": "flutter",
-			"args": [
-				"pub",
-				"run",
-				"build_runner",
-				"serve",
-				"web"
-			],
-			"group": "build",
-			"isBackground": true,
-			"problemMatcher": [
-				"$dart-pub-build_runner"
-			]
-		},
-		{
 			"label": "Build Release Package",
 			"type": "shell",
 			"options": {


### PR DESCRIPTION
These were an old way to run and debug the DDC dart:html version of the app (via the Chrome Debugger extension) in VS Code. These are superseded by `flutter run` and the being able to use the Dart debugger for Flutter web projects.