### PR TITLE
Consider API responses to api/ping with text/html header as failures

### DIFF
--- a/packages/devtools_app/lib/src/server_api_client.dart
+++ b/packages/devtools_app/lib/src/server_api_client.dart
@@ -35,7 +35,12 @@ class DevToolsServerConnection {
     try {
       // ignore: unused_local_variable
       final response = await http.get(uri).timeout(const Duration(seconds: 1));
-      if (response.statusCode != 200) {
+      if (response.statusCode != 200 ||
+          // When running locally with `flutter run`, missing request return a 200
+          // status with the HTML of the homepage so also consider text/html as
+          // not valid.
+          // https://github.com/flutter/flutter/issues/67053
+          response.headers['content-type'] == 'text/html') {
         // unable to locate dev server
         log('devtools server not available (${response.statusCode})');
         return null;

--- a/packages/devtools_app/lib/src/server_api_client.dart
+++ b/packages/devtools_app/lib/src/server_api_client.dart
@@ -39,6 +39,8 @@ class DevToolsServerConnection {
           // When running locally with `flutter run`, missing request return a 200
           // status with the HTML of the homepage so also consider text/html as
           // not valid.
+          // TODO(dantup): Remove this check and/or change this to inspect ping's
+          // response depending on the outcome of
           // https://github.com/flutter/flutter/issues/67053
           response.headers['content-type'] == 'text/html') {
         // unable to locate dev server


### PR DESCRIPTION
When running locally in Chrome without the server, I see errors trying to connect to the SSE backend. This seems to be because of https://github.com/flutter/flutter/issues/67053 - the call to `api/ping` returns a 200 status and that's considered successful.

I added a check for text/html (which is the type it returns). The real API responses are `text/plain` (I'm not sure if that's correct, but it's at least not - and should likely never be - HTML).