### PR TITLE
expose information about oversized images

### DIFF
--- a/case_study/memory_leak/pubspec.yaml
+++ b/case_study/memory_leak/pubspec.yaml
@@ -8,9 +8,6 @@ dependencies:
   flutter:
     sdk: flutter
 
-environment:
-  sdk: ">=2.10.0 <3.0.0"
-
 dev_dependencies:
   flutter_test:
     sdk: flutter

--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -53,6 +53,45 @@ class Console extends StatelessWidget {
   }
 }
 
+/// Renders a _ConsoleText widget with ConsoleControls overlaid on the
+/// top-right corner.
+class ConsoleUsingTextWidget extends StatelessWidget {
+  const ConsoleUsingTextWidget({
+    this.controls,
+    @required this.lines,
+    this.title,
+  }) : super();
+
+  final Widget title;
+  final List<Widget> controls;
+  final List<String> lines;
+
+  String get textContent => lines.join('\n');
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (title != null) title,
+        Expanded(
+          child: Material(
+            child: Stack(
+              fit: StackFit.expand,
+              children: [
+                _ConsoleText(text: textContent),
+                if (controls != null && controls.isNotEmpty)
+                  _ConsoleControls(
+                    controls: controls,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
 /// Renders a top-right aligned ButtonBar wrapping a List of IconButtons
 /// (`controls`).
 class _ConsoleControls extends StatelessWidget {
@@ -70,6 +109,30 @@ class _ConsoleControls extends StatelessWidget {
         buttonPadding: EdgeInsets.zero,
         alignment: MainAxisAlignment.end,
         children: controls,
+      ),
+    );
+  }
+}
+
+class _ConsoleText extends StatelessWidget {
+  const _ConsoleText({@required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle =
+        theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
+
+    return Padding(
+      padding: const EdgeInsets.all(denseSpacing),
+      child: SingleChildScrollView(
+        child: Text(
+          text,
+          style: textStyle,
+          softWrap: true,
+        ),
       ),
     );
   }
@@ -114,7 +177,6 @@ class _ConsoleOutputState extends State<_ConsoleOutput> {
       child: ListView.builder(
         padding: const EdgeInsets.all(denseSpacing),
         itemCount: widget.lines?.length ?? 0,
-        // TODO: Get from theme?
         itemExtent: CodeView.rowHeight,
         controller: _scroll,
         itemBuilder: (context, index) {

--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -53,45 +53,6 @@ class Console extends StatelessWidget {
   }
 }
 
-/// Renders a _ConsoleText widget with ConsoleControls overlaid on the
-/// top-right corner.
-class ConsoleUsingTextWidget extends StatelessWidget {
-  const ConsoleUsingTextWidget({
-    this.controls,
-    @required this.lines,
-    this.title,
-  }) : super();
-
-  final Widget title;
-  final List<Widget> controls;
-  final List<String> lines;
-
-  String get textContent => lines.join('\n');
-
-  @override
-  Widget build(BuildContext context) {
-    return Column(
-      children: [
-        if (title != null) title,
-        Expanded(
-          child: Material(
-            child: Stack(
-              fit: StackFit.expand,
-              children: [
-                _ConsoleText(text: textContent),
-                if (controls != null && controls.isNotEmpty)
-                  _ConsoleControls(
-                    controls: controls,
-                  ),
-              ],
-            ),
-          ),
-        ),
-      ],
-    );
-  }
-}
-
 /// Renders a top-right aligned ButtonBar wrapping a List of IconButtons
 /// (`controls`).
 class _ConsoleControls extends StatelessWidget {
@@ -109,30 +70,6 @@ class _ConsoleControls extends StatelessWidget {
         buttonPadding: EdgeInsets.zero,
         alignment: MainAxisAlignment.end,
         children: controls,
-      ),
-    );
-  }
-}
-
-class _ConsoleText extends StatelessWidget {
-  const _ConsoleText({@required this.text});
-
-  final String text;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final textStyle =
-        theme.textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
-
-    return Padding(
-      padding: const EdgeInsets.all(denseSpacing),
-      child: SingleChildScrollView(
-        child: Text(
-          text,
-          style: textStyle,
-          softWrap: true,
-        ),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -179,7 +179,10 @@ class _InspectorScreenBodyState extends State<InspectorScreenBody>
       const SizedBox(width: denseSpacing),
       ServiceExtensionButtonGroup(
         minIncludeTextWidth: 1250,
-        extensions: [extensions.repaintRainbow, extensions.debugAllowBanner],
+        extensions: [
+          extensions.repaintRainbow,
+          extensions.invertOversizedImages,
+        ],
       ),
       // TODO(jacobr): implement TogglePlatformSelector.
       //  TogglePlatformSelector().selector

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -340,10 +340,9 @@ class LoggingController {
         summary: frameInfoText,
       ));
     } else if (e.extensionKind == ImageSizesForFrame.eventName) {
-      final List<ImageSizesForFrame> images =
-          ImageSizesForFrame.from(e.extensionData.data);
+      final images = ImageSizesForFrame.from(e.extensionData.data);
 
-      for (ImageSizesForFrame image in images) {
+      for (final image in images) {
         log(LogData(
           e.extensionKind.toLowerCase(),
           jsonEncode(image.rawJson),
@@ -775,9 +774,12 @@ class LogData {
   }
 
   String get prettyPrinted {
-    if (needsComputing) return details;
+    if (needsComputing) {
+      return details;
+    }
+
     try {
-      return prettyPrinter.convert(jsonDecode(details));
+      return prettyPrinter.convert(jsonDecode(details)).replaceAll(r'\n', '\n');
     } catch (_) {
       return details;
     }

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -221,10 +221,7 @@ class _LogDetailsState extends State<LogDetails>
     }
   }
 
-  bool showInspector(LogData log) => log != null && log.node != null;
-
-  bool showSimple(LogData log) =>
-      log != null && log.node == null && !log.needsComputing;
+  bool showSimple(LogData log) => log != null && !log.needsComputing;
 
   @override
   Widget build(BuildContext context) {
@@ -234,27 +231,21 @@ class _LogDetailsState extends State<LogDetails>
   }
 
   Widget _buildContent(BuildContext context, LogData log) {
-    if (showInspector(log)) {
-      return _buildInspector(context, log);
-    } else {
-      return Stack(
-        children: [
-          _buildSimpleLog(context, log),
-          if (log != null && log.needsComputing)
-            const Center(child: CircularProgressIndicator()),
-        ],
-      );
-    }
+    // TODO(#1370): Handle showing flutter errors in a structured manner.
+    return Stack(
+      children: [
+        _buildSimpleLog(context, log),
+        if (log != null && log.needsComputing)
+          const Center(child: CircularProgressIndicator()),
+      ],
+    );
   }
-
-  // TODO(#1370): implement this.
-  Widget _buildInspector(BuildContext context, LogData log) => const SizedBox();
 
   Widget _buildSimpleLog(BuildContext context, LogData log) {
     final disabled = log?.details == null || log.details.isEmpty;
 
     return OutlineDecoration(
-      child: Console(
+      child: ConsoleUsingTextWidget(
         title: areaPaneHeader(
           context,
           title: 'Details',
@@ -266,7 +257,7 @@ class _LogDetailsState extends State<LogDetails>
             ),
           ],
         ),
-        lines: log?.prettyPrinted?.split('\n'),
+        lines: log?.prettyPrinted?.split('\n') ?? [],
       ),
     );
   }
@@ -296,7 +287,7 @@ class _KindColumn extends ColumnData<LogData>
   bool get supportsSorting => false;
 
   @override
-  double get fixedWidthPx => 145;
+  double get fixedWidthPx => 155;
 
   @override
   String getValue(LogData dataObject) => dataObject.kind;

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -289,7 +289,7 @@ class _LogDetailsState extends State<LogDetails>
     final disabled = log?.details == null || log.details.isEmpty;
 
     return OutlineDecoration(
-      child: ConsoleUsingTextWidget(
+      child: Console(
         title: areaPaneHeader(
           context,
           title: 'Details',

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -8,13 +8,14 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import 'analytics/constants.dart' as ga;
+import 'theme.dart';
 import 'ui/icons.dart';
 
 // Each service extension needs to be added to [_extensionDescriptions].
 class ToggleableServiceExtensionDescription<T>
     extends ServiceExtensionDescription {
   ToggleableServiceExtensionDescription._({
-    Image icon,
+    Widget icon,
     @required String extension,
     @required String description,
     @required T enabledValue,
@@ -66,7 +67,7 @@ class ServiceExtensionDescription<T> {
 
   final String description;
 
-  final Image icon;
+  final Widget icon;
 
   final List<T> values;
 
@@ -96,11 +97,11 @@ final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
 final invertOversizedImages = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.invertOversizedImages',
   description: 'Invert Oversized Images',
-  icon: createImageIcon('icons/debug_banner@2x.png'),
+  icon: const Icon(Icons.image, size: actionsIconSize),
   enabledValue: true,
   disabledValue: false,
-  enabledTooltip: 'Enable Invert Oversized Images',
-  disabledTooltip: 'Disable Invert Oversized Images',
+  enabledTooltip: 'Disable Invert Oversized Images',
+  disabledTooltip: 'Enable Invert Oversized Images',
   gaScreenName: ga.inspector,
   gaItem: ga.debugBanner,
 );

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -93,6 +93,18 @@ final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   gaItem: ga.debugBanner,
 );
 
+final invertOversizedImages = ToggleableServiceExtensionDescription<bool>._(
+  extension: 'ext.flutter.invertOversizedImages',
+  description: 'Invert Oversized Images',
+  icon: createImageIcon('icons/debug_banner@2x.png'),
+  enabledValue: true,
+  disabledValue: false,
+  enabledTooltip: 'Enable Invert Oversized Images',
+  disabledTooltip: 'Disable Invert Oversized Images',
+  gaScreenName: ga.inspector,
+  gaItem: ga.debugBanner,
+);
+
 final debugPaint = ToggleableServiceExtensionDescription<bool>._(
   extension: 'ext.flutter.debugPaint',
   description: 'Debug Paint',
@@ -285,6 +297,7 @@ final List<ServiceExtensionDescription> _extensionDescriptions = [
   structuredErrors,
   httpEnableTimelineLogging,
   socketProfiling,
+  invertOversizedImages,
 ];
 
 final Map<String, ServiceExtensionDescription> serviceExtensionsAllowlist =

--- a/packages/devtools_app/lib/src/ui/label.dart
+++ b/packages/devtools_app/lib/src/ui/label.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 class ImageIconLabel extends StatelessWidget {
   const ImageIconLabel(this.icon, this.text, {this.minIncludeTextWidth});
 
-  final Image icon;
+  final Widget icon;
   final String text;
   final double minIncludeTextWidth;
 

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -208,8 +208,8 @@ void main() {
           (WidgetTester tester) async {
         const index = 9;
         bool containsJson(Widget widget) {
-          if (widget is! Console) return false;
-          final content = (widget as Console).textContent.trim();
+          if (widget is! ConsoleUsingTextWidget) return false;
+          final content = (widget as ConsoleUsingTextWidget).textContent.trim();
           return content.startsWith('{') && content.endsWith('}');
         }
 

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -238,8 +238,8 @@ void main() {
           (WidgetTester tester) async {
         const index = 9;
         bool containsJson(Widget widget) {
-          if (widget is! ConsoleUsingTextWidget) return false;
-          final content = (widget as ConsoleUsingTextWidget).textContent.trim();
+          if (widget is! Console) return false;
+          final content = (widget as Console).textContent.trim();
           return content.startsWith('{') && content.endsWith('}');
         }
 


### PR DESCRIPTION
expose information about oversized images:
- add a toggle for the `ext.flutter. invertOversizedImages` service extension; this is on the Inspector page right now - it seems more immediately something people would use while looking at their app that a memory related toggle. Happy to move to to wherever is most useful however
- process the new `Flutter.ImageSizesForFrame` events; these include information about how much more memory an image is using than it needs
- handle displaying Flutter.Error event information on the logging page. Previously we had a todo here to render using the Inspector mechanisms. Since this was not implemented however, the user just saw a blank details area. This instead renders as JSON; we can improve this going forward.

@terrylucas and @jacob314 for review and comments

@dnfield - the default value for `debugImageOverheadAllowance` seems super twitchy. I think we should likely dial it back so that the flutter image errors trigger less often. I _believe_ it's currently on overage of 1024 bytes. Perhaps some value like 2x memory usage?

<img width="459" alt="Screen Shot 2020-11-17 at 1 41 45 PM" src="https://user-images.githubusercontent.com/1269969/99454963-fea35d00-28db-11eb-9d7d-3807759fefda.png">

<img width="749" alt="Screen Shot 2020-11-17 at 1 42 17 PM" src="https://user-images.githubusercontent.com/1269969/99454979-05ca6b00-28dc-11eb-9e8e-aa93b24489b3.png">

<img width="1395" alt="Screen Shot 2020-11-17 at 1 43 24 PM" src="https://user-images.githubusercontent.com/1269969/99455072-2abede00-28dc-11eb-844e-91f5eb0874c9.png">

<img width="890" alt="Screen Shot 2020-11-17 at 1 44 01 PM" src="https://user-images.githubusercontent.com/1269969/99455030-1aa6fe80-28dc-11eb-9116-ed5f73a7a01c.png">
