### PR TITLE
Ensure sort by absolute value for diff table

### DIFF
--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -182,8 +182,9 @@ class CodeSizeDiffTable extends StatelessWidget {
 class _DiffColumn extends ColumnData<TreemapNode> {
   _DiffColumn() : super('Change', alignment: ColumnAlignment.right);
 
+  // Ensure sort by absolute size.
   @override
-  dynamic getValue(TreemapNode dataObject) => dataObject.byteSize;
+  dynamic getValue(TreemapNode dataObject) => dataObject.unsignedByteSize;
 
 // TODO(peterdjlee): Add up or down arrows indicating increase or decrease for display value.
   @override


### PR DESCRIPTION
Ensure sort by absolute value for diff table
  * Previously the diff table was sorted with the signed byte size of each node, but sorting by the absolute value allows the user to evaluate the size of the changes without thinking about what kind of change it was (i.e. increase, decrease).