### PR TITLE
Use font size from IDE in theme (WIP)

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -250,7 +250,7 @@ class DevToolsAppState extends State<DevToolsApp> {
         return MaterialApp(
           title: 'Dart DevTools',
           debugShowCheckedModeBanner: false,
-          theme: themeFor(isDarkTheme: value, ideTheme: ideTheme, context: context),
+          theme: themeFor(isDarkTheme: value, ideTheme: ideTheme, theme: Theme.of(context)),
           builder: (context, child) => Notifications(child: child),
           onGenerateRoute: _generateRoute,
         );

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -250,7 +250,7 @@ class DevToolsAppState extends State<DevToolsApp> {
         return MaterialApp(
           title: 'Dart DevTools',
           debugShowCheckedModeBanner: false,
-          theme: themeFor(isDarkTheme: value, ideTheme: ideTheme),
+          theme: themeFor(isDarkTheme: value, ideTheme: ideTheme, context: context),
           builder: (context, child) => Notifications(child: child),
           onGenerateRoute: _generateRoute,
         );

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -28,7 +28,7 @@ class CodeView extends StatefulWidget {
     this.onSelected,
   }) : super(key: key);
 
-  static const rowHeight = 20.0;
+  static double get rowHeight => 20.0 * fontSizeFactorFromTheme();
   static const assumedCharacterWidth = 16.0;
 
   final DebuggerController controller;

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -29,7 +29,7 @@ class CodeView extends StatefulWidget {
   }) : super(key: key);
 
   static double get rowHeight => 20.0 * fontSizeFactorFromTheme();
-  static const assumedCharacterWidth = 16.0;
+  static double get assumedCharacterWidth => 16.0 * fontSizeFactorFromTheme();
 
   final DebuggerController controller;
   final ScriptRef scriptRef;

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -44,6 +44,14 @@ const double iconPadding = 5.0;
 const double chartLineStrokeWidth = 1.0;
 const double columnWidth = 16.0;
 
+double verticalPadding() {
+  return 10.0 * fontSizeFactorFromTheme();
+}
+
+double rowHeight() {
+  return 24.0 * fontSizeFactorFromTheme();
+}
+
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector
 /// specific as that is the only case we care about.
@@ -456,7 +464,7 @@ abstract class InspectorTreeController {
   }
 
   double getRowY(int index) {
-    return rowHeightFromTheme() * index + verticalPaddingFromTheme();
+    return rowHeight() * index + verticalPadding();
   }
 
   void nodeChanged(InspectorTreeNode node) {
@@ -509,7 +517,7 @@ abstract class InspectorTreeController {
   int get numRows => root != null ? root.subtreeSize : 0;
 
   int getRowIndex(double y) =>
-      (y - verticalPaddingFromTheme()) ~/ rowHeightFromTheme();
+      (y - verticalPadding()) ~/ rowHeight();
 
   InspectorTreeRow getRowForNode(InspectorTreeNode node) {
     return getCachedRow(root.getRowIndex(node));
@@ -693,7 +701,7 @@ mixin InspectorTreeFixedRowHeightController on InspectorTreeController {
 
     if (targetRect == null || targetRect.isEmpty) return;
 
-    targetRect = targetRect.inflate(deltaFromTheme());
+    targetRect = targetRect.inflate(20.0 * fontSizeFactorFromTheme());
     scrollToRect(targetRect);
   }
 }

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -43,14 +43,8 @@ extension InspectorColorScheme on ColorScheme {
 const double iconPadding = 5.0;
 const double chartLineStrokeWidth = 1.0;
 const double columnWidth = 16.0;
-
-double verticalPadding() {
-  return 10.0 * fontSizeFactorFromTheme();
-}
-
-double rowHeight() {
-  return 24.0 * fontSizeFactorFromTheme();
-}
+double get verticalPadding => 10.0 * fontSizeFactorFromTheme();
+double get rowHeight => 24.0 * fontSizeFactorFromTheme();
 
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector
@@ -464,7 +458,7 @@ abstract class InspectorTreeController {
   }
 
   double getRowY(int index) {
-    return rowHeight() * index + verticalPadding();
+    return rowHeight * index + verticalPadding;
   }
 
   void nodeChanged(InspectorTreeNode node) {
@@ -517,7 +511,7 @@ abstract class InspectorTreeController {
   int get numRows => root != null ? root.subtreeSize : 0;
 
   int getRowIndex(double y) =>
-      (y - verticalPadding()) ~/ rowHeight();
+      (y - verticalPadding) ~/ rowHeight;
 
   InspectorTreeRow getRowForNode(InspectorTreeNode node) {
     return getCachedRow(root.getRowIndex(node));

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -16,6 +16,7 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import '../config_specific/logger/logger.dart';
+import '../theme.dart';
 import '../ui/theme.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service.dart';
@@ -42,8 +43,6 @@ extension InspectorColorScheme on ColorScheme {
 const double iconPadding = 5.0;
 const double chartLineStrokeWidth = 1.0;
 const double columnWidth = 16.0;
-const double verticalPadding = 10.0;
-const double rowHeight = 24.0;
 
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector
@@ -457,7 +456,7 @@ abstract class InspectorTreeController {
   }
 
   double getRowY(int index) {
-    return rowHeight * index + verticalPadding;
+    return rowHeightFromTheme() * index + verticalPaddingFromTheme();
   }
 
   void nodeChanged(InspectorTreeNode node) {
@@ -509,7 +508,8 @@ abstract class InspectorTreeController {
 
   int get numRows => root != null ? root.subtreeSize : 0;
 
-  int getRowIndex(double y) => (y - verticalPadding) ~/ rowHeight;
+  int getRowIndex(double y) =>
+      (y - verticalPaddingFromTheme()) ~/ rowHeightFromTheme();
 
   InspectorTreeRow getRowForNode(InspectorTreeNode node) {
     return getCachedRow(root.getRowIndex(node));
@@ -693,7 +693,7 @@ mixin InspectorTreeFixedRowHeightController on InspectorTreeController {
 
     if (targetRect == null || targetRect.isEmpty) return;
 
-    targetRect = targetRect.inflate(20.0);
+    targetRect = targetRect.inflate(deltaFromTheme());
     scrollToRect(targetRect);
   }
 }

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
@@ -42,7 +42,7 @@ class _InspectorTreeRowState extends State<_InspectorTreeRowWidget>
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: rowHeightFromTheme(),
+      height: rowHeight(),
       child: InspectorRowContent(
         row: widget.row,
         expandArrowAnimation: expandArrowAnimation,
@@ -103,7 +103,7 @@ class InspectorTreeControllerFlutter extends Object
       getDepthIndent(row.depth),
       getRowY(row.index),
       rowWidth,
-      rowHeightFromTheme(),
+      rowHeight(),
     );
   }
 
@@ -400,7 +400,7 @@ class _InspectorTreeState extends State<InspectorTree>
                 autofocus: widget.isSummaryTree,
                 focusNode: _focusNode,
                 child: ListView.custom(
-                  itemExtent: rowHeightFromTheme(),
+                  itemExtent: rowHeight(),
                   childrenDelegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final InspectorTreeRow row =
@@ -463,7 +463,7 @@ class _RowPainter extends CustomPainter {
       // an ancestor of this node and some other node in the tree.
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeightFromTheme()),
+        Offset(currentX, rowHeight()),
         paint,
       );
     }
@@ -474,12 +474,12 @@ class _RowPainter extends CustomPainter {
       final double width = showExpandCollapse ? columnWidth * 0.5 : columnWidth;
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeightFromTheme() * 0.5),
+        Offset(currentX, rowHeight() * 0.5),
         paint,
       );
       canvas.drawLine(
-        Offset(currentX, rowHeightFromTheme() * 0.5),
-        Offset(currentX + width, rowHeightFromTheme() * 0.5),
+        Offset(currentX, rowHeight() * 0.5),
+        Offset(currentX + width, rowHeight() * 0.5),
         paint,
       );
     }
@@ -535,7 +535,7 @@ class InspectorRowContent extends StatelessWidget {
     final node = row.node;
     return CustomPaint(
       painter: _RowPainter(row, controller, colorScheme),
-      size: Size(currentX, rowHeightFromTheme()),
+      size: Size(currentX, rowHeight()),
       child: Padding(
         padding: EdgeInsets.only(left: currentX),
         child: ClipRect(
@@ -568,7 +568,7 @@ class InspectorRowContent extends StatelessWidget {
                     controller.requestFocus();
                   },
                   child: Container(
-                    height: rowHeightFromTheme(),
+                    height: rowHeight(),
                     padding: const EdgeInsets.symmetric(horizontal: 4.0),
                     child: DiagnosticsNodeDescription(node.diagnostic),
                   ),

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
@@ -42,7 +42,7 @@ class _InspectorTreeRowState extends State<_InspectorTreeRowWidget>
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: rowHeight(),
+      height: rowHeight,
       child: InspectorRowContent(
         row: widget.row,
         expandArrowAnimation: expandArrowAnimation,
@@ -103,7 +103,7 @@ class InspectorTreeControllerFlutter extends Object
       getDepthIndent(row.depth),
       getRowY(row.index),
       rowWidth,
-      rowHeight(),
+      rowHeight,
     );
   }
 
@@ -400,7 +400,7 @@ class _InspectorTreeState extends State<InspectorTree>
                 autofocus: widget.isSummaryTree,
                 focusNode: _focusNode,
                 child: ListView.custom(
-                  itemExtent: rowHeight(),
+                  itemExtent: rowHeight,
                   childrenDelegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final InspectorTreeRow row =
@@ -463,7 +463,7 @@ class _RowPainter extends CustomPainter {
       // an ancestor of this node and some other node in the tree.
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeight()),
+        Offset(currentX, rowHeight),
         paint,
       );
     }
@@ -474,12 +474,12 @@ class _RowPainter extends CustomPainter {
       final double width = showExpandCollapse ? columnWidth * 0.5 : columnWidth;
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeight() * 0.5),
+        Offset(currentX, rowHeight * 0.5),
         paint,
       );
       canvas.drawLine(
-        Offset(currentX, rowHeight() * 0.5),
-        Offset(currentX + width, rowHeight() * 0.5),
+        Offset(currentX, rowHeight * 0.5),
+        Offset(currentX + width, rowHeight * 0.5),
         paint,
       );
     }
@@ -535,7 +535,7 @@ class InspectorRowContent extends StatelessWidget {
     final node = row.node;
     return CustomPaint(
       painter: _RowPainter(row, controller, colorScheme),
-      size: Size(currentX, rowHeight()),
+      size: Size(currentX, rowHeight),
       child: Padding(
         padding: EdgeInsets.only(left: currentX),
         child: ClipRect(
@@ -568,7 +568,7 @@ class InspectorRowContent extends StatelessWidget {
                     controller.requestFocus();
                   },
                   child: Container(
-                    height: rowHeight(),
+                    height: rowHeight,
                     padding: const EdgeInsets.symmetric(horizontal: 4.0),
                     child: DiagnosticsNodeDescription(node.diagnostic),
                   ),

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
@@ -42,7 +42,7 @@ class _InspectorTreeRowState extends State<_InspectorTreeRowWidget>
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: rowHeight,
+      height: rowHeightFromTheme(),
       child: InspectorRowContent(
         row: widget.row,
         expandArrowAnimation: expandArrowAnimation,
@@ -103,7 +103,7 @@ class InspectorTreeControllerFlutter extends Object
       getDepthIndent(row.depth),
       getRowY(row.index),
       rowWidth,
-      rowHeight,
+      rowHeightFromTheme(),
     );
   }
 
@@ -400,7 +400,7 @@ class _InspectorTreeState extends State<InspectorTree>
                 autofocus: widget.isSummaryTree,
                 focusNode: _focusNode,
                 child: ListView.custom(
-                  itemExtent: rowHeight,
+                  itemExtent: rowHeightFromTheme(),
                   childrenDelegate: SliverChildBuilderDelegate(
                     (context, index) {
                       final InspectorTreeRow row =
@@ -463,7 +463,7 @@ class _RowPainter extends CustomPainter {
       // an ancestor of this node and some other node in the tree.
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeight),
+        Offset(currentX, rowHeightFromTheme()),
         paint,
       );
     }
@@ -474,12 +474,12 @@ class _RowPainter extends CustomPainter {
       final double width = showExpandCollapse ? columnWidth * 0.5 : columnWidth;
       canvas.drawLine(
         Offset(currentX, 0.0),
-        Offset(currentX, rowHeight * 0.5),
+        Offset(currentX, rowHeightFromTheme() * 0.5),
         paint,
       );
       canvas.drawLine(
-        Offset(currentX, rowHeight * 0.5),
-        Offset(currentX + width, rowHeight * 0.5),
+        Offset(currentX, rowHeightFromTheme() * 0.5),
+        Offset(currentX + width, rowHeightFromTheme() * 0.5),
         paint,
       );
     }
@@ -535,7 +535,7 @@ class InspectorRowContent extends StatelessWidget {
     final node = row.node;
     return CustomPaint(
       painter: _RowPainter(row, controller, colorScheme),
-      size: Size(currentX, rowHeight),
+      size: Size(currentX, rowHeightFromTheme()),
       child: Padding(
         padding: EdgeInsets.only(left: currentX),
         child: ClipRect(
@@ -568,7 +568,7 @@ class InspectorRowContent extends StatelessWidget {
                     controller.requestFocus();
                   },
                   child: Container(
-                    height: rowHeight,
+                    height: rowHeightFromTheme(),
                     padding: const EdgeInsets.symmetric(horizontal: 4.0),
                     child: DiagnosticsNodeDescription(node.diagnostic),
                   ),

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -12,16 +12,8 @@ import 'ui/theme.dart';
 const DEFAULT_FONT_SIZE = 14.0;
 var fontSizeFactor = 1.0;
 
-double rowHeightFromTheme() {
-  return fontSizeFactor * (DEFAULT_FONT_SIZE + 10.0);
-}
-
-double verticalPaddingFromTheme() {
-  return fontSizeFactor * 10.0;
-}
-
-double deltaFromTheme() {
-  return fontSizeFactor * 20.0;
+double fontSizeFactorFromTheme() {
+  return fontSizeFactor;
 }
 
 /// Constructs the light or dark theme for the app taking into account

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -9,20 +9,43 @@ import 'common_widgets.dart';
 import 'config_specific/ide_theme/ide_theme.dart';
 import 'ui/theme.dart';
 
+const DEFAULT_FONT_SIZE = 14.0;
+
 /// Constructs the light or dark theme for the app taking into account
 /// IDE-supplied theming.
 ThemeData themeFor({
   @required bool isDarkTheme,
   @required IdeTheme ideTheme,
+  BuildContext context,
 }) {
+  ThemeData colorTheme;
   // If the theme specifies a background color, use it to infer a theme.
   if (isValidDarkColor(ideTheme?.backgroundColor)) {
-    return _darkTheme(ideTheme);
+    colorTheme = _darkTheme(ideTheme);
   } else if (isValidLightColor(ideTheme?.backgroundColor)) {
-    return _lightTheme(ideTheme);
+    colorTheme = _lightTheme(ideTheme);
+  } else {
+    colorTheme = isDarkTheme ? _darkTheme(ideTheme) : _lightTheme(ideTheme);
   }
 
-  return isDarkTheme ? _darkTheme(ideTheme) : _lightTheme(ideTheme);
+  final fontSizeFactor = ideTheme?.fontSize != null && context != null
+      ? ideTheme.fontSize / DEFAULT_FONT_SIZE
+      : 1.0;
+
+  return colorTheme.copyWith(
+    primaryTextTheme: Theme.of(context)
+        .primaryTextTheme
+        .merge(colorTheme.primaryTextTheme)
+        .apply(fontSizeFactor: fontSizeFactor),
+    textTheme: Theme.of(context)
+        .textTheme
+        .merge(colorTheme.textTheme)
+        .apply(fontSizeFactor: fontSizeFactor),
+    accentTextTheme: Theme.of(context)
+        .accentTextTheme
+        .merge(colorTheme.accentTextTheme)
+        .apply(fontSizeFactor: fontSizeFactor),
+  );
 }
 
 ThemeData _darkTheme(IdeTheme ideTheme) {

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -10,13 +10,26 @@ import 'config_specific/ide_theme/ide_theme.dart';
 import 'ui/theme.dart';
 
 const DEFAULT_FONT_SIZE = 14.0;
+var fontSizeFactor = 1.0;
+
+double rowHeightFromTheme() {
+  return fontSizeFactor * (DEFAULT_FONT_SIZE + 10.0);
+}
+
+double verticalPaddingFromTheme() {
+  return fontSizeFactor * 10.0;
+}
+
+double deltaFromTheme() {
+  return fontSizeFactor * 20.0;
+}
 
 /// Constructs the light or dark theme for the app taking into account
 /// IDE-supplied theming.
 ThemeData themeFor({
   @required bool isDarkTheme,
   @required IdeTheme ideTheme,
-  BuildContext context,
+  ThemeData theme,
 }) {
   ThemeData colorTheme;
   // If the theme specifies a background color, use it to infer a theme.
@@ -28,20 +41,20 @@ ThemeData themeFor({
     colorTheme = isDarkTheme ? _darkTheme(ideTheme) : _lightTheme(ideTheme);
   }
 
-  final fontSizeFactor = ideTheme?.fontSize != null && context != null
-      ? ideTheme.fontSize / DEFAULT_FONT_SIZE
-      : 1.0;
+  if (ideTheme?.fontSize != null && theme != null) {
+    fontSizeFactor = ideTheme.fontSize / DEFAULT_FONT_SIZE;
+  }
 
   return colorTheme.copyWith(
-    primaryTextTheme: Theme.of(context)
+    primaryTextTheme: theme
         .primaryTextTheme
         .merge(colorTheme.primaryTextTheme)
         .apply(fontSizeFactor: fontSizeFactor),
-    textTheme: Theme.of(context)
+    textTheme: theme
         .textTheme
         .merge(colorTheme.textTheme)
         .apply(fontSizeFactor: fontSizeFactor),
-    accentTextTheme: Theme.of(context)
+    accentTextTheme: theme
         .accentTextTheme
         .merge(colorTheme.accentTextTheme)
         .apply(fontSizeFactor: fontSizeFactor),


### PR DESCRIPTION
This passes font size from URL parameters and scales all text to the input size. I assumed based on https://api.flutter.dev/flutter/material/TextTheme-class.html that size 14 is default for body text, and visually it looks like if I pass in `?fontSize=14` things are unchanged. 

Examples:

`?fontSize=10`
![Screen Shot 2020-10-28 at 2 20 54 PM](https://user-images.githubusercontent.com/6379305/97501601-c4731b00-192e-11eb-8078-0fa8a0c7b56a.png)
![Screen Shot 2020-10-28 at 2 56 21 PM](https://user-images.githubusercontent.com/6379305/97501609-c89f3880-192e-11eb-9c8f-5f6a135103d1.png)

`?fontSize=20
![Screen Shot 2020-10-28 at 2 21 23 PM](https://user-images.githubusercontent.com/6379305/97501623-d3f26400-192e-11eb-89cd-839cb79e52eb.png)
![Screen Shot 2020-10-28 at 2 55 58 PM](https://user-images.githubusercontent.com/6379305/97501637-d8b71800-192e-11eb-8835-877d301c2b77.png)
