### PR TITLE
Move custom row offset for top padding into timeline flame chart

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -372,7 +372,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
 
       // TODO(kenz): consult with Flutter team to see if there is a better place
       // to call this that guarantees the scroll controller offsets will be
-      // updated for the new zoom level and layout size.
+      // updated for the new zoom level and layout size
       // https://github.com/flutter/devtools/issues/2012.
       linkedHorizontalScrollControllerGroup.jumpTo(
           newScrollOffset.clamp(FlameChart.minScrollOffset, maxScrollOffset));

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -25,7 +25,6 @@ const double rowHeightWithPadding = rowHeight + rowPadding;
 const double sectionSpacing = 15.0;
 const double sideInset = 70.0;
 const double sideInsetSmall = 40.0;
-const int defaultRowOffsetForTopPadding = 3;
 
 // TODO(kenz): remove the hard coded hack once
 // https://github.com/flutter/flutter/issues/33675 is fixed.
@@ -86,7 +85,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
 // like implementation).
 abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     with AutoDisposeMixin, FlameChartColorMixin, TickerProviderStateMixin {
-  int get rowOffsetForTopPadding => defaultRowOffsetForTopPadding;
+  int get rowOffsetForTopPadding => 1;
 
   // The "top" positional value for each flame chart node will be 0.0 because
   // each node is positioned inside its own list.

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -33,9 +33,6 @@ class _CpuProfileFlameChartState
     extends FlameChartState<CpuProfileFlameChart, CpuStackFrame> {
   static const stackFramePadding = 1;
 
-  @override
-  int get rowOffsetForTopPadding => 1;
-
   int _colorOffset = 0;
 
   final Map<String, double> stackFrameLefts = {};

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -56,7 +56,11 @@ class TimelineFlameChart extends FlameChart<TimelineData, TimelineEvent> {
   }
 
   /// Offset for drawing async guidelines.
-  static int asyncGuidelineOffset = 1;
+  static const int asyncGuidelineOffset = 1;
+
+  // Rows of top padding needed to create room for the timestamp labels and the
+  // selected frame brackets.
+  static const int rowOffsetForTopPadding = 3;
 
   @override
   TimelineFlameChartState createState() => TimelineFlameChartState();
@@ -83,6 +87,9 @@ class TimelineFlameChartState
   TimelineController _timelineController;
 
   TimelineFrame _selectedFrame;
+
+  @override
+  int get rowOffsetForTopPadding => TimelineFlameChart.rowOffsetForTopPadding;
 
   @override
   void didChangeDependencies() {
@@ -484,7 +491,8 @@ class SectionLabelPainter extends FlameChartPainter {
     ));
 
     // Start at row height to account for timestamps at top of chart.
-    var startSectionPx = sectionSpacing * defaultRowOffsetForTopPadding;
+    var startSectionPx =
+        sectionSpacing * TimelineFlameChart.rowOffsetForTopPadding;
     for (String groupName in eventGroups.keys) {
       final group = eventGroups[groupName];
       final labelTop = startSectionPx - verticalScrollOffset;


### PR DESCRIPTION
Addressing comment from https://github.com/flutter/devtools/pull/2113 and improve so that the customization lives where it is used, instead of being the default value.