### PR TITLE
Don't try to initialize if it isn't enabled

### DIFF
--- a/packages/devtools_app/lib/src/analytics/remote_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/remote_provider.dart
@@ -34,6 +34,7 @@ class _RemoteAnalyticsProvider implements AnalyticsProvider {
 
   @override
   void setUpAnalytics() {
+    if (!_isGtagsEnabled) return;
     analytics.initializeGA();
     analytics.jsHookupListenerForGA();
   }


### PR DESCRIPTION
Our internal infrastructure always calls `setUpAnalytics` which can cause issues during development. Properly handle when the GTAGs are not enabled.