### PR TITLE
Remove Source column from cpu profiler for flutter apps

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
@@ -19,7 +19,9 @@ class CpuBottomUpTable extends StatelessWidget {
       TotalTimeColumn(),
       startingSortColumn,
       treeColumn,
-      SourceColumn(),
+      // TODO(kenz): add source column when
+      // https://github.com/dart-lang/sdk/issues/37553 is fixed.
+      // SourceColumn(),
     ]);
     return CpuBottomUpTable._(
       key,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../globals.dart';
 import '../table.dart';
 import '../table_data.dart';
 import '../utils.dart';
@@ -19,9 +20,9 @@ class CpuBottomUpTable extends StatelessWidget {
       TotalTimeColumn(),
       startingSortColumn,
       treeColumn,
-      // TODO(kenz): add source column when
+      // TODO(kenz): add source column for flutter apps once
       // https://github.com/dart-lang/sdk/issues/37553 is fixed.
-      // SourceColumn(),
+      if (serviceManager.connectedApp.isDartCliAppNow) SourceColumn(),
     ]);
     return CpuBottomUpTable._(
       key,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../globals.dart';
 import '../table.dart';
 import '../table_data.dart';
 import '../utils.dart';
@@ -19,9 +20,9 @@ class CpuCallTreeTable extends StatelessWidget {
       startingSortColumn,
       SelfTimeColumn(),
       treeColumn,
-      // TODO(kenz): add source column when
+      // TODO(kenz): add source column for flutter apps once
       // https://github.com/dart-lang/sdk/issues/37553 is fixed.
-      // SourceColumn(),
+      if (serviceManager.connectedApp.isDartCliAppNow) SourceColumn(),
     ]);
     return CpuCallTreeTable._(
       key,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
@@ -19,7 +19,9 @@ class CpuCallTreeTable extends StatelessWidget {
       startingSortColumn,
       SelfTimeColumn(),
       treeColumn,
-      SourceColumn(),
+      // TODO(kenz): add source column when
+      // https://github.com/dart-lang/sdk/issues/37553 is fixed.
+      // SourceColumn(),
     ]);
     return CpuCallTreeTable._(
       key,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
@@ -60,18 +60,8 @@ class TotalTimeColumn extends ColumnData<CpuStackFrame> {
 class MethodNameColumn extends TreeColumnData<CpuStackFrame> {
   MethodNameColumn() : super('Method');
 
-  static const maxMethodNameLength = 75;
-
   @override
   dynamic getValue(CpuStackFrame dataObject) => dataObject.name;
-
-  @override
-  String getDisplayValue(CpuStackFrame dataObject) {
-    if (dataObject.name.length > maxMethodNameLength) {
-      return dataObject.name.substring(0, maxMethodNameLength) + '...';
-    }
-    return dataObject.name;
-  }
 
   @override
   bool get supportsSorting => true;

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -635,6 +635,8 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   }
 }
 
+// TODO(kenz): https://github.com/flutter/devtools/issues/1522. The table code
+// needs to be refactored to support flexible column widths.
 class _Table<T> extends StatefulWidget {
   const _Table({
     Key key,
@@ -667,7 +669,7 @@ class _Table<T> extends StatefulWidget {
   final ValueListenable<T> activeSearchMatchNotifier;
 
   /// The width to assume for columns that don't specify a width.
-  static const defaultColumnWidth = 500.0;
+  static const defaultColumnWidth = 1000.0;
 
   @override
   _TableState<T> createState() => _TableState<T>();

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_transformer.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_bottom_up.dart';
@@ -9,22 +10,30 @@ import 'package:devtools_app/src/profiler/cpu_profile_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_call_tree.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_flame_chart.dart';
 import 'package:devtools_app/src/profiler/cpu_profiler.dart';
+import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
+import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() {
   CpuProfiler cpuProfiler;
   CpuProfileData cpuProfileData;
   CpuProfilerController controller;
+  FakeServiceManager fakeServiceManager;
 
   setUp(() async {
     final transformer = CpuProfileTransformer();
     controller = CpuProfilerController();
     cpuProfileData = CpuProfileData.parse(goldenCpuProfileDataJson);
     await transformer.processData(cpuProfileData);
+
+    fakeServiceManager = FakeServiceManager();
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
+    when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(true);
   });
 
   group('Cpu Profiler', () {

--- a/packages/devtools_app/test/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance_screen_test.dart
@@ -27,6 +27,7 @@ void main() {
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)
           .thenReturn(false);
+      when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const PerformanceScreen();
     });


### PR DESCRIPTION
We do not have stack frame source information in profile mode, and we recommend that users profile flutter apps in profile mode. Users have filed issues about the "missing" source information (see https://github.com/flutter/devtools/issues/2391), but we do not have this information to show (see https://github.com/dart-lang/sdk/issues/37553)