### PR TITLE
Change flutter frames chart y axis scale to 2 * target frame time.

### DIFF
--- a/packages/devtools_app/lib/src/timeline/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter_frames_chart.dart
@@ -50,6 +50,10 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
 
   double get availableChartHeight => defaultChartHeight - defaultSpacing;
 
+  /// Milliseconds per pixel value for the y-axis.
+  ///
+  /// This value will result in a y-axis time range spanning two times the
+  /// target frame time for a single frame (e.g. 16.6 * 2 for a 60 FPS device).
   double get msPerPx =>
       // Multiply by two to reach two times the target frame time.
       1 / widget.displayRefreshRate * 1000 * 2 / availableChartHeight;

--- a/packages/devtools_app/lib/src/timeline/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/timeline/flutter_frames_chart.dart
@@ -16,15 +16,12 @@ import 'timeline_model.dart';
 class FlutterFramesChart extends StatefulWidget {
   const FlutterFramesChart(
     this.frames,
-    this.longestFrameDurationMs,
     this.displayRefreshRate,
   );
 
   static const chartLegendKey = Key('Flutter frames chart legend');
 
   final List<TimelineFrame> frames;
-
-  final int longestFrameDurationMs;
 
   final double displayRefreshRate;
 
@@ -34,9 +31,6 @@ class FlutterFramesChart extends StatefulWidget {
 
 class _FlutterFramesChartState extends State<FlutterFramesChart>
     with AutoDisposeMixin {
-  static const maxMsForDisplay = 48.0;
-  static const minMsForDisplay = 18.0;
-
   static const defaultFrameWidthWithPadding =
       FlutterFramesChartItem.defaultFrameWidth + densePadding * 2;
 
@@ -57,8 +51,8 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
   double get availableChartHeight => defaultChartHeight - defaultSpacing;
 
   double get msPerPx =>
-      widget.longestFrameDurationMs.clamp(minMsForDisplay, maxMsForDisplay) /
-      availableChartHeight;
+      // Multiply by two to reach two times the target frame time.
+      1 / widget.displayRefreshRate * 1000 * 2 / availableChartHeight;
 
   @override
   void initState() {

--- a/packages/devtools_app/lib/src/timeline/timeline_controller.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_controller.dart
@@ -128,13 +128,6 @@ class TimelineController
   /// This list is cleared and repopulated each time "Refresh" is clicked.
   List<TraceEventWrapper> allTraceEvents = [];
 
-  /// Tracks the longest frame portion (UI or Raster) time for the current
-  /// timeline data.
-  ///
-  /// This is used by [FlutterFramesChart] when calculating the scale for the
-  /// chart's Y axis.
-  int longestFramePortionMs = 0;
-
   void _startTimeline() async {
     await serviceManager.onServiceAvailable;
     unawaited(allowedError(
@@ -211,14 +204,7 @@ class TimelineController
   }
 
   void addFrame(TimelineFrame frame) {
-    // Ensure we start tracking [longestFramePortionMs] at 0.
-    if (data.frames.isEmpty) longestFramePortionMs = 0;
-
     data.frames.add(frame);
-    if (frame.uiDurationMs > longestFramePortionMs ||
-        frame.rasterDurationMs > longestFramePortionMs) {
-      longestFramePortionMs = frame.time.duration.inMilliseconds;
-    }
   }
 
   Future<void> refreshData() async {
@@ -478,7 +464,6 @@ class TimelineController
     cpuProfilerController.reset();
     data?.clear();
     processor?.reset();
-    longestFramePortionMs = 0;
     _flutterFrames.value = [];
     _selectedTimelineEventNotifier.value = null;
     _selectedFrameNotifier.value = null;

--- a/packages/devtools_app/lib/src/timeline/timeline_screen.dart
+++ b/packages/devtools_app/lib/src/timeline/timeline_screen.dart
@@ -149,7 +149,6 @@ class TimelineScreenBodyState extends State<TimelineScreenBody>
               builder: (context, displayRefreshRate, _) {
                 return FlutterFramesChart(
                   frames,
-                  controller.longestFramePortionMs,
                   displayRefreshRate,
                 );
               },

--- a/packages/devtools_app/test/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/flutter_frames_chart_test.dart
@@ -22,7 +22,7 @@ void main() {
     @required List<TimelineFrame> frames,
   }) async {
     await tester.pumpWidget(wrapWithControllers(
-      FlutterFramesChart(frames, 20, defaultRefreshRate),
+      FlutterFramesChart(frames, defaultRefreshRate),
       timeline: TimelineController(),
     ));
     await tester.pumpAndSettle();


### PR DESCRIPTION
Addresses part of https://github.com/flutter/devtools/issues/2025. Before, this was variable based on the longest frame time. This gives the chart a consistent scale.