### PR TITLE
Add support for DDS connections when using Devtools on web

### DIFF
--- a/packages/devtools_app/lib/src/service.dart
+++ b/packages/devtools_app/lib/src/service.dart
@@ -76,7 +76,8 @@ Future<VmServiceWrapper> _connectWithWebSocket(
         ],
       );
       final wsTargetResponse = await http.get(getWebSocketTargetUrl);
-      final target = WebSocketTarget.parse(json.decode(wsTargetResponse.body)['result']);
+      final target =
+          WebSocketTarget.parse(json.decode(wsTargetResponse.body)['result']);
       uri = Uri.parse(target.uri);
     }
   } else {

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -379,6 +379,11 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
+  Future<ProcessMemoryUsage> getProcessMemoryUsage() {
+    return _trackFuture('getProcessMemoryUsage', _vmService.getProcessMemoryUsage());
+  }
+
+  @override
   Future<SourceReport> getSourceReport(
     String isolateId,
     List<String> reports, {
@@ -426,6 +431,11 @@ class VmServiceWrapper implements VmService {
           await _trackFuture('getVMTimeline', callMethod('_getVMTimeline'));
       return Timeline.parse(response.json);
     }
+  }
+
+  @override
+  Future<WebSocketTarget> getWebSocketTarget() {
+    return _trackFuture('getWebSocketTarget', _vmService.getWebSocketTarget());
   }
 
   // TODO(kenz): move this method to

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -37,7 +37,7 @@ dependencies:
   provider: ^4.0.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^4.1.0
+  vm_service: ^4.2.0
   sse: ^3.1.2
   web_socket_channel: ^1.1.0
   flutter:


### PR DESCRIPTION
As of 3.37 the VM service will attempt to redirect web socket connections to DDS if DDS is connected. This works fine with some web socket implementations (e.g., dart:io's WebSocket) but is unsupported in others (e.g., dart:html's WebSocket). On the web we need to query the VM service via HTTP first to determine which web socket URI we should use (see [getWebSocketTarget](https://github.com/dart-lang/sdk/blob/master/runtime/vm/service/service.md#getwebsockettarget) RPC for details).