### PR TITLE
some minor tweaks to the debugger presentation

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/call_stack.dart
@@ -62,8 +62,7 @@ class _CallStackState extends State<CallStack> {
     Widget child;
 
     final asyncMarker = frame.frame.kind == FrameKind.kAsyncSuspensionMarker;
-    final asyncFrame = frame.frame.kind == FrameKind.kAsyncCausal ||
-        frame.frame.kind == FrameKind.kAsyncActivation ||
+    final asyncFrame = frame.frame.kind == FrameKind.kAsyncActivation ||
         frame.frame.kind == FrameKind.kAsyncSuspensionMarker;
     final noLineInfo = frame.line == null;
 
@@ -145,7 +144,7 @@ class _CallStackState extends State<CallStack> {
       return uri;
     }
     final file = uri.split('/').last;
-    return frame.line == null ? ' $file' : ' $file:${frame.line}';
+    return frame.line == null ? ' $file' : ' $file ${frame.line}';
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/variables.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/variables.dart
@@ -37,7 +37,7 @@ class Variables extends StatelessWidget {
       maxLines: 1,
       overflow: TextOverflow.ellipsis,
       text: TextSpan(
-        text: '${v.boundVar.name} ',
+        text: '${v.boundVar.name}: ',
         style: theme.regularTextStyle,
         children: [
           TextSpan(

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -336,14 +336,14 @@ void main() {
       expect(
         find.byWidgetPredicate((Widget widget) =>
             widget is RichText &&
-            widget.text.toPlainText().contains('testCodeRef() script.dart:0')),
+            widget.text.toPlainText().contains('testCodeRef() script.dart 0')),
         findsOneWidget,
       );
       // Stack frame 1
       expect(
         find.byWidgetPredicate((Widget widget) =>
             widget is RichText &&
-            widget.text.toPlainText().contains('<none> script1.dart:1')),
+            widget.text.toPlainText().contains('<none> script1.dart 1')),
         findsOneWidget,
       );
       // Stack frame 2
@@ -352,7 +352,7 @@ void main() {
             widget is RichText &&
             widget.text
                 .toPlainText()
-                .contains('testCodeRef2() script2.dart:2')),
+                .contains('testCodeRef2() script2.dart 2')),
         findsOneWidget,
       );
       // Stack frame 3
@@ -361,7 +361,7 @@ void main() {
             widget is RichText &&
             widget.text
                 .toPlainText()
-                .contains('testCodeRef3.<closure>() script3.dart:3')),
+                .contains('testCodeRef3.<closure>() script3.dart 3')),
         findsOneWidget,
       );
       // Stack frame 4
@@ -378,7 +378,9 @@ void main() {
 
       final listFinder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&
-          widget.text.toPlainText().contains('Root 1 _GrowableList (2 items)'));
+          widget.text
+              .toPlainText()
+              .contains('Root 1: _GrowableList (2 items)'));
       final listChild1Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText && widget.text.toPlainText().contains('0: 3'));
       final listChild2Finder = find.byWidgetPredicate((Widget widget) =>
@@ -388,26 +390,26 @@ void main() {
           widget is RichText &&
           widget.text
               .toPlainText()
-              .contains('Root 2 _InternalLinkedHashmap (2 items)'));
+              .contains('Root 2: _InternalLinkedHashmap (2 items)'));
       final mapElement1Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&
-          widget.text.toPlainText().contains("['key1'] 1.0"));
+          widget.text.toPlainText().contains("['key1']: 1.0"));
       final mapElement2Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&
-          widget.text.toPlainText().contains("['key2'] 1.1"));
+          widget.text.toPlainText().contains("['key2']: 1.1"));
 
       expect(listFinder, findsOneWidget);
       expect(mapFinder, findsOneWidget);
       expect(
         find.byWidgetPredicate((Widget widget) =>
             widget is RichText &&
-            widget.text.toPlainText().contains("Root 3 'test str...'")),
+            widget.text.toPlainText().contains("Root 3: 'test str...'")),
         findsOneWidget,
       );
       expect(
         find.byWidgetPredicate((Widget widget) =>
             widget is RichText &&
-            widget.text.toPlainText().contains('Root 4 true')),
+            widget.text.toPlainText().contains('Root 4: true')),
         findsOneWidget,
       );
 
@@ -515,7 +517,7 @@ final testVariables = [
   ))
     ..addAllChildren([
       Variable.create(BoundVariable(
-        name: '0:',
+        name: '0',
         value: InstanceRef(
           kind: InstanceKind.kInt,
           classRef: ClassRef(name: 'Integer'),
@@ -527,7 +529,7 @@ final testVariables = [
         scopeStartTokenPos: null,
       )),
       Variable.create(BoundVariable(
-        name: '1:',
+        name: '1',
         value: InstanceRef(
           kind: InstanceKind.kInt,
           classRef: ClassRef(name: 'Integer'),


### PR DESCRIPTION
some minor tweaks to the debugger presentation:
- use `:` to separate variable names from values
- adjust when we display an async frame w/ 'subtle' text
