### PR TITLE
remove the animation for appbar layout changes

### DIFF
--- a/packages/devtools_app/lib/src/flutter/scaffold.dart
+++ b/packages/devtools_app/lib/src/flutter/scaffold.dart
@@ -309,8 +309,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
       preferredSize = isNarrow
           ? const Size.fromHeight(kToolbarHeight + 40.0)
           : const Size.fromHeight(kToolbarHeight);
-      final animatedAlignment =
-          isNarrow ? Alignment.bottomLeft : Alignment.centerRight;
+      final alignment = isNarrow ? Alignment.bottomLeft : Alignment.centerRight;
 
       final rightAdjust =
           isNarrow ? 0.0 : DevToolsScaffold.actionWidgetSize / 2;
@@ -322,7 +321,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
                   rightAdjust);
 
       flexibleSpace = Align(
-        alignment: animatedAlignment,
+        alignment: alignment,
         child: Padding(
           padding: EdgeInsets.only(
             top: 4.0,


### PR DESCRIPTION
- remove the animation for appbar layout changes

This fixes the issue where the memory page would deadlock when running on Flutter desktop. Because of where the animation was defined in the widget hierarchy, it would cause the app screens to rebuild often. There may still be a deadlock in the memory page, but if so we no longer seem to hit it.

Most pages only rebuild once now when switching screens. The memory page may rebuild twice (from brief observation). And - not topical for this PR - it seems to take about 300-400ms to build the frame when switching into the Inspector page; that all seems to be spent in layout.
