### PR TITLE
Check for a known response from api/ping instead of content type

### DIFF
--- a/packages/devtools_app/lib/src/server_api_client.dart
+++ b/packages/devtools_app/lib/src/server_api_client.dart
@@ -35,14 +35,11 @@ class DevToolsServerConnection {
     try {
       // ignore: unused_local_variable
       final response = await http.get(uri).timeout(const Duration(seconds: 1));
-      if (response.statusCode != 200 ||
-          // When running locally with `flutter run`, missing request return a 200
-          // status with the HTML of the homepage so also consider text/html as
-          // not valid.
-          // TODO(dantup): Remove this check and/or change this to inspect ping's
-          // response depending on the outcome of
-          // https://github.com/flutter/flutter/issues/67053
-          response.headers['content-type'] == 'text/html') {
+      // When running with the local dev server Flutter may serve its index page
+      // for missing files to support the hashless url strategy. Check the response
+      // content to confirm it came from our server.
+      // See https://github.com/flutter/flutter/issues/67053
+      if (response.statusCode != 200 || response.body != 'OK') {
         // unable to locate dev server
         log('devtools server not available (${response.statusCode})');
         return null;

--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -88,7 +88,7 @@ Future<shelf.Handler> defaultHandler(
     }
 
     if (request.url.path == 'api/ping') {
-      return shelf.Response(HttpStatus.ok);
+      return shelf.Response(HttpStatus.ok, body: 'OK');
     }
 
     // The API handler takes all other calls to api/.


### PR DESCRIPTION
Slight improvement to the workaround for Flutter serving 200 status where we expected 404s. I've suggested returning a 404 in https://github.com/flutter/flutter/issues/67053 - though if that's changed it'll still be a while before it's in a stable release so it's worth retaining a workaround here.

(relates to comments at https://github.com/flutter/devtools/pull/2396#discussion_r499683978)