### PR TITLE
add a title to the logging console

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -9,6 +9,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
+import 'flex_split_column.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 import 'ui/label.dart';
@@ -21,6 +22,8 @@ const debuggerDeviceWidth = 800.0;
 const mediumDeviceWidth = 1000.0;
 
 const defaultDialogRadius = 20.0;
+
+const areaPaneHeaderHeight = 36.0;
 
 List<Widget> headerInColumn(TextTheme textTheme, String title) {
   return [
@@ -416,6 +419,85 @@ class ActionButton extends StatelessWidget {
       child: child,
     );
   }
+}
+
+/// A wrapper around a FlatButton, an Icon, and an optional Tooltip; used for
+/// small toolbar actions.
+class ToolbarAction extends StatelessWidget {
+  const ToolbarAction({
+    @required this.icon,
+    @required this.onPressed,
+    this.tooltip,
+    Key key,
+  }) : super(key: key);
+
+  final IconData icon;
+  final String tooltip;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final button = FlatButton(
+      padding: EdgeInsets.zero,
+      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+      onPressed: onPressed,
+      child: Icon(icon, size: actionsIconSize),
+    );
+
+    return tooltip == null
+        ? button
+        : Tooltip(
+            message: tooltip,
+            waitDuration: tooltipWait,
+            child: button,
+          );
+  }
+}
+
+/// Create a bordered, fixed-height header area with a title and optional child
+/// on the right-hand side.
+///
+/// This is typically used as a title for a logical area of the screen.
+// TODO(devoncarew): Refactor this into an 'AreaPaneHeader' widget.
+Widget areaPaneHeader(
+  BuildContext context, {
+  @required String title,
+  bool needsTopBorder = true,
+  List<Widget> actions = const [],
+  double rightPadding = densePadding,
+}) {
+  final theme = Theme.of(context);
+
+  return FlexSplitColumnHeader(
+    height: areaPaneHeaderHeight,
+    child: Container(
+      decoration: BoxDecoration(
+        border: Border(
+          top: needsTopBorder
+              ? BorderSide(color: theme.focusColor)
+              : BorderSide.none,
+          bottom: BorderSide(color: theme.focusColor),
+        ),
+        color: titleSolidBackgroundColor(theme),
+      ),
+      padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
+      alignment: Alignment.centerLeft,
+      height: areaPaneHeaderHeight,
+      child: Row(
+        children: [
+          Expanded(
+            child: Text(
+              title,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.subtitle2,
+            ),
+          ),
+          ...actions,
+        ],
+      ),
+    ),
+  );
 }
 
 /// A FlatButton used to close a containing dialog.

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
-import 'flex_split_column.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 import 'ui/label.dart';
@@ -459,7 +458,7 @@ class ToolbarAction extends StatelessWidget {
 ///
 /// This is typically used as a title for a logical area of the screen.
 // TODO(devoncarew): Refactor this into an 'AreaPaneHeader' widget.
-Widget areaPaneHeader(
+SizedBox areaPaneHeader(
   BuildContext context, {
   @required String title,
   bool needsTopBorder = true,
@@ -468,7 +467,7 @@ Widget areaPaneHeader(
 }) {
   final theme = Theme.of(context);
 
-  return FlexSplitColumnHeader(
+  return SizedBox(
     height: areaPaneHeaderHeight,
     child: Container(
       decoration: BoxDecoration(
@@ -482,7 +481,6 @@ Widget areaPaneHeader(
       ),
       padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
       alignment: Alignment.centerLeft,
-      height: areaPaneHeaderHeight,
       child: Row(
         children: [
           Expanded(

--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -135,38 +135,6 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
 
 // CONTROLS
 
-/// A pre-configured IconButton that fits the ux of the Console widget.
-///
-/// The customizations are:
-///  * Icon size: [actionsIconSize]
-///  * Do not show [tooltip] if the button is disabled
-///  * [VisualDensity.compact]
-class ConsoleControl extends StatelessWidget {
-  const ConsoleControl({
-    this.icon,
-    this.tooltip,
-    this.onPressed,
-    this.buttonKey,
-  });
-
-  final IconData icon;
-  final String tooltip;
-  final VoidCallback onPressed;
-  final Key buttonKey;
-
-  @override
-  Widget build(BuildContext context) {
-    final disabled = onPressed == null;
-    return IconButton(
-      icon: Icon(icon, size: actionsIconSize),
-      onPressed: onPressed,
-      tooltip: disabled ? null : tooltip,
-      visualDensity: VisualDensity.compact,
-      key: buttonKey,
-    );
-  }
-}
-
 /// A Console Control to "delete" the contents of the console.
 ///
 /// This just preconfigures a ConsoleControl with the `delete` icon,
@@ -184,11 +152,11 @@ class DeleteControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ConsoleControl(
+    return ToolbarAction(
       icon: Icons.delete,
       tooltip: tooltip,
       onPressed: onPressed,
-      buttonKey: buttonKey,
+      key: buttonKey,
     );
   }
 }
@@ -215,13 +183,13 @@ class CopyToClipboardControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final disabled = dataProvider == null;
-    return ConsoleControl(
+    return ToolbarAction(
       icon: Icons.content_copy,
       tooltip: tooltip,
       onPressed: disabled
           ? null
           : () => copyToClipboard(dataProvider(), successMessage, context),
-      buttonKey: buttonKey,
+      key: buttonKey,
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -284,18 +284,18 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
           theme,
           child: Row(
             children: [
-              DebuggerToolbarAction(
-                Icons.chevron_left,
+              ToolbarAction(
+                icon: Icons.chevron_left,
                 onPressed:
                     scriptsHistory.hasPrevious ? scriptsHistory.moveBack : null,
               ),
-              DebuggerToolbarAction(
-                Icons.chevron_right,
+              ToolbarAction(
+                icon: Icons.chevron_right,
                 onPressed:
                     scriptsHistory.hasNext ? scriptsHistory.moveForward : null,
               ),
               const SizedBox(width: denseSpacing),
-              const VerticalDivider(),
+              const VerticalDivider(thickness: 1.0),
               const SizedBox(width: defaultSpacing),
               Expanded(
                 child: Text(
@@ -304,7 +304,6 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                 ),
               ),
               const SizedBox(width: denseSpacing),
-              const VerticalDivider(),
               PopupMenuButton<ScriptRef>(
                 itemBuilder: _buildScriptMenuFromHistory,
                 enabled: scriptsHistory.hasScripts,

--- a/packages/devtools_app/lib/src/debugger/common.dart
+++ b/packages/devtools_app/lib/src/debugger/common.dart
@@ -4,8 +4,8 @@
 
 import 'package:flutter/material.dart';
 
+import '../common_widgets.dart';
 import '../theme.dart';
-import 'debugger_screen.dart';
 
 /// Create a header area for a debugger component.
 ///
@@ -23,7 +23,7 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
     ),
     padding: const EdgeInsets.only(left: defaultSpacing),
     alignment: Alignment.centerLeft,
-    height: DebuggerScreen.debuggerPaneHeaderHeight,
+    height: areaPaneHeaderHeight,
     child: child != null ? child : Text(text, style: theme.textTheme.subtitle2),
   );
 }
@@ -44,25 +44,4 @@ Widget createAnimatedCircleWidget(double radius, Color color) {
     duration: defaultDuration,
     decoration: BoxDecoration(color: color, shape: BoxShape.circle),
   );
-}
-
-/// A wrapper around a FlatButton and an Icon, used for small toolbar actions.
-class DebuggerToolbarAction extends StatelessWidget {
-  const DebuggerToolbarAction(
-    this.icon, {
-    @required this.onPressed,
-  });
-
-  final IconData icon;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return FlatButton(
-      padding: EdgeInsets.zero,
-      materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
-      onPressed: onPressed,
-      child: Icon(icon, size: actionsIconSize),
-    );
-  }
 }

--- a/packages/devtools_app/lib/src/debugger/console.dart
+++ b/packages/devtools_app/lib/src/debugger/console.dart
@@ -8,7 +8,6 @@ import 'package:flutter/material.dart';
 import '../common_widgets.dart';
 import '../console.dart';
 import '../utils.dart';
-import 'common.dart';
 import 'debugger_controller.dart';
 
 // TODO(devoncarew): Show some small UI indicator when we receive stdout/stderr.
@@ -60,20 +59,25 @@ class _DebuggerConsoleState extends State<DebuggerConsole> {
 
     return OutlineDecoration(
       child: Console(
-        title: debuggerSectionTitle(Theme.of(context), text: 'Console'),
+        title: areaPaneHeader(
+          context,
+          title: 'Console',
+          needsTopBorder: false,
+          actions: [
+            CopyToClipboardControl(
+              dataProvider: disabled ? null : () => _lines.join('\n'),
+              successMessage:
+                  'Copied $numLines ${pluralize('line', numLines)}.',
+              buttonKey: DebuggerConsole.copyToClipboardButtonKey,
+            ),
+            DeleteControl(
+              buttonKey: DebuggerConsole.clearStdioButtonKey,
+              tooltip: 'Clear console output',
+              onPressed: disabled ? null : widget.controller.clearStdio,
+            ),
+          ],
+        ),
         lines: _lines,
-        controls: [
-          CopyToClipboardControl(
-            dataProvider: disabled ? null : () => _lines.join('\n'),
-            successMessage: 'Copied $numLines ${pluralize('line', numLines)}.',
-            buttonKey: DebuggerConsole.copyToClipboardButtonKey,
-          ),
-          DeleteControl(
-            onPressed: disabled ? null : widget.controller.clearStdio,
-            tooltip: 'Clear console output',
-            buttonKey: DebuggerConsole.clearStdioButtonKey,
-          ),
-        ],
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -208,7 +208,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           totalHeight: constraints.maxHeight,
           initialFractions: const [0.38, 0.38, 0.24],
           minSizes: const [0.0, 0.0, 0.0],
-          headers: [
+          headers: <SizedBox>[
             areaPaneHeader(
               context,
               title: callStackTitle,

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -21,7 +21,6 @@ import '../theme.dart';
 import 'breakpoints.dart';
 import 'call_stack.dart';
 import 'codeview.dart';
-import 'common.dart';
 import 'console.dart';
 import 'controls.dart';
 import 'debugger_controller.dart';
@@ -36,8 +35,6 @@ const bool debugShowCallStackCount = false;
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
       : super('debugger', title: 'Debugger', icon: Octicons.bug);
-
-  static const debuggerPaneHeaderHeight = 36.0;
 
   @override
   String get docPageId => screenId;
@@ -212,19 +209,19 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
           initialFractions: const [0.38, 0.38, 0.24],
           minSizes: const [0.0, 0.0, 0.0],
           headers: [
-            debuggerPaneHeader(
+            areaPaneHeader(
               context,
-              callStackTitle,
+              title: callStackTitle,
               needsTopBorder: false,
-              rightChild:
-                  // ignore: avoid_redundant_argument_values
-                  debugShowCallStackCount ? _callStackRightChild() : null,
+              actions: debugShowCallStackCount ? [_callStackRightChild()] : [],
             ),
-            debuggerPaneHeader(context, variablesTitle),
-            debuggerPaneHeader(
+            areaPaneHeader(context, title: variablesTitle),
+            areaPaneHeader(
               context,
-              breakpointsTitle,
-              rightChild: _breakpointsRightChild(),
+              title: breakpointsTitle,
+              actions: [
+                _breakpointsRightChild(),
+              ],
               rightPadding: 0.0,
             ),
           ],
@@ -254,8 +251,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         return Row(children: [
           BreakpointsCountBadge(breakpoints: breakpoints),
           ActionButton(
-            child: DebuggerToolbarAction(
-              Icons.delete,
+            child: ToolbarAction(
+              icon: Icons.delete,
               onPressed:
                   breakpoints.isNotEmpty ? controller.clearBreakpoints : null,
             ),
@@ -366,45 +363,4 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
 
     return 'paused$reason$fileName $pos';
   }
-}
-
-FlexSplitColumnHeader debuggerPaneHeader(
-  BuildContext context,
-  String title, {
-  bool needsTopBorder = true,
-  Widget rightChild,
-  double rightPadding = 4.0,
-}) {
-  final theme = Theme.of(context);
-
-  return FlexSplitColumnHeader(
-    height: DebuggerScreen.debuggerPaneHeaderHeight,
-    child: Container(
-      decoration: BoxDecoration(
-        border: Border(
-          top: needsTopBorder
-              ? BorderSide(color: theme.focusColor)
-              : BorderSide.none,
-          bottom: BorderSide(color: theme.focusColor),
-        ),
-        color: titleSolidBackgroundColor(theme),
-      ),
-      padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
-      alignment: Alignment.centerLeft,
-      height: DebuggerScreen.debuggerPaneHeaderHeight,
-      child: Row(
-        children: [
-          Expanded(
-            child: Text(
-              title,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-              style: Theme.of(context).textTheme.subtitle2,
-            ),
-          ),
-          if (rightChild != null) rightChild,
-        ],
-      ),
-    ),
-  );
 }

--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -69,14 +69,16 @@ class ScriptPickerState extends State<ScriptPicker> {
     return OutlineDecoration(
       child: Column(
         children: [
-          debuggerPaneHeader(
+          areaPaneHeader(
             context,
-            'Libraries',
+            title: 'Libraries',
             needsTopBorder: false,
-            rightChild: CountBadge(
-              filteredItems: _filteredItems,
-              items: _items,
-            ),
+            actions: [
+              CountBadge(
+                filteredItems: _filteredItems,
+                items: _items,
+              ),
+            ],
           ),
           Container(
             decoration: BoxDecoration(

--- a/packages/devtools_app/lib/src/flex_split_column.dart
+++ b/packages/devtools_app/lib/src/flex_split_column.dart
@@ -43,7 +43,7 @@ class FlexSplitColumn extends StatelessWidget {
   /// creators of [FlexSplitColumn] can be unaware of the under-the-hood
   /// calculations necessary to achieve the UI requirements specified by
   /// [initialFractions] and [minSizes].
-  final List<FlexSplitColumnHeader> headers;
+  final List<SizedBox> headers;
 
   /// The children that will be laid out below each corresponding header in
   /// [headers].
@@ -71,7 +71,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<Widget> buildChildrenWithFirstHeader(
     List<Widget> children,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
   ) {
     return [
       Column(
@@ -87,7 +87,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<double> modifyInitialFractionsToIncludeFirstHeader(
     List<double> initialFractions,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
     double totalHeight,
   ) {
     var totalHeaderHeight = 0.0;
@@ -110,7 +110,7 @@ class FlexSplitColumn extends StatelessWidget {
   @visibleForTesting
   static List<double> modifyMinSizesToIncludeFirstHeader(
     List<double> minSizes,
-    List<FlexSplitColumnHeader> headers,
+    List<SizedBox> headers,
   ) {
     return [
       minSizes[0] + headers[0].height,

--- a/packages/devtools_app/lib/src/flex_split_column.dart
+++ b/packages/devtools_app/lib/src/flex_split_column.dart
@@ -129,11 +129,3 @@ class FlexSplitColumn extends StatelessWidget {
     );
   }
 }
-
-// TODO(kenz): add support for arbitrarily sized widgets.
-class FlexSplitColumnHeader extends SizedBox {
-  const FlexSplitColumnHeader({
-    @required double height,
-    @required Widget child,
-  }) : super(height: height, child: child);
-}

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -130,7 +130,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
       Expanded(
         child: Split(
           axis: Axis.vertical,
-          initialFractions: const [0.78, 0.22],
+          initialFractions: const [0.72, 0.28],
           children: [
             OutlineDecoration(
               child: LogsTable(
@@ -250,15 +250,21 @@ class _LogDetailsState extends State<LogDetails>
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
     final disabled = log?.details == null || log.details.isEmpty;
+
     return OutlineDecoration(
       child: Console(
+        title: areaPaneHeader(
+          context,
+          title: 'Details',
+          needsTopBorder: false,
+          actions: [
+            CopyToClipboardControl(
+              dataProvider: disabled ? null : () => log?.prettyPrinted,
+              buttonKey: LogDetails.copyToClipboardButtonKey,
+            ),
+          ],
+        ),
         lines: log?.prettyPrinted?.split('\n'),
-        controls: [
-          CopyToClipboardControl(
-            dataProvider: disabled ? null : () => log?.prettyPrinted,
-            buttonKey: LogDetails.copyToClipboardButtonKey,
-          ),
-        ],
       ),
     );
   }

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -128,7 +128,7 @@ void main() {
 
         final clearStdioElement =
             find.byKey(DebuggerConsole.clearStdioButtonKey).evaluate().first;
-        final clearStdioButton = clearStdioElement.widget as IconButton;
+        final clearStdioButton = clearStdioElement.widget as ToolbarAction;
         expect(clearStdioButton.onPressed, isNull);
       });
 

--- a/packages/devtools_app/test/flex_split_column_test.dart
+++ b/packages/devtools_app/test/flex_split_column_test.dart
@@ -15,10 +15,10 @@ void main() {
     const children = [SizedBox(), SizedBox(), SizedBox(), SizedBox()];
     const firstHeaderKey = Key('first header');
     const headers = [
-      FlexSplitColumnHeader(height: 50.0, child: SizedBox(key: firstHeaderKey)),
-      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
-      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
-      FlexSplitColumnHeader(height: 50.0, child: SizedBox()),
+      SizedBox(height: 50.0, key: firstHeaderKey),
+      SizedBox(height: 50.0),
+      SizedBox(height: 50.0),
+      SizedBox(height: 50.0),
     ];
     const initialFractions = [0.25, 0.25, 0.25, 0.25];
     const minSizes = [10.0, 10.0, 10.0, 10.0];

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -163,7 +163,7 @@ void main() {
             .byKey(LogDetails.copyToClipboardButtonKey)
             .evaluate()
             .first
-            .widget as IconButton;
+            .widget as ToolbarAction;
 
         expect(
           copyButton().onPressed,


### PR DESCRIPTION
- redux of https://github.com/flutter/devtools/pull/2049 w/ review comments addressed
- add a title to the logging page's details area (Details)
- refactor to allow the debugger's ToolbarAction widget to be available to other parts of the app
- refactor to allow the debugger's debuggerPaneHeader (areaPaneHeader) to be available to other parts of the app
- address a portion of #1982

Now that both the debugger's console, and the logging page's details area, have titles, I moved their floating action button's unto their toolbars. This mirrors the area toolbars we have in other places (in the breakpoints view, and in the code area's title area).

This combines the ConsoleControl widget into an existing DebuggerToolbarAction widget and renames it to ToolbarAction.
