### PR TITLE
Add support for hide=debugger

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -166,13 +166,15 @@ class DevToolsAppState extends State<DevToolsApp> {
       page = params['page'];
     }
     final embed = params['embed'] == 'true';
+    final hide = {...?params['hide']?.split(',')};
     return Initializer(
       url: vmServiceUri,
       allowConnectionScreenOnDisconnect: !embed,
       builder: (_) {
-        final tabs = embed && page != null
-            ? _visibleScreens().where((p) => p.screenId == page).toList()
-            : _visibleScreens();
+        final tabs = _visibleScreens()
+            .where((p) => embed && page != null ? p.screenId == page : true)
+            .where((p) => !hide.contains(p.screenId))
+            .toList();
         if (tabs.isEmpty) {
           return DevToolsScaffold.withChild(
             child: CenteredMessage(

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -111,8 +111,8 @@ the following parameters.
   the query string that may influence DevTools behaviour, such as:
   - `theme` - allows using the `dark` theme
   - `ide` - the client (eg. `VSCode`) to be logged in analytics
-  - `hide` - IDs of pages to hide (eg. `debugger` when launching from an IDE
-    with its own debugger)
+  - `hide` - comma-separated list of IDs of pages to hide (eg. `debugger` when
+    launching from an IDE with its own debugger)
 
 #### Example
 

--- a/packages/devtools_server/docs/daemon.md
+++ b/packages/devtools_server/docs/daemon.md
@@ -125,7 +125,7 @@ the following parameters.
 		'notify': true,
 		'page': 'inspector',
 		'queryParams': {
-			'hide': 'debugger',
+			'hide': 'debugger,logging',
 			'ide': 'VSCode',
 			'theme': 'dark'
 		},


### PR DESCRIPTION
I think this was only in the HTML version before and lost in the migration to Flutter.

Fixes #2486.