### PR TITLE
Use new BreadcrumbNavigator widget in code size screen

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -514,15 +514,18 @@ class _TreemapState extends State<Treemap> {
 
   Widget buildBreadcrumbNavigator() {
     final pathFromRoot = widget.rootNode.pathFromRoot();
-    final breadcrumbs = List<Breadcrumb>.generate(pathFromRoot.length, (index) {
-      final node = pathFromRoot[index];
-      return Breadcrumb(
-        text: index < pathFromRoot.length - 1 ? node.name : node.displayText(),
-        isRoot: index == 0,
-        onPressed: () => widget.onRootChangedCallback(node),
-      );
-    });
-    return BreadcrumbNavigator(breadcrumbs: breadcrumbs);
+    return BreadcrumbNavigator.builder(
+      itemCount: pathFromRoot.length,
+      builder: (context, index) {
+        final node = pathFromRoot[index];
+        return Breadcrumb(
+          text:
+              index < pathFromRoot.length - 1 ? node.name : node.displayText(),
+          isRoot: index == 0,
+          onPressed: () => widget.onRootChangedCallback(node),
+        );
+      },
+    );
   }
 
   /// Builds a selectable container with [child] as its child.

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -482,7 +482,7 @@ class _TreemapState extends State<Treemap> {
 
   Widget buildTitleText(BuildContext context) {
     if (widget.isOutermostLevel) {
-      return buildBreadcrumbsNavigator();
+      return buildBreadcrumbNavigator();
     } else {
       return buildSelectable(
         child: Container(
@@ -512,29 +512,17 @@ class _TreemapState extends State<Treemap> {
     );
   }
 
-  Container buildBreadcrumbsNavigator() {
+  Widget buildBreadcrumbNavigator() {
     final pathFromRoot = widget.rootNode.pathFromRoot();
-    return Container(
-      height: Treemap.treeMapHeaderHeight,
-      child: ListView.separated(
-        shrinkWrap: true,
-        scrollDirection: Axis.horizontal,
-        separatorBuilder: (context, index) {
-          return const Text(' > ');
-        },
-        itemCount: pathFromRoot.length,
-        itemBuilder: (BuildContext context, int index) {
-          return buildSelectable(
-            child: Text(
-              index < pathFromRoot.length - 1
-                  ? pathFromRoot[index].name
-                  : pathFromRoot[index].displayText(),
-            ),
-            newRoot: pathFromRoot[index],
-          );
-        },
-      ),
-    );
+    final breadcrumbs = List<Breadcrumb>.generate(pathFromRoot.length, (index) {
+      final node = pathFromRoot[index];
+      return Breadcrumb(
+        text: index < pathFromRoot.length - 1 ? node.name : node.displayText(),
+        isRoot: index == 0,
+        onPressed: () => widget.onRootChangedCallback(node),
+      );
+    });
+    return BreadcrumbNavigator(breadcrumbs: breadcrumbs);
   }
 
   /// Builds a selectable container with [child] as its child.

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -720,18 +720,24 @@ Color _colorForIndex(Color color, int index, ColorScheme colorScheme) {
 }
 
 class BreadcrumbNavigator extends StatelessWidget {
-  const BreadcrumbNavigator({@required this.breadcrumbs});
+  const BreadcrumbNavigator.builder({
+    @required this.itemCount,
+    @required this.builder,
+  });
 
-  final List<Breadcrumb> breadcrumbs;
+  final int itemCount;
+
+  final IndexedWidgetBuilder builder;
 
   @override
   Widget build(BuildContext context) {
     return Container(
       height: Breadcrumb.height + 2 * borderPadding,
       alignment: Alignment.centerLeft,
-      child: ListView(
+      child: ListView.builder(
         scrollDirection: Axis.horizontal,
-        children: breadcrumbs,
+        itemCount: itemCount,
+        itemBuilder: builder,
       ),
     );
   }

--- a/packages/devtools_app/test/code_size_screen_test.dart
+++ b/packages/devtools_app/test/code_size_screen_test.dart
@@ -142,8 +142,10 @@ void main() {
       );
       expect(find.byKey(CodeSizeScreen.snapshotViewTreemapKey), findsOneWidget);
 
-      final List<Breadcrumb> breadcrumbs =
-          tester.widgetList(find.byType(Breadcrumb));
+      final List<Breadcrumb> breadcrumbs = tester
+          .widgetList(find.byType(Breadcrumb))
+          .map((widget) => widget as Breadcrumb)
+          .toList();
       expect(breadcrumbs.length, 1);
       expect(breadcrumbs.first.text, equals('Root [6.0 MB]'));
       expect(find.byType(BreadcrumbNavigator), findsOneWidget);
@@ -249,7 +251,12 @@ void main() {
         findsNothing,
       );
 
-      expect(find.text('Root [+1.5 MB]'), findsOneWidget);
+      final List<Breadcrumb> breadcrumbs = tester
+          .widgetList(find.byType(Breadcrumb))
+          .map((widget) => widget as Breadcrumb)
+          .toList();
+      expect(breadcrumbs.length, 1);
+      expect(breadcrumbs.first.text, equals('Root [+1.5 MB]'));
       expect(find.text('package:pointycastle'), findsOneWidget);
       expect(find.text('package:flutter'), findsOneWidget);
 
@@ -270,7 +277,12 @@ void main() {
       await tester.tap(find.text('Increase Only').hitTestable());
       await tester.pumpAndSettle();
 
-      expect(find.text('Root [+1.6 MB]'), findsOneWidget);
+      final List<Breadcrumb> breadcrumbs = tester
+          .widgetList(find.byType(Breadcrumb))
+          .map((widget) => widget as Breadcrumb)
+          .toList();
+      expect(breadcrumbs.length, 1);
+      expect(breadcrumbs.first.text, equals('Root [+1.6 MB]'));
       expect(find.text('package:pointycastle'), findsOneWidget);
       expect(find.text('package:flutter'), findsOneWidget);
 

--- a/packages/devtools_app/test/code_size_screen_test.dart
+++ b/packages/devtools_app/test/code_size_screen_test.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app/src/code_size/code_size_screen.dart';
 import 'package:devtools_app/src/code_size/code_size_controller.dart';
 import 'package:devtools_app/src/code_size/code_size_table.dart';
 import 'package:devtools_app/src/code_size/file_import_container.dart';
+import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/notifications.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/utils.dart';
@@ -141,7 +142,11 @@ void main() {
       );
       expect(find.byKey(CodeSizeScreen.snapshotViewTreemapKey), findsOneWidget);
 
-      expect(find.text('Root [6.0 MB]'), findsOneWidget);
+      final List<Breadcrumb> breadcrumbs =
+          tester.widgetList(find.byType(Breadcrumb));
+      expect(breadcrumbs.length, 1);
+      expect(breadcrumbs.first.text, equals('Root [6.0 MB]'));
+      expect(find.byType(BreadcrumbNavigator), findsOneWidget);
       expect(find.text('package:flutter'), findsOneWidget);
       expect(find.text('dart:core'), findsOneWidget);
 


### PR DESCRIPTION
In the user studies, we observed that it was not obvious to users that the breadcrumbs were clickable. This breadcrumb Navigator is similar to an IDE breadcrumb navigator and should feel more familiar to users. The breadcrumbs also look more clickable in this version. 

![Screen Shot 2020-08-27 at 2 34 36 PM](https://user-images.githubusercontent.com/43759233/91497856-93656400-e873-11ea-9dc7-85ae867f9686.png)
