### PR TITLE
Cleanup custom painters to paint based on listening to scroll controllers rather than depending on setState

### DIFF
--- a/packages/devtools_app/lib/src/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/flutter_widgets/linked_scroll_controller.dart
@@ -27,6 +27,7 @@ class LinkedScrollControllerGroup {
 
   final _allControllers = <_LinkedScrollController>[];
 
+  ChangeNotifier get offsetNotifier => _offsetNotifier;
   _LinkedScrollControllerGroupOffsetNotifier _offsetNotifier;
 
   bool get hasAttachedControllers => _attachedControllers.isNotEmpty;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -84,7 +84,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataVerticallyInView(CpuStackFrame data) {
-    final verticalScrollOffset = verticalScrollController.offset;
+    final verticalScrollOffset = verticalController.offset;
     final stackFrameTopY = topYForData(data);
     return stackFrameTopY > verticalScrollOffset &&
         stackFrameTopY + rowHeightWithPadding <
@@ -93,7 +93,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataHorizontallyInView(CpuStackFrame data) {
-    final horizontalScrollOffset = linkedHorizontalScrollControllerGroup.offset;
+    final horizontalScrollOffset = horizontalController.offset;
     final startX = startXForData(data);
     return startX >= horizontalScrollOffset &&
         startX <= horizontalScrollOffset + widget.containerWidth;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -84,6 +84,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataVerticallyInView(CpuStackFrame data) {
+    final verticalScrollOffset = verticalScrollController.offset;
     final stackFrameTopY = topYForData(data);
     return stackFrameTopY > verticalScrollOffset &&
         stackFrameTopY + rowHeightWithPadding <
@@ -92,6 +93,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataHorizontallyInView(CpuStackFrame data) {
+    final horizontalScrollOffset = linkedHorizontalScrollControllerGroup.offset;
     final startX = startXForData(data);
     return startX >= horizontalScrollOffset &&
         startX <= horizontalScrollOffset + widget.containerWidth;

--- a/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_flame_chart.dart
@@ -228,7 +228,7 @@ class TimelineFlameChartState
   @override
   bool isDataVerticallyInView(TimelineEvent data) {
     final eventTopY = topYForData(data);
-    final verticalScrollOffset = verticalScrollController.offset;
+    final verticalScrollOffset = verticalController.offset;
     return eventTopY > verticalScrollOffset &&
         eventTopY + rowHeightWithPadding <
             verticalScrollOffset + widget.containerHeight;
@@ -424,8 +424,8 @@ class TimelineFlameChartState
         painter: AsyncGuidelinePainter(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScrollController,
-          horizontalScroll: linkedHorizontalScrollControllerGroup,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           verticalGuidelines: verticalGuidelines,
           horizontalGuidelines: horizontalGuidelines,
           chartStartInset: widget.startInset,
@@ -436,8 +436,8 @@ class TimelineFlameChartState
         painter: TimelineGridPainter(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScrollController,
-          horizontalScroll: linkedHorizontalScrollControllerGroup,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: widget.startInset,
           chartEndInset: widget.endInset,
           flameChartWidth: widthWithZoom,
@@ -450,8 +450,8 @@ class TimelineFlameChartState
           _selectedFrame,
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScrollController,
-          horizontalScroll: linkedHorizontalScrollControllerGroup,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: widget.startInset,
           startTimeOffsetMicros: startTimeOffset,
           startingPxPerMicro: startingPxPerMicro,
@@ -468,8 +468,8 @@ class TimelineFlameChartState
           _timelineController.data.eventGroups,
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScrollController,
-          horizontalScroll: linkedHorizontalScrollControllerGroup,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: widget.startInset,
           colorScheme: colorScheme,
         ),
@@ -635,15 +635,15 @@ class SectionLabelPainter extends FlameChartPainter {
     this.eventGroups, {
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalScroll,
-    @required LinkedScrollControllerGroup horizontalScroll,
+    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required ColorScheme colorScheme,
   }) : super(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScroll,
-          horizontalScroll: horizontalScroll,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: chartStartInset,
           colorScheme: colorScheme,
         );
@@ -652,7 +652,7 @@ class SectionLabelPainter extends FlameChartPainter {
 
   @override
   void paint(Canvas canvas, Size size) {
-    final verticalScrollOffset = verticalScroll.offset;
+    final verticalScrollOffset = verticalController.offset;
     canvas.clipRect(Rect.fromLTWH(
       0.0,
       rowHeight, // We do not want to paint inside the timestamp section.
@@ -708,9 +708,11 @@ class SectionLabelPainter extends FlameChartPainter {
 
   @override
   bool shouldRepaint(CustomPainter oldDelegate) {
-    return oldDelegate is SectionLabelPainter &&
-            eventGroups != oldDelegate.eventGroups ||
-        super.shouldRepaint(oldDelegate);
+    if (oldDelegate is SectionLabelPainter) {
+      return eventGroups != oldDelegate.eventGroups ||
+          super.shouldRepaint(oldDelegate);
+    }
+    return true;
   }
 }
 
@@ -718,8 +720,8 @@ class AsyncGuidelinePainter extends FlameChartPainter {
   AsyncGuidelinePainter({
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalScroll,
-    @required LinkedScrollControllerGroup horizontalScroll,
+    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required this.verticalGuidelines,
     @required this.horizontalGuidelines,
@@ -727,8 +729,8 @@ class AsyncGuidelinePainter extends FlameChartPainter {
   }) : super(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScroll,
-          horizontalScroll: horizontalScroll,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: chartStartInset,
           colorScheme: colorScheme,
         );
@@ -783,8 +785,8 @@ class AsyncGuidelinePainter extends FlameChartPainter {
     List<LineSegment> guidelines,
     int firstLineIndex,
   ) {
-    final horizontalScrollOffset = horizontalScroll.offset;
-    final verticalScrollOffset = verticalScroll.offset;
+    final horizontalScrollOffset = horizontalController.offset;
+    final verticalScrollOffset = verticalController.offset;
 
     final paint = Paint()..color = colorScheme.treeGuidelineColor;
     for (int i = firstLineIndex; i < guidelines.length; i++) {
@@ -849,8 +851,8 @@ class TimelineGridPainter extends FlameChartPainter {
   TimelineGridPainter({
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalScroll,
-    @required LinkedScrollControllerGroup horizontalScroll,
+    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required this.chartEndInset,
     @required this.flameChartWidth,
@@ -859,8 +861,8 @@ class TimelineGridPainter extends FlameChartPainter {
   }) : super(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScroll,
-          horizontalScroll: horizontalScroll,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: chartStartInset,
           colorScheme: colorScheme,
         );
@@ -969,7 +971,7 @@ class TimelineGridPainter extends FlameChartPainter {
   }
 
   int _startingTimestamp(double intervalWidth, int microsPerInterval) {
-    final horizontalScrollOffset = horizontalScroll.offset;
+    final horizontalScrollOffset = horizontalController.offset;
 
     final startingIntervalIndex = horizontalScrollOffset < chartStartInset
         ? 0
@@ -985,7 +987,7 @@ class TimelineGridPainter extends FlameChartPainter {
     return zoom == other.zoom &&
         constraints == other.constraints &&
         flameChartWidth == other.flameChartWidth &&
-        horizontalScroll == other.horizontalScroll &&
+        horizontalController == other.horizontalController &&
         duration == other.duration &&
         colorScheme == other.colorScheme;
   }
@@ -995,7 +997,7 @@ class TimelineGridPainter extends FlameChartPainter {
         zoom,
         constraints,
         flameChartWidth,
-        horizontalScroll,
+        horizontalController,
         duration,
         colorScheme,
       );
@@ -1006,8 +1008,8 @@ class SelectedFrameBracketPainter extends FlameChartPainter {
     this.selectedFrame, {
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalScroll,
-    @required LinkedScrollControllerGroup horizontalScroll,
+    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required this.startTimeOffsetMicros,
     @required this.startingPxPerMicro,
@@ -1016,8 +1018,8 @@ class SelectedFrameBracketPainter extends FlameChartPainter {
   }) : super(
           zoom: zoom,
           constraints: constraints,
-          verticalScroll: verticalScroll,
-          horizontalScroll: horizontalScroll,
+          verticalController: verticalController,
+          horizontalController: horizontalController,
           chartStartInset: chartStartInset,
           colorScheme: colorScheme,
         );
@@ -1159,8 +1161,8 @@ class SelectedFrameBracketPainter extends FlameChartPainter {
         selectedFrame == other.selectedFrame &&
         zoom == other.zoom &&
         constraints == other.constraints &&
-        verticalScroll == other.verticalScroll &&
-        horizontalScroll == other.horizontalScroll &&
+        verticalController == other.verticalController &&
+        horizontalController == other.horizontalController &&
         colorScheme == other.colorScheme;
   }
 
@@ -1169,8 +1171,8 @@ class SelectedFrameBracketPainter extends FlameChartPainter {
         selectedFrame,
         zoom,
         constraints,
-        verticalScroll,
-        horizontalScroll,
+        verticalController,
+        horizontalController,
         colorScheme,
       );
 }

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -49,7 +49,7 @@ void main() {
       final FlameChartState state = tester.state(find.byWidget(flameChart));
 
       expect(state.zoomController.value, equals(1.0));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(0.0));
+      expect(state.horizontalController.offset, equals(0.0));
       state.mouseHoverX = 100.0;
       state.focusNode.requestFocus();
       await tester.pumpAndSettle();
@@ -61,31 +61,31 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(30.0));
+      expect(state.horizontalController.offset, equals(30.0));
 
       // Zoom in further.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(75.0));
+      expect(state.horizontalController.offset, equals(75.0));
 
       // Zoom out.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(30.0));
+      expect(state.horizontalController.offset, equals(30.0));
 
       // Zoom out further.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.0));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(0.0));
+      expect(state.horizontalController.offset, equals(0.0));
 
       // Zoom out and verify we cannot go beyond the minimum zoom level (1.0);
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.0));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(0.0));
+      expect(state.horizontalController.offset, equals(0.0));
 
       // Verify that the scroll position does not change when the mouse is
       // positioned in an unzoomable area (start or end inset).
@@ -93,7 +93,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(0.0));
+      expect(state.horizontalController.offset, equals(0.0));
     });
 
     testWidgets('WASD keys pan chart', (WidgetTester tester) async {
@@ -102,7 +102,7 @@ void main() {
       final FlameChartState state = tester.state(find.byWidget(flameChart));
 
       expect(state.zoomController.value, equals(1.0));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(0.0));
+      expect(state.horizontalController.offset, equals(0.0));
       state.mouseHoverX = 500.0;
       state.focusNode.requestFocus();
       await tester.pumpAndSettle();
@@ -116,39 +116,37 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(575.0));
+      expect(state.horizontalController.offset, equals(575.0));
 
       // Pan left. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyA, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(325.0));
+      expect(state.horizontalController.offset, equals(325.0));
 
       // Pan right. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyD, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(575.0));
+      expect(state.horizontalController.offset, equals(575.0));
 
       // Zoom in.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(
-          state.linkedHorizontalScrollControllerGroup.offset, equals(1092.5));
+      expect(state.horizontalController.offset, equals(1092.5));
 
       // Pan left. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyA, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(state.linkedHorizontalScrollControllerGroup.offset, equals(842.5));
+      expect(state.horizontalController.offset, equals(842.5));
 
       // Pan right. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyD, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(
-          state.linkedHorizontalScrollControllerGroup.offset, equals(1092.5));
+      expect(state.horizontalController.offset, equals(1092.5));
     });
   });
 


### PR DESCRIPTION
We were calling setState on the overall FlameChart widget every time the scroll changed which is expensive and defeats some of the lazy logic in the sliver views rendering the more heavyweight content part of the view.
If scroll offsets ever changed due to layout as happens if the offset goes off the edge of the scroll view due to content shrinking, then the current approach would cause rendering artifacts as well as slightly hurting performance as one offset would be used for the list view and another offset would be used by the custom painters.