### PR TITLE
Tweak launch.json for VS Code launching

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -44,6 +44,21 @@
 			"env": {
 				"WEBDEV_RELEASE": true,
 			}
-		}
+		},
+		{
+			"name": "Test on Device",
+			"type": "dart",
+			"request": "launch",
+			"runTestsOnDevice": true,
+			"program": "${file}",
+			"codeLens": {
+				"for": [
+					"debug-test-file",
+					"run-test-file"
+				],
+				"path": "packages/devtools_app/test",
+				"title": "${debugType} on Device"
+			}
+		},
 	]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,12 +7,6 @@
 			"request": "launch",
 			"program": "lib/main.dart",
 			"cwd": "${workspaceFolder}/packages/devtools_app",
-			// TODO: I can't get the flutter device selector to show up from the top level
-			// directory. I can get it when running vscode on packages/devtools_app.
-			"args": [
-				"-d",
-				"chrome"
-			]
 		},
 		{
 			"type": "dart",


### PR DESCRIPTION
1. The `launch.json` was previously forcing use of the Chrome device regardless of the device selected in VS Code. I can't reproduce the issue described in the TODO, so presume it must've been fixed at some point. Without that `-d`, I can launch on any device selected in the VS Code device selector (while opening the root repo, and not the sub-folder).

2. Adds a code-lens link that allows easily running test files on-device for debugging (it's sometimes convenient to visually see what's being rendered):

<img width="406" alt="Screenshot 2020-10-07 at 09 57 06" src="https://user-images.githubusercontent.com/1078012/95309775-7add6600-0883-11eb-89a0-aa4eea293d16.png">
