### PR TITLE
Hide unavailable screens from the navigation

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -137,6 +137,7 @@ class DevToolsAppState extends State<DevToolsApp> {
             url: params['uri'],
             allowConnectionScreenOnDisconnect: !embed,
             builder: (_) {
+              // TODO(dantup): Handle when `page` is not in the list of visible screens.
               final tabs = embed && page != null
                   ? _visibleScreens().where((p) => p.screenId == page).toList()
                   : _visibleScreens();
@@ -183,22 +184,7 @@ class DevToolsAppState extends State<DevToolsApp> {
     _routes = null;
   }
 
-  List<Screen> _visibleScreens() {
-    final visibleScreens = <Screen>[];
-    for (var screen in _screens) {
-      if (screen.conditionalLibrary != null) {
-        if (serviceManager.isServiceAvailable &&
-            serviceManager
-                .isolateManager.selectedIsolateAvailable.isCompleted &&
-            serviceManager.libraryUriAvailableNow(screen.conditionalLibrary)) {
-          visibleScreens.add(screen);
-        }
-      } else {
-        visibleScreens.add(screen);
-      }
-    }
-    return visibleScreens;
-  }
+  List<Screen> _visibleScreens() => _screens.where(shouldShowScreen).toList();
 
   Widget _providedControllers({@required Widget child, bool offline = false}) {
     final _providers = widget.screens

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -133,28 +133,30 @@ class DevToolsAppState extends State<DevToolsApp> {
         if (params['uri']?.isNotEmpty ?? false) {
           final embed = params['embed'] == 'true';
           final page = params['page'];
-          final tabs = embed && page != null
-              ? _visibleScreens().where((p) => p.screenId == page).toList()
-              : _visibleScreens();
           return Initializer(
             url: params['uri'],
             allowConnectionScreenOnDisconnect: !embed,
-            builder: (_) => _providedControllers(
-              child: DevToolsScaffold(
-                embed: embed,
-                ideTheme: ideTheme,
-                initialPage: page,
-                tabs: tabs,
-                actions: [
-                  if (serviceManager.connectedApp.isFlutterAppNow) ...[
-                    HotReloadButton(),
-                    HotRestartButton(),
+            builder: (_) {
+              final tabs = embed && page != null
+                  ? _visibleScreens().where((p) => p.screenId == page).toList()
+                  : _visibleScreens();
+              return _providedControllers(
+                child: DevToolsScaffold(
+                  embed: embed,
+                  ideTheme: ideTheme,
+                  initialPage: page,
+                  tabs: tabs,
+                  actions: [
+                    if (serviceManager.connectedApp.isFlutterAppNow) ...[
+                      HotReloadButton(),
+                      HotRestartButton(),
+                    ],
+                    OpenSettingsAction(),
+                    OpenAboutAction(),
                   ],
-                  OpenSettingsAction(),
-                  OpenAboutAction(),
-                ],
-              ),
-            ),
+                ),
+              );
+            },
           );
         } else {
           return DevToolsScaffold.withChild(

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -568,57 +568,6 @@ class RoundedOutlinedBorder extends StatelessWidget {
 /// Makes for nice-looking rectangles.
 final goldenRatio = 1 + sqrt(5) / 2;
 
-class DisabledForProfileBuildMessage extends StatelessWidget {
-  const DisabledForProfileBuildMessage();
-
-  static const message =
-      'This screen is disabled because you are running a profile build of your '
-      'application.';
-
-  @override
-  Widget build(BuildContext context) {
-    return const CenteredMessage(message);
-  }
-}
-
-class DisabledForWebAppMessage extends StatelessWidget {
-  const DisabledForWebAppMessage();
-
-  static const message =
-      'This screen is disabled because you are connected to a web application.';
-
-  @override
-  Widget build(BuildContext context) {
-    return const CenteredMessage(message);
-  }
-}
-
-class DisabledForFlutterWebProfileBuildMessage extends StatelessWidget {
-  const DisabledForFlutterWebProfileBuildMessage();
-
-  static const message =
-      'This screen is disabled because you are connected to a profile build of '
-      'your Flutter Web application.';
-
-  @override
-  Widget build(BuildContext context) {
-    return const CenteredMessage(message);
-  }
-}
-
-class DisabledForNonFlutterAppMessage extends StatelessWidget {
-  const DisabledForNonFlutterAppMessage();
-
-  static const message =
-      'This screen is disabled because you are not running a Flutter '
-      'application.';
-
-  @override
-  Widget build(BuildContext context) {
-    return const CenteredMessage(message);
-  }
-}
-
 class CenteredMessage extends StatelessWidget {
   const CenteredMessage(this.message);
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -13,7 +13,6 @@ import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
 import '../config_specific/host_platform/host_platform.dart';
 import '../flex_split_column.dart';
-import '../globals.dart';
 import '../octicons.dart';
 import '../screen.dart';
 import '../split.dart';
@@ -34,7 +33,12 @@ const bool debugShowCallStackCount = false;
 
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
-      : super('debugger', title: 'Debugger', icon: Octicons.bug);
+      : super.conditional(
+          id: 'debugger',
+          requiresDebugBuild: true,
+          title: 'Debugger',
+          icon: Octicons.bug,
+        );
 
   @override
   String get docPageId => screenId;
@@ -43,11 +47,7 @@ class DebuggerScreen extends Screen {
   bool get showIsolateSelector => true;
 
   @override
-  Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isProfileBuildNow
-        ? const DebuggerScreenBody()
-        : const DisabledForProfileBuildMessage();
-  }
+  Widget build(BuildContext context) => const DebuggerScreenBody();
 
   @override
   Widget buildStatus(BuildContext context, TextTheme textTheme) {

--- a/packages/devtools_app/lib/src/example/conditional_screen.dart
+++ b/packages/devtools_app/lib/src/example/conditional_screen.dart
@@ -19,7 +19,7 @@ class ExampleConditionalScreen extends Screen {
   const ExampleConditionalScreen()
       : super.conditional(
           id: id,
-          conditionalLibrary: 'package:flutter/',
+          requiresLibrary: 'package:flutter/',
           title: 'Example',
           icon: Icons.palette,
         );

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -7,7 +7,6 @@ import 'package:vm_service/vm_service.dart' hide Stack;
 
 import '../auto_dispose_mixin.dart';
 import '../blocking_action_mixin.dart';
-import '../common_widgets.dart';
 import '../connected_app.dart';
 import '../globals.dart';
 import '../initializer.dart';
@@ -27,7 +26,8 @@ class InspectorScreen extends Screen {
   const InspectorScreen()
       : super.conditional(
           id: 'inspector',
-          conditionalLibrary: flutterLibraryUri,
+          requiresLibrary: flutterLibraryUri,
+          requiresDebugBuild: true,
           title: 'Flutter Inspector',
           icon: Octicons.deviceMobile,
         );
@@ -36,16 +36,7 @@ class InspectorScreen extends Screen {
   String get docPageId => screenId;
 
   @override
-  Widget build(BuildContext context) {
-    final isFlutterApp = serviceManager.connectedApp.isFlutterAppNow;
-    final isProfileBuild = serviceManager.connectedApp.isProfileBuildNow;
-    if (!isFlutterApp || isProfileBuild) {
-      return !isFlutterApp
-          ? const DisabledForNonFlutterAppMessage()
-          : const DisabledForProfileBuildMessage();
-    }
-    return const InspectorScreenBody();
-  }
+  Widget build(BuildContext context) => const InspectorScreenBody();
 }
 
 class InspectorScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -8,6 +8,7 @@ import 'package:vm_service/vm_service.dart' hide Stack;
 import '../auto_dispose_mixin.dart';
 import '../blocking_action_mixin.dart';
 import '../common_widgets.dart';
+import '../connected_app.dart';
 import '../globals.dart';
 import '../initializer.dart';
 import '../octicons.dart';
@@ -24,8 +25,9 @@ import 'inspector_tree_flutter.dart';
 
 class InspectorScreen extends Screen {
   const InspectorScreen()
-      : super(
-          'inspector',
+      : super.conditional(
+          id: 'inspector',
+          conditionalLibrary: flutterLibraryUri,
           title: 'Flutter Inspector',
           icon: Octicons.deviceMobile,
         );

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -10,7 +10,6 @@ import 'package:provider/provider.dart';
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
 import '../console.dart';
-import '../globals.dart';
 import '../octicons.dart';
 import '../screen.dart';
 import '../split.dart';
@@ -30,12 +29,7 @@ class LoggingScreen extends Screen {
   String get docPageId => screenId;
 
   @override
-  Widget build(BuildContext context) {
-    return !(serviceManager.connectedApp.isFlutterWebAppNow &&
-            serviceManager.connectedApp.isProfileBuildNow)
-        ? const LoggingScreenBody()
-        : const DisabledForFlutterWebProfileBuildMessage();
-  }
+  Widget build(BuildContext context) => const LoggingScreenBody();
 
   @override
   Widget buildStatus(BuildContext context, TextTheme textTheme) {

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -22,7 +22,13 @@ import 'memory_heap_tree_view.dart';
 const _primaryControlsMinVerboseWidth = 1100.0;
 
 class MemoryScreen extends Screen {
-  const MemoryScreen() : super(id, title: 'Memory', icon: Octicons.package);
+  const MemoryScreen()
+      : super.conditional(
+          id: id,
+          requiresDartVm: true,
+          title: 'Memory',
+          icon: Octicons.package,
+        );
 
   @visibleForTesting
   static const pauseButtonKey = Key('Pause Button');
@@ -59,12 +65,7 @@ class MemoryScreen extends Screen {
   String get docPageId => id;
 
   @override
-  Widget build(BuildContext context) {
-    final connected = serviceManager?.connectedApp;
-    return connected != null && !connected.isDartWebAppNow
-        ? const MemoryBody()
-        : const DisabledForWebAppMessage();
-  }
+  Widget build(BuildContext context) => const MemoryBody();
 }
 
 class MemoryBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -8,7 +8,6 @@ import 'package:provider/provider.dart';
 
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
-import '../globals.dart';
 import '../screen.dart';
 import '../split.dart';
 import '../table.dart';
@@ -33,11 +32,7 @@ class NetworkScreen extends Screen {
   static const recordingInstructionsKey = Key('Recording Instructions');
 
   @override
-  Widget build(BuildContext context) {
-    return !serviceManager.connectedApp.isDartWebAppNow
-        ? const NetworkScreenBody()
-        : const DisabledForWebAppMessage();
-  }
+  Widget build(BuildContext context) => const NetworkScreenBody();
 
   @override
   Widget buildStatus(BuildContext context, TextTheme textTheme) {

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -20,7 +20,12 @@ import 'network_request_inspector.dart';
 
 class NetworkScreen extends Screen {
   const NetworkScreen()
-      : super('network', title: 'Network', icon: Icons.network_check);
+      : super.conditional(
+          id: 'network',
+          requiresDartVm: true,
+          title: 'Network',
+          icon: Icons.network_check,
+        );
 
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -25,7 +25,13 @@ import 'performance_controller.dart';
 
 class PerformanceScreen extends Screen {
   const PerformanceScreen()
-      : super(id, title: 'Performance', icon: Octicons.dashboard);
+      : super.conditional(
+          id: id,
+          requiresDartVm: true,
+          worksOffline: true,
+          title: 'Performance',
+          icon: Octicons.dashboard,
+        );
 
   @visibleForTesting
   static const clearButtonKey = Key('Clear Button');
@@ -46,11 +52,7 @@ class PerformanceScreen extends Screen {
   String get docPageId => id;
 
   @override
-  Widget build(BuildContext context) {
-    return offlineMode || !serviceManager.connectedApp.isDartWebAppNow
-        ? const PerformanceScreenBody()
-        : const DisabledForWebAppMessage();
-  }
+  Widget build(BuildContext context) => const PerformanceScreenBody();
 }
 
 class PerformanceScreenBody extends StatefulWidget {

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import 'globals.dart';
 import 'scaffold.dart';
 import 'theme.dart';
 
@@ -17,18 +18,27 @@ abstract class Screen {
     this.title,
     this.icon,
     this.tabKey,
-    this.conditionalLibrary,
+    this.requiresLibrary,
+    this.requiresDartVm = false,
+    this.requiresDebugBuild = false,
+    this.worksOffline = false,
   });
 
   const Screen.conditional({
     @required String id,
-    @required String conditionalLibrary,
+    String requiresLibrary,
+    bool requiresDartVm = false,
+    bool requiresDebugBuild = false,
+    bool worksOffline = false,
     String title,
     IconData icon,
     Key tabKey,
   }) : this(
           id,
-          conditionalLibrary: conditionalLibrary,
+          requiresLibrary: requiresLibrary,
+          requiresDartVm: requiresDartVm,
+          requiresDebugBuild: requiresDebugBuild,
+          worksOffline: worksOffline,
           title: title,
           icon: icon,
           tabKey: tabKey,
@@ -48,12 +58,21 @@ abstract class Screen {
   /// Library uri that determines whether to include this screen in DevTools.
   ///
   /// This can either be a full library uri or it can be a prefix. If null, this
-  /// screen will be shown unconditionally.
+  /// screen will be shown if it meets all other criteria.
   ///
   /// Examples:
   ///  * 'package:provider/provider.dart'
   ///  * 'package:provider/'
-  final String conditionalLibrary;
+  final String requiresLibrary;
+
+  /// Whether this screen should only be included when the app is running on the Dart VM.
+  final bool requiresDartVm;
+
+  /// Whether this screen should only be included when the app is debuggable.
+  final bool requiresDebugBuild;
+
+  /// Whether this screen works offline and should show in offline mode even if conditions are not met.
+  final bool worksOffline;
 
   /// Whether this screen should display the isolate selector in the status
   /// line.
@@ -116,4 +135,31 @@ mixin OfflineScreenMixin<T extends StatefulWidget, U> on State<T> {
       _loadingOfflineData = false;
     });
   }
+}
+
+/// Check whether a screen should be shown in the UI.
+bool shouldShowScreen(Screen screen) {
+  if (offlineMode && screen.worksOffline) {
+    return true;
+  }
+  if (screen.requiresLibrary != null) {
+    if (!serviceManager.isServiceAvailable ||
+        !serviceManager.isolateManager.selectedIsolateAvailable.isCompleted ||
+        !serviceManager.libraryUriAvailableNow(screen.requiresLibrary)) {
+      return false;
+    }
+  }
+  if (screen.requiresDartVm) {
+    if (!serviceManager.isServiceAvailable ||
+        !serviceManager.connectedApp.isRunningOnDartVM) {
+      return false;
+    }
+  }
+  if (screen.requiresDebugBuild) {
+    if (!serviceManager.isServiceAvailable ||
+        serviceManager.connectedApp.isProfileBuildNow) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -139,8 +139,8 @@ mixin OfflineScreenMixin<T extends StatefulWidget, U> on State<T> {
 
 /// Check whether a screen should be shown in the UI.
 bool shouldShowScreen(Screen screen) {
-  if (offlineMode && screen.worksOffline) {
-    return true;
+  if (offlineMode) {
+    return screen.worksOffline;
   }
   if (screen.requiresLibrary != null) {
     if (!serviceManager.isServiceAvailable ||

--- a/packages/devtools_app/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_screen.dart
@@ -32,7 +32,14 @@ import 'timeline_model.dart';
 // where applicable.
 
 class TimelineScreen extends Screen {
-  const TimelineScreen() : super(id, title: 'Timeline', icon: Octicons.pulse);
+  const TimelineScreen()
+      : super.conditional(
+          id: id,
+          requiresDartVm: true,
+          worksOffline: true,
+          title: 'Timeline',
+          icon: Octicons.pulse,
+        );
 
   @visibleForTesting
   static const refreshButtonKey = Key('Refresh Button');
@@ -47,11 +54,7 @@ class TimelineScreen extends Screen {
   String get docPageId => id;
 
   @override
-  Widget build(BuildContext context) {
-    return offlineMode || !serviceManager.connectedApp.isDartWebAppNow
-        ? const TimelineScreenBody()
-        : const DisabledForWebAppMessage();
-  }
+  Widget build(BuildContext context) => const TimelineScreenBody();
 }
 
 class TimelineScreenBody extends StatefulWidget {

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -71,14 +71,6 @@ void main() {
       expect(find.text('Debugger'), findsOneWidget);
     });
 
-    testWidgets('builds disabled message when disabled for profile mode',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(DebuggerScreenBody), findsNothing);
-      expect(find.byType(DisabledForProfileBuildMessage), findsOneWidget);
-    });
-
     testWidgets('has Console / stdio area', (WidgetTester tester) async {
       when(debuggerController.stdio).thenReturn(ValueNotifier(['test stdio']));
 

--- a/packages/devtools_app/test/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector_screen_test.dart
@@ -4,15 +4,14 @@
 
 import 'dart:convert';
 
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
-import 'package:devtools_app/src/inspector/inspector_screen.dart';
-import 'package:devtools_app/src/inspector/layout_explorer/flex/flex.dart';
-import 'package:devtools_app/src/inspector/layout_explorer/layout_explorer.dart';
 import 'package:devtools_app/src/inspector/inspector_controller.dart';
+import 'package:devtools_app/src/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
 import 'package:devtools_app/src/inspector/inspector_tree.dart';
+import 'package:devtools_app/src/inspector/layout_explorer/flex/flex.dart';
+import 'package:devtools_app/src/inspector/layout_explorer/layout_explorer.dart';
 import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
@@ -87,24 +86,6 @@ void main() {
       // await setWindowSize(const Size(1000.0, 1200.0));
       // Verify that description text is no-longer shown.
       // expect(find.text(extensions.debugPaint.description), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for non-flutter app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(false);
-      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(InspectorScreenBody), findsNothing);
-      expect(find.byType(DisabledForNonFlutterAppMessage), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for profile mode',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(InspectorScreenBody), findsNothing);
-      expect(find.byType(DisabledForProfileBuildMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -9,8 +9,8 @@ import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/console.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/logging/logging_screen.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
+import 'package:devtools_app/src/logging/logging_screen.dart';
 import 'package:devtools_app/src/service_extensions.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/service_extension_widgets.dart';
@@ -56,16 +56,6 @@ void main() {
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
       expect(find.text('Logging'), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for flutter web app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isFlutterWebAppNow).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(LoggingScreenBody), findsNothing);
-      expect(find.byType(DisabledForFlutterWebProfileBuildMessage),
-          findsOneWidget);
     });
 
     testWidgets('builds with no data', (WidgetTester tester) async {

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('vm')
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/memory/memory_chart.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
@@ -52,14 +50,6 @@ void main() {
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
       expect(find.text('Memory'), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for web app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(MemoryBody), findsNothing);
-      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('builds proper content for state', windowSize,

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('vm')
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/memory/memory_chart.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';

--- a/packages/devtools_app/test/network_screen_test.dart
+++ b/packages/devtools_app/test/network_screen_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/network/network_screen.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -28,14 +27,6 @@ void main() {
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(Builder(builder: screen.buildTab)));
       expect(find.text('Network'), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for web app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(NetworkScreenBody), findsNothing);
-      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
   });
 }

--- a/packages/devtools_app/test/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance_screen_test.dart
@@ -2,10 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/performance/performance_screen.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
+import 'package:devtools_app/src/performance/performance_screen.dart';
 import 'package:devtools_app/src/profiler/cpu_profiler.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/vm_flag_widgets.dart';
@@ -63,14 +62,6 @@ void main() {
         performance: PerformanceController(),
       ));
       expect(find.text('Performance'), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for web app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(PerformanceScreenBody), findsNothing);
-      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
 
     const windowSize = Size(1000.0, 1000.0);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -33,6 +33,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
     bool useFakeService = false,
     this.hasConnection = true,
     this.availableServices = const [],
+    this.availableLibraries = const [],
     Timeline timelineData,
     SocketProfile socketProfile,
   }) : service = useFakeService
@@ -44,6 +45,8 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   static final _flagManager = VmFlagManager();
 
   final List<String> availableServices;
+
+  final List<String> availableLibraries;
 
   final MockVM _mockVM = MockVM();
 
@@ -93,6 +96,11 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   }
 
   @override
+  bool libraryUriAvailableNow(String uri) {
+    return availableLibraries.any((u) => u.startsWith(uri));
+  }
+
+  @override
   Future<Response> getFlutterVersion() {
     return Future.value(Response.parse({
       'type': 'Success',
@@ -117,6 +125,9 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
     hasConnection = value;
     stateChangeStream.add(value);
   }
+
+  @override
+  ValueListenable<bool> get deviceBusy => ValueNotifier(false);
 }
 
 class FakeVmService extends Fake implements VmServiceWrapper {
@@ -338,6 +349,10 @@ class FakeIsolateManager extends Fake implements IsolateManager {
 
   @override
   Stream<IsolateRef> get onSelectedIsolateChanged => const Stream.empty();
+
+  @override
+  Completer<bool> get selectedIsolateAvailable =>
+      Completer<bool>()..complete(true);
 }
 
 class MockServiceManager extends Mock implements ServiceConnectionManager {}
@@ -653,7 +668,18 @@ Future<void> ensureInspectorDependencies() async {
   await initializer.ensureInspectorDependencies();
 }
 
-void mockIsFlutterApp(MockConnectedApp connectedApp) {
-  when(connectedApp.isFlutterAppNow).thenReturn(true);
-  when(connectedApp.isFlutterApp).thenAnswer((_) => Future.value(true));
+void mockIsFlutterApp(MockConnectedApp connectedApp, [isFlutterApp = true]) {
+  when(connectedApp.isFlutterAppNow).thenReturn(isFlutterApp);
+  when(connectedApp.isFlutterApp).thenAnswer((_) => Future.value(isFlutterApp));
+  when(connectedApp.isDebugFlutterAppNow).thenReturn(true);
+  when(connectedApp.isProfileBuildNow).thenReturn(false);
+}
+
+void mockIsDebugFlutterApp(MockConnectedApp connectedApp,
+    [isDebugFlutterApp = true]) {
+  when(connectedApp.isDebugFlutterAppNow).thenReturn(isDebugFlutterApp);
+}
+
+void mockIsDartVmApp(MockConnectedApp connectedApp, [isDartVmApp = true]) {
+  when(connectedApp.isRunningOnDartVM).thenReturn(isDartVmApp);
 }

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -672,12 +672,18 @@ void mockIsFlutterApp(MockConnectedApp connectedApp, [isFlutterApp = true]) {
   when(connectedApp.isFlutterAppNow).thenReturn(isFlutterApp);
   when(connectedApp.isFlutterApp).thenAnswer((_) => Future.value(isFlutterApp));
   when(connectedApp.isDebugFlutterAppNow).thenReturn(true);
-  when(connectedApp.isProfileBuildNow).thenReturn(false);
 }
 
 void mockIsDebugFlutterApp(MockConnectedApp connectedApp,
     [isDebugFlutterApp = true]) {
   when(connectedApp.isDebugFlutterAppNow).thenReturn(isDebugFlutterApp);
+  when(connectedApp.isProfileBuildNow).thenReturn(!isDebugFlutterApp);
+}
+
+void mockIsProfileFlutterApp(MockConnectedApp connectedApp,
+    [isProfileFlutterApp = true]) {
+  when(connectedApp.isDebugFlutterAppNow).thenReturn(!isProfileFlutterApp);
+  when(connectedApp.isProfileBuildNow).thenReturn(isProfileFlutterApp);
 }
 
 void mockIsDartVmApp(MockConnectedApp connectedApp, [isDartVmApp = true]) {

--- a/packages/devtools_app/test/timeline_screen_test.dart
+++ b/packages/devtools_app/test/timeline_screen_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('vm')
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';

--- a/packages/devtools_app/test/timeline_screen_test.dart
+++ b/packages/devtools_app/test/timeline_screen_test.dart
@@ -2,16 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-@TestOn('vm')
-import 'package:devtools_app/src/common_widgets.dart';
-import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/timeline/event_details.dart';
 import 'package:devtools_app/src/timeline/flutter_frames_chart.dart';
+import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_flame_chart.dart';
 import 'package:devtools_app/src/timeline/timeline_screen.dart';
-import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_testing/support/timeline_test_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -69,14 +67,6 @@ void main() {
         timeline: TimelineController(),
       ));
       expect(find.text('Timeline'), findsOneWidget);
-    });
-
-    testWidgets('builds disabled message when disabled for web app',
-        (WidgetTester tester) async {
-      when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(true);
-      await tester.pumpWidget(wrap(Builder(builder: screen.build)));
-      expect(find.byType(TimelineScreenBody), findsNothing);
-      expect(find.byType(DisabledForWebAppMessage), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('builds initial content', windowSize,

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -48,6 +48,8 @@ void main() {
       }
       mockIsDebugFlutterApp(
           fakeServiceManager.connectedApp, flutter && !profileMode);
+      mockIsProfileFlutterApp(
+          fakeServiceManager.connectedApp, flutter && profileMode);
     }
 
     testWidgets('are correct for Dart CLI app', (WidgetTester tester) async {
@@ -78,9 +80,9 @@ void main() {
             // MemoryScreen,
             // PerformanceScreen,
             DebuggerScreen,
-            NetworkScreen,
+            // NetworkScreen,
             LoggingScreen,
-            if (codeSizeScreenEnabled) CodeSizeScreen,
+            // if (codeSizeScreenEnabled) CodeSizeScreen,
           ]));
     });
 
@@ -109,11 +111,11 @@ void main() {
       expect(
           visibleScreenTypes,
           equals([
-            InspectorScreen,
+            // InspectorScreen,
             TimelineScreen,
             MemoryScreen,
             PerformanceScreen,
-            DebuggerScreen,
+            // DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
             if (codeSizeScreenEnabled) CodeSizeScreen,
@@ -132,9 +134,9 @@ void main() {
             // MemoryScreen,
             // PerformanceScreen,
             DebuggerScreen,
-            NetworkScreen,
+            // NetworkScreen,
             LoggingScreen,
-            if (codeSizeScreenEnabled) CodeSizeScreen,
+            // if (codeSizeScreenEnabled) CodeSizeScreen,
           ]));
     });
 
@@ -145,14 +147,16 @@ void main() {
       expect(
           visibleScreenTypes,
           equals([
-            InspectorScreen,
+            // InspectorScreen,
             // TimelineScreen,
             // MemoryScreen,
             // PerformanceScreen,
-            DebuggerScreen,
-            NetworkScreen,
+            // DebuggerScreen,
+            // NetworkScreen,
+            // TODO(dantup): Find out if this should be disabled (and if so
+            // how best to represent it).
             LoggingScreen,
-            if (codeSizeScreenEnabled) CodeSizeScreen,
+            // if (codeSizeScreenEnabled) CodeSizeScreen,
           ]));
     });
 
@@ -167,10 +171,10 @@ void main() {
             TimelineScreen, // Works offline, so appears regardless of web flag
             // MemoryScreen,
             PerformanceScreen, // Works offline, so appears regardless of web flag
-            DebuggerScreen,
-            NetworkScreen,
-            LoggingScreen,
-            if (codeSizeScreenEnabled) CodeSizeScreen,
+            // DebuggerScreen,
+            // NetworkScreen,
+            // LoggingScreen,
+            // if (codeSizeScreenEnabled) CodeSizeScreen,
           ]));
     });
   });

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -35,7 +35,7 @@ void main() {
     void setupMockValues({
       bool web = false,
       bool flutter = false,
-      bool profileMode = false,
+      bool debugMode = true,
     }) {
       mockIsDartVmApp(fakeServiceManager.connectedApp, !web);
       if (web) {
@@ -47,9 +47,9 @@ void main() {
             .add('package:flutter/src/widgets/binding.dart');
       }
       mockIsDebugFlutterApp(
-          fakeServiceManager.connectedApp, flutter && !profileMode);
+          fakeServiceManager.connectedApp, flutter && debugMode);
       mockIsProfileFlutterApp(
-          fakeServiceManager.connectedApp, flutter && profileMode);
+          fakeServiceManager.connectedApp, flutter && !debugMode);
     }
 
     testWidgets('are correct for Dart CLI app', (WidgetTester tester) async {
@@ -106,7 +106,7 @@ void main() {
 
     testWidgets('are correct for Flutter (non-web) profile app',
         (WidgetTester tester) async {
-      setupMockValues(flutter: true, profileMode: true);
+      setupMockValues(flutter: true, debug: false);
 
       expect(
           visibleScreenTypes,
@@ -142,7 +142,7 @@ void main() {
 
     testWidgets('are correct for Flutter web profile app',
         (WidgetTester tester) async {
-      setupMockValues(flutter: true, web: true, profileMode: true);
+      setupMockValues(flutter: true, web: true, debug: false);
 
       expect(
           visibleScreenTypes,

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -140,26 +140,6 @@ void main() {
           ]));
     });
 
-    testWidgets('are correct for Flutter web profile app',
-        (WidgetTester tester) async {
-      setupMockValues(flutter: true, web: true, debugMode: false);
-
-      expect(
-          visibleScreenTypes,
-          equals([
-            // InspectorScreen,
-            // TimelineScreen,
-            // MemoryScreen,
-            // PerformanceScreen,
-            // DebuggerScreen,
-            // NetworkScreen,
-            // TODO(dantup): Find out if this should be disabled (and if so
-            // how best to represent it).
-            LoggingScreen,
-            // if (codeSizeScreenEnabled) CodeSizeScreen,
-          ]));
-    });
-
     testWidgets('are correct when offline', (WidgetTester tester) async {
       offlineMode = true;
       setupMockValues(web: true); // Web apps would normally hide

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -1,0 +1,183 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/app.dart';
+import 'package:devtools_app/src/code_size/code_size_screen.dart';
+import 'package:devtools_app/src/debugger/debugger_screen.dart';
+import 'package:devtools_app/src/framework_controller.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/inspector/inspector_screen.dart';
+import 'package:devtools_app/src/logging/logging_screen.dart';
+import 'package:devtools_app/src/memory/memory_screen.dart';
+import 'package:devtools_app/src/network/network_screen.dart';
+import 'package:devtools_app/src/performance/performance_screen.dart';
+import 'package:devtools_app/src/screen.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/timeline/timeline_screen.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/mocks.dart';
+
+void main() {
+  group('visible_screens', () {
+    FakeServiceManager fakeServiceManager;
+
+    setUp(() async {
+      fakeServiceManager =
+          FakeServiceManager(useFakeService: true, availableLibraries: []);
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(FrameworkController, FrameworkController());
+
+      await serviceManager.isolateManager.selectedIsolateAvailable.future;
+    });
+
+    void setupMockValues({
+      bool web = false,
+      bool flutter = false,
+      bool profileMode = false,
+    }) {
+      mockIsDartVmApp(fakeServiceManager.connectedApp, !web);
+      if (web) {
+        fakeServiceManager.availableLibraries.add('dart:html');
+      }
+      mockIsFlutterApp(fakeServiceManager.connectedApp, flutter);
+      if (flutter) {
+        fakeServiceManager.availableLibraries
+            .add('package:flutter/src/widgets/binding.dart');
+      }
+      mockIsDebugFlutterApp(
+          fakeServiceManager.connectedApp, flutter && !profileMode);
+    }
+
+    testWidgets('are correct for Dart CLI app', (WidgetTester tester) async {
+      setupMockValues();
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            // InspectorScreen,
+            TimelineScreen,
+            MemoryScreen,
+            PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct for Dart Web app', (WidgetTester tester) async {
+      setupMockValues(web: true);
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            // InspectorScreen,
+            // TimelineScreen,
+            // MemoryScreen,
+            // PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct for Flutter (non-web) debug app',
+        (WidgetTester tester) async {
+      setupMockValues(flutter: true);
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            InspectorScreen,
+            TimelineScreen,
+            MemoryScreen,
+            PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct for Flutter (non-web) profile app',
+        (WidgetTester tester) async {
+      setupMockValues(flutter: true, profileMode: true);
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            InspectorScreen,
+            TimelineScreen,
+            MemoryScreen,
+            PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct for Flutter web debug app',
+        (WidgetTester tester) async {
+      setupMockValues(flutter: true, web: true);
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            InspectorScreen,
+            // TimelineScreen,
+            // MemoryScreen,
+            // PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct for Flutter web profile app',
+        (WidgetTester tester) async {
+      setupMockValues(flutter: true, web: true, profileMode: true);
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            InspectorScreen,
+            // TimelineScreen,
+            // MemoryScreen,
+            // PerformanceScreen,
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+
+    testWidgets('are correct when offline', (WidgetTester tester) async {
+      offlineMode = true;
+      setupMockValues(web: true); // Web apps would normally hide
+
+      expect(
+          visibleScreenTypes,
+          equals([
+            // InspectorScreen,
+            TimelineScreen, // Works offline, so appears regardless of web flag
+            // MemoryScreen,
+            PerformanceScreen, // Works offline, so appears regardless of web flag
+            DebuggerScreen,
+            NetworkScreen,
+            LoggingScreen,
+            if (codeSizeScreenEnabled) CodeSizeScreen,
+          ]));
+    });
+  });
+}
+
+List<Type> get visibleScreenTypes => defaultScreens
+    .map((s) => s.screen)
+    .where(shouldShowScreen)
+    .map((s) => s.runtimeType)
+    .toList();

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -106,7 +106,7 @@ void main() {
 
     testWidgets('are correct for Flutter (non-web) profile app',
         (WidgetTester tester) async {
-      setupMockValues(flutter: true, debug: false);
+      setupMockValues(flutter: true, debugMode: false);
 
       expect(
           visibleScreenTypes,
@@ -142,7 +142,7 @@ void main() {
 
     testWidgets('are correct for Flutter web profile app',
         (WidgetTester tester) async {
-      setupMockValues(flutter: true, web: true, debug: false);
+      setupMockValues(flutter: true, web: true, debugMode: false);
 
       expect(
           visibleScreenTypes,


### PR DESCRIPTION
Turns out the race here was introduced by [my embed changes](https://github.com/flutter/devtools/pull/1995/files#diff-9b4fa0fbc9e2d26e0f66b7d4b1b59eccR128-L131).. I'd moved the screen filtering out of a function that was being called after the connection to before.

This seems to work correctly now - however there was only one screen where we showed a message saying it wasn't available for Flutter (the Inspector screen). All of the others seem to "work" for Dart apps (as in, they render - I don't know whether it's possible to get data to the - for example the Timeline in a non-Flutter app?).

Are there any other screens that should be hidden? (Currently a Dart app will start off on the Timeline screen)

@jacob314 @kenzieschmoll @grouma 