### PR TITLE
use a common style for hyperlinks

### DIFF
--- a/packages/devtools_app/lib/src/flutter/app.dart
+++ b/packages/devtools_app/lib/src/flutter/app.dart
@@ -368,13 +368,7 @@ class DevToolsAboutDialog extends StatelessWidget {
         const reportIssuesUrl = 'https://$urlPath';
         await launchUrl(reportIssuesUrl, context);
       },
-      child: Text(
-        urlPath,
-        style: textTheme.bodyText2.copyWith(
-          decoration: TextDecoration.underline,
-          color: devtoolsLink,
-        ),
-      ),
+      child: const Text(urlPath, style: linkTextStyle),
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/status_line.dart
+++ b/packages/devtools_app/lib/src/flutter/status_line.dart
@@ -104,10 +104,7 @@ class StatusLine extends StatelessWidget {
         },
         child: Text(
           'flutter.dev/devtools/$docPageId',
-          style: textTheme.bodyText2.copyWith(
-            decoration: TextDecoration.underline,
-            color: devtoolsLink,
-          ),
+          style: linkTextStyle,
         ),
       );
     } else {

--- a/packages/devtools_app/lib/src/flutter/theme.dart
+++ b/packages/devtools_app/lib/src/flutter/theme.dart
@@ -93,6 +93,11 @@ const devtoolsWarning = Color(0xFFFDFAD5);
 
 const devtoolsLink = ThemedColor(Color(0xFF1976D2), Colors.lightBlueAccent);
 
+const linkTextStyle = TextStyle(
+  color: devtoolsLink,
+  decoration: TextDecoration.underline,
+);
+
 /// A short duration to use for animations.
 ///
 /// Use this when you want less emphasis on the animation and more on the


### PR DESCRIPTION
- use a common style for hyperlinks
- fix an issue where the text size for the link in the about box was slightly too small
