### PR TITLE
expose launchDevTools from devtools server

### DIFF
--- a/packages/devtools_server/lib/devtools_server.dart
+++ b/packages/devtools_server/lib/devtools_server.dart
@@ -3,4 +3,5 @@
 // found in the LICENSE file.
 
 export 'src/external_handlers.dart';
-export 'src/server.dart' show serveDevTools, serveDevToolsWithArgs;
+export 'src/server.dart'
+    show launchDevTools, serveDevTools, serveDevToolsWithArgs;


### PR DESCRIPTION
This method is used internally and the latest roll broke some targets - internal fix submitted - this is a mirror of the change