### PR TITLE
move the existing memory page content into tabs

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
 import '../common_widgets.dart';
+import '../theme.dart';
 import '../trees.dart';
 import '../ui/colors.dart';
 import '../utils.dart';
@@ -514,17 +515,21 @@ class _TreemapState extends State<Treemap> {
 
   Widget buildBreadcrumbNavigator() {
     final pathFromRoot = widget.rootNode.pathFromRoot();
-    return BreadcrumbNavigator.builder(
-      itemCount: pathFromRoot.length,
-      builder: (context, index) {
-        final node = pathFromRoot[index];
-        return Breadcrumb(
-          text:
-              index < pathFromRoot.length - 1 ? node.name : node.displayText(),
-          isRoot: index == 0,
-          onPressed: () => widget.onRootChangedCallback(node),
-        );
-      },
+    return Padding(
+      padding: const EdgeInsets.only(bottom: denseRowSpacing),
+      child: BreadcrumbNavigator.builder(
+        itemCount: pathFromRoot.length,
+        builder: (context, index) {
+          final node = pathFromRoot[index];
+          return Breadcrumb(
+            text: index < pathFromRoot.length - 1
+                ? node.name
+                : node.displayText(),
+            isRoot: index == 0,
+            onPressed: () => widget.onRootChangedCallback(node),
+          );
+        },
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/config_specific/logger/logger.dart
+++ b/packages/devtools_app/lib/src/config_specific/logger/logger.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'logger_default.dart' if (dart.library.html) 'logger_html.dart';
+export 'logger_default.dart'
+    if (dart.library.html) 'logger_html.dart'
+    if (dart.library.io) 'logger_io.dart';
 
 enum LogLevel {
   debug,

--- a/packages/devtools_app/lib/src/config_specific/logger/logger_io.dart
+++ b/packages/devtools_app/lib/src/config_specific/logger/logger_io.dart
@@ -1,0 +1,18 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'logger.dart';
+
+void log(String message, [LogLevel level = LogLevel.debug]) {
+  switch (level) {
+    case LogLevel.debug:
+      print(message);
+      break;
+    case LogLevel.warning:
+      print('[WARNING]: $message');
+      break;
+    case LogLevel.error:
+      print('[ERROR]: $message');
+  }
+}

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -45,8 +45,7 @@ final String _memoryLogFilename =
 /// This class contains the business logic for [memory.dart].
 ///
 /// This class must not have direct dependencies on dart:html. This allows tests
-/// of the complicated logic in this class to run on the VM and will help
-/// simplify porting this code to work with Flutter Web.
+/// of the complicated logic in this class to run on the VM.
 class MemoryController extends DisposableController
     with
         AutoDisposeControllerMixin,
@@ -59,15 +58,7 @@ class MemoryController extends DisposableController
 
   static const logFilenamePrefix = 'memory_log_';
 
-  final _showTreemap = ValueNotifier<bool>(false);
-
-  ValueListenable<bool> get showTreemap => _showTreemap;
-
-  void toggleShowTreemap(bool value) {
-    _showTreemap.value = value;
-  }
-
-  final snapshots = <Snapshot>[];
+  final List<Snapshot> snapshots = [];
 
   Snapshot get lastSnapshot => snapshots.safeLast;
 
@@ -1135,11 +1126,16 @@ class MPChartData {
 
   /// Compute each dataset Entry's.
   List<Entry> get used => datasets[ChartDataSets.usedSet.index];
+
   List<Entry> get capacity => datasets[ChartDataSets.capacitySet.index];
+
   List<Entry> get externalHeap => datasets[ChartDataSets.externalHeapSet.index];
+
   List<Entry> get residentSetSize => datasets[ChartDataSets.rssSet.index];
+
   List<Entry> get rasterLayerSetSize =>
       datasets[ChartDataSets.rasterLayerSet.index];
+
   List<Entry> get rasterPictureSetSize =>
       datasets[ChartDataSets.rasterPictureSet.index];
 
@@ -1218,13 +1214,20 @@ class MPEventsChartData {
 
   /// Compute each dataset Entry's.
   List<Entry> get ghosts => datasets[EventDataSets.ghostsSet.index];
+
   List<Entry> get gcUser => datasets[EventDataSets.gcUserSet.index];
+
   List<Entry> get gcVm => datasets[EventDataSets.gcVmSet.index];
+
   List<Entry> get snapshot => datasets[EventDataSets.snapshotSet.index];
+
   List<Entry> get snapshotAuto => datasets[EventDataSets.snapshotAutoSet.index];
+
   List<Entry> get monitorStart => datasets[EventDataSets.monitorStartSet.index];
+
   List<Entry> get monitorContinues =>
       datasets[EventDataSets.monitorContinuesSet.index];
+
   List<Entry> get monitorReset => datasets[EventDataSets.monitorResetSet.index];
 
   /// Add each entry to its corresponding trace.
@@ -1304,18 +1307,25 @@ class MPEngineChartData {
 
   // Datapoint entries for each Java heap value.
   List<Entry> get javaHeap => datasets[ADBDataSets.javaHeapSet.index];
+
   // Datapoint entries for each native heap value.
   List<Entry> get nativeHeap => datasets[ADBDataSets.nativeHeapSet.index];
+
   // Datapoint entries for code size value.
   List<Entry> get code => datasets[ADBDataSets.codeSet.index];
+
   // Datapoint entries for stack size value.
   List<Entry> get stack => datasets[ADBDataSets.stackSet.index];
+
   // Datapoint entries for graphics size value.
   List<Entry> get graphics => datasets[ADBDataSets.graphicsSet.index];
+
   // Datapoint entries for other size value.
   List<Entry> get other => datasets[ADBDataSets.otherSet.index];
+
   // Datapoint entries for system size value.
   List<Entry> get system => datasets[ADBDataSets.systemSet.index];
+
   // Datapoint entries for total size value.
   List<Entry> get total => datasets[ADBDataSets.totalSet.index];
 

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -3,11 +3,9 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:math';
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:mp_chart/mp/core/entry/entry.dart';

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -360,24 +360,26 @@ class HeapTreeViewState extends State<HeapTree>
       snapshotDisplay = const SizedBox();
     }
 
-    return Column(
-      children: [
-        const SizedBox(height: denseRowSpacing),
-        Row(
-          children: [
-            _buildSnapshotControls(textTheme),
-            const Expanded(child: SizedBox(width: defaultSpacing)),
-            // TODO(peterdjlee): Implement filter and search functionality for treemap.
-            _buildSearchFilterControls(),
-          ],
-        ),
-        const SizedBox(height: denseRowSpacing),
-        Expanded(
-          child: OutlineDecoration(
-            child: buildSnapshotTables(snapshotDisplay),
+    return Padding(
+      padding: const EdgeInsets.only(top: denseRowSpacing),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              _buildSnapshotControls(textTheme),
+              const Expanded(child: SizedBox(width: defaultSpacing)),
+              // TODO(peterdjlee): Implement filter and search functionality for treemap.
+              _buildSearchFilterControls(),
+            ],
           ),
-        ),
-      ],
+          const SizedBox(height: denseRowSpacing),
+          Expanded(
+            child: OutlineDecoration(
+              child: buildSnapshotTables(snapshotDisplay),
+            ),
+          ),
+        ],
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -27,7 +27,6 @@ import 'memory_graph_model.dart';
 import 'memory_instance_tree_view.dart';
 import 'memory_protocol.dart';
 import 'memory_snapshot_models.dart';
-import 'memory_treemap.dart';
 
 final memorySearchFieldKey = GlobalKey(debugLabel: 'MemorySearchFieldKey');
 
@@ -172,6 +171,7 @@ class HeapTreeViewState extends State<HeapTree>
 
     final newController = Provider.of<MemoryController>(context);
     if (newController == controller) return;
+
     controller = newController;
 
     cancel();
@@ -307,7 +307,7 @@ class HeapTreeViewState extends State<HeapTree>
       // TODO(terry): Should get the real sum of the snapshot not the current memory.
       //              Snapshot can take a bit and could be a lag.
       lastSnapshotMemoryTotal = heapSum;
-      _snapshot(userGenerated: false);
+      _takeHeapSnapshot(userGenerated: false);
     } else if (heapMovingAverage.isDipping()) {
       // Reset the two things we're tracking spikes and RSS exceeded.
       heapMovingAverage.clear();
@@ -354,23 +354,21 @@ class HeapTreeViewState extends State<HeapTree>
       );
     } else if (controller.snapshotByLibraryData != null ||
         controller.monitorAllocations.isNotEmpty) {
-      if (controller.showTreemap.value) {
-        snapshotDisplay = MemoryTreemap(controller);
-      } else {
-        snapshotDisplay = MemorySnapshotTable();
-      }
+      snapshotDisplay = MemoryHeapTable();
     } else {
+      // TODO: Have some help text about how to take a snapshot.
       snapshotDisplay = const SizedBox();
     }
 
     return Column(
       children: [
+        const SizedBox(height: denseRowSpacing),
         Row(
           children: [
             _buildSnapshotControls(textTheme),
             const Expanded(child: SizedBox(width: defaultSpacing)),
             // TODO(peterdjlee): Implement filter and search functionality for treemap.
-            if (!controller.showTreemap.value) _buildSearchFilterControls(),
+            _buildSearchFilterControls(),
           ],
         ),
         const SizedBox(height: denseRowSpacing),
@@ -459,83 +457,67 @@ class HeapTreeViewState extends State<HeapTree>
   Widget _buildSnapshotControls(TextTheme textTheme) {
     return Row(
       children: [
-        Tooltip(
-          message: 'Take snapshot',
+        ActionButton(
+          tooltip: 'Take a memory profile snapshot',
           child: OutlineButton(
             key: snapshotButtonKey,
-            onPressed: _isSnapshotRunning ? null : _snapshot,
-            child: const MaterialIconLabel(Icons.camera, 'Snapshot'),
+            onPressed: _isSnapshotRunning ? null : _takeHeapSnapshot,
+            child: const MaterialIconLabel(
+              Icons.camera,
+              'Take Heap Snapshot',
+            ),
           ),
         ),
         const SizedBox(width: defaultSpacing),
-        Row(
-          children: [
-            const Text('Treemap'),
-            Switch(
-              value: controller.showTreemap.value,
-              onChanged: (value) {
-                setState(() {
-                  controller.closeAutoCompleteOverlay();
-                  controller.toggleShowTreemap(value);
-                  controller.resetSearch();
-                  controller.selectedLeaf = null;
-                });
-              },
-            ),
-          ],
-        ),
-        if (!controller.showTreemap.value) ...[
-          const SizedBox(width: defaultSpacing),
-          _groupByDropdown(textTheme),
-          const SizedBox(width: defaultSpacing),
-          // TODO(terry): Mechanism to handle expand/collapse on both tables
-          // objects/fields. Maybe notion in table?
-          Tooltip(
-            message: 'Collapse All',
-            child: OutlineButton(
-              key: collapseAllButtonKey,
-              onPressed: snapshotDisplay is MemorySnapshotTable
-                  ? () {
-                      if (snapshotDisplay is MemorySnapshotTable) {
-                        controller.groupByTreeTable.dataRoots.every((element) {
-                          element.collapseCascading();
-                          return true;
-                        });
-                        if (controller.instanceFieldsTreeTable != null) {
-                          // We're collapsing close the fields table.
-                          controller.selectedLeaf = null;
-                        }
-                        // All nodes collapsed - signal tree state changed.
-                        controller.treeChanged();
+        _groupByDropdown(textTheme),
+        const SizedBox(width: defaultSpacing),
+        // TODO(terry): Mechanism to handle expand/collapse on both tables
+        // objects/fields. Maybe notion in table?
+        ActionButton(
+          tooltip: 'Collapse All',
+          child: OutlineButton(
+            key: collapseAllButtonKey,
+            onPressed: snapshotDisplay is MemoryHeapTable
+                ? () {
+                    if (snapshotDisplay is MemoryHeapTable) {
+                      controller.groupByTreeTable.dataRoots.every((element) {
+                        element.collapseCascading();
+                        return true;
+                      });
+                      if (controller.instanceFieldsTreeTable != null) {
+                        // We're collapsing close the fields table.
+                        controller.selectedLeaf = null;
                       }
-                    }
-                  : null,
-              child: createIcon(Icons.vertical_align_top),
-            ),
-          ),
-          Tooltip(
-            message: 'Expand All',
-            child: OutlineButton(
-              key: expandAllButtonKey,
-              onPressed: snapshotDisplay is MemorySnapshotTable
-                  ? () {
-                      if (snapshotDisplay is MemorySnapshotTable) {
-                        controller.groupByTreeTable.dataRoots.every((element) {
-                          element.expandCascading();
-                          return true;
-                        });
-                      }
-                      // All nodes expanded - signal tree state  changed.
+                      // All nodes collapsed - signal tree state changed.
                       controller.treeChanged();
                     }
-                  : null,
-              child: createIcon(Icons.vertical_align_bottom),
-            ),
+                  }
+                : null,
+            child: createIcon(Icons.vertical_align_top),
           ),
-        ],
+        ),
+        ActionButton(
+          tooltip: 'Expand All',
+          child: OutlineButton(
+            key: expandAllButtonKey,
+            onPressed: snapshotDisplay is MemoryHeapTable
+                ? () {
+                    if (snapshotDisplay is MemoryHeapTable) {
+                      controller.groupByTreeTable.dataRoots.every((element) {
+                        element.expandCascading();
+                        return true;
+                      });
+                    }
+                    // All nodes expanded - signal tree state  changed.
+                    controller.treeChanged();
+                  }
+                : null,
+            child: createIcon(Icons.vertical_align_bottom),
+          ),
+        ),
         const SizedBox(width: defaultSpacing),
-        Tooltip(
-          message: 'Monitor Allocations',
+        ActionButton(
+          tooltip: 'Monitor Allocations',
           child: OutlineButton(
             key: allocationMonitorKey,
             onPressed: () async {
@@ -548,8 +530,8 @@ class HeapTreeViewState extends State<HeapTree>
             ),
           ),
         ),
-        Tooltip(
-          message: 'Reset Accumulators',
+        ActionButton(
+          tooltip: 'Reset Accumulators',
           child: OutlineButton(
             key: allocationMonitorResetKey,
             onPressed: () async {
@@ -570,7 +552,8 @@ class HeapTreeViewState extends State<HeapTree>
   final _debugAllocationMonitoring = false;
 
   Future<void> _allocationStart() async {
-    // TODO(terry): Look at grouping by library or classes also filtering e.g., await controller.computeLibraries();
+    // TODO(terry): Look at grouping by library or classes also filtering e.g.,
+    // await controller.computeLibraries();
     controller.memoryTimeline.addMonitorStartEvent();
 
     final allocationtimestamp = DateTime.now();
@@ -656,7 +639,7 @@ class HeapTreeViewState extends State<HeapTree>
   /// Match, found,  select it and process via ValueNotifiers.
   void selectTheMatch(String foundName) {
     setState(() {
-      if (snapshotDisplay is MemorySnapshotTable) {
+      if (snapshotDisplay is MemoryHeapTable) {
         controller.groupByTreeTable.dataRoots.every((element) {
           element.collapseCascading();
           return true;
@@ -680,8 +663,7 @@ class HeapTreeViewState extends State<HeapTree>
             controller: controller,
             searchFieldKey: memorySearchFieldKey,
             searchFieldEnabled: controller.snapshots.isNotEmpty,
-            shouldRequestFocus:
-                controller.showTreemap.value && controller.snapshots.isNotEmpty,
+            shouldRequestFocus: controller.snapshots.isNotEmpty,
             onSelection: selectTheMatch,
           ),
         ),
@@ -707,7 +689,9 @@ class HeapTreeViewState extends State<HeapTree>
     );
   }
 
-  void _snapshot({userGenerated = true}) async {
+  // TODO: Much of the logic for _takeHeapSnapshot() might want to move into the
+  // controller.
+  void _takeHeapSnapshot({bool userGenerated = true}) async {
     // VmService not available (disconnected/crashed).
     if (serviceManager.service == null) return;
 
@@ -715,7 +699,7 @@ class HeapTreeViewState extends State<HeapTree>
     // is probably in progress.
     if (snapshotState != SnapshotStatus.none &&
         snapshotState != SnapshotStatus.done) {
-      debugLogger('Snapshop in progress - ignoring this request.');
+      debugLogger('Snapshot in progress - ignoring this request.');
       return;
     }
 
@@ -874,13 +858,13 @@ class HeapTreeViewState extends State<HeapTree>
 }
 
 /// Snapshot TreeTable
-class MemorySnapshotTable extends StatefulWidget {
+class MemoryHeapTable extends StatefulWidget {
   @override
-  MemorySnapshotTableState createState() => MemorySnapshotTableState();
+  MemoryHeapTableState createState() => MemoryHeapTableState();
 }
 
 /// A table of the Memory graph class top-down call tree.
-class MemorySnapshotTableState extends State<MemorySnapshotTable>
+class MemoryHeapTableState extends State<MemoryHeapTable>
     with AutoDisposeMixin {
   MemoryController controller;
 
@@ -1404,7 +1388,8 @@ class _ShallowSizeColumn extends ColumnData<Reference> {
 /*
     final total = dataObject.controller.snapshots.last.snapshotGraph.capacity;
     final percentage = (value / total) * 100;
-    final displayPercentage = percentage < .050 ? '<<1%' : '${NumberFormat.compact().format(percentage)}%';
+    final displayPercentage = percentage < .050 ? '<<1%'
+        : '${NumberFormat.compact().format(percentage)}%';
     print('$displayPercentage [${NumberFormat.compact().format(percentage)}%]');
 */
     if ((dataObject.isAnalysis ||

--- a/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
@@ -106,24 +106,20 @@ class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
       );
     }
 
-    return Column(
-      children: [
-        const SizedBox(height: denseRowSpacing),
-        Expanded(
-          child: LayoutBuilder(
-            builder: (context, constraints) {
-              return Treemap.fromRoot(
-                rootNode: root,
-                levelsVisible: 2,
-                isOutermostLevel: true,
-                width: constraints.maxWidth,
-                height: constraints.maxHeight,
-                onRootChangedCallback: _onRootChanged,
-              );
-            },
-          ),
-        ),
-      ],
+    return Padding(
+      padding: const EdgeInsets.only(top: denseRowSpacing),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return Treemap.fromRoot(
+            rootNode: root,
+            levelsVisible: 2,
+            isOutermostLevel: true,
+            width: constraints.maxWidth,
+            height: constraints.maxHeight,
+            onRootChangedCallback: _onRootChanged,
+          );
+        },
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
@@ -8,21 +8,23 @@ import 'package:provider/provider.dart';
 
 import '../auto_dispose_mixin.dart';
 import '../charts/treemap.dart';
-
+import '../common_widgets.dart';
+import '../theme.dart';
 import 'memory_controller.dart';
 import 'memory_graph_model.dart';
 
-class MemoryTreemap extends StatefulWidget {
-  const MemoryTreemap(this.controller);
+class MemoryHeapTreemap extends StatefulWidget {
+  const MemoryHeapTreemap(this.controller);
 
   final MemoryController controller;
 
   @override
-  MemoryTreemapState createState() => MemoryTreemapState(controller);
+  MemoryHeapTreemapState createState() => MemoryHeapTreemapState(controller);
 }
 
-class MemoryTreemapState extends State<MemoryTreemap> with AutoDisposeMixin {
-  MemoryTreemapState(this.controller);
+class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
+    with AutoDisposeMixin {
+  MemoryHeapTreemapState(this.controller);
 
   InstructionsSize sizes;
 
@@ -41,9 +43,10 @@ class MemoryTreemapState extends State<MemoryTreemap> with AutoDisposeMixin {
     // TODO(terry): Unable to short-circuit need to investigate why?
     controller = Provider.of<MemoryController>(context);
 
-    sizes = InstructionsSize.fromSnapshot(controller);
-
-    root = sizes.root;
+    if (controller.heapGraph != null) {
+      sizes = InstructionsSize.fromSnapshot(controller);
+      root = sizes.root;
+    }
 
     cancel();
 
@@ -90,22 +93,38 @@ class MemoryTreemapState extends State<MemoryTreemap> with AutoDisposeMixin {
 
   @override
   Widget build(BuildContext context) {
-    if (sizes != null) {
-      return LayoutBuilder(
-        builder: (context, constraints) {
-          return Treemap.fromRoot(
-            rootNode: root,
-            levelsVisible: 2,
-            isOutermostLevel: true,
-            width: constraints.maxWidth,
-            height: constraints.maxHeight,
-            onRootChangedCallback: _onRootChanged,
-          );
-        },
+    if (sizes == null) {
+      return Column(
+        children: [
+          const SizedBox(height: denseRowSpacing),
+          Expanded(
+            child: OutlineDecoration(
+              child: Row(children: const [SizedBox()]),
+            ),
+          ),
+        ],
       );
-    } else {
-      return const SizedBox();
     }
+
+    return Column(
+      children: [
+        const SizedBox(height: denseRowSpacing),
+        Expanded(
+          child: LayoutBuilder(
+            builder: (context, constraints) {
+              return Treemap.fromRoot(
+                rootNode: root,
+                levelsVisible: 2,
+                isOutermostLevel: true,
+                width: constraints.maxWidth,
+                height: constraints.maxHeight,
+                onRootChangedCallback: _onRootChanged,
+              );
+            },
+          ),
+        ),
+      ],
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -78,12 +78,9 @@ class MemoryScreen extends Screen {
 class MemoryBody extends StatefulWidget {
   const MemoryBody();
 
-  static const ValueKey dartHeapTabKey = ValueKey('Dart Heap');
-  static const ValueKey heapTreemapTabKey = ValueKey('Heap Treemap');
-
-  static final List<Tab> memoryTabs = [
-    Tab(text: dartHeapTabKey.value, key: dartHeapTabKey),
-    Tab(text: heapTreemapTabKey.value, key: heapTreemapTabKey),
+  static const List<Tab> memoryTabs = [
+    Tab(text: 'Dart Heap'),
+    Tab(text: 'Heap Treemap'),
   ];
 
   @override
@@ -94,9 +91,6 @@ class MemoryBodyState extends State<MemoryBody>
     with AutoDisposeMixin, SingleTickerProviderStateMixin {
   @visibleForTesting
   static const androidChartButtonKey = Key('Android Chart');
-
-  MemoryChart _memoryChart;
-  MemoryEventsPane _memoryEvents;
 
   MemoryController controller;
   TabController tabController;
@@ -165,10 +159,6 @@ class MemoryBodyState extends State<MemoryBody>
         ? MemoryScreen.memorySourceMenuItemPrefix
         : '';
 
-    _memoryEvents ??= MemoryEventsPane();
-    // TODO: Should this use ??= ?
-    _memoryChart = MemoryChart();
-
     return Column(
       children: [
         Row(
@@ -181,10 +171,10 @@ class MemoryBodyState extends State<MemoryBody>
         ),
         SizedBox(
           height: 50,
-          child: _memoryEvents,
+          child: MemoryEventsPane(),
         ),
         SizedBox(
-          child: _memoryChart,
+          child: MemoryChart(),
         ),
         const SizedBox(height: defaultSpacing),
         Row(

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -21,7 +21,7 @@ import 'memory_chart.dart';
 import 'memory_controller.dart';
 import 'memory_events_pane.dart';
 import 'memory_heap_tree_view.dart';
-//import 'memory_heap_treemap.dart';
+import 'memory_heap_treemap.dart';
 
 /// Width of application when memory buttons loose their text.
 const _primaryControlsMinVerboseWidth = 1100.0;
@@ -80,7 +80,7 @@ class MemoryBody extends StatefulWidget {
 
   static const List<Tab> memoryTabs = [
     Tab(text: 'Dart Heap'),
-    //Tab(text: 'Heap Treemap'),
+    Tab(text: 'Heap Treemap'),
   ];
 
   @override
@@ -195,7 +195,7 @@ class MemoryBodyState extends State<MemoryBody>
             controller: tabController,
             children: [
               HeapTree(controller),
-              //MemoryHeapTreemap(controller),
+              MemoryHeapTreemap(controller),
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -21,7 +21,7 @@ import 'memory_chart.dart';
 import 'memory_controller.dart';
 import 'memory_events_pane.dart';
 import 'memory_heap_tree_view.dart';
-import 'memory_heap_treemap.dart';
+//import 'memory_heap_treemap.dart';
 
 /// Width of application when memory buttons loose their text.
 const _primaryControlsMinVerboseWidth = 1100.0;
@@ -80,7 +80,7 @@ class MemoryBody extends StatefulWidget {
 
   static const List<Tab> memoryTabs = [
     Tab(text: 'Dart Heap'),
-    Tab(text: 'Heap Treemap'),
+    //Tab(text: 'Heap Treemap'),
   ];
 
   @override
@@ -195,7 +195,7 @@ class MemoryBodyState extends State<MemoryBody>
             controller: tabController,
             children: [
               HeapTree(controller),
-              MemoryHeapTreemap(controller),
+              //MemoryHeapTreemap(controller),
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/memory/memory_timeline.dart
+++ b/packages/devtools_app/lib/src/memory/memory_timeline.dart
@@ -7,7 +7,6 @@ import 'dart:ui' as dart_ui;
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:mp_chart/mp/core/entry/entry.dart';
 
@@ -222,6 +221,7 @@ class MemoryTimeline {
   }
 
   /// dart_ui.Image Image asset displayed for each entry plotted in a chart.
+  // TODO: Resolve this unused field.
   // ignore: unused_field
   dart_ui.Image _img;
 


### PR DESCRIPTION
- move the existing memory page content into tabs (`Dart Heap` and `Heap treemap`)
- fix https://github.com/flutter/devtools/issues/2444
- some minor changes to use `ActionButton` in places - it gives us consistent tooltip delay behavior

<img width="1402" alt="Screen Shot 2020-10-22 at 2 31 59 PM" src="https://user-images.githubusercontent.com/1269969/96932460-c7c05f80-1473-11eb-9c92-2367f809c421.png">

<img width="1399" alt="Screen Shot 2020-10-22 at 2 32 12 PM" src="https://user-images.githubusercontent.com/1269969/96932489-d3138b00-1473-11eb-97e5-4c415e016490.png">

I'm having some trouble with ~4 of the service extension tests - not sure how those failures are related to the changes in this PR.
