### PR TITLE
Add fraction digits parameter to all print byte methods

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -552,7 +552,7 @@ class TreemapNode extends TreeNode<TreemapNode> {
   String prettyByteSize() {
     // Negative sign isn't explicitly added since a regular print of a negative number includes it.
     final plusSign = showDiff && byteSize > 0 ? '+' : '';
-    return '$plusSign${prettyPrintBytes(byteSize, includeUnit: true)}';
+    return '$plusSign${prettyPrintBytes(byteSize, fractionDigits: 2, includeUnit: true)}';
   }
 
   /// Returns a list of [TreemapNode] in the path from root node to [this].

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -552,7 +552,7 @@ class TreemapNode extends TreeNode<TreemapNode> {
   String prettyByteSize() {
     // Negative sign isn't explicitly added since a regular print of a negative number includes it.
     final plusSign = showDiff && byteSize > 0 ? '+' : '';
-    return '$plusSign${prettyPrintBytes(byteSize, fractionDigits: 2, includeUnit: true)}';
+    return '$plusSign${prettyPrintBytes(byteSize, kbFractionDigits: 1, includeUnit: true)}';
   }
 
   /// Returns a list of [TreemapNode] in the path from root node to [this].

--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -85,7 +85,7 @@ class _SizeColumn extends ColumnData<TreemapNode> {
   String getDisplayValue(TreemapNode dataObject) {
     return prettyPrintBytes(
       dataObject.byteSize,
-      fractionDigits: 2,
+      kbFractionDigits: 1,
       includeUnit: true,
     );
   }

--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -82,8 +82,13 @@ class _SizeColumn extends ColumnData<TreemapNode> {
   dynamic getValue(TreemapNode dataObject) => dataObject.byteSize;
 
   @override
-  String getDisplayValue(TreemapNode dataObject) =>
-      prettyPrintBytes(dataObject.byteSize, includeUnit: true);
+  String getDisplayValue(TreemapNode dataObject) {
+    return prettyPrintBytes(
+      dataObject.byteSize,
+      fractionDigits: 2,
+      includeUnit: true,
+    );
+  }
 
   @override
   bool get supportsSorting => true;

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -67,14 +67,15 @@ String percent2(double d) => '${(d * 100).toStringAsFixed(2)}%';
 
 String prettyPrintBytes(
   num bytes, {
-  int fractionDigits = 0,
+  int kbFractionDigits = 0,
+  int mbFractionDigits = 1,
   bool includeUnit = false,
 }) {
   final sizeInKB = bytes.abs() / 1024.0;
   if (sizeInKB < 1024.0) {
-    return '${printKB(bytes, fractionDigits: fractionDigits, includeUnit: includeUnit)}';
+    return '${printKB(bytes, fractionDigits: kbFractionDigits, includeUnit: includeUnit)}';
   } else {
-    return '${printMB(bytes, fractionDigits: fractionDigits, includeUnit: includeUnit)}';
+    return '${printMB(bytes, fractionDigits: mbFractionDigits, includeUnit: includeUnit)}';
   }
 }
 
@@ -84,6 +85,7 @@ String printKB(num bytes, {int fractionDigits = 0, bool includeUnit = false}) {
 
   // We add ((1024/2)-1) to the value before formatting so that a non-zero byte
   // value doesn't round down to 0. If showing decimal points, let it round normally.
+  // TODO(peterdjlee): Round up to the respective digit when fractionDigits > 0.
   final processedBytes = fractionDigits == 0 ? bytes + 511 : bytes;
   var output = _kbPattern.format(processedBytes / 1024);
   if (includeUnit) {

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -65,7 +65,11 @@ final NumberFormat nf = NumberFormat.decimalPattern();
 
 String percent2(double d) => '${(d * 100).toStringAsFixed(2)}%';
 
-String prettyPrintBytes(num bytes, {int fractionDigits = 0, bool includeUnit = false}) {
+String prettyPrintBytes(
+  num bytes, {
+  int fractionDigits = 0,
+  bool includeUnit = false,
+}) {
   final sizeInKB = bytes.abs() / 1024.0;
   if (sizeInKB < 1024.0) {
     return '${printKB(bytes, fractionDigits: fractionDigits, includeUnit: includeUnit)}';

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -65,22 +65,23 @@ final NumberFormat nf = NumberFormat.decimalPattern();
 
 String percent2(double d) => '${(d * 100).toStringAsFixed(2)}%';
 
-String prettyPrintBytes(num bytes, {bool includeUnit = false}) {
+String prettyPrintBytes(num bytes, {int fractionDigits = 0, bool includeUnit = false}) {
   final sizeInKB = bytes.abs() / 1024.0;
   if (sizeInKB < 1024.0) {
-    return '${printKB(bytes, includeUnit: includeUnit)}';
+    return '${printKB(bytes, fractionDigits: fractionDigits, includeUnit: includeUnit)}';
   } else {
-    return '${printMB(bytes, fractionDigits: 2, includeUnit: includeUnit)}';
+    return '${printMB(bytes, fractionDigits: fractionDigits, includeUnit: includeUnit)}';
   }
 }
 
-final NumberFormat _kbPattern = NumberFormat.decimalPattern()
-  ..maximumFractionDigits = 0;
+String printKB(num bytes, {int fractionDigits = 0, bool includeUnit = false}) {
+  final NumberFormat _kbPattern = NumberFormat.decimalPattern()
+    ..maximumFractionDigits = fractionDigits;
 
-String printKB(num bytes, {bool includeUnit = false}) {
   // We add ((1024/2)-1) to the value before formatting so that a non-zero byte
-  // value doesn't round down to 0.
-  var output = _kbPattern.format((bytes + 511) / 1024);
+  // value doesn't round down to 0. If showing decimal points, let it round normally.
+  final processedBytes = fractionDigits == 0 ? bytes + 511 : bytes;
+  var output = _kbPattern.format(processedBytes / 1024);
   if (includeUnit) {
     output += ' KB';
   }

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -16,15 +16,15 @@ void main() {
       const int mb = 1024 * kb;
 
       expect(prettyPrintBytes(kb), '1');
-      expect(prettyPrintBytes(kb + 100, fractionDigits: 1), '1.1');
-      expect(prettyPrintBytes(kb + 150, fractionDigits: 2), '1.15');
+      expect(prettyPrintBytes(kb + 100, kbFractionDigits: 1), '1.1');
+      expect(prettyPrintBytes(kb + 150, kbFractionDigits: 2), '1.15');
       expect(prettyPrintBytes(kb, includeUnit: true), '1 KB');
       expect(prettyPrintBytes(kb * 1000, includeUnit: true), '1,000 KB');
 
-      expect(prettyPrintBytes(mb), '1');
-      expect(prettyPrintBytes(mb + kb * 100, fractionDigits: 1), '1.1');
-      expect(prettyPrintBytes(mb + kb * 150, fractionDigits: 2), '1.15');
-      expect(prettyPrintBytes(mb, includeUnit: true), '1 MB');
+      expect(prettyPrintBytes(mb), '1.0');
+      expect(prettyPrintBytes(mb + kb * 100), '1.1');
+      expect(prettyPrintBytes(mb + kb * 150, mbFractionDigits: 2), '1.15');
+      expect(prettyPrintBytes(mb, includeUnit: true), '1.0 MB');
       expect(prettyPrintBytes(mb - kb, includeUnit: true), '1,023 KB');
     });
 

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -16,11 +16,15 @@ void main() {
       const int mb = 1024 * kb;
 
       expect(prettyPrintBytes(kb), '1');
+      expect(prettyPrintBytes(kb + 100, fractionDigits: 1), '1.1');
+      expect(prettyPrintBytes(kb + 150, fractionDigits: 2), '1.15');
       expect(prettyPrintBytes(kb, includeUnit: true), '1 KB');
       expect(prettyPrintBytes(kb * 1000, includeUnit: true), '1,000 KB');
 
-      expect(prettyPrintBytes(mb), '1.00');
-      expect(prettyPrintBytes(mb, includeUnit: true), '1.00 MB');
+      expect(prettyPrintBytes(mb), '1');
+      expect(prettyPrintBytes(mb + kb * 100, fractionDigits: 1), '1.1');
+      expect(prettyPrintBytes(mb + kb * 150, fractionDigits: 2), '1.15');
+      expect(prettyPrintBytes(mb, includeUnit: true), '1 MB');
       expect(prettyPrintBytes(mb - kb, includeUnit: true), '1,023 KB');
     });
 


### PR DESCRIPTION
* Add fraction digits parameter to `prettyPrintBytes` and `printKB` to make byte display more flexible