### PR TITLE
add padding between columns in tables

### DIFF
--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -1,3 +1,7 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -1250,8 +1254,9 @@ class _TableRowState<T> extends State<TableRow<T>>
         );
       }
 
-      content = SizedBox(
+      content = Container(
         width: columnWidth,
+        padding: const EdgeInsets.only(right: borderPadding),
         child: Align(
           alignment: _alignmentFor(column),
           child: content,


### PR DESCRIPTION
- add padding between columns in tables

This adds `borderPadding` padding (~2px) between columns in a table - this prevents adjacent cell content from running into each other. This does not increase the width of cells, but insets each cell a small amount (a cell the requests 20px will instead get 18px for its content).

If this lands it will likely supersede https://github.com/flutter/devtools/pull/2087.

cc @jacob314 @kenzieschmoll 

<img width="322" alt="Screen Shot 2020-11-24 at 4 28 45 PM" src="https://user-images.githubusercontent.com/1269969/100296505-4875ee00-2f41-11eb-8bc7-4210f4db48ff.png">
