### PR TITLE
change the mouse cursor when over the splitter control

### DIFF
--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -301,8 +301,7 @@ class _SplitState extends State<Split> {
     // The material icon for a drag handle is not currently available.
     // For now, draw an indicator that is 3 lines running in the direction
     // of the main axis, like a hamburger menu.
-    // TODO(https://github.com/flutter/devtools/issues/1265): update mouse
-    // to indicate that this is resizable.
+    // TODO: use Icons.drag_handle
     final defaultDragIndicator = Flex(
       direction: isHorizontal ? Axis.vertical : Axis.horizontal,
       mainAxisSize: MainAxisSize.min,

--- a/packages/devtools_app/lib/src/flutter/split.dart
+++ b/packages/devtools_app/lib/src/flutter/split.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 
 import '../utils.dart';
 
@@ -254,20 +255,23 @@ class _SplitState extends State<Split> {
           child: widget.children[i],
         ),
         if (i < widget.children.length - 1)
-          GestureDetector(
-            key: widget.dividerKey(i),
-            behavior: HitTestBehavior.translucent,
-            onHorizontalDragUpdate: (details) =>
-                isHorizontal ? updateSpacing(details, i) : null,
-            onVerticalDragUpdate: (details) =>
-                isHorizontal ? null : updateSpacing(details, i),
-            // DartStartBehavior.down is needed to keep the mouse pointer stuck to
-            // the drag bar. There still appears to be a few frame lag before the
-            // drag action triggers which is't ideal but isn't a launch blocker.
-            dragStartBehavior: DragStartBehavior.down,
-            child: widget.splitters != null
-                ? widget.splitters[i]
-                : _defaultSplitter(layoutHeight: height, layoutWidth: width),
+          MouseRegion(
+            cursor: SystemMouseCursors.grab,
+            child: GestureDetector(
+              key: widget.dividerKey(i),
+              behavior: HitTestBehavior.translucent,
+              onHorizontalDragUpdate: (details) =>
+                  isHorizontal ? updateSpacing(details, i) : null,
+              onVerticalDragUpdate: (details) =>
+                  isHorizontal ? null : updateSpacing(details, i),
+              // DartStartBehavior.down is needed to keep the mouse pointer stuck to
+              // the drag bar. There still appears to be a few frame lag before the
+              // drag action triggers which is't ideal but isn't a launch blocker.
+              dragStartBehavior: DragStartBehavior.down,
+              child: widget.splitters != null
+                  ? widget.splitters[i]
+                  : _defaultSplitter(layoutHeight: height, layoutWidth: width),
+            ),
           ),
       ]);
     }


### PR DESCRIPTION
- change the mouse cursor when over the splitter control
- fix #1265
