### PR TITLE
Cleanup in logging_controller and remove some unnecessary code.

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -63,6 +63,6 @@ void main() async {
 
   // Now run the app.
   runApp(
-    DevToolsApp(defaultScreens, preferences, ideTheme, await analyticsProvider),
+    DevToolsApp(defaultScreens, ideTheme, await analyticsProvider),
   );
 }

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -34,7 +34,6 @@ import 'network/network_screen.dart';
 import 'notifications.dart';
 import 'performance/performance_controller.dart';
 import 'performance/performance_screen.dart';
-import 'preferences.dart';
 import 'routing.dart';
 import 'scaffold.dart';
 import 'screen.dart';
@@ -58,22 +57,16 @@ bool isExternalBuild = true;
 class DevToolsApp extends StatefulWidget {
   const DevToolsApp(
     this.screens,
-    this.preferences,
     this.ideTheme,
     this.analyticsProvider,
   );
 
   final List<DevToolsScreen> screens;
-  final PreferencesController preferences;
   final IdeTheme ideTheme;
   final AnalyticsProvider analyticsProvider;
 
   @override
   State<DevToolsApp> createState() => DevToolsAppState();
-
-  static DevToolsAppState of(BuildContext context) {
-    return context.findAncestorStateOfType<DevToolsAppState>();
-  }
 }
 
 /// Initializer for the [FrameworkCore] and the app's navigation.
@@ -85,7 +78,6 @@ class DevToolsApp extends StatefulWidget {
 class DevToolsAppState extends State<DevToolsApp> {
   List<Screen> get _screens => widget.screens.map((s) => s.screen).toList();
 
-  PreferencesController get preferences => widget.preferences;
   IdeTheme get ideTheme => widget.ideTheme;
 
   bool get isDarkThemeEnabled => _isDarkThemeEnabled;
@@ -472,7 +464,6 @@ class DevToolsAboutDialog extends StatelessWidget {
 class SettingsDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    final preferences = DevToolsApp.of(context).preferences;
     return DevToolsDialog(
       title: dialogTitleText(Theme.of(context), 'Settings'),
       content: Column(

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -353,7 +353,6 @@ class LoggingController extends DisposableController
         summary: '${changedInfo.extension}: ${changedInfo.value}',
       ));
     } else if (e.extensionKind == 'Flutter.Error') {
-      print('logging error event in loggign controller');
       // TODO(pq): add tests for error extension handling once framework changes
       // are landed.
       final RemoteDiagnosticsNode node =

--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -56,7 +56,6 @@ Future<void> main() async {
         bundle: _DiskAssetBundle(),
         child: DevToolsApp(
           const [],
-          preferences,
           null,
           await analyticsProvider,
         ),


### PR DESCRIPTION
Use existing AutoDispose code in logging_controller.dart and remove `preferences` from `DevToolsApp` constructor. `preferences` is a global var as of some recent code changes.