### PR TITLE
make the heap data table the default view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -87,7 +87,7 @@ class ScriptPickerState extends State<ScriptPicker> {
             child: Padding(
               padding: const EdgeInsets.all(denseSpacing),
               child: SizedBox(
-                height: 36.0,
+                height: defaultSearchTextHeight,
                 child: TextField(
                   decoration: InputDecoration(
                     labelText:

--- a/packages/devtools_app/lib/src/device_dialog.dart
+++ b/packages/devtools_app/lib/src/device_dialog.dart
@@ -169,8 +169,8 @@ class _VMFlagsDialogState extends State<VMFlagsDialog> with AutoDisposeMixin {
               Text('VM Flags', style: textTheme.headline6),
               const Expanded(child: SizedBox(width: denseSpacing)),
               Container(
-                width: 200.0,
-                height: 36.0,
+                width: defaultSearchTextWidth,
+                height: defaultSearchTextHeight,
                 child: TextField(
                   controller: filterController,
                   decoration: const InputDecoration(

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -109,8 +109,8 @@ class _LoggingScreenState extends State<LoggingScreenBody>
           clearButton(onPressed: _clearLogs),
           const Spacer(),
           Container(
-            width: 200.0,
-            height: 36.0,
+            width: defaultSearchTextWidth,
+            height: defaultSearchTextHeight,
             child: TextField(
               controller: filterController,
               decoration: const InputDecoration(

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -52,7 +52,13 @@ class MemoryController extends DisposableController
 
   static const logFilenamePrefix = 'memory_log_';
 
-  bool showHeatMap = true;
+  final _showHeatMap = ValueNotifier<bool>(false);
+
+  ValueListenable<bool> get showHeatMap => _showHeatMap;
+
+  void toggleShowHeatMap(bool value) {
+    _showHeatMap.value = value;
+  }
 
   final snapshots = <Snapshot>[];
 
@@ -698,6 +704,7 @@ class MemoryController extends DisposableController
       );
 
   bool _gcing = false;
+
   bool get isGcing => _gcing;
 
   Future<void> gc() async {

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -98,6 +98,9 @@ const linkTextStyle = TextStyle(
   decoration: TextDecoration.underline,
 );
 
+const defaultSearchTextWidth = 200.0;
+const defaultSearchTextHeight = 36.0;
+
 /// A short duration to use for animations.
 ///
 /// Use this when you want less emphasis on the animation and more on the


### PR DESCRIPTION
- make the heap data table the default view
- add an outline around the heap data table
- use common constants for the search box sizes

This PR has a few UI related changes, but the main change is that it changes the default view for the heap snapshot from the heat map to the heap data table.

cc @terrylucas 