### PR TITLE
Fix flame chart zoom bug

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -745,7 +745,7 @@ class FlameChartUtils {
     // the issue described in the bug where the scroll extent is smaller than
     // where we want to `jumpTo`. Smaller values were experimented with but the
     // issue still persisted, so we are using a very large number.
-    if (index == nodes.length - 1) return 1000000.0;
+    if (index == nodes.length - 1) return 10000000.0;
     final node = nodes[index];
     final nextNode = index == nodes.length - 1 ? null : nodes[index + 1];
     final nodeZoom = zoomForNode(node, chartZoom);

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -435,7 +435,7 @@ void main() {
       expect(paddedZoomedIntervals[0], equals(const Range(0.0, 120.0)));
       expect(paddedZoomedIntervals[1], equals(const Range(120.0, 180.0)));
       expect(paddedZoomedIntervals[2], equals(const Range(180.0, 240.0)));
-      expect(paddedZoomedIntervals[3], equals(const Range(240.0, 1000540.0)));
+      expect(paddedZoomedIntervals[3], equals(const Range(240.0, 10000540.0)));
     });
 
     test('toPaddedZoomedIntervals calculation is accurate for zoomed row', () {
@@ -447,7 +447,7 @@ void main() {
       expect(paddedZoomedIntervals[0], equals(const Range(0.0, 170.0)));
       expect(paddedZoomedIntervals[1], equals(const Range(170.0, 290.0)));
       expect(paddedZoomedIntervals[2], equals(const Range(290.0, 410.0)));
-      expect(paddedZoomedIntervals[3], equals(const Range(410.0, 1001010.0)));
+      expect(paddedZoomedIntervals[3], equals(const Range(410.0, 10001010.0)));
     });
   });
 
@@ -487,7 +487,7 @@ void main() {
       expect(
           FlameChartUtils.rightPaddingForNode(3, testNodes,
               chartZoom: 1.0, chartStartInset: sideInset, chartWidth: 610.0),
-          equals(1000000.0));
+          equals(10000000.0));
     });
 
     test('leftPaddingForNode returns correct value for zoomed row', () {
@@ -525,7 +525,7 @@ void main() {
       expect(
           FlameChartUtils.rightPaddingForNode(3, testNodes,
               chartZoom: 2.0, chartStartInset: sideInset, chartWidth: 1080.0),
-          equals(1000000.0));
+          equals(10000000.0));
     });
 
     test('zoomForNode returns correct values', () {


### PR DESCRIPTION
This is a band aid for https://github.com/flutter/devtools/issues/2185. The original issue is here: https://github.com/flutter/devtools/issues/2012, and the attempted fix for that was landed in 
https://github.com/flutter/devtools/pull/2013. We can't just keep adding zeros forever, but I was able to reproduce before and not after making this change, so it can't hurt.

Fixes https://github.com/flutter/devtools/issues/2185