### PR TITLE
Use CustomPainter to render Treemap cells instead of building widgets

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -357,11 +357,12 @@ class Treemap extends StatelessWidget {
   /// ```
   Widget buildTreemap(BuildContext context) {
     if (rootNode.children.isNotEmpty) {
+      final treemapFromNodes = buildTreemapFromNodes(context);
       return Padding(
         padding: const EdgeInsets.all(1.0),
         child: isOutermostLevel
-            ? buildTreemapFromNodes(context)
-            : buildSelectable(child: buildTreemapFromNodes(context)),
+            ? treemapFromNodes
+            : buildSelectable(child: treemapFromNodes),
       );
     } else {
       return Column(
@@ -499,7 +500,8 @@ class Treemap extends StatelessWidget {
           height: constraints.maxHeight,
         );
         if (levelsVisible <= 1) {
-          // If this is the second to the last level, paint all widgets in the last level.
+          // If this is the second to the last level, paint all cells in the last level
+          // instead of creating widgets to improve performance.
           return CustomPaint(
             painter: MultiCellPainter(nodes: positionedChildren),
             size: Size(constraints.maxWidth, constraints.maxHeight),

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -2,10 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:convert';
-
-import 'package:devtools_app/src/code_size/stub_data/new_v8.dart';
-import 'package:devtools_app/src/code_size/stub_data/sizes.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_snapshot_analysis/program_info.dart';

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
+import 'package:devtools_app/src/code_size/stub_data/new_v8.dart';
+import 'package:devtools_app/src/code_size/stub_data/sizes.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_snapshot_analysis/program_info.dart';

--- a/packages/devtools_app/lib/src/code_size/code_size_screen.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_screen.dart
@@ -254,6 +254,7 @@ class _SnapshotViewState extends State<SnapshotView> with AutoDisposeMixin {
           rootNode: snapshotRoot,
           levelsVisible: 2,
           isOutermostLevel: true,
+          width: constraints.maxWidth,
           height: constraints.maxHeight,
           onRootChangedCallback: controller.changeSnapshotRoot,
         );
@@ -396,6 +397,7 @@ class _DiffViewState extends State<DiffView> with AutoDisposeMixin {
           rootNode: diffRoot,
           levelsVisible: 2,
           isOutermostLevel: true,
+          width: constraints.maxWidth,
           height: constraints.maxHeight,
           onRootChangedCallback: controller.changeDiffRoot,
         );

--- a/packages/devtools_app/lib/src/memory/memory_treemap.dart
+++ b/packages/devtools_app/lib/src/memory/memory_treemap.dart
@@ -97,6 +97,7 @@ class MemoryTreemapState extends State<MemoryTreemap> with AutoDisposeMixin {
             rootNode: root,
             levelsVisible: 2,
             isOutermostLevel: true,
+            width: constraints.maxWidth,
             height: constraints.maxHeight,
             onRootChangedCallback: _onRootChanged,
           );

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -526,7 +526,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.1"
+    version: "4.3.2"
   pub_semver:
     dependency: transitive
     description:
@@ -762,7 +762,7 @@ packages:
       name: vm_snapshot_analysis
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.2"
+    version: "0.5.3"
   watcher:
     dependency: transitive
     description:

--- a/packages/devtools_app/test/treemap_test.dart
+++ b/packages/devtools_app/test/treemap_test.dart
@@ -38,6 +38,7 @@ void main() {
               rootNode: root,
               levelsVisible: 2,
               isOutermostLevel: true,
+              width: constraints.maxWidth,
               height: constraints.maxHeight,
               onRootChangedCallback: changeRoot,
             );
@@ -119,6 +120,7 @@ void main() {
               rootNode: root,
               levelsVisible: 2,
               isOutermostLevel: true,
+              width: constraints.maxWidth,
               height: constraints.maxHeight,
               onRootChangedCallback: changeRoot,
             );


### PR DESCRIPTION
Use CustomPainter to render Treemap cells instead of building widgets. This makes navigating between levels much faster than before. On a medium-sized app, it reduces the on-click loading time from 10 seconds to almost instant (profile mode).