### PR TITLE
finish the CI refactor from flutter/devtools/pull/2267

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: minimal
-dist: bionic
+dist: xenial
 addons:
   chrome: stable
 os:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,65 +1,38 @@
-os:
-  - linux
-  - osx
-  # TODO(devoncarew): Skip testing on windows bots to work around a travis regression.
-  #- windows
-
-language: dart
-dart:
-  - dev
-# Exclude stable for now as we depend on Flutter features not availabe on
-# stable.
-#  - stable
+language: minimal
 addons:
   chrome: stable
+os:
+  - linux
+  # TODO(devoncarew): The macos bots are generally failing; we should determine
+  # what we need to do to get them back on-line.
+  #- osx
+  # TODO(dantup): Skip on windows until we understand/fix Flutter crashing
+  # with "failed to delete build/assets: file is locked by another process".
+  #- windows
 
 matrix:
   fast_finish: true
-
-  exclude:
-    # Skip main bot for Stable build since it does formatting/building checks;
-    # - Formatting will fail on old SDK if the formatter changed in latest.
-    # - Builds are always done by us on latest SDKs so we don't need to ensure
-    #     we can build on an older SDK.
-    - dart: stable
-      env: BOT=main
-
-    # TODO(https://github.com/flutter/devtools/issues/1161): Skip test bots for dart
-    # stable on Linux. They are failing with incompatible kernel versions right now.
-    - os: linux
-      dart: stable
-      env: BOT=test_ddc
-    - os: linux
-      dart: stable
-      env: BOT=test_dart2js
-
-    # TODO(dantup): Skip Flutter builds until we understand/fix Flutter crashing
-    # with "failed to delete build/assets: file is locked by another process".
-    - os: windows
-      env:
-        - BOT=flutter_sdk_tests
-        - BOT=test_ddc
-        - BOT=test_dart2js
-        - BOT=integration_ddc
-        - BOT=integration_dart2js
     
-  include:
-    - dart: dev
-      env: BOT=packages
   # Allow windows bots to fail until we can make the windows tests less flaky.
   # https://github.com/flutter/devtools/issues/963
   allow_failures:
     - os: windows
     - os: osx
+    - env: BOT=main CHANNEL=master
 
 env:
-  - BOT=main
-  - BOT=test_ddc PLATFORM=vm
-  - BOT=test_ddc PLATFORM=chrome
-  - BOT=test_dart2js PLATFORM=vm
-  - BOT=test_dart2js PLATFORM=chrome
-  - BOT=integration_ddc
-  - BOT=integration_dart2js
+  global:
+    - CHANNEL=dev
+  jobs:
+    - BOT=main
+    - BOT=packages
+    - BOT=test_ddc            PLATFORM=vm
+    - BOT=test_ddc            PLATFORM=chrome
+    - BOT=test_dart2js        PLATFORM=vm
+    - BOT=test_dart2js        PLATFORM=chrome
+    - BOT=integration_ddc
+    - BOT=integration_dart2js
+    - BOT=main                CHANNEL=master
 
 script: ./tool/travis.sh
 
@@ -70,8 +43,8 @@ script: ./tool/travis.sh
 # branches:
 #   only: [master]
 
-#cache:
-#  directories:
-#  - $HOME/.pub-cache # macOS / Linux
-#  - $APPDATA/Roaming/Pub/Cache # Windows
-#  - packages/devtools_app/.dart_tool/build
+cache:
+ directories:
+ - $HOME/.pub-cache # macOS / Linux
+ - $APPDATA/Roaming/Pub/Cache # Windows
+ - packages/devtools_app/.dart_tool/build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-language: minimal
-dist: xenial
+language: generic
+dist: focal
 addons:
   chrome: stable
+
 os:
   - linux
   # TODO(devoncarew): The macos bots are generally failing; we should determine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: minimal
+dist: bionic
 addons:
   chrome: stable
 os:
@@ -19,6 +20,8 @@ matrix:
     - os: windows
     - os: osx
     - env: BOT=main CHANNEL=master
+    - env: BOT=main CHANNEL=beta
+    - env: BOT=main CHANNEL=stable
 
 env:
   global:
@@ -32,6 +35,8 @@ env:
     - BOT=test_dart2js        PLATFORM=chrome
     - BOT=integration_ddc
     - BOT=integration_dart2js
+    - BOT=main                CHANNEL=stable
+    - BOT=main                CHANNEL=beta
     - BOT=main                CHANNEL=master
 
 script: ./tool/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: generic
 dist: focal
 addons:
   chrome: stable
-
 os:
   - linux
   # TODO(devoncarew): The macos bots are generally failing; we should determine
@@ -36,9 +35,9 @@ env:
     - BOT=test_dart2js        PLATFORM=chrome
     - BOT=integration_ddc
     - BOT=integration_dart2js
-    - BOT=main                CHANNEL=stable
-    - BOT=main                CHANNEL=beta
     - BOT=main                CHANNEL=master
+    - BOT=main                CHANNEL=beta
+    - BOT=main                CHANNEL=stable
 
 script: ./tool/travis.sh
 

--- a/bin/repo_tool
+++ b/bin/repo_tool
@@ -4,10 +4,10 @@ set -e
 
 REPO_DIR=$(dirname $(dirname $BASH_SOURCE))
 
-# Potentially run pub get
+# Potentially run flutter pub get
 if [[ "$REPO_DIR/tool/pubspec.yaml" -nt "$REPO_DIR/tool/.packages" ]]; then
-  echo Running pub get...
-  (cd $REPO_DIR/tool; pub get)
+  echo Running flutter pub get...
+  (cd $REPO_DIR/tool; flutter pub get)
 fi
 
 dart $REPO_DIR/tool/bin/repo_tool.dart "$@"


### PR DESCRIPTION
- finish the CI refactor from https://github.com/flutter/devtools/pull/2267
- have the flutter channel we test and build against be configurable
- refactor the travis bits that we run per PR
- use ubuntu focal and language: generic to allow us to install chrome
- also test on flutter master, beta, and stable (on bots that are allowed to fail)
