### PR TITLE
add navigation elements to the debugger page

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -224,7 +224,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
     return OutlineDecoration(
       child: Column(
         children: [
-          debuggerSectionTitle(theme, text: scriptRef?.uri ?? ' '),
+          buildCodeviewTitle(theme),
           DefaultTextStyle(
             style: theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono'),
             child: Expanded(
@@ -274,6 +274,77 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
         ],
       ),
     );
+  }
+
+  Widget buildCodeviewTitle(ThemeData theme) {
+    return ValueListenableBuilder(
+      valueListenable: widget.controller.scriptsHistory,
+      builder: (context, scriptsHistory, _) {
+        return debuggerSectionTitle(
+          theme,
+          child: Row(
+            children: [
+              DebuggerToolbarAction(
+                Icons.chevron_left,
+                onPressed:
+                    scriptsHistory.hasPrevious ? scriptsHistory.moveBack : null,
+              ),
+              DebuggerToolbarAction(
+                Icons.chevron_right,
+                onPressed:
+                    scriptsHistory.hasNext ? scriptsHistory.moveForward : null,
+              ),
+              const SizedBox(width: denseSpacing),
+              const VerticalDivider(),
+              const SizedBox(width: defaultSpacing),
+              Expanded(
+                child: Text(
+                  scriptRef?.uri ?? ' ',
+                  style: theme.textTheme.subtitle2,
+                ),
+              ),
+              const SizedBox(width: denseSpacing),
+              const VerticalDivider(),
+              PopupMenuButton<ScriptRef>(
+                itemBuilder: _buildScriptMenuFromHistory,
+                enabled: scriptsHistory.hasScripts,
+                onSelected: (scriptRef) {
+                  widget.controller
+                      .showScriptLocation(ScriptLocation(scriptRef));
+                },
+                offset: const Offset(
+                  actionsIconSize + denseSpacing,
+                  buttonMinWidth + denseSpacing,
+                ),
+                child: const Icon(
+                  Icons.keyboard_arrow_down,
+                  size: actionsIconSize,
+                ),
+              ),
+              const SizedBox(width: denseSpacing),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  List<PopupMenuEntry<ScriptRef>> _buildScriptMenuFromHistory(
+    BuildContext context,
+  ) {
+    return widget.controller.scriptsHistory.openedScripts
+        .take(16)
+        .map((scriptRef) {
+      return PopupMenuItem(
+        value: scriptRef,
+        child: Text(
+          scriptRef.uri,
+          overflow: TextOverflow.ellipsis,
+          maxLines: 2,
+          style: const TextStyle(fontSize: 14.0),
+        ),
+      );
+    }).toList();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -332,8 +332,10 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
   List<PopupMenuEntry<ScriptRef>> _buildScriptMenuFromHistory(
     BuildContext context,
   ) {
+    const scriptHistorySize = 16;
+
     return widget.controller.scriptsHistory.openedScripts
-        .take(16)
+        .take(scriptHistorySize)
         .map((scriptRef) {
       return PopupMenuItem(
         value: scriptRef,

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -45,3 +45,24 @@ Widget createAnimatedCircleWidget(double radius, Color color) {
     decoration: BoxDecoration(color: color, shape: BoxShape.circle),
   );
 }
+
+/// A wrapper around a FlatButton and an Icon, used for small toolbar actions.
+class DebuggerToolbarAction extends StatelessWidget {
+  const DebuggerToolbarAction(
+    this.icon, {
+    @required this.onPressed,
+  });
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FlatButton(
+      padding: EdgeInsets.zero,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: onPressed,
+      child: Icon(icon, size: actionsIconSize),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -33,11 +33,19 @@ class DebuggerController extends DisposableController
     autoDispose(_service.onIsolateEvent.listen(_handleIsolateEvent));
     autoDispose(_service.onStdoutEvent.listen(_handleStdoutEvent));
     autoDispose(_service.onStderrEvent.listen(_handleStderrEvent));
+
+    _scriptHistoryListener = () {
+      _showScriptLocation(ScriptLocation(scriptsHistory.currentScript));
+    };
+    scriptsHistory.addListener(_scriptHistoryListener);
   }
 
   VmService get _service => serviceManager.service;
 
   final ScriptCache _scriptCache = ScriptCache();
+
+  final ScriptsHistory scriptsHistory = ScriptsHistory();
+  VoidCallback _scriptHistoryListener;
 
   final _isPaused = ValueNotifier<bool>(false);
 
@@ -67,6 +75,18 @@ class DebuggerController extends DisposableController
 
   /// Jump to the given ScriptRef and optional SourcePosition.
   void showScriptLocation(ScriptLocation scriptLocation) {
+    _showScriptLocation(scriptLocation);
+
+    // Update the scripts history (and make sure we don't react to the
+    // subsequent event).
+    scriptsHistory.removeListener(_scriptHistoryListener);
+    scriptsHistory.pushEntry(scriptLocation.scriptRef);
+    scriptsHistory.addListener(_scriptHistoryListener);
+  }
+
+  /// Show the given script location (without updating the script navigation
+  /// history).
+  void _showScriptLocation(ScriptLocation scriptLocation) {
     _currentScriptRef.value = scriptLocation?.scriptRef;
     _scriptLocation.value = scriptLocation;
   }
@@ -835,4 +855,75 @@ class ScriptCache {
     _scripts = {};
     _inProgress.clear();
   }
+}
+
+/// Maintains the navigation history of the debugger's code area - which files
+/// were opened, whether it's possible to navigate forwards and backwards in the
+/// history, ...
+class ScriptsHistory extends ChangeNotifier
+    implements ValueListenable<ScriptsHistory> {
+  // TODO(devoncarew): This class should also record and restore scroll
+  // positions.
+
+  ScriptsHistory();
+
+  final List<ScriptRef> _history = [];
+  int _historyIndex = -1;
+
+  final Set<ScriptRef> _openedScripts = {};
+
+  bool get hasPrevious {
+    return _history.isNotEmpty && _historyIndex > 0;
+  }
+
+  bool get hasNext {
+    return _history.isNotEmpty && _historyIndex < _history.length - 1;
+  }
+
+  bool get hasScripts => _openedScripts.isNotEmpty;
+
+  ScriptRef moveForward() {
+    if (!hasNext) throw StateError('no next history item');
+
+    _historyIndex++;
+
+    notifyListeners();
+
+    return currentScript;
+  }
+
+  ScriptRef moveBack() {
+    if (!hasPrevious) throw StateError('no previous history item');
+
+    _historyIndex--;
+
+    notifyListeners();
+
+    return currentScript;
+  }
+
+  ScriptRef get currentScript {
+    return _history.isEmpty ? null : _history[_historyIndex];
+  }
+
+  void pushEntry(ScriptRef ref) {
+    if (ref == currentScript) return;
+
+    while (hasNext) {
+      _history.removeLast();
+    }
+
+    _openedScripts.remove(ref);
+    _openedScripts.add(ref);
+
+    _history.add(ref);
+    _historyIndex++;
+
+    notifyListeners();
+  }
+
+  @override
+  ScriptsHistory get value => this;
+
+  Iterable<ScriptRef> get openedScripts => _openedScripts.toList().reversed;
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_controller.dart
@@ -867,10 +867,10 @@ class ScriptsHistory extends ChangeNotifier
 
   ScriptsHistory();
 
-  final List<ScriptRef> _history = [];
+  final _history = <ScriptRef>[];
   int _historyIndex = -1;
 
-  final Set<ScriptRef> _openedScripts = {};
+  final _openedScripts = <ScriptRef>{};
 
   bool get hasPrevious {
     return _history.isNotEmpty && _historyIndex > 0;

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -21,6 +21,7 @@ import '../../globals.dart';
 import 'breakpoints.dart';
 import 'call_stack.dart';
 import 'codeview.dart';
+import 'common.dart';
 import 'console.dart';
 import 'controls.dart';
 import 'debugger_controller.dart';
@@ -253,9 +254,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         return Row(children: [
           BreakpointsCountBadge(breakpoints: breakpoints),
           ActionButton(
-            child: FlatButton(
-              padding: EdgeInsets.zero,
-              child: const Icon(Icons.delete, size: actionsIconSize),
+            child: DebuggerToolbarAction(
+              Icons.delete,
               onPressed:
                   breakpoints.isNotEmpty ? controller.clearBreakpoints : null,
             ),

--- a/packages/devtools_app/test/flutter/debugger_controller_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_controller_test.dart
@@ -1,0 +1,112 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/debugger/flutter/debugger_controller.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+
+void main() {
+  group('ScriptsHistory', () {
+    ScriptsHistory history;
+
+    final ScriptRef ref1 = ScriptRef(uri: 'package:foo/foo.dart')..id = 'id-1';
+    final ScriptRef ref2 = ScriptRef(uri: 'package:bar/bar.dart')..id = 'id-2';
+    final ScriptRef ref3 = ScriptRef(uri: 'package:baz/baz.dart')..id = 'id-3';
+
+    setUp(() {
+      history = ScriptsHistory();
+    });
+
+    test('initial values', () {
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, false);
+      expect(history.currentScript, isNull);
+      expect(history.hasScripts, false);
+    });
+
+    test('moveBack', () {
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+      history.pushEntry(ref3);
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.currentScript, ref3);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, true);
+      expect(history.currentScript, ref2);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, false);
+      expect(history.currentScript, ref1);
+    });
+
+    test('moveBack', () {
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.currentScript, ref2);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, false);
+      expect(history.currentScript, ref1);
+
+      history.moveForward();
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.currentScript, ref2);
+    });
+
+    test('openedScripts', () {
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+      history.pushEntry(ref3);
+
+      expect(history.openedScripts, orderedEquals([ref3, ref2, ref1]));
+
+      // verify that pushing re-orders
+      history.pushEntry(ref2);
+      expect(history.openedScripts, orderedEquals([ref2, ref3, ref1]));
+    });
+
+    test('ref can be in history twice', () {
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+
+      expect(history.currentScript, ref2);
+      history.moveBack();
+      expect(history.currentScript, ref1);
+      history.moveBack();
+      expect(history.currentScript, ref2);
+      history.moveBack();
+      expect(history.currentScript, ref1);
+    });
+
+    test('pushEntry removes next entries', () {
+      history.pushEntry(ref1);
+      history.pushEntry(ref2);
+
+      expect(history.currentScript, ref2);
+      expect(history.hasNext, isFalse);
+      history.moveBack();
+      expect(history.currentScript, ref1);
+      expect(history.hasNext, isTrue);
+      history.pushEntry(ref3);
+      expect(history.currentScript, ref3);
+      expect(history.hasNext, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
add navigation elements to the debugger page:
- add forward and backwards buttons
- add an 'script history' pulldown menu in the code viewer's toolbar
- introduce a `ScriptsHistory` class in the debugger's controller, and write tests for it

<img width="504" alt="Screen Shot 2020-06-02 at 10 10 51 PM" src="https://user-images.githubusercontent.com/1269969/83603811-ef954200-a529-11ea-9615-5ba45ec0ea0c.png">

<img width="191" alt="Screen Shot 2020-06-02 at 10 10 55 PM" src="https://user-images.githubusercontent.com/1269969/83603830-f58b2300-a529-11ea-85f4-9ea8c8af6244.png">

<img width="351" alt="Screen Shot 2020-06-02 at 10 11 01 PM" src="https://user-images.githubusercontent.com/1269969/83603844-fa4fd700-a529-11ea-8d3e-d79befec32d9.png">
