### PR TITLE
Add search and filter to the logging page; refactor filter code

### DIFF
--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -165,12 +165,12 @@ class LoggingController
 
   static const kindFilterId = 'logging-kind-filter';
 
-  final _filterArgs = [
-    FilterArgument(id: kindFilterId, keys: ['kind', 'k']),
-  ];
+  final _filterArgs = {
+    kindFilterId: FilterArgument(keys: ['kind', 'k']),
+  };
 
   @override
-  List<FilterArgument> get filterArgs => _filterArgs;
+  Map<String, FilterArgument> get filterArgs => _filterArgs;
 
   /// Listen on a stream and track the stream subscription for automatic
   /// disposal if the dispose method is called.
@@ -634,25 +634,25 @@ class LoggingController
       filteredData.value = List.from(data);
     } else {
       filteredData.value = data.where((log) {
-        for (final arg in filter.filterArguments) {
-          if (arg.id == kindFilterId) {
-            if (!arg.matchesValue(log.kind.toLowerCase())) {
-              return false;
-            }
-          }
+        final kindArg = filter.filterArguments[kindFilterId];
+        if (kindArg != null && !kindArg.matchesValue(log.kind.toLowerCase())) {
+          return false;
         }
+
         if (filter.substrings.isNotEmpty) {
           for (final substring in filter.substrings) {
             final caseInsensitiveSubstring = substring.toLowerCase();
             final matchesKind = log.kind != null &&
                 log.kind.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesKind) return true;
+
             final matchesSummary = log.summary != null &&
                 log.summary.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesSummary) return true;
+
             final matchesDetails = log.details != null &&
                 log.summary.toLowerCase().contains(caseInsensitiveSubstring);
-            if (matchesKind || matchesSummary || matchesDetails) {
-              return true;
-            }
+            if (matchesDetails) return true;
           }
           return false;
         }

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -165,6 +165,13 @@ class LoggingController
 
   static const kindFilterId = 'logging-kind-filter';
 
+  final _filterArgs = [
+    FilterArgument(id: kindFilterId, keys: ['kind', 'k']),
+  ];
+
+  @override
+  List<FilterArgument> get filterArgs => _filterArgs;
+
   /// Listen on a stream and track the stream subscription for automatic
   /// disposal if the dispose method is called.
   StreamSubscription<T> _listen<T>(Stream<T> stream, void onData(T event)) {

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -12,12 +12,13 @@ import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart' as logger;
-import '../core/filtering.dart';
 import '../core/message_bus.dart';
 import '../globals.dart';
 import '../inspector/diagnostics_node.dart';
 import '../inspector/inspector_service.dart';
 import '../inspector/inspector_tree.dart';
+import '../ui/filter.dart';
+import '../ui/search.dart';
 import '../utils.dart';
 import '../vm_service_wrapper.dart';
 
@@ -151,7 +152,8 @@ class LoggingDetailsController {
   }
 }
 
-class LoggingController {
+class LoggingController
+    with SearchControllerMixin<LogData>, FilterControllerMixin<LogData> {
   LoggingController({this.inspectorService}) {
     _listen(serviceManager.onConnectionAvailable, _handleConnectionStart);
     if (serviceManager.hasConnection) {
@@ -160,6 +162,8 @@ class LoggingController {
     _listen(serviceManager.onConnectionClosed, _handleConnectionStop);
     _handleBusEvents();
   }
+
+  static const kindFilterId = 'logging-kind-filter';
 
   /// Listen on a stream and track the stream subscription for automatic
   /// disposal if the dispose method is called.
@@ -183,61 +187,29 @@ class LoggingController {
 
   List<LogData> data = <LogData>[];
 
-  // If non-null, this is an up-to-date cache of the filtered view of items.
-  List<LogData> _cachedFilteredData;
-
-  /// Get the view of the [data] items, filtered by the current value of
-  /// [filterText].
-  List<LogData> get filteredData {
-    if (filterText == null || filterText.trim().isEmpty) {
-      return data;
-    }
-
-    if (_cachedFilteredData != null) {
-      return _cachedFilteredData;
-    }
-
-    // Filter using both positive and negative terms.
-    final filter = Filter.compile(filterText);
-    _cachedFilteredData = data.where((LogData logData) {
-      return filter.matches(logData.matchesFilter);
-    }).toList();
-    return _cachedFilteredData;
-  }
-
   final _selectedLog = ValueNotifier<LogData>(null);
 
   ValueListenable<LogData> get selectedLog => _selectedLog;
 
   final List<StreamSubscription> _subscriptions = [];
 
-  final Reporter onLogsUpdated = Reporter();
-
-  String _filterText;
-
-  /// The search term used to filter [data] - the list of items.
-  ///
-  /// See also [filteredData] for the filtered view of [data].
-  String get filterText => _filterText;
-
-  set filterText(String value) {
-    _filterText = value;
-    _cachedFilteredData = null;
-    _updateSelection();
-
-    onLogsUpdated.notify();
-    _updateStatus();
-  }
-
   void selectLog(LogData data) {
     _selectedLog.value = data;
+  }
+
+  void _updateData(List<LogData> logs) {
+    data = logs;
+    filterData(activeFilter.value);
+    refreshSearchMatches();
+    _updateSelection();
+    _updateStatus();
   }
 
   void _updateSelection() {
     final selected = _selectedLog.value;
     if (selected != null) {
-      final List<LogData> items = filteredData;
-      if (!items.contains(selected)) {
+      final logs = filteredData.value;
+      if (!logs.contains(selected)) {
         _selectedLog.value = null;
       }
     }
@@ -248,7 +220,7 @@ class LoggingController {
 
   String get statusText {
     final int totalCount = data.length;
-    final int showingCount = filteredData.length;
+    final int showingCount = filteredData.value.length;
 
     String label;
 
@@ -270,10 +242,8 @@ class LoggingController {
   }
 
   void clear() {
-    data.clear();
-    _cachedFilteredData = null;
-    _selectedLog.value = null;
-    _updateStatus();
+    resetFilter();
+    _updateData([]);
   }
 
   void _handleConnectionStart(VmServiceWrapper service) async {
@@ -507,28 +477,25 @@ class LoggingController {
   void _handleConnectionStop(dynamic event) {}
 
   void log(LogData log) {
-    _cachedFilteredData = null;
+    List<LogData> currentLogs = List.from(data);
 
     // Insert the new item and clamped the list to kMaxLogItemsLength.
-    data.add(log);
+    currentLogs.add(log);
 
     // Note: We need to drop rows from the start because we want to drop old
     // rows but because that's expensive, we only do it periodically (eg. when
     // the list is 500 rows more).
-    if (data.length > kMaxLogItemsUpperBound) {
-      int itemsToRemove = data.length - kMaxLogItemsLowerBound;
+    if (currentLogs.length > kMaxLogItemsUpperBound) {
+      int itemsToRemove = currentLogs.length - kMaxLogItemsLowerBound;
       // Ensure we remove an even number of rows to keep the alternating
       // background in-sync.
       if (itemsToRemove % 2 == 1) {
         itemsToRemove--;
       }
-      data = data.sublist(itemsToRemove);
+      currentLogs = currentLogs.sublist(itemsToRemove);
     }
 
-    _updateSelection();
-
-    onLogsUpdated.notify();
-    _updateStatus();
+    _updateData(currentLogs);
   }
 
   static RemoteDiagnosticsNode _findFirstSummary(RemoteDiagnosticsNode node) {
@@ -634,6 +601,58 @@ class LoggingController {
         summary: summary,
       ),
     );
+  }
+
+  @override
+  List<LogData> matchesForSearch(String search) {
+    if (search == null || search.isEmpty) return [];
+    final matches = <LogData>[];
+    final caseInsensitiveSearch = search.toLowerCase();
+
+    final currentLogs = filteredData.value;
+    for (final log in currentLogs) {
+      if ((log.summary != null &&
+              log.summary.toLowerCase().contains(caseInsensitiveSearch)) ||
+          (log.details != null &&
+              log.details.toLowerCase().contains(caseInsensitiveSearch))) {
+        matches.add(log);
+      }
+    }
+    return matches;
+  }
+
+  @override
+  void filterData(QueryFilter filter) {
+    if (filter == null) {
+      filteredData.value = List.from(data);
+    } else {
+      filteredData.value = data.where((log) {
+        for (final arg in filter.filterArguments) {
+          if (arg.id == kindFilterId) {
+            if (!arg.matchesValue(log.kind.toLowerCase())) {
+              return false;
+            }
+          }
+        }
+        if (filter.substrings.isNotEmpty) {
+          for (final substring in filter.substrings) {
+            final caseInsensitiveSubstring = substring.toLowerCase();
+            final matchesKind = log.kind != null &&
+                log.kind.toLowerCase().contains(caseInsensitiveSubstring);
+            final matchesSummary = log.summary != null &&
+                log.summary.toLowerCase().contains(caseInsensitiveSubstring);
+            final matchesDetails = log.details != null &&
+                log.summary.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesKind || matchesSummary || matchesDetails) {
+              return true;
+            }
+          }
+          return false;
+        }
+        return true;
+      }).toList();
+    }
+    activeFilter.value = filter;
   }
 }
 

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -133,6 +133,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
         const Spacer(),
         StructuredErrorsToggle(),
         const SizedBox(width: denseSpacing),
+        // TODO(kenz): fix focus issue when state is refreshed
         Container(
           width: wideSearchTextWidth,
           height: defaultTextFieldHeight,
@@ -140,7 +141,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
             controller: controller,
             searchFieldKey: loggingSearchFieldKey,
             searchFieldEnabled: hasData,
-            shouldRequestFocus: true,
+            shouldRequestFocus: false,
             supportsNavigation: true,
           ),
         ),

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -64,10 +64,10 @@ Type a filter query to show or hide specific logs.
 Any text that is not paired with an available filter key below will be queried against all categories (kind, message).
 
 Available filters:
-    'kind', 'k'       (e.g. 'k:flutter.frame', '-k:gc')
+    'kind', 'k'       (e.g. 'k:flutter.frame', '-k:gc,stdout')
 
 Example queries:
-    'my log message k:stdout'
+    'my log message k:stdout,stdin'
     'flutter -k:gc'
 ''';
 

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -20,9 +20,13 @@ import '../table.dart';
 import '../table_data.dart';
 import '../theme.dart';
 import '../ui/colors.dart';
+import '../ui/filter.dart';
+import '../ui/search.dart';
 import '../ui/service_extension_widgets.dart';
 import '../utils.dart';
 import 'logging_controller.dart';
+
+final loggingSearchFieldKey = GlobalKey(debugLabel: 'LoggingSearchFieldKey');
 
 /// Presents logs from the connected app.
 class LoggingScreen extends Screen {
@@ -54,24 +58,39 @@ class LoggingScreen extends Screen {
 class LoggingScreenBody extends StatefulWidget {
   const LoggingScreenBody();
 
+  static const filterQueryInstructions = '''
+Type a filter query to show or hide specific logs.
+
+Any text that is not paired with an available filter key below will be queried against all categories (kind, message).
+
+Available filters:
+    'kind', 'k'       (e.g. 'k:flutter.frame', '-k:gc')
+
+Example queries:
+    'my log message k:stdout'
+    'flutter -k:gc'
+''';
+
   @override
   _LoggingScreenState createState() => _LoggingScreenState();
 }
 
 class _LoggingScreenState extends State<LoggingScreenBody>
-    with AutoDisposeMixin {
+    with AutoDisposeMixin, SearchFieldMixin {
+  final filterArgs = [
+    FilterArgument(id: LoggingController.kindFilterId, keys: ['kind', 'k']),
+  ];
+
   LogData selected;
 
-  TextEditingController filterController;
-
   LoggingController controller;
+
+  List<LogData> filteredLogs;
 
   @override
   void initState() {
     super.initState();
     ga.screen(LoggingScreen.id);
-
-    filterController = TextEditingController();
   }
 
   @override
@@ -84,9 +103,11 @@ class _LoggingScreenState extends State<LoggingScreenBody>
 
     cancel();
 
-    filterController.text = controller.filterText;
-    filterController.addListener(() {
-      controller.filterText = filterController.text;
+    filteredLogs = controller.filteredData.value;
+    addAutoDisposeListener(controller.filteredData, () {
+      setState(() {
+        filteredLogs = controller.filteredData.value;
+      });
     });
 
     selected = controller.selectedLog.value;
@@ -95,74 +116,98 @@ class _LoggingScreenState extends State<LoggingScreenBody>
         selected = controller.selectedLog.value;
       });
     });
-
-    addAutoDisposeListener(controller.onLogsUpdated);
   }
 
   @override
   Widget build(BuildContext context) {
     return Column(children: [
-      Row(
-        children: [
-          ClearButton(onPressed: _clearLogs),
-          const Spacer(),
-          Container(
-            width: defaultSearchTextWidth,
-            height: defaultTextFieldHeight,
-            child: TextField(
-              controller: filterController,
-              decoration: const InputDecoration(
-                isDense: true,
-                border: OutlineInputBorder(),
-                labelText: 'Filter',
-                // TODO(devoncarew): Include hint text (this currently has an
-                // issue w/ sizing of the search field's contents).
-                //hintText: 'term -term',
-              ),
-            ),
-          ),
-          const SizedBox(width: 8.0),
-          StructuredErrorsToggle(),
-        ],
-      ),
+      _buildLoggingControls(),
+      const SizedBox(height: denseRowSpacing),
       Expanded(
-        child: Split(
-          axis: Axis.vertical,
-          initialFractions: const [0.72, 0.28],
-          children: [
-            OutlineDecoration(
-              child: LogsTable(
-                data: controller.filteredData,
-                onItemSelected: controller.selectLog,
-                selectionNotifier: controller.selectedLog,
-              ),
-            ),
-            LogDetails(log: selected),
-          ],
-        ),
+        child: _buildLoggingBody(),
       ),
     ]);
   }
 
-  void _clearLogs() {
-    setState(() {
-      controller.clear();
-      selected = null;
-    });
+  Widget _buildLoggingControls() {
+    final hasData = controller.filteredData.value.isNotEmpty;
+    return Row(
+      children: [
+        ClearButton(onPressed: controller.clear),
+        const Spacer(),
+        StructuredErrorsToggle(),
+        const SizedBox(width: denseSpacing),
+        Container(
+          width: wideSearchTextWidth,
+          height: defaultTextFieldHeight,
+          child: buildSearchField(
+            controller: controller,
+            searchFieldKey: loggingSearchFieldKey,
+            searchFieldEnabled: hasData,
+            shouldRequestFocus: true,
+            supportsNavigation: true,
+          ),
+        ),
+        const SizedBox(width: denseSpacing),
+        FilterButton(
+          onPressed: _showFilterDialog,
+          isFilterActive: filteredLogs.length != controller.data.length,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLoggingBody() {
+    return Split(
+      axis: Axis.vertical,
+      initialFractions: const [0.72, 0.28],
+      children: [
+        OutlineDecoration(
+          child: LogsTable(
+            data: controller.filteredData.value,
+            onItemSelected: controller.selectLog,
+            selectionNotifier: controller.selectedLog,
+            searchMatchesNotifier: controller.searchMatches,
+            activeSearchMatchNotifier: controller.activeSearchMatch,
+          ),
+        ),
+        LogDetails(log: selected),
+      ],
+    );
+  }
+
+  void _showFilterDialog() {
+    showDialog(
+      context: context,
+      builder: (context) => FilterDialog(
+        controller: controller,
+        onApplyFilter: (query) => controller.filterData(
+          QueryFilter.parse(
+            query,
+            filterArgs,
+          ),
+        ),
+        queryInstructions: LoggingScreenBody.filterQueryInstructions,
+      ),
+    );
   }
 }
 
 class LogsTable extends StatelessWidget {
   LogsTable({
     Key key,
-    this.data,
-    this.onItemSelected,
-    this.selectionNotifier,
+    @required this.data,
+    @required this.onItemSelected,
+    @required this.selectionNotifier,
+    @required this.searchMatchesNotifier,
+    @required this.activeSearchMatchNotifier,
   }) : super(key: key);
 
   final List<LogData> data;
   final ItemCallback<LogData> onItemSelected;
   final ValueListenable<LogData> selectionNotifier;
+  final ValueListenable<List<LogData>> searchMatchesNotifier;
+  final ValueListenable<LogData> activeSearchMatchNotifier;
 
   final ColumnData<LogData> when = _WhenColumn();
   final ColumnData<LogData> kind = _KindColumn();
@@ -181,6 +226,8 @@ class LogsTable extends StatelessWidget {
       selectionNotifier: selectionNotifier,
       sortColumn: when,
       sortDirection: SortDirection.ascending,
+      searchMatchesNotifier: searchMatchesNotifier,
+      activeSearchMatchNotifier: activeSearchMatchNotifier,
     );
   }
 }

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -77,10 +77,6 @@ Example queries:
 
 class _LoggingScreenState extends State<LoggingScreenBody>
     with AutoDisposeMixin, SearchFieldMixin {
-  final filterArgs = [
-    FilterArgument(id: LoggingController.kindFilterId, keys: ['kind', 'k']),
-  ];
-
   LogData selected;
 
   LoggingController controller;
@@ -184,7 +180,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
         onApplyFilter: (query) => controller.filterData(
           QueryFilter.parse(
             query,
-            filterArgs,
+            controller.filterArgs,
           ),
         ),
         queryInstructions: LoggingScreenBody.filterQueryInstructions,

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -12,16 +12,24 @@ import '../config_specific/logger/allowed_error.dart';
 import '../globals.dart';
 import '../http/http_request_data.dart';
 import '../http/http_service.dart';
+import '../ui/filter.dart';
 import '../ui/search.dart';
 import 'network_model.dart';
 import 'network_service.dart';
 
-class NetworkController with SearchControllerMixin<NetworkRequest> {
+class NetworkController
+    with
+        SearchControllerMixin<NetworkRequest>,
+        FilterControllerMixin<NetworkRequest> {
   NetworkController() {
     _networkService = NetworkService(this);
   }
 
-  static NetworkFilter defaultFilter = NetworkFilter();
+  static const methodFilterId = 'network-method-filter';
+
+  static const statusFilterId = 'network-status-filter';
+
+  static const typeFilterId = 'network-type-filter';
 
   /// Notifies that new Network requests have been processed.
   ValueListenable<NetworkRequests> get requests => _requests;
@@ -31,15 +39,6 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
   ValueListenable<NetworkRequest> get selectedRequest => _selectedRequest;
 
   final _selectedRequest = ValueNotifier<NetworkRequest>(null);
-
-  ValueListenable<List<NetworkRequest>> get filteredRequests =>
-      _filteredRequests;
-
-  final _filteredRequests = ValueNotifier<List<NetworkRequest>>([]);
-
-  ValueListenable<NetworkFilter> get activeFilter => _activeFilter;
-
-  final _activeFilter = ValueNotifier<NetworkFilter>(defaultFilter);
 
   /// Notifies that the timeline is currently being recorded.
   ValueListenable<bool> get recordingNotifier => _recordingNotifier;
@@ -187,8 +186,8 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
       invalidRequests: [],
       outstandingRequestsMap: Map.from(requests.value.outstandingHttpRequests),
     );
-    filterData(_activeFilter.value);
-    refreshSearchMatches();
+    _updateData();
+    _updateSelection();
   }
 
   Future<void> _toggleHttpTimelineRecording(bool state) async {
@@ -274,9 +273,24 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
   Future<void> clear() async {
     await _networkService.clearData();
     _requests.value = NetworkRequests();
-    _filteredRequests.value = [];
+    resetFilter();
+    _updateData();
+    _updateSelection();
+  }
+
+  void _updateData() {
+    filterData(activeFilter.value);
     refreshSearchMatches();
-    _selectedRequest.value = null;
+  }
+
+  void _updateSelection() {
+    final selected = _selectedRequest.value;
+    if (selected != null) {
+      final requests = filteredData.value;
+      if (!requests.contains(selected)) {
+        _selectedRequest.value = null;
+      }
+    }
   }
 
   @override
@@ -285,7 +299,7 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
     final matches = <NetworkRequest>[];
     final caseInsensitiveSearch = search.toLowerCase();
 
-    final currentRequests = _filteredRequests.value;
+    final currentRequests = filteredData.value;
     for (final request in currentRequests) {
       if (request.uri.toLowerCase().contains(caseInsensitiveSearch)) {
         matches.add(request);
@@ -294,121 +308,50 @@ class NetworkController with SearchControllerMixin<NetworkRequest> {
     return matches;
   }
 
-  void filterData(NetworkFilter filter) {
-    if (filter == defaultFilter) {
-      _filteredRequests.value = List.from(_requests.value.requests);
-    }
-    _filteredRequests.value =
-        _requests.value.requests.where((NetworkRequest r) {
-      if (filter.method != null &&
-          r.method.toLowerCase() != filter.method.toLowerCase()) {
-        return false;
-      }
-      if (filter.status != null &&
-          r.status?.toLowerCase() != filter.status.toLowerCase()) {
-        return false;
-      }
-      if (filter.type != null &&
-          r.type.toLowerCase() != filter.type.toLowerCase()) {
-        return false;
-      }
-      if (filter.substrings.isNotEmpty) {
-        for (final substring in filter.substrings) {
-          final caseInsensitiveSubstring = substring.toLowerCase();
-          final matchesUri =
-              r.uri.toLowerCase().contains(caseInsensitiveSubstring);
-          final matchesMethod =
-              r.method.toLowerCase().contains(caseInsensitiveSubstring);
-          final matchesStatus =
-              r.status?.toLowerCase()?.contains(caseInsensitiveSubstring) ??
-                  false;
-          final matchesType =
-              r.type.toLowerCase().contains(caseInsensitiveSubstring);
-          if (matchesUri || matchesMethod || matchesStatus || matchesType) {
-            return true;
+  @override
+  void filterData(QueryFilter filter) {
+    if (filter == null) {
+      filteredData.value = List.from(_requests.value.requests);
+    } else {
+      filteredData.value = _requests.value.requests.where((NetworkRequest r) {
+        for (final arg in filter.filterArguments) {
+          if (arg.id == methodFilterId) {
+            if (!arg.matchesValue(r.method.toLowerCase())) {
+              return false;
+            }
+          }
+          if (arg.id == statusFilterId) {
+            if (!arg.matchesValue(r.status?.toLowerCase())) {
+              return false;
+            }
+          }
+          if (arg.id == typeFilterId) {
+            if (!arg.matchesValue(r.type.toLowerCase())) {
+              return false;
+            }
           }
         }
-        return false;
-      }
-      return true;
-    }).toList();
-    _activeFilter.value = filter;
-  }
-
-  void resetFilters() {
-    _activeFilter.value = defaultFilter;
-  }
-}
-
-class NetworkFilter {
-  NetworkFilter({
-    this.method,
-    this.substrings = const [],
-    this.status,
-    this.type,
-  });
-
-  factory NetworkFilter.from(NetworkFilter filter) {
-    return NetworkFilter(
-      method: filter.method,
-      substrings: filter.substrings,
-      status: filter.status,
-      type: filter.type,
-    );
-  }
-
-  factory NetworkFilter.fromQuery(String query) {
-    final partsBySpace = query.split(' ');
-
-    final substrings = <String>[];
-    String method;
-    String status;
-    String type;
-    for (final part in partsBySpace) {
-      final querySeparatorIndex = part.indexOf(':');
-      if (querySeparatorIndex != -1) {
-        final value = part.substring(querySeparatorIndex + 1);
-        if (value != '') {
-          if (isValidFilter(keys: ['m', 'method'], query: part)) {
-            method = value;
-          } else if (isValidFilter(keys: ['s', 'status'], query: part)) {
-            status = value;
-          } else if (isValidFilter(keys: ['t', 'type'], query: part)) {
-            type = value;
+        if (filter.substrings.isNotEmpty) {
+          for (final substring in filter.substrings) {
+            final caseInsensitiveSubstring = substring.toLowerCase();
+            final matchesUri =
+                r.uri.toLowerCase().contains(caseInsensitiveSubstring);
+            final matchesMethod =
+                r.method.toLowerCase().contains(caseInsensitiveSubstring);
+            final matchesStatus =
+                r.status?.toLowerCase()?.contains(caseInsensitiveSubstring) ??
+                    false;
+            final matchesType =
+                r.type.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesUri || matchesMethod || matchesStatus || matchesType) {
+              return true;
+            }
           }
+          return false;
         }
-      } else {
-        substrings.add(part);
-      }
+        return true;
+      }).toList();
     }
-    return NetworkFilter(
-      method: method,
-      substrings: substrings,
-      status: status,
-      type: type,
-    );
-  }
-
-  String method;
-
-  List<String> substrings;
-
-  String status;
-
-  String type;
-
-  String get query {
-    final _substrings = substrings.join(' ');
-    final _method = method != null ? 'method:$method' : '';
-    final _status = status != null ? 'status:$status' : '';
-    final _type = type != null ? 'type:$type' : '';
-    return '$_substrings $_method $_status $_type'.trim();
-  }
-
-  static bool isValidFilter({@required List<String> keys, String query}) {
-    for (final key in keys) {
-      if (query.startsWith('$key:')) return true;
-    }
-    return false;
+    activeFilter.value = filter;
   }
 }

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -31,14 +31,14 @@ class NetworkController
 
   static const typeFilterId = 'network-type-filter';
 
-  final _filterArgs = [
-    FilterArgument(id: NetworkController.methodFilterId, keys: ['method', 'm']),
-    FilterArgument(id: NetworkController.statusFilterId, keys: ['status', 's']),
-    FilterArgument(id: NetworkController.typeFilterId, keys: ['type', 't']),
-  ];
+  final _filterArgs = {
+    methodFilterId: FilterArgument(keys: ['method', 'm']),
+    statusFilterId: FilterArgument(keys: ['status', 's']),
+    typeFilterId: FilterArgument(keys: ['type', 't']),
+  };
 
   @override
-  List<FilterArgument> get filterArgs => _filterArgs;
+  Map<String, FilterArgument> get filterArgs => _filterArgs;
 
   /// Notifies that new Network requests have been processed.
   ValueListenable<NetworkRequests> get requests => _requests;
@@ -323,38 +323,42 @@ class NetworkController
       filteredData.value = List.from(_requests.value.requests);
     } else {
       filteredData.value = _requests.value.requests.where((NetworkRequest r) {
-        for (final arg in filter.filterArguments) {
-          if (arg.id == methodFilterId) {
-            if (!arg.matchesValue(r.method.toLowerCase())) {
-              return false;
-            }
-          }
-          if (arg.id == statusFilterId) {
-            if (!arg.matchesValue(r.status?.toLowerCase())) {
-              return false;
-            }
-          }
-          if (arg.id == typeFilterId) {
-            if (!arg.matchesValue(r.type.toLowerCase())) {
-              return false;
-            }
-          }
+        final methodArg = filter.filterArguments[methodFilterId];
+        if (methodArg != null &&
+            !methodArg.matchesValue(r.method.toLowerCase())) {
+          return false;
         }
+
+        final statusArg = filter.filterArguments[statusFilterId];
+        if (statusArg != null &&
+            !statusArg.matchesValue(r.status?.toLowerCase())) {
+          return false;
+        }
+
+        final typeArg = filter.filterArguments[typeFilterId];
+        if (typeArg != null && !typeArg.matchesValue(r.type.toLowerCase())) {
+          return false;
+        }
+
         if (filter.substrings.isNotEmpty) {
           for (final substring in filter.substrings) {
             final caseInsensitiveSubstring = substring.toLowerCase();
             final matchesUri =
                 r.uri.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesUri) return true;
+
             final matchesMethod =
                 r.method.toLowerCase().contains(caseInsensitiveSubstring);
+            if (matchesMethod) return true;
+
             final matchesStatus =
                 r.status?.toLowerCase()?.contains(caseInsensitiveSubstring) ??
                     false;
+            if (matchesStatus) return true;
+
             final matchesType =
                 r.type.toLowerCase().contains(caseInsensitiveSubstring);
-            if (matchesUri || matchesMethod || matchesStatus || matchesType) {
-              return true;
-            }
+            if (matchesType) return true;
           }
           return false;
         }

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -31,6 +31,15 @@ class NetworkController
 
   static const typeFilterId = 'network-type-filter';
 
+  final _filterArgs = [
+    FilterArgument(id: NetworkController.methodFilterId, keys: ['method', 'm']),
+    FilterArgument(id: NetworkController.statusFilterId, keys: ['status', 's']),
+    FilterArgument(id: NetworkController.typeFilterId, keys: ['type', 't']),
+  ];
+
+  @override
+  List<FilterArgument> get filterArgs => _filterArgs;
+
   /// Notifies that new Network requests have been processed.
   ValueListenable<NetworkRequests> get requests => _requests;
 

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -97,13 +97,13 @@ Type a filter query to show or hide specific requests.
 Any text that is not paired with an available filter key below will be queried against all categories (method, uri, status, type).
 
 Available filters:
-    'method', 'm'       (e.g. 'm:get', '-m:put')
+    'method', 'm'       (e.g. 'm:get', '-m:put,patch')
     'status', 's'           (e.g. 's:200', '-s:404')
     'type', 't'               (e.g. 't:json', '-t:ws')
 
 Example queries:
-    'my-endpoint method:put -status:404 type:json'
-    'example.com -m:get s:200 t:htm'
+    'my-endpoint method:put,post -status:404 type:json'
+    'example.com -m:get s:200,201 t:htm,html,json'
     'http s:404'
     'POST'
 ''';

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -11,13 +11,12 @@ import '../analytics/analytics_stub.dart'
     if (dart.library.html) '../analytics/analytics.dart' as ga;
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
-import '../dialogs.dart';
 import '../screen.dart';
 import '../split.dart';
 import '../table.dart';
 import '../table_data.dart';
 import '../theme.dart';
-import '../ui/label.dart';
+import '../ui/filter.dart';
 import '../ui/search.dart';
 import '../utils.dart';
 import 'network_controller.dart';
@@ -54,7 +53,7 @@ class NetworkScreen extends Screen {
           valueListenable: networkController.requests,
           builder: (context, networkRequests, _) {
             return ValueListenableBuilder<List<NetworkRequest>>(
-              valueListenable: networkController.filteredRequests,
+              valueListenable: networkController.filteredData,
               builder: (context, filteredRequests, _) {
                 final filteredCount = filteredRequests.length;
                 final totalCount = networkRequests.requests.length;
@@ -92,12 +91,35 @@ class NetworkScreen extends Screen {
 class NetworkScreenBody extends StatefulWidget {
   const NetworkScreenBody();
 
+  static const filterQueryInstructions = '''
+Type a filter query to show or hide specific requests.
+
+Any text that is not paired with an available filter key below will be queried against all categories (method, uri, status, type).
+
+Available filters:
+    'method', 'm'       (e.g. 'm:get', '-m:put')
+    'status', 's'           (e.g. 's:200', '-s:404')
+    'type', 't'               (e.g. 't:json', '-t:ws')
+
+Example queries:
+    'my-endpoint method:put -status:404 type:json'
+    'example.com -m:get s:200 t:htm'
+    'http s:404'
+    'POST'
+''';
+
   @override
   State<StatefulWidget> createState() => _NetworkScreenBodyState();
 }
 
 class _NetworkScreenBodyState extends State<NetworkScreenBody>
     with AutoDisposeMixin, SearchFieldMixin {
+  final filterArgs = [
+    FilterArgument(id: NetworkController.methodFilterId, keys: ['method', 'm']),
+    FilterArgument(id: NetworkController.statusFilterId, keys: ['status', 's']),
+    FilterArgument(id: NetworkController.typeFilterId, keys: ['type', 't']),
+  ];
+
   NetworkController _networkController;
 
   bool recording;
@@ -136,10 +158,10 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
         recording = _networkController.recordingNotifier.value;
       });
     });
-    filteredRequests = _networkController.filteredRequests.value;
-    addAutoDisposeListener(_networkController.filteredRequests, () {
+    filteredRequests = _networkController.filteredData.value;
+    addAutoDisposeListener(_networkController.filteredData, () {
       setState(() {
-        filteredRequests = _networkController.filteredRequests.value;
+        filteredRequests = _networkController.filteredData.value;
       });
     });
   }
@@ -183,7 +205,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
             controller: _networkController,
             searchFieldKey: networkSearchFieldKey,
             searchFieldEnabled: hasRequests,
-            shouldRequestFocus: false,
+            shouldRequestFocus: true,
             supportsNavigation: true,
           ),
         ),
@@ -236,7 +258,16 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
   void _showFilterDialog() {
     showDialog(
       context: context,
-      builder: (context) => NetworkFilterDialog(_networkController),
+      builder: (context) => FilterDialog(
+        controller: _networkController,
+        onApplyFilter: (query) => _networkController.filterData(
+          QueryFilter.parse(
+            query,
+            filterArgs,
+          ),
+        ),
+        queryInstructions: NetworkScreenBody.filterQueryInstructions,
+      ),
     );
   }
 
@@ -417,113 +448,5 @@ class TimestampColumn extends ColumnData<NetworkRequest> {
   @override
   String getDisplayValue(NetworkRequest dataObject) {
     return formatDateTime(dataObject.startTimestamp);
-  }
-}
-
-class NetworkFilterDialog extends StatefulWidget {
-  const NetworkFilterDialog(this.controller);
-
-  final NetworkController controller;
-
-  @override
-  _NetworkFilterDialogState createState() => _NetworkFilterDialogState();
-}
-
-class _NetworkFilterDialogState extends State<NetworkFilterDialog> {
-  static const dialogWidth = 500.0;
-
-  static const queryInstructions = '''
-Type a filter query to show specific requests.
-
-Any text that is not paired with an available filter key below will be queried against all categories (method, uri, status, type).
-
-Available filters:
-    'method', 'm'       (e.g. 'm:get', 'm:put')
-    'status', 's'           (e.g. 's:200', 's:404')
-    'type', 't'               (e.g. 't:json', 't:ws')
-
-Example queries:
-    'my-endpoint method:put status:404 type:json'
-    'example.com m:get s:200 t:htm'
-    'http s:404'
-    'POST'
-''';
-
-  TextEditingController queryTextFieldController;
-
-  @override
-  void initState() {
-    super.initState();
-    queryTextFieldController =
-        TextEditingController(text: widget.controller.activeFilter.value.query);
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return DevToolsDialog(
-      title: _buildDialogTitle(),
-      content: Container(
-        padding: const EdgeInsets.symmetric(
-          horizontal: defaultSpacing,
-        ),
-        width: dialogWidth,
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            _buildQueryTextField(),
-            const SizedBox(height: defaultSpacing),
-            _buildQueryInstructions(),
-          ],
-        ),
-      ),
-      actions: [
-        DialogApplyButton(
-          onPressed: () {
-            widget.controller.filterData(
-                NetworkFilter.fromQuery(queryTextFieldController.value.text));
-          },
-        ),
-        DialogCancelButton(),
-      ],
-    );
-  }
-
-  Widget _buildDialogTitle() {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
-      children: [
-        dialogTitleText(Theme.of(context), 'Filters'),
-        FlatButton(
-          onPressed: queryTextFieldController.clear,
-          child: const MaterialIconLabel(
-            Icons.replay,
-            'Reset to default',
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildQueryTextField() {
-    return Container(
-      height: defaultTextFieldHeight,
-      child: TextField(
-        controller: queryTextFieldController,
-        decoration: InputDecoration(
-          contentPadding: const EdgeInsets.all(denseSpacing),
-          border: const OutlineInputBorder(),
-          labelText: 'Filter query',
-          suffix: clearInputButton(queryTextFieldController.clear),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildQueryInstructions() {
-    return Text(
-      queryInstructions,
-      style: Theme.of(context).subtleTextStyle,
-    );
   }
 }

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -114,12 +114,6 @@ Example queries:
 
 class _NetworkScreenBodyState extends State<NetworkScreenBody>
     with AutoDisposeMixin, SearchFieldMixin {
-  final filterArgs = [
-    FilterArgument(id: NetworkController.methodFilterId, keys: ['method', 'm']),
-    FilterArgument(id: NetworkController.statusFilterId, keys: ['status', 's']),
-    FilterArgument(id: NetworkController.typeFilterId, keys: ['type', 't']),
-  ];
-
   NetworkController _networkController;
 
   bool recording;
@@ -263,7 +257,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
         onApplyFilter: (query) => _networkController.filterData(
           QueryFilter.parse(
             query,
-            filterArgs,
+            _networkController.filterArgs,
           ),
         ),
         queryInstructions: NetworkScreenBody.filterQueryInstructions,

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -192,6 +192,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
           },
         ),
         const Expanded(child: SizedBox()),
+        // TODO(kenz): fix focus issue when state is refreshed
         Container(
           width: wideSearchTextWidth,
           height: defaultTextFieldHeight,
@@ -199,7 +200,7 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
             controller: _networkController,
             searchFieldKey: networkSearchFieldKey,
             searchFieldEnabled: hasRequests,
-            shouldRequestFocus: true,
+            shouldRequestFocus: false,
             supportsNavigation: true,
           ),
         ),

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -11,6 +11,8 @@ mixin FilterControllerMixin<T> {
 
   final activeFilter = ValueNotifier<QueryFilter>(null);
 
+  List<FilterArgument> get filterArgs;
+
   void filterData(QueryFilter filter);
 
   void resetFilter() {

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import '../common_widgets.dart';
+import '../dialogs.dart';
+import '../theme.dart';
+import 'label.dart';
+
+mixin FilterControllerMixin<T> {
+  final filteredData = ValueNotifier<List<T>>([]);
+
+  final activeFilter = ValueNotifier<QueryFilter>(null);
+
+  void filterData(QueryFilter filter);
+
+  void resetFilter() {
+    activeFilter.value = null;
+  }
+}
+
+class FilterDialog<FilterControllerMixin> extends StatefulWidget {
+  const FilterDialog({
+    @required this.controller,
+    @required this.onApplyFilter,
+    @required this.queryInstructions,
+  });
+
+  final FilterControllerMixin controller;
+
+  final void Function(String query) onApplyFilter;
+
+  final String queryInstructions;
+
+  @override
+  _FilterDialogState createState() => _FilterDialogState();
+}
+
+class _FilterDialogState extends State<FilterDialog> {
+  static const dialogWidth = 500.0;
+
+  TextEditingController queryTextFieldController;
+
+  @override
+  void initState() {
+    super.initState();
+    queryTextFieldController = TextEditingController(
+        text: widget.controller.activeFilter.value?.query ?? '');
+  }
+
+  @override
+  void dispose() {
+    queryTextFieldController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DevToolsDialog(
+      title: _buildDialogTitle(),
+      content: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: defaultSpacing,
+        ),
+        width: dialogWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildQueryTextField(),
+            const SizedBox(height: defaultSpacing),
+            _buildQueryInstructions(),
+          ],
+        ),
+      ),
+      actions: [
+        DialogApplyButton(
+          onPressed: () =>
+              widget.onApplyFilter(queryTextFieldController.value.text),
+        ),
+        DialogCancelButton(),
+      ],
+    );
+  }
+
+  Widget _buildDialogTitle() {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        dialogTitleText(Theme.of(context), 'Filters'),
+        FlatButton(
+          onPressed: queryTextFieldController.clear,
+          child: const MaterialIconLabel(
+            Icons.replay,
+            'Reset to default',
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildQueryTextField() {
+    return Container(
+      height: defaultTextFieldHeight,
+      child: TextField(
+        controller: queryTextFieldController,
+        decoration: InputDecoration(
+          contentPadding: const EdgeInsets.all(denseSpacing),
+          border: const OutlineInputBorder(),
+          labelText: 'Filter query',
+          suffix: clearInputButton(queryTextFieldController.clear),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQueryInstructions() {
+    return Text(
+      widget.queryInstructions,
+      style: Theme.of(context).subtleTextStyle,
+    );
+  }
+}
+
+class QueryFilter<T> {
+  QueryFilter({
+    this.filterArguments,
+    this.substrings = const [],
+  });
+
+  factory QueryFilter.parse(String query, List<FilterArgument> args) {
+    // Reset all argument values before generating a new QueryFilter.
+    for (final arg in args) {
+      arg.reset();
+    }
+
+    final partsBySpace = query.split(' ');
+    final substrings = <String>[];
+    for (final part in partsBySpace) {
+      final querySeparatorIndex = part.indexOf(':');
+      if (querySeparatorIndex != -1) {
+        final value = part.substring(querySeparatorIndex + 1);
+        if (value != '') {
+          for (var arg in args) {
+            if (arg.matchesKey(part)) {
+              arg.isNegative = part.startsWith('-');
+              arg.value = value;
+            }
+          }
+        }
+      } else {
+        substrings.add(part);
+      }
+    }
+    return QueryFilter(filterArguments: args, substrings: substrings);
+  }
+
+  final List<FilterArgument> filterArguments;
+
+  final List<String> substrings;
+
+  String get query => [
+        ...substrings,
+        for (final arg in filterArguments) arg.display,
+      ].join(' ').trim();
+}
+
+class FilterArgument {
+  FilterArgument({
+    @required this.id,
+    @required this.keys,
+    this.value,
+    this.isNegative = false,
+  });
+
+  final String id;
+
+  final List<String> keys;
+
+  String value;
+
+  bool isNegative;
+
+  String get display =>
+      value != null ? '${isNegative ? '-' : ''}${keys.first}:$value' : '';
+
+  bool matchesKey(String query) {
+    for (final key in keys) {
+      if (query.startsWith('$key:') || query.startsWith('-$key:')) return true;
+    }
+    return false;
+  }
+
+  bool matchesValue(String dataValue) {
+    if (value != null) {
+      final match = dataValue == value.toLowerCase();
+      return isNegative ? !match : match;
+    }
+    // If the filter argument value is not specified, consider [dataValue] to
+    // match this filter.
+    return true;
+  }
+
+  void reset() {
+    value = null;
+    isNegative = false;
+  }
+}

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -42,14 +42,14 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.2"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   browser_launcher:
     dependency: transitive
     description:
@@ -119,14 +119,14 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.4"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.3"
   checked_yaml:
     dependency: transitive
     description:
@@ -147,7 +147,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   code_builder:
     dependency: transitive
     description:
@@ -161,7 +161,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.4"
+    version: "1.15.0-nullsafety.5"
   convert:
     dependency: transitive
     description:
@@ -224,7 +224,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.3"
   file:
     dependency: "direct main"
     description:
@@ -316,7 +316,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3-nullsafety.2"
+    version: "0.6.3-nullsafety.3"
   json_annotation:
     dependency: transitive
     description:
@@ -337,14 +337,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.2"
+    version: "0.12.10-nullsafety.3"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.5"
+    version: "1.3.0-nullsafety.6"
   mime:
     dependency: "direct main"
     description:
@@ -421,7 +421,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.3"
   path_drawing:
     dependency: transitive
     description:
@@ -587,7 +587,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.8.0-nullsafety.4"
   sse:
     dependency: "direct main"
     description:
@@ -601,14 +601,14 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.5"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.2"
+    version: "2.1.0-nullsafety.3"
   stream_transform:
     dependency: transitive
     description:
@@ -622,35 +622,35 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.2"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.2"
+    version: "1.2.0-nullsafety.3"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.7"
+    version: "1.16.0-nullsafety.9"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.4"
+    version: "0.2.19-nullsafety.6"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.7"
+    version: "0.3.12-nullsafety.9"
   timing:
     dependency: transitive
     description:
@@ -664,7 +664,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.4"
+    version: "1.3.0-nullsafety.5"
   url_launcher:
     dependency: "direct main"
     description:
@@ -727,7 +727,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.4"
+    version: "2.1.0-nullsafety.5"
   vm_service:
     dependency: "direct main"
     description:
@@ -771,5 +771,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.11.0-180.0.dev <=2.12.0-3.0.dev"
+  dart: ">=2.12.0-0.0 <=2.12.0-27.0.dev"
   flutter: ">=1.22.0 <2.0.0"

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -77,7 +77,28 @@ void main() {
       expect(controller.filteredData.value, isEmpty);
     });
 
-    test('filteredData', () {
+    test('matchesForSearch', () {
+      addStdoutData('abc');
+      addStdoutData('def');
+      addStdoutData('abc ghi');
+      addGcData('gc1');
+      addGcData('gc2');
+
+      expect(controller.filteredData.value, hasLength(5));
+      expect(controller.matchesForSearch('abc').length, equals(2));
+      expect(controller.matchesForSearch('ghi').length, equals(1));
+      expect(controller.matchesForSearch('abcd').length, equals(0));
+      expect(controller.matchesForSearch('').length, equals(0));
+
+      // Search by event kind.
+      expect(controller.matchesForSearch('stdout').length, equals(3));
+      expect(controller.matchesForSearch('gc').length, equals(2));
+
+      // Search with incorrect case.
+      expect(controller.matchesForSearch('STDOUT').length, equals(3));
+    });
+
+    test('filterData', () {
       addStdoutData('abc');
       addStdoutData('def');
       addStdoutData('abc ghi');
@@ -87,18 +108,29 @@ void main() {
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(5));
 
-      controller.filterData(QueryFilter.parse('abc', []));
-
+      controller.filterData(QueryFilter.parse('abc', controller.filterArgs));
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(2));
 
-      controller.filterData(QueryFilter.parse('def', []));
-
+      controller.filterData(QueryFilter.parse('def', controller.filterArgs));
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(1));
 
-      controller.filterData(null);
+      controller
+          .filterData(QueryFilter.parse('kind:gc', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(2));
 
+      controller
+          .filterData(QueryFilter.parse('k:stdout', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(3));
+
+      controller.filterData(QueryFilter.parse('-k:gc', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(3));
+
+      controller.filterData(null);
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(5));
     });

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/ui/filter.dart';
 import 'package:test/test.dart';
 
 import 'inspector_screen_test.dart';
@@ -27,6 +28,15 @@ void main() {
       ));
     }
 
+    void addGcData(String message) {
+      controller.log(LogData(
+        'gc',
+        jsonEncode({'kind': 'gc', 'message': message}),
+        0,
+        summary: message,
+      ));
+    }
+
     setUp(() async {
       setGlobal(
         ServiceConnectionManager,
@@ -40,8 +50,8 @@ void main() {
 
     test('initial state', () {
       expect(controller.data, isEmpty);
-      expect(controller.filteredData, isEmpty);
-      expect(controller.filterText, isNull);
+      expect(controller.filteredData.value, isEmpty);
+      expect(controller.activeFilter.value, isNull);
     });
 
     test('receives data', () {
@@ -50,7 +60,7 @@ void main() {
       addStdoutData('Abc.');
 
       expect(controller.data, isNotEmpty);
-      expect(controller.filteredData, isNotEmpty);
+      expect(controller.filteredData.value, isNotEmpty);
 
       expect(controller.data.first.summary, contains('Abc'));
     });
@@ -59,36 +69,38 @@ void main() {
       addStdoutData('Abc.');
 
       expect(controller.data, isNotEmpty);
-      expect(controller.filteredData, isNotEmpty);
+      expect(controller.filteredData.value, isNotEmpty);
 
       controller.clear();
 
       expect(controller.data, isEmpty);
-      expect(controller.filteredData, isEmpty);
+      expect(controller.filteredData.value, isEmpty);
     });
 
     test('filteredData', () {
       addStdoutData('abc');
       addStdoutData('def');
       addStdoutData('abc ghi');
+      addGcData('gc1');
+      addGcData('gc2');
 
-      expect(controller.data, hasLength(3));
-      expect(controller.filteredData, hasLength(3));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(5));
 
-      controller.filterText = 'abc';
+      controller.filterData(QueryFilter.parse('abc', []));
 
-      expect(controller.data, hasLength(3));
-      expect(controller.filteredData, hasLength(2));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(2));
 
-      controller.filterText = 'def';
+      controller.filterData(QueryFilter.parse('def', []));
 
-      expect(controller.data, hasLength(3));
-      expect(controller.filteredData, hasLength(1));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(1));
 
-      controller.filterText = null;
+      controller.filterData(null);
 
-      expect(controller.data, hasLength(3));
-      expect(controller.filteredData, hasLength(3));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(5));
     });
   });
 

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -116,19 +116,34 @@ void main() {
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(1));
 
+      controller.filterData(
+          QueryFilter.parse('k:stdout abc def', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(3));
+
       controller
           .filterData(QueryFilter.parse('kind:gc', controller.filterArgs));
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(2));
 
       controller
-          .filterData(QueryFilter.parse('k:stdout', controller.filterArgs));
+          .filterData(QueryFilter.parse('k:stdout abc', controller.filterArgs));
       expect(controller.data, hasLength(5));
-      expect(controller.filteredData.value, hasLength(3));
+      expect(controller.filteredData.value, hasLength(2));
 
       controller.filterData(QueryFilter.parse('-k:gc', controller.filterArgs));
       expect(controller.data, hasLength(5));
       expect(controller.filteredData.value, hasLength(3));
+
+      controller
+          .filterData(QueryFilter.parse('-k:gc,stdout', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(0));
+
+      controller.filterData(QueryFilter.parse(
+          'k:gc,stdout,stdin,flutter.frame', controller.filterArgs));
+      expect(controller.data, hasLength(5));
+      expect(controller.filteredData.value, hasLength(5));
 
       controller.filterData(null);
       expect(controller.data, hasLength(5));

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -134,5 +134,7 @@ void main() {
       expect(profile.outstandingHttpRequests.isEmpty, true);
       controller.removeClient();
     });
+
+    // TODO(kenz): add filter tests before landing this CL.
   });
 }

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -161,6 +161,10 @@ void main() {
       await controller.networkService.refreshNetworkData();
       final profile = requestsNotifier.value;
 
+      for (final r in profile.requests) {
+        print('${r.uri}, ${r.method}, ${r.status}, ${r.type}');
+      }
+
       expect(profile.requests, hasLength(numRequests));
       expect(controller.filteredData.value, hasLength(numRequests));
 
@@ -231,6 +235,26 @@ void main() {
       controller.filterData(null);
       expect(profile.requests, hasLength(numRequests));
       expect(controller.filteredData.value, hasLength(numRequests));
+
+      controller
+          .filterData(QueryFilter.parse('-t:ws,http', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(7));
+
+      controller.filterData(
+          QueryFilter.parse('-t:ws,http method:put', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(1));
+
+      controller.filterData(
+          QueryFilter.parse('-status:error method:get', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(3));
+
+      controller.filterData(QueryFilter.parse(
+          '-status:error method:get t:conf', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(1));
     });
   });
 }

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app/src/http/http_request_data.dart';
 import 'package:devtools_app/src/network/network_controller.dart';
 import 'package:devtools_app/src/network/network_model.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:devtools_app/src/ui/filter.dart';
 import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -21,12 +22,9 @@ void main() {
     Timeline timeline;
     SocketProfile socketProfile;
 
-    setUpAll(() async {
+    setUp(() async {
       timeline = await loadNetworkProfileTimeline();
       socketProfile = loadSocketProfile();
-    });
-
-    setUp(() {
       fakeServiceManager = FakeServiceManager(
         useFakeService: true,
         timelineData: timeline,
@@ -135,6 +133,104 @@ void main() {
       controller.removeClient();
     });
 
-    // TODO(kenz): add filter tests before landing this CL.
+    test('matchesForSearch', () async {
+      // The number of valid requests recorded in the test data.
+      const numRequests = 16;
+
+      final requestsNotifier = controller.requests;
+      // Refresh network data and ensure requests are populated.
+      await controller.networkService.refreshNetworkData();
+      final profile = requestsNotifier.value;
+      expect(profile.requests.length, numRequests);
+
+      expect(controller.matchesForSearch('year=2019').length, equals(5));
+      expect(controller.matchesForSearch('127.0.0.1').length, equals(14));
+      expect(controller.matchesForSearch('IPv6').length, equals(2));
+      expect(controller.matchesForSearch('').length, equals(0));
+
+      // Search with incorrect case.
+      expect(controller.matchesForSearch('YEAR').length, equals(5));
+    });
+
+    test('filterData', () async {
+      // The number of valid requests recorded in the test data.
+      const numRequests = 16;
+
+      final requestsNotifier = controller.requests;
+      // Refresh network data and ensure requests are populated.
+      await controller.networkService.refreshNetworkData();
+      final profile = requestsNotifier.value;
+
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(numRequests));
+
+      controller
+          .filterData(QueryFilter.parse('127.0.0.1', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(14));
+
+      controller.filterData(QueryFilter.parse('', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(numRequests));
+
+      controller
+          .filterData(QueryFilter.parse('method:put', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(2));
+
+      controller.filterData(QueryFilter.parse('m:head', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(2));
+
+      controller
+          .filterData(QueryFilter.parse('-method:put', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(14));
+
+      controller
+          .filterData(QueryFilter.parse('status:Error', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(7));
+
+      controller.filterData(QueryFilter.parse('s:101', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(2));
+
+      controller
+          .filterData(QueryFilter.parse('-s:Error', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(9));
+
+      controller
+          .filterData(QueryFilter.parse('type:http', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(7));
+
+      controller.filterData(QueryFilter.parse('t:ws', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(2));
+
+      controller.filterData(QueryFilter.parse('-t:ws', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(14));
+
+      controller.filterData(QueryFilter.parse('-', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(0));
+
+      controller
+          .filterData(QueryFilter.parse('nonsense', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(0));
+
+      controller
+          .filterData(QueryFilter.parse('-nonsense', controller.filterArgs));
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(0));
+
+      controller.filterData(null);
+      expect(profile.requests, hasLength(numRequests));
+      expect(controller.filteredData.value, hasLength(numRequests));
+    });
   });
 }


### PR DESCRIPTION
This adds a search and filter experience consistent with what is on other pages of DevTools (timeline, network, performance), and refactors some of the filter code to be reusable across devtools.

![Screen Shot 2020-11-05 at 3 25 45 PM](https://user-images.githubusercontent.com/43759233/98425208-27f4fb00-2049-11eb-8463-e1cbb1e69282.png)

![Screen Shot 2020-11-06 at 4 06 42 PM](https://user-images.githubusercontent.com/43759233/98425475-15c78c80-204a-11eb-8a40-cbf2ab3656fd.png)

Addresses part of https://github.com/flutter/devtools/issues/1982