### PR TITLE
Display call graph and dominator tree for code size Diffs

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -647,7 +647,16 @@ class TreemapNode extends TreeNode<TreemapNode> {
         // the Dart AOT snapshot.
         return reversedPath.reversed.toList();
       }
-      if (current.name.contains('package:')) {
+
+      // Prevent duplicated package names from being added to the path.
+      // Sometimes the hierarchy can look like this:
+      // package:a
+      //     package: a
+      //     <Type>
+      //     <OneByteString>
+      if ((current.name.contains('package:') ||
+              current.name.contains('dart:')) &&
+          (reversedPath.isEmpty || reversedPath.last != current.name)) {
         reversedPath.add(current.name);
       }
       current = current.parent;

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -654,8 +654,8 @@ class TreemapNode extends TreeNode<TreemapNode> {
       //     package: a
       //     <Type>
       //     <OneByteString>
-      if ((current.name.contains('package:') ||
-              current.name.contains('dart:')) &&
+      if ((current.name.startsWith('package:') ||
+              current.name.startsWith('dart:')) &&
           (reversedPath.isEmpty || reversedPath.last != current.name)) {
         reversedPath.add(current.name);
       }

--- a/packages/devtools_app/lib/src/code_size/code_size_screen.dart
+++ b/packages/devtools_app/lib/src/code_size/code_size_screen.dart
@@ -246,10 +246,10 @@ class _SnapshotViewState extends State<SnapshotView> with AutoDisposeMixin {
                     Flexible(
                       child: CodeSizeSnapshotTable(rootNode: snapshotRoot),
                     ),
-                    if (controller.callGraphRoot.value != null)
+                    if (controller.analysisCallGraphRoot.value != null)
                       Flexible(
                         child: CallGraphWithDominators(
-                          callGraphRoot: controller.callGraphRoot.value,
+                          callGraphRoot: controller.analysisCallGraphRoot.value,
                         ),
                       ),
                   ],
@@ -396,7 +396,19 @@ class _DiffViewState extends State<DiffView> with AutoDisposeMixin {
               axis: Axis.vertical,
               children: [
                 _buildTreemap(),
-                CodeSizeDiffTable(rootNode: diffRoot),
+                Row(
+                  children: [
+                    Flexible(
+                      child: CodeSizeDiffTable(rootNode: diffRoot),
+                    ),
+                    if (controller.diffCallGraphRoot.value != null)
+                      Flexible(
+                        child: CallGraphWithDominators(
+                          callGraphRoot: controller.diffCallGraphRoot.value,
+                        ),
+                      ),
+                  ],
+                ),
               ],
               initialFractions: const [
                 initialFractionForTreemap,

--- a/packages/devtools_app/test/treemap_test.dart
+++ b/packages/devtools_app/test/treemap_test.dart
@@ -68,6 +68,24 @@ void main() {
           ),
       ]);
 
+    final nodeWithDuplicatePackageNameGrandchild =
+        TreemapNode(name: 'grandchild');
+    final nodeWithDuplicatePackageNameChild1 = TreemapNode(name: 'package:a');
+    final nodeWithDuplicatePackageNameChild2 = TreemapNode(name: '<Type>');
+    final nodeWithDuplicatePackageName = TreemapNode(name: 'package:a');
+    TreemapNode(name: 'libapp.so (Dart AOT)')
+      ..addChild(nodeWithDuplicatePackageName
+        ..addAllChildren([
+          nodeWithDuplicatePackageNameChild1
+            ..addChild(nodeWithDuplicatePackageNameGrandchild),
+          nodeWithDuplicatePackageNameChild2,
+        ]));
+
+    final dartLibraryChild = TreemapNode(name: 'dart lib child');
+    final dartLibraryNode = TreemapNode(name: 'dart:core');
+    TreemapNode(name: 'libapp.so (Dart AOT)')
+      ..addChild(dartLibraryNode..addChild(dartLibraryChild));
+
     test('packagePath returns correct values', () {
       expect(testRoot.packagePath(), equals([]));
       expect(grandchild1.packagePath(), equals(['package:child1']));
@@ -82,6 +100,15 @@ void main() {
             'package:grandchild2',
             'package:greatGrandchild2',
           ]));
+    });
+
+    test('packagePath returns correct values for duplicate package name', () {
+      expect(nodeWithDuplicatePackageNameGrandchild.packagePath(),
+          equals(['package:a']));
+    });
+
+    test('packagePath returns correct value for dart library node', () {
+      expect(dartLibraryChild.packagePath(), equals(['dart:core']));
     });
   });
 


### PR DESCRIPTION
We generate the call graph for both the old and new snapshot. When a node is selected in the diff tree map:
- we start by looking up the node in the new call graph data
- if we cannot find the node there, we lookup the node in the old call graph
- if we still cannot find the matching node, we default to the root of the new call graph.

![Screen Shot 2020-09-17 at 11 01 04 AM](https://user-images.githubusercontent.com/43759233/93521208-92f54180-f8e4-11ea-834c-5d32cb9d56bf.png)
Fixes https://github.com/flutter/devtools/issues/2343