### PR TITLE
Rewrite flutter frames chart.

### DIFF
--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -157,8 +157,8 @@ Color titleSolidBackgroundColor(ThemeData theme) {
 }
 
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);
-
 const chartAccentColor = ThemedColor(Color(0xFFCCCCCC), Color(0xFF585858));
+const chartTextColor = ThemedColor(Colors.black, Colors.white);
 
 final chartLightTypeFace = TypeFace(
   fontFamily: 'OpenSans',

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -57,7 +57,7 @@ const smallProgressSize = 12.0;
 
 const defaultListItemHeight = 28.0;
 
-const liveChartHeight = 160.0;
+const defaultChartHeight = 160.0;
 
 const defaultTabBarViewPhysics = NeverScrollableScrollPhysics();
 
@@ -157,6 +157,8 @@ Color titleSolidBackgroundColor(ThemeData theme) {
 }
 
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);
+
+const chartAccentColor = ThemedColor(Color(0xFFCCCCCC), Color(0xFF585858));
 
 final chartLightTypeFace = TypeFace(
   fontFamily: 'OpenSans',

--- a/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_chart.dart
@@ -211,7 +211,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
                   mainAxisAlignment: MainAxisAlignment.start,
                   children: [
                     SizedBox(
-                      height: liveChartHeight,
+                      height: defaultChartHeight,
                       child: LineChart(dartChartController),
                     ),
                     _timelineSlider,
@@ -223,7 +223,7 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
         if (controller.isAndroidChartVisible)
           Expanded(
             child: SizedBox(
-              height: liveChartHeight,
+              height: defaultChartHeight,
               child: LineChart(androidChartController),
             ),
           ),

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -2,93 +2,71 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math' as math;
-import 'dart:ui';
-
 import 'package:flutter/material.dart';
-import 'package:mp_chart/mp/chart/bar_chart.dart';
-import 'package:mp_chart/mp/controller/bar_chart_controller.dart';
-import 'package:mp_chart/mp/core/axis/x_axis.dart';
-import 'package:mp_chart/mp/core/common_interfaces.dart';
-import 'package:mp_chart/mp/core/data/bar_data.dart';
-import 'package:mp_chart/mp/core/data_set/bar_data_set.dart';
-import 'package:mp_chart/mp/core/description.dart';
-import 'package:mp_chart/mp/core/entry/bar_entry.dart';
-import 'package:mp_chart/mp/core/entry/entry.dart';
-import 'package:mp_chart/mp/core/enums/limit_label_postion.dart';
-import 'package:mp_chart/mp/core/enums/x_axis_position.dart';
-import 'package:mp_chart/mp/core/highlight/highlight.dart';
-import 'package:mp_chart/mp/core/limit_line.dart';
-import 'package:mp_chart/mp/core/marker/line_chart_marker.dart';
-import 'package:mp_chart/mp/core/poolable/point.dart';
-import 'package:mp_chart/mp/core/utils/color_utils.dart';
-import 'package:mp_chart/mp/core/utils/painter_utils.dart';
-import 'package:mp_chart/mp/core/value_formatter/default_value_formatter.dart';
-import 'package:mp_chart/mp/core/value_formatter/value_formatter.dart';
 import 'package:provider/provider.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
+import '../../flutter/common_widgets.dart' show ScrollControllerAutoScroll;
 import '../../flutter/theme.dart';
 import '../../ui/colors.dart';
-import '../../ui/theme.dart';
+import '../../utils.dart';
 import 'timeline_controller.dart';
 import 'timeline_model.dart';
 
 class FlutterFramesChart extends StatefulWidget {
-  const FlutterFramesChart();
+  const FlutterFramesChart(
+    this.frames,
+    this.longestFrameDurationMs,
+    this.displayRefreshRate,
+  );
+
+  final List<TimelineFrame> frames;
+
+  final int longestFrameDurationMs;
+
+  final double displayRefreshRate;
 
   @override
   _FlutterFramesChartState createState() => _FlutterFramesChartState();
 }
 
 class _FlutterFramesChartState extends State<FlutterFramesChart>
-    with AutoDisposeMixin
-    implements OnChartValueSelectedListener {
-  static const maxFrames = 150;
+    with AutoDisposeMixin {
+  static const maxMsForDisplay = 48.0;
+  static const minMsForDisplay = 18.0;
 
-  /// Datapoint entry for each frame duration (UI/Raster) for stacked bars.
-  final _frameDurations = <BarEntry>[];
+  static const defaultFrameWidth = 32.0;
+  static const defaultFrameWidthWithPadding =
+      defaultFrameWidth + densePadding * 2;
 
-  /// Set of all duration information (the data, colors, etc).
-  BarDataSet frameDurationsSet;
+  static const yAxisUnitsSpace = 48.0;
 
-  BarChartController _chartController;
-
-  BarChartController get chartController => _chartController;
+  static const legendSquareSize = 16.0;
 
   TimelineController _controller;
 
-  int indexOffset = 0;
+  ScrollController scrollController;
 
-  /// Compute the FPS highwater mark based on the displayRefreshRate from
-  /// FrameBasedTimeline.
-  void _setupFPSHighwaterLine() async {
-    if (_chartController.axisLeftSettingFunction == null) {
-      final fpsRate = await _controller.displayRefreshRate;
+  TimelineFrame _selectedFrame;
 
-      // Max FPS non-jank value in ms. E.g., 16.6 for 60 FPS, 8.3 for 120 FPS.
-      final targetMsPerFrame = 1 / fpsRate * 1000;
+  double horizontalScrollOffset = 0.0;
 
-      _chartController.axisLeftSettingFunction = (axisLeft, controller) {
-        axisLeft
-          ..setStartAtZero(true)
-          ..typeface = chartLightTypeFace
-          ..textColor = defaultForeground
-          ..drawGridLines = false
-          ..setValueFormatter(YAxisUnitFormatter())
-          ..addLimitLine(LimitLine(
-            targetMsPerFrame,
-            '${fpsRate.toStringAsFixed(0)} FPS',
-          )
-            // TODO(terry): LEFT_TOP is clipped need to fix in MPFlutterChart.
-            ..labelPosition = LimitLabelPosition.RIGHT_TOP
-            ..textSize = 10
-            ..typeface = chartBoldTypeFace
-            // TODO(terry): Below crashed Flutter in Travis see issues/1338.
-            // ..enableDashedLine(5, 5, 0)
-            ..lineColor = const Color.fromARGB(0x80, 0xff, 0x44, 0x44));
-      };
-    }
+  double get totalChartWidth =>
+      widget.frames.length * defaultFrameWidthWithPadding;
+
+  double get availableChartHeight => defaultChartHeight - defaultSpacing;
+
+  double get msPerPx =>
+      widget.longestFrameDurationMs.clamp(minMsForDisplay, maxMsForDisplay) /
+      availableChartHeight;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollController = ScrollController()
+      ..addListener(() {
+        horizontalScrollOffset = scrollController.offset;
+      });
   }
 
   @override
@@ -99,269 +77,324 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     _controller = newController;
 
     cancel();
-    autoDispose(_controller.onTimelineCleared.listen((_) {
+    addAutoDisposeListener(_controller.selectedFrame, () {
       setState(() {
-        _frameDurations.clear();
-        _updateChart();
+        _selectedFrame = _controller.selectedFrame.value;
       });
-    }));
-
-    setState(() {
-      _setupFPSHighwaterLine();
     });
-    autoDispose(_controller.onTimelineProcessed.listen((_) => _loadData()));
-    autoDispose(_controller.onLoadOfflineData.listen((_) => _loadData()));
-  }
-
-  void _loadData() {
-    _frameDurations.clear();
-    final frames = _controller.data?.frames ?? [];
-    if (frames.isNotEmpty) {
-      final startFrameIndex = math.max(0, frames.length - maxFrames);
-      for (int i = startFrameIndex; i < frames.length; i++) {
-        _frameDurations.add(createBarEntry(frames[i], i - startFrameIndex));
-      }
-    }
-    _updateChart();
   }
 
   @override
-  void initState() {
-    _initChartController();
-    _initData();
-    super.initState();
-  }
-
-  void _initChartController() {
-    final desc = Description()..enabled = false;
-    _chartController = BarChartController(
-      backgroundColor: chartBackgroundColor,
-      // The axisLeftSettingFunction is computed in didChangeDependencies,
-      // see _setupFPSHighwaterLine.
-      axisRightSettingFunction: (axisRight, controller) {
-        axisRight.enabled = false;
-      },
-      xAxisSettingFunction: (XAxis xAxis, controller) {
-        xAxis
-          ..enabled = true
-          ..drawLabels = true
-          ..setLabelCount1(3)
-          ..textColor = defaultForeground
-          ..position = XAxisPosition.BOTTOM;
-      },
-      legendSettingFunction: (legend, controller) {
-        legend.enabled = false;
-      },
-      drawGridBackground: false,
-//      dragXEnabled: true,
-//      dragYEnabled: true,
-//      scaleXEnabled: true,
-//      scaleYEnabled: true,
-//      pinchZoomEnabled: false,
-//      maxVisibleCount: 60,
-      drawBarShadow: false,
-      description: desc,
-      highLightPerTapEnabled: true,
-      marker: SelectedDataPoint(onSelected: onBarSelected),
-      selectionListener: this,
-    );
-
-    // Compute padding around chart.
-    _chartController.setViewPortOffsets(
-        defaultSpacing * 3, denseSpacing, defaultSpacing, defaultSpacing);
-  }
-
-  void onBarSelected(int index) {
-    _controller.selectFrame(_controller.data.frames[index + indexOffset]);
-  }
-
-  void _initData() {
-    // Create place holder for empty chart.
-    // TODO(terry): Look at fixing MPFlutterChart to handle empty data entries.
-    _frameDurations.add(createStubBarEntry());
-
-    // Create heap used dataset.
-    frameDurationsSet = BarDataSet(_frameDurations, 'Durations')
-      ..setColors1([mainRasterColor, mainUiColor])
-      ..setDrawValues(false);
-
-    // Create a data object with all the data sets - stacked bar.
-    _chartController.data = BarData([]..add(frameDurationsSet));
-
-    // specify the width each bar should have
-    _chartController.data.barWidth = 0.8;
-  }
-
-  BarEntry createStubBarEntry() {
-    return BarEntry.fromListYVals(x: 0.0, vals: [0.0, 0.0]);
-  }
-
-  // TODO(terry): Consider grouped bars (UI/Raster) not stacked.
-  BarEntry createBarEntry(TimelineFrame frame, int index) {
-    if (frame.uiDurationMs + frame.rasterDurationMs > 250) {
-      // Constrain the y-axis so outliers don't blow the barchart scale.
-      // TODO(terry): Need to have a max where the hover value shows the real #s but the chart just looks pinned to the top.
-      _chartController.axisLeft?.setAxisMaximum(250);
+  void didUpdateWidget(FlutterFramesChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (scrollController.hasClients && scrollController.atScrollBottom) {
+      scrollController.autoScrollToBottom();
     }
-
-    // TODO(terry): Structured class item 0 is Raster, item 1 is UI if not stacked.
-    final entry = BarEntry.fromListYVals(
-      x: index.toDouble(),
-      vals: [
-        frame.rasterDurationMs.toDouble(),
-        frame.uiDurationMs.toDouble(),
-      ],
-    );
-
-    return entry;
   }
 
-  void _updateChart() {
-    _chartController.data = BarData([]..add(frameDurationsSet));
-
-    setState(() {
-      // Signal data has changed.
-      frameDurationsSet.notifyDataSetChanged();
-      _setupFPSHighwaterLine();
-    });
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(
+        left: denseSpacing,
+        right: denseSpacing,
+        bottom: defaultSpacing,
+      ),
+      height: defaultChartHeight,
+      child: Row(
+        children: [
+          Expanded(child: _buildChart()),
+          const SizedBox(width: defaultSpacing),
+          _buildChartLegend(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChart() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final chart = ListView.builder(
+          controller: scrollController,
+          scrollDirection: Axis.horizontal,
+          itemCount: widget.frames.length,
+          itemExtent: defaultFrameWidthWithPadding,
+          itemBuilder: (context, index) => _buildFrame(widget.frames[index]),
+        );
+        final chartAxisPainter = CustomPaint(
+          painter: ChartAxisPainter(
+            constraints: constraints,
+            totalWidth: totalChartWidth,
+            displayRefreshRate: widget.displayRefreshRate,
+            msPerPx: msPerPx,
+          ),
+        );
+        final fpsLinePainter = CustomPaint(
+          painter: FPSLinePainter(
+            constraints: constraints,
+            totalWidth: totalChartWidth,
+            displayRefreshRate: widget.displayRefreshRate,
+            msPerPx: msPerPx,
+          ),
+        );
+        return Stack(
+          children: [
+            chartAxisPainter,
+            Padding(
+              padding: const EdgeInsets.only(left: yAxisUnitsSpace),
+              child: chart,
+            ),
+            fpsLinePainter,
+          ],
+        );
+      },
+    );
+  }
+
+  // TODO(kenz): add some indicator when a frame is so janky that it exceeds the
+  // available axis space.
+  Widget _buildFrame(TimelineFrame frame) {
+    final selected = frame == _selectedFrame;
+    final janky = _isFrameJanky(frame);
+
+    Color uiColor() {
+      if (selected) return selectedFlutterFrameUiColor;
+      if (janky) return uiJankColor;
+      return mainUiColor;
+    }
+
+    Color rasterColor() {
+      if (selected) return selectedFlutterFrameRasterColor;
+      if (janky) return rasterJankColor;
+      return mainRasterColor;
+    }
+
+    final ui = Container(
+      width: defaultFrameWidth / 2,
+      height: (frame.uiDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      color: uiColor(),
+    );
+    final raster = Container(
+      width: defaultFrameWidth / 2,
+      height:
+          (frame.rasterDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      color: rasterColor(),
+    );
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: densePadding),
+      child: Column(
+        children: [
+          // Dummy child so that the InkWell does not take up the entire column.
+          const Expanded(child: SizedBox()),
+          InkWell(
+            // TODO(kenz): make tooltip to persist if the frame is selected.
+            // TODO(kenz): change color on hover.
+            onTap: () => _controller.selectFrame(frame),
+            child: Tooltip(
+              message: _tooltipText(frame),
+              padding: const EdgeInsets.all(denseSpacing),
+              preferBelow: false,
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: [
+                  ui,
+                  raster,
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChartLegend() {
     return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Container(
-          height: liveChartHeight,
-          child: BarChart(_chartController),
-        ),
-        const SizedBox(height: denseSpacing),
+        _legendItem('UI (Dart)', mainUiColor),
+        _legendItem('Raster (Flutter Engine)', mainRasterColor),
+        _legendItem('Jank (slow frame)', uiJankColor),
+        _legendItem('Selected frame', selectedFlutterFrameUiColor),
       ],
     );
   }
 
-  /// OnChartValueSelectedListener override.
-  @override
-  void onNothingSelected() {
-    print('Nothing Selected');
+  Widget _legendItem(String description, Color color) {
+    return Row(
+      children: [
+        Container(
+          height: legendSquareSize,
+          width: legendSquareSize,
+          color: color,
+        ),
+        const SizedBox(width: denseSpacing),
+        Text(description),
+      ],
+    );
   }
 
-  /// OnChartValueSelectedListener override.
-  @override
-  void onValueSelected(Entry e, Highlight h) {
-    // TODO(terry): Either use onTouchDown or add mouse position to laggy.
-    final yValues = (e as BarEntry).yVals;
-    print(
-      'onValueSelected - Frame Index = ${e.x}, '
-      'Raster = ${yValues[0]}, UI = ${yValues[1]}',
-    );
+  String _tooltipText(TimelineFrame frame) {
+    return 'UI: ${msText(frame.uiEventFlow.time.duration)}\n'
+        'Raster: ${msText(frame.rasterEventFlow.time.duration)}';
+  }
+
+  bool _isFrameJanky(TimelineFrame frame) {
+    final targetMsPerFrame = 1 / widget.displayRefreshRate * 1000;
+    return frame.uiDurationMs > targetMsPerFrame ||
+        frame.rasterDurationMs > targetMsPerFrame;
   }
 }
 
-class YAxisUnitFormatter extends ValueFormatter {
-  @override
-  String getFormattedValue1(double value) => '${value.toInt()} ms';
-}
+class ChartAxisPainter extends CustomPainter {
+  ChartAxisPainter({
+    @required this.constraints,
+    @required this.totalWidth,
+    @required this.displayRefreshRate,
+    @required this.msPerPx,
+  });
 
-typedef SelectionCallback = void Function(int frameIndex);
+  final BoxConstraints constraints;
 
-/// Selection of a point in the Bar chart displays the data point values
-/// UI duration and Raster duration. Also, highlight the selected stacked bar.
-/// Uses marker/highlight mechanism which lags because it uses onTapUp maybe
-/// onTapDown would be less laggy.
-///
-/// TODO(terry): Highlighting is not efficient, a faster mechanism to return
-/// the Entry being clicked is needed.
-///
-/// onSelected callback function invoked when bar entry is selected.
-class SelectedDataPoint extends LineChartMarker {
-  SelectedDataPoint({
-    this.textColor,
-    this.backColor,
-    this.fontSize,
-    this.onSelected,
-  }) {
-    _formatter = DefaultValueFormatter(2);
-    textColor ??= ColorUtils.WHITE;
-    backColor ??= const Color.fromARGB(127, 0, 0, 0);
-    fontSize ??= 10;
-  }
+  final double totalWidth;
 
-  Entry _entry;
+  final double displayRefreshRate;
 
-  DefaultValueFormatter _formatter;
-
-  Color textColor;
-
-  Color backColor;
-
-  double fontSize;
-
-  int _lastFrameIndex = -1;
-
-  final SelectionCallback onSelected;
+  final double msPerPx;
 
   @override
-  void draw(Canvas canvas, double posX, double posY) {
-    const positionAboveBar = 15;
-    const paddingAroundText = 5;
-    const rectangleCurve = 5.0;
-
-    final yValues = (_entry as BarEntry).yVals;
-
-    final num uiDuration = yValues[1];
-    final num rasterDuration = yValues[0];
-
-    final TextPainter painter = PainterUtils.create(
-      null,
-      'UI  = ${_formatter.getFormattedValue1(uiDuration)}\n'
-      'Raster = ${_formatter.getFormattedValue1(rasterDuration)}',
-      textColor,
-      fontSize,
-    )..textAlign = TextAlign.left;
-
-    final Paint paint = Paint()
-      ..color = backColor
-      ..strokeWidth = 2
-      ..isAntiAlias = true
-      ..style = PaintingStyle.fill;
-
-    final MPPointF offset = getOffsetForDrawingAtPoint(
-      posX,
-      posY,
+  void paint(Canvas canvas, Size size) {
+    // The absolute coordinates of the chart's visible area.
+    final chartArea = Rect.fromLTWH(
+      _FlutterFramesChartState.yAxisUnitsSpace,
+      0.0,
+      constraints.maxWidth - _FlutterFramesChartState.yAxisUnitsSpace,
+      constraints.maxHeight,
     );
 
-    canvas.save();
-    // translate to the correct position and draw
-    painter.layout();
-    final Offset pos = calculatePos(
-      posX + offset.x,
-      posY + offset.y - positionAboveBar,
-      painter.width,
-      painter.height,
+    // Paint the Y axis.
+    canvas.drawLine(
+      chartArea.topLeft,
+      chartArea.bottomLeft,
+      Paint()..color = chartAccentColor,
     );
-    canvas.drawRRect(
-      RRect.fromLTRBR(
-        pos.dx - paddingAroundText,
-        pos.dy - paddingAroundText,
-        pos.dx + painter.width + paddingAroundText,
-        pos.dy + painter.height + paddingAroundText,
-        const Radius.circular(rectangleCurve),
-      ),
-      paint,
-    );
-    painter.paint(canvas, pos);
-    canvas.restore();
-  }
 
-  @override
-  void refreshContent(Entry e, Highlight highlight) async {
-    _entry = e;
-    // TODO(kenz): see if we can make `x` an int - double seems strange.
-    final frameIndex = _entry.x.toInt();
-    if (onSelected != null && _lastFrameIndex != frameIndex) {
-      _lastFrameIndex = frameIndex;
-      WidgetsBinding.instance
-          .addPostFrameCallback((_) => onSelected(frameIndex));
+    // Paint the X axis
+    canvas.drawLine(
+      chartArea.bottomLeft,
+      chartArea.bottomRight,
+      Paint()..color = chartAccentColor,
+    );
+
+    const yAxisTickWidth = 8.0;
+    const yAxisLabelCount = 6;
+    final totalMs = msPerPx * constraints.maxHeight;
+    // Subtract 1 because one of the labels will be 0.0 ms.
+    final timeUnitMs = totalMs ~/ (yAxisLabelCount - 1);
+    for (int i = 0; i < yAxisLabelCount; i++) {
+      final labelMs = i * timeUnitMs;
+      final labelText = msText(
+        Duration(milliseconds: labelMs),
+        fractionDigits: 0,
+      );
+
+      // Paint a tick on the axis.
+      final tickY = constraints.maxHeight - labelMs / msPerPx;
+      canvas.drawLine(
+        Offset(chartArea.left - yAxisTickWidth / 2, tickY),
+        Offset(chartArea.left + yAxisTickWidth / 2, tickY),
+        Paint()..color = chartAccentColor,
+      );
+
+      // Paint the axis label.
+      final textPainter = TextPainter(
+        text: TextSpan(text: labelText),
+        textAlign: TextAlign.right,
+        textDirection: TextDirection.ltr,
+      )..layout();
+
+      textPainter.paint(
+        canvas,
+        Offset(
+          0.0,
+          constraints.maxHeight - labelMs / msPerPx - textPainter.height / 2,
+        ),
+      );
     }
+  }
+
+  @override
+  bool shouldRepaint(ChartAxisPainter oldDelegate) {
+    return false;
+  }
+}
+
+class FPSLinePainter extends CustomPainter {
+  FPSLinePainter({
+    @required this.constraints,
+    @required this.totalWidth,
+    @required this.displayRefreshRate,
+    @required this.msPerPx,
+  });
+
+  static const fpsLineColor = Color.fromARGB(0x80, 0xff, 0x44, 0x44);
+
+  static const fpsTextSpace = 60.0;
+
+  final BoxConstraints constraints;
+
+  final double totalWidth;
+
+  final double displayRefreshRate;
+
+  final double msPerPx;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // The absolute coordinates of the chart's visible area.
+    final chartArea = Rect.fromLTWH(
+      _FlutterFramesChartState.yAxisUnitsSpace,
+      0.0,
+      constraints.maxWidth - _FlutterFramesChartState.yAxisUnitsSpace,
+      constraints.maxHeight,
+    );
+
+    // Max FPS non-jank value in ms. E.g., 16.6 for 60 FPS, 8.3 for 120 FPS.
+    final targetMsPerFrame = 1 / displayRefreshRate * 1000;
+    final targetLineY = constraints.maxHeight - targetMsPerFrame / msPerPx;
+
+    canvas.drawLine(
+      Offset(chartArea.left, targetLineY),
+      Offset(chartArea.right - fpsTextSpace, targetLineY),
+      Paint()
+        ..color = fpsLineColor
+        ..strokeWidth = 2.0,
+    );
+
+    final textPainter = TextPainter(
+      text: TextSpan(text: '${displayRefreshRate.toStringAsFixed(0)} FPS'),
+      textAlign: TextAlign.right,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    textPainter.paint(
+      canvas,
+      Offset(
+        chartArea.right - fpsTextSpace + denseSpacing,
+        targetLineY - textPainter.height / 2,
+      ),
+    );
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return false;
   }
 }

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_flame_chart.dart
@@ -583,10 +583,6 @@ class TimelineGridPainter extends CustomPainter {
   });
 
   static const baseGridIntervalPx = 150.0;
-  static const gridLineColor = ThemedColor(
-    Color(0xFFCCCCCC),
-    Color(0xFF585858),
-  );
   static const timestampOffset = 6.0;
   static const timestampColor = ThemedColor(
     Color(0xFF24292E),
@@ -686,7 +682,7 @@ class TimelineGridPainter extends CustomPainter {
     canvas.drawLine(
       Offset(lineX, origin),
       Offset(lineX, constraints.maxHeight),
-      Paint()..color = gridLineColor,
+      Paint()..color = chartAccentColor,
     );
   }
 

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -146,7 +146,19 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
         const SizedBox(height: denseRowSpacing),
         if (isOfflineFlutterApp ||
             (!offlineMode && serviceManager.connectedApp.isFlutterAppNow))
-          const FlutterFramesChart(),
+          ValueListenableBuilder(
+            valueListenable: controller.flutterFrames,
+            builder: (context, frames, _) => ValueListenableBuilder(
+              valueListenable: controller.displayRefreshRate,
+              builder: (context, displayRefreshRate, _) {
+                return FlutterFramesChart(
+                  frames,
+                  controller.longestFramePortionMs,
+                  displayRefreshRate,
+                );
+              },
+            ),
+          ),
         Expanded(
           child: Split(
             axis: Axis.vertical,
@@ -293,12 +305,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
 
     return Padding(
       padding: const EdgeInsets.only(bottom: 8.0),
-      child: Container(
-        decoration: BoxDecoration(
-          border: Border.all(color: Theme.of(context).focusColor),
-        ),
-        child: content,
-      ),
+      child: OutlineDecoration(child: content),
     );
   }
 

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -34,15 +34,6 @@ const mainRasterColorDark = Color(0xFF1A73E8); // Blue 600 Material Dark
 const mainUiColorSelectedDark = Colors.white;
 const mainRasterColorSelectedDark = Color(0xFFC9C9C9); // Grey.
 
-const Color selectedUiColor = ThemedColor(
-  mainUiColorSelectedLight,
-  mainUiColorSelectedDark,
-);
-const Color selectedRasterColor = ThemedColor(
-  mainRasterColorSelectedLight,
-  mainRasterColorSelectedDark,
-);
-
 // Light Blue 50: 200-400 (light mode) - see https://material.io/design/color/the-color-system.html#tools-for-picking-colors.
 // Blue Material Dark: 200-400 (dark mode) - see https://standards.google/guidelines/google-material/color/dark-theme.html#style.
 final uiColorPalette = [

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -84,17 +84,13 @@ const selectedFlameChartItemColor = ThemedColor(
   mainUiColorSelectedLight,
 );
 
-// Light is Red @ .2 opacity, Dark is Red 200 Material Dark @ .2 opacity.
-const Color jankGlowInside = ThemedColor(
-  Color(0x66FF0000),
-  Color(0x66F29C99),
-);
+final selectedFlutterFrameUiColor = Colors.yellow[500];
+final selectedFlutterFrameRasterColor = Colors.yellow[700];
 
-// Light is Red @ .5 opacity, Dark is Red 600 Material Dark @ .6 opacity.
-const Color jankGlowEdge = ThemedColor(
-  Color(0x80FF0000),
-  Color(0x99CE191C),
-);
+// [mainUiColor] with a red 0.4 opacity overlay.
+final uiJankColor = ThemedColor.fromSingleColor(const Color(0xFFCA82A1));
+// [mainRasterColor] with a red 0.4 opacity overlay.
+final rasterJankColor = ThemedColor.fromSingleColor(const Color(0xFF845697));
 
 // Red 50 - 400 is light at 1/2 opacity, Dark Red 500 Material Dark.
 const Color highwater16msColor = mainUiColorSelectedLight;

--- a/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
@@ -43,7 +43,7 @@ void main() {
     });
 
     testWidgets('builds with frames', (WidgetTester tester) async {
-      await pumpChart(tester, frames: [testFrame1, testFrame2]);
+      await pumpChart(tester, frames: [testFrame0, testFrame1]);
       expect(find.byKey(FlutterFramesChart.chartLegendKey), findsOneWidget);
       expect(find.byType(FlutterFramesChartItem), findsNWidgets(2));
     });
@@ -62,33 +62,3 @@ void main() {
     });
   });
 }
-
-final testFrame1 = TimelineFrame('testFrame1')
-  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 10)
-      ..end = const Duration(milliseconds: 20)))
-  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 15)
-      ..end = const Duration(milliseconds: 25)));
-
-final testFrame2 = TimelineFrame('testFrame2')
-  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 30)
-      ..end = const Duration(milliseconds: 35)))
-  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 33)
-      ..end = const Duration(milliseconds: 40)));
-
-final jankyFrame = TimelineFrame('jankyFrame')
-  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 50)
-      ..end = const Duration(milliseconds: 70)))
-  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
-    ..time = (TimeRange()
-      ..start = const Duration(milliseconds: 68)
-      ..end = const Duration(milliseconds: 75)));

--- a/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/timeline/flutter/flutter_frames_chart.dart';
+import 'package:devtools_app/src/timeline/flutter/timeline_model.dart';
+import 'package:devtools_app/src/timeline/flutter/timeline_controller.dart';
+import 'package:devtools_app/src/ui/colors.dart';
+import 'package:devtools_app/src/utils.dart';
+import 'package:devtools_testing/support/flutter/timeline_test_data.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../support/mocks.dart';
+import 'wrappers.dart';
+
+void main() {
+  Future<void> pumpChart(
+    WidgetTester tester, {
+    @required List<TimelineFrame> frames,
+  }) async {
+    await tester.pumpWidget(wrapWithControllers(
+      FlutterFramesChart(frames, 20, defaultRefreshRate),
+      timeline: TimelineController(),
+    ));
+    await tester.pumpAndSettle();
+    expect(find.byType(FlutterFramesChart), findsOneWidget);
+  }
+
+  group('TimelineScreen', () {
+    setUp(() async {
+      setGlobal(
+          ServiceConnectionManager, FakeServiceManager(useFakeService: true));
+    });
+
+    testWidgets('builds with no frames', (WidgetTester tester) async {
+      await pumpChart(tester, frames: []);
+      expect(find.byKey(FlutterFramesChart.chartLegendKey), findsOneWidget);
+      expect(find.byType(FlutterFramesChartItem), findsNothing);
+    });
+
+    testWidgets('builds with frames', (WidgetTester tester) async {
+      await pumpChart(tester, frames: [testFrame1, testFrame2]);
+      expect(find.byKey(FlutterFramesChart.chartLegendKey), findsOneWidget);
+      expect(find.byType(FlutterFramesChartItem), findsNWidgets(2));
+    });
+
+    testWidgets('builds with janky frame', (WidgetTester tester) async {
+      await pumpChart(tester, frames: [jankyFrame]);
+      expect(find.byKey(FlutterFramesChart.chartLegendKey), findsOneWidget);
+      expect(find.byType(FlutterFramesChartItem), findsOneWidget);
+      final ui = tester.widget(find.byKey(const Key('frame jankyFrame - ui')))
+          as Container;
+      expect(ui.color, equals(uiJankColor));
+      final raster =
+          tester.widget(find.byKey(const Key('frame jankyFrame - raster')))
+              as Container;
+      expect(raster.color, equals(rasterJankColor));
+    });
+  });
+}
+
+final testFrame1 = TimelineFrame('testFrame1')
+  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 10)
+      ..end = const Duration(milliseconds: 20)))
+  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 15)
+      ..end = const Duration(milliseconds: 25)));
+
+final testFrame2 = TimelineFrame('testFrame2')
+  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 30)
+      ..end = const Duration(milliseconds: 35)))
+  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 33)
+      ..end = const Duration(milliseconds: 40)));
+
+final jankyFrame = TimelineFrame('jankyFrame')
+  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 50)
+      ..end = const Duration(milliseconds: 70)))
+  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 68)
+      ..end = const Duration(milliseconds: 75)));

--- a/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/flutter/flutter_frames_chart_test.dart
@@ -9,7 +9,6 @@ import 'package:devtools_app/src/timeline/flutter/flutter_frames_chart.dart';
 import 'package:devtools_app/src/timeline/flutter/timeline_model.dart';
 import 'package:devtools_app/src/timeline/flutter/timeline_controller.dart';
 import 'package:devtools_app/src/ui/colors.dart';
-import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_testing/support/flutter/timeline_test_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
@@ -8,6 +8,7 @@
 @TestOn('vm')
 import 'package:devtools_app/src/timeline/flutter/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/flutter/timeline_model.dart';
+import 'package:devtools_app/src/utils.dart';
 import 'package:test/test.dart';
 
 import '../support/flutter/timeline_test_data.dart';
@@ -86,12 +87,11 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       await env.setupEnvironment();
 
       // Select a frame.
-      final frame_0 = TimelineFrame('id_0');
       expect(timelineController.data.selectedFrame, isNull);
-      timelineController.selectFrame(frame_0);
+      timelineController.selectFrame(testFrame0);
       expect(
         timelineController.data.selectedFrame,
-        equals(frame_0),
+        equals(testFrame0),
       );
 
       // Select a timeline event.
@@ -101,11 +101,10 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
       expect(timelineController.data.selectedEvent, equals(vsyncEvent));
 
       // Select a different frame.
-      final frame_1 = TimelineFrame('id_1');
-      timelineController.selectFrame(frame_1);
+      timelineController.selectFrame(testFrame1);
       expect(
         timelineController.data.selectedFrame,
-        equals(frame_1),
+        equals(testFrame1),
       );
       expect(timelineController.data.selectedEvent, isNull);
       expect(timelineController.data.cpuProfileData, isNull);
@@ -116,7 +115,7 @@ Future<void> runTimelineControllerTests(FlutterTestEnvironment env) async {
     test('add frame', () async {
       await env.setupEnvironment();
       expect(timelineController.data.frames, isEmpty);
-      timelineController.addFrame(TimelineFrame('id'));
+      timelineController.addFrame(testFrame1);
       expect(
         timelineController.data.frames.length,
         equals(1),

--- a/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
+++ b/packages/devtools_testing/lib/flutter/timeline_controller_test.dart
@@ -8,7 +8,6 @@
 @TestOn('vm')
 import 'package:devtools_app/src/timeline/flutter/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/flutter/timeline_model.dart';
-import 'package:devtools_app/src/utils.dart';
 import 'package:test/test.dart';
 
 import '../support/flutter/timeline_test_data.dart';

--- a/packages/devtools_testing/lib/support/flutter/timeline_test_data.dart
+++ b/packages/devtools_testing/lib/support/flutter/timeline_test_data.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:devtools_app/src/timeline/flutter/timeline_model.dart';
 import 'package:devtools_app/src/trace_event.dart';
+import 'package:devtools_app/src/utils.dart';
 
 import '../cpu_profile_test_data.dart';
 import 'test_utils.dart';
@@ -45,6 +46,18 @@ final testFrame0 = TimelineFrame('id_0')
 final testFrame1 = TimelineFrame('id_1')
   ..setEventFlow(goldenUiTimelineEvent)
   ..setEventFlow(goldenRasterTimelineEvent);
+
+final jankyFrame = TimelineFrame('jankyFrame')
+  // ignore: invalid_use_of_visible_for_testing_member
+  ..eventFlows[0] = (goldenUiTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 50)
+      ..end = const Duration(milliseconds: 70)))
+  // ignore: invalid_use_of_visible_for_testing_member
+  ..eventFlows[1] = (goldenRasterTimelineEvent.deepCopy()
+    ..time = (TimeRange()
+      ..start = const Duration(milliseconds: 68)
+      ..end = const Duration(milliseconds: 75)));
 
 // Mark: UI golden data.
 // None of the following data should be modified. If you have a need to modify


### PR DESCRIPTION
- Rewrite chart without the mp_chart dependency.
- Place UI / Raster times side-by-side instead of stacking them. We were previously giving noisy results for UI jank. Both the UI and Raster portion of the frame should be given 16.6 ms before we label the frame as "janky" - cc @liyuqian (related https://github.com/flutter/devtools/issues/451 https://github.com/flutter/devtools/issues/450)
- Color janky frames in a red overlay
- Color selected frame in Flutter yellow selection color (cc @raison00)
- Add chart legend on the right side

<img width="1329" alt="Screen Shot 2020-05-25 at 1 45 15 PM" src="https://user-images.githubusercontent.com/43759233/82842686-51510e80-9e8f-11ea-9b51-550d3e8dcf2f.png">

**EDIT**
<img width="1113" alt="Screen Shot 2020-05-26 at 2 33 51 PM" src="https://user-images.githubusercontent.com/43759233/83039544-2bdd1580-9ff3-11ea-9613-6e1f0d4c0da9.png">
<img width="1114" alt="Screen Shot 2020-05-26 at 1 12 54 PM" src="https://user-images.githubusercontent.com/43759233/83039564-313a6000-9ff3-11ea-80b1-faa5c38cb7c5.png">

Fixes https://github.com/flutter/devtools/issues/1381
Fixes https://github.com/flutter/devtools/issues/1030
Fixes https://github.com/flutter/devtools/issues/1338