### PR TITLE
CI: use `dev` instead of `dev/raw/latest`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ os:
 
 language: dart
 dart:
-  - "dev/raw/latest"
+  - dev
 # Exclude stable for now as we depend on Flutter features not availabe on
 # stable.
 #  - stable


### PR DESCRIPTION
These are almost always identical – and `dev` is more standard