### PR TITLE
misc inspector work

### DIFF
--- a/packages/devtools_app/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics_node.dart
@@ -598,11 +598,6 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   Widget get icon {
     if (isProperty) return null;
 
-//    Widget icon = widget?.icon;
-//    if (icon == null && widgetRuntimeType != null) {
-//      icon ??= iconMaker.fromWidgetName(widgetRuntimeType);
-//    }
-
     return iconMaker.fromWidgetName(widgetRuntimeType);
   }
 

--- a/packages/devtools_app/lib/src/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics_node.dart
@@ -597,11 +597,13 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
 
   Widget get icon {
     if (isProperty) return null;
-    Widget icon = widget?.icon;
-    if (icon == null && widgetRuntimeType != null) {
-      icon ??= iconMaker.fromWidgetName(widgetRuntimeType);
-    }
-    return icon;
+
+//    Widget icon = widget?.icon;
+//    if (icon == null && widgetRuntimeType != null) {
+//      icon ??= iconMaker.fromWidgetName(widgetRuntimeType);
+//    }
+
+    return iconMaker.fromWidgetName(widgetRuntimeType);
   }
 
   /// Returns true if two diagnostic nodes are indistinguishable from

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen.dart
@@ -192,39 +192,32 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
 
   Widget _expandCollapseButtons() {
     if (!_expandCollapseSupported) return null;
+
     return Align(
       alignment: Alignment.topRight,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 6),
-        // Add a semi-transparent background to the
-        // expand and collapse buttons so they don't interfere
-        // too badly with the tree content when the tree
-        // is narrow.
-        color: Theme.of(context).scaffoldBackgroundColor.withAlpha(200),
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.end,
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Flexible(
-              child: OutlineButton(
-                onPressed: enableButtons ? _onExpandClick : null,
-                child: const Text(
-                  'Expand all',
-                  overflow: TextOverflow.ellipsis,
-                ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Flexible(
+            child: OutlineButton(
+              onPressed: enableButtons ? _onExpandClick : null,
+              child: const Text(
+                'Expand all',
+                overflow: TextOverflow.ellipsis,
               ),
             ),
-            Flexible(
-              child: OutlineButton(
-                onPressed: enableButtons ? _onResetClick : null,
-                child: const Text(
-                  'Collapse to selected',
-                  overflow: TextOverflow.ellipsis,
-                ),
+          ),
+          Flexible(
+            child: OutlineButton(
+              onPressed: enableButtons ? _onResetClick : null,
+              child: const Text(
+                'Collapse to selected',
+                overflow: TextOverflow.ellipsis,
               ),
-            )
-          ],
-        ),
+            ),
+          )
+        ],
       ),
     );
   }

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_screen_details_tab.dart
@@ -67,47 +67,57 @@ class _InspectorDetailsTabControllerState
     final _tabController = widget.layoutExplorerSupported
         ? _tabControllerWithLayoutExplorer
         : _tabControllerWithoutLayoutExplorer;
-    final focusColor = Theme.of(context).focusColor;
-    return Container(
-      decoration: BoxDecoration(
-        border: Border.all(color: focusColor),
-      ),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Container(
-            padding: const EdgeInsets.only(bottom: 8.0),
-            child: Row(
-              children: <Widget>[
-                Flexible(
-                  child: Container(
-                    color: focusColor,
-                    child: TabBar(
-                      controller: _tabController,
-                      labelColor: Theme.of(context).textTheme.bodyText1.color,
-                      tabs: tabs,
-                      isScrollable: true,
-                    ),
-                  ),
+
+    final theme = Theme.of(context);
+    final focusColor = theme.focusColor;
+    final borderSide = BorderSide(color: focusColor);
+    final hasActionButtons = widget.actionButtons != null &&
+        _tabController.index == _detailsTreeTabIndex;
+
+    return Column(
+      children: <Widget>[
+        SizedBox(
+          height: 50.0,
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.end,
+            children: <Widget>[
+              Container(
+                color: focusColor,
+                child: TabBar(
+                  controller: _tabController,
+                  labelColor: theme.textTheme.bodyText1.color,
+                  tabs: tabs,
+                  isScrollable: true,
                 ),
-                if (widget.actionButtons != null &&
-                    _tabController.index == _detailsTreeTabIndex)
-                  Expanded(
-                    child: widget.actionButtons,
-                  ),
-              ],
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            ),
+              ),
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(border: Border(bottom: borderSide)),
+                  child: hasActionButtons
+                      ? widget.actionButtons
+                      : const SizedBox(),
+                ),
+              ),
+            ],
           ),
-          Expanded(
+        ),
+        Expanded(
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(
+                left: borderSide,
+                bottom: borderSide,
+                right: borderSide,
+              ),
+            ),
             child: TabBarView(
               physics: defaultTabBarViewPhysics,
               controller: _tabController,
               children: tabViews,
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
@@ -191,6 +191,8 @@ class _InspectorTreeState extends State<InspectorTree>
     super.initState();
     _scrollControllerX = ScrollController();
     _scrollControllerY = ScrollController();
+    // TODO(devoncarew): Commented out as per flutter/devtools/pull/2001.
+    //_scrollControllerY.addListener(_onScrollYChange);
     if (isSummaryTree) {
       constraintDisplayController = longAnimationController(this);
     }
@@ -224,6 +226,23 @@ class _InspectorTreeState extends State<InspectorTree>
   void requestFocus() {
     _focusNode.requestFocus();
   }
+
+  // TODO(devoncarew): Commented out as per flutter/devtools/pull/2001.
+//  void _onScrollYChange() {
+//    if (controller == null) return;
+//
+//    // If the vertical position  is already being animated we should not trigger
+//    // a new animation of the horizontal position as a more direct animation of
+//    // the horizontal position has already been triggered.
+//    if (currentAnimateY != null) return;
+//
+//    final x = _computeTargetX(_scrollControllerY.offset);
+//    _scrollControllerX.animateTo(
+//      x,
+//      duration: defaultDuration,
+//      curve: defaultCurve,
+//    );
+//  }
 
   /// Compute the goal x scroll given a y scroll value.
   ///

--- a/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/flutter/inspector_tree_flutter.dart
@@ -6,8 +6,8 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:flutter/services.dart';
+import 'package:pedantic/pedantic.dart';
 
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/collapsible_mixin.dart';
@@ -191,7 +191,6 @@ class _InspectorTreeState extends State<InspectorTree>
     super.initState();
     _scrollControllerX = ScrollController();
     _scrollControllerY = ScrollController();
-    _scrollControllerY.addListener(_onScrollYChange);
     if (isSummaryTree) {
       constraintDisplayController = longAnimationController(this);
     }
@@ -224,22 +223,6 @@ class _InspectorTreeState extends State<InspectorTree>
   @override
   void requestFocus() {
     _focusNode.requestFocus();
-  }
-
-  void _onScrollYChange() {
-    if (controller == null) return;
-
-    // If the vertical position  is already being animated we should not trigger
-    // a new animation of the horizontal position as a more direct animation of
-    // the horizontal position has already been triggered.
-    if (currentAnimateY != null) return;
-
-    final x = _computeTargetX(_scrollControllerY.offset);
-    _scrollControllerX.animateTo(
-      x,
-      duration: defaultDuration,
-      curve: defaultCurve,
-    );
   }
 
   /// Compute the goal x scroll given a y scroll value.

--- a/packages/devtools_testing/goldens/inspector_controller_initial_tree_with_styles.txt
+++ b/packages/devtools_testing/goldens/inspector_controller_initial_tree_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]MaterialApp
       ▼[S]Scaffold
       ├───▼[C]Center
-      │     [icons/inspector/textArea.png]Text
+      │     [T]Text
       └─▼[A]AppBar
-          [icons/inspector/textArea.png]Text
+          [T]Text

--- a/packages/devtools_testing/goldens/inspector_controller_selection_with_styles.txt
+++ b/packages/devtools_testing/goldens/inspector_controller_selection_with_styles.txt
@@ -3,6 +3,6 @@
     ▼[M]MaterialApp
       ▼[S]Scaffold
       ├───▼[C]Center
-      │     [icons/inspector/textArea.png]Text <-- selected
+      │     [T]Text <-- selected
       └─▼[A]AppBar
-          [icons/inspector/textArea.png]Text
+          [T]Text

--- a/packages/devtools_testing/goldens/inspector_controller_text_details_tree.txt
+++ b/packages/devtools_testing/goldens/inspector_controller_text_details_tree.txt
@@ -1,4 +1,4 @@
-▼[icons/inspector/textArea.png]Text <-- selected
+▼[T]Text <-- selected
 │ "Hello, World!"
 │ textAlign: null [D]
 │ textDirection: null [D]
@@ -10,7 +10,7 @@
 │ textWidthBasis: null [D]
 │ textHeightBehavior: null [D]
 │ dependencies: [MediaQuery, DefaultTextStyle]
-└─▼[icons/inspector/textArea.png]RichText
+└─▼[R]RichText
     softWrap: wrapping at box width
     maxLines: unlimited
     text: "Hello, World!"

--- a/packages/devtools_testing/lib/inspector_controller_test.dart
+++ b/packages/devtools_testing/lib/inspector_controller_test.dart
@@ -86,9 +86,9 @@ Future<void> runInspectorControllerTests(FlutterTestEnvironment env) async {
           '    ▼[M]MaterialApp\n'
           '      ▼[S]Scaffold\n'
           '      ├───▼[C]Center\n'
-          '      │     [icons/inspector/textArea.png]Text\n'
+          '      │     [T]Text\n'
           '      └─▼[A]AppBar\n'
-          '          [icons/inspector/textArea.png]Text\n',
+          '          [T]Text\n',
         ),
       );
 


### PR DESCRIPTION
misc inspector work:
- some tweaks to the inspector screen to move a divider line from above the tab controls to just below the tabs
- fix an issue where the user couldn't scroll vertically for long distances - we'd interrupt the scroll with a horizontal scroll (and inadvertently cancel the user's vertical scroll); fix https://github.com/flutter/devtools/issues/1709; our animated scrolls to widgets still work
- remove the custom icons for widget types - just use a consistent 'round circle' icon for widgets

@jacob314 


