### PR TITLE
TBR: Add getSupportedProtocols to VM Service Wrapper + pin webdev

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.6-dev.2
 * Ship Flutter Web version of DevTools by default
+* Update package:vm_service dependency to ^4.1.0
 
 ## 0.2.5 2020-05-07
 * Persist connected app URI when switching to Flutter web version of DevTools [#1933](https://github.com/flutter/devtools/pull/1933)

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -729,6 +729,19 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
+  Future<ProtocolList> getSupportedProtocols() async {
+    if (await isProtocolVersionSupported(
+        supportedVersion: SemanticVersion(major: 3, minor: 35))) {
+      return _trackFuture(
+        'getSupportedProtocols',
+        _vmService.getSupportedProtocols(),
+      );
+    } else {
+      return null;
+    }
+  }
+
+  @override
   Future<Success> requirePermissionToResume({
     bool onPauseStart,
     bool onPauseReload,

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   provider: ^4.0.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^4.0.2
+  vm_service: ^4.1.0
   sse: ^3.1.2
   web_socket_channel: ^1.1.0
   flutter:

--- a/packages/devtools_app/test/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger_controller_test.dart
@@ -10,9 +10,9 @@ void main() {
   group('ScriptsHistory', () {
     ScriptsHistory history;
 
-    final ScriptRef ref1 = ScriptRef(uri: 'package:foo/foo.dart')..id = 'id-1';
-    final ScriptRef ref2 = ScriptRef(uri: 'package:bar/bar.dart')..id = 'id-2';
-    final ScriptRef ref3 = ScriptRef(uri: 'package:baz/baz.dart')..id = 'id-3';
+    final ScriptRef ref1 = ScriptRef(uri: 'package:foo/foo.dart', id: 'id-1');
+    final ScriptRef ref2 = ScriptRef(uri: 'package:bar/bar.dart', id: 'id-2');
+    final ScriptRef ref3 = ScriptRef(uri: 'package:baz/baz.dart', id: 'id-3');
 
     setUp(() {
       history = ScriptsHistory();

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:ansicolor/ansicolor.dart';
+import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/debugger/console.dart';
 import 'package:devtools_app/src/debugger/controls.dart';
 import 'package:devtools_app/src/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/debugger/debugger_screen.dart';
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
@@ -193,7 +193,9 @@ void main() {
     });
 
     testWidgets('Libraries hidden', (WidgetTester tester) async {
-      final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
+      final scripts = [
+        ScriptRef(uri: 'package:/test/script.dart', id: 'test-script')
+      ];
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
 
@@ -205,7 +207,9 @@ void main() {
     });
 
     testWidgets('Libraries visible', (WidgetTester tester) async {
-      final scripts = [ScriptRef(uri: 'package:/test/script.dart')];
+      final scripts = [
+        ScriptRef(uri: 'package:/test/script.dart', id: 'test-script')
+      ];
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
 
@@ -222,6 +226,7 @@ void main() {
       final breakpoints = [
         Breakpoint(
           breakpointNumber: 1,
+          id: 'bp1',
           resolved: false,
           location: UnresolvedSourceLocation(
             scriptUri: 'package:/test/script.dart',
@@ -265,9 +270,11 @@ void main() {
       final stackFrames = [
         Frame(
           index: 0,
-          code: CodeRef(name: 'testCodeRef', kind: CodeKind.kDart),
+          code: CodeRef(
+              name: 'testCodeRef', id: 'testCodeRef', kind: CodeKind.kDart),
           location: SourceLocation(
-            script: ScriptRef(uri: 'package:/test/script.dart'),
+            script:
+                ScriptRef(uri: 'package:/test/script.dart', id: 'script.dart'),
             tokenPos: 10,
           ),
           kind: FrameKind.kRegular,
@@ -275,7 +282,8 @@ void main() {
         Frame(
           index: 1,
           location: SourceLocation(
-            script: ScriptRef(uri: 'package:/test/script1.dart'),
+            script: ScriptRef(
+                uri: 'package:/test/script1.dart', id: 'script1.dart'),
             tokenPos: 10,
           ),
           kind: FrameKind.kRegular,
@@ -284,10 +292,12 @@ void main() {
           index: 2,
           code: CodeRef(
             name: '[Unoptimized] testCodeRef2',
+            id: 'testCodeRef2',
             kind: CodeKind.kDart,
           ),
           location: SourceLocation(
-            script: ScriptRef(uri: 'package:/test/script2.dart'),
+            script: ScriptRef(
+                uri: 'package:/test/script2.dart', id: 'script2.dart'),
             tokenPos: 10,
           ),
           kind: FrameKind.kRegular,
@@ -296,10 +306,12 @@ void main() {
           index: 3,
           code: CodeRef(
             name: 'testCodeRef3.<anonymous closure>',
+            id: 'testCodeRef3.closure',
             kind: CodeKind.kDart,
           ),
           location: SourceLocation(
-            script: ScriptRef(uri: 'package:/test/script3.dart'),
+            script: ScriptRef(
+                uri: 'package:/test/script3.dart', id: 'script3.dart'),
             tokenPos: 10,
           ),
           kind: FrameKind.kRegular,
@@ -307,7 +319,8 @@ void main() {
         Frame(
           index: 4,
           location: SourceLocation(
-            script: ScriptRef(uri: 'package:/test/script4.dart'),
+            script: ScriptRef(
+                uri: 'package:/test/script4.dart', id: 'script4.dart'),
             tokenPos: 10,
           ),
           kind: FrameKind.kAsyncSuspensionMarker,
@@ -507,8 +520,12 @@ final testVariables = [
   Variable.create(BoundVariable(
     name: 'Root 1',
     value: InstanceRef(
+      id: 'ref1',
       kind: InstanceKind.kList,
-      classRef: ClassRef(name: '_GrowableList'),
+      classRef: ClassRef(
+        name: '_GrowableList',
+        id: 'ref2',
+      ),
       length: 2,
     ),
     declarationTokenPos: null,
@@ -519,8 +536,9 @@ final testVariables = [
       Variable.create(BoundVariable(
         name: '0',
         value: InstanceRef(
+          id: 'ref3',
           kind: InstanceKind.kInt,
-          classRef: ClassRef(name: 'Integer'),
+          classRef: ClassRef(name: 'Integer', id: 'ref4'),
           valueAsString: '3',
           valueAsStringIsTruncated: false,
         ),
@@ -531,8 +549,9 @@ final testVariables = [
       Variable.create(BoundVariable(
         name: '1',
         value: InstanceRef(
+          id: 'ref5',
           kind: InstanceKind.kInt,
-          classRef: ClassRef(name: 'Integer'),
+          classRef: ClassRef(name: 'Integer', id: 'ref6'),
           valueAsString: '4',
           valueAsStringIsTruncated: false,
         ),
@@ -544,8 +563,9 @@ final testVariables = [
   Variable.create(BoundVariable(
     name: 'Root 2',
     value: InstanceRef(
+      id: 'ref7',
       kind: InstanceKind.kMap,
-      classRef: ClassRef(name: '_InternalLinkedHashmap'),
+      classRef: ClassRef(name: '_InternalLinkedHashmap', id: 'ref8'),
       length: 2,
     ),
     declarationTokenPos: null,
@@ -556,8 +576,9 @@ final testVariables = [
       Variable.create(BoundVariable(
         name: "['key1']",
         value: InstanceRef(
+          id: 'ref9',
           kind: InstanceKind.kDouble,
-          classRef: ClassRef(name: 'Double'),
+          classRef: ClassRef(name: 'Double', id: 'ref10'),
           valueAsString: '1.0',
           valueAsStringIsTruncated: false,
         ),
@@ -568,8 +589,9 @@ final testVariables = [
       Variable.create(BoundVariable(
         name: "['key2']",
         value: InstanceRef(
+          id: 'ref11',
           kind: InstanceKind.kDouble,
-          classRef: ClassRef(name: 'Double'),
+          classRef: ClassRef(name: 'Double', id: 'ref12'),
           valueAsString: '1.1',
           valueAsStringIsTruncated: false,
         ),
@@ -581,8 +603,9 @@ final testVariables = [
   Variable.create(BoundVariable(
     name: 'Root 3',
     value: InstanceRef(
+      id: 'ref13',
       kind: InstanceKind.kString,
-      classRef: ClassRef(name: 'String'),
+      classRef: ClassRef(name: 'String', id: 'ref14'),
       valueAsString: 'test str',
       valueAsStringIsTruncated: true,
     ),
@@ -593,8 +616,9 @@ final testVariables = [
   Variable.create(BoundVariable(
     name: 'Root 4',
     value: InstanceRef(
+      id: 'ref15',
       kind: InstanceKind.kBool,
-      classRef: ClassRef(name: 'Boolean'),
+      classRef: ClassRef(name: 'Boolean', id: 'ref16'),
       valueAsString: 'true',
       valueAsStringIsTruncated: false,
     ),

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.6-dev.2
+- Updated package:vm_service to >= 4.1.0
+
 ## 0.2.3
 - Updated package:vm_service to >= 3.0.0
 - Move shared code out of handlers.dart and rename to `external_handlers.dart`

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   shelf_static: ^0.2.8
   http_multi_server: ^2.2.0
   usage: ^3.4.1
-  vm_service: ^4.0.2
+  vm_service: ^4.1.0
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   package_resolver: ^1.0.0
   pedantic: ^1.7.0
   test: any # This version is pinned by Flutter so we don't need to set one explicitly.
-  vm_service: ^4.0.2
+  vm_service: ^4.1.0
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -92,6 +92,8 @@ if [ "$BOT" = "main" ]; then
 
     # Provision our packages.
     flutter pub get
+    # TODO(dantup): Remove this version number once the webdev issue is resolved
+    # https://github.com/dart-lang/webdev/issues/1037
     flutter pub global activate webdev 2.5.6
 
     # Verify that flutter format has been run.

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -92,7 +92,7 @@ if [ "$BOT" = "main" ]; then
 
     # Provision our packages.
     flutter pub get
-    flutter pub global activate webdev
+    flutter pub global activate webdev 2.5.6
 
     # Verify that flutter format has been run.
     echo "Checking flutter format..."


### PR DESCRIPTION
v4.1.0 of vm_service adds a new method (`getSupportedProtocols`). I don't think this is technically a breaking change, however both DevTools and webdev `implement` the `VmServiceInterface` which means they don't compile with that version.

This change:

1. Pins the webdev version activated on Travis back to version 2.5.6 which compiles (it gets vm_service v3)
2. Requires v4.1 of vm_service for DevTools so we can access the new types, and provides an implementation for `getSupportedProtocols` to address the same issue for DevTools

If this goes green, I may land TBR so I can rebase my other PR and ensure it's passing, but we'll want to revert the hard-coded webdev version here as soon as webdev publishes a fix.

Related:

- https://github.com/dart-lang/webdev/issues/1036
- https://github.com/dart-lang/webdev/issues/1037
- https://github.com/dart-lang/sdk/commit/54fb6ce3c07719d72eec0a14c00f905b724873c2


