### PR TITLE
Don't try to start Chrome in --machine mode unless --launch-browser is supplied

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+4
+* Do not try to launch Chrome by default when running the server in `--machine` mode
+* Prevent exceptions launching Chrome from terminate the server
+
 ## 0.9.3+3
 * Remove flutter dependency from devtools_shared
 

--- a/packages/devtools/pubspec.lock
+++ b/packages/devtools/pubspec.lock
@@ -56,14 +56,14 @@ packages:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   http:
     dependency: "direct main"
     description:

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -8,7 +8,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.9.3+3
+version: 0.9.3+4
 
 homepage: https://github.com/flutter/devtools
 
@@ -16,8 +16,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_server: 0.9.3+3
-  devtools_shared: 0.9.3+3
+  devtools_server: 0.9.3+4
+  devtools_shared: 0.9.3+4
   http: ^0.12.0+1
   intl: ^0.16.0
 

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.sh matches the following line so
 // if you change it you must also modify tools/update_version.sh.
-const String version = '0.9.3+3';
+const String version = '0.9.3+4';

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -203,28 +203,28 @@ packages:
       path: "../devtools"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   devtools_server:
     dependency: "direct overridden"
     description:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   devtools_testing:
     dependency: "direct dev"
     description:
       path: "../devtools_testing"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   fake_async:
     dependency: transitive
     description:
@@ -827,5 +827,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-161.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-180.0.dev"
   flutter: ">1.21.0 <2.0.0"

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Web-based performance tooling for Dart and Flutter.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.9.3+3
+version: 0.9.3+4
 
 homepage: https://github.com/flutter/devtools
 
@@ -23,7 +23,7 @@ dependencies:
     ^0.0.2
 #     path: ../../third_party/packages/ansi_up
   collection: ^1.15.0-nnbd
-  devtools_shared: 0.9.3+3
+  devtools_shared: 0.9.3+4
   file: ^5.1.0
   flutter_web_plugins:
     sdk: flutter
@@ -52,7 +52,7 @@ dev_dependencies:
   webkit_inspection_protocol: '>=0.5.0 <0.8.0'
   devtools: #^0.1.7
     path: ../devtools
-  devtools_testing: 0.9.3+3
+  devtools_testing: 0.9.3+4
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -74,7 +74,9 @@ Future<void> _serveDevToolsWithArgs(
 }) async {
   final help = args[argHelp];
   final bool machineMode = args[argMachine];
-  final bool launchBrowser = args[argLaunchBrowser];
+  // launchBrowser defaults based on machine-mode if not explicitly supplied.
+  final bool launchBrowser =
+      args.wasParsed(argLaunchBrowser) ? args[argLaunchBrowser] : !machineMode;
   final bool enableNotifications = args[argEnableNotifications];
   final bool allowEmbedding = args[argAllowEmbedding];
   final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
@@ -210,7 +212,11 @@ Future<HttpServer> serveDevTools({
       }).toString();
     }
 
-    await Chrome.start([url]);
+    try {
+      await Chrome.start([url]);
+    } catch (e) {
+      print('Unable to launch Chrome: $e\n');
+    }
   }
 
   if (enableStdinCommands) {
@@ -456,8 +462,8 @@ ArgParser _createArgsParser(bool verbose) {
     )
     ..addFlag(
       argLaunchBrowser,
-      defaultsTo: true,
-      help: 'Launches DevTools in a browser immediately at start.',
+      help:
+          'Launches DevTools in a browser immediately at start.\n(defaults to on unless in --machine mode)',
     )
 // TODO: Remove this - prefer that clients use the rest arg.
     ..addOption(

--- a/packages/devtools_server/pubspec.lock
+++ b/packages/devtools_server/pubspec.lock
@@ -56,7 +56,7 @@ packages:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.3+3"
+    version: "0.9.3+4"
   http:
     dependency: transitive
     description:

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -3,7 +3,7 @@ description: A server that supports Dart DevTools.
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3+3
+version: 0.9.3+4
 
 homepage: https://github.com/flutter/devtools
 
@@ -13,7 +13,7 @@ environment:
 dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.5
-  devtools_shared: 0.9.3+3
+  devtools_shared: 0.9.3+4
   intl: ^0.16.0
   meta: ^1.1.0
   path: ^1.6.0

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package of shared structures between devtools_app and devtools_serv
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3+3
+version: 0.9.3+4
 
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: devtools_testing
 description: Package of shared testing code for Dart DevTools.
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.3+3
+version: 0.9.3+4
 
 homepage: https://github.com/flutter/devtools
 
@@ -10,8 +10,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_app: 0.9.3+3
-  devtools_shared: 0.9.3+3
+  devtools_app: 0.9.3+4
+  devtools_shared: 0.9.3+4
   flutter:
     sdk: flutter
   flutter_test:

--- a/tool/update_version.sh
+++ b/tool/update_version.sh
@@ -29,17 +29,17 @@ pushd packages
 # We could use LAST_VERSION instead of allowing any previous version
 
 # Update the version of all packages.
-perl -pi -e "s/^(\\W*version:) [0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*version:) [0-9.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
 
 # Update all references to package versions
-perl -pi -e "s/^(\\W*devtools_shared:) \\^?[0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
-perl -pi -e "s/^(\\W*devtools_server:) \\^?[0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
-perl -pi -e "s/^(\\W*devtools:) \\^?[0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
-perl -pi -e "s/^(\\W*devtools_app:) \\^?[0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
-perl -pi -e "s/^(\\W*devtools_testing:) \\^?[0-9.dev-]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_shared:) \\^?[0-9\.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_server:) \\^?[0-9\.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools:) \\^?[0-9\.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_app:) \\^?[0-9\.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
+perl -pi -e "s/^(\\W*devtools_testing:) \\^?[0-9\.dev\-+]+/\$1 $VERSION/g" $PUBSPECS
 
 # Update version defined in the source code in devtools_app.
-perl -pi -e "s/^(\\W*const String version =) '[0-9.dev-]+'/\$1 '$VERSION'/g" ./devtools_app/lib/devtools.dart
+perl -pi -e "s/^(\\W*const String version =) '[0-9.dev\-+]+'/\$1 '$VERSION'/g" ./devtools_app/lib/devtools.dart
 
 popd
 


### PR DESCRIPTION
\+ don't crash server if Chrome can't be launched.

Fixes #2405.
Fixes #1936.

@devoncarew @jacob314 

I had to tweak the update_version script to make it work properly (it seemed to not handle the `+` so I ended up with the existing `+3` tagged onto the end of the new version supplied. Also unsure if the change should've gone in the server changelog or devtools (lmk if I should move it to server).