### PR TITLE
Avoid throwing exceptions accessing the server when it is not available.

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/server/_server_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/server/_server_web.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+// TODO(jacobr): this should use package:http instead of dart:html.
 import 'dart:html';
 
 import 'package:devtools_shared/devtools_shared.dart';

--- a/packages/devtools_app/lib/src/survey.dart
+++ b/packages/devtools_app/lib/src/survey.dart
@@ -29,11 +29,11 @@ class SurveyService {
 
   Future<DevToolsSurvey> get activeSurvey async {
     _cachedSurvey ??= await _fetchSurveyContent();
-    if (_cachedSurvey != null) {
+    if (_cachedSurvey != null && server.isDevToolsServerAvailable) {
       await server.setActiveSurvey(_cachedSurvey.id);
     }
 
-    if (await _shouldShowSurvey()) {
+    if ( server.isDevToolsServerAvailable && await _shouldShowSurvey()) {
       return _cachedSurvey;
     }
     return null;

--- a/packages/devtools_app/lib/src/survey.dart
+++ b/packages/devtools_app/lib/src/survey.dart
@@ -28,12 +28,15 @@ class SurveyService {
   DevToolsSurvey _cachedSurvey;
 
   Future<DevToolsSurvey> get activeSurvey async {
+    // If the server is unavailable we don't need to do anything survey related.
+    if (!server.isDevToolsServerAvailable) return null;
+
     _cachedSurvey ??= await _fetchSurveyContent();
-    if (_cachedSurvey != null && server.isDevToolsServerAvailable) {
+    if (_cachedSurvey != null) {
       await server.setActiveSurvey(_cachedSurvey.id);
     }
 
-    if ( server.isDevToolsServerAvailable && await _shouldShowSurvey()) {
+    if (await _shouldShowSurvey()) {
       return _cachedSurvey;
     }
     return null;


### PR DESCRIPTION
These exceptions occur every time the app starts up making it annoying to run the app while breaking on exceptions.