### PR TITLE
Added initial VM developer mode support

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -428,33 +428,49 @@ class SettingsDialog extends StatelessWidget {
   Widget build(BuildContext context) {
     final preferences = DevToolsApp.of(context).preferences;
 
+    InkWell buildOption({
+      Text label,
+      ValueListenable listenable,
+      Function(bool) toggle,
+    }) {
+      return InkWell(
+        onTap: () => toggle(!listenable.value),
+        child: Row(
+          children: [
+            ValueListenableBuilder(
+              valueListenable: listenable,
+              builder: (context, value, _) {
+                return Checkbox(
+                  value: value,
+                  onChanged: (bool value) => toggle(value),
+                );
+              },
+            ),
+            label,
+          ],
+        ),
+      );
+    }
+
+    // Disabled until VM developer mode functionality is added.
+    const showVmDeveloperMode = false;
     return DevToolsDialog(
       title: dialogTitleText(Theme.of(context), 'Settings'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          InkWell(
-            onTap: () {
-              preferences.toggleDarkModeTheme(!preferences.darkModeTheme.value);
-            },
-            child: Row(
-              children: [
-                ValueListenableBuilder(
-                  valueListenable: preferences.darkModeTheme,
-                  builder: (context, value, _) {
-                    return Checkbox(
-                      value: value,
-                      onChanged: (bool value) {
-                        preferences.toggleDarkModeTheme(value);
-                      },
-                    );
-                  },
-                ),
-                const Text('Use a dark theme'),
-              ],
-            ),
+          buildOption(
+            label: const Text('Use a dark theme'),
+            listenable: preferences.darkModeTheme,
+            toggle: preferences.toggleDarkModeTheme,
           ),
+          if (showVmDeveloperMode)
+            buildOption(
+              label: const Text('Enable VM developer mode'),
+              listenable: preferences.vmDeveloperModeEnabled,
+              toggle: preferences.toggleVmDeveloperMode,
+            ),
         ],
       ),
       actions: [

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -47,6 +47,9 @@ const homeRoute = '/';
 const snapshotRoute = '/snapshot';
 const appSizeRoute = '/app-size';
 
+// Disabled until VM developer mode functionality is added.
+const showVmDeveloperMode = false;
+
 /// Top-level configuration for the app.
 @immutable
 class DevToolsApp extends StatefulWidget {
@@ -422,51 +425,23 @@ class DevToolsAboutDialog extends StatelessWidget {
 }
 
 // TODO(devoncarew): Add an analytics setting.
-
 class SettingsDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final preferences = DevToolsApp.of(context).preferences;
-
-    InkWell buildOption({
-      Text label,
-      ValueListenable listenable,
-      Function(bool) toggle,
-    }) {
-      return InkWell(
-        onTap: () => toggle(!listenable.value),
-        child: Row(
-          children: [
-            ValueListenableBuilder(
-              valueListenable: listenable,
-              builder: (context, value, _) {
-                return Checkbox(
-                  value: value,
-                  onChanged: (bool value) => toggle(value),
-                );
-              },
-            ),
-            label,
-          ],
-        ),
-      );
-    }
-
-    // Disabled until VM developer mode functionality is added.
-    const showVmDeveloperMode = false;
     return DevToolsDialog(
       title: dialogTitleText(Theme.of(context), 'Settings'),
       content: Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          buildOption(
+          _buildOption(
             label: const Text('Use a dark theme'),
             listenable: preferences.darkModeTheme,
             toggle: preferences.toggleDarkModeTheme,
           ),
           if (showVmDeveloperMode)
-            buildOption(
+            _buildOption(
               label: const Text('Enable VM developer mode'),
               listenable: preferences.vmDeveloperModeEnabled,
               toggle: preferences.toggleVmDeveloperMode,
@@ -476,6 +451,30 @@ class SettingsDialog extends StatelessWidget {
       actions: [
         DialogCloseButton(),
       ],
+    );
+  }
+
+  Widget _buildOption({
+    Text label,
+    ValueListenable<bool> listenable,
+    Function(bool) toggle,
+  }) {
+    return InkWell(
+      onTap: () => toggle(!listenable.value),
+      child: Row(
+        children: [
+          ValueListenableBuilder<bool>(
+            valueListenable: listenable,
+            builder: (context, value, _) {
+              return Checkbox(
+                value: value,
+                onChanged: toggle,
+              );
+            },
+          ),
+          label,
+        ],
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/preferences.dart
+++ b/packages/devtools_app/lib/src/preferences.dart
@@ -25,7 +25,7 @@ class PreferencesController {
 
     // Get the current values and listen for and write back changes.
     String value = await storage.getValue('ui.darkMode');
-    _darkModeTheme.value = value == null || value == 'true';
+    toggleDarkModeTheme(value == null || value == 'true');
     _darkModeTheme.addListener(() {
       storage.setValue('ui.darkMode', '${_darkModeTheme.value}');
     });

--- a/packages/devtools_app/lib/src/preferences.dart
+++ b/packages/devtools_app/lib/src/preferences.dart
@@ -13,8 +13,8 @@ class PreferencesController {
   final ValueNotifier<bool> _darkModeTheme = ValueNotifier(true);
   final ValueNotifier<bool> _vmDeveloperMode = ValueNotifier(false);
 
-  ValueListenable get darkModeTheme => _darkModeTheme;
-  ValueListenable get vmDeveloperModeEnabled => _vmDeveloperMode;
+  ValueListenable<bool> get darkModeTheme => _darkModeTheme;
+  ValueListenable<bool> get vmDeveloperModeEnabled => _vmDeveloperMode;
 
   Future<void> init() async {
     if (storage == null) {
@@ -31,7 +31,7 @@ class PreferencesController {
     });
 
     value = await storage.getValue('ui.vmDeveloperMode');
-    toggleVmDeveloperMode(value == 'false');
+    toggleVmDeveloperMode(value == 'true');
     _vmDeveloperMode.addListener(() {
       storage.setValue('ui.vmDeveloperMode', '${_vmDeveloperMode.value}');
     });

--- a/packages/devtools_app/lib/src/preferences.dart
+++ b/packages/devtools_app/lib/src/preferences.dart
@@ -6,12 +6,15 @@ import 'package:flutter/foundation.dart';
 
 import 'config_specific/logger/logger.dart';
 import 'globals.dart';
+import 'vm_service_wrapper.dart';
 
 /// A controller for global application preferences.
 class PreferencesController {
   final ValueNotifier<bool> _darkModeTheme = ValueNotifier(true);
+  final ValueNotifier<bool> _vmDeveloperMode = ValueNotifier(false);
 
   ValueListenable get darkModeTheme => _darkModeTheme;
+  ValueListenable get vmDeveloperModeEnabled => _vmDeveloperMode;
 
   Future<void> init() async {
     if (storage == null) {
@@ -21,15 +24,27 @@ class PreferencesController {
     }
 
     // Get the current values and listen for and write back changes.
-    final String value = await storage.getValue('ui.darkMode');
+    String value = await storage.getValue('ui.darkMode');
     _darkModeTheme.value = value == null || value == 'true';
     _darkModeTheme.addListener(() {
       storage.setValue('ui.darkMode', '${_darkModeTheme.value}');
+    });
+
+    value = await storage.getValue('ui.vmDeveloperMode');
+    toggleVmDeveloperMode(value == 'false');
+    _vmDeveloperMode.addListener(() {
+      storage.setValue('ui.vmDeveloperMode', '${_vmDeveloperMode.value}');
     });
   }
 
   /// Change the value for the dark mode setting.
   void toggleDarkModeTheme(bool useDarkMode) {
     _darkModeTheme.value = useDarkMode;
+  }
+
+  /// Change the value for the VM developer mode setting.
+  void toggleVmDeveloperMode(bool enableVmDeveloperMode) {
+    _vmDeveloperMode.value = enableVmDeveloperMode;
+    VmServicePrivate.enablePrivateRpcs = enableVmDeveloperMode;
   }
 }

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -10,16 +10,12 @@ import 'package:vm_service/vm_service.dart';
 import 'profiler/cpu_profile_model.dart';
 import 'version.dart';
 
-typedef TrackFuture = Future<T> Function<T>(String, Future<T>);
-
 class VmServiceWrapper implements VmService {
   VmServiceWrapper(
     this._vmService,
     this.connectedUri, {
     this.trackFutures = false,
-  }) {
-    trackFuture = _trackFuture;
-  }
+  });
 
   VmServiceWrapper.fromNewVmService(
     Stream<dynamic> /*String|List<int>*/ inStream,
@@ -35,7 +31,6 @@ class VmServiceWrapper implements VmService {
       log: log,
       disposeHandler: disposeHandler,
     );
-    trackFuture = _trackFuture;
   }
 
   VmService _vmService;
@@ -45,8 +40,6 @@ class VmServiceWrapper implements VmService {
   final bool trackFutures;
   final Map<String, Future<Success>> _activeStreams = {};
 
-  @visibleForTesting
-  TrackFuture trackFuture;
   final Set<TrackedFuture<Object>> activeFutures = {};
   Completer<bool> _allFuturesCompleter = Completer<bool>()
     // Mark the future as completed by default so if we don't track any
@@ -894,7 +887,8 @@ class VmServiceWrapper implements VmService {
           ? 'Service'
           : '_Service';
 
-  Future<T> _trackFuture<T>(String name, Future<T> future) {
+  @visibleForTesting
+  Future<T> trackFuture<T>(String name, Future<T> future) {
     if (!trackFutures) {
       return future;
     }

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -38,7 +38,8 @@ void main() {
         valueChanged = true;
       });
 
-      controller.toggleVmDeveloperMode(!controller.vmDeveloperModeEnabled.value);
+      controller
+          .toggleVmDeveloperMode(!controller.vmDeveloperModeEnabled.value);
       expect(valueChanged, isTrue);
       expect(controller.vmDeveloperModeEnabled.value, isNot(originalValue));
     });

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -38,7 +38,7 @@ void main() {
         valueChanged = true;
       });
 
-      controller.toggleVmDeveloperMode(!controller.darkModeTheme.value);
+      controller.toggleVmDeveloperMode(!controller.vmDeveloperModeEnabled.value);
       expect(valueChanged, isTrue);
       expect(controller.vmDeveloperModeEnabled.value, isNot(originalValue));
     });

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -29,5 +29,18 @@ void main() {
       expect(valueChanged, isTrue);
       expect(controller.darkModeTheme.value, isNot(originalValue));
     });
+
+    test('toggleVmDeveloperMode', () {
+      bool valueChanged = false;
+      final originalValue = controller.vmDeveloperModeEnabled.value;
+
+      controller.vmDeveloperModeEnabled.addListener(() {
+        valueChanged = true;
+      });
+
+      controller.toggleVmDeveloperMode(!controller.darkModeTheme.value);
+      expect(valueChanged, isTrue);
+      expect(controller.vmDeveloperModeEnabled.value, isNot(originalValue));
+    });
   });
 }

--- a/packages/devtools_app/test/vm_service_private_test.dart
+++ b/packages/devtools_app/test/vm_service_private_test.dart
@@ -1,0 +1,43 @@
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/vm_service_wrapper.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+
+import 'support/mocks.dart';
+
+void main() {
+  FakeServiceManager fakeServiceManager;
+
+  setUp(() {
+    fakeServiceManager = FakeServiceManager();
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
+  });
+  test('Ensure private RPCs can only be enabled with VM Developer Mode enabled',
+      () async {
+    // ignore: unnecessary_cast
+    when(fakeServiceManager.service.trackFuture as Function).thenReturn(
+      <T>(String _, Future<T> future) => future,
+    );
+    when(fakeServiceManager.service
+            .callMethod(argThat(equals('_collectAllGarbage'))))
+        .thenAnswer(
+      (_) => Future.value(Success()),
+    );
+    VmServicePrivate.enablePrivateRpcs = false;
+    try {
+      await fakeServiceManager.service.collectAllGarbage();
+      fail('Should not be able to invoke private RPCs');
+    } on StateError {
+      /* expected */
+    }
+
+    VmServicePrivate.enablePrivateRpcs = true;
+    try {
+      await fakeServiceManager.service.collectAllGarbage();
+    } on StateError {
+      fail('Should be able to invoke private RPCs');
+    }
+  });
+}

--- a/packages/devtools_app/test/vm_service_private_test.dart
+++ b/packages/devtools_app/test/vm_service_private_test.dart
@@ -14,6 +14,7 @@ void main() {
     fakeServiceManager = FakeServiceManager();
     setGlobal(ServiceConnectionManager, fakeServiceManager);
   });
+
   test('Ensure private RPCs can only be enabled with VM Developer Mode enabled',
       () async {
     // ignore: unnecessary_cast

--- a/packages/devtools_app/test/vm_service_private_test.dart
+++ b/packages/devtools_app/test/vm_service_private_test.dart
@@ -17,9 +17,8 @@ void main() {
 
   test('Ensure private RPCs can only be enabled with VM Developer Mode enabled',
       () async {
-    // ignore: unnecessary_cast
-    when(fakeServiceManager.service.trackFuture as Function).thenReturn(
-      <T>(String _, Future<T> future) => future,
+    when(fakeServiceManager.service.trackFuture(any, any)).thenAnswer(
+      (invocation) => invocation.positionalArguments[1],
     );
     when(fakeServiceManager.service
             .callMethod(argThat(equals('_collectAllGarbage'))))


### PR DESCRIPTION
- Added `VmServicePrivate` extension to `VmServiceWrapper` where all private
  RPC calls required for VM developer options will be implemented. These
  RPCs will throw if invoked while VM developer mode is disabled.

- Added a "Enable VM developer mode" toggle under preferences. Currently
  hidden until VM developer functionality is added.

- Refactored `VmServiceWrapper` to allow for `trackFuture` to be mocked.

![image](https://user-images.githubusercontent.com/24210656/95346099-52983c00-0870-11eb-8c7d-8941db15233e.png)
