### PR TITLE
Auto expand root for tree table on page load

### DIFF
--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -11,7 +11,7 @@ import '../ui/colors.dart';
 import '../utils.dart';
 
 class CodeSizeSnapshotTable extends StatelessWidget {
-  factory CodeSizeSnapshotTable({@required rootNode}) {
+  factory CodeSizeSnapshotTable({@required rootNode, autoExpandRoot = true}) {
     final treeColumn = _NameColumn(currentRootLevel: rootNode.level);
     final sizeColumn = _SizeColumn();
     final columns = List<ColumnData<TreemapNode>>.unmodifiable([
@@ -22,6 +22,7 @@ class CodeSizeSnapshotTable extends StatelessWidget {
 
     return CodeSizeSnapshotTable._(
       rootNode,
+      autoExpandRoot,
       treeColumn,
       sizeColumn,
       columns,
@@ -30,6 +31,7 @@ class CodeSizeSnapshotTable extends StatelessWidget {
 
   const CodeSizeSnapshotTable._(
     this.rootNode,
+    this.autoExpandRoot,
     this.treeColumn,
     this.sortColumn,
     this.columns,
@@ -37,14 +39,17 @@ class CodeSizeSnapshotTable extends StatelessWidget {
 
   final TreemapNode rootNode;
 
+  final bool autoExpandRoot;
+
   final TreeColumnData<TreemapNode> treeColumn;
   final ColumnData<TreemapNode> sortColumn;
   final List<ColumnData<TreemapNode>> columns;
 
   @override
   Widget build(BuildContext context) {
-    // Ensure root node is already expanded on load.
-    rootNode.expand();
+    if (autoExpandRoot) {
+      rootNode.expand();
+    }
     return TreeTable<TreemapNode>(
       dataRoots: [rootNode],
       columns: columns,
@@ -135,7 +140,7 @@ class _SizePercentageColumn extends ColumnData<TreemapNode> {
 }
 
 class CodeSizeDiffTable extends StatelessWidget {
-  factory CodeSizeDiffTable({@required rootNode}) {
+  factory CodeSizeDiffTable({@required rootNode, autoExpandRoot = true}) {
     final treeColumn = _NameColumn(currentRootLevel: rootNode.level);
     final diffColumn = _DiffColumn();
     final columns = List<ColumnData<TreemapNode>>.unmodifiable([
@@ -145,6 +150,7 @@ class CodeSizeDiffTable extends StatelessWidget {
 
     return CodeSizeDiffTable._(
       rootNode,
+      autoExpandRoot,
       treeColumn,
       diffColumn,
       columns,
@@ -153,12 +159,15 @@ class CodeSizeDiffTable extends StatelessWidget {
 
   const CodeSizeDiffTable._(
     this.rootNode,
+    this.autoExpandRoot,
     this.treeColumn,
     this.sortColumn,
     this.columns,
   );
 
   final TreemapNode rootNode;
+
+  final bool autoExpandRoot;
 
   final TreeColumnData<TreemapNode> treeColumn;
   final ColumnData<TreemapNode> sortColumn;
@@ -168,8 +177,9 @@ class CodeSizeDiffTable extends StatelessWidget {
   //                  if the table is only showing negative values.
   @override
   Widget build(BuildContext context) {
-    // Ensure root node is already expanded on load.
-    rootNode.expand();
+    if (autoExpandRoot) {
+      rootNode.expand();
+    }
     return TreeTable<TreemapNode>(
       dataRoots: [rootNode],
       columns: columns,

--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -43,6 +43,8 @@ class CodeSizeSnapshotTable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // Ensure root node is already expanded on load.
+    rootNode.expand();
     return TreeTable<TreemapNode>(
       dataRoots: [rootNode],
       columns: columns,
@@ -166,6 +168,8 @@ class CodeSizeDiffTable extends StatelessWidget {
   //                  if the table is only showing negative values.
   @override
   Widget build(BuildContext context) {
+    // Ensure root node is already expanded on load.
+    rootNode.expand();
     return TreeTable<TreemapNode>(
       dataRoots: rootNode.children,
       columns: columns,

--- a/packages/devtools_app/lib/src/code_size/code_size_table.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_table.dart
@@ -171,7 +171,7 @@ class CodeSizeDiffTable extends StatelessWidget {
     // Ensure root node is already expanded on load.
     rootNode.expand();
     return TreeTable<TreemapNode>(
-      dataRoots: rootNode.children,
+      dataRoots: [rootNode],
       columns: columns,
       treeColumn: treeColumn,
       keyFactory: (node) => PageStorageKey<String>(node.name),


### PR DESCRIPTION
Auto expand root for tree table on page load
  * On page load [Before]
<img width="729" alt="Screen Shot 2020-08-17 at 11 38 43 AM" src="https://user-images.githubusercontent.com/22206026/90415008-80d27a00-e07e-11ea-8ae4-c0bfaf4f1a94.png">
  * On page load [After
<img width="757" alt="Screen Shot 2020-08-17 at 11 39 15 AM" src="https://user-images.githubusercontent.com/22206026/90415058-921b8680-e07e-11ea-8f04-3449ac2b423c.png">

