### PR TITLE
Typo fix in CHANGELOG.md: "meory" to "memory"

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.9.0
 * Add search functionality to Timeline flame chart [#2164](https://github.com/flutter/devtools/pull/2164)
 * Add socket profiling to Network page [#2191](https://github.com/flutter/devtools/pull/2191)
-* Support multiple meory snapshots and support automatic snapshots [#2105](https://github.com/flutter/devtools/pull/2105)
+* Support multiple memory snapshots and support automatic snapshots [#2105](https://github.com/flutter/devtools/pull/2105)
 * Add memory events pane and support for tracking # allocations of each class without a full snapshot [#2166](https://github.com/flutter/devtools/pull/2166)
 * Replace heatmap with treemap on the memory page [#2131](https://github.com/flutter/devtools/pull/2131)
 * Have the cmd-p keybinding toggle the libraries debugger pane [#2187](https://github.com/flutter/devtools/pull/2187)


### PR DESCRIPTION
I corrected a minor typo in the CHANGELOG.md.
```diff
- meory
+ memory
```

I've completed the Contributor License Agreement.
I can add myself to the AUTHORS file if you want but I didn't submit actual code on this project yet.