### PR TITLE
fix the test expectations for debugger_screen_test.dart

### DIFF
--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -200,7 +200,7 @@ void main() {
       when(debuggerController.librariesVisible)
           .thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('Libraries and Classes'), findsNothing);
+      expect(find.text('Libraries'), findsNothing);
     });
 
     testWidgets('Libraries visible', (WidgetTester tester) async {


### PR DESCRIPTION
- fix the test expectations for debugger_screen_test.dart

This test had not been updated when we changed the debugger area title.