### PR TITLE
Add ErrorBadgeManager and UI for badging Screen tabs

### DIFF
--- a/packages/devtools_app/lib/src/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/error_badge_manager.dart
@@ -1,0 +1,49 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
+
+import 'auto_dispose.dart';
+import 'globals.dart';
+import 'service_extensions.dart' as extensions;
+import 'vm_service_wrapper.dart';
+
+class ErrorBadgeManager extends DisposableController
+    with AutoDisposeControllerMixin {
+  // TODO(kenz): populate this map with screens as support is added
+  // (e.g. { LoggingScreen.id: ValueNotifier<int>(0) }
+  final _activeErrorCounts = <String, ValueNotifier<int>>{};
+
+  void vmServiceOpened(VmServiceWrapper service) {
+    // Ensure structured errors are enabled.
+    serviceManager.serviceExtensionManager.setServiceExtensionState(
+      extensions.structuredErrors.extension,
+      true,
+      true,
+    );
+
+    // Log Flutter extension events.
+    autoDispose(service.onExtensionEvent.listen(_handleExtensionEvent));
+
+    // Log stderr events.
+    autoDispose(service.onStderrEvent.listen(_handleStdErr));
+  }
+
+  void _handleExtensionEvent(Event e) async {
+    // TODO(kenz): handle Flutter.Error extension events.
+  }
+
+  void _handleStdErr(Event e) {
+    // TODO(kenz): handle stderr events
+  }
+
+  ValueListenable<int> errorCountNotifier(String screenId) {
+    return _activeErrorCounts[screenId] ?? ValueNotifier<int>(0);
+  }
+
+  void clearErrors(String screenId) {
+    _activeErrorCounts[screenId]?.value = 0;
+  }
+}

--- a/packages/devtools_app/lib/src/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/error_badge_manager.dart
@@ -7,6 +7,7 @@ import 'package:vm_service/vm_service.dart';
 
 import 'auto_dispose.dart';
 import 'globals.dart';
+import 'listenable.dart';
 import 'service_extensions.dart' as extensions;
 import 'vm_service_wrapper.dart';
 

--- a/packages/devtools_app/lib/src/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/error_badge_manager.dart
@@ -40,7 +40,7 @@ class ErrorBadgeManager extends DisposableController
   }
 
   ValueListenable<int> errorCountNotifier(String screenId) {
-    return _activeErrorCounts[screenId] ?? ValueNotifier<int>(0);
+    return _activeErrorCounts[screenId] ?? const FixedValueListenable<int>(0);
   }
 
   void clearErrors(String screenId) {

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -23,6 +23,7 @@ import '../ui/filter.dart';
 import '../ui/search.dart';
 import '../utils.dart';
 import '../vm_service_wrapper.dart';
+import 'logging_screen.dart';
 
 // For performance reasons, we drop old logs in batches, so the log will grow
 // to kMaxLogItemsUpperBound then truncate to kMaxLogItemsLowerBound.
@@ -251,6 +252,7 @@ class LoggingController
   void clear() {
     resetFilter();
     _updateData([]);
+    serviceManager.errorBadgeManager.clearErrors(LoggingScreen.id);
   }
 
   void _handleConnectionStart(VmServiceWrapper service) async {

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -96,24 +97,54 @@ abstract class Screen {
   /// should return `null`.
   String get docPageId => null;
 
+  int get badgeCount => 0;
+
   /// Builds the tab to show for this screen in the [DevToolsScaffold]'s main
   /// navbar.
   ///
   /// This will not be used if the [Screen] is the only one shown in the
   /// scaffold.
   Widget buildTab(BuildContext context) {
-    return Tab(
+    final tab = Tab(
       key: tabKey,
       child: Row(
         children: <Widget>[
           Icon(icon, size: defaultIconSize),
           Padding(
-            padding: const EdgeInsets.only(left: 8.0),
+            padding: const EdgeInsets.only(left: denseSpacing),
             child: Text(title),
           ),
         ],
       ),
     );
+
+    if (badgeCount > 0) {
+      // Calculate the width of the title text so that we can provide an accurate
+      // size for the [TabBadgePainter]
+      final painter = TextPainter(
+        text: TextSpan(
+          text: title,
+        ),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      final titleWidth = painter.width;
+
+      return LayoutBuilder(
+        builder: (context, constraints) {
+          return Stack(
+            children: [
+              CustomPaint(
+                size: Size(defaultIconSize + denseSpacing + titleWidth, 0),
+                painter: TabBadgePainter(count: 2),
+              ),
+              tab,
+            ],
+          );
+        },
+      );
+    }
+
+    return tab;
   }
 
   /// Builds the body to display for this tab.
@@ -176,4 +207,51 @@ bool shouldShowScreen(Screen screen) {
     }
   }
   return true;
+}
+
+class TabBadgePainter extends CustomPainter {
+  TabBadgePainter({@required this.count});
+
+  final int count;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    print(size.width);
+    final paint = Paint()
+      ..color = devtoolsError
+      ..style = PaintingStyle.fill;
+
+    final countPainter = TextPainter(
+      text: TextSpan(
+        text: '$count',
+        style: const TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    final badgeWidth = math.max(
+      defaultIconSize,
+      countPainter.width + denseSpacing,
+    );
+    canvas.drawOval(
+      Rect.fromLTWH(size.width, 0, badgeWidth, defaultIconSize),
+      paint,
+    );
+
+    countPainter.paint(
+      canvas,
+      Offset(size.width + (badgeWidth - countPainter.width) / 2, 0),
+    );
+  }
+
+  @override
+  bool shouldRepaint(covariant CustomPainter oldDelegate) {
+    if (oldDelegate is TabBadgePainter) {
+      return count != oldDelegate.count;
+    }
+    return true;
+  }
 }

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -105,46 +105,53 @@ abstract class Screen {
   /// This will not be used if the [Screen] is the only one shown in the
   /// scaffold.
   Widget buildTab(BuildContext context) {
-    final tab = Tab(
-      key: tabKey,
-      child: Row(
-        children: <Widget>[
-          Icon(icon, size: defaultIconSize),
-          Padding(
-            padding: const EdgeInsets.only(left: denseSpacing),
-            child: Text(title),
-          ),
-        ],
-      ),
-    );
-
-    if (badgeCount > 0) {
-      // Calculate the width of the title text so that we can provide an accurate
-      // size for the [TabBadgePainter]
-      final painter = TextPainter(
-        text: TextSpan(
-          text: title,
-        ),
-        textDirection: TextDirection.ltr,
-      )..layout();
-      final titleWidth = painter.width;
-
-      return LayoutBuilder(
-        builder: (context, constraints) {
-          return Stack(
-            children: [
-              CustomPaint(
-                size: Size(defaultIconSize + denseSpacing + titleWidth, 0),
-                painter: TabBadgePainter(count: 2),
+    return ValueListenableBuilder<int>(
+      valueListenable:
+          serviceManager.errorBadgeManager.errorCountNotifier(screenId),
+      builder: (context, count, _) {
+        print('tab: $screenId, count: $count');
+        final tab = Tab(
+          key: tabKey,
+          child: Row(
+            children: <Widget>[
+              Icon(icon, size: defaultIconSize),
+              Padding(
+                padding: const EdgeInsets.only(left: denseSpacing),
+                child: Text(title),
               ),
-              tab,
             ],
-          );
-        },
-      );
-    }
+          ),
+        );
 
-    return tab;
+        if (count > 0) {
+          // Calculate the width of the title text so that we can provide an accurate
+          // size for the [TabBadgePainter]
+          final painter = TextPainter(
+            text: TextSpan(
+              text: title,
+            ),
+            textDirection: TextDirection.ltr,
+          )..layout();
+          final titleWidth = painter.width;
+
+          return LayoutBuilder(
+            builder: (context, constraints) {
+              return Stack(
+                children: [
+                  CustomPaint(
+                    size: Size(defaultIconSize + denseSpacing + titleWidth, 0),
+                    painter: TabBadgePainter(count: 2),
+                  ),
+                  tab,
+                ],
+              );
+            },
+          );
+        }
+
+        return tab;
+      },
+    );
   }
 
   /// Builds the body to display for this tab.

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -109,7 +109,6 @@ abstract class Screen {
       valueListenable:
           serviceManager.errorBadgeManager.errorCountNotifier(screenId),
       builder: (context, count, _) {
-        print('tab: $screenId, count: $count');
         final tab = Tab(
           key: tabKey,
           child: Row(
@@ -140,7 +139,7 @@ abstract class Screen {
                 children: [
                   CustomPaint(
                     size: Size(defaultIconSize + denseSpacing + titleWidth, 0),
-                    painter: TabBadgePainter(count: 2),
+                    painter: TabBadgePainter(count: count),
                   ),
                   tab,
                 ],

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -17,6 +17,7 @@ import 'auto_dispose.dart';
 import 'config_specific/logger/logger.dart';
 import 'connected_app.dart';
 import 'core/message_bus.dart';
+import 'error_badge_manager.dart';
 import 'globals.dart';
 import 'logging/vm_service_logger.dart';
 import 'service_extensions.dart' as extensions;
@@ -77,6 +78,9 @@ class ServiceConnectionManager {
 
   IsolateManager get isolateManager => _isolateManager;
   IsolateManager _isolateManager;
+
+  ErrorBadgeManager get errorBadgeManager => _errorBadgeManager;
+  final _errorBadgeManager = ErrorBadgeManager();
 
   ServiceExtensionManager get serviceExtensionManager =>
       _serviceExtensionManager;
@@ -158,6 +162,7 @@ class ServiceConnectionManager {
     // race conditions where managers cannot listen for events soon enough.
     isolateManager.vmServiceOpened(service);
     vmFlagManager.vmServiceOpened(service);
+    errorBadgeManager.vmServiceOpened(service);
 
     serviceExtensionManager.vmServiceOpened(service, connectedApp);
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -162,9 +162,10 @@ class ServiceConnectionManager {
     // race conditions where managers cannot listen for events soon enough.
     isolateManager.vmServiceOpened(service);
     vmFlagManager.vmServiceOpened(service);
-    errorBadgeManager.vmServiceOpened(service);
-
     serviceExtensionManager.vmServiceOpened(service, connectedApp);
+    // This needs to be called last in the above group of `vmServiceOpened`
+    // calls.
+    errorBadgeManager.vmServiceOpened(service);
 
     if (debugLogServiceProtocolEvents) {
       serviceTrafficLogger = VmServiceTrafficLogger(service);

--- a/packages/devtools_app/test/app_size_screen_test.dart
+++ b/packages/devtools_app/test/app_size_screen_test.dart
@@ -9,17 +9,21 @@ import 'package:devtools_app/src/app_size/app_size_controller.dart';
 import 'package:devtools_app/src/app_size/app_size_table.dart';
 import 'package:devtools_app/src/app_size/file_import_container.dart';
 import 'package:devtools_app/src/common_widgets.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/notifications.dart';
+import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 import 'support/app_size_test_controller.dart';
 import 'support/app_size_test_data/new_v8.dart';
 import 'support/app_size_test_data/old_v8.dart';
 import 'support/app_size_test_data/sizes.dart';
 import 'support/app_size_test_data/unsupported_file.dart';
+import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() {
@@ -39,6 +43,7 @@ void main() {
 
   AppSizeScreen screen;
   AppSizeTestController appSizeController;
+  FakeServiceManager fakeServiceManager;
 
   const windowSize = Size(2560.0, 1338.0);
 
@@ -70,6 +75,10 @@ void main() {
     setUp(() async {
       screen = const AppSizeScreen();
       appSizeController = AppSizeTestController();
+      fakeServiceManager = FakeServiceManager();
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
     });
 
     testWidgets('builds its tab', (WidgetTester tester) async {

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -39,6 +39,8 @@ void main() {
       fakeServiceManager = FakeServiceManager();
       when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
 
       screen = const DebuggerScreen();
 

--- a/packages/devtools_app/test/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector_screen_test.dart
@@ -33,6 +33,8 @@ void main() {
       fakeExtensionManager = fakeServiceManager.serviceExtensionManager;
       when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
       when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
 
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       mockIsFlutterApp(serviceManager.connectedApp);

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -53,6 +53,8 @@ void main() {
       when(fakeServiceManager.connectedApp.isFlutterWebAppNow)
           .thenReturn(false);
       when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
       setGlobal(ServiceConnectionManager, fakeServiceManager);
 
       screen = const LoggingScreen();

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -36,6 +36,8 @@ void main() {
         .thenReturn(false);
     when(fakeServiceManager.connectedApp.isDartWebApp)
         .thenAnswer((_) => Future.value(false));
+    when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+        .thenReturn(ValueNotifier<int>(0));
     setGlobal(ServiceConnectionManager, fakeServiceManager);
 
     controller.offline = true;

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -36,8 +36,6 @@ void main() {
         .thenReturn(false);
     when(fakeServiceManager.connectedApp.isDartWebApp)
         .thenAnswer((_) => Future.value(false));
-    when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
-        .thenReturn(ValueNotifier<int>(0));
     setGlobal(ServiceConnectionManager, fakeServiceManager);
 
     controller.offline = true;
@@ -70,9 +68,11 @@ void main() {
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)
           .thenReturn(false);
       when(fakeServiceManager.vm.operatingSystem).thenReturn('iOS');
-      setGlobal(ServiceConnectionManager, fakeServiceManager);
-      when(serviceManager.connectedApp.isDartWebApp)
+      when(fakeServiceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const MemoryScreen();
     });
 

--- a/packages/devtools_app/test/network_profiler_test.dart
+++ b/packages/devtools_app/test/network_profiler_test.dart
@@ -66,14 +66,6 @@ void main() {
       setGlobal(ServiceConnectionManager, fakeServiceManager);
     });
 
-    testWidgets('builds its tab', (WidgetTester tester) async {
-      await tester.pumpWidget(wrapWithControllers(
-        Builder(builder: const NetworkScreen().buildTab),
-        network: NetworkController(),
-      ));
-      expect(find.text('Network'), findsOneWidget);
-    });
-
     testWidgetsWithWindowSize('starts and stops', windowSize, (
       WidgetTester tester,
     ) async {

--- a/packages/devtools_app/test/network_screen_test.dart
+++ b/packages/devtools_app/test/network_screen_test.dart
@@ -21,6 +21,8 @@ void main() {
       fakeServiceManager = FakeServiceManager();
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
       screen = const NetworkScreen();
     });
 

--- a/packages/devtools_app/test/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance_screen_test.dart
@@ -28,6 +28,8 @@ void main() {
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)
           .thenReturn(false);
       when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(true);
+      when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       screen = const PerformanceScreen();
     });

--- a/packages/devtools_app/test/scaffold_test.dart
+++ b/packages/devtools_app/test/scaffold_test.dart
@@ -25,6 +25,13 @@ void main() {
       when(mockServiceManager.service).thenReturn(null);
       when(mockServiceManager.onStateChange)
           .thenAnswer((_) => const Stream<bool>.empty());
+
+      final mockErrorBadgeManager = MockErrorBadgeManager();
+      when(mockServiceManager.errorBadgeManager)
+          .thenReturn(mockErrorBadgeManager);
+      when(mockErrorBadgeManager.errorCountNotifier(any))
+          .thenReturn(ValueNotifier<int>(0));
+
       setGlobal(ServiceConnectionManager, mockServiceManager);
       setGlobal(FrameworkController, FrameworkController());
       setGlobal(SurveyService, SurveyService());

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:devtools_app/src/banner_messages.dart';
 import 'package:devtools_app/src/connected_app.dart';
 import 'package:devtools_app/src/debugger/debugger_controller.dart';
+import 'package:devtools_app/src/error_badge_manager.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart'
     as flutter_memory;
@@ -80,6 +81,9 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
 
   @override
   final IsolateManager isolateManager = FakeIsolateManager();
+
+  @override
+  final ErrorBadgeManager errorBadgeManager = MockErrorBadgeManager();
 
   @override
   VM get vm => _mockVM;
@@ -419,6 +423,8 @@ class MockLoggingController extends Mock implements LoggingController {
     _selectedLog.value = data;
   }
 }
+
+class MockErrorBadgeManager extends Mock implements ErrorBadgeManager {}
 
 class MockMemoryController extends Mock implements MemoryController {}
 

--- a/packages/devtools_app/test/timeline_screen_test.dart
+++ b/packages/devtools_app/test/timeline_screen_test.dart
@@ -32,6 +32,8 @@ void main() {
         timelineData: vm_service.Timeline.parse(timelineJson),
       ),
     );
+    when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
+        .thenReturn(ValueNotifier<int>(0));
     when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
     when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
     when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(false);


### PR DESCRIPTION
This CL adds the skeleton for adding error-badging to devtools tabs. 

This is a checkpoint with the base support, and error handling for appropriate screens will be done in follow up PRs. The result will look like this:
![Screen Shot 2020-12-15 at 4 35 23 PM](https://user-images.githubusercontent.com/43759233/102549166-86fa5680-4070-11eb-912f-d04d53786677.png)
![Screen Shot 2020-12-15 at 4 35 27 PM](https://user-images.githubusercontent.com/43759233/102549174-895cb080-4070-11eb-82cb-a11a842ec71f.png)
