### PR TITLE
add a title to the logging page's details area

### DIFF
--- a/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/codeview.dart
@@ -284,18 +284,20 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
           theme,
           child: Row(
             children: [
-              DebuggerToolbarAction(
-                Icons.chevron_left,
+              ToolbarAction(
+                icon: Icons.chevron_left,
                 onPressed:
                     scriptsHistory.hasPrevious ? scriptsHistory.moveBack : null,
+                tooltip: 'Back',
               ),
-              DebuggerToolbarAction(
-                Icons.chevron_right,
+              ToolbarAction(
+                icon: Icons.chevron_right,
                 onPressed:
                     scriptsHistory.hasNext ? scriptsHistory.moveForward : null,
+                tooltip: 'Forward',
               ),
               const SizedBox(width: denseSpacing),
-              const VerticalDivider(),
+              const VerticalDivider(thickness: 1.0),
               const SizedBox(width: defaultSpacing),
               Expanded(
                 child: Text(
@@ -304,7 +306,6 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                 ),
               ),
               const SizedBox(width: denseSpacing),
-              const VerticalDivider(),
               PopupMenuButton<ScriptRef>(
                 itemBuilder: _buildScriptMenuFromHistory,
                 enabled: scriptsHistory.hasScripts,

--- a/packages/devtools_app/lib/src/debugger/flutter/common.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/common.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../../flutter/common_widgets.dart';
 import '../../flutter/theme.dart';
-import 'debugger_screen.dart';
 
 /// Create a header area for a debugger component.
 ///
@@ -23,7 +23,7 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
     ),
     padding: const EdgeInsets.only(left: defaultSpacing),
     alignment: Alignment.centerLeft,
-    height: DebuggerScreen.debuggerPaneHeaderHeight,
+    height: areaPaneHeaderHeight,
     child: child != null ? child : Text(text, style: theme.textTheme.subtitle2),
   );
 }
@@ -44,25 +44,4 @@ Widget createAnimatedCircleWidget(double radius, Color color) {
     duration: defaultDuration,
     decoration: BoxDecoration(color: color, shape: BoxShape.circle),
   );
-}
-
-/// A wrapper around a FlatButton and an Icon, used for small toolbar actions.
-class DebuggerToolbarAction extends StatelessWidget {
-  const DebuggerToolbarAction(
-    this.icon, {
-    @required this.onPressed,
-  });
-
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return FlatButton(
-      padding: EdgeInsets.zero,
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      onPressed: onPressed,
-      child: Icon(icon, size: actionsIconSize),
-    );
-  }
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/console.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/console.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import '../../flutter/common_widgets.dart';
 import '../../flutter/console.dart';
 import '../../utils.dart';
-import 'common.dart';
 import 'debugger_controller.dart';
 
 // TODO(devoncarew): Show some small UI indicator when we receive stdout/stderr.
@@ -60,20 +59,27 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
 
     return OutlineDecoration(
       child: Console(
-        title: debuggerSectionTitle(Theme.of(context), text: 'Console'),
+        title: areaPaneHeader(
+          context,
+          title: 'Console',
+          needsTopBorder: false,
+          rightChild: Row(
+            children: [
+              CopyToClipboardControl(
+                dataProvider: disabled ? null : () => _lines.join('\n'),
+                successMessage:
+                    'Copied $numLines ${pluralize('line', numLines)}.',
+                buttonKey: DebuggerConsole.copyToClipboardButtonKey,
+              ),
+              DeleteControl(
+                buttonKey: DebuggerConsole.clearStdioButtonKey,
+                tooltip: 'Clear console output',
+                onPressed: disabled ? null : widget.controller.clearStdio,
+              ),
+            ],
+          ),
+        ),
         lines: _lines,
-        controls: [
-          CopyToClipboardControl(
-            dataProvider: disabled ? null : () => _lines.join('\n'),
-            successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
-            buttonKey: DebuggerConsole.copyToClipboardButtonKey,
-          ),
-          DeleteControl(
-            onPressed: disabled ? null : widget.controller.clearStdio,
-            tooltip: 'Clear console output',
-            buttonKey: DebuggerConsole.clearStdioButtonKey,
-          ),
-        ],
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/debugger_screen.dart
@@ -21,7 +21,6 @@ import '../../globals.dart';
 import 'breakpoints.dart';
 import 'call_stack.dart';
 import 'codeview.dart';
-import 'common.dart';
 import 'console.dart';
 import 'controls.dart';
 import 'debugger_controller.dart';
@@ -36,8 +35,6 @@ const bool debugShowCallStackCount = false;
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
       : super('debugger', title: 'Debugger', icon: Octicons.bug);
-
-  static const debuggerPaneHeaderHeight = 36.0;
 
   @override
   String get docPageId => screenId;
@@ -212,18 +209,18 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           initialFractions: const [0.38, 0.38, 0.24],
           minSizes: const [0.0, 0.0, 0.0],
           headers: [
-            debuggerPaneHeader(
+            areaPaneHeader(
               context,
-              callStackTitle,
+              title: callStackTitle,
               needsTopBorder: false,
               rightChild:
                   // ignore: avoid_redundant_argument_values
                   debugShowCallStackCount ? _callStackRightChild() : null,
             ),
-            debuggerPaneHeader(context, variablesTitle),
-            debuggerPaneHeader(
+            areaPaneHeader(context, title: variablesTitle),
+            areaPaneHeader(
               context,
-              breakpointsTitle,
+              title: breakpointsTitle,
               rightChild: _breakpointsRightChild(),
               rightPadding: 0.0,
             ),
@@ -253,12 +250,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       builder: (context, breakpoints, _) {
         return Row(children: [
           BreakpointsCountBadge(breakpoints: breakpoints),
-          ActionButton(
-            child: DebuggerToolbarAction(
-              Icons.delete,
-              onPressed:
-                  breakpoints.isNotEmpty ? controller.clearBreakpoints : null,
-            ),
+          ToolbarAction(
+            icon: Icons.delete,
+            onPressed:
+                breakpoints.isNotEmpty ? controller.clearBreakpoints : null,
             tooltip: 'Remove all breakpoints',
           ),
         ]);
@@ -366,45 +361,4 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
 
     return 'paused$reason$fileName $pos';
   }
-}
-
-FlexSplitColumnHeader debuggerPaneHeader(
-  BuildContext context,
-  String title, {
-  bool needsTopBorder = true,
-  Widget rightChild,
-  double rightPadding = 4.0,
-}) {
-  final theme = Theme.of(context);
-
-  return FlexSplitColumnHeader(
-    height: DebuggerScreen.debuggerPaneHeaderHeight,
-    child: Container(
-      decoration: BoxDecoration(
-        border: Border(
-          top: needsTopBorder
-              ? BorderSide(color: theme.focusColor)
-              : BorderSide.none,
-          bottom: BorderSide(color: theme.focusColor),
-        ),
-        color: titleSolidBackgroundColor(theme),
-      ),
-      padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
-      alignment: Alignment.centerLeft,
-      height: DebuggerScreen.debuggerPaneHeaderHeight,
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.subtitle2,
-            ),
-          ),
-          if (rightChild != null) rightChild,
-        ],
-      ),
-    ),
-  );
 }

--- a/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/flutter/scripts.dart
@@ -70,9 +70,9 @@ class ScriptPickerState extends State<ScriptPicker> {
     return OutlineDecoration(
       child: Column(
         children: [
-          debuggerPaneHeader(
+          areaPaneHeader(
             context,
-            'Libraries',
+            title: 'Libraries',
             needsTopBorder: false,
             rightChild: CountBadge(
               filteredItems: _filteredItems,

--- a/packages/devtools_app/lib/src/flutter/common_widgets.dart
+++ b/packages/devtools_app/lib/src/flutter/common_widgets.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../ui/flutter/label.dart';
+import 'flex_split_column.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
@@ -418,6 +419,39 @@ class ActionButton extends StatelessWidget {
   }
 }
 
+/// A wrapper around a FlatButton, an Icon, and an optional Tooltip; used for
+/// small toolbar actions.
+class ToolbarAction extends StatelessWidget {
+  const ToolbarAction({
+    @required this.icon,
+    @required this.onPressed,
+    this.tooltip,
+    Key key,
+  }) : super(key: key);
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = FlatButton(
+      padding: EdgeInsets.zero,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: onPressed,
+      child: Icon(icon, size: actionsIconSize),
+    );
+
+    return tooltip == null
+        ? button
+        : Tooltip(
+            message: tooltip,
+            waitDuration: tooltipWait,
+            child: button,
+          );
+  }
+}
+
 /// A FlatButton used to close a containing dialog.
 class DialogCloseButton extends StatelessWidget {
   @override
@@ -713,4 +747,51 @@ extension ThemeDataExtension on ThemeData {
   TextStyle get subtleTextStyle => TextStyle(color: unselectedWidgetColor);
 
   TextStyle get selectedTextStyle => TextStyle(color: textSelectionColor);
+}
+
+const areaPaneHeaderHeight = 36.0;
+
+/// Create a bordered, fixed-height header area with a title and optional child
+/// on the right-hand side.
+///
+/// This is typically used as a title for a logical area of the screen.
+Widget areaPaneHeader(
+  BuildContext context, {
+  @required String title,
+  bool needsTopBorder = true,
+  Widget rightChild,
+  double rightPadding = densePadding,
+}) {
+  final theme = Theme.of(context);
+
+  return FlexSplitColumnHeader(
+    height: areaPaneHeaderHeight,
+    child: Container(
+      decoration: BoxDecoration(
+        border: Border(
+          top: needsTopBorder
+              ? BorderSide(color: theme.focusColor)
+              : BorderSide.none,
+          bottom: BorderSide(color: theme.focusColor),
+        ),
+        color: titleSolidBackgroundColor(theme),
+      ),
+      padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
+      alignment: Alignment.centerLeft,
+      height: areaPaneHeaderHeight,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.subtitle2,
+            ),
+          ),
+          if (rightChild != null) rightChild,
+        ],
+      ),
+    ),
+  );
 }

--- a/packages/devtools_app/lib/src/flutter/console.dart
+++ b/packages/devtools_app/lib/src/flutter/console.dart
@@ -135,42 +135,10 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
 
 // CONTROLS
 
-/// A pre-configured IconButton that fits the ux of the Console widget.
-///
-/// The customizations are:
-///  * Icon size: [actionsIconSize]
-///  * Do not show [tooltip] if the button is disabled
-///  * [VisualDensity.compact]
-class ConsoleControl extends StatelessWidget {
-  const ConsoleControl({
-    this.icon,
-    this.tooltip,
-    this.onPressed,
-    this.buttonKey,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  final Key buttonKey;
-
-  @override
-  Widget build(BuildContext context) {
-    final disabled = onPressed == null;
-    return IconButton(
-      icon: Icon(icon, size: actionsIconSize),
-      onPressed: onPressed,
-      tooltip: disabled ? null : tooltip,
-      visualDensity: VisualDensity.compact,
-      key: buttonKey,
-    );
-  }
-}
-
 /// A Console Control to "delete" the contents of the console.
 ///
-/// This just preconfigures a ConsoleControl with the `delete` icon,
-/// and the `onPressed` function passed from the outside.
+/// This just preconfigures a ConsoleControl with the `delete` icon, and the
+/// `onPressed` function passed from the outside.
 class DeleteControl extends StatelessWidget {
   const DeleteControl({
     this.onPressed,
@@ -184,11 +152,11 @@ class DeleteControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConsoleControl(
+    return ToolbarAction(
       icon: Icons.delete,
-      tooltip: tooltip,
       onPressed: onPressed,
-      buttonKey: buttonKey,
+      key: buttonKey,
+      tooltip: tooltip,
     );
   }
 }
@@ -215,13 +183,13 @@ class CopyToClipboardControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final disabled = dataProvider == null;
-    return ConsoleControl(
+    return ToolbarAction(
       icon: Icons.content_copy,
-      tooltip: tooltip,
       onPressed: disabled
           ? null
           : () => copyToClipboard(dataProvider(), successMessage, context),
-      buttonKey: buttonKey,
+      key: buttonKey,
+      tooltip: tooltip,
     );
   }
 }

--- a/packages/devtools_app/lib/src/flutter/flex_split_column.dart
+++ b/packages/devtools_app/lib/src/flutter/flex_split_column.dart
@@ -43,7 +43,7 @@ class FlexSplitColumn extends StatelessWidget {
   /// creators of [FlexSplitColumn] can be unaware of the under-the-hood
   /// calculations necessary to achieve the UI requirements specified by
   /// [initialFractions] and [minSizes].
-  final List<FlexSplitColumnHeader> headers;
+  final List<SizedBox> headers;
 
   /// The children that will be laid out below each corresponding header in
   /// [headers].
@@ -71,7 +71,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<Widget> buildChildrenWithFirstHeader(
     List<Widget> children,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
   ) {
     return [
       Column(
@@ -87,7 +87,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<double> modifyInitialFractionsToIncludeFirstHeader(
     List<double> initialFractions,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
     double totalHeight,
   ) {
     var totalHeaderHeight = 0.0;
@@ -110,7 +110,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<double> modifyMinSizesToIncludeFirstHeader(
     List<double> minSizes,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
   ) {
     return [
       minSizes[0] + headers[0].height,

--- a/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/flutter/logging_screen.dart
@@ -131,7 +131,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
       Expanded(
         child: Split(
           axis: Axis.vertical,
-          initialFractions: const [0.78, 0.22],
+          initialFractions: const [0.72, 0.28],
           children: [
             OutlineDecoration(
               child: LogsTable(
@@ -252,12 +252,21 @@ class _LogDetailsState extends State<LogDetails>
   Widget _buildSimpleLog(BuildContext context, LogData log) {
     final disabled = log?.details == null || log.details.isEmpty;
     return OutlineDecoration(
-      child: Console(
-        lines: log?.prettyPrinted?.split('\n'),
-        controls: [
-          CopyToClipboardControl(
-            dataProvider: disabled ? null : () => log?.prettyPrinted,
-            buttonKey: LogDetails.copyToClipboardButtonKey,
+      child: Column(
+        children: [
+          areaPaneHeader(
+            context,
+            title: 'Details',
+            needsTopBorder: false,
+            rightChild: CopyToClipboardControl(
+              dataProvider: disabled ? null : () => log?.prettyPrinted,
+              buttonKey: LogDetails.copyToClipboardButtonKey,
+            ),
+          ),
+          Expanded(
+            child: Console(
+              lines: log?.prettyPrinted?.split('\n'),
+            ),
           ),
         ],
       ),

--- a/packages/devtools_app/test/flutter/debugger_screen_test.dart
+++ b/packages/devtools_app/test/flutter/debugger_screen_test.dart
@@ -128,7 +128,7 @@ void main() {
 
         final clearStdioElement =
             find.byKey(DebuggerConsole.clearStdioButtonKey).evaluate().first;
-        final clearStdioButton = clearStdioElement.widget as IconButton;
+        final clearStdioButton = clearStdioElement.widget as ToolbarAction;
         expect(clearStdioButton.onPressed, isNull);
       });
 

--- a/packages/devtools_app/test/flutter/logging_screen_test.dart
+++ b/packages/devtools_app/test/flutter/logging_screen_test.dart
@@ -163,7 +163,7 @@ void main() {
             .byKey(LogDetails.copyToClipboardButtonKey)
             .evaluate()
             .first
-            .widget as IconButton;
+            .widget as ToolbarAction;
 
         expect(
           copyButton().onPressed,


### PR DESCRIPTION
- add a title to the logging page's details area (`Details`)
- refactor to allow the debugger's `ToolbarAction` widget to be available to other parts of the app
- refactor to allow the debugger's `debuggerPaneHeader` (`areaPaneHeader`) to be available to other parts of the app
- address a portion of https://github.com/flutter/devtools/issues/1982

Now that both the debugger's console, and the logging page's details area, have titles, I moved their floating action button's unto their toolbars. This mirrors the area toolbars we have in other places (in the breakpoints view, and in the code area's title area).

This combines the `ConsoleControl` widget into an existing `DebuggerToolbarAction` widget and renames it to `ToolbarAction`; cc @ditman .

<img width="1022" alt="Screen Shot 2020-06-05 at 3 50 00 PM" src="https://user-images.githubusercontent.com/1269969/83928333-4e360800-a744-11ea-917b-a28833f2f908.png">

<img width="984" alt="Screen Shot 2020-06-05 at 3 50 11 PM" src="https://user-images.githubusercontent.com/1269969/83928347-542be900-a744-11ea-8de4-27c86ec8054d.png">
