### PR TITLE
Fix exception in CPU profile transformer

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -53,6 +53,7 @@ class CpuProfilerController {
   Future<void> pullAndProcessProfile({
     @required int startMicros,
     @required int extentMicros,
+    String processId,
   }) async {
     if (!profilerEnabled) return;
     assert(_dataNotifier.value != null);
@@ -71,7 +72,7 @@ class CpuProfilerController {
     );
 
     try {
-      await transformer.processData(cpuProfileData);
+      await transformer.processData(cpuProfileData, processId: processId);
       _dataNotifier.value = cpuProfileData;
       _processingNotifier.value = false;
     } on AssertionError catch (_) {
@@ -80,6 +81,9 @@ class CpuProfilerController {
       // Rethrow after setting notifiers so that cpu profile data is included
       // in the timeline export.
       rethrow;
+    } on ProcessCancelledException catch (_) {
+      // Do nothing because the attempt to process data has been cancelled in
+      // favor of a new one.
     }
   }
 

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
@@ -56,10 +56,6 @@ class CpuProfileTransformer {
 
     // Use batch processing to maintain a responsive UI.
     while (_stackFramesProcessed < _stackFramesCount) {
-      if (processId != _activeProcessId) {
-        throw ProcessCancelledException();
-      }
-
       _processBatch(batchSize, cpuProfileData);
       _progressNotifier.value = _stackFramesProcessed / _stackFramesCount;
 
@@ -67,6 +63,9 @@ class CpuProfileTransformer {
       // progress indicator. Use a longer delay than the default (0) so that the
       // progress indicator will look smoother.
       await delayForBatchProcessing(micros: 5000);
+      if (processId != _activeProcessId) {
+        throw ProcessCancelledException();
+      }
     }
 
     _setExclusiveSampleCounts(cpuProfileData);

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -157,8 +157,7 @@ class TimelineController
 
     cpuProfilerController.reset();
 
-    // Fetch a profile if we are not in offline mode and if the profiler is
-    // enabled.
+    // Fetch a profile if not in offline mode and if the profiler is enabled.
     if ((!offlineMode || offlineTimelineData == null) &&
         cpuProfilerController.profilerEnabled) {
       await getCpuProfileForSelectedEvent();

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -172,6 +172,7 @@ class TimelineController
     await cpuProfilerController.pullAndProcessProfile(
       startMicros: selectedEvent.time.start.inMicroseconds,
       extentMicros: selectedEvent.time.duration.inMicroseconds,
+      processId: '${selectedEvent.traceEvents.first.id}',
     );
     data.cpuProfileData = cpuProfilerController.dataNotifier.value;
   }


### PR DESCRIPTION
An exception would be thrown when we select a UI timeline event and attempt to pull a CPU profile, and then select another  UI timeline event before the first profile was done being processed. Now we bail out early if the processId's do not match.