### PR TITLE
Don't reuse embedded windows in launchDevTools

### DIFF
--- a/packages/devtools_app/lib/src/framework_controller.dart
+++ b/packages/devtools_app/lib/src/framework_controller.dart
@@ -23,7 +23,7 @@ class FrameworkController {
   final StreamController<Uri> _connectedController =
       StreamController.broadcast();
   final StreamController _disconnectedController = StreamController.broadcast();
-  final StreamController<String> _pageChangeController =
+  final StreamController<PageChangeEvent> _pageChangeController =
       StreamController.broadcast();
 
   /// Show the indicated page.
@@ -50,13 +50,11 @@ class FrameworkController {
   Stream<Uri> get onConnected => _connectedController.stream;
 
   /// Notifies when the current page changes.
-  ///
-  /// This notifies with the page ID.
-  Stream<String> get onPageChange => _pageChangeController.stream;
+  Stream<PageChangeEvent> get onPageChange => _pageChangeController.stream;
 
   /// Notify the controller that the current page has changed.
-  void notifyPageChange(String pageId) {
-    _pageChangeController.add(pageId);
+  void notifyPageChange(PageChangeEvent page) {
+    _pageChangeController.add(page);
   }
 
   /// Notifies when a device disconnects from DevTools.
@@ -78,4 +76,11 @@ class ConnectVmEvent {
 
   final Uri serviceProtocolUri;
   final bool notify;
+}
+
+class PageChangeEvent {
+  PageChangeEvent(this.id, this.embedded);
+
+  final String id;
+  final bool embedded;
 }

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -204,7 +204,9 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
 
         // Send the page change info to the framework controller (it can then
         // send it on to the devtools server, if one is connected).
-        frameworkController.notifyPageChange(screen?.screenId);
+        frameworkController.notifyPageChange(
+          PageChangeEvent(screen?.screenId, widget.embed),
+        );
 
         // If the tab index is 0 and the current route has no page ID (eg. we're
         // at the URL /?uri= with no page ID), those are equivalent pages but
@@ -222,7 +224,9 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     });
 
     // Broadcast the initial page.
-    frameworkController.notifyPageChange(_currentScreen.value.screenId);
+    frameworkController.notifyPageChange(
+      PageChangeEvent(_currentScreen.value.screenId, widget.embed),
+    );
   }
 
   /// Connects to the VM with the given URI. This request usually comes from the

--- a/packages/devtools_app/lib/src/server_api_client.dart
+++ b/packages/devtools_app/lib/src/server_api_client.dart
@@ -10,6 +10,7 @@ import 'package:http/http.dart' as http;
 import 'config_specific/logger/logger.dart';
 import 'config_specific/notifications/notifications.dart';
 import 'config_specific/sse/sse_shim.dart';
+import 'framework_controller.dart';
 import 'globals.dart';
 
 /// This class coordinates the connection between the DevTools server and the
@@ -72,8 +73,8 @@ class DevToolsServerConnection {
       _notifyConnected(vmServiceUri);
     });
 
-    frameworkController.onPageChange.listen((pageId) {
-      _notifyCurrentPage(pageId);
+    frameworkController.onPageChange.listen((page) {
+      _notifyCurrentPage(page);
     });
 
     frameworkController.onDisconnected.listen((_) {
@@ -162,8 +163,14 @@ class DevToolsServerConnection {
     _callMethod('connected', {'uri': vmServiceUri.toString()});
   }
 
-  void _notifyCurrentPage(String pageId) {
-    _callMethod('currentPage', {'id': pageId});
+  void _notifyCurrentPage(PageChangeEvent page) {
+    _callMethod(
+      'currentPage',
+      {
+        'id': page.id,
+        if (page.embedded != null) 'embedded': page.embedded,
+      },
+    );
   }
 
   void _notifyDisconnected() {

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -703,6 +703,7 @@ Future<void> _handleClientsList(
             .map((c) => {
                   'hasConnection': c.hasConnection,
                   'currentPage': c.currentPage,
+                  'embedded': c.embedded,
                   'vmServiceUri': c.vmServiceUri?.toString(),
                 })
             .toList()
@@ -719,7 +720,8 @@ Future<bool> _tryReuseExistingDevToolsInstance(
 ) async {
   // First try to find a client that's already connected to this VM service,
   // and just send the user a notification for that one.
-  final existingClient = clients.findExistingConnectedClient(vmServiceUri);
+  final existingClient =
+      clients.findExistingConnectedReusableClient(vmServiceUri);
   if (existingClient != null) {
     try {
       await existingClient.showPage(page);


### PR DESCRIPTION
By default, `launchDevTools` will try to reuse existing open DevTools instances when told to launch (and show a notification, or reconnect disconnected ones). Embedded windows should be entirely excluded from these, as their windows are managed entirely by the IDE and not launched by DevTools.

This updates the `changePage` call to also transmit a whether the page is embedded or not, and the server to ignore any embedded clients when looking for a client to reuse.

Fixes https://github.com/Dart-Code/Dart-Code/issues/2931.