### PR TITLE
fps chart tweaks

### DIFF
--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -159,6 +159,8 @@ Color titleSolidBackgroundColor(ThemeData theme) {
 final chartBackgroundColor = ThemedColor(Colors.grey[50], Colors.grey[850]);
 const chartAccentColor = ThemedColor(Color(0xFFCCCCCC), Color(0xFF585858));
 const chartTextColor = ThemedColor(Colors.black, Colors.white);
+const chartSubtleColor = ThemedColor(Color(0xFF999999), Color(0xFF8A8A8A));
+const chartFontSizeSmall = 12.0;
 
 final chartLightTypeFace = TypeFace(
   fontFamily: 'OpenSans',

--- a/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/flutter_frames_chart.dart
@@ -175,11 +175,12 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
   Widget _buildChartLegend() {
     return Column(
       key: FlutterFramesChart.chartLegendKey,
-      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         _legendItem('Frame Time (UI)', mainUiColor),
+        const SizedBox(height: denseRowSpacing),
         _legendItem('Frame Time (Raster)', mainRasterColor),
+        const SizedBox(height: denseRowSpacing),
         _legendItem('Jank (slow frame)', uiJankColor),
       ],
     );
@@ -385,11 +386,16 @@ class ChartAxisPainter extends CustomPainter {
     final textPainter = TextPainter(
       text: TextSpan(
         text: labelText,
-        style: const TextStyle(color: chartTextColor),
+        style: const TextStyle(
+          color: chartSubtleColor,
+          fontSize: chartFontSizeSmall,
+        ),
       ),
       textAlign: TextAlign.end,
       textDirection: TextDirection.ltr,
     )..layout();
+
+    const baselineAdjust = 2.0;
 
     textPainter.paint(
       canvas,
@@ -398,7 +404,10 @@ class ChartAxisPainter extends CustomPainter {
             yAxisTickWidth / 2 -
             densePadding - // Padding between y axis tick and label
             textPainter.width,
-        constraints.maxHeight - timeMs / msPerPx - textPainter.height / 2,
+        constraints.maxHeight -
+            timeMs / msPerPx -
+            textPainter.height / 2 -
+            baselineAdjust,
       ),
     );
   }
@@ -418,9 +427,7 @@ class FPSLinePainter extends CustomPainter {
     @required this.themeData,
   });
 
-  static const fpsLineColor = Color.fromARGB(0x80, 0xff, 0x44, 0x44);
-
-  static const fpsTextSpace = 60.0;
+  static const fpsTextSpace = 40.0;
 
   final BoxConstraints constraints;
 
@@ -448,16 +455,17 @@ class FPSLinePainter extends CustomPainter {
 
     canvas.drawLine(
       Offset(chartArea.left, targetLineY),
-      Offset(chartArea.right - fpsTextSpace, targetLineY),
-      Paint()
-        ..color = fpsLineColor
-        ..strokeWidth = 2.0,
+      Offset(chartArea.right, targetLineY),
+      Paint()..color = chartAccentColor,
     );
 
     final textPainter = TextPainter(
       text: TextSpan(
         text: '${displayRefreshRate.toStringAsFixed(0)} FPS',
-        style: const TextStyle(color: chartTextColor),
+        style: const TextStyle(
+          color: chartSubtleColor,
+          fontSize: chartFontSizeSmall,
+        ),
       ),
       textAlign: TextAlign.right,
       textDirection: TextDirection.ltr,
@@ -466,8 +474,8 @@ class FPSLinePainter extends CustomPainter {
     textPainter.paint(
       canvas,
       Offset(
-        chartArea.right - fpsTextSpace + denseSpacing,
-        targetLineY - textPainter.height / 2,
+        chartArea.right - fpsTextSpace,
+        targetLineY + borderPadding,
       ),
     );
   }

--- a/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter/timeline_screen.dart
@@ -358,8 +358,6 @@ class TimelineConfigurationsDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Dialog(
-      shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(defaultDialogRadius)),
       child: Container(
         width: dialogWidth,
         padding: const EdgeInsets.all(defaultSpacing),


### PR DESCRIPTION
Some minor tweaks to the fps chart:
- use a smaller font for the y axis labels
- use a more muted color for the chart text
- adjust the vertical alignment of the labels

