### PR TITLE
Add support for diffing APKs

### DIFF
--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -171,8 +171,8 @@ class CodeSizeController {
 
     if (!isLeafNode) {
       final List<dynamic> rawChildren = json['children'] as List<dynamic>;
-      for (Map<String, dynamic> child in rawChildren) {
-        _apkJsonToProgramInfo(program, node, child);
+      for (Map<String, dynamic> childJson in rawChildren) {
+        _apkJsonToProgramInfo(program, node, childJson);
       }
     } else {
       node.size = json['value'] ?? 0;

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -134,16 +134,16 @@ class CodeSizeController {
     if (oldFile.isApkFile && newFile.isApkFile) {
       final oldApkProgramInfo = ProgramInfo();
       _apkJsonToProgramInfo(
-        oldApkProgramInfo,
-        oldApkProgramInfo.root,
-        oldFile.data,
+        program: oldApkProgramInfo,
+        parent: oldApkProgramInfo.root,
+        json: oldFile.data,
       );
 
       final newApkProgramInfo = ProgramInfo();
       _apkJsonToProgramInfo(
-        newApkProgramInfo,
-        newApkProgramInfo.root,
-        newFile.data,
+        program: newApkProgramInfo,
+        parent: newApkProgramInfo.root,
+        json: newFile.data,
       );
 
       diffMap = compareProgramInfo(oldApkProgramInfo, newApkProgramInfo);
@@ -157,11 +157,11 @@ class CodeSizeController {
     changeDiffRoot(newRoot);
   }
 
-  ProgramInfoNode _apkJsonToProgramInfo(
-    ProgramInfo program,
-    ProgramInfoNode parent,
-    Map<String, dynamic> json,
-  ) {
+  ProgramInfoNode _apkJsonToProgramInfo({
+    @required ProgramInfo program,
+    @required ProgramInfoNode parent,
+    @required Map<String, dynamic> json,
+  }) {
     final bool isLeafNode = json['children'] == null;
     final node = program.makeNode(
       name: json['n'],
@@ -172,7 +172,7 @@ class CodeSizeController {
     if (!isLeafNode) {
       final List<dynamic> rawChildren = json['children'] as List<dynamic>;
       for (Map<String, dynamic> childJson in rawChildren) {
-        _apkJsonToProgramInfo(program, node, childJson);
+        _apkJsonToProgramInfo(program: program, parent: node, json: childJson);
       }
     } else {
       node.size = json['value'] ?? 0;

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -168,7 +168,7 @@ class CodeSizeController {
       parent: parent,
       type: NodeType.other,
     );
-    
+
     if (!isLeafNode) {
       final List<dynamic> rawChildren = json['children'] as List<dynamic>;
       for (Map<String, dynamic> child in rawChildren) {
@@ -234,8 +234,11 @@ class CodeSizeController {
 
   /// Builds a node by recursively building all of its children first
   /// in order to calculate the sum of its children's sizes.
-  TreemapNode _buildNodeWithChildren(Map<String, dynamic> treeJson,
-      {bool showDiff = false}) {
+  TreemapNode _buildNodeWithChildren(
+    Map<String, dynamic> treeJson, {
+    bool showDiff = false,
+    DiffTreeType diffTreeType = DiffTreeType.combined,
+  }) {
     final rawChildren = treeJson['children'];
     final treemapNodeChildren = <TreemapNode>[];
     int totalByteSize = 0;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -11,17 +11,16 @@ version: 0.8.1-dev.1
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: '>=2.6.0 <3.0.0'
+  sdk: ">=2.6.0 <3.0.0"
   # The flutter desktop support interacts with build scripts on the Flutter
   # side that are not yet stable, so it requires a very recent version of
   # Flutter. This version will increase regularly as the build scripts change.
-  flutter: '>=1.10.0'
+  flutter: ">=1.10.0"
 
 dependencies:
   ansicolor: ^1.0.2
-  ansi_up:
-    ^0.0.2
-#     path: ../../third_party/packages/ansi_up
+  ansi_up: ^0.0.2
+  #     path: ../../third_party/packages/ansi_up
   collection: ^1.14.11
   devtools_shared: 0.8.1-dev.1
   file: ^5.1.0
@@ -42,13 +41,13 @@ dependencies:
   web_socket_channel: ^1.1.0
   flutter:
     sdk: flutter
-  vm_snapshot_analysis: ^0.5.0+1
+  vm_snapshot_analysis: ^0.5.3
 
 dev_dependencies:
   build_runner: ^1.3.0
   mockito: ^4.0.0
   test: any # This version is pinned by Flutter so we don't need to set one explicitly.
-  webkit_inspection_protocol: '>=0.5.0 <0.8.0'
+  webkit_inspection_protocol: ">=0.5.0 <0.8.0"
   devtools: #^0.1.7
     path: ../devtools
   devtools_testing: 0.8.1-dev.1
@@ -106,12 +105,12 @@ flutter:
         - asset: fonts/Octicons.ttf
 
 dependency_overrides:
-# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-# All overriden dependencies are published together so there is no harm
-# in treating them like they are part of a mono-repo while developing.
-  devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT
-  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
-  devtools_testing:  #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_testing  #OVERRIDE_FOR_DEVELOPMENT
+  # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+  # All overriden dependencies are published together so there is no harm
+  # in treating them like they are part of a mono-repo while developing.
+  devtools_shared: #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_shared #OVERRIDE_FOR_DEVELOPMENT
+  devtools_server: #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_server #OVERRIDE_FOR_DEVELOPMENT
+  devtools_testing: #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_testing #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -19,7 +19,7 @@ environment:
 
 dependencies:
   ansicolor: ^1.0.2
-  ansi_up: 
+  ansi_up:
     ^0.0.2
 #     path: ../../third_party/packages/ansi_up
   collection: ^1.14.11

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -11,16 +11,17 @@ version: 0.8.1-dev.1
 homepage: https://github.com/flutter/devtools
 
 environment:
-  sdk: ">=2.6.0 <3.0.0"
+  sdk: '>=2.6.0 <3.0.0'
   # The flutter desktop support interacts with build scripts on the Flutter
   # side that are not yet stable, so it requires a very recent version of
   # Flutter. This version will increase regularly as the build scripts change.
-  flutter: ">=1.10.0"
+  flutter: '>=1.10.0'
 
 dependencies:
   ansicolor: ^1.0.2
-  ansi_up: ^0.0.2
-  #     path: ../../third_party/packages/ansi_up
+  ansi_up: 
+    ^0.0.2
+#     path: ../../third_party/packages/ansi_up
   collection: ^1.14.11
   devtools_shared: 0.8.1-dev.1
   file: ^5.1.0
@@ -47,7 +48,7 @@ dev_dependencies:
   build_runner: ^1.3.0
   mockito: ^4.0.0
   test: any # This version is pinned by Flutter so we don't need to set one explicitly.
-  webkit_inspection_protocol: ">=0.5.0 <0.8.0"
+  webkit_inspection_protocol: '>=0.5.0 <0.8.0'
   devtools: #^0.1.7
     path: ../devtools
   devtools_testing: 0.8.1-dev.1
@@ -105,12 +106,12 @@ flutter:
         - asset: fonts/Octicons.ttf
 
 dependency_overrides:
-  # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
-  # All overriden dependencies are published together so there is no harm
-  # in treating them like they are part of a mono-repo while developing.
-  devtools_shared: #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_shared #OVERRIDE_FOR_DEVELOPMENT
-  devtools_server: #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_server #OVERRIDE_FOR_DEVELOPMENT
-  devtools_testing: #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_testing #OVERRIDE_FOR_DEVELOPMENT
+# The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
+# All overriden dependencies are published together so there is no harm
+# in treating them like they are part of a mono-repo while developing.
+  devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
+  devtools_testing:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools_testing  #OVERRIDE_FOR_DEVELOPMENT


### PR DESCRIPTION
Add support for diffing APKs by using the newly exposed `compareProgramInfo` method in package:vm_snapshot_analysis. Need https://dart-review.googlesource.com/c/sdk/+/157080 to land first to update package dependency.