### PR TITLE
Remove unused import which shares prefix name with a used import.

### DIFF
--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -10,7 +10,6 @@ import 'dart:isolate';
 import 'package:path/path.dart' as path;
 import 'package:shelf/shelf.dart' as shelf;
 import 'package:shelf/shelf.dart';
-import 'package:shelf/shelf_io.dart' as shelf;
 import 'package:shelf_proxy/shelf_proxy.dart';
 import 'package:shelf_static/shelf_static.dart';
 import 'package:sse/server/sse_handler.dart';

--- a/packages/devtools_server/lib/src/server_api.dart
+++ b/packages/devtools_server/lib/src/server_api.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:shelf/shelf.dart' as shelf;
-import 'package:shelf/shelf_io.dart' as shelf;
 
 import 'usage.dart';
 


### PR DESCRIPTION
Due to a bug in analyzer [1], some unused imports are not reported when
multiple import directives share a prefix name, and one or more are unused.

[1] https://github.com/dart-lang/sdk/issues/38784