### PR TITLE
Checkbox polish

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -22,7 +22,6 @@ import '../service_manager.dart';
 import '../table.dart';
 import '../table_data.dart';
 import '../ui/search.dart';
-import '../ui/utils.dart';
 import '../utils.dart';
 import 'memory_filter.dart';
 import 'memory_graph_model.dart';
@@ -519,19 +518,19 @@ class MemoryController extends DisposableController
   }
 
   /// Hide any class that hasn't been constructed (zero instances).
-  final filterZeroInstances = CheckboxValueNotifier(true);
+  final filterZeroInstances = ValueNotifier(true);
 
   ValueListenable<bool> get filterZeroInstancesListenable =>
       filterZeroInstances;
 
   /// Hide any private class, prefixed with an underscore.
-  final filterPrivateClasses = CheckboxValueNotifier(true);
+  final filterPrivateClasses = ValueNotifier(true);
 
   ValueListenable<bool> get filterPrivateClassesListenable =>
       filterPrivateClasses;
 
   /// Hide any library with no constructed class instances.
-  final filterLibraryNoInstances = CheckboxValueNotifier(true);
+  final filterLibraryNoInstances = ValueNotifier(true);
 
   ValueListenable<bool> get filterLibraryNoInstancesListenable =>
       filterLibraryNoInstances;

--- a/packages/devtools_app/lib/src/memory/memory_filter.dart
+++ b/packages/devtools_app/lib/src/memory/memory_filter.dart
@@ -139,24 +139,6 @@ class SnapshotFilterState extends State<SnapshotFilterDialog>
     controller = widget.controller;
 
     cancel();
-
-    // Detect and handle checkboxes state changing.
-    addAutoDisposeListener(controller.filterPrivateClassesListenable, () {
-      setState(() {
-        privateClasses.notifier.value = controller.filterPrivateClasses.value;
-      });
-    });
-    addAutoDisposeListener(controller.filterLibraryNoInstancesListenable, () {
-      setState(() {
-        libraryNoInstances.notifier.value =
-            controller.filterLibraryNoInstances.value;
-      });
-    });
-    addAutoDisposeListener(controller.filterZeroInstancesListenable, () {
-      setState(() {
-        zeroInstances.notifier.value = controller.filterZeroInstances.value;
-      });
-    });
   }
 
   void addLibrary(String libraryName, {bool hideState = false}) {

--- a/packages/devtools_app/lib/src/memory/memory_filter.dart
+++ b/packages/devtools_app/lib/src/memory/memory_filter.dart
@@ -279,19 +279,9 @@ class SnapshotFilterState extends State<SnapshotFilterDialog>
     );
   }
 
-  NotifierCheckbox privateClasses;
-  NotifierCheckbox zeroInstances;
-  NotifierCheckbox libraryNoInstances;
-
   @override
   Widget build(BuildContext context) {
     buildFilters();
-
-    privateClasses =
-        NotifierCheckbox(notifier: controller.filterPrivateClasses);
-    zeroInstances = NotifierCheckbox(notifier: controller.filterZeroInstances);
-    libraryNoInstances =
-        NotifierCheckbox(notifier: controller.filterLibraryNoInstances);
 
     // Dialog has three main vertical sections:
     //      - three checkboxes
@@ -323,19 +313,22 @@ class SnapshotFilterState extends State<SnapshotFilterDialog>
                       ),
                       Row(
                         children: [
-                          privateClasses,
+                          NotifierCheckbox(
+                              notifier: controller.filterPrivateClasses),
                           const Text('Hide Private Class e.g.,_className'),
                         ],
                       ),
                       Row(
                         children: [
-                          zeroInstances,
+                          NotifierCheckbox(
+                              notifier: controller.filterZeroInstances),
                           const Text('Hide Classes with No Instances'),
                         ],
                       ),
                       Row(
                         children: [
-                          libraryNoInstances,
+                          NotifierCheckbox(
+                              notifier: controller.filterLibraryNoInstances),
                           const Text('Hide Library with No Instances'),
                         ],
                       ),

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -38,7 +38,6 @@ class _NotifierCheckboxState extends State<NotifierCheckbox>
 
   @override
   void initState() {
-    // TODO: implement initState
     super.initState();
     _trackValue();
   }

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -7,44 +7,71 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-/// Used to create a Checkbox widget who's boolean value is attached
-/// to a ValueNotifier<bool>.  This allows for the pattern:
+import '../auto_dispose_mixin.dart';
+
+/// Stateful Checkbox Widget class using a [ValueNotifier].
 ///
-/// Create the NotifierCheckbox widget in build e.g.,
+/// Used to create a Checkbox widget who's boolean value is attached
+/// to a [ValueNotifier<bool>].  This allows for the pattern:
+///
+/// Create the [NotifierCheckbox] widget in build e.g.,
 ///
 ///   myCheckboxWidget = NotifierCheckbox(notifier: controller.myCheckbox);
 ///
-/// Add a listener in didChangeDependencies to rebuild when checkbox value
-/// changes e.g.,
-///
-/// addAutoDisposeListener(controller.myCheckboxListenable, () {
-///   setState(() {
-///     myCheckbox.notifier.value = controller.myCheckbox.value;
-///   });
-/// });
-
-/// Checkbox Widget class using a ValueNotifier.
-class NotifierCheckbox extends Checkbox {
-  NotifierCheckbox({
+/// The checkbox and the value notifier are now linked with clicks updating the
+/// [ValueNotifier] and changes to the [ValueNotifier] updating the checkbox.
+class NotifierCheckbox extends StatefulWidget {
+  const NotifierCheckbox({
     Key key,
     @required this.notifier,
-  }) : super(
-          key: key,
-          value: notifier.value,
-          onChanged: notifier.onChanged,
-        );
+  }) : super(key: key);
 
-  final CheckboxValueNotifier notifier;
+  final ValueNotifier<bool> notifier;
 
-  /// Notifies that the value of the checkbox has changed.
-  ValueListenable<bool> get valueListenable => notifier;
+  @override
+  _NotifierCheckboxState createState() => _NotifierCheckboxState();
 }
 
-/// ValueNotifier associated with a Checkbox widget.
-class CheckboxValueNotifier extends ValueNotifier<bool> {
-  CheckboxValueNotifier(bool value) : super(value);
+class _NotifierCheckboxState extends State<NotifierCheckbox>
+    with AutoDisposeMixin {
+  bool currentValue;
 
-  void onChanged(bool newValue) {
-    value = newValue;
+  @override
+  void initState() {
+    // TODO: implement initState
+    super.initState();
+    _trackValue();
+  }
+
+  @override
+  void didUpdateWidget(NotifierCheckbox oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (oldWidget.notifier == widget.notifier) return;
+
+    cancel();
+    _trackValue();
+  }
+
+  void _trackValue() {
+    _updateValue();
+    addAutoDisposeListener(widget.notifier, _updateValue);
+  }
+
+  void _updateValue() {
+    if (currentValue == widget.notifier.value) return;
+    setState(() {
+      currentValue = widget.notifier.value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Checkbox(
+      value: currentValue,
+      onChanged: (value) {
+        widget.notifier.value = value;
+      },
+    );
   }
 }

--- a/packages/devtools_app/test/ui_utils_test.dart
+++ b/packages/devtools_app/test/ui_utils_test.dart
@@ -1,0 +1,81 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/ui/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/wrappers.dart';
+
+void main() {
+  bool findCheckboxValue() {
+    final Checkbox checkboxWidget =
+        find.byType(Checkbox).evaluate().first.widget;
+    return checkboxWidget.value;
+  }
+
+  group('NotifierCheckbox', () {
+    testWidgets('tap checkbox', (WidgetTester tester) async {
+      final notifier = ValueNotifier<bool>(false);
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: notifier)));
+      final checkbox = find.byType(Checkbox);
+      expect(checkbox, findsOneWidget);
+      expect(notifier.value, isFalse);
+      expect(findCheckboxValue(), isFalse);
+      await tester.tap(checkbox);
+      await tester.pump();
+      expect(notifier.value, isTrue);
+      expect(findCheckboxValue(), isTrue);
+
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+      expect(notifier.value, isFalse);
+      expect(findCheckboxValue(), isFalse);
+    });
+
+    testWidgets('change notifier value', (WidgetTester tester) async {
+      final notifier = ValueNotifier<bool>(false);
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: notifier)));
+      expect(notifier.value, isFalse);
+      expect(findCheckboxValue(), isFalse);
+
+      notifier.value = true;
+      await tester.pump();
+      expect(notifier.value, isTrue);
+      expect(findCheckboxValue(), isTrue);
+
+      notifier.value = false;
+      await tester.tap(find.byType(Checkbox));
+      await tester.pump();
+      expect(notifier.value, isFalse);
+      expect(findCheckboxValue(), isFalse);
+    });
+
+    testWidgets('change notifier', (WidgetTester tester) async {
+      final falseNotifier = ValueNotifier<bool>(false);
+      final trueNotifier = ValueNotifier<bool>(true);
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: falseNotifier)));
+      expect(findCheckboxValue(), isFalse);
+
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: trueNotifier)));
+      expect(findCheckboxValue(), isTrue);
+
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: falseNotifier)));
+      expect(findCheckboxValue(), isFalse);
+
+      await tester.pumpWidget(wrap(NotifierCheckbox(notifier: trueNotifier)));
+      expect(findCheckboxValue(), isTrue);
+
+      // ensure we can modify the value of the notifier and changes are
+      // reflected even though this is different than the initial notifier.
+      trueNotifier.value = false;
+      await tester.pump();
+      expect(findCheckboxValue(), isFalse);
+
+      trueNotifier.value = true;
+      await tester.pump();
+      expect(findCheckboxValue(), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Fyi @terrylucas 

Cleaning up the NotifierCheckbox so it is more convenient to reuse in the inspector page.
This class now gives us a really terse checkbox fully linked to a ValueNotifier. I recommend we use it for all our UI that needs to link checkboxes to ValueNotifier objects in our controllers.