### PR TITLE
Remove max zoom level bound for flame charts

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -47,7 +47,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
   });
 
   static const minZoomLevel = 1.0;
-  static const maxZoomLevel = 1000000.0;
+  static const maxZoomLevel = double.infinity;
   static const zoomMultiplier = 0.01;
   static const minScrollOffset = 0.0;
   static const rowOffsetForBottomPadding = 1;

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -47,7 +47,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
   });
 
   static const minZoomLevel = 1.0;
-  static const maxZoomLevel = 32000.0;
+  static const maxZoomLevel = 1000000.0;
   static const zoomMultiplier = 0.01;
   static const minScrollOffset = 0.0;
   static const rowOffsetForBottomPadding = 1;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/2424. 

AnimationController's `upperBound` member defaults to 1.0 unless specified, so we need to specify an `upperBound` (`FlameChart.maxZoomLevel`). `AnimationController.unbounded(...)` defaults the `upperBound` member to `double.infinity`, so we are mimicking that behavior here.