### PR TITLE
Fix a race in server tests

### DIFF
--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -472,8 +472,12 @@ Future<Map<String, dynamic>> _waitForClients({
   }
 
   final isOnPage = (client) => client['currentPage'] == requiredPage;
-  final hasConnectionState =
-      (client) => client['hasConnection'] == requiredConnectionState;
+  final hasConnectionState = (client) => requiredConnectionState
+      // If we require a connected client, also require a non-null page. This
+      // avoids a race in tests where we pay proceed to send messages to a client
+      // that is not fully initialised.
+      ? (client['hasConnection'] && client['currentPage'] != null)
+      : !client['hasConnection'];
 
   await waitFor(
     () async {

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -474,7 +474,7 @@ Future<Map<String, dynamic>> _waitForClients({
   final isOnPage = (client) => client['currentPage'] == requiredPage;
   final hasConnectionState = (client) => requiredConnectionState
       // If we require a connected client, also require a non-null page. This
-      // avoids a race in tests where we pay proceed to send messages to a client
+      // avoids a race in tests where we may proceed to send messages to a client
       // that is not fully initialised.
       ? (client['hasConnection'] && client['currentPage'] != null)
       : !client['hasConnection'];


### PR DESCRIPTION
I tracked down another race that our server tests were triggering. The test does:

- Spawn DevTools for an app
- Wait for DevTools to connect back to the server and announce it's connected to the VM service
- Terminate the app
- Start a new app
- Tell DevTools to connect to the new app

The issue is that when DevTools tells the server it's connected to a VM service, the widgets may not be fully initialised (especially on a low-power CI VM) so the event handler that handles being told to connect to another VM service may not be wired up yet:

https://github.com/flutter/devtools/blob/0e571a1eb57824f82249e50461213581d2fd6f2a/packages/devtools_app/lib/src/server_api_client.dart#L67

Ideally, DevTools probably shouldn't tell the server it's connected until it's fully initialised, but I can't find a simple way to do that so as a fix for now, this changes the tests to wait for DevTools to connect to the server *and* announce a page (which only happens when it's properly initialised).

@devoncarew 