### PR TITLE
Tweak CHANGELOG for better display

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -58,12 +58,12 @@
 * Ship Flutter Web version of DevTools by default
 * Update package:vm_service dependency to ^4.1.0
 
-## 0.2.5 2020-05-07
+## 0.2.5
 * Persist connected app URI when switching to Flutter web version of DevTools [#1933](https://github.com/flutter/devtools/pull/1933)
 * Fix CPU profiler bug where we were unintentionally mutating data [#1923](https://github.com/flutter/devtools/pull/1923)
 * Add "Remove all breakpoints" functionality to debugger [#1914](https://github.com/flutter/devtools/pull/1914)
 
-## 0.2.4+1 2020-05-05
+## 0.2.4+1
 * Memory Snapshot [#1885](https://github.com/flutter/devtools/pull/1885)
 * Added new debugger page.
 * Added new Network page.
@@ -78,12 +78,12 @@
 * Fix bug causing import to fail when DevTools is not connected to an app [#1703](https://github.com/flutter/devtools/pull/1703)
 * Update package:vm_service dependency to ^4.0.0
 
-## 0.2.3 2020-03-03
+## 0.2.3
 * Disable Q1 DevTools survey - postponing until Q2 [#1695](https://github.com/flutter/devtools/pull/1695)
 * Fix async timeline event rendering bug [#1690](https://github.com/flutter/devtools/pull/1690)
 * Update package:vm_service dependency to ^3.0.0 [#1696](https://github.com/flutter/devtools/pull/1696)
 
-## 0.2.2 2020-02-28
+## 0.2.2
 * Remove cpu profiling timeout [#1683]((https://github.com/flutter/devtools/pull/1683)
 * Prep for Q1 DevTools survey [#1574](https://github.com/flutter/devtools/pull/1574)
 * Use ExtentDelegateListView for flame chart rows [#1676](https://github.com/flutter/devtools/pull/1676)
@@ -119,13 +119,13 @@
 * Initial devtools_shared package [#1619](https://github.com/flutter/devtools/pull/1619)
 * Remove --trace-systrace flag from MacOs and Linux configs [#1614](https://github.com/flutter/devtools/pull/1614)
 
-## 0.1.15 2020-02-07
+## 0.1.15
 * Fix a stack overflow error that was caused by a change in Dart's RTI implementation [#1615](https://github.com/flutter/devtools/pull/1615).
 * Hide annotations that Flutter re-exports [#1606](https://github.com/flutter/devtools/pull/1606)
 * Update package:devtools_server dependency to 0.1.13 or newer [#1603](https://github.com/flutter/devtools/pull/1603)
 * Update package:sse dependency to 3.1.2 or newer [#1601](https://github.com/flutter/devtools/pull/1601)
 
-## 0.1.14 2020-02-03
+## 0.1.14
 * Added collecting of Android Debug Bridge (adb) Java memory information see [PR](https://github.com/flutter/devtools/pull/1553).
 * Added multiple charts to memory profiling (Dart VM and Java memory).
 * Added display interval e.g., 1 minute, 5 minutes, 10 minutes for memory charts.
@@ -142,14 +142,14 @@
 * Improve hint text on connect screen.
 * Update package:vm_service dependency to ^2.2.0.
 
-## 0.1.13 - 2019-12-10
+## 0.1.13
 * Fix crash opening macOS desktop apps in DevTools.
 * Enable layout explorer.
 * Hide legacy page content in the flutter version of DevTools.
 * Fix offline import bug in Timeline.
 * Use published version of mp_chart package.
 
-## 0.1.12 - 2019-12-06
+## 0.1.12
 * Enable testing the alpha version of DevTools written in Flutter. Click the "beaker" icon in the upper-right to launch DevTools in Flutter.
 * Fix a regression that showed an inaccurate error on the connect screen.
 * Fix bug causing async events with the same name to overlap each other in the Timeline.
@@ -159,7 +159,7 @@
 * Check for a debug service extension instead of using eval to distinguish between debug and profile builds.
 * Depend on the latest `package:sse`.
 
-## 0.1.11 - 2019-11-08
+## 0.1.11
 * Add full timeline mode with support for async and recorded tracing.
 * Add event summary section that shows metadata for non-ui events on the Timeline page.
 * Enable full timeline for Dart CLI applications.
@@ -167,10 +167,10 @@
 * Fix a bug with processing CPU profile responses.
 * Reduce race conditions in integration tests.
 
-## 0.1.10 - 2019-10-18
+## 0.1.10
 * Change wording of DevTools survey prompt.
 
-## 0.1.9 - 2019-10-17
+## 0.1.9
 * Launched the Q3 DevTools Survey.
 * Bug fixes related to layouts and logging.
 * Update to use latest devtools_server 0.1.12.
@@ -179,12 +179,12 @@
 * Now devtools_app will request and set property values, in ~/.devtools, via HTTP requests to the devtools_server.
 * Store survey properties on whether the user has answered or dismissed a survey in the ~/.devtools file too.
 
-## 0.1.8 - 2019-10-01
+## 0.1.8
 * Query a flutter isolate for the target frame rate (e.g. 60FPS vs 120FPS). Respect this value in the Timeline.
 * Polish import / export flow for Timeline.
 * Depend on latest `package:devtools_server`.
 
-## 0.1.7 - 2019-09-09
+## 0.1.7
 * Fix bug with profile mode detection.
 * Enable expand all / collapse to selected functionality in the inspector (available in Flutter versions 1.10.1 or later).
 * Fix analytics bug for apps running in profile mode.
@@ -194,7 +194,7 @@
 * Various CSS fixes.
 * Code health improvements.
 
-## 0.1.6 - 2019-09-04
+## 0.1.6
 * Add a page to show Flutter version and Dart VM flags details.
 * Add settings dialog to memory page that supports filtering snapshots and enabling experiments.
 * Various css fixes.
@@ -215,7 +215,7 @@
 * Fix NPE in the Debugger.
 * Improve testing on Windows.
 
-## 0.1.5 - 2019-08-05
+## 0.1.5
 * Support expanding or collapsing all values in the Call Tree and Bottom Up views (parts of the CPU profiler).
 * Support touchscreen scrolling and selection in flame charts.
 * Display structured error messages in the Logging view when "show structured errors" is enabled.
@@ -224,16 +224,16 @@
 * Disable unsupported DevTools pages for Dart web apps.
 * Debugger dark mode improvements.
 
-## 0.1.4 - 2019-07-19
+## 0.1.4
 * Add Performance page. This has a traditional CPU profiler for Dart applications.
 * Add ability to specify the profile granularity for the CPU profiler.
 * Bug fixes for DevTools tables, memory page, and cpu profiler.
 
-## 0.1.3 - 2019-07-11
+## 0.1.3
 * Link to new flutter.dev hosted DevTools documentation.
 * Inspector UI improvements.
 
-## 0.1.2 - 2019-07-01
+## 0.1.2
 * Add Call Tree and Bottom Up views to CPU profiler.
 * Pre-fetch CPU profiles so that we have profiling information for every frame in the timeline.
 * Trim Mixins from class name reporting in the CPU profiler.
@@ -246,13 +246,13 @@
 * Cleanup warning message presentation.
 * Bug fixes and improvements.
 
-## 0.1.1 - 2019-05-30
+## 0.1.1
 * Make timeline snapshot format compatible with trace viewers such as chrome://tracing.
 * Add ability to import timeline snapshots via drag-and-drop.
 * Memory instance viewer handles all InstanceKind lists.
 * CPU profiler bug fixes and improvements.
 
-## 0.1.0 - 2019-05-02
+## 0.1.0
 * Expose functionality to export timeline trace and CPU profiles.
 * Add "Clear" button to the timeline page.
 * CPU profiler bug fixes and improvements.
@@ -261,12 +261,12 @@
 * Add ability to inspect an instance of a memory object in the memory profiler page after a snapshot of active memory objects.
 * First time DevTools is launched, prompt with an opt-in dialog to report DevTools usage statistics and crash reports of DevTools to Google.
 
-## 0.0.19 - 2019-05-01
+## 0.0.19
 * Update DevTools server to better handle failures when launching browsers.
 * Support additional formats for VM service uris.
 * Link to documentation from --track-widget-creation warning in the Inspector.
 
-## 0.0.18 - 2019-04-30
+## 0.0.18
 * Fix release bug (0.0.17-dev.1 did not include build folder).
 * Add CPU profiler (preview) to timeline page.
 * CPU flame chart UI improvements and bug fixes.
@@ -274,16 +274,16 @@
 * DevTools server released with support for launching DevTools in Chrome.
 * Dark mode improvements.
 
-## 0.0.16 - 2019-04-17
+## 0.0.16
 * Reduce the minimum Dart SDK requirements for activating DevTools to cover Flutter v1.2.1 (Dart v2.1)
 
-## 0.0.15 - 2019-04-16
+## 0.0.15
 * Warn users when they should be using a profile build of their application instead of a debug build.
 * Warn users using Microsoft browsers (IE and Edge) that they should be using Chrome to run DevTools.
 * Dark mode improvements.
 * Open scripts in the debugger using ctrl + o.
 
-## 0.0.14 - 2019-03-26
+## 0.0.14
 * Dark mode is ready to use, add ```&theme=dark``` at the end of the URI used to open the DevTool in Chrome. We look forward to your feedback.
 * Added event timeline to memory profiler to track DevTool's Snapshot and Reset events.
 * Timeline CPU renamed to UI, janky defined as UI duration + GPU duration > 16 ms.
@@ -292,23 +292,11 @@
 * Warn users when they are using an unsupported browser.
 * Properly disable features that aren't supported for the connected application.
 * Fix screens for different widths.
-## 0.0.13 - 2019-03-15
+
+## 0.0.13
 * Dark mode, still being polished, is available.  Add ```&theme=dark``` at the end of URI used to open DevTools in the Chrome browser.
-### Memory
 * Added showing GCs on the timeline and leak detection.
-### Timeline
 * Fix bugs when events were received out of order.
 
 ## 0.0.1
 - initial (pre-release) release
-
-<!--
-List of possible sections to use for areas that have changed.
-### Documentation
-### Debugger
-### Inspector
-### Logging
-### Memory
-### Table
-### Timeline
--->


### PR DESCRIPTION
The old dates on the changelog entries seem to be tripping up pub.dev and causing them to be indented under 0.8.0:
![image](https://user-images.githubusercontent.com/2319867/95105004-649ca200-06eb-11eb-9801-60ebed1c2e7b.png)

We can safely remove them anyway, which is also consistent with other packages.