### PR TITLE
add tooptips to the debugger page

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -15,6 +15,7 @@ import 'ui/label.dart';
 import 'ui/theme.dart';
 
 const tooltipWait = Duration(milliseconds: 500);
+const tooltipWaitLong = Duration(milliseconds: 1000);
 
 /// The width of the package:flutter_test debugger device.
 const debuggerDeviceWidth = 800.0;

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -66,6 +66,9 @@ class _CallStackState extends State<CallStack> {
         frame.frame.kind == FrameKind.kAsyncSuspensionMarker;
     final noLineInfo = frame.line == null;
 
+    final frameDescription = _descriptionFor(frame);
+    final locationDescription = _locationFor(frame);
+
     if (asyncMarker) {
       child = Row(
         children: [
@@ -73,7 +76,7 @@ class _CallStackState extends State<CallStack> {
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: densePadding),
             child: Text(
-              _descriptionFor(frame),
+              frameDescription,
               style: selected ? theme.selectedTextStyle : theme.subtleTextStyle,
             ),
           ),
@@ -85,7 +88,7 @@ class _CallStackState extends State<CallStack> {
         maxLines: 1,
         overflow: TextOverflow.ellipsis,
         text: TextSpan(
-          text: _descriptionFor(frame),
+          text: frameDescription,
           style: selected
               ? theme.selectedTextStyle
               : (asyncFrame || noLineInfo
@@ -93,7 +96,7 @@ class _CallStackState extends State<CallStack> {
                   : theme.regularTextStyle),
           children: [
             TextSpan(
-              text: _locationFor(frame),
+              text: ' $locationDescription',
               style: selected ? theme.selectedTextStyle : theme.subtleTextStyle,
             ),
           ],
@@ -101,7 +104,9 @@ class _CallStackState extends State<CallStack> {
       );
     }
 
-    return Material(
+    final isAsyncBreak = frame.frame.kind == FrameKind.kAsyncSuspensionMarker;
+
+    final result = Material(
       color: selected ? theme.selectedRowColor : null,
       child: InkWell(
         onTap: () => _onStackFrameSelected(frame),
@@ -112,6 +117,18 @@ class _CallStackState extends State<CallStack> {
         ),
       ),
     );
+
+    if (isAsyncBreak) {
+      return result;
+    } else {
+      return Tooltip(
+        message: locationDescription == null
+            ? frameDescription
+            : '$frameDescription $locationDescription',
+        waitDuration: tooltipWaitLong,
+        child: result,
+      );
+    }
   }
 
   Future<void> _onStackFrameSelected(StackFrameAndSourcePosition frame) async {
@@ -144,7 +161,7 @@ class _CallStackState extends State<CallStack> {
       return uri;
     }
     final file = uri.split('/').last;
-    return frame.line == null ? ' $file' : ' $file ${frame.line}';
+    return frame.line == null ? file : '$file ${frame.line}';
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/debugger/variables.dart
@@ -31,20 +31,30 @@ class Variables extends StatelessWidget {
     );
   }
 
-  Widget displayProvider(BuildContext context, Variable v) {
+  Widget displayProvider(BuildContext context, Variable variable) {
     final theme = Theme.of(context);
-    return RichText(
-      maxLines: 1,
-      overflow: TextOverflow.ellipsis,
-      text: TextSpan(
-        text: '${v.boundVar.name}: ',
-        style: theme.regularTextStyle,
-        children: [
-          TextSpan(
-            text: v.displayValue,
-            style: theme.subtleTextStyle,
-          ),
-        ],
+
+    // TODO(devoncarew): Here, we want to wait until the tooltip wants to show,
+    // then call toString() on variable and render the result in a tooltip. We
+    // should also include the type of the value in the tooltip if the variable
+    // is not null.
+
+    return Tooltip(
+      message: variable.displayValue,
+      waitDuration: tooltipWaitLong,
+      child: RichText(
+        maxLines: 1,
+        overflow: TextOverflow.ellipsis,
+        text: TextSpan(
+          text: '${variable.boundVar.name}: ',
+          style: theme.regularTextStyle,
+          children: [
+            TextSpan(
+              text: variable.displayValue,
+              style: theme.subtleTextStyle,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -349,6 +349,13 @@ void main() {
             widget.text.toPlainText().contains('testCodeRef() script.dart 0')),
         findsOneWidget,
       );
+
+      // verify that the frame has a tooltip
+      expect(
+        find.byTooltip('testCodeRef() script.dart 0'),
+        findsOneWidget,
+      );
+
       // Stack frame 1
       expect(
         find.byWidgetPredicate((Widget widget) =>
@@ -395,6 +402,12 @@ void main() {
           widget is RichText && widget.text.toPlainText().contains('0: 3'));
       final listChild2Finder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText && widget.text.toPlainText().contains('1: 4'));
+
+      // expect a tooltip for the list value
+      expect(
+        find.byTooltip('_GrowableList (2 items)'),
+        findsOneWidget,
+      );
 
       final mapFinder = find.byWidgetPredicate((Widget widget) =>
           widget is RichText &&


### PR DESCRIPTION
- add tooptips to the debugger page (to the call stack and the variables view)

I added a todo to have a more sophisticated tooltip for the variables view - something that either displays the toString() of the object via expr eval.
