### PR TITLE
normalize icon usage across pages

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -554,16 +554,17 @@ class HeapTreeViewState extends State<HeapTree> with AutoDisposeMixin {
             ),
           ),
         ),
-        const SizedBox(width: denseSpacing),
-        OutlineButton(
-          key: settingsButtonKey,
-          onPressed: _settings,
-          child: const MaterialIconLabel(
-            Icons.settings,
-            'Settings',
-            includeTextWidth: 200,
-          ),
-        ),
+        // TODO: Add these back in when _settings() is implemented.
+//        const SizedBox(width: denseSpacing),
+//        OutlineButton(
+//          key: settingsButtonKey,
+//          onPressed: _settings,
+//          child: const MaterialIconLabel(
+//            Icons.tune,
+//            'Settings',
+//            includeTextWidth: 200,
+//          ),
+//        ),
       ],
     );
   }
@@ -717,6 +718,7 @@ class HeapTreeViewState extends State<HeapTree> with AutoDisposeMixin {
     setState(() {});
   }
 
+  // ignore: unused_element
   void _settings() {
     // TODO(terry): TBD
   }

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -321,7 +321,7 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
           key: MemoryScreen.resetButtonKey,
           onPressed: _reset,
           child: const MaterialIconLabel(
-            Icons.settings_backup_restore,
+            Icons.restore,
             'Reset',
             includeTextWidth: _primaryControlsMinVerboseWidth,
           ),
@@ -331,7 +331,7 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
           key: MemoryScreen.gcButtonKey,
           onPressed: controller.isGcing ? null : _gc,
           child: const MaterialIconLabel(
-            Icons.delete_sweep,
+            Icons.delete,
             'GC',
             includeTextWidth: _primaryControlsMinVerboseWidth,
           ),

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -79,7 +79,7 @@ class ServiceExtensionDescription<T> {
 final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugAllowBanner',
   description: 'Debug Banner',
-  icon: createImageIcon('icons/debug_banner.png'),
+  icon: createImageIcon('icons/debug_banner@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Debug Banner',
@@ -91,7 +91,7 @@ final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
 final debugPaint = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaint',
   description: 'Debug Paint',
-  icon: createImageIcon('icons/debug_paint.png'),
+  icon: createImageIcon('icons/debug_paint@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Debug Paint',
@@ -103,7 +103,7 @@ final debugPaint = ToggleableServiceExtensionDescription<bool>._(
 final debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaintBaselinesEnabled',
   description: 'Paint Baselines',
-  icon: createImageIcon('icons/inspector/textArea.png'),
+  icon: createImageIcon('icons/inspector/textArea@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Paint Baselines',
@@ -115,7 +115,7 @@ final debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
 final performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.showPerformanceOverlay',
   description: 'Performance Overlay',
-  icon: createImageIcon('icons/general/performance_overlay.png'),
+  icon: createImageIcon('icons/general/performance_overlay@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Performance Overlay',
@@ -127,7 +127,7 @@ final performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
 final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.profileWidgetBuilds',
   description: 'Track Widget Builds',
-  icon: createImageIcon('icons/widget_tree.png'),
+  icon: createImageIcon('icons/widget_tree@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Disable tracking widget builds',
@@ -139,7 +139,7 @@ final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
 final repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.repaintRainbow',
   description: 'Repaint Rainbow',
-  icon: createImageIcon('icons/repaint_rainbow.png'),
+  icon: createImageIcon('icons/repaint_rainbow@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Hide Repaint Rainbow',
@@ -151,7 +151,7 @@ final repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
 final slowAnimations = ToggleableServiceExtensionDescription<num>._(
   extension: 'ext.flutter.timeDilation',
   description: 'Slow Animations',
-  icon: createImageIcon('icons/history.png'),
+  icon: createImageIcon('icons/history@2x.png'),
   enabledValue: 5.0,
   disabledValue: 1.0,
   enabledTooltip: 'Disable Slow Animations',
@@ -163,7 +163,7 @@ final slowAnimations = ToggleableServiceExtensionDescription<num>._(
 final togglePlatformMode = ServiceExtensionDescription<String>(
   extension: 'ext.flutter.platformOverride',
   description: 'Override target platform',
-  icon: createImageIcon('icons/phone.png'),
+  icon: createImageIcon('icons/phone@2x.png'),
   values: ['iOS', 'android', 'fuchsia', 'macOS', 'linux'],
   displayValues: [
     'Platform: iOS',
@@ -185,7 +185,7 @@ final toggleOnDeviceWidgetInspector =
   // versions of package:flutter it makes sense to describe this extension as
   // toggling widget select mode as it is the only way to toggle that mode.
   description: 'Select Widget Mode',
-  icon: createImageIcon('icons/general/locate.png'),
+  icon: createImageIcon('icons/general/locate@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Disable select widget mode',
@@ -199,7 +199,7 @@ final toggleOnDeviceWidgetInspector =
 final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.selectMode',
   description: 'Select widget mode',
-  icon: createImageIcon('icons/general/locate.png'),
+  icon: createImageIcon('icons/general/locate@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Exit select widget mode',
@@ -216,7 +216,7 @@ final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
 final enableOnDeviceInspector = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.enable',
   description: 'Enable on-device inspector',
-  icon: createImageIcon('icons/general/locate.png'),
+  icon: createImageIcon('icons/general/locate@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Exit on-device inspector',
@@ -228,7 +228,7 @@ final enableOnDeviceInspector = ToggleableServiceExtensionDescription<bool>._(
 final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.inspector.structuredErrors',
   description: 'Show structured errors',
-  icon: createImageIcon('icons/perf/RedExcl.png'),
+  icon: createImageIcon('icons/perf/RedExcl@2x.png'),
   enabledValue: true,
   disabledValue: false,
   enabledTooltip: 'Disable structured errors for Flutter framework issues',

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import 'theme.dart';
 import 'ui/icons.dart';
 
 class RegisteredServiceDescription {
@@ -15,7 +16,7 @@ class RegisteredServiceDescription {
 
   final String service;
   final String title;
-  final Image icon;
+  final Widget icon;
 }
 
 /// Hot reload service registered by Flutter Tools.
@@ -24,16 +25,19 @@ class RegisteredServiceDescription {
 final hotReload = RegisteredServiceDescription._(
   service: 'reloadSources',
   title: 'Hot Reload',
-  icon: createImageIcon('icons/hot-reload-white.png'),
+  icon: createImageIcon(
+    'icons/hot-reload-white@2x.png',
+    size: defaultIconThemeSize,
+  ),
 );
 
 /// Hot restart service registered by Flutter Tools.
 ///
 /// We call this service to perform a hot restart.
-final hotRestart = RegisteredServiceDescription._(
+const hotRestart = RegisteredServiceDescription._(
   service: 'hotRestart',
   title: 'Hot Restart',
-  icon: createImageIcon('icons/hot-restart-white.png'),
+  icon: Icon(Icons.settings_backup_restore),
 );
 
 /// Flutter version service registered by Flutter Tools.

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -44,8 +44,11 @@ ThemeData _lightTheme() {
 }
 
 const buttonMinWidth = 36.0;
+
 const defaultIconSize = 16.0;
 const actionsIconSize = 20.0;
+const defaultIconThemeSize = 24.0;
+
 const defaultSpacing = 16.0;
 const denseSpacing = 8.0;
 const denseRowSpacing = 6.0;

--- a/packages/devtools_app/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_screen.dart
@@ -252,7 +252,7 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
         ActionButton(
           child: OutlineButton(
             child: const Icon(
-              Icons.more_vert,
+              Icons.tune,
               size: defaultIconSize,
             ),
             onPressed: _openSettingsDialog,

--- a/packages/devtools_app/lib/src/ui/icons.dart
+++ b/packages/devtools_app/lib/src/ui/icons.dart
@@ -243,10 +243,10 @@ class FlutterMaterialIcons {
   }
 }
 
-Image createImageIcon(String url) {
+Image createImageIcon(String url, {double size = defaultIconSize}) {
   return Image(
     image: AssetImage(url),
-    height: defaultIconSize,
-    width: defaultIconSize,
+    height: size,
+    width: size,
   );
 }


### PR DESCRIPTION
- use the `tune` material icon for settings in-line in a page (as a distinct icon from the gear icon at the application level)
- use the higher def resolution icons for the service extension actions
- make the reload and restart icons larger (to match the size of the other toolbar icons)
- use a material icon for restart (it looks better than the png we currently have for restart)

<img width="236" alt="Screen Shot 2020-06-10 at 9 03 56 PM" src="https://user-images.githubusercontent.com/1269969/84345393-11ae4600-ab62-11ea-8805-9237f43e48ad.png">

<img width="205" alt="Screen Shot 2020-06-10 at 9 03 11 PM" src="https://user-images.githubusercontent.com/1269969/84345381-0fe48280-ab62-11ea-9c96-85ad0cc966cd.png">

<img width="354" alt="Screen Shot 2020-06-10 at 9 03 16 PM" src="https://user-images.githubusercontent.com/1269969/84345386-107d1900-ab62-11ea-8fc5-5bc6ab7ef2af.png">

<img width="273" alt="Screen Shot 2020-06-10 at 9 03 21 PM" src="https://user-images.githubusercontent.com/1269969/84345390-1115af80-ab62-11ea-97f6-47dd96334709.png">

<img width="366" alt="Screen Shot 2020-06-10 at 9 03 36 PM" src="https://user-images.githubusercontent.com/1269969/84345391-11ae4600-ab62-11ea-9add-20859fd6fa89.png">
