### PR TITLE
Support code size analysis files from all platforms

### DIFF
--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -405,6 +405,9 @@ class CodeSizeController {
 
 extension CodeSizeJsonFileExtension on DevToolsJsonFile {
   static const _supportedAnalyzeSizePlatforms = [
+    // TODO(kenz): remove 'apk' once
+    // https://github.com/flutter/flutter/pull/63610 is in stable.
+    'apk',
     'android',
     'ios',
     'macos',

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -147,7 +147,7 @@ class CodeSizeController {
     await delayForBatchProcessing(micros: 10000);
 
     Map<String, dynamic> processedJson;
-    if (jsonFile.isApkFile) {
+    if (jsonFile.isAnalyzeSizeFile) {
       // APK analysis json should be processed already.
       processedJson = jsonFile.data;
     } else {
@@ -188,7 +188,7 @@ class CodeSizeController {
       return;
     }
 
-    if (oldFile.isApkFile != newFile.isApkFile ||
+    if (oldFile.isAnalyzeSizeFile != newFile.isAnalyzeSizeFile ||
         oldFile.isV8Snapshot != newFile.isV8Snapshot) {
       onError(differentTypesError);
       return;
@@ -202,7 +202,7 @@ class CodeSizeController {
     await delayForBatchProcessing(micros: 10000);
 
     Map<String, dynamic> diffMap;
-    if (oldFile.isApkFile && newFile.isApkFile) {
+    if (oldFile.isAnalyzeSizeFile && newFile.isAnalyzeSizeFile) {
       final oldApkProgramInfo = ProgramInfo();
       _apkJsonToProgramInfo(
         program: oldApkProgramInfo,
@@ -404,10 +404,20 @@ class CodeSizeController {
 }
 
 extension CodeSizeJsonFileExtension on DevToolsJsonFile {
-  bool get isApkFile {
+  static const _supportedAnalyzeSizePlatforms = [
+    'android',
+    'ios',
+    'macos',
+    'windows',
+    'linux'
+  ];
+
+  bool get isAnalyzeSizeFile {
     if (data is Map<String, dynamic>) {
       final dataMap = data as Map<String, dynamic>;
-      return dataMap['type'] == 'apk';
+      final type = dataMap['type'];
+      return CodeSizeJsonFileExtension._supportedAnalyzeSizePlatforms
+          .contains(type);
     }
     return false;
   }

--- a/packages/devtools_app/lib/src/code_size/code_size_controller.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_controller.dart
@@ -405,10 +405,8 @@ class CodeSizeController {
 
 extension CodeSizeJsonFileExtension on DevToolsJsonFile {
   static const _supportedAnalyzeSizePlatforms = [
-    // TODO(kenz): remove 'apk' once
-    // https://github.com/flutter/flutter/pull/63610 is in stable.
     'apk',
-    'android',
+    'aab',
     'ios',
     'macos',
     'windows',

--- a/packages/devtools_app/lib/src/code_size/code_size_screen.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_screen.dart
@@ -183,7 +183,7 @@ class SnapshotView extends StatefulWidget {
   // TODO(kenz): add links to documentation on how to generate these files, and
   // mention the import file button once it is hooked up to a file picker.
   static const importInstructions = 'Drag and drop an AOT snapshot or'
-      ' code size analysis file for code size debugging';
+      ' size analysis file for debugging';
 
   @override
   _SnapshotViewState createState() => _SnapshotViewState();
@@ -321,9 +321,9 @@ class DiffView extends StatefulWidget {
   // TODO(kenz): add links to documentation on how to generate these files, and
   // mention the import file button once it is hooked up to a file picker.
   static const importOldInstructions = 'Drag and drop an original (old) AOT '
-      'snapshot or code size analysis file for code size debugging';
+      'snapshot or size analysis file for debugging';
   static const importNewInstructions = 'Drag and drop a modified (new) AOT '
-      'snapshot or code size analysis file for code size debugging';
+      'snapshot or size analysis file for debugging';
 
   @override
   _DiffViewState createState() => _DiffViewState();

--- a/packages/devtools_app/lib/src/code_size/code_size_screen.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_screen.dart
@@ -183,7 +183,7 @@ class SnapshotView extends StatefulWidget {
   // TODO(kenz): add links to documentation on how to generate these files, and
   // mention the import file button once it is hooked up to a file picker.
   static const importInstructions = 'Drag and drop an AOT snapshot or'
-      ' "apk-analysis.json" file for code size debugging';
+      ' code size analysis file for code size debugging';
 
   @override
   _SnapshotViewState createState() => _SnapshotViewState();
@@ -253,8 +253,9 @@ class _SnapshotViewState extends State<SnapshotView> with AutoDisposeMixin {
   }
 
   String _generateSingleFileHeaderText() {
-    String output =
-        controller.snapshotJsonFile.value.isApkFile ? 'APK: ' : 'Snapshot: ';
+    String output = controller.snapshotJsonFile.value.isAnalyzeSizeFile
+        ? 'Total Size Analysis: '
+        : 'Dart AOT Snapshot: ';
     output += controller.snapshotJsonFile.value.displayText;
     return output;
   }
@@ -320,9 +321,9 @@ class DiffView extends StatefulWidget {
   // TODO(kenz): add links to documentation on how to generate these files, and
   // mention the import file button once it is hooked up to a file picker.
   static const importOldInstructions = 'Drag and drop an original (old) AOT '
-      'snapshot or "apk-analysis.json" file for code size debugging';
+      'snapshot or code size analysis file for code size debugging';
   static const importNewInstructions = 'Drag and drop a modified (new) AOT '
-      'snapshot or "apk-analysis.json" file for code size debugging';
+      'snapshot or code size analysis file for code size debugging';
 
   @override
   _DiffViewState createState() => _DiffViewState();
@@ -396,7 +397,7 @@ class _DiffViewState extends State<DiffView> with AutoDisposeMixin {
 
   String _generateDualFileHeaderText() {
     String output = 'Diffing ';
-    output += controller.oldDiffSnapshotJsonFile.value.isApkFile
+    output += controller.oldDiffSnapshotJsonFile.value.isAnalyzeSizeFile
         ? 'APKs: '
         : 'Snapshots: ';
     output += controller.oldDiffSnapshotJsonFile.value.displayText;

--- a/packages/devtools_app/lib/src/code_size/code_size_screen.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_screen.dart
@@ -254,8 +254,8 @@ class _SnapshotViewState extends State<SnapshotView> with AutoDisposeMixin {
 
   String _generateSingleFileHeaderText() {
     String output = controller.snapshotJsonFile.value.isAnalyzeSizeFile
-        ? 'Total Size Analysis: '
-        : 'Dart AOT Snapshot: ';
+        ? 'Total size analysis: '
+        : 'Dart AOT snapshot: ';
     output += controller.snapshotJsonFile.value.displayText;
     return output;
   }
@@ -398,8 +398,8 @@ class _DiffViewState extends State<DiffView> with AutoDisposeMixin {
   String _generateDualFileHeaderText() {
     String output = 'Diffing ';
     output += controller.oldDiffSnapshotJsonFile.value.isAnalyzeSizeFile
-        ? 'APKs: '
-        : 'Snapshots: ';
+        ? 'total size analyses: '
+        : 'Dart AOT snapshots: ';
     output += controller.oldDiffSnapshotJsonFile.value.displayText;
     output += ' (OLD)    vs    (NEW) ';
     output += controller.newDiffSnapshotJsonFile.value.displayText;

--- a/packages/devtools_app/test/code_size_screen_test.dart
+++ b/packages/devtools_app/test/code_size_screen_test.dart
@@ -116,7 +116,7 @@ void main() {
       expect(find.byType(SnapshotView), findsOneWidget);
       expect(
         find.text(
-          'Snapshot: lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
+          'Dart AOT Snapshot: lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
         ),
         findsOneWidget,
       );

--- a/packages/devtools_app/test/code_size_screen_test.dart
+++ b/packages/devtools_app/test/code_size_screen_test.dart
@@ -116,7 +116,7 @@ void main() {
       expect(find.byType(SnapshotView), findsOneWidget);
       expect(
         find.text(
-          'Dart AOT Snapshot: lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
+          'Dart AOT snapshot: lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
         ),
         findsOneWidget,
       );
@@ -171,7 +171,7 @@ void main() {
       expect(find.byType(DiffView), findsOneWidget);
       expect(
         find.text(
-          'Diffing Snapshots: lib/src/code_size/stub_data/old_v8.dart - 7/28/2020 1:29 PM (OLD)    vs    (NEW) lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
+          'Diffing Dart AOT snapshots: lib/src/code_size/stub_data/old_v8.dart - 7/28/2020 1:29 PM (OLD)    vs    (NEW) lib/src/code_size/stub_data/new_v8.dart - 7/28/2020 1:29 PM',
         ),
         findsOneWidget,
       );


### PR DESCRIPTION
Prepares for changes in https://github.com/flutter/flutter/pull/63610, which supports `--analyze size` for all platforms.
@jonahwilliams 