### PR TITLE
Fix bug in timeline imports caused by upstream event changes.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -338,8 +338,7 @@ class TimelineController
 
     // TODO(kenz): once each trace event has a ui/raster distinction bit added to
     // the trace, we will not need to infer thread ids. This is not robust.
-    final uiThreadId =
-        _threadIdForEvents({uiEventName, uiEventNameOld}, traceEvents);
+    final uiThreadId = _threadIdForEvents({uiEventName}, traceEvents);
     final rasterThreadId = _threadIdForEvents({rasterEventName}, traceEvents);
 
     offlineTimelineData = offlineData.shallowClone();

--- a/packages/devtools_app/lib/src/timeline/timeline_model.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_model.dart
@@ -11,6 +11,7 @@ import '../service_manager.dart';
 import '../trace_event.dart';
 import '../trees.dart';
 import '../utils.dart';
+import 'timeline_processor.dart';
 
 class TimelineData {
   TimelineData({
@@ -735,7 +736,7 @@ class SyncTimelineEvent extends TimelineEvent {
   SyncTimelineEvent(TraceEventWrapper firstTraceEvent) : super(firstTraceEvent);
 
   bool get isUiEventFlow => subtreeHasNodeWithCondition(
-      (TimelineEvent event) => event.name.contains('Engine::BeginFrame'));
+      (TimelineEvent event) => event.name.contains(uiEventName));
 
   bool get isRasterEventFlow => subtreeHasNodeWithCondition(
       (TimelineEvent event) => event.name.contains('PipelineConsume'));

--- a/packages/devtools_app/lib/src/timeline/timeline_processor.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_processor.dart
@@ -40,11 +40,7 @@ StringBuffer debugFrameTracking = StringBuffer();
 
 const String rasterEventName = 'GPURasterizer::Draw';
 
-// For older versions of Flutter, the starting event for the UI portion of a
-// Flutter frame was 'VSYNC'. We need to check for both so that we can still
-// support users on older versions of Flutter.
-const String uiEventNameOld = 'VSYNC';
-const String uiEventName = 'VsyncProcessCallback';
+const String uiEventName = 'Engine::BeginFrame';
 
 const String messageLoopFlushTasks = 'MessageLoop::FlushTasks';
 


### PR DESCRIPTION
We were getting the wrong UI thread for offline imports because the VSYNC event is now an async event coming from a different thread. 