### PR TITLE
Fix flaky tests due to Isolates that appear/vanish at startup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,6 @@ matrix:
     - env: BOT=main CHANNEL=master
     - env: BOT=main CHANNEL=beta
     - env: BOT=main CHANNEL=stable
-  # Allow integration tests to fail until we can make them less flaky.
-  # https://github.com/flutter/devtools/issues/2324
-    - env: BOT=integration_ddc
-    - env: BOT=integration_dart2js
 
 env:
   global:


### PR DESCRIPTION
This code assumes all isolates present in a call to `getVM()` are still valid moments later (and `getIsolate()` will not return a Sentinel). This is not currently true - isolates can appear/disappear very quickly at startup. See https://github.com/flutter/devtools/issues/2324#issuecomment-690128227 for more info.

This just ignores these isolates (it turns out they're not the ones we care about) and seems to resolve the flakiness:

![Screenshot 2020-09-10 at 11 59 57](https://user-images.githubusercontent.com/1078012/92721195-97a67c80-f35d-11ea-8ec7-baca08c7942c.png)

If it turns out the VM service is incorrect, we can revert this change once it's fixed (and filters through to the channel we're testing against).

@jacob314 