### PR TITLE
don't install webdev

### DIFF
--- a/packages/devtools_app/test/integration_tests/app.dart
+++ b/packages/devtools_app/test/integration_tests/app.dart
@@ -23,7 +23,7 @@ void appTests() {
 
   test('can switch pages', () async {
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('logging');
 
@@ -33,9 +33,9 @@ void appTests() {
 
   test('connect dialog displays', () async {
     // start with no port
-    final Uri baseAppUri = webdevFixture.baseUri.resolve('index.html');
+    final Uri baseAppUri = webBuildFixture.baseUri.resolve('index.html');
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(
       appFixture,
       overrideUri: baseAppUri,

--- a/packages/devtools_app/test/integration_tests/debugger.dart
+++ b/packages/devtools_app/test/integration_tests/debugger.dart
@@ -25,7 +25,7 @@ void debuggingTests() {
     appFixture = await CliAppFixture.create('test/fixtures/debugging_app.dart');
 
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 
@@ -53,7 +53,7 @@ void debuggingTests() {
         CliAppFixture.parseBreakpointLines(source);
 
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 
@@ -121,7 +121,7 @@ void debuggingTests() {
     final List<int> steppingLines = CliAppFixture.parseSteppingLines(source);
 
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 
@@ -199,7 +199,7 @@ void debuggingTests() {
     final int exceptionLine = CliAppFixture.parseExceptionLines(source).first;
 
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 
@@ -245,7 +245,7 @@ void debuggingTests() {
     appFixture = await CliAppFixture.create(
         'test/fixtures/color_console_output_app.dart');
 
-    final tools = DevtoolsManager(tabInstance, webdevFixture.baseUri);
+    final tools = DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 
@@ -288,7 +288,7 @@ void debuggingTests() {
     appFixture = await CliAppFixture.create('test/fixtures/debugging_app.dart');
 
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('debugger');
 

--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -18,7 +18,7 @@ import '../support/utils.dart';
 
 const bool verboseTesting = false;
 
-WebdevFixture webdevFixture;
+WebBuildFixture webBuildFixture;
 BrowserManager browserManager;
 
 Future<void> waitFor(
@@ -278,10 +278,10 @@ class AppError {
   String toString() => '$message\n$stackTrace';
 }
 
-class WebdevFixture {
-  WebdevFixture._(this.process, this.url, this.verbose);
+class WebBuildFixture {
+  WebBuildFixture._(this.process, this.url, this.verbose);
 
-  static Future<WebdevFixture> serve({
+  static Future<WebBuildFixture> serve({
     bool release = false,
     bool verbose = false,
   }) async {
@@ -335,7 +335,7 @@ class WebdevFixture {
 
     await delay();
 
-    return WebdevFixture._(process, url, verbose);
+    return WebBuildFixture._(process, url, verbose);
   }
 
   static Future<void> build({

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -23,14 +23,14 @@ void main() {
         final bool testInReleaseMode =
             Platform.environment['WEBDEV_RELEASE'] == 'true';
 
-        webdevFixture = await WebdevFixture.serve(
+        webBuildFixture = await WebBuildFixture.serve(
             release: testInReleaseMode, verbose: true);
         browserManager = await BrowserManager.create();
       });
 
       tearDownAll(() async {
         await browserManager?.teardown();
-        await webdevFixture?.teardown();
+        await webBuildFixture?.teardown();
       });
 
       group('app', appTests, skip: true);

--- a/packages/devtools_app/test/integration_tests/logging.dart
+++ b/packages/devtools_app/test/integration_tests/logging.dart
@@ -23,7 +23,7 @@ void loggingTests() {
 
   test('displays log data', () async {
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('logging');
 
@@ -43,7 +43,7 @@ void loggingTests() {
 
   test('log screen postpones write when offscreen', () async {
     final DevtoolsManager tools =
-        DevtoolsManager(tabInstance, webdevFixture.baseUri);
+        DevtoolsManager(tabInstance, webBuildFixture.baseUri);
     await tools.start(appFixture);
     await tools.switchPage('logging');
 

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -45,7 +45,7 @@ void main() {
       Directory('build').deleteSync(recursive: true);
     }
     // Build the app, as the server can't start without the build output.
-    await WebdevFixture.build(verbose: true);
+    await WebBuildFixture.build(verbose: true);
 
     // The devtools package build directory needs to reflect the latest
     // devtools_app package contents.

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -13,10 +13,7 @@ const verbose = true;
 class DevToolsServerDriver {
   DevToolsServerDriver._(this._process, this._stdin, Stream<String> _stdout,
       Stream<String> _stderr)
-      : stdout = _stdout.map((line) {
-          _trace('<== $line');
-          return line;
-        }).map((line) => jsonDecode(line) as Map<String, dynamic>),
+      : stdout = _convertToMapStream(_stdout),
         stderr = _stderr.map((line) {
           _trace('<== STDERR $line');
           return line;
@@ -31,6 +28,22 @@ class DevToolsServerDriver {
     final line = jsonEncode(request);
     _trace('==> $line');
     _stdin.writeln(line);
+  }
+
+  static Stream<Map<String, dynamic>> _convertToMapStream(
+    Stream<String> stream,
+  ) {
+    return stream.map((line) {
+      _trace('<== $line');
+      return line;
+    }).map((line) {
+      try {
+        return jsonDecode(line) as Map<String, dynamic>;
+      } catch (e) {
+        print('item not json: "$line"');
+        return null;
+      }
+    }).where((item) => item != null);
   }
 
   static void _trace(String message) {
@@ -66,9 +79,10 @@ class DevToolsServerDriver {
     final Process process = await Process.start('dart', args);
 
     return DevToolsServerDriver._(
-        process,
-        process.stdin,
-        process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
-        process.stderr.transform(utf8.decoder).transform(const LineSplitter()));
+      process,
+      process.stdin,
+      process.stdout.transform(utf8.decoder).transform(const LineSplitter()),
+      process.stderr.transform(utf8.decoder).transform(const LineSplitter()),
+    );
   }
 }

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -61,16 +61,6 @@ class DevToolsServerDriver {
     int tryPorts,
     List<String> additionalArgs = const [],
   }) async {
-    // Here, we call the 'dart' command once, in order to ensure that it's not
-    // in use from elsewhere.
-    // TODO: file a bug about this - the 'flutter/bin/dart' script should not
-    // generally print "Waiting for another flutter command to release the
-    // startup lock..."
-    final Stopwatch timer = Stopwatch()..start();
-    final ProcessResult result = await Process.run('dart', ['--version']);
-    print('dart --version (${timer.elapsedMicroseconds / 1000}ms):');
-    print(_resultToString(result));
-
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
     final args = [
@@ -97,15 +87,4 @@ class DevToolsServerDriver {
       process.stderr.transform(utf8.decoder).transform(const LineSplitter()),
     );
   }
-}
-
-String _resultToString(ProcessResult result) {
-  final StringBuffer buf = StringBuffer();
-  if (result.stdout.isNotEmpty) {
-    buf.writeln('  ${result.stdout.trim()}');
-  }
-  if (result.stderr.isNotEmpty) {
-    buf.writeln('  ${result.stderr.trim()}');
-  }
-  return buf.toString();
 }

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -11,9 +11,12 @@ import 'chrome.dart';
 const verbose = true;
 
 class DevToolsServerDriver {
-  DevToolsServerDriver._(this._process, this._stdin, Stream<String> _stdout,
-      Stream<String> _stderr)
-      : stdout = _convertToMapStream(_stdout),
+  DevToolsServerDriver._(
+    this._process,
+    this._stdin,
+    Stream<String> _stdout,
+    Stream<String> _stderr,
+  )   : stdout = _convertToMapStream(_stdout),
         stderr = _stderr.map((line) {
           _trace('<== STDERR $line');
           return line;
@@ -58,6 +61,16 @@ class DevToolsServerDriver {
     int tryPorts,
     List<String> additionalArgs = const [],
   }) async {
+    // Here, we call the 'dart' command once, in order to ensure that it's not
+    // in use from elsewhere.
+    // TODO: file a bug about this - the 'flutter/bin/dart' script should not
+    // generally print "Waiting for another flutter command to release the
+    // startup lock..."
+    final Stopwatch timer = Stopwatch()..start();
+    final ProcessResult result = await Process.run('dart', ['--version']);
+    print('dart --version ran in ${timer.elapsed}.');
+    print(result.stdout);
+
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
     final args = [

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -68,8 +68,8 @@ class DevToolsServerDriver {
     // startup lock..."
     final Stopwatch timer = Stopwatch()..start();
     final ProcessResult result = await Process.run('dart', ['--version']);
-    print('dart --version ran in ${timer.elapsed}.');
-    print(result.stdout);
+    print('dart --version (${timer.elapsedMicroseconds / 1000}ms):');
+    print(_resultToString(result));
 
     // These tests assume that the devtools package is present in a sibling
     // directory of the devtools_app package.
@@ -97,4 +97,15 @@ class DevToolsServerDriver {
       process.stderr.transform(utf8.decoder).transform(const LineSplitter()),
     );
   }
+}
+
+String _resultToString(ProcessResult result) {
+  final StringBuffer buf = StringBuffer();
+  if (result.stdout.isNotEmpty) {
+    buf.writeln('  ${result.stdout.trim()}');
+  }
+  if (result.stderr.isNotEmpty) {
+    buf.writeln('  ${result.stderr.trim()}');
+  }
+  return buf.toString();
 }

--- a/packages/devtools_app/test/support/devtools_server_driver.dart
+++ b/packages/devtools_app/test/support/devtools_server_driver.dart
@@ -40,7 +40,6 @@ class DevToolsServerDriver {
       try {
         return jsonDecode(line) as Map<String, dynamic>;
       } catch (e) {
-        print('item not json: "$line"');
         return null;
       }
     }).where((item) => item != null);

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -64,26 +64,23 @@ else
     export DEVTOOLS_GOLDENS_SUFFIX=""
 fi
 
-export PATH=`pwd`/flutter/bin:$PATH
-export PATH=`pwd`/flutter/bin/cache/dart-sdk/bin:$PATH
-export PATH=`pwd`/bin:$PATH
+export PATH=`pwd`/flutter/bin:`pwd`/bin:$PATH
 
 flutter config --no-analytics
 flutter doctor
 
-# We should be using dart from ../flutter/bin/cache/dart-sdk/bin/dart.
+# We should be using dart from ../flutter/bin/dart.
+echo "which flutter: " `which flutter`
 echo "which dart: " `which dart`
-
-pushd packages/devtools_app
-echo `pwd`
 
 # Disable analytics to ensure that the welcome message for the dart cli tooling
 # doesn't interrupt travis.
 dart --disable-analytics
 
 # Print out the versions and ensure we can call Dart, Pub, and Flutter.
+flutter --version
 dart --version
-flutter pub --version
+
 # Put the Flutter version into a variable.
 # First awk extracts "Flutter x.y.z-pre.a":
 #   -F '•'         uses the bullet as field separator
@@ -92,6 +89,17 @@ flutter pub --version
 # Second awk splits on space (default) and takes the second field (the version)
 export FLUTTER_VERSION=$(flutter --version | awk -F '•' 'NR==1{print $1}' | awk '{print $2}')
 echo "Flutter version is '$FLUTTER_VERSION'"
+
+# Some integration tests assume the devtools package is up to date and located
+# adjacent to the devtools_app package.
+pushd packages/devtools
+    # We want to make sure that devtools is retrievable with regular pub.
+    flutter pub get
+popd
+
+# Change the CI to the packages/devtools_app directory.
+pushd packages/devtools_app
+echo `pwd`
 
 if [ "$BOT" = "main" ]; then
 

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -97,7 +97,6 @@ if [ "$BOT" = "main" ]; then
 
     # Provision our packages.
     flutter pub get
-    flutter pub global activate webdev
 
     # Verify that dart format has been run.
     echo "Checking formatting..."

--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -64,12 +64,16 @@ else
     export DEVTOOLS_GOLDENS_SUFFIX=""
 fi
 
-export PATH=`pwd`/flutter/bin:`pwd`/bin:$PATH
+# Look in the dart bin dir first, then the flutter one, then the one for
+# the devtools repo.
+# We don't use the dart script from flutter/bin as that script can and
+# does print 'Waiting for another flutter command...' at inopportune times.
+export PATH=`pwd`/flutter/bin/cache/dart-sdk/bin:`pwd`/flutter/bin:`pwd`/bin:$PATH
 
 flutter config --no-analytics
 flutter doctor
 
-# We should be using dart from ../flutter/bin/dart.
+# We should be using dart from ../flutter/bin/cache/dart-sdk/dart.
 echo "which flutter: " `which flutter`
 echo "which dart: " `which dart`
 


### PR DESCRIPTION
More CI refactoring:

- don't install webdev
- some cleanup around the path, and printing dart and flutter versions
- handle the 'waiting for another flutter command' text when starting tests
- handle the 'waiting for another flutter command' text in /devtools_server_driver.dart
- ensure that we use the `dart` from `flutter/bin/flutter/cache/dart-sdk/bin` and not `flutter/bin/dart` (the dart script from `flutter/bin/` will break everything everywhere due to https://github.com/flutter/devtools/pull/2319#issuecomment-688553860)