### PR TITLE
Make hint text for entering a vm service url less confusing.

### DIFF
--- a/packages/devtools_app/lib/src/landing_screen.dart
+++ b/packages/devtools_app/lib/src/landing_screen.dart
@@ -147,8 +147,8 @@ class _LandingScreenBodyState extends State<LandingScreenBody> {
               Padding(
                 padding: const EdgeInsets.all(8.0),
                 child: Text(
-                  '(http://127.0.0.1:12345/auth_code=)',
-                  textAlign: TextAlign.end,
+                  '(e.g., http://127.0.0.1:12345/auth_code=...)',
+                  textAlign: TextAlign.start,
                   style: Theme.of(context).textTheme.caption,
                 ),
               ),

--- a/packages/devtools_app/lib/src/landing_screen.dart
+++ b/packages/devtools_app/lib/src/landing_screen.dart
@@ -145,7 +145,7 @@ class _LandingScreenBodyState extends State<LandingScreenBody> {
                 controller: connectDialogController,
               ),
               Padding(
-                padding: const EdgeInsets.all(8.0),
+                padding: const EdgeInsets.symmetric(vertical: 8.0),
                 child: Text(
                   '(e.g., http://127.0.0.1:12345/auth_code=...)',
                   textAlign: TextAlign.start,

--- a/packages/devtools_app/lib/src/landing_screen.dart
+++ b/packages/devtools_app/lib/src/landing_screen.dart
@@ -123,23 +123,36 @@ class _LandingScreenBodyState extends State<LandingScreenBody> {
     final CallbackDwell connectDebounce = CallbackDwell(_connect);
 
     return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         SizedBox(
           width: 350.0,
-          child: TextField(
-            onSubmitted: (str) => connectDebounce.invoke(),
-            autofocus: true,
-            decoration: const InputDecoration(
-              isDense: true,
-              border: OutlineInputBorder(),
-              enabledBorder: OutlineInputBorder(
-                // TODO(jacobr): we need to use themed colors everywhere instead
-                // of hard coding material colors.
-                borderSide: BorderSide(width: 0.5, color: Colors.grey),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                onSubmitted: (str) => connectDebounce.invoke(),
+                autofocus: true,
+                decoration: const InputDecoration(
+                  isDense: true,
+                  border: OutlineInputBorder(),
+                  enabledBorder: OutlineInputBorder(
+                    // TODO(jacobr): we need to use themed colors everywhere instead
+                    // of hard coding material colors.
+                    borderSide: BorderSide(width: 0.5, color: Colors.grey),
+                  ),
+                ),
+                controller: connectDialogController,
               ),
-              hintText: 'http://127.0.0.1:12345/auth_code=',
-            ),
-            controller: connectDialogController,
+              Padding(
+                padding: const EdgeInsets.all(8.0),
+                child: Text(
+                  '(http://127.0.0.1:12345/auth_code=)',
+                  textAlign: TextAlign.end,
+                  style: Theme.of(context).textTheme.caption,
+                ),
+              ),
+            ],
           ),
         ),
         const Padding(


### PR DESCRIPTION
@csells noted that the hint text for the vm service url makes it look like one has already been typed.
Before:
<img width="498" alt="Screen Shot 2020-08-12 at 11 00 30 AM" src="https://user-images.githubusercontent.com/1226812/90050560-38384c80-dc8b-11ea-9a96-fee77bc13abf.png">
After:
<img width="488" alt="Screen Shot 2020-08-12 at 10 38 26 AM" src="https://user-images.githubusercontent.com/1226812/90050566-3a9aa680-dc8b-11ea-9846-44a58dc1e895.png">

Tip: when reviewing CLs like this be sure to turn off white space only diffs. Wish we could set that as the default.