### PR TITLE
Cleanup DevToolsDialogs so that they are scrollable and don't take up the full vertical size.

### DIFF
--- a/packages/devtools_app/lib/src/dialogs.dart
+++ b/packages/devtools_app/lib/src/dialogs.dart
@@ -39,9 +39,8 @@ class DevToolsDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AlertDialog(
+      scrollable: true,
       title: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        mainAxisSize: MainAxisSize.min,
         children: [
           title,
           const PaddedDivider(


### PR DESCRIPTION
After:
![scrollable](https://user-images.githubusercontent.com/1226812/94720949-f9795700-0309-11eb-82e1-b3059482a8a1.gif)

<img width="1353" alt="Screen Shot 2020-09-30 at 10 45 23 AM" src="https://user-images.githubusercontent.com/1226812/94721000-0eee8100-030a-11eb-94af-f4035db45b62.png">
