### PR TITLE
fix a 'capacity' typo

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -355,7 +355,7 @@ class MemoryController extends DisposableController
     for (var arg in args) {
       memoryTimeline.dartChartData.addTraceEntries(
         rssValue: arg[MemoryTimeline.rssValueKey],
-        capacityValue: arg[MemoryTimeline.capcityValueKey],
+        capacityValue: arg[MemoryTimeline.capacityValueKey],
         usedValue: arg[MemoryTimeline.usedValueKey],
         externalValue: arg[MemoryTimeline.externalValueKey],
         rasterLayerValue: arg[MemoryTimeline.rasterLayerValueKey],

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -405,7 +405,7 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
   static const resetLegend = '${base}reset_glyph.png';
   static const gcManualLegend = '${base}gc_manual_glyph.png';
   static const gcVMLegend = '${base}gc_vm_glyph.png';
-  static const capcityLegend = '${base}capacity_glyph.png';
+  static const capacityLegend = '${base}capacity_glyph.png';
   static const usedLegend = '${base}used_glyph.png';
   static const externalLegend = '${base}external_glyph.png';
   static const rssLegend = '${base}rss_glyph.png';
@@ -517,7 +517,7 @@ class MemoryBodyState extends State<MemoryBody> with AutoDisposeMixin {
                   padding: const EdgeInsets.fromLTRB(5, 0, 0, 4),
                   child: Text('Memory Legend', style: legendHeading),
                 ),
-                legendRow(name1: 'Capcity', image1: capcityLegend),
+                legendRow(name1: 'Capacity', image1: capacityLegend),
                 legendRow(name1: 'Used', image1: usedLegend),
                 legendRow(name1: 'External', image1: externalLegend),
                 legendRow(name1: 'RSS', image1: rssLegend),

--- a/packages/devtools_app/lib/src/memory/memory_timeline.dart
+++ b/packages/devtools_app/lib/src/memory/memory_timeline.dart
@@ -30,7 +30,7 @@ class MemoryTimeline {
   static const version = 1;
 
   /// Keys used in a map to store all the MPChart Entries we construct to be plotted.
-  static const capcityValueKey = 'capacityValue';
+  static const capacityValueKey = 'capacityValue';
   static const usedValueKey = 'usedValue';
   static const externalValueKey = 'externalValue';
   static const rssValueKey = 'rssValue';
@@ -401,7 +401,7 @@ class MemoryTimeline {
       );
 
       final args = {
-        capcityValueKey: capacityEntry,
+        capacityValueKey: capacityEntry,
         usedValueKey: usedEntry,
         externalValueKey: extEntry,
         rssValueKey: rssEntry,


### PR DESCRIPTION
- fix a typo - change `capcity` to `capacity`
