### PR TITLE
Support truncated frames

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.9.6-dev
+* Support truncated frames with a corresponding `SHOW ALL` button.
+
 ## 0.9.5
 * Add padding between columns and add minWidth for flexible columns. [#2526](https://github.com/flutter/devtools/pull/2526)
 * Fix import bug. [#2528](https://github.com/flutter/devtools/pull/2528)

--- a/packages/devtools/pubspec.lock
+++ b/packages/devtools/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: browser_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.7"
+    version: "0.1.8"
   charcode:
     dependency: transitive
     description:
@@ -63,14 +63,14 @@ packages:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   http:
     dependency: "direct main"
     description:

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -8,7 +8,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 0.9.5
+version: 0.9.6
 
 homepage: https://github.com/flutter/devtools
 
@@ -16,8 +16,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_server: 0.9.5
-  devtools_shared: 0.9.5
+  devtools_server: 0.9.6
+  devtools_shared: 0.9.6
   http: ^0.12.0+1
 
 dependency_overrides:

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.sh matches the following line so
 // if you change it you must also modify tools/update_version.sh.
-const String version = '0.9.5';
+const String version = '0.9.6';

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -34,23 +34,30 @@ class _CallStackState extends State<CallStack> {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
-      valueListenable: controller.stackFramesWithLocation,
-      builder: (context, stackFrames, _) {
-        return ValueListenableBuilder<StackFrameAndSourcePosition>(
-          valueListenable: controller.selectedStackFrame,
-          builder: (context, selectedFrame, _) {
-            return ListView.builder(
-              itemCount: stackFrames.length,
-              itemExtent: defaultListItemHeight,
-              itemBuilder: (_, index) {
-                final frame = stackFrames[index];
-                return _buildStackFrame(frame, frame == selectedFrame);
+        valueListenable: controller.stackFramesWithLocation,
+        builder: (context, stackFrames, _) {
+          return Column(children: [
+            Expanded(
+                child: ValueListenableBuilder<StackFrameAndSourcePosition>(
+              valueListenable: controller.selectedStackFrame,
+              builder: (context, selectedFrame, _) {
+                return ListView.builder(
+                  itemCount: stackFrames.length,
+                  itemExtent: defaultListItemHeight,
+                  itemBuilder: (_, index) {
+                    final frame = stackFrames[index];
+                    return _buildStackFrame(frame, frame == selectedFrame);
+                  },
+                );
               },
-            );
-          },
-        );
-      },
-    );
+            )),
+            if (controller.hasTruncatedFrames)
+              FlatButton(
+                onPressed: () => controller.getFullStack(),
+                child: const Text('SHOW ALL'),
+              )
+          ]);
+        });
   }
 
   Widget _buildStackFrame(

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -33,11 +33,11 @@ class _CallStackState extends State<CallStack> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
-        valueListenable: controller.stackFramesWithLocation,
-        builder: (context, stackFrames, _) {
-          return Column(children: [
-            Expanded(
+    return Column(children: [
+      ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
+          valueListenable: controller.stackFramesWithLocation,
+          builder: (context, stackFrames, _) {
+            return Expanded(
                 child: ValueListenableBuilder<StackFrameAndSourcePosition>(
               valueListenable: controller.selectedStackFrame,
               builder: (context, selectedFrame, _) {
@@ -50,14 +50,20 @@ class _CallStackState extends State<CallStack> {
                   },
                 );
               },
-            )),
-            if (controller.hasTruncatedFrames)
-              FlatButton(
+            ));
+          }),
+      ValueListenableBuilder<bool>(
+          valueListenable: controller.hasTruncatedFrames,
+          builder: (_, hasTruncatedFrames, __) {
+            if (hasTruncatedFrames) {
+              return FlatButton(
                 onPressed: () => controller.getFullStack(),
                 child: const Text('SHOW ALL'),
-              )
-          ]);
-        });
+              );
+            }
+            return Container(height: 0, width: 0);
+          })
+    ]);
   }
 
   Widget _buildStackFrame(

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -61,7 +61,7 @@ class _CallStackState extends State<CallStack> {
                 child: const Text('SHOW ALL'),
               );
             }
-            return Container(height: 0, width: 0);
+            return const SizedBox(height: 0, width: 0);
           })
     ]);
   }

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -569,8 +569,8 @@ class DebuggerController extends DisposableController
     }
   }
 
-  bool _hasTruncatedFrames = false;
-  bool get hasTruncatedFrames => _hasTruncatedFrames;
+  final _hasTruncatedFrames = ValueNotifier<bool>(false);
+  ValueListenable<bool> get hasTruncatedFrames => _hasTruncatedFrames;
 
   CancelableOperation<_StackInfo> _getStackOperation;
 
@@ -623,9 +623,10 @@ class DebuggerController extends DisposableController
 
   void _populateFrameInfo(List<StackFrameAndSourcePosition> frames,
       {bool truncated}) {
+    truncated ??= false;
     _log.log('populated frame info');
     _stackFramesWithLocation.value = frames;
-    _hasTruncatedFrames = truncated ??= false;
+    _hasTruncatedFrames.value = truncated;
     if (frames.isEmpty) {
       selectStackFrame(null);
     } else {

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:typed_data';
 
+import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:pedantic/pedantic.dart';
@@ -213,7 +214,8 @@ class DebuggerController extends DisposableController
     if (ref == null) {
       _breakpoints.value = [];
       _breakpointsWithLocation.value = [];
-      _stackFramesWithLocation.value = [];
+      await _getStackOperation?.cancel();
+      _populateFrameInfo([]);
       return;
     }
 
@@ -567,15 +569,20 @@ class DebuggerController extends DisposableController
     }
   }
 
+  bool _hasTruncatedFrames = false;
+  bool get hasTruncatedFrames => _hasTruncatedFrames;
+
+  CancelableOperation<_StackInfo> _getStackOperation;
+
   Future<void> _pause(bool paused, {Event pauseEvent}) async {
+    await _getStackOperation?.cancel();
     _isPaused.value = paused;
 
     _log.log('_pause(running: ${!paused})');
 
     // Perform an early exit if we're not paused.
     if (!paused) {
-      _stackFramesWithLocation.value = [];
-      selectStackFrame(null);
+      _populateFrameInfo([]);
       return;
     }
 
@@ -585,31 +592,52 @@ class DebuggerController extends DisposableController
         [pauseEvent.topFrame],
         reportedException: pauseEvent?.exception,
       );
-      _stackFramesWithLocation.value = [
-        await _createStackFrameWithLocation(tempFrames.first),
-      ];
+      _populateFrameInfo(
+          [await _createStackFrameWithLocation(tempFrames.first)],
+          truncated: true);
       _log.log('created first frame');
-      selectStackFrame(_stackFramesWithLocation.value.first);
     }
 
-    // Then, issue an asynchronous request to populate the frame information.
-    _log.log('getStack()');
-    final stack = await _service.getStack(isolateRef.id);
+    // We populate the first 10 frames to match the behavior in VS Code.
+    _getStackOperation =
+        CancelableOperation.fromFuture(_getStackInfo(limit: 10));
+    final stackInfo = await _getStackOperation.value;
+    _populateFrameInfo(stackInfo.frames, truncated: stackInfo.truncated);
+  }
+
+  Future<_StackInfo> _getStackInfo({int limit}) async {
+    _log.log('getStack() with limit: $limit');
+    final stack = await _service.getStack(isolateRef.id, limit: limit);
     _log.log('getStack() completed (frames: ${stack.frames.length})');
+
     final frames = _framesForCallStack(
       stack.frames,
       asyncCausalFrames: stack.asyncCausalFrames,
-      reportedException: pauseEvent?.exception,
+      reportedException: _lastEvent?.exception,
     );
 
-    _stackFramesWithLocation.value =
-        await Future.wait(frames.map(_createStackFrameWithLocation));
+    return _StackInfo(
+        await Future.wait(frames.map(_createStackFrameWithLocation)),
+        stack.truncated);
+  }
+
+  void _populateFrameInfo(List<StackFrameAndSourcePosition> frames,
+      {bool truncated}) {
     _log.log('populated frame info');
-    if (_stackFramesWithLocation.value.isEmpty) {
+    _stackFramesWithLocation.value = frames;
+    _hasTruncatedFrames = truncated ??= false;
+    if (frames.isEmpty) {
       selectStackFrame(null);
     } else {
-      selectStackFrame(_stackFramesWithLocation.value.first);
+      selectStackFrame(frames.first);
     }
+  }
+
+  Future<void> getFullStack() async {
+    await _getStackOperation?.cancel();
+    _getStackOperation = CancelableOperation.fromFuture(_getStackInfo());
+    final stackInfo = await _getStackOperation.value;
+    _populateFrameInfo(stackInfo.frames, truncated: stackInfo.truncated);
   }
 
   void _clearCaches() {
@@ -1144,4 +1172,10 @@ class EvalHistory {
   String get currentText {
     return _historyPosition == -1 ? null : _evalHistory[_historyPosition];
   }
+}
+
+class _StackInfo {
+  final List<StackFrameAndSourcePosition> frames;
+  final bool truncated;
+  _StackInfo(this.frames, this.truncated);
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -1175,7 +1175,7 @@ class EvalHistory {
 }
 
 class _StackInfo {
+  _StackInfo(this.frames, this.truncated);
   final List<StackFrameAndSourcePosition> frames;
   final bool truncated;
-  _StackInfo(this.frames, this.truncated);
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -593,8 +593,9 @@ class DebuggerController extends DisposableController
         reportedException: pauseEvent?.exception,
       );
       _populateFrameInfo(
-          [await _createStackFrameWithLocation(tempFrames.first)],
-          truncated: true);
+        [await _createStackFrameWithLocation(tempFrames.first)],
+        truncated: true,
+      );
       _log.log('created first frame');
     }
 
@@ -617,12 +618,15 @@ class DebuggerController extends DisposableController
     );
 
     return _StackInfo(
-        await Future.wait(frames.map(_createStackFrameWithLocation)),
-        stack.truncated);
+      await Future.wait(frames.map(_createStackFrameWithLocation)),
+      stack.truncated,
+    );
   }
 
-  void _populateFrameInfo(List<StackFrameAndSourcePosition> frames,
-      {bool truncated}) {
+  void _populateFrameInfo(
+    List<StackFrameAndSourcePosition> frames, {
+    bool truncated,
+  }) {
     truncated ??= false;
     _log.log('populated frame info');
     _stackFramesWithLocation.value = frames;

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -37,7 +37,7 @@ packages:
     source: hosted
     version: "1.6.0"
   async:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: async
       url: "https://pub.dartlang.org"
@@ -70,7 +70,7 @@ packages:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.4"
+    version: "0.4.5"
   build_daemon:
     dependency: transitive
     description:
@@ -91,14 +91,14 @@ packages:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.7"
+    version: "1.10.9"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   built_collection:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   cli_util:
     dependency: transitive
     description:
@@ -196,28 +196,28 @@ packages:
       path: "../devtools"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   devtools_server:
     dependency: "direct overridden"
     description:
       path: "../devtools_server"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   devtools_shared:
     dependency: "direct main"
     description:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   devtools_testing:
     dependency: "direct dev"
     description:
       path: "../devtools_testing"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   fake_async:
     dependency: transitive
     description:
@@ -428,7 +428,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2+2"
+    version: "4.3.2+3"
   pub_semver:
     dependency: transitive
     description:
@@ -442,7 +442,7 @@ packages:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.1.7"
   quiver:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.9"
+    version: "0.9.10"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -566,7 +566,7 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0-nullsafety.12"
+    version: "1.16.0-nullsafety.13"
   test_api:
     dependency: transitive
     description:
@@ -580,14 +580,14 @@ packages:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.12-nullsafety.11"
+    version: "0.3.12-nullsafety.12"
   timing:
     dependency: transitive
     description:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1+2"
+    version: "0.1.1+3"
   typed_data:
     dependency: transitive
     description:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Web-based performance tooling for Dart and Flutter.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 0.9.5
+version: 0.9.6
 
 homepage: https://github.com/flutter/devtools
 
@@ -24,8 +24,9 @@ dependencies:
   ansi_up:
     ^0.0.2
 #     path: ../../third_party/packages/ansi_up
+  async: ^2.0.0 
   collection: ^1.15.0-nnbd
-  devtools_shared: 0.9.5
+  devtools_shared: 0.9.6
   file: ^5.1.0
   flutter_web_plugins:
     sdk: flutter
@@ -53,7 +54,7 @@ dev_dependencies:
   webkit_inspection_protocol: '>=0.5.0 <0.8.0'
   devtools: #^0.1.7
     path: ../devtools
-  devtools_testing: 0.9.5
+  devtools_testing: 0.9.6
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -391,7 +391,6 @@ void main() {
       when(debuggerController.hasTruncatedFrames)
           .thenReturn(ValueNotifier(true));
       await pumpDebuggerScreen(tester, debuggerController);
-      // SHOW ALL when truncated
       expect(find.text('SHOW ALL'), findsOneWidget);
     });
 
@@ -401,7 +400,6 @@ void main() {
       when(debuggerController.hasTruncatedFrames)
           .thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
-      // SHOW ALL when truncated
       expect(find.text('SHOW ALL'), findsNothing);
     });
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -59,6 +59,8 @@ void main() {
           .thenReturn(ValueNotifier([]));
       when(debuggerController.selectedStackFrame)
           .thenReturn(ValueNotifier(null));
+      when(debuggerController.hasTruncatedFrames)
+          .thenReturn(ValueNotifier(false));
       when(debuggerController.stdio).thenReturn(ValueNotifier(['']));
       when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
       when(debuggerController.exceptionPauseMode)
@@ -384,7 +386,24 @@ void main() {
       // Stack frame 4
       expect(find.text('<async break>'), findsOneWidget);
     });
+    testWidgetsWithWindowSize('Call Stack displays "SHOW ALL" when truncated',
+        const Size(1000.0, 4000.0), (WidgetTester tester) async {
+      when(debuggerController.hasTruncatedFrames)
+          .thenReturn(ValueNotifier(true));
+      await pumpDebuggerScreen(tester, debuggerController);
+      // SHOW ALL when truncated
+      expect(find.text('SHOW ALL'), findsOneWidget);
+    });
 
+    testWidgetsWithWindowSize(
+        'Call Stack does not display "SHOW ALL" when not truncated',
+        const Size(1000.0, 4000.0), (WidgetTester tester) async {
+      when(debuggerController.hasTruncatedFrames)
+          .thenReturn(ValueNotifier(false));
+      await pumpDebuggerScreen(tester, debuggerController);
+      // SHOW ALL when truncated
+      expect(find.text('SHOW ALL'), findsNothing);
+    });
     testWidgetsWithWindowSize(
         'Variables shows items', const Size(1000.0, 4000.0),
         (WidgetTester tester) async {

--- a/packages/devtools_server/pubspec.lock
+++ b/packages/devtools_server/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: browser_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.7"
+    version: "0.1.8"
   charcode:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       path: "../devtools_shared"
       relative: true
     source: path
-    version: "0.9.5"
+    version: "0.9.6"
   http:
     dependency: transitive
     description:

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -3,7 +3,7 @@ description: A server that supports Dart DevTools.
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.5
+version: 0.9.6
 
 homepage: https://github.com/flutter/devtools
 
@@ -13,7 +13,7 @@ environment:
 dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.5
-  devtools_shared: 0.9.5
+  devtools_shared: 0.9.6
   intl: ^0.17.0-nullsafety.1
   meta: ^1.1.0
   path: ^1.6.0

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package of shared structures between devtools_app and devtools_serv
 
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.5
+version: 0.9.6
 
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: devtools_testing
 description: Package of shared testing code for Dart DevTools.
 # Note: this version should only be updated by running tools/update_version.sh
 # that updates all versions of packages from packages/devtools.
-version: 0.9.5
+version: 0.9.6
 
 homepage: https://github.com/flutter/devtools
 
@@ -10,8 +10,8 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_app: 0.9.5
-  devtools_shared: 0.9.5
+  devtools_app: 0.9.6
+  devtools_shared: 0.9.6
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
Use the new optional `limit` parameter to `getStack` to display the first 10 frames by default. This improves the perceived stepping performance. When the frames are truncated, display a new `SHOW ALL` button which will collect all frames. Also rework the logic to no longer have a race condition when a user steps multiple times before the full stack value is returned.

<img width="794" alt="Screen Shot 2020-12-10 at 11 56 31 AM" src="https://user-images.githubusercontent.com/1840773/101822852-d07dfb00-3ade-11eb-9ac2-bc3e8c5685e1.png">

Closes https://github.com/flutter/devtools/issues/2507
