### PR TITLE
improve how we display device info for web

### DIFF
--- a/packages/devtools_app/lib/src/flutter/device_dialog.dart
+++ b/packages/devtools_app/lib/src/flutter/device_dialog.dart
@@ -41,10 +41,14 @@ class DeviceDialog extends StatelessWidget {
       version = version.substring(0, version.indexOf(' '));
     }
 
+    var bits = '';
+    if (vm.architectureBits != -1) {
+      bits = '-${vm.architectureBits}';
+    }
+
     final items = {
       'Dart Version': version,
-      'CPU / OS':
-          '${vm.targetCPU}-${vm.architectureBits} / ${vm.operatingSystem}',
+      'CPU / OS': '${vm.targetCPU}$bits / ${vm.operatingSystem}',
     };
 
     if (flutterVersion != null) {


### PR DESCRIPTION
- improve how we display device info for web

For web devices, `vm.architectureBit` returns -1.

<img width="416" alt="Screen Shot 2020-06-02 at 1 43 47 PM" src="https://user-images.githubusercontent.com/1269969/83568013-5f2e1180-a4d7-11ea-9588-ecf5f73924c1.png">
