### PR TITLE
remove the classes from the Libraries and Classes view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -137,7 +137,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       valueListenable: controller.librariesVisible,
       builder: (context, visible, _) {
         if (visible) {
-          // Focus the filter textfield when the ScriptPicker opens
+          // Focus the filter textfield when the ScriptPicker opens.
           _libraryFilterFocusNode.requestFocus();
 
           // TODO(devoncarew): Animate this opening and closing.
@@ -146,17 +146,13 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             initialFractions: const [0.70, 0.30],
             children: [
               codeView,
-              AnimatedBuilder(
-                animation: Listenable.merge([
-                  controller.sortedScripts,
-                  controller.sortedClasses,
-                ]),
-                builder: (context, _) {
+              ValueListenableBuilder(
+                valueListenable: controller.sortedScripts,
+                builder: (context, scripts, _) {
                   return ScriptPicker(
                     key: DebuggerScreenBody.scriptViewKey,
                     controller: controller,
-                    scripts: controller.sortedScripts.value,
-                    classes: controller.sortedClasses.value,
+                    scripts: scripts,
                     onSelected: _onLocationSelected,
                     libraryFilterFocusNode: _libraryFilterFocusNode,
                   );

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -15,21 +15,19 @@ import 'debugger_screen.dart';
 const libraryIcon = Icons.insert_chart;
 const classIcon = Icons.album;
 
-/// Picker that takes a list of scripts and classes and allows filtering and
-/// selection of items.
+/// Picker that takes a list of scripts and allows filtering and selection of
+/// items.
 class ScriptPicker extends StatefulWidget {
   const ScriptPicker({
     Key key,
     @required this.controller,
     @required this.scripts,
-    @required this.classes,
     @required this.onSelected,
     this.libraryFilterFocusNode,
   }) : super(key: key);
 
   final DebuggerController controller;
   final List<ScriptRef> scripts;
-  final List<ClassRef> classes;
   final void Function(ScriptLocation scriptRef) onSelected;
   final FocusNode libraryFilterFocusNode;
 
@@ -71,7 +69,7 @@ class ScriptPickerState extends State<ScriptPicker> {
         children: [
           debuggerPaneHeader(
             context,
-            'Libraries and Classes',
+            'Libraries',
             needsTopBorder: false,
             rightChild: CountBadge(
               filteredItems: _filteredItems,
@@ -165,14 +163,10 @@ class ScriptPickerState extends State<ScriptPicker> {
   void _updateFiltered() {
     final filterText = _filterController.text.trim().toLowerCase();
 
-    _items = [...widget.scripts, ...widget.classes];
-
-    _filteredItems = [
-      ...widget.scripts
-          .where((ref) => ref.uri.toLowerCase().contains(filterText)),
-      ...widget.classes
-          .where((ref) => ref.name.toLowerCase().contains(filterText)),
-    ];
+    _items = widget.scripts;
+    _filteredItems = widget.scripts
+        .where((ref) => ref.uri.toLowerCase().contains(filterText))
+        .toList();
   }
 
   void _handleSelected(ObjRef ref) async {

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -53,7 +53,6 @@ void main() {
           .thenReturn(ValueNotifier(false));
       when(debuggerController.currentScriptRef).thenReturn(ValueNotifier(null));
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
-      when(debuggerController.sortedClasses).thenReturn(ValueNotifier([]));
       when(debuggerController.selectedBreakpoint)
           .thenReturn(ValueNotifier(null));
       when(debuggerController.stackFramesWithLocation)
@@ -205,19 +204,16 @@ void main() {
 
     testWidgets('Libraries visible', (WidgetTester tester) async {
       final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
-      final classes = [ClassRef(name: 'Foo')];
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
-      when(debuggerController.sortedClasses).thenReturn(ValueNotifier(classes));
 
       // Libraries view is shown
       when(debuggerController.librariesVisible).thenReturn(ValueNotifier(true));
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('Libraries and Classes'), findsOneWidget);
+      expect(find.text('Libraries'), findsOneWidget);
 
-      // test for items in the libraries and classes list
+      // test for items in the libraries list
       expect(find.text(scripts.first.uri), findsOneWidget);
-      expect(find.text(classes.first.name), findsOneWidget);
     });
 
     testWidgets('Breakpoints show items', (WidgetTester tester) async {


### PR DESCRIPTION
- remove the classes from the Libraries and Classes view

This makes that view too busy. In the future, we should likely have a 'Search' field, with a drop down when you have content in the field, and code completion for the available items.