### PR TITLE
Updated to use intl 0.17.0-nullsafety.1

### DIFF
--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -19,7 +19,6 @@ dependencies:
   devtools_server: 0.9.3+4
   devtools_shared: 0.9.3+4
   http: ^0.12.0+1
-  intl: ^0.16.0
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -28,11 +28,11 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http: ^0.12.0+1
-  intl: ^0.16.0
+  intl: ^0.17.0-nullsafety.1
   js: ^0.6.1+1
   meta: ^1.1.0
   mime: ^0.9.7
-  mp_chart: ^0.3.0
+  mp_chart: ^0.3.1
   path: ^1.6.0
   pedantic: ^1.7.0
   provider: ^4.0.0

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.5
   devtools_shared: 0.9.3+4
-  intl: ^0.16.0
+  intl: ^0.17.0-nullsafety.1
   meta: ^1.1.0
   path: ^1.6.0
   sse: ^3.1.2


### PR DESCRIPTION
Update to mp_chart, that uses 0.17.0-nullsafety.1.
Updated our pubspec's that use intl to use 0.17.0-nullsafety.1 too.
Removed intl dependency in devtools pubspec - no intl usage in this code.