### PR TITLE
Support --start-paused and retain profile history after disconnect/crash.

### DIFF
--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -4,11 +4,8 @@
 
 import 'dart:async';
 
-import 'package:vm_service/vm_service.dart';
-
 import 'eval_on_dart_library.dart';
 import 'globals.dart';
-import 'service_extensions.dart' as extensions;
 
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const dartHtmlLibraryUri = 'dart:html';

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -145,10 +145,11 @@ class _InitializerState extends State<Initializer>
                 ),
               const Spacer(),
               RaisedButton(
-                  onPressed: () {
-                    overlay.remove();
-                  },
-                  child: const Text('Review History')),
+                onPressed: () {
+                  overlay.remove();
+                },
+                child: const Text('Review History'),
+              ),
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -144,6 +144,11 @@ class _InitializerState extends State<Initializer>
                   style: theme.textTheme.bodyText2,
                 ),
               const Spacer(),
+              RaisedButton(
+                  onPressed: () {
+                    overlay.remove();
+                  },
+                  child: const Text('Review History')),
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -561,13 +561,7 @@ class ObjectGroup {
     String methodName,
     Map<String, Object> params,
   ) {
-    final callMethodName = 'ext.flutter.inspector.$methodName';
-    if (serviceManager.serviceExtensionManager
-        .isServiceExtensionAvailable(callMethodName)) {
-      return null;
-    }
-
-    return _callServiceExtension(callMethodName, params);
+    return _callServiceExtension('ext.flutter.inspector.$methodName', params);
   }
 
   Future<Object> invokeServiceMethodDaemonInspectorRef(

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -561,7 +561,13 @@ class ObjectGroup {
     String methodName,
     Map<String, Object> params,
   ) {
-    return _callServiceExtension('ext.flutter.inspector.$methodName', params);
+    final callMethodName = 'ext.flutter.inspector.$methodName';
+    if (!serviceManager.serviceExtensionManager
+        .isServiceExtensionAvailable(callMethodName)) {
+      return null;
+    }
+
+    return _callServiceExtension(callMethodName, params);
   }
 
   Future<Object> invokeServiceMethodDaemonInspectorRef(

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -380,8 +380,14 @@ class InspectorService extends DisposableController
 
   Future<Object> invokeServiceMethodDaemonNoGroup(
       String methodName, Map<String, Object> args) async {
+    final callMethodName = 'ext.flutter.inspector.$methodName';
+    if (!serviceManager.serviceExtensionManager
+        .isServiceExtensionAvailable(callMethodName)) {
+      return {'result': null};
+    }
+
     final r = await vmService.callServiceExtension(
-      'ext.flutter.inspector.$methodName',
+      callMethodName,
       isolateId: inspectorLibrary.isolateId,
       args: args,
     );
@@ -555,7 +561,13 @@ class ObjectGroup {
     String methodName,
     Map<String, Object> params,
   ) {
-    return _callServiceExtension('ext.flutter.inspector.$methodName', params);
+    final callMethodName = 'ext.flutter.inspector.$methodName';
+    if (serviceManager.serviceExtensionManager
+        .isServiceExtensionAvailable(callMethodName)) {
+      return null;
+    }
+
+    return _callServiceExtension(callMethodName, params);
   }
 
   Future<Object> invokeServiceMethodDaemonInspectorRef(

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -538,7 +538,7 @@ class MemoryController extends DisposableController
   }
 
   bool get isConnectedDeviceAndroid {
-    return serviceManager.vm.operatingSystem == 'android';
+    return serviceManager?.vm?.operatingSystem == 'android';
   }
 
   Future<List<InstanceSummary>> getInstances(

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -510,8 +510,8 @@ class MemoryController extends DisposableController
   }
 
   Future<HeapSnapshotGraph> snapshotMemory() async {
-    return await serviceManager.service
-        .getHeapSnapshotGraph(serviceManager.isolateManager.selectedIsolate);
+    return await serviceManager?.service
+        ?.getHeapSnapshotGraph(serviceManager?.isolateManager?.selectedIsolate);
   }
 
   Future<List<ClassHeapDetailStats>> resetAllocationProfile() =>

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -13,6 +13,7 @@ import 'package:provider/provider.dart';
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
 import '../config_specific/logger/logger.dart' as logger;
+import '../globals.dart';
 import '../table.dart';
 import '../table_data.dart';
 import '../theme.dart';
@@ -570,6 +571,9 @@ class HeapTreeViewState extends State<HeapTree> with AutoDisposeMixin {
   }
 
   void _snapshot() async {
+    // VmService not available (disconnected/crashed).
+    if (serviceManager.service == null) return;
+
     setState(() {
       snapshotState = SnapshotStatus.streaming;
     });
@@ -577,6 +581,10 @@ class HeapTreeViewState extends State<HeapTree> with AutoDisposeMixin {
     final snapshotTimestamp = DateTime.now();
 
     final graph = await controller.snapshotMemory();
+
+    // No snapshot collected, disconnected/crash application.
+    if (graph == null) return;
+
     final snapshotCollectionTime = DateTime.now();
 
     setState(() {

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -55,15 +55,18 @@ class MemoryTracker {
   }
 
   void _updateLiveDataPolling([bool paused]) {
+    if (service == null) {
+      // A service of null implies we're disconnected - signal paused.
+      memoryController.pauseLiveFeed();
+    }
     paused ??= memoryController.paused.value;
 
-    // A service of null implies we're disconnected.
-    if (paused || service == null) {
+    if (paused) {
       _pollingTimer?.cancel();
       _gcStreamListener?.cancel();
     } else {
       _pollingTimer = Timer(Duration.zero, _pollMemory);
-      _gcStreamListener = service.onGCEvent.listen(_handleGCEvent);
+      _gcStreamListener = service?.onGCEvent?.listen(_handleGCEvent);
     }
   }
 

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -57,7 +57,8 @@ class MemoryTracker {
   void _updateLiveDataPolling([bool paused]) {
     paused ??= memoryController.paused.value;
 
-    if (paused) {
+    // A service of null implies we're disconnected.
+    if (paused || service == null) {
       _pollingTimer?.cancel();
       _gcStreamListener?.cancel();
     } else {

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -60,7 +60,8 @@ class MemoryScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppNow
+    final connected = serviceManager?.connectedApp;
+    return connected != null && !connected.isDartWebAppNow
         ? const MemoryBody()
         : const DisabledForWebAppMessage();
   }

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -643,7 +643,7 @@ class ServiceExtensionManager {
               _service,
             );
             final InstanceRef value = await flutterLibrary.eval(
-              'WidgetsBinding.instance.debugDidSendFirstFrameEvent',
+              'WidgetsBinding?.instance?.debugDidSendFirstFrameEvent ?? false',
               isAlive: null,
             );
 


### PR DESCRIPTION
- Flutter application started with --start-paused causes the main isolate to pause.  The debugger detects the pause states and correctly enables the 'Resume' button.  If Resume is pressed that isolate will resume.  Unfortunately, other isolates created (after the main isolate is resumed) will subsequently be created in a pause start state (requiring subsequent isolates to be resumed).  This PR will correctly resume any future created isolates in a pause state.
- Fixed inspector to not throw exceptions when launched (default DevTools) and Flutter was started with --start-paused.  Open [issue](https://github.com/flutter/devtools/issues/2081) to fix the inspector to properly reconnect when Flutter is running again (Resume from debugger).
- Added ability to review collected memory statistics if application is disconnected or crash (e.g., review graph, snapshots, and any analyzes).
