### PR TITLE
Async Analytics Provider

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -4,6 +4,8 @@
 
 import 'package:flutter/material.dart';
 
+import 'src/analytics/stub_provider.dart'
+    if (dart.library.html) 'src/analytics/remote_provider.dart';
 import 'src/app.dart';
 import 'src/config_specific/framework_initialize/framework_initialize.dart';
 import 'src/config_specific/ide_theme/ide_theme.dart';
@@ -61,6 +63,6 @@ void main() async {
 
   // Now run the app.
   runApp(
-    DevToolsApp(defaultScreens, preferences, ideTheme),
+    DevToolsApp(defaultScreens, preferences, ideTheme, await analyticsProvider),
   );
 }

--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -36,23 +36,19 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
   @override
   void initState() {
     super.initState();
-    () async {
-      try {
-        await _provider.initialize();
-
-        if (_provider.isGtagsEnabled) {
-          if (await _provider.isFirstRun) {
-            setState(() {
-              _isVisible = true;
-            });
-          } else if (await _provider.isEnabled) {
-            _provider.setUpAnalytics();
-          }
+    try {
+      if (_provider.isGtagsEnabled) {
+        if (_provider.isFirstRun) {
+          setState(() {
+            _isVisible = true;
+          });
+        } else if (_provider.isEnabled) {
+          _provider.setUpAnalytics();
         }
-      } catch (e) {
-        print('Error collecting analytics:\n$e');
       }
-    }();
+    } catch (e) {
+      print('Error collecting analytics:\n$e');
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -36,18 +36,12 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
   @override
   void initState() {
     super.initState();
-    try {
-      if (_provider.isGtagsEnabled) {
-        if (_provider.isFirstRun) {
-          setState(() {
-            _isVisible = true;
-          });
-        } else if (_provider.isEnabled) {
-          _provider.setUpAnalytics();
-        }
+    if (_provider.isGtagsEnabled) {
+      if (_provider.isFirstRun) {
+        _isVisible = true;
+      } else if (_provider.isEnabled) {
+        _provider.setUpAnalytics();
       }
-    } catch (e) {
-      print('Error collecting analytics:\n$e');
     }
   }
 

--- a/packages/devtools_app/lib/src/analytics/provider.dart
+++ b/packages/devtools_app/lib/src/analytics/provider.dart
@@ -3,10 +3,9 @@
 // found in the LICENSE file.
 
 abstract class AnalyticsProvider {
-  Future<void> initialize();
   bool get isGtagsEnabled;
-  Future<bool> get isFirstRun;
-  Future<bool> get isEnabled;
+  bool get isFirstRun;
+  bool get isEnabled;
   void setUpAnalytics();
   void setAllowAnalytics();
   void setDontAllowAnalytics();

--- a/packages/devtools_app/lib/src/analytics/remote_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/remote_provider.dart
@@ -38,17 +38,21 @@ class _RemoteAnalyticsProvider implements AnalyticsProvider {
 Future<AnalyticsProvider> get analyticsProvider async {
   if (_providerCompleter != null) return _providerCompleter.future;
   _providerCompleter = Completer<AnalyticsProvider>();
-  analytics.exposeGaDevToolsEnabledToJs();
-  if (analytics.isGtagsReset()) {
-    await analytics.resetDevToolsFile();
-  }
   var isEnabled = false;
   var isFirstRun = false;
-  if (await analytics.isEnabled) {
-    isEnabled = true;
-    if (await analytics.isFirstRun) {
-      isFirstRun = true;
+  try {
+    analytics.exposeGaDevToolsEnabledToJs();
+    if (analytics.isGtagsReset()) {
+      await analytics.resetDevToolsFile();
     }
+    if (await analytics.isEnabled) {
+      isEnabled = true;
+      if (await analytics.isFirstRun) {
+        isFirstRun = true;
+      }
+    }
+  } catch (_) {
+    // Ignore issues if analytics could not be initialized.
   }
   _providerCompleter.complete(_RemoteAnalyticsProvider(isEnabled, isFirstRun));
   return _providerCompleter.future;

--- a/packages/devtools_app/lib/src/analytics/remote_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/remote_provider.dart
@@ -2,27 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'analytics.dart' as analytics;
 import 'platform.dart' as platform;
 import 'provider.dart';
 
 class _RemoteAnalyticsProvider implements AnalyticsProvider {
-  @override
-  Future<void> initialize() async {
-    analytics.exposeGaDevToolsEnabledToJs();
-    if (analytics.isGtagsReset()) {
-      await analytics.resetDevToolsFile();
-    }
-  }
+  _RemoteAnalyticsProvider(this._isEnabled, this._isFirstRun);
 
   @override
-  Future<bool> get isEnabled async => _isEnabled ??= await analytics.isEnabled;
-  bool _isEnabled;
+  bool get isEnabled => _isEnabled;
+  final bool _isEnabled;
 
   @override
-  Future<bool> get isFirstRun async =>
-      _isFirstRun ??= await analytics.isFirstRun;
-  bool _isFirstRun;
+  bool get isFirstRun => _isFirstRun;
+  final bool _isFirstRun;
 
   @override
   bool get isGtagsEnabled => analytics.isGtagsEnabled();
@@ -40,5 +35,23 @@ class _RemoteAnalyticsProvider implements AnalyticsProvider {
   }
 }
 
-AnalyticsProvider get provider => _provider;
-AnalyticsProvider _provider = _RemoteAnalyticsProvider();
+Future<AnalyticsProvider> get analyticsProvider async {
+  if (_providerCompleter != null) return _providerCompleter.future;
+  _providerCompleter = Completer<AnalyticsProvider>();
+  analytics.exposeGaDevToolsEnabledToJs();
+  if (analytics.isGtagsReset()) {
+    await analytics.resetDevToolsFile();
+  }
+  var isEnabled = false;
+  var isFirstRun = false;
+  if (await analytics.isEnabled) {
+    isEnabled = true;
+    if (await analytics.isFirstRun) {
+      isFirstRun = true;
+    }
+  }
+  _providerCompleter.complete(_RemoteAnalyticsProvider(isEnabled, isFirstRun));
+  return _providerCompleter.future;
+}
+
+Completer<AnalyticsProvider> _providerCompleter;

--- a/packages/devtools_app/lib/src/analytics/stub_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/stub_provider.dart
@@ -6,13 +6,10 @@ import 'provider.dart';
 
 class _StubProvider implements AnalyticsProvider {
   @override
-  Future<void> initialize() async {}
+  bool get isEnabled => false;
 
   @override
-  Future<bool> get isEnabled async => false;
-
-  @override
-  Future<bool> get isFirstRun async => false;
+  bool get isFirstRun => false;
 
   @override
   bool get isGtagsEnabled => false;
@@ -27,5 +24,5 @@ class _StubProvider implements AnalyticsProvider {
   void setUpAnalytics() {}
 }
 
-AnalyticsProvider get provider => _provider;
+Future<AnalyticsProvider> get analyticsProvider async => _provider;
 AnalyticsProvider _provider = _StubProvider();

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -8,6 +8,7 @@ import 'package:pedantic/pedantic.dart';
 import 'package:provider/provider.dart';
 
 import '../devtools.dart' as devtools;
+import 'analytics/provider.dart';
 import 'code_size/code_size_controller.dart';
 import 'code_size/code_size_screen.dart';
 import 'common_widgets.dart';
@@ -46,11 +47,17 @@ const codeSizeRoute = '/codeSize';
 /// Top-level configuration for the app.
 @immutable
 class DevToolsApp extends StatefulWidget {
-  const DevToolsApp(this.screens, this.preferences, this.ideTheme);
+  const DevToolsApp(
+    this.screens,
+    this.preferences,
+    this.ideTheme,
+    this.analyticsProvider,
+  );
 
   final List<DevToolsScreen> screens;
   final PreferencesController preferences;
   final IdeTheme ideTheme;
+  final AnalyticsProvider analyticsProvider;
 
   @override
   State<DevToolsApp> createState() => DevToolsAppState();
@@ -122,6 +129,7 @@ class DevToolsAppState extends State<DevToolsApp> {
         return DevToolsScaffold.withChild(
           child: CenteredMessage("'$uri' not found."),
           ideTheme: ideTheme,
+          analyticsProvider: widget.analyticsProvider,
         );
       },
     );
@@ -146,6 +154,7 @@ class DevToolsAppState extends State<DevToolsApp> {
                   child: CenteredMessage(
                       'The "$page" screen is not available for this application.'),
                   ideTheme: ideTheme,
+                  analyticsProvider: widget.analyticsProvider,
                 );
               }
               return _providedControllers(
@@ -154,6 +163,7 @@ class DevToolsAppState extends State<DevToolsApp> {
                   ideTheme: ideTheme,
                   initialPage: page,
                   tabs: tabs,
+                  analyticsProvider: widget.analyticsProvider,
                   actions: [
                     if (serviceManager.connectedApp.isFlutterAppNow) ...[
                       HotReloadButton(),
@@ -172,6 +182,7 @@ class DevToolsAppState extends State<DevToolsApp> {
           return DevToolsScaffold.withChild(
             child: LandingScreenBody(),
             ideTheme: ideTheme,
+            analyticsProvider: widget.analyticsProvider,
             actions: [
               OpenSettingsAction(),
               OpenAboutAction(),
@@ -181,6 +192,7 @@ class DevToolsAppState extends State<DevToolsApp> {
       },
       snapshotRoute: (_, __, args) {
         return DevToolsScaffold.withChild(
+          analyticsProvider: widget.analyticsProvider,
           child: _providedControllers(
             offline: true,
             child: SnapshotScreenBody(args, _screens),
@@ -190,6 +202,7 @@ class DevToolsAppState extends State<DevToolsApp> {
       },
       codeSizeRoute: (_, __, ___) {
         return DevToolsScaffold.withChild(
+          analyticsProvider: widget.analyticsProvider,
           child: _providedControllers(
             child: const CodeSizeBody(),
           ),

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -10,8 +10,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'analytics/prompt.dart';
-import 'analytics/stub_provider.dart'
-    if (dart.library.html) 'analytics/remote_provider.dart';
+import 'analytics/provider.dart';
 import 'app.dart';
 import 'banner_messages.dart';
 import 'common_widgets.dart';
@@ -37,6 +36,7 @@ class DevToolsScaffold extends StatefulWidget {
   const DevToolsScaffold({
     Key key,
     @required this.tabs,
+    @required this.analyticsProvider,
     this.initialPage,
     this.actions,
     this.embed = false,
@@ -48,10 +48,12 @@ class DevToolsScaffold extends StatefulWidget {
     Key key,
     @required Widget child,
     @required IdeTheme ideTheme,
+    @required AnalyticsProvider analyticsProvider,
     List<Widget> actions,
   }) : this(
           key: key,
           tabs: [SimpleScreen(child)],
+          analyticsProvider: analyticsProvider,
           ideTheme: ideTheme,
           actions: actions,
         );
@@ -93,6 +95,8 @@ class DevToolsScaffold extends StatefulWidget {
   ///
   /// These will generally be [RegisteredServiceExtensionButton]s.
   final List<Widget> actions;
+
+  final AnalyticsProvider analyticsProvider;
 
   @override
   State<StatefulWidget> createState() => DevToolsScaffoldState();
@@ -280,7 +284,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           alignment: Alignment.topLeft,
           child: FocusScope(
             child: AnalyticsPrompt(
-              provider: provider,
+              provider: widget.analyticsProvider,
               child: BannerMessages(
                 screen: screen,
               ),

--- a/packages/devtools_app/test/analytics_prompt_test.dart
+++ b/packages/devtools_app/test/analytics_prompt_test.dart
@@ -21,13 +21,10 @@ class FakeProvider implements AnalyticsProvider {
   final bool firstRun;
 
   @override
-  Future<void> initialize() async {}
+  bool get isEnabled => enabled;
 
   @override
-  Future<bool> get isEnabled async => enabled;
-
-  @override
-  Future<bool> get isFirstRun async => firstRun;
+  bool get isFirstRun => firstRun;
 
   @override
   bool get isGtagsEnabled => gtagsEnabled;

--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
+import 'package:devtools_app/src/analytics/stub_provider.dart';
 import 'package:devtools_app/src/app.dart';
 import 'package:devtools_app/src/framework/framework_core.dart';
 import 'package:devtools_app/src/inspector/flutter_widget.dart';
@@ -55,7 +56,8 @@ Future<void> main() async {
       await preferences.init();
       final app = DefaultAssetBundle(
         bundle: _DiskAssetBundle(),
-        child: DevToolsApp(const [], preferences, null),
+        child:
+            DevToolsApp(const [], preferences, null, await analyticsProvider),
       );
       await tester.pumpWidget(app);
       await tester.pumpAndSettle();

--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -56,8 +56,12 @@ Future<void> main() async {
       await preferences.init();
       final app = DefaultAssetBundle(
         bundle: _DiskAssetBundle(),
-        child:
-            DevToolsApp(const [], preferences, null, await analyticsProvider),
+        child: DevToolsApp(
+          const [],
+          preferences,
+          null,
+          await analyticsProvider,
+        ),
       );
       await tester.pumpWidget(app);
       await tester.pumpAndSettle();

--- a/packages/devtools_app/test/scaffold_test.dart
+++ b/packages/devtools_app/test/scaffold_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/analytics/stub_provider.dart';
 import 'package:devtools_app/src/framework_controller.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/scaffold.dart';
@@ -31,9 +32,10 @@ void main() {
         const Size(DevToolsScaffold.narrowWidthThreshold - 200.0, 1200.0),
         (WidgetTester tester) async {
       await tester.pumpWidget(wrap(
-        const DevToolsScaffold(
-          tabs: [screen1, screen2, screen3, screen4, screen5],
+        DevToolsScaffold(
+          tabs: const [screen1, screen2, screen3, screen4, screen5],
           ideTheme: null,
+          analyticsProvider: await analyticsProvider,
         ),
       ));
       expect(find.byKey(k1), findsOneWidget);
@@ -45,9 +47,10 @@ void main() {
         const Size(DevToolsScaffold.narrowWidthThreshold + 3.0, 1200.0),
         (WidgetTester tester) async {
       await tester.pumpWidget(wrap(
-        const DevToolsScaffold(
-          tabs: [screen1, screen2, screen3, screen4, screen5],
+        DevToolsScaffold(
+          tabs: const [screen1, screen2, screen3, screen4, screen5],
           ideTheme: null,
+          analyticsProvider: await analyticsProvider,
         ),
       ));
       expect(find.byKey(k1), findsOneWidget);
@@ -58,7 +61,11 @@ void main() {
     testWidgets('displays no tabs when only one is given',
         (WidgetTester tester) async {
       await tester.pumpWidget(wrap(
-        const DevToolsScaffold(tabs: [screen1], ideTheme: null),
+        DevToolsScaffold(
+          tabs: const [screen1],
+          ideTheme: null,
+          analyticsProvider: await analyticsProvider,
+        ),
       ));
       expect(find.byKey(k1), findsOneWidget);
       expect(find.byKey(t1), findsNothing);
@@ -66,7 +73,11 @@ void main() {
 
     testWidgets('displays only the selected tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(
-        const DevToolsScaffold(tabs: [screen1, screen2], ideTheme: null),
+        DevToolsScaffold(
+          tabs: const [screen1, screen2],
+          ideTheme: null,
+          analyticsProvider: await analyticsProvider,
+        ),
       ));
       expect(find.byKey(k1), findsOneWidget);
       expect(find.byKey(k2), findsNothing);
@@ -92,6 +103,7 @@ void main() {
           tabs: const [screen1, screen2],
           initialPage: screen2.screenId,
           ideTheme: null,
+          analyticsProvider: await analyticsProvider,
         ),
       ));
 


### PR DESCRIPTION
Move the async work required for the remote provider into `main.dart` so there isn't potentially a flash with the `AnalyticsPrompt`.