### PR TITLE
simplify the debugger's libraries view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -285,6 +285,7 @@ class FileNode extends TreeNode<FileNode> {
       for (var name in directoryParts) {
         node = node._getCreateChild(name);
       }
+
       node.scriptRef = script;
     }
 
@@ -309,6 +310,21 @@ class FileNode extends TreeNode<FileNode> {
 
     for (var child in children) {
       child._trimChildrenAsMapEntries();
+    }
+  }
+
+  @override
+  int get hashCode => scriptRef?.hashCode ?? name.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! FileNode) return false;
+    final FileNode node = other;
+
+    if (scriptRef == null) {
+      return node.scriptRef != null ? false : name == node.name;
+    } else {
+      return node.scriptRef == null ? false : scriptRef == node.scriptRef;
     }
   }
 }
@@ -347,6 +363,13 @@ class ScriptRefUtils {
       ];
     }
 
-    return parts;
+    if (parts.length > 1) {
+      return [
+        parts.first,
+        parts.sublist(1).join('/'),
+      ];
+    } else {
+      return parts;
+    }
   }
 }

--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -130,7 +130,6 @@ class ScriptPickerState extends State<ScriptPicker> {
       waitDuration: tooltipWait,
       preferBelow: false,
       message: node.name,
-      key: ValueKey(node.name),
       child: Material(
         child: InkWell(
           onTap: () {

--- a/packages/devtools_app/test/debugger_model_test.dart
+++ b/packages/devtools_app/test/debugger_model_test.dart
@@ -65,15 +65,7 @@ void main() {
         expect(child.scriptRef, isNull);
 
         child = child.children[0];
-        expect(child.name, 'bar');
-        expect(child.scriptRef, isNull);
-
-        child = child.children[0];
-        expect(child.name, 'baz');
-        expect(child.scriptRef, isNull);
-
-        child = child.children[0];
-        expect(child.name, 'qux.dart');
+        expect(child.name, 'bar/baz/qux.dart');
         expect(child.scriptRef, isNotNull);
       });
 
@@ -89,11 +81,7 @@ void main() {
         expect(child.scriptRef, isNull);
 
         child = child.children[0];
-        expect(child.name, 'bar');
-        expect(child.scriptRef, isNull);
-
-        child = child.children[0];
-        expect(child.name, 'baz.dart');
+        expect(child.name, 'bar/baz.dart');
         expect(child.scriptRef, isNotNull);
       });
     });
@@ -111,12 +99,12 @@ void main() {
         expect(
           ScriptRefUtils.splitDirectoryParts(
               ScriptRef(uri: 'package:foo.bar.baz/qux.dart', id: 'id-5')),
-          orderedEquals(['package:foo', 'bar', 'baz', 'qux.dart']),
+          orderedEquals(['package:foo', 'bar/baz/qux.dart']),
         );
         expect(
           ScriptRefUtils.splitDirectoryParts(
               ScriptRef(uri: 'google3:///foo/bar/baz.dart', id: 'id-6')),
-          orderedEquals(['google3:foo', 'bar', 'baz.dart']),
+          orderedEquals(['google3:foo', 'bar/baz.dart']),
         );
       });
     });


### PR DESCRIPTION
- simplify the debugger's libraries view
- fix https://github.com/flutter/devtools/issues/2327

@grouma - this flattens the Libraries view contents to one level (the top package level and the a flat list of libraries contained in that package). Is something like this what you were thinking of?

<img width="384" alt="Screen Shot 2020-09-29 at 10 59 33 AM" src="https://user-images.githubusercontent.com/1269969/94598568-fb78e280-0243-11eb-92e9-6dbc78f8201f.png">
