### PR TITLE
remove the date from network timestamps

### DIFF
--- a/packages/devtools_app/lib/src/network/flutter/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/flutter/network_screen.dart
@@ -301,7 +301,7 @@ class DurationColumn extends ColumnData<HttpRequestData> {
 
 class TimestampColumn extends ColumnData<HttpRequestData> {
   TimestampColumn()
-      : super('Timestamp', alignment: ColumnAlignment.right, fixedWidthPx: 165);
+      : super('Timestamp', alignment: ColumnAlignment.right, fixedWidthPx: 135);
 
   @override
   dynamic getValue(HttpRequestData dataObject) {
@@ -315,6 +315,6 @@ class TimestampColumn extends ColumnData<HttpRequestData> {
 
   @visibleForTesting
   static String formatRequestTime(DateTime requestTime) {
-    return DateFormat.Hms().add_yMd().format(requestTime);
+    return DateFormat('h:mm:ss.S a').format(requestTime);
   }
 }

--- a/packages/devtools_app/test/flutter/network_model_test.dart
+++ b/packages/devtools_app/test/flutter/network_model_test.dart
@@ -69,12 +69,10 @@ void main() {
 
       // The hours field may be unreliable since it depends on the timezone the
       // test is running in.
-      expect(column.getDisplayValue(request), contains(':25:34 1/3/1970'));
+      expect(column.getDisplayValue(request), contains(':25:34.126'));
 
-      expect(
-        TimestampColumn.formatRequestTime(DateTime(2020, 1, 16, 13)),
-        '13:00:00 1/16/2020',
-      );
+      expect(TimestampColumn.formatRequestTime(DateTime(2020, 1, 16, 13)),
+          '1:00:00.000 PM');
     });
   });
 }


### PR DESCRIPTION
- remove the date from network timestamps
- work towards https://github.com/flutter/devtools/issues/1980

<img width="286" alt="Screen Shot 2020-06-04 at 4 28 08 PM" src="https://user-images.githubusercontent.com/1269969/83820839-94c32e00-a682-11ea-8a18-8b88bbeaf2a4.png">
