### PR TITLE
Theming tweaks

### DIFF
--- a/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
+import '../../../common_widgets.dart';
 import '../../../theme.dart';
 import '../../../ui/theme.dart';
 import '../../../utils.dart';
@@ -1245,7 +1246,8 @@ class WidgetVisualizer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
     final properties = layoutProperties;
     Color borderColor = regularWidgetColor;
     if (properties is FlexLayoutProperties) {
@@ -1317,7 +1319,7 @@ class WidgetVisualizer extends StatelessWidget {
         border: Border.all(
           color: borderColor,
         ),
-        color: colorScheme.backgroundColor,
+        color: theme.canvasColor.darken(0.2),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
@@ -1319,7 +1319,7 @@ class WidgetVisualizer extends StatelessWidget {
         border: Border.all(
           color: borderColor,
         ),
-        color: theme.canvasColor.darken(0.2),
+        color: theme.canvasColor.darken(),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -972,7 +972,8 @@ class _TableRowState<T> extends State<TableRow<T>>
     final box = SizedBox(
       height: defaultRowHeight,
       child: Material(
-        color: widget.backgroundColor ?? Theme.of(context).canvasColor,
+        color: widget.backgroundColor ??
+            titleSolidBackgroundColor(Theme.of(context)),
         child: widget.onPressed != null
             ? InkWell(
                 canRequestFocus: false,

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:mp_chart/mp/core/adapter_android_mp.dart';
 
@@ -63,22 +61,26 @@ ThemeData _lightTheme(IdeTheme ideTheme) {
   );
 }
 
+/// Threshold used to determine whether a colour is light/dark enough for us to
+/// override the default DevTools themes with.
+///
+/// A value of 0.5 would result in all colours being considered light/dark, and
+/// a value of 0.1 allowing around only the 10% darkest/lightest colours by
+/// Flutter's luminance calculation.
+const _lightDarkLuminanceThreshold = 0.1;
+
 bool isValidDarkColor(Color color) {
   if (color == null) {
     return false;
   }
-  // TODO(dantup): Pick good threshold
-  final components = [color.red, color.green, color.blue];
-  return components.reduce(max) < 50;
+  return color.computeLuminance() <= _lightDarkLuminanceThreshold;
 }
 
 bool isValidLightColor(Color color) {
   if (color == null) {
     return false;
   }
-  // TODO(dantup): Pick good threshold
-  final components = [color.red, color.green, color.blue];
-  return components.reduce(min) > 205;
+  return color.computeLuminance() >= 1 - _lightDarkLuminanceThreshold;
 }
 
 const buttonMinWidth = 36.0;

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -27,6 +27,10 @@ ThemeData themeFor({
 
 ThemeData _darkTheme(IdeTheme ideTheme) {
   final theme = ThemeData.dark();
+  final background = isValidDarkColor(ideTheme?.backgroundColor)
+      ? ideTheme?.backgroundColor
+      : null;
+
   return theme.copyWith(
     primaryColor: devtoolsGrey[900],
     primaryColorDark: devtoolsBlue[700],
@@ -34,17 +38,19 @@ ThemeData _darkTheme(IdeTheme ideTheme) {
     indicatorColor: devtoolsBlue[400],
     accentColor: devtoolsBlue[400],
     backgroundColor: devtoolsGrey[600],
+    canvasColor: background,
     toggleableActiveColor: devtoolsBlue[400],
     selectedRowColor: devtoolsGrey[600],
     buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth),
-    scaffoldBackgroundColor: isValidDarkColor(ideTheme?.backgroundColor)
-        ? ideTheme?.backgroundColor
-        : null,
+    scaffoldBackgroundColor: background,
   );
 }
 
 ThemeData _lightTheme(IdeTheme ideTheme) {
   final theme = ThemeData.light();
+  final background = isValidLightColor(ideTheme?.backgroundColor)
+      ? ideTheme?.backgroundColor
+      : null;
   return theme.copyWith(
     primaryColor: devtoolsBlue[600],
     primaryColorDark: devtoolsBlue[700],
@@ -52,12 +58,11 @@ ThemeData _lightTheme(IdeTheme ideTheme) {
     indicatorColor: Colors.yellowAccent[400],
     accentColor: devtoolsBlue[400],
     backgroundColor: devtoolsGrey[600],
+    canvasColor: background,
     toggleableActiveColor: devtoolsBlue[400],
     selectedRowColor: devtoolsBlue[600],
     buttonTheme: theme.buttonTheme.copyWith(minWidth: buttonMinWidth),
-    scaffoldBackgroundColor: isValidLightColor(ideTheme?.backgroundColor)
-        ? ideTheme?.backgroundColor
-        : null,
+    scaffoldBackgroundColor: background,
   );
 }
 
@@ -217,7 +222,7 @@ CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
 
 Color titleSolidBackgroundColor(ThemeData theme) {
-  return theme.isDarkTheme ? devtoolsGrey[900] : devtoolsGrey[50];
+  return theme.canvasColor.darken(0.2);
 }
 
 const chartFontSizeSmall = 12.0;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -478,7 +478,7 @@ Future<Map<String, dynamic>> _waitForClients({
           (requiredConnectionState == null || clients.any(hasConnectionState));
     },
     timeoutMessage: timeoutMessage,
-    delay: const Duration(seconds: 1),
+    delay: const Duration(seconds: 5),
   );
 
   return serverResponse;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -478,7 +478,7 @@ Future<Map<String, dynamic>> _waitForClients({
           (requiredConnectionState == null || clients.any(hasConnectionState));
     },
     timeoutMessage: timeoutMessage,
-    delay: const Duration(seconds: 5),
+    delay: const Duration(seconds: 1),
   );
 
   return serverResponse;


### PR DESCRIPTION
This tweaks the threshold used for deciding whether the querystring-supplied background/foreground colors are dark/light enough to use Flutter's `calculateLuminance` (and currently has a threshold of 0.1 out of 1 at both ends).

It also tweaks a few places that were using a default grey colour to instead use the background lightened/darkened. There are still a few places that grey shows up, but some may be more difficult to fix (they come from our custom `DevToolsColorScheme` overrides that might not have access to the real theme/context).

![Screenshot 2020-08-03 at 18 05 25](https://user-images.githubusercontent.com/1078012/89208471-554a8c80-d5b4-11ea-9b6b-377280b74cd8.png)

![Screenshot 2020-08-03 at 18 06 00](https://user-images.githubusercontent.com/1078012/89208473-55e32300-d5b4-11ea-8098-5eb7257d1677.png)

![Screenshot 2020-08-03 at 18 06 17](https://user-images.githubusercontent.com/1078012/89208474-567bb980-d5b4-11ea-9a68-ab136b22a6f7.png)

@jacob314 