### PR TITLE
Add more logging when running tests or running the server with --verbose

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -310,7 +310,7 @@ void main() {
         // Spawn our own Chrome process so we can terminate it.
         final devToolsUri =
             'http://${event['params']['host']}:${event['params']['port']}';
-        final chrome = await Chrome.locate().start(url: devToolsUri);
+        final chrome = await _spawnChrome(devToolsUri);
 
         // Wait for DevTools to inform server that it's connected.
         await _waitForClients();
@@ -386,6 +386,21 @@ void main() {
       // The API only works in release mode.
     }, skip: !testInReleaseMode);
   }
+}
+
+Future<ChromeProcess> _spawnChrome(String devToolsUri) async {
+  final chrome = Chrome.locate();
+  print('Located Chrome at ${chrome?.executable}. Launching $devToolsUri...');
+  final proc = await chrome.start(url: devToolsUri);
+
+  // ignore: unawaited_futures
+  proc.process.exitCode.then((code) => print('chrome: exited with code $code'));
+  proc.process.stdout
+      .listen((data) => print('chrome stdout: ${utf8.decode(data)}'));
+  proc.process.stderr
+      .listen((data) => print('chrome stderr: ${utf8.decode(data)}'));
+
+  return proc;
 }
 
 Future<Map<String, dynamic>> _sendLaunchDevToolsRequest({

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -50,6 +50,7 @@ class DevToolsServerDriver {
     // directory of the devtools_app package.
     final args = [
       '../devtools/bin/devtools.dart',
+      '--verbose',
       '--machine',
       '--port',
       '$port',
@@ -63,6 +64,8 @@ class DevToolsServerDriver {
     if (useChromeHeadless && headlessModeIsSupported) {
       args.add('--headless');
     }
+
+    print('Spawning dart with args: $args');
     final Process process = await Process.start('dart', args);
 
     return DevToolsServerDriver._(

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -60,6 +60,14 @@ contains the following params:
 - `protocolVersion` - the version number for this protocol (if this field is
   missing it is protocol version `1.0.0`)
 
+#### server.log Event
+
+When running the server with `--verbose` the server may emit verbose log events
+including the stdout/stderr from the launched browser processes (which may
+include console.log output). Each event contains the following params:
+
+- `message` - a string message
+
 <!--
 This request is only used for testing purposes so is currently "undocumented"
 


### PR DESCRIPTION
This adds logging for the Chrome processes spawned in tests, and also by the server (as `server.log` events if in machine mode) when run in `--verbose` mode. Chrome writes `console.log()` output to its `stderr` stream, so this may help track down failures caused by errors in the browser:

```
<== {"event":"server.log","params":{"message":"chrome stderr: \nDevTools listening on ws://127.0.0.1:9223/devtools/browser/281f8c27-2840-4dcb-b350-21682d2c7c8b\n"}}
```

However, it may be a bit spammy if users may use `--verbose` when running the server, so we may want to put this behind another flag (`--very-verbose`? `--trace`?) if the extra output would be unhelpful to them.