### PR TITLE
Correctly provide getDevToolsFirstRun

### DIFF
--- a/packages/devtools_app/lib/src/analytics/remote_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/remote_provider.dart
@@ -52,9 +52,9 @@ Future<AnalyticsProvider> get analyticsProvider async {
     }
     if (await analytics.isEnabled) {
       isEnabled = true;
-      if (await analytics.isFirstRun) {
-        isFirstRun = true;
-      }
+    }
+    if (await analytics.isFirstRun) {
+      isFirstRun = true;
     }
     isGtagsEnabled = analytics.isGtagsEnabled();
   } catch (_) {


### PR DESCRIPTION
Fix an issue where we were not setting `isFirstRun` correctly if analytics was disabled. This was causing the prompt to not show. We have proper unit tests but to properly test this behavior would require a full E2E test which we do not have.