### PR TITLE
Use Object instead of Map<String, dynamic> for DevToolsJsonFile

### DIFF
--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -249,7 +249,13 @@ class CodeSizeController {
 }
 
 extension CodeSizeJsonFileExtension on DevToolsJsonFile {
-  bool get isApkFile => data['type'] == 'apk';
+  bool get isApkFile {
+    if (data is Map<String, dynamic>) {
+      final dataMap = data as Map<String, dynamic>;
+      return dataMap['type'] == 'apk';
+    }
+    return false;
+  }
 
   String get displayText {
     return '$path - $formattedTime';

--- a/packages/devtools_app/lib/src/config_specific/drag_and_drop/_drag_and_drop_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/drag_and_drop/_drag_and_drop_web.dart
@@ -77,7 +77,7 @@ class DragAndDropManagerWeb extends DragAndDropManager {
     final FileReader reader = FileReader();
     reader.onLoad.listen((_) {
       try {
-        final Map<String, dynamic> json = jsonDecode(reader.result);
+        final Object json = jsonDecode(reader.result);
         final devToolsJsonFile = DevToolsJsonFile(
           name: droppedFile.name,
           lastModifiedTime: droppedFile.lastModifiedDate,

--- a/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
@@ -59,15 +59,17 @@ class ImportController {
     }
     previousImportTime = now;
 
-    final isDevToolsSnapshot = json[devToolsSnapshotKey];
+    final isDevToolsSnapshot =
+        json is Map<String, dynamic> && json[devToolsSnapshotKey];
     if (isDevToolsSnapshot == null || !isDevToolsSnapshot) {
       _notifications.push(nonDevToolsFileMessage);
       return;
     }
 
+    final devToolsSnapshot = json as Map<String, dynamic>;
     // TODO(kenz): support imports for more than one screen at a time.
-    final activeScreenId = json[activeScreenIdKey];
-    offlineDataJson = json;
+    final activeScreenId = devToolsSnapshot[activeScreenIdKey];
+    offlineDataJson = devToolsSnapshot;
     _notifications.push(attemptingToImportMessage(activeScreenId));
     _pushSnapshotScreenForImport(activeScreenId);
   }

--- a/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
@@ -60,8 +60,8 @@ class ImportController {
     previousImportTime = now;
 
     final isDevToolsSnapshot =
-        json is Map<String, dynamic> && json[devToolsSnapshotKey];
-    if (isDevToolsSnapshot == null || !isDevToolsSnapshot) {
+        json is Map<String, dynamic> && json[devToolsSnapshotKey] == true;
+    if (!isDevToolsSnapshot) {
       _notifications.push(nonDevToolsFileMessage);
       return;
     }

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -945,11 +945,11 @@ num degToRad(num deg) => deg * (pi / 180.0);
 
 typedef DevToolsJsonFileHandler = void Function(DevToolsJsonFile file);
 
-class DevToolsJsonFile extends DevToolsFile<Map<String, dynamic>> {
+class DevToolsJsonFile extends DevToolsFile<Object> {
   const DevToolsJsonFile({
     @required String name,
     @required DateTime lastModifiedTime,
-    @required Map<String, dynamic> data,
+    @required Object data,
   }) : super(
           path: name,
           lastModifiedTime: lastModifiedTime,

--- a/packages/devtools_app/test/import_export_test.dart
+++ b/packages/devtools_app/test/import_export_test.dart
@@ -25,8 +25,14 @@ void main() async {
 
       await Future.delayed(const Duration(
           milliseconds: ImportController.repeatImportTimeBufferMs));
-      importController.importData(devToolsFileJson);
+      importController.importData(nonDevToolsFileJsonWithListData);
       expect(notifications.messages.length, equals(2));
+      expect(notifications.messages, contains(nonDevToolsFileMessage));
+
+      await Future.delayed(const Duration(
+          milliseconds: ImportController.repeatImportTimeBufferMs));
+      importController.importData(devToolsFileJson);
+      expect(notifications.messages.length, equals(3));
       expect(
         notifications.messages,
         contains(attemptingToImportMessage('example')),
@@ -39,6 +45,11 @@ final nonDevToolsFileJson = DevToolsJsonFile(
   name: 'nonDevToolsFileJson',
   lastModifiedTime: DateTime.fromMicrosecondsSinceEpoch(1000),
   data: <String, dynamic>{},
+);
+final nonDevToolsFileJsonWithListData = DevToolsJsonFile(
+  name: 'nonDevToolsFileJsonWithListData',
+  lastModifiedTime: DateTime.fromMicrosecondsSinceEpoch(1000),
+  data: <Map<String, dynamic>>[],
 );
 final devToolsFileJson = DevToolsJsonFile(
   name: 'devToolsFileJson',


### PR DESCRIPTION
We need to use Object instead of Map<String, dynamic> because instruction_sizes input is actually a List of Maps, and v8 input is a map. package:vm_snapshot_analysis uses Object as an expected type in utility methods for this reason.