### PR TITLE
Restore httpEnableTimelineLogging state after hot restart

### DIFF
--- a/packages/devtools/pubspec.lock
+++ b/packages/devtools/pubspec.lock
@@ -250,4 +250,4 @@ packages:
     source: hosted
     version: "0.7.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-177.0.dev"

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -177,6 +177,17 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
   gaItem: ga.togglePlatform,
 );
 
+final httpEnableTimelineLogging = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.dart.io.httpEnableTimelineLogging',
+  description: 'Whether HTTP timeline logging is enabled',
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'HTTP timeline logging enabled',
+  disabledTooltip: 'HTTP timeline logging disabled',
+  gaScreenName: null,
+  gaItem: null,
+);
+
 // Legacy extension to show the inspector and enable inspector select mode.
 final toggleOnDeviceWidgetInspector =
     ToggleableServiceExtensionDescription<bool>._(
@@ -254,6 +265,7 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   togglePlatformMode,
   slowAnimations,
   structuredErrors,
+  httpEnableTimelineLogging,
 ];
 
 final Map<String, ServiceExtensionDescription> serviceExtensionsAllowlist =

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -586,28 +586,27 @@ class ServiceExtensionManager {
         await _onFrameEventReceived();
         break;
       case 'Flutter.ServiceExtensionStateChanged':
-        final String name = event.json['extensionData']['extension'].toString();
-        final String valueString =
-            event.json['extensionData']['value'].toString();
-        await _updateServiceExtensionForStateChange(name, valueString);
+        final name = event.json['extensionData']['extension'].toString();
+        final encodedValue = event.json['extensionData']['value'].toString();
+        await _updateServiceExtensionForStateChange(name, encodedValue);
         break;
       case 'HttpTimelineLoggingStateChange':
         final name = extensions.httpEnableTimelineLogging.extension;
-        final valueString = event.json['extensionData']['enabled'].toString();
-        await _updateServiceExtensionForStateChange(name, valueString);
+        final encodedValue = event.json['extensionData']['enabled'].toString();
+        await _updateServiceExtensionForStateChange(name, encodedValue);
     }
   }
 
   Future<void> _updateServiceExtensionForStateChange(
     String name,
-    String valueString,
+    String encodedValue,
   ) async {
     final extension = extensions.serviceExtensionsAllowlist[name];
     if (extension != null) {
-      final dynamic value = _getExtensionValue(name, valueString);
+      final dynamic extensionValue = _getExtensionValue(name, encodedValue);
       final enabled =
           extension is extensions.ToggleableServiceExtensionDescription
-              ? value == extension.enabledValue
+              ? extensionValue == extension.enabledValue
               // For extensions that have more than two states
               // (enabled / disabled), we will always consider them to be
               // enabled with the current value.
@@ -616,23 +615,23 @@ class ServiceExtensionManager {
       await setServiceExtensionState(
         name,
         enabled,
-        value,
+        encodedValue,
         callExtension: false,
       );
     }
   }
 
-  dynamic _getExtensionValue(String name, String valueString) {
+  dynamic _getExtensionValue(String name, String encodedValue) {
     final expectedValueType =
         extensions.serviceExtensionsAllowlist[name].values.first.runtimeType;
     switch (expectedValueType) {
       case bool:
-        return valueString == 'true';
+        return encodedValue == 'true';
       case int:
       case double:
-        return num.parse(valueString);
+        return num.parse(encodedValue);
       default:
-        return valueString;
+        return encodedValue;
     }
   }
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -587,42 +587,52 @@ class ServiceExtensionManager {
         break;
       case 'Flutter.ServiceExtensionStateChanged':
         final String name = event.json['extensionData']['extension'].toString();
-        final String valueFromJson =
+        final String valueString =
             event.json['extensionData']['value'].toString();
-
-        final extension = extensions.serviceExtensionsAllowlist[name];
-        if (extension != null) {
-          final dynamic value = _getExtensionValueFromJson(name, valueFromJson);
-
-          final enabled =
-              extension is extensions.ToggleableServiceExtensionDescription
-                  ? value == extension.enabledValue
-                  // For extensions that have more than two states
-                  // (enabled / disabled), we will always consider them to be
-                  // enabled with the current value.
-                  : true;
-
-          await setServiceExtensionState(
-            name,
-            enabled,
-            value,
-            callExtension: false,
-          );
-        }
+        await _updateServiceExtensionForStateChange(name, valueString);
+        break;
+      case 'HttpTimelineLoggingStateChange':
+        final name = extensions.httpEnableTimelineLogging.extension;
+        final valueString = event.json['extensionData']['enabled'].toString();
+        await _updateServiceExtensionForStateChange(name, valueString);
     }
   }
 
-  dynamic _getExtensionValueFromJson(String name, String valueFromJson) {
+  Future<void> _updateServiceExtensionForStateChange(
+    String name,
+    String valueString,
+  ) async {
+    final extension = extensions.serviceExtensionsAllowlist[name];
+    if (extension != null) {
+      final dynamic value = _getExtensionValue(name, valueString);
+      final enabled =
+          extension is extensions.ToggleableServiceExtensionDescription
+              ? value == extension.enabledValue
+              // For extensions that have more than two states
+              // (enabled / disabled), we will always consider them to be
+              // enabled with the current value.
+              : true;
+
+      await setServiceExtensionState(
+        name,
+        enabled,
+        value,
+        callExtension: false,
+      );
+    }
+  }
+
+  dynamic _getExtensionValue(String name, String valueString) {
     final expectedValueType =
         extensions.serviceExtensionsAllowlist[name].values.first.runtimeType;
     switch (expectedValueType) {
       case bool:
-        return valueFromJson == 'true' ? true : false;
+        return valueString == 'true';
       case int:
       case double:
-        return num.parse(valueFromJson);
+        return num.parse(valueString);
       default:
-        return valueFromJson;
+        return valueString;
     }
   }
 
@@ -788,11 +798,20 @@ class ServiceExtensionManager {
 
     assert(value != null);
     if (value is bool) {
-      await _service.callServiceExtension(
-        name,
-        isolateId: _isolateManager.selectedIsolate.id,
-        args: {'enabled': value},
-      );
+      // TODO(kenz): stop special casing http timeline logging once it can be
+      // called via `callServiceExtension`. See
+      // https://github.com/dart-lang/sdk/issues/43628.
+      if (name == extensions.httpEnableTimelineLogging.extension) {
+        await _service.forEachIsolate((isolate) async {
+          await _service.httpEnableTimelineLogging(isolate.id, value);
+        });
+      } else {
+        await _service.callServiceExtension(
+          name,
+          isolateId: _isolateManager.selectedIsolate.id,
+          args: {'enabled': value},
+        );
+      }
     } else if (value is String) {
       await _service.callServiceExtension(
         name,

--- a/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
@@ -427,7 +427,9 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
     } catch (e, st) {
       log('$e\n$st');
 
-      Notifications.of(context).push(widget.describeError(e));
+      if (mounted) {
+        Notifications.of(context).push(widget.describeError(e));
+      }
     } finally {
       if (mounted) {
         setState(() {

--- a/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
@@ -421,7 +421,7 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
     try {
       await action();
 
-      if (widget.completedText != null) {
+      if (mounted && widget.completedText != null) {
         Notifications.of(context).push(widget.completedText);
       }
     } catch (e, st) {
@@ -429,9 +429,11 @@ mixin _ServiceExtensionMixin<T extends _ServiceExtensionWidget> on State<T> {
 
       Notifications.of(context).push(widget.describeError(e));
     } finally {
-      setState(() {
-        disabled = false;
-      });
+      if (mounted) {
+        setState(() {
+          disabled = false;
+        });
+      }
     }
   }
 }

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -776,7 +776,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0+1"
+    version: "5.2.0"
   vm_snapshot_analysis:
     dependency: "direct main"
     description:
@@ -827,5 +827,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-177.0.dev"
   flutter: ">1.21.0 <2.0.0"

--- a/packages/devtools_server/pubspec.lock
+++ b/packages/devtools_server/pubspec.lock
@@ -243,4 +243,4 @@ packages:
     source: hosted
     version: "0.7.3"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-177.0.dev"

--- a/packages/devtools_testing/lib/service_manager_test.dart
+++ b/packages/devtools_testing/lib/service_manager_test.dart
@@ -201,6 +201,8 @@ Future<void> runServiceManagerTests(FlutterTestEnvironment env) async {
       await env.tearDownEnvironment();
     });
 
+    // TODO(kenz): once hot restart tests are fixed, add a hot restart test
+    // that verifies the state of service extensions after a hot restart.
     // TODO(jacobr): uncomment out the hotRestart tests once
     // https://github.com/flutter/devtools/issues/337 is fixed.
     /*
@@ -423,15 +425,11 @@ Future<void> runServiceManagerTestsWithDriverFactory(
       );
       await serviceManager
           .serviceExtensionManager.extensionStatesUpdated.future;
-      // TODO(kenz): Uncomment this once
-      // https://github.com/flutter/devtools/issues/1351 is fixed.
-      /*
       await _verifyExtensionStateInServiceManager(
         boolExtensionDescription.extension,
         true,
         boolExtensionDescription.enabledValue,
       );
-      */
       await _verifyExtensionStateInServiceManager(
         stringExtensionDescription.extension,
         true,

--- a/packages/devtools_testing/pubspec.lock
+++ b/packages/devtools_testing/pubspec.lock
@@ -615,7 +615,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0+1"
+    version: "5.2.0"
   vm_snapshot_analysis:
     dependency: transitive
     description:
@@ -659,5 +659,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-177.0.dev"
   flutter: ">1.21.0 <2.0.0"


### PR DESCRIPTION
This partially addresses https://github.com/flutter/devtools/issues/1968. To completely fix the issue, we need a socket rpc change like https://github.com/dart-lang/sdk/commit/e85e5b6264edf554c13d328a0af9c38672c4a0c3 @bkonyi 