### PR TITLE
Hide "Disconnected" overlay if DevTools is reconnected to a VM

### DIFF
--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -125,6 +125,7 @@ class _InitializerState extends State<Initializer>
         disconnectedOverlayReconnectSubscription = serviceManager.onStateChange
             .where((connected) => connected)
             .listen((_) => hideDisconnectedOverlay());
+        autoDispose(disconnectedOverlayReconnectSubscription);
       }
     });
   }

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -60,6 +60,9 @@ class _InitializerState extends State<Initializer>
 
   bool _dependenciesLoaded = false;
 
+  OverlayEntry currentDisconnectedOverlay;
+  StreamSubscription<bool> disconnectedOverlayReconnectSubscription;
+
   @override
   void initState() {
     super.initState();
@@ -113,16 +116,29 @@ class _InitializerState extends State<Initializer>
   /// Shows a "disconnected" overlay if the [service.serviceManager] is not currently connected.
   void _handleNoConnection() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!_checkLoaded() && ModalRoute.of(context).isCurrent) {
+      if (!_checkLoaded() &&
+          ModalRoute.of(context).isCurrent &&
+          currentDisconnectedOverlay == null) {
         Overlay.of(context).insert(_createDisconnectedOverlay());
+
+        // Set up a subscription to hide the overlay if we become reconnected.
+        disconnectedOverlayReconnectSubscription = serviceManager.onStateChange
+            .where((connected) => connected)
+            .listen((_) => hideDisconnectedOverlay());
       }
     });
   }
 
+  void hideDisconnectedOverlay() {
+    currentDisconnectedOverlay?.remove();
+    currentDisconnectedOverlay = null;
+    disconnectedOverlayReconnectSubscription?.cancel();
+    disconnectedOverlayReconnectSubscription = null;
+  }
+
   OverlayEntry _createDisconnectedOverlay() {
     final theme = Theme.of(context);
-    OverlayEntry overlay;
-    overlay = OverlayEntry(
+    currentDisconnectedOverlay = OverlayEntry(
       builder: (context) => Container(
         // TODO(dantup): Change this to a theme colour and ensure it works in both dart/light themes
         color: const Color.fromRGBO(128, 128, 128, 0.5),
@@ -134,7 +150,7 @@ class _InitializerState extends State<Initializer>
               if (widget.allowConnectionScreenOnDisconnect)
                 RaisedButton(
                     onPressed: () {
-                      overlay.remove();
+                      hideDisconnectedOverlay();
                       Navigator.of(context).popAndPushNamed(homeRoute);
                     },
                     child: const Text('Connect to Another App'))
@@ -145,9 +161,7 @@ class _InitializerState extends State<Initializer>
                 ),
               const Spacer(),
               RaisedButton(
-                onPressed: () {
-                  overlay.remove();
-                },
+                onPressed: hideDisconnectedOverlay,
                 child: const Text('Review History'),
               ),
             ],
@@ -155,7 +169,7 @@ class _InitializerState extends State<Initializer>
         ),
       ),
     );
-    return overlay;
+    return currentDisconnectedOverlay;
   }
 
   @override

--- a/packages/devtools_app/test/initializer_test.dart
+++ b/packages/devtools_app/test/initializer_test.dart
@@ -67,6 +67,25 @@ void main() {
       expect(find.text('Disconnected'), findsOneWidget);
     });
 
+    testWidgets('closes disconnected overlay upon reconnect',
+        (WidgetTester tester) async {
+      final serviceManager = FakeServiceManager(useFakeService: true);
+      setGlobal(ServiceConnectionManager, serviceManager);
+
+      // Trigger a disconnect and ensure the overlay appears.
+      await tester.pumpFrames(app, const Duration(milliseconds: 100));
+      serviceManager.changeState(false);
+      await tester.pumpFrames(app, const Duration(milliseconds: 100));
+      expect(find.text('Disconnected'), findsOneWidget);
+
+      // Trigger a reconnect
+      serviceManager.changeState(true);
+
+      // Expect no overlay.
+      await tester.pumpFrames(app, const Duration(milliseconds: 100));
+      expect(find.text('Disconnected'), findsNothing);
+    });
+
     testWidgets('builds contents when initialized',
         (WidgetTester tester) async {
       await tester.pumpWidget(app);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -110,7 +110,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   @override
   Stream<bool> get onStateChange => stateChangeStream.stream;
 
-  StreamController<bool> stateChangeStream = StreamController();
+  StreamController<bool> stateChangeStream = StreamController.broadcast();
 
   void changeState(bool value) {
     hasConnection = value;


### PR DESCRIPTION
When running in the existing non-embedded mode from VS Code, you can reconnect DevTools to  a new VM (using the server API). This didn't cause the disconnected overlay to be hidden so you'd end up with the overlay still visible but could see the tools in the background reconnected.