### PR TITLE
Fix a bug causing extra evaluation for primitive values

### DIFF
--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -172,8 +172,9 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField> {
   }
 
   Future<String> _getBestStringValue(InstanceRef response) async {
-    // Return the string value if present and not truncated.
-    // Note: string value is truncated iff not null and true
+    // Return the string value iff present and not truncated.
+    // Note: string value is truncated iff [valueAsStringIsTruncated]
+    // is not null and is set to true.
     if (response.valueAsString != null &&
         response.valueAsStringIsTruncated != true) {
       return response.valueAsString;

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -174,8 +174,8 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField> {
   Future<String> _getBestStringValue(InstanceRef response) async {
     // Return the string value iff present and not truncated.
     // Note: [valueAsStringIsTruncated] is actually a tri-state:
-    // string value is truncated iff [valueAsStringIsTruncated]
-    // is not null and [valueAsStringIsTruncated] is true.
+    // string value is not truncated iff [valueAsStringIsTruncated]
+    // is null or [valueAsStringIsTruncated] is false.
     if (response.valueAsString != null &&
         response.valueAsStringIsTruncated != true) {
       return response.valueAsString;

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -172,8 +172,7 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField> {
   }
 
   Future<String> _getBestStringValue(InstanceRef response) async {
-    if (response.valueAsString != null &&
-        response.valueAsStringIsTruncated == false) {
+    if (response.valueAsString != null && !response.valueAsStringIsTruncated) {
       return response.valueAsString;
     }
 
@@ -202,7 +201,7 @@ String _valueAsString(InstanceRef ref) {
     return ref.valueAsString;
   }
 
-  if (ref.valueAsStringIsTruncated == true) {
+  if (ref.valueAsStringIsTruncated) {
     return '${ref.valueAsString}...';
   } else {
     return ref.valueAsString;

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -172,7 +172,10 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField> {
   }
 
   Future<String> _getBestStringValue(InstanceRef response) async {
-    if (response.valueAsString != null && !response.valueAsStringIsTruncated) {
+    // Return the string value if present and not truncated.
+    // Note: string value is truncated iff not null and true
+    if (response.valueAsString != null &&
+        response.valueAsStringIsTruncated != true) {
       return response.valueAsString;
     }
 
@@ -201,7 +204,7 @@ String _valueAsString(InstanceRef ref) {
     return ref.valueAsString;
   }
 
-  if (ref.valueAsStringIsTruncated) {
+  if (ref.valueAsStringIsTruncated == true) {
     return '${ref.valueAsString}...';
   } else {
     return ref.valueAsString;

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -173,8 +173,9 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField> {
 
   Future<String> _getBestStringValue(InstanceRef response) async {
     // Return the string value iff present and not truncated.
-    // Note: string value is truncated iff [valueAsStringIsTruncated]
-    // is not null and is set to true.
+    // Note: [valueAsStringIsTruncated] is actually a tri-state:
+    // string value is truncated iff [valueAsStringIsTruncated]
+    // is not null and [valueAsStringIsTruncated] is true.
     if (response.valueAsString != null &&
         response.valueAsStringIsTruncated != true) {
       return response.valueAsString;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -38,7 +38,7 @@ dependencies:
   provider: ^4.0.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^4.1.0
+  vm_service: ^4.2.0
   sse: ^3.1.2
   web_socket_channel: ^1.1.0
   flutter:


### PR DESCRIPTION
I discovered this bug during my implementation of expression evaluation in webdev (soon to follow,  I am making this change in advance so expression evaluation will work correctly in webdev when checked in):

`response.valueAsStringIsTruncated == false` was evaluated to `false` on primitive JS values that had it set to `null`, causing the devtools to call `toString()` method to extract the string value, which in turn resulted in a crash.

Fixed to check a boolean condition instead.

Also, had to upgrade vm_service version, as the version would resolve but the code wouldn't compile if version 4.1.0 is installed by pub from other projects, like on my machine.