### PR TITLE
have the shows scripts keybinding work better across platforms

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/flutter/framework_initialize/_framework_initialize_web.dart
@@ -25,6 +25,23 @@ Future<String> initializePlatform() async {
     setGlobal(Storage, BrowserStorage());
   }
 
+  // Prevent the browser default behavior for specific keybindings we'll later
+  // handle in the app. This is a workaround for
+  // https://github.com/flutter/flutter/issues/58119.
+  window.onKeyDown.listen((event) {
+    if (!event.metaKey) {
+      return;
+    }
+
+    if (!window.navigator.userAgent.contains('Macintosh')) {
+      return;
+    }
+
+    if (event.key == 'p') {
+      event.preventDefault();
+    }
+  });
+
   return '${window.location}';
 }
 

--- a/packages/devtools_app/lib/src/config_specific/host_platform/host_platform.dart
+++ b/packages/devtools_app/lib/src/config_specific/host_platform/host_platform.dart
@@ -1,0 +1,7 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+export 'host_platform_stub.dart'
+    if (dart.library.html) 'host_platform_web.dart'
+    if (dart.library.io) 'host_platform_desktop.dart';

--- a/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_desktop.dart
+++ b/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_desktop.dart
@@ -1,0 +1,13 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'dart:io';
+
+class HostPlatform {
+  HostPlatform._();
+
+  static final HostPlatform instance = HostPlatform._();
+
+  bool get isMacOS => Platform.isMacOS;
+}

--- a/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_stub.dart
+++ b/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_stub.dart
@@ -7,5 +7,5 @@ class HostPlatform {
   // ignore: prefer_const_declarations
   static final HostPlatform instance = null;
 
-  bool get isMacOS => false;
+  bool get isMacOS => throw UnimplementedError();
 }

--- a/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_stub.dart
+++ b/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_stub.dart
@@ -1,0 +1,11 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+// ignore: avoid_classes_with_only_static_members
+class HostPlatform {
+  // ignore: prefer_const_declarations
+  static final HostPlatform instance = null;
+
+  bool get isMacOS => false;
+}

--- a/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/host_platform/host_platform_web.dart
@@ -1,0 +1,17 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be found
+// in the LICENSE file.
+
+import 'dart:html';
+
+class HostPlatform {
+  HostPlatform._() {
+    _isMacOS = window.navigator.userAgent.contains('Macintosh');
+  }
+
+  static final HostPlatform instance = HostPlatform._();
+
+  bool _isMacOS;
+
+  bool get isMacOS => _isMacOS;
+}

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../config_specific/host_platform/host_platform.dart';
 import '../../flutter/auto_dispose_mixin.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/flex_split_column.dart';
@@ -168,12 +169,12 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
     return Shortcuts(
       shortcuts: <LogicalKeySet, Intent>{
-        LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyP):
-            FilterLibraryIntent(_libraryFilterFocusNode, controller),
+        focusLibraryFilterKeySet:
+            FocusLibraryFilterIntent(_libraryFilterFocusNode, controller),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{
-          FilterLibraryIntent: FilterLibraryAction(),
+          FocusLibraryFilterIntent: FocusLibraryFilterAction(),
         },
         child: Split(
           axis: Axis.horizontal,
@@ -266,8 +267,15 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   }
 }
 
-class FilterLibraryIntent extends Intent {
-  const FilterLibraryIntent(
+final LogicalKeySet focusLibraryFilterKeySet = LogicalKeySet(
+  HostPlatform.instance.isMacOS
+      ? LogicalKeyboardKey.meta
+      : LogicalKeyboardKey.control,
+  LogicalKeyboardKey.keyP,
+);
+
+class FocusLibraryFilterIntent extends Intent {
+  const FocusLibraryFilterIntent(
     this.focusNode,
     this.debuggerController,
   )   : assert(debuggerController != null),
@@ -277,11 +285,10 @@ class FilterLibraryIntent extends Intent {
   final DebuggerController debuggerController;
 }
 
-class FilterLibraryAction extends Action<FilterLibraryIntent> {
+class FocusLibraryFilterAction extends Action<FocusLibraryFilterIntent> {
   @override
-  void invoke(FilterLibraryIntent intent) {
+  void invoke(FocusLibraryFilterIntent intent) {
     intent.debuggerController.openLibrariesView();
-    intent.focusNode.requestFocus();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -5,8 +5,10 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../config_specific/host_platform/host_platform.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
+import '../../flutter/utils.dart';
 import '../../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
@@ -63,6 +65,7 @@ class ScriptPickerState extends State<ScriptPicker> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final isMacOS = HostPlatform.instance.isMacOS;
 
     return OutlineDecoration(
       child: Column(
@@ -87,9 +90,10 @@ class ScriptPickerState extends State<ScriptPicker> {
               child: SizedBox(
                 height: 36.0,
                 child: TextField(
-                  decoration: const InputDecoration(
-                    labelText: 'Filter (Ctrl + P)',
-                    border: OutlineInputBorder(),
+                  decoration: InputDecoration(
+                    labelText:
+                        'Filter (${focusLibraryFilterKeySet.describeKeys(isMacOS: isMacOS)})',
+                    border: const OutlineInputBorder(),
                   ),
                   controller: _filterController,
                   onChanged: (value) => updateFilter(),

--- a/packages/devtools_app/lib/src/flutter/utils.dart
+++ b/packages/devtools_app/lib/src/flutter/utils.dart
@@ -62,3 +62,49 @@ Color colorFromAnsi(List<int> ansiInput) {
   assert(ansiInput.length == 3, 'Ansi color list should contain 3 elements');
   return Color.fromRGBO(ansiInput[0], ansiInput[1], ansiInput[2], 1);
 }
+
+/// An extension on [LogicalKeySet] to provide user-facing names for key
+/// bindings.
+extension LogicalKeySetExtension on LogicalKeySet {
+  static final Set<LogicalKeyboardKey> _modifiers = {
+    LogicalKeyboardKey.alt,
+    LogicalKeyboardKey.control,
+    LogicalKeyboardKey.meta,
+    LogicalKeyboardKey.shift,
+  };
+
+  static final Map<LogicalKeyboardKey, String> _modifierNames = {
+    LogicalKeyboardKey.alt: 'Alt',
+    LogicalKeyboardKey.control: 'Control',
+    LogicalKeyboardKey.meta: 'Meta',
+    LogicalKeyboardKey.shift: 'Shift',
+  };
+
+  /// Return a user-facing name for the [LogicalKeySet].
+  String describeKeys({bool isMacOS = false}) {
+    // Put the modifiers first. If it has a synonym, then it's something like
+    // shiftLeft, altRight, etc.
+    final List<LogicalKeyboardKey> sortedKeys = keys.toList()
+      ..sort((a, b) {
+        final aIsModifier = a.synonyms.isNotEmpty || _modifiers.contains(a);
+        final bIsModifier = b.synonyms.isNotEmpty || _modifiers.contains(b);
+        if (aIsModifier && !bIsModifier) {
+          return -1;
+        } else if (bIsModifier && !aIsModifier) {
+          return 1;
+        }
+        return a.keyLabel.compareTo(b.keyLabel);
+      });
+
+    return sortedKeys.map((key) {
+      if (_modifiers.contains(key)) {
+        if (isMacOS && key == LogicalKeyboardKey.meta) {
+          return '⌘';
+        }
+        return '${_modifierNames[key]}-';
+      } else {
+        return key.keyLabel.toUpperCase();
+      }
+    }).join();
+  }
+}

--- a/packages/devtools_app/test/flutter/utils_test.dart
+++ b/packages/devtools_app/test/flutter/utils_test.dart
@@ -1,0 +1,30 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/flutter/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LogicalKeySetExtension', () {
+    testWidgets('meta non-mac', (WidgetTester tester) async {
+      final keySet =
+          LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyP);
+      expect(keySet.describeKeys(), 'Meta-P');
+    });
+
+    testWidgets('meta mac', (WidgetTester tester) async {
+      final keySet =
+          LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyP);
+      expect(keySet.describeKeys(isMacOS: true), '⌘P');
+    });
+
+    testWidgets('ctrl', (WidgetTester tester) async {
+      final keySet =
+          LogicalKeySet(LogicalKeyboardKey.control, LogicalKeyboardKey.keyP);
+      expect(keySet.describeKeys(), 'Control-P');
+    });
+  });
+}


### PR DESCRIPTION
have the shows scripts keybinding work better across platforms:
- implement platform detection for desktop and flutter web
- add the ability to render a keybinding to user-facing text
- prevent the browser's default behavior on the mac for the command-P keybinding

We now show `⌘P` in the `Libraries` filter text field; some work towards https://github.com/flutter/devtools/issues/1972.
