### PR TITLE
Remove Restoration Framework

### DIFF
--- a/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
@@ -9,6 +9,7 @@ import 'dart:ui';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
 /// A [ScrollView] that uses a single child layout model and allows for custom


### PR DESCRIPTION
https://github.com/flutter/devtools/pull/2264/ pulled in the restoration framework, whose API are still in flux. Since devtool doesn't seem to use restoration yet, I removed the framework again. Devtools dependency on that API was causing trouble for google3 rolls. Once the restoration framework is stabilized, I'll add this back in.