### PR TITLE
Pause should still record memory stats just not update charts.

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_chart.dart
+++ b/packages/devtools_app/lib/src/memory/memory_chart.dart
@@ -597,6 +597,9 @@ class MemoryChartState extends State<MemoryChart> with AutoDisposeMixin {
 
   /// Display any newly received heap sample(s) in the chart.
   void _updateAllCharts() {
+    // If paused don't update the chart (data is still collected).
+    if (controller.paused.value) return;
+
     setState(() {
       // Update Dart VM chart datasets.
       dartChartController.data = LineData.fromList(chartDatasets);

--- a/packages/devtools_app/lib/src/memory/memory_events_pane.dart
+++ b/packages/devtools_app/lib/src/memory/memory_events_pane.dart
@@ -244,6 +244,9 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
 
   /// Loads all heap samples (live data or offline).
   void _processAndUpdate() {
+    // If paused don't update the chart (data is still collected).
+    if (_memoryController.paused.value) return;
+
     setState(() {
       // Display new events in the pane.
       _updateEventPane();
@@ -252,14 +255,12 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
 
   /// Display any newly received events in the chart.
   void _updateEventPane() {
-    setState(() {
-      _controller.data = ScatterData.fromList(datasets);
+    _controller.data = ScatterData.fromList(datasets);
 
-      // Received new samples ready to plot, signal data has changed.
-      for (final dataset in datasets) {
-        dataset.notifyDataSetChanged();
-      }
-    });
+    // Received new samples ready to plot, signal data has changed.
+    for (final dataset in datasets) {
+      dataset.notifyDataSetChanged();
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -64,17 +64,9 @@ class MemoryTracker {
       // A service of null implies we're disconnected - signal paused.
       memoryController.pauseLiveFeed();
     }
-    paused ??= memoryController.paused.value;
 
-    if (paused) {
-      _pollingTimer?.cancel();
-      _gcStreamListener?.cancel();
-      _gcStreamListener = null;
-      _pollingTimer = null;
-    } else {
-      _pollingTimer ??= Timer(MemoryTimeline.updateDelay, _pollMemory);
-      _gcStreamListener ??= service?.onGCEvent?.listen(_handleGCEvent);
-    }
+    _pollingTimer ??= Timer(MemoryTimeline.updateDelay, _pollMemory);
+    _gcStreamListener ??= service?.onGCEvent?.listen(_handleGCEvent);
   }
 
   void stop() {
@@ -128,9 +120,7 @@ class MemoryTracker {
     // Polls for current RSS size.
     _update(await service.getVM(), isolateMemory);
 
-    if (!memoryController.paused.value) {
-      _pollingTimer ??= Timer(MemoryTimeline.updateDelay, _pollMemory);
-    }
+    _pollingTimer ??= Timer(MemoryTimeline.updateDelay, _pollMemory);
   }
 
   void _update(VM vm, Map<IsolateRef, MemoryUsage> isolateMemory) {

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -72,6 +72,12 @@ class MemoryTracker {
   void stop() {
     _updateLiveDataPolling(false);
     memoryController.paused.removeListener(_updateLiveDataPolling);
+
+    _pollingTimer?.cancel();
+    _gcStreamListener?.cancel();
+    _gcStreamListener = null;
+    _pollingTimer = null;
+
     serviceManager = null;
   }
 


### PR DESCRIPTION
Pause holds the charts UI (memory and event pane), however, new memory data is still collected.  When resumed all the new data received during pause will immediately appear.