### PR TITLE
add text to the Snapshot button

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -460,11 +460,11 @@ class HeapTreeViewState extends State<HeapTree>
     return Row(
       children: [
         Tooltip(
-          message: 'Snapshot',
+          message: 'Take snapshot',
           child: OutlineButton(
             key: snapshotButtonKey,
             onPressed: _isSnapshotRunning ? null : _snapshot,
-            child: createIcon(Icons.camera),
+            child: const MaterialIconLabel(Icons.camera, 'Snapshot'),
           ),
         ),
         const SizedBox(width: defaultSpacing),
@@ -538,7 +538,8 @@ class HeapTreeViewState extends State<HeapTree>
                   child: createIcon(Icons.vertical_align_bottom),
                 ),
               ),
-        const SizedBox(width: defaultSpacing),
+
+        if (!controller.showTreemap.value) const SizedBox(width: defaultSpacing),
 
         Tooltip(
           message: 'Monitor Allocations',

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -484,63 +484,56 @@ class HeapTreeViewState extends State<HeapTree>
             ),
           ],
         ),
-        const SizedBox(width: defaultSpacing),
-        controller.showTreemap.value
-            ? const SizedBox()
-            : _groupByDropdown(textTheme),
-        const SizedBox(width: defaultSpacing),
-        // TODO(terry): Mechanism to handle expand/collapse on both
-        // tables objects/fields. Maybe notion in table?
-        controller.showTreemap.value
-            ? const SizedBox()
-            : Tooltip(
-                message: 'Collapse All',
-                child: OutlineButton(
-                  key: collapseAllButtonKey,
-                  onPressed: snapshotDisplay is MemorySnapshotTable
-                      ? () {
-                          if (snapshotDisplay is MemorySnapshotTable) {
-                            controller.groupByTreeTable.dataRoots
-                                .every((element) {
-                              element.collapseCascading();
-                              return true;
-                            });
-                            if (controller.instanceFieldsTreeTable != null) {
-                              // We're collapsing close the fields table.
-                              controller.selectedLeaf = null;
-                            }
-                            // All nodes collapsed - signal tree state changed.
-                            controller.treeChanged();
-                          }
+        if (!controller.showTreemap.value) ...[
+          const SizedBox(width: defaultSpacing),
+          _groupByDropdown(textTheme),
+          const SizedBox(width: defaultSpacing),
+          // TODO(terry): Mechanism to handle expand/collapse on both tables
+          // objects/fields. Maybe notion in table?
+          Tooltip(
+            message: 'Collapse All',
+            child: OutlineButton(
+              key: collapseAllButtonKey,
+              onPressed: snapshotDisplay is MemorySnapshotTable
+                  ? () {
+                      if (snapshotDisplay is MemorySnapshotTable) {
+                        controller.groupByTreeTable.dataRoots.every((element) {
+                          element.collapseCascading();
+                          return true;
+                        });
+                        if (controller.instanceFieldsTreeTable != null) {
+                          // We're collapsing close the fields table.
+                          controller.selectedLeaf = null;
                         }
-                      : null,
-                  child: createIcon(Icons.vertical_align_top),
-                )),
-        controller.showTreemap.value
-            ? const SizedBox()
-            : Tooltip(
-                message: 'Expand All',
-                child: OutlineButton(
-                  key: expandAllButtonKey,
-                  onPressed: snapshotDisplay is MemorySnapshotTable
-                      ? () {
-                          if (snapshotDisplay is MemorySnapshotTable) {
-                            controller.groupByTreeTable.dataRoots
-                                .every((element) {
-                              element.expandCascading();
-                              return true;
-                            });
-                          }
-                          // All nodes expanded - signal tree state  changed.
-                          controller.treeChanged();
-                        }
-                      : null,
-                  child: createIcon(Icons.vertical_align_bottom),
-                ),
-              ),
-
-        if (!controller.showTreemap.value) const SizedBox(width: defaultSpacing),
-
+                        // All nodes collapsed - signal tree state changed.
+                        controller.treeChanged();
+                      }
+                    }
+                  : null,
+              child: createIcon(Icons.vertical_align_top),
+            ),
+          ),
+          Tooltip(
+            message: 'Expand All',
+            child: OutlineButton(
+              key: expandAllButtonKey,
+              onPressed: snapshotDisplay is MemorySnapshotTable
+                  ? () {
+                      if (snapshotDisplay is MemorySnapshotTable) {
+                        controller.groupByTreeTable.dataRoots.every((element) {
+                          element.expandCascading();
+                          return true;
+                        });
+                      }
+                      // All nodes expanded - signal tree state  changed.
+                      controller.treeChanged();
+                    }
+                  : null,
+              child: createIcon(Icons.vertical_align_bottom),
+            ),
+          ),
+        ],
+        const SizedBox(width: defaultSpacing),
         Tooltip(
           message: 'Monitor Allocations',
           child: OutlineButton(


### PR DESCRIPTION
- add text to the Snapshot button
- don't indent the `Monitor Allocations` and `Reset Accumulators` buttons if there's nothing to their left

This is the primary thing that people need to interact with on this screen (at least initially); having text on it helps to emphasize it.

cc @terrylucas @jacob314 