### PR TITLE
Remove hard-coded webdev version

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -92,9 +92,7 @@ if [ "$BOT" = "main" ]; then
 
     # Provision our packages.
     flutter pub get
-    # TODO(dantup): Remove this version number once the webdev issue is resolved
-    # https://github.com/dart-lang/webdev/issues/1037
-    flutter pub global activate webdev 2.5.6
+    flutter pub global activate webdev
 
     # Verify that flutter format has been run.
     echo "Checking flutter format..."


### PR DESCRIPTION
This reverts the part of #2062 that hard-coded a webdev version due to the latest version failing with the latest `package:vm_service`. A new version of webdev was published that fixes the issue so we can use the latest one again.