### PR TITLE
Prepare for v0.9.3 release.

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -10,6 +10,10 @@
 * Fix analytics bug giving the incorrect value for "first run" [#2369](https://github.com/flutter/devtools/pull/2369)
 * Collect RasterCache estimates from the Flutter engine in the Memory profiler [#2371](https://github.com/flutter/devtools/pull/2371)
 * Display HTTP and HTTPS response bodies in the Network profiler [#2374](https://github.com/flutter/devtools/pull/2374)
+* Pause should still record memory stats just not update charts [#2382](https://github.com/flutter/devtools/pull/2382)
+* Simplify the debugger's libraries view [#2386](https://github.com/flutter/devtools/pull/2386)
+* Make inspector polyfill compatible with both null safe and legacy Flutter [#2387](https://github.com/flutter/devtools/pull/2387)
+* Fixed RSS plotting and plotting RasterCache data [#2389](https://github.com/flutter/devtools/pull/2389)
 
 ## 0.9.2
 * Fix a bug causing extra evaluation for primitive values

--- a/packages/devtools/pubspec.lock
+++ b/packages/devtools/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   flutter:
     dependency: transitive
     description: flutter
@@ -117,7 +117,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -213,7 +213,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   usage:
     dependency: transitive
     description:
@@ -234,14 +234,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+1"
+    version: "5.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -250,4 +250,4 @@ packages:
     source: hosted
     version: "0.7.3"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -8,7 +8,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.9.3-dev.1
+version: 0.9.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -16,8 +16,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_server: 0.9.3-dev.1
-  devtools_shared: 0.9.3-dev.1
+  devtools_server: 0.9.3
+  devtools_shared: 0.9.3
   http: ^0.12.0+1
   intl: ^0.16.0
 

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.sh matches the following line so
 // if you change it you must also modify tools/update_version.sh.
-const String version = '0.9.3-dev.1';
+const String version = '0.9.3';

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -441,16 +441,16 @@ class VmServiceWrapper implements VmService {
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('getHttpEnableTimelineLogging',
-        _vmService.getHttpEnableTimelineLogging(isolateId));
+        _vmService.httpEnableTimelineLogging(isolateId));
   }
 
-  Future<Success> setHttpEnableTimelineLogging(
+  Future<HttpTimelineLoggingState> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('setHttpEnableTimelineLogging',
-        _vmService.setHttpEnableTimelineLogging(isolateId, enable));
+        _vmService.httpEnableTimelineLogging(isolateId, enable));
   }
 
   // TODO(kenz): move this method to

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -436,11 +436,12 @@ class VmServiceWrapper implements VmService {
         .contains('ext.dart.io.setHttpEnableTimelineLogging');
   }
 
-  // ignore: deprecated_member_use
   Future<HttpTimelineLoggingState> getHttpEnableTimelineLogging(
     String isolateId,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
+    // TODO(terry): Need to migrate from deprecated getHttpEnableTimelineLogging
+    //              to httpEnableTimelineLogging.
     return _trackFuture(
         'getHttpEnableTimelineLogging',
         // ignore: deprecated_member_use
@@ -452,6 +453,8 @@ class VmServiceWrapper implements VmService {
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
+    // TODO(terry): Need to migrate from deprecated setHttpEnableTimelineLogging
+    //              to httpEnableTimelineLogging.
     return _trackFuture(
         'setHttpEnableTimelineLogging',
         // ignore: deprecated_member_use

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -441,16 +441,16 @@ class VmServiceWrapper implements VmService {
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('getHttpEnableTimelineLogging',
-        _vmService.httpEnableTimelineLogging(isolateId));
+        _vmService.getHttpEnableTimelineLogging(isolateId));
   }
 
-  Future<HttpTimelineLoggingState> setHttpEnableTimelineLogging(
+  Future<Success> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('setHttpEnableTimelineLogging',
-        _vmService.httpEnableTimelineLogging(isolateId, enable));
+        _vmService.setHttpEnableTimelineLogging(isolateId, enable));
   }
 
   // TODO(kenz): move this method to

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -442,16 +442,17 @@ class VmServiceWrapper implements VmService {
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('getHttpEnableTimelineLogging',
+        // ignore: deprecated_member_use
         _vmService.getHttpEnableTimelineLogging(isolateId));
   }
 
-  // ignore: deprecated_member_use
   Future<Success> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
     return _trackFuture('setHttpEnableTimelineLogging',
+        // ignore: deprecated_member_use
         _vmService.setHttpEnableTimelineLogging(isolateId, enable));
   }
 

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -440,6 +440,7 @@ class VmServiceWrapper implements VmService {
     String isolateId,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
+    // ignore: deprecated_member_use
     return _trackFuture('getHttpEnableTimelineLogging',
         _vmService.getHttpEnableTimelineLogging(isolateId));
   }
@@ -449,6 +450,7 @@ class VmServiceWrapper implements VmService {
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
+    // ignore: deprecated_member_use
     return _trackFuture('setHttpEnableTimelineLogging',
         _vmService.setHttpEnableTimelineLogging(isolateId, enable));
   }

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -436,21 +436,21 @@ class VmServiceWrapper implements VmService {
         .contains('ext.dart.io.setHttpEnableTimelineLogging');
   }
 
+  // ignore: deprecated_member_use
   Future<HttpTimelineLoggingState> getHttpEnableTimelineLogging(
     String isolateId,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
-    // ignore: deprecated_member_use
     return _trackFuture('getHttpEnableTimelineLogging',
         _vmService.getHttpEnableTimelineLogging(isolateId));
   }
 
+  // ignore: deprecated_member_use
   Future<Success> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
-    // ignore: deprecated_member_use
     return _trackFuture('setHttpEnableTimelineLogging',
         _vmService.setHttpEnableTimelineLogging(isolateId, enable));
   }

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -441,7 +441,8 @@ class VmServiceWrapper implements VmService {
     String isolateId,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
-    return _trackFuture('getHttpEnableTimelineLogging',
+    return _trackFuture(
+        'getHttpEnableTimelineLogging',
         // ignore: deprecated_member_use
         _vmService.getHttpEnableTimelineLogging(isolateId));
   }
@@ -451,7 +452,8 @@ class VmServiceWrapper implements VmService {
     bool enable,
   ) async {
     assert(await isHttpTimelineLoggingAvailable(isolateId));
-    return _trackFuture('setHttpEnableTimelineLogging',
+    return _trackFuture(
+        'setHttpEnableTimelineLogging',
         // ignore: deprecated_member_use
         _vmService.setHttpEnableTimelineLogging(isolateId, enable));
   }

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -776,7 +776,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "5.1.0+1"
   vm_snapshot_analysis:
     dependency: "direct main"
     description:

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   browser_launcher:
     dependency: transitive
     description:
@@ -119,14 +119,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   code_builder:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -203,35 +203,35 @@ packages:
       path: "../devtools"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_server:
     dependency: "direct overridden"
     description:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_testing:
     dependency: "direct dev"
     description:
       path: "../devtools_testing"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   ffi:
     dependency: transitive
     description:
@@ -337,14 +337,14 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety"
+    version: "0.6.3-nullsafety.1"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   logging:
     dependency: transitive
     description:
@@ -358,14 +358,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: "direct main"
     description:
@@ -442,7 +442,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_drawing:
     dependency: transitive
     description:
@@ -463,7 +463,7 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.16"
+    version: "1.6.18"
   path_provider_linux:
     dependency: transitive
     description:
@@ -491,14 +491,14 @@ packages:
       name: path_provider_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.4"
+    version: "0.0.4+1"
   pedantic:
     dependency: "direct main"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   platform:
     dependency: transitive
     description:
@@ -506,27 +506,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.2.1"
-  platform_detect:
-    dependency: transitive
-    description:
-      name: platform_detect
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.4.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety"
+    version: "1.5.0-nullsafety.1"
   process:
     dependency: transitive
     description:
@@ -615,28 +608,28 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6"
+    version: "0.9.7+1"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety"
+    version: "0.10.10-nullsafety.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   sse:
     dependency: "direct main"
     description:
@@ -650,14 +643,14 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   stream_transform:
     dependency: transitive
     description:
@@ -671,35 +664,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.4"
+    version: "1.16.0-nullsafety.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.4"
+    version: "0.3.12-nullsafety.5"
   timing:
     dependency: transitive
     description:
@@ -713,14 +706,14 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: "direct main"
     description:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.7.0"
+    version: "5.7.2"
   url_launcher_linux:
     dependency: transitive
     description:
@@ -748,7 +741,7 @@ packages:
       name: url_launcher_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3+2"
+    version: "0.1.4+1"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -776,14 +769,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: "direct main"
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+1"
+    version: "5.2.0"
   vm_snapshot_analysis:
     dependency: "direct main"
     description:
@@ -834,5 +827,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
   flutter: ">1.21.0 <2.0.0"

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -38,9 +38,7 @@ dependencies:
   provider: ^4.0.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-# TODO(terry): pin vm_service to previous version.
-# vm_service: ^5.1.0+1
-  vm_service: 5.1.0+1
+  vm_service: ^5.1.0+1
   sse: ^3.1.2
   web_socket_channel: ^1.1.0
   flutter:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -38,7 +38,9 @@ dependencies:
   provider: ^4.0.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^5.0.0+1
+# TODO(terry): pin vm_service to previous version.
+# vm_service: ^5.1.0+1
+  vm_service: 5.1.0+1
   sse: ^3.1.2
   web_socket_channel: ^1.1.0
   flutter:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Web-based performance tooling for Dart and Flutter.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.9.3-dev.1
+version: 0.9.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -23,7 +23,7 @@ dependencies:
     ^0.0.2
 #     path: ../../third_party/packages/ansi_up
   collection: ^1.15.0-nnbd
-  devtools_shared: 0.9.3-dev.1
+  devtools_shared: 0.9.3
   file: ^5.1.0
   flutter_web_plugins:
     sdk: flutter
@@ -52,7 +52,7 @@ dev_dependencies:
   webkit_inspection_protocol: '>=0.5.0 <0.8.0'
   devtools: #^0.1.7
     path: ../devtools
-  devtools_testing: 0.9.3-dev.1
+  devtools_testing: 0.9.3
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -338,16 +338,15 @@ class FakeVmService extends Fake implements VmServiceWrapper {
 
   @override
   Future<HttpTimelineLoggingState> getHttpEnableTimelineLogging(
-    String isolateId,
-  ) async =>
+          String isolateId) async =>
       HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
 
   @override
-  Future<HttpTimelineLoggingState> setHttpEnableTimelineLogging(
+  Future<Success> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async =>
-      HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
+      Success();
 
   @override
   Future<Timestamp> getVMTimelineMicros() async => Timestamp(timestamp: 0);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -338,7 +338,8 @@ class FakeVmService extends Fake implements VmServiceWrapper {
 
   @override
   Future<HttpTimelineLoggingState> getHttpEnableTimelineLogging(
-          String isolateId) async =>
+    String isolateId,
+  ) async =>
       HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
 
   @override
@@ -346,7 +347,7 @@ class FakeVmService extends Fake implements VmServiceWrapper {
     String isolateId,
     bool enable,
   ) async =>
-      HttpTimelineLoggingState(enabled: enable);
+      HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
 
   @override
   Future<Timestamp> getVMTimelineMicros() async => Timestamp(timestamp: 0);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -342,11 +342,11 @@ class FakeVmService extends Fake implements VmServiceWrapper {
       HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
 
   @override
-  Future<Success> setHttpEnableTimelineLogging(
+  Future<HttpTimelineLoggingState> setHttpEnableTimelineLogging(
     String isolateId,
     bool enable,
   ) async =>
-      Success();
+      HttpTimelineLoggingState(enabled: enable);
 
   @override
   Future<Timestamp> getVMTimelineMicros() async => Timestamp(timestamp: 0);

--- a/packages/devtools_server/pubspec.lock
+++ b/packages/devtools_server/pubspec.lock
@@ -28,7 +28,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   flutter:
     dependency: transitive
     description: flutter
@@ -110,7 +110,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -206,7 +206,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   usage:
     dependency: "direct main"
     description:
@@ -227,14 +227,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: "direct main"
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0+1"
+    version: "5.2.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
@@ -243,4 +243,4 @@ packages:
     source: hosted
     version: "0.7.3"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -3,7 +3,7 @@ description: A server that supports Dart DevTools.
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3-dev.1
+version: 0.9.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -13,7 +13,7 @@ environment:
 dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.5
-  devtools_shared: 0.9.3-dev.1
+  devtools_shared: 0.9.3
   intl: ^0.16.0
   meta: ^1.1.0
   path: ^1.6.0

--- a/packages/devtools_shared/pubspec.lock
+++ b/packages/devtools_shared/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -26,7 +26,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -38,13 +38,13 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package of shared structures between devtools_app and devtools_serv
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3-dev.1
+version: 0.9.3
 
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools_testing/pubspec.lock
+++ b/packages/devtools_testing/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety"
+    version: "2.5.0-nullsafety.1"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   browser_launcher:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   cli_util:
     dependency: transitive
     description:
@@ -84,14 +84,14 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.2"
+    version: "1.15.0-nullsafety.3"
   convert:
     dependency: transitive
     description:
@@ -126,28 +126,28 @@ packages:
       path: "../devtools_app"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_server:
     dependency: "direct overridden"
     description:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3-dev.1"
+    version: "0.9.3"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   file:
     dependency: transitive
     description:
@@ -232,7 +232,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety"
+    version: "0.6.3-nullsafety.1"
   logging:
     dependency: transitive
     description:
@@ -246,14 +246,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety"
+    version: "0.12.10-nullsafety.1"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   mime:
     dependency: transitive
     description:
@@ -323,7 +323,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.1"
   path_drawing:
     dependency: transitive
     description:
@@ -372,7 +372,7 @@ packages:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   platform:
     dependency: transitive
     description:
@@ -400,7 +400,7 @@ packages:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0-nullsafety"
+    version: "1.5.0-nullsafety.1"
   process:
     dependency: transitive
     description:
@@ -475,21 +475,21 @@ packages:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.2"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10-nullsafety"
+    version: "0.10.10-nullsafety.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety"
+    version: "1.8.0-nullsafety.2"
   sse:
     dependency: transitive
     description:
@@ -503,56 +503,56 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety"
+    version: "1.10.0-nullsafety.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety"
+    version: "2.1.0-nullsafety.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety"
+    version: "1.1.0-nullsafety.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety"
+    version: "1.2.0-nullsafety.1"
   test:
     dependency: "direct main"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.4"
+    version: "1.16.0-nullsafety.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety"
+    version: "0.2.19-nullsafety.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.4"
+    version: "0.3.12-nullsafety.5"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.2"
+    version: "1.3.0-nullsafety.3"
   url_launcher:
     dependency: transitive
     description:
@@ -608,7 +608,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   vm_service:
     dependency: "direct main"
     description:
@@ -659,5 +659,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-0.0.dev <2.10.0"
+  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
   flutter: ">1.21.0 <2.0.0"

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: devtools_testing
 description: Package of shared testing code for Dart DevTools.
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3-dev.1
+version: 0.9.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -10,8 +10,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_app: 0.9.3-dev.1
-  devtools_shared: 0.9.3-dev.1
+  devtools_app: 0.9.3
+  devtools_shared: 0.9.3
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
- Updated CHANGELOG with history of PRs.
- Updated vm_service_wrapper.dart to use httpEnableTimelineLogging instead of deprecated methods getHttpEnableTimelineLogging and setHttpEnableTimelineLogging (DartIO Service Extension).