### PR TITLE
Restore socket profiling state after hot restart

### DIFF
--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -189,7 +189,7 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
   void _updatePollingState(bool recording) {
     if (recording) {
       _pollingTimer ??= Timer.periodic(
-        const Duration(milliseconds: 500),
+        const Duration(milliseconds: 2000),
         (_) => _networkService.refreshNetworkData(),
       );
     } else {

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -13,6 +13,7 @@ import '../globals.dart';
 import '../http/http_request_data.dart';
 import '../http/http_service.dart';
 import '../ui/search.dart';
+import '../utils.dart';
 import 'network_model.dart';
 import 'network_service.dart';
 
@@ -60,12 +61,6 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
   /// The last timestamp at which HTTP and Socket information was refreshed.
   int lastRefreshMicros = 0;
 
-  // TODO(jacobr): clear this flag on hot restart.
-  bool _recordingStateInitializedForIsolates = false;
-
-  // The number of active clients helps us track whether we should be polling
-  // or not.
-  int _countActiveClients = 0;
   Timer _pollingTimer;
 
   @visibleForTesting
@@ -191,22 +186,8 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
     refreshSearchMatches();
   }
 
-  Future<void> _toggleHttpTimelineRecording(bool state) async {
-    await HttpService.toggleHttpRequestLogging(state);
-    // Start polling once we've enabled logging.
-    updatePollingState(state);
-    _recordingNotifier.value = state;
-  }
-
-  Future<void> _toggleSocketProfiling(bool state) async {
-    await networkService.toggleSocketProfiling(state);
-    // Start polling once we've enabled socket profiling.
-    updatePollingState(state);
-    _recordingNotifier.value = state;
-  }
-
-  void updatePollingState(bool recording) {
-    if (recording && _countActiveClients > 0) {
+  void _updatePollingState(bool recording) {
+    if (recording) {
       _pollingTimer ??= Timer.periodic(
         const Duration(milliseconds: 500),
         (_) => _networkService.refreshNetworkData(),
@@ -217,16 +198,24 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
     }
   }
 
+  Future<void> startRecording() async {
+    await _startRecording(alreadyRecordingHttp: await recordingHttpTraffic());
+  }
+
   /// Enables network traffic recording on all isolates and starts polling for
   /// HTTP and Socket information.
   ///
   /// If `alreadyRecording` is true, the last refresh time will be assumed to
   /// be the beginning of the process (time 0).
-  Future<void> startRecording({
-    bool alreadyRecording = false,
+  Future<void> _startRecording({
+    bool alreadyRecordingHttp = false,
   }) async {
+    // Cancel existing polling timer before starting recording.
+    _updatePollingState(false);
+
     final timestamp = await _networkService.updateLastRefreshTime(
-        alreadyRecording: alreadyRecording);
+      alreadyRecordingHttp: alreadyRecordingHttp,
+    );
 
     // Determine the offset that we'll use to calculate the approximate
     // wall-time a request was made. This won't be 100% accurate, but it should
@@ -239,33 +228,40 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
     await allowedError(
         serviceManager.service.setVMTimelineFlags(['GC', 'Dart', 'Embedder']));
 
-    await _toggleHttpTimelineRecording(true);
-    await _toggleSocketProfiling(true);
+    // TODO(kenz): only call these if http logging and socket profiling are not
+    // already enabled. Listen to service manager streams for this info.
+    await Future.wait([
+      HttpService.toggleHttpRequestLogging(true),
+      networkService.toggleSocketProfiling(true),
+    ]);
+    togglePolling(true);
   }
 
-  /// Pauses the output of HTTP traffic to the timeline, as well as pauses any
-  /// socket profiling.
-  ///
-  /// May result in some incomplete timeline events.
-  Future<void> stopRecording() async {
-    await _toggleHttpTimelineRecording(false);
-    await _toggleSocketProfiling(false);
+  void stopRecording() {
+    togglePolling(false);
   }
 
-  /// Checks to see if HTTP requests are currently being output. If so, recording
-  /// is automatically started upon initialization.
-  Future<void> addClient() async {
-    _countActiveClients++;
-    if (!_recordingStateInitializedForIsolates) {
-      _recordingStateInitializedForIsolates = true;
-      await _networkService.initializeRecordingState();
-    }
-    updatePollingState(_recordingNotifier.value);
+  void togglePolling(bool state) {
+    // Do not toggle the vm recording state - just enable or disable polling.
+    _updatePollingState(state);
+    _recordingNotifier.value = state;
   }
 
-  void removeClient() {
-    _countActiveClients--;
-    updatePollingState(_recordingNotifier.value);
+  Future<bool> recordingHttpTraffic() async {
+    bool enabled = true;
+    await serviceManager.service.forEachIsolate(
+      (isolate) async {
+        final httpFuture =
+            serviceManager.service.httpEnableTimelineLogging(isolate.id);
+        // The above call won't complete immediately if the isolate is paused,
+        // so give up waiting after 500ms.
+        final state = await timeout(httpFuture, 500);
+        if (state == null || !state.enabled) {
+          enabled = false;
+        }
+      },
+    );
+    return enabled;
   }
 
   /// Clears the previously collected HTTP timeline events, clears the socket

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -189,6 +189,8 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
   void _updatePollingState(bool recording) {
     if (recording) {
       _pollingTimer ??= Timer.periodic(
+        // TODO(kenz): look into improving performance by caching more data.
+        // Polling less frequently helps performance.
         const Duration(milliseconds: 2000),
         (_) => _networkService.refreshNetworkData(),
       );

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -37,8 +37,6 @@ class NetworkScreen extends Screen {
 
   static const id = 'network';
 
-  static const recordingInstructionsKey = Key('Recording Instructions');
-
   @override
   Widget build(BuildContext context) => const NetworkScreenBody();
 

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -119,10 +119,8 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
     final newController = Provider.of<NetworkController>(context);
     if (newController == _networkController) return;
 
-    _networkController?.removeClient();
-
     _networkController = newController;
-    _networkController.addClient();
+    _networkController.startRecording();
 
     requests = _networkController.requests.value;
     addAutoDisposeListener(_networkController.requests, () {
@@ -146,7 +144,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   void dispose() {
-    _networkController?.removeClient();
+    _networkController?.stopRecording();
     super.dispose();
   }
 
@@ -157,17 +155,16 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
     final hasRequests = filteredRequests.isNotEmpty;
     return Row(
       children: [
-        RecordButton(
-          recording: recording,
-          labelOverride: 'Record network traffic',
+        PauseButton(
           includeTextWidth: includeTextWidth,
-          onPressed: _networkController.startRecording,
+          onPressed:
+              recording ? () => _networkController.togglePolling(false) : null,
         ),
         const SizedBox(width: denseSpacing),
-        StopRecordingButton(
-          recording: recording,
+        ResumeButton(
           includeTextWidth: includeTextWidth,
-          onPressed: _networkController.stopRecording,
+          onPressed:
+              recording ? null : () => _networkController.togglePolling(true),
         ),
         const SizedBox(width: denseSpacing),
         ClearButton(
@@ -201,33 +198,20 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
       valueListenable: _networkController.selectedRequest,
       builder: (context, selectedRequest, _) {
         return Expanded(
-          child: (!recording && filteredRequests.isEmpty)
-              ? Center(
-                  child: RecordingInfo(
-                    instructionsKey: NetworkScreen.recordingInstructionsKey,
-                    recording: recording,
-                    // TODO(kenz): create a processing notifier if necessary
-                    // for this data.
-                    processing: false,
-                    recordedObject: 'network traffic',
-                    isPause: true,
-                  ),
-                )
-              : Split(
-                  initialFractions: const [0.5, 0.5],
-                  minSizes: const [200, 200],
-                  axis: Axis.horizontal,
-                  children: [
-                    NetworkRequestsTable(
-                      networkController: _networkController,
-                      requests: filteredRequests,
-                      searchMatchesNotifier: _networkController.searchMatches,
-                      activeSearchMatchNotifier:
-                          _networkController.activeSearchMatch,
-                    ),
-                    NetworkRequestInspector(selectedRequest),
-                  ],
-                ),
+          child: Split(
+            initialFractions: const [0.5, 0.5],
+            minSizes: const [200, 200],
+            axis: Axis.horizontal,
+            children: [
+              NetworkRequestsTable(
+                networkController: _networkController,
+                requests: filteredRequests,
+                searchMatchesNotifier: _networkController.searchMatches,
+                activeSearchMatchNotifier: _networkController.activeSearchMatch,
+              ),
+              NetworkRequestInspector(selectedRequest),
+            ],
+          ),
         );
       },
     );

--- a/packages/devtools_app/lib/src/network/network_service.dart
+++ b/packages/devtools_app/lib/src/network/network_service.dart
@@ -15,17 +15,17 @@ class NetworkService {
 
   /// Updates the last refresh time to the current time.
   ///
-  /// If [alreadyRecording] is true it's unclear when the last refresh time
+  /// If [alreadyRecordingHttp] is true it's unclear when the last refresh time
   /// would have occurred, so the refresh time is not updated. Otherwise,
   /// [NetworkController.lastRefreshMicros] is updated to the current
   /// timeline timestamp.
   ///
   /// Returns the current timestamp.
-  Future<int> updateLastRefreshTime({bool alreadyRecording = false}) async {
+  Future<int> updateLastRefreshTime({bool alreadyRecordingHttp = false}) async {
     // Set the current timeline time as the time of the last refresh.
     final timestamp = await serviceManager.service.getVMTimelineMicros();
 
-    if (!alreadyRecording) {
+    if (!alreadyRecordingHttp) {
       // Only include HTTP requests issued after the current time.
       networkController.lastRefreshMicros = timestamp.timestamp;
     }
@@ -49,40 +49,6 @@ class NetworkService {
       timeline: timeline,
       sockets: sockets,
     );
-  }
-
-  /// Determines if HTTP logging is already enabled on at least one isolate and
-  /// updates the recording state accordingly.
-  ///
-  /// If at least one isolate is already logging, this method will enable logging
-  /// on all isolates and enable recording for [NetworkScreen].
-  Future<bool> initializeRecordingState() async {
-    assert(serviceManager.service != null);
-    if (serviceManager.service == null) return false;
-
-    // TODO(jacobr): this method does not properly handle isolates that are
-    // restarted.
-    // TODO(kenz): should we be checking if socket profiling has started? There is
-    // not currently a method we can call that returns this value.
-    bool enabled = false;
-    await serviceManager.service.forEachIsolate(
-      (isolate) async {
-        // TODO(bkonyi): perform VM service version check.
-        final httpFuture =
-            serviceManager.service.httpEnableTimelineLogging(isolate.id);
-        // The above call won't complete immediately if the isolate is paused,
-        // so give up waiting after 500ms.
-        final state = await timeout(httpFuture, 500);
-        if (state != null && state.enabled) {
-          enabled = true;
-        }
-      },
-    );
-
-    if (enabled) {
-      await networkController.startRecording(alreadyRecording: true);
-    }
-    return enabled;
   }
 
   Future<List<SocketStatistic>> _refreshSockets() async {
@@ -126,12 +92,8 @@ class NetworkService {
       final socketProfilingAvailable =
           await serviceManager.service.isSocketProfilingAvailable(isolate.id);
       if (socketProfilingAvailable) {
-        Future future;
-        if (state) {
-          future = serviceManager.service.startSocketProfiling(isolate.id);
-        } else {
-          future = serviceManager.service.pauseSocketProfiling(isolate.id);
-        }
+        final future =
+            serviceManager.service.socketProfilingEnabled(isolate.id, state);
         // The above call won't complete immediately if the isolate is paused, so
         // give up waiting after 500ms. However, the call will complete eventually
         // if the isolate is eventually resumed.

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -23,6 +23,7 @@ class ToggleableServiceExtensionDescription<T>
     @required String disabledTooltip,
     @required String gaScreenName,
     @required String gaItem,
+    bool shouldCallOnAllIsolates = false,
   }) : super(
           extension: extension,
           description: description,
@@ -31,6 +32,7 @@ class ToggleableServiceExtensionDescription<T>
           tooltips: [enabledTooltip, disabledTooltip],
           gaScreenName: gaScreenName,
           gaItem: gaItem,
+          shouldCallOnAllIsolates: shouldCallOnAllIsolates,
         );
 
   static const enabledValueIndex = 0;
@@ -56,6 +58,7 @@ class ServiceExtensionDescription<T> {
     @required this.tooltips,
     @required this.gaScreenName,
     @required this.gaItem,
+    this.shouldCallOnAllIsolates = false,
   }) : displayValues =
             displayValues ?? values.map((v) => v.toString()).toList();
 
@@ -74,6 +77,8 @@ class ServiceExtensionDescription<T> {
   final String gaScreenName; // Analytics screen (screen name where item lives).
 
   final String gaItem; // Analytics item name (toggleable item's name).
+
+  final bool shouldCallOnAllIsolates;
 }
 
 final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
@@ -186,6 +191,19 @@ final httpEnableTimelineLogging = ToggleableServiceExtensionDescription<bool>._(
   disabledTooltip: 'HTTP timeline logging disabled',
   gaScreenName: null,
   gaItem: null,
+  shouldCallOnAllIsolates: true,
+);
+
+final socketProfiling = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.dart.io.socketProfilingEnabled',
+  description: 'Whether socket profiling is enabled',
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'Socket profiling enabled',
+  disabledTooltip: 'Socket profiling disabled',
+  gaScreenName: null,
+  gaItem: null,
+  shouldCallOnAllIsolates: true,
 );
 
 // Legacy extension to show the inspector and enable inspector select mode.
@@ -266,6 +284,7 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   slowAnimations,
   structuredErrors,
   httpEnableTimelineLogging,
+  socketProfiling,
 ];
 
 final Map<String, ServiceExtensionDescription> serviceExtensionsAllowlist =

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -16,6 +16,7 @@ import 'package:vm_service/vm_service.dart';
 import '../support/chrome.dart';
 import '../support/cli_test_driver.dart';
 import '../support/devtools_server_driver.dart';
+import '../support/utils.dart';
 import 'integration.dart';
 
 CliAppFixture appFixture;
@@ -481,6 +482,9 @@ Future<Map<String, dynamic>> _waitForClients({
 
   await waitFor(
     () async {
+      // Await a short delay to give the client time to connect.
+      await delay();
+
       serverResponse = await _send('client.list');
       final clients = serverResponse['clients'];
       return clients is List &&
@@ -489,7 +493,7 @@ Future<Map<String, dynamic>> _waitForClients({
           (requiredConnectionState == null || clients.any(hasConnectionState));
     },
     timeoutMessage: timeoutMessage,
-    delay: const Duration(seconds: 10),
+    delay: const Duration(seconds: 1),
   );
 
   return serverResponse;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -489,7 +489,7 @@ Future<Map<String, dynamic>> _waitForClients({
           (requiredConnectionState == null || clients.any(hasConnectionState));
     },
     timeoutMessage: timeoutMessage,
-    delay: const Duration(seconds: 1),
+    delay: const Duration(seconds: 10),
   );
 
   return serverResponse;

--- a/packages/devtools_app/test/network_profiler_test.dart
+++ b/packages/devtools_app/test/network_profiler_test.dart
@@ -77,23 +77,22 @@ void main() {
       WidgetTester tester,
     ) async {
       controller = NetworkController();
-      await pumpNetworkScreen(tester);
 
       // Ensure we're not recording initially.
       expect(controller.isPolling, false);
       expect(controller.recordingNotifier.value, false);
 
-      // Start recording.
-      await tester.tap(find.byType(RecordButton));
-      await tester.pump();
+      await pumpNetworkScreen(tester);
+      await tester.pumpAndSettle();
 
       // Check that we're polling.
       expect(controller.isPolling, true);
       expect(controller.recordingNotifier.value, true);
 
-      // Stop recording.
-      await tester.tap(find.byType(StopRecordingButton));
-      await tester.pump();
+      // Pause recording.
+      expect(find.byType(PauseButton), findsOneWidget);
+      await tester.tap(find.byType(PauseButton));
+      await tester.pumpAndSettle();
 
       // Check that we've stopped polling.
       expect(controller.isPolling, false);
@@ -103,24 +102,10 @@ void main() {
     });
 
     Future<void> loadRequestsAndCheck(WidgetTester tester) async {
-      final splitFinder = find.byType(Split);
-
-      // We're not recording; only expect the instructions and buttons to be
-      // visible.
-      expect(splitFinder, findsNothing);
-      expect(find.byType(RecordButton), findsOneWidget);
-      expect(find.byType(StopRecordingButton), findsOneWidget);
+      expect(find.byType(ResumeButton), findsOneWidget);
+      expect(find.byType(PauseButton), findsOneWidget);
       expect(find.byType(ClearButton), findsOneWidget);
-      expect(
-        find.byKey(NetworkScreen.recordingInstructionsKey),
-        findsOneWidget,
-      );
-
-      // Start recording.
-      await tester.tap(find.byType(RecordButton));
-      await tester.pump();
-
-      expect(splitFinder, findsOneWidget);
+      expect(find.byType(Split), findsOneWidget);
 
       // Advance the clock to populate the network requests table.
       await tester.pump(const Duration(seconds: 1));
@@ -278,8 +263,8 @@ void main() {
         await validateOverviewTab(selection);
       }
 
-      // Stop recording.
-      await tester.tap(find.byType(StopRecordingButton));
+      // Pause recording.
+      await tester.tap(find.byType(PauseButton));
       await tester.pump();
 
       await clearTimeouts(tester);
@@ -294,23 +279,14 @@ void main() {
       // Populate the screen with requests.
       await loadRequestsAndCheck(tester);
 
-      // Stop the profiler.
-      await tester.tap(find.byType(StopRecordingButton));
+      // Pause the profiler.
+      await tester.tap(find.byType(PauseButton));
       await tester.pumpAndSettle();
 
       // Clear the results.
       await tester.tap(find.byType(ClearButton));
       // Wait to ensure all the timers have been cancelled.
       await tester.pumpAndSettle(const Duration(seconds: 2));
-
-      // Ensure that the recording instructions are displayed when no requests
-      // are displayed and recording is disabled.
-      expect(find.byType(PaginatedDataTable), findsNothing);
-      expect(find.byType(NetworkRequestInspector), findsNothing);
-      expect(
-        find.byKey(NetworkScreen.recordingInstructionsKey),
-        findsOneWidget,
-      );
     });
   });
 

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -147,6 +147,9 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   /// Specifies the return value of `httpEnableTimelineLogging`.
   bool httpEnableTimelineLoggingResult = true;
 
+  /// Specifies the return value of `socketProfilingEnabled`.
+  bool socketProfilingEnabledResult = true;
+
   final VmFlagManager _vmFlagManager;
   final Timeline _timelineData;
   SocketProfile _socketProfile;
@@ -295,13 +298,15 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   }
 
   @override
-  Future<Success> startSocketProfiling(String isolateId) {
-    return Future.value(Success());
-  }
-
-  @override
-  Future<Success> pauseSocketProfiling(String isolateId) {
-    return Future.value(Success());
+  Future<SocketProfilingState> socketProfilingEnabled(
+    String isolateId, [
+    bool enabled,
+  ]) {
+    if (enabled != null) {
+      return Future.value(SocketProfilingState(enabled: enabled));
+    }
+    return Future.value(
+        SocketProfilingState(enabled: socketProfilingEnabledResult));
   }
 
   @override
@@ -338,12 +343,13 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   @override
   Future<HttpTimelineLoggingState> httpEnableTimelineLogging(
     String isolateId, [
-    bool enable,
+    bool enabled,
   ]) async {
-    if (enable != null) {
-      return HttpTimelineLoggingState(enabled: enable);
+    if (enabled != null) {
+      return Future.value(HttpTimelineLoggingState(enabled: enabled));
     }
-    return HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult);
+    return Future.value(
+        HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult));
   }
 
   @override


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/1968

This CL also enables network recording by default once the network page is opened and changes the buttons from record/stop to pause/resume.