### PR TITLE
have the cmd-p keybinding toggle open and closed the debugger libraries pane

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -150,11 +150,6 @@ class DebuggerController extends DisposableController
     _librariesVisible.value = !_librariesVisible.value;
   }
 
-  /// Make the 'Libraries' view on the right-hand side of the screen visible.
-  void openLibrariesView() {
-    _librariesVisible.value = true;
-  }
-
   final _stdio = ValueNotifier<List<String>>([]);
   bool _stdioTrailingNewline = false;
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -136,7 +136,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       valueListenable: controller.librariesVisible,
       builder: (context, visible, _) {
         if (visible) {
-          // Focus the filter textfield when the ScriptPicker opens.
+          // Focus the filter text field when the ScriptPicker opens.
           _libraryFilterFocusNode.requestFocus();
 
           // TODO(devoncarew): Animate this opening and closing.
@@ -285,7 +285,7 @@ class FocusLibraryFilterIntent extends Intent {
 class FocusLibraryFilterAction extends Action<FocusLibraryFilterIntent> {
   @override
   void invoke(FocusLibraryFilterIntent intent) {
-    intent.debuggerController.openLibrariesView();
+    intent.debuggerController.toggleLibrariesVisible();
   }
 }
 


### PR DESCRIPTION
- have the cmd-p keybinding toggle the libraries pane
- fix https://github.com/flutter/devtools/issues/2060

cc @grouma
