### PR TITLE
add types for method parameters

### DIFF
--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -97,7 +97,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
 
   // Whenever the widget updates, refresh the scroll position if needed.
   @override
-  void didUpdateWidget(oldWidget) {
+  void didUpdateWidget(Widget oldWidget) {
     if (_scroll.hasClients && _scroll.atScrollBottom) {
       _scroll.autoScrollToBottom();
     }

--- a/packages/devtools_app/lib/src/geometry.dart
+++ b/packages/devtools_app/lib/src/geometry.dart
@@ -33,7 +33,7 @@ abstract class LineSegment {
   @visibleForTesting
   static double zoomedXPosition({
     @required double x,
-    @required zoom,
+    @required double zoom,
     @required double unzoomableOffset,
   }) {
     assert(x >= unzoomableOffset);

--- a/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/flutter/memory_controller.dart
@@ -211,7 +211,7 @@ class MemoryController extends DisposableController
     // TODO(terry): need to recomputeOffline data?
   }
 
-  void processDataset(args) {
+  void processDataset(List<Map> args) {
     // Add entries of entries plotted in the chart.  Entries plotted
     // may not match data collected (based on display interval).
     for (var arg in args) {

--- a/packages/devtools_app/lib/src/stream_value_listenable.dart
+++ b/packages/devtools_app/lib/src/stream_value_listenable.dart
@@ -40,7 +40,7 @@ class StreamValueListenable<T> extends ChangeNotifier
   String toString() => '${describeIdentity(this)}($value)';
 
   @override
-  void addListener(listener) {
+  void addListener(VoidCallback listener) {
     if (!hasListeners) {
       subscription = _onListen(this);
       _value = _lookupValue();
@@ -49,7 +49,7 @@ class StreamValueListenable<T> extends ChangeNotifier
   }
 
   @override
-  void removeListener(listener) {
+  void removeListener(VoidCallback listener) {
     super.removeListener(listener);
     if (!hasListeners) {
       subscription?.cancel();


### PR DESCRIPTION
- add types for method parameters

This was found using `type_annotate_public_apis`, which seems to be generally what we want modulo the results for the equals (`==`) methods.
