### PR TITLE
Fix part not initialize bug.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -221,7 +221,7 @@ class InspectorService extends DisposableController
     final parts = path.split('/');
     String pubRootDirectory;
     for (int i = parts.length - 1; i >= 0; i--) {
-      String part;
+      final part = parts[i];
       if (part == 'lib' || part == 'web') {
         pubRootDirectory = parts.sublist(0, i).join('/');
         break;

--- a/packages/devtools_testing/lib/inspector_service_test.dart
+++ b/packages/devtools_testing/lib/inspector_service_test.dart
@@ -88,7 +88,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
         await inspectorService.setPubRootDirectories([]);
         final String rootDirectory =
             await inspectorService.inferPubRootDirectoryIfNeeded();
-        expect(rootDirectory, endsWith('/fixtures/flutter_app/lib'));
+        expect(rootDirectory, endsWith('/fixtures/flutter_app'));
         await group.dispose();
       });
 


### PR DESCRIPTION
The part field is not initialized.

This will cause the code in the subprojects under the current project to not be displayed in the inspector summary tree.