### PR TITLE
Improvements to performance tooling from UXR

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -32,8 +32,8 @@ import 'memory/memory_screen.dart';
 import 'network/network_controller.dart';
 import 'network/network_screen.dart';
 import 'notifications.dart';
-import 'performance/performance_controller.dart';
-import 'performance/performance_screen.dart';
+import 'profiler/profiler_screen.dart';
+import 'profiler/profiler_screen_controller.dart';
 import 'routing.dart';
 import 'scaffold.dart';
 import 'screen.dart';
@@ -533,14 +533,14 @@ List<DevToolsScreen> get defaultScreens => <DevToolsScreen>[
         createController: () => TimelineController(),
         supportsOffline: true,
       ),
+      DevToolsScreen<ProfilerScreenController>(
+        const ProfilerScreen(),
+        createController: () => ProfilerScreenController(),
+        supportsOffline: true,
+      ),
       DevToolsScreen<MemoryController>(
         const MemoryScreen(),
         createController: () => MemoryController(),
-      ),
-      DevToolsScreen<PerformanceController>(
-        const PerformanceScreen(),
-        createController: () => PerformanceController(),
-        supportsOffline: true,
       ),
       DevToolsScreen<DebuggerController>(
         const DebuggerScreen(),

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -5,11 +5,11 @@
 import 'package:flutter/foundation.dart';
 import 'package:meta/meta.dart';
 
-import '../profiler/cpu_profile_model.dart';
-import '../profiler/cpu_profile_service.dart';
-import '../profiler/cpu_profile_transformer.dart';
 import '../ui/search.dart';
 import '../utils.dart';
+import 'cpu_profile_model.dart';
+import 'cpu_profile_service.dart';
+import 'cpu_profile_transformer.dart';
 
 class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
   /// Data for the initial value and reset value of [_dataNotifier].

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
@@ -7,8 +7,8 @@ import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../globals.dart';
-import '../profiler/cpu_profile_model.dart';
 import '../vm_flags.dart' as vm_flags;
+import 'cpu_profile_model.dart';
 
 /// Manages interactions between the Cpu Profiler and the VmService.
 class CpuProfilerService {

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -48,9 +48,9 @@ class CpuProfiler extends StatefulWidget {
   // TODO(kenz): the summary tab should be available for UI events in the
   // timeline.
   static const tabs = [
-    Tab(key: flameChartTab, text: 'CPU Flame Chart'),
-    Tab(key: callTreeTab, text: 'Call Tree'),
     Tab(key: bottomUpTab, text: 'Bottom Up'),
+    Tab(key: callTreeTab, text: 'Call Tree'),
+    Tab(key: flameChartTab, text: 'CPU Flame Chart'),
   ];
 
   static const emptyCpuProfile = 'No CPU profile data';
@@ -155,6 +155,8 @@ class _CpuProfilerState extends State<CpuProfiler>
   }
 
   List<Widget> _buildProfilerViews() {
+    final bottomUp = CpuBottomUpTable(widget.bottomUpRoots);
+    final callTree = CpuCallTreeTable(widget.callTreeRoots);
     final cpuFlameChart = LayoutBuilder(
       builder: (context, constraints) {
         return CpuProfileFlameChart(
@@ -169,10 +171,8 @@ class _CpuProfilerState extends State<CpuProfiler>
         );
       },
     );
-    final callTree = CpuCallTreeTable(widget.callTreeRoots);
-    final bottomUp = CpuBottomUpTable(widget.bottomUpRoots);
     // TODO(kenz): make this order configurable.
-    return [cpuFlameChart, callTree, bottomUp];
+    return [bottomUp, callTree, cpuFlameChart ];
   }
 
   Widget _expandAllButton(Tab currentTab) {

--- a/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
@@ -5,12 +5,12 @@
 import 'package:flutter/foundation.dart';
 
 import '../config_specific/import_export/import_export.dart';
-import '../profiler/cpu_profile_controller.dart';
-import '../profiler/cpu_profile_model.dart';
 import '../utils.dart';
-import 'performance_screen.dart';
+import 'cpu_profile_controller.dart';
+import 'cpu_profile_model.dart';
+import 'profiler_screen.dart';
 
-class PerformanceController with CpuProfilerControllerProviderMixin {
+class ProfilerScreenController with CpuProfilerControllerProviderMixin {
   final _exportController = ExportController();
 
   CpuProfileData get cpuProfileData => cpuProfilerController.dataNotifier.value;
@@ -36,12 +36,12 @@ class PerformanceController with CpuProfilerControllerProviderMixin {
     );
   }
 
-  /// Exports the current performance data to a .json file.
+  /// Exports the current profiler data to a .json file.
   ///
   /// This method returns the name of the file that was downloaded.
   String exportData() {
     final encodedData =
-        _exportController.encode(PerformanceScreen.id, cpuProfileData.json);
+        _exportController.encode(ProfilerScreen.id, cpuProfileData.json);
     return _exportController.downloadFile(encodedData);
   }
 

--- a/packages/devtools_app/lib/src/timeline/event_details.dart
+++ b/packages/devtools_app/lib/src/timeline/event_details.dart
@@ -40,9 +40,7 @@ class EventDetails extends StatelessWidget {
           areaPaneHeader(
             context,
             needsTopBorder: false,
-            title: selectedEvent != null
-                ? '${selectedEvent.name} - ${msText(selectedEvent.time.duration)}'
-                : noEventSelected,
+            title: _generateHeaderText(selectedEvent),
           ),
           Expanded(
             child: selectedEvent != null
@@ -52,6 +50,14 @@ class EventDetails extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _generateHeaderText(TimelineEvent event) {
+    if (selectedEvent == null) {
+      return noEventSelected;
+    }
+    return '${selectedEvent.isUiEvent ? 'CPU Profile: ' : ''}'
+        '${selectedEvent.name} (${msText(selectedEvent.time.duration)})';
   }
 
   Widget _buildDetails(TimelineController controller) {

--- a/packages/devtools_app/test/banner_messages_test.dart
+++ b/packages/devtools_app/test/banner_messages_test.dart
@@ -5,7 +5,7 @@
 import 'package:devtools_app/src/banner_messages.dart';
 import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/performance/performance_screen.dart';
+import 'package:devtools_app/src/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/scaffold.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
@@ -162,7 +162,7 @@ BannerMessagesController bannerMessagesController(BuildContext context) {
 
 const testMessage1ScreenId = SimpleScreen.id;
 const testMessage2ScreenId = SimpleScreen.id;
-const testMessage3ScreenId = PerformanceScreen.id;
+const testMessage3ScreenId = ProfilerScreen.id;
 const k1 = Key('test message 1');
 const k2 = Key('test message 2');
 const k3 = Key('test message 3');

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -37,7 +37,10 @@ void main() {
   });
 
   group('Cpu Profiler', () {
-    testWidgets('builds for null cpuProfileData', (WidgetTester tester) async {
+    const windowSize = Size(2000.0, 1000.0);
+
+    testWidgetsWithWindowSize('builds for null cpuProfileData', windowSize,
+        (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: null,
         controller: controller,
@@ -51,7 +54,8 @@ void main() {
       expect(find.byType(CpuBottomUpTable), findsNothing);
     });
 
-    testWidgets('builds for empty cpuProfileData', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for empty cpuProfileData', windowSize,
+        (WidgetTester tester) async {
       cpuProfileData = CpuProfileData.parse(emptyCpuProfileDataJson);
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
@@ -66,19 +70,7 @@ void main() {
       expect(find.byType(CpuBottomUpTable), findsNothing);
     });
 
-    testWidgets('builds for valid cpuProfileData', (WidgetTester tester) async {
-      cpuProfiler = CpuProfiler(
-        data: cpuProfileData,
-        controller: controller,
-      );
-      await tester.pumpWidget(wrap(cpuProfiler));
-      expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
-      expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
-      expect(find.byType(CpuProfileFlameChart), findsOneWidget);
-    });
-
-    testWidgetsWithWindowSize('switches tabs', const Size(1000, 1000),
+    testWidgetsWithWindowSize('builds for valid cpuProfileData', windowSize,
         (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,
@@ -88,11 +80,24 @@ void main() {
       expect(find.byType(TabBar), findsOneWidget);
       expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
-      expect(find.byType(CpuProfileFlameChart), findsOneWidget);
+      expect(find.byType(CpuBottomUpTable), findsOneWidget);
+    });
+
+    testWidgetsWithWindowSize('switches tabs', windowSize,
+        (WidgetTester tester) async {
+      cpuProfiler = CpuProfiler(
+        data: cpuProfileData,
+        controller: controller,
+      );
+      await tester.pumpWidget(wrap(cpuProfiler));
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
+      expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
+      expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);
-      expect(find.byType(CpuBottomUpTable), findsNothing);
-      expect(find.byKey(CpuProfiler.expandButtonKey), findsNothing);
-      expect(find.byKey(CpuProfiler.collapseButtonKey), findsNothing);
+      expect(find.byType(CpuBottomUpTable), findsOneWidget);
+      expect(find.byKey(CpuProfiler.expandButtonKey), findsOneWidget);
+      expect(find.byKey(CpuProfiler.collapseButtonKey), findsOneWidget);
 
       await tester.tap(find.text('Call Tree'));
       await tester.pumpAndSettle();
@@ -102,17 +107,16 @@ void main() {
       expect(find.byKey(CpuProfiler.expandButtonKey), findsOneWidget);
       expect(find.byKey(CpuProfiler.collapseButtonKey), findsOneWidget);
 
-      await tester.tap(find.text('Bottom Up'));
+      await tester.tap(find.text('CPU Flame Chart'));
       await tester.pumpAndSettle();
-      expect(find.byType(CpuProfileFlameChart), findsNothing);
+      expect(find.byType(CpuProfileFlameChart), findsOneWidget);
       expect(find.byType(CpuCallTreeTable), findsNothing);
-      expect(find.byType(CpuBottomUpTable), findsOneWidget);
-      expect(find.byKey(CpuProfiler.expandButtonKey), findsOneWidget);
-      expect(find.byKey(CpuProfiler.collapseButtonKey), findsOneWidget);
+      expect(find.byType(CpuBottomUpTable), findsNothing);
+      expect(find.byKey(CpuProfiler.expandButtonKey), findsNothing);
+      expect(find.byKey(CpuProfiler.collapseButtonKey), findsNothing);
     });
 
-    testWidgetsWithWindowSize(
-        'can expand and collapse data', const Size(1000, 1000),
+    testWidgetsWithWindowSize('can expand and collapse data', windowSize,
         (WidgetTester tester) async {
       cpuProfiler = CpuProfiler(
         data: cpuProfileData,

--- a/packages/devtools_app/test/event_details_test.dart
+++ b/packages/devtools_app/test/event_details_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/timeline/timeline_controller.dart';
 import 'package:devtools_app/src/timeline/timeline_model.dart';
 import 'package:devtools_app/src/vm_flags.dart' as vm_flags;
 import 'package:devtools_testing/support/timeline_test_data.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
@@ -17,6 +18,8 @@ import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() {
+  const windowSize = Size(2050.0, 1000.0);
+
   group('EventDetails', () {
     EventDetails eventDetails;
 
@@ -38,7 +41,8 @@ void main() {
       when(serviceManager.connectedApp.isDartWebAppNow).thenReturn(false);
     });
 
-    testWidgets('builds for UI event', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for UI event', windowSize,
+        (WidgetTester tester) async {
       await pumpEventDetails(goldenUiTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsOneWidget);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
@@ -47,7 +51,8 @@ void main() {
       expect(find.text(EventDetails.instructions), findsNothing);
     });
 
-    testWidgets('builds for Raster event', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for Raster event', windowSize,
+        (WidgetTester tester) async {
       await pumpEventDetails(goldenRasterTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsNothing);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
@@ -56,7 +61,8 @@ void main() {
       expect(find.text(EventDetails.instructions), findsNothing);
     });
 
-    testWidgets('builds for ASYNC event', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for ASYNC event', windowSize,
+        (WidgetTester tester) async {
       await pumpEventDetails(asyncEventWithInstantChildren, tester);
       expect(find.byType(CpuProfiler), findsNothing);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
@@ -65,7 +71,8 @@ void main() {
       expect(find.text(EventDetails.instructions), findsNothing);
     });
 
-    testWidgets('builds for null event', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for null event', windowSize,
+        (WidgetTester tester) async {
       await pumpEventDetails(null, tester);
       expect(find.byType(CpuProfiler), findsNothing);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
@@ -74,7 +81,8 @@ void main() {
       expect(find.text(EventDetails.instructions), findsOneWidget);
     });
 
-    testWidgets('builds for disabled profiler', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds for disabled profiler', windowSize,
+        (WidgetTester tester) async {
       await serviceManager.service.setFlag(vm_flags.profiler, 'false');
       await pumpEventDetails(goldenUiTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsNothing);

--- a/packages/devtools_app/test/event_details_test.dart
+++ b/packages/devtools_app/test/event_details_test.dart
@@ -18,7 +18,7 @@ import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() {
-  const windowSize = Size(2050.0, 1000.0);
+  const windowSize = Size(2000.0, 1000.0);
 
   group('EventDetails', () {
     EventDetails eventDetails;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -276,19 +276,15 @@ void main() {
 
         // Re-launch, allowing reuse and with a different page.
         await _sendLaunchDevToolsRequest(
-            useVmService: useVmService,
-            reuseWindows: true,
-            page: 'performance');
+            useVmService: useVmService, reuseWindows: true, page: 'logging');
 
-        final serverResponse =
-            await _waitForClients(requiredPage: 'performance');
+        final serverResponse = await _waitForClients(requiredPage: 'logging');
         expect(serverResponse, isNotNull);
         expect(serverResponse['clients'], hasLength(1));
         expect(serverResponse['clients'][0]['hasConnection'], isTrue);
         expect(serverResponse['clients'][0]['vmServiceUri'],
             equals(appFixture.serviceUri.toString()));
-        expect(
-            serverResponse['clients'][0]['currentPage'], equals('performance'));
+        expect(serverResponse['clients'][0]['currentPage'], equals('logging'));
       }, timeout: const Timeout.factor(10));
 
       test('DevTools reports disconnects from a VM', () async {

--- a/packages/devtools_app/test/profiler_screen_controller_test.dart
+++ b/packages/devtools_app/test/profiler_screen_controller_test.dart
@@ -2,21 +2,21 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/performance/performance_controller.dart';
+import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:test/test.dart';
 
 import 'support/mocks.dart';
 
 void main() {
-  group('PerformanceController', () {
-    PerformanceController controller;
+  group('ProfilerScreenController', () {
+    ProfilerScreenController controller;
     FakeServiceManager fakeServiceManager;
 
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      controller = PerformanceController();
+      controller = ProfilerScreenController();
     });
 
     test('start and stop recording', () async {

--- a/packages/devtools_app/test/profiler_screen_test.dart
+++ b/packages/devtools_app/test/profiler_screen_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/performance/performance_controller.dart';
-import 'package:devtools_app/src/performance/performance_screen.dart';
+import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
+import 'package:devtools_app/src/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/profiler/cpu_profiler.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/vm_flag_widgets.dart';
@@ -18,10 +18,10 @@ import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() {
-  PerformanceScreen screen;
+  ProfilerScreen screen;
   FakeServiceManager fakeServiceManager;
 
-  group('PerformanceScreen', () {
+  group('ProfilerScreen', () {
     setUp(() async {
       fakeServiceManager = FakeServiceManager();
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
@@ -29,40 +29,40 @@ void main() {
           .thenReturn(false);
       when(fakeServiceManager.connectedApp.isDartCliAppNow).thenReturn(true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      screen = const PerformanceScreen();
+      screen = const ProfilerScreen();
     });
 
     void verifyBaseState(
-      PerformanceScreenBody perfScreenBody,
+      ProfilerScreenBody perfScreenBody,
       WidgetTester tester,
     ) {
       expect(find.byType(RecordButton), findsOneWidget);
       expect(find.byType(StopRecordingButton), findsOneWidget);
       expect(find.byType(ClearButton), findsOneWidget);
       expect(find.byType(ProfileGranularityDropdown), findsOneWidget);
-      expect(find.byKey(PerformanceScreen.recordingInstructionsKey),
+      expect(find.byKey(ProfilerScreen.recordingInstructionsKey),
           findsOneWidget);
-      expect(find.byKey(PerformanceScreen.recordingStatusKey), findsNothing);
+      expect(find.byKey(ProfilerScreen.recordingStatusKey), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.byType(CpuProfiler), findsNothing);
     }
 
-    Future<void> pumpPerformanceBody(
+    Future<void> pumpProfilerScreenBody(
       WidgetTester tester,
-      PerformanceScreenBody body,
+        ProfilerScreenBody body,
     ) async {
       await tester.pumpWidget(wrapWithControllers(
         body,
-        performance: PerformanceController(),
+        profiler: ProfilerScreenController(),
       ));
     }
 
     testWidgets('builds its tab', (WidgetTester tester) async {
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.buildTab),
-        performance: PerformanceController(),
+        profiler: ProfilerScreenController(),
       ));
-      expect(find.text('Performance'), findsOneWidget);
+      expect(find.text('CPU Profiler'), findsOneWidget);
     });
 
     const windowSize = Size(1000.0, 1000.0);
@@ -71,18 +71,18 @@ void main() {
       'builds proper content for recording state',
       windowSize,
       (WidgetTester tester) async {
-        const perfScreenBody = PerformanceScreenBody();
-        await pumpPerformanceBody(tester, perfScreenBody);
-        expect(find.byType(PerformanceScreenBody), findsOneWidget);
+        const perfScreenBody = ProfilerScreenBody();
+        await pumpProfilerScreenBody(tester, perfScreenBody);
+        expect(find.byType(ProfilerScreenBody), findsOneWidget);
         verifyBaseState(perfScreenBody, tester);
 
         // Start recording.
         await tester.tap(find.byType(RecordButton));
         await tester.pump();
-        expect(find.byKey(PerformanceScreen.recordingInstructionsKey),
+        expect(find.byKey(ProfilerScreen.recordingInstructionsKey),
             findsNothing);
         expect(
-            find.byKey(PerformanceScreen.recordingStatusKey), findsOneWidget);
+            find.byKey(ProfilerScreen.recordingStatusKey), findsOneWidget);
         expect(find.byType(CircularProgressIndicator), findsOneWidget);
         expect(find.byType(CpuProfiler), findsNothing);
 
@@ -102,11 +102,11 @@ void main() {
     testWidgetsWithWindowSize('builds for disabled profiler', windowSize,
         (WidgetTester tester) async {
       await serviceManager.service.setFlag(vm_flags.profiler, 'false');
-      const perfScreenBody = PerformanceScreenBody();
-      await pumpPerformanceBody(tester, perfScreenBody);
+      const perfScreenBody = ProfilerScreenBody();
+      await pumpProfilerScreenBody(tester, perfScreenBody);
       expect(find.byType(CpuProfilerDisabled), findsOneWidget);
       expect(
-        find.byKey(PerformanceScreen.recordingInstructionsKey),
+        find.byKey(ProfilerScreen.recordingInstructionsKey),
         findsNothing,
       );
       expect(find.byType(RecordButton), findsNothing);

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -11,7 +11,7 @@ import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart'
     as flutter_memory;
 import 'package:devtools_app/src/memory/memory_controller.dart';
-import 'package:devtools_app/src/performance/performance_controller.dart';
+import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/profiler/profile_granularity.dart';
 import 'package:devtools_app/src/service_extensions.dart' as extensions;
@@ -427,7 +427,8 @@ class MockFlutterMemoryController extends Mock
 
 class MockTimelineController extends Mock implements TimelineController {}
 
-class MockPerformanceController extends Mock implements PerformanceController {}
+class MockProfilerScreenController extends Mock
+    implements ProfilerScreenController {}
 
 class MockDebuggerController extends Mock implements DebuggerController {}
 

--- a/packages/devtools_app/test/support/wrappers.dart
+++ b/packages/devtools_app/test/support/wrappers.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/network/network_controller.dart';
 import 'package:devtools_app/src/notifications.dart';
-import 'package:devtools_app/src/performance/performance_controller.dart';
+import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/routing.dart';
 import 'package:devtools_app/src/theme.dart';
 import 'package:devtools_app/src/timeline/timeline_controller.dart';
@@ -54,7 +54,7 @@ Widget wrapWithControllers(
   LoggingController logging,
   MemoryController memory,
   TimelineController timeline,
-  PerformanceController performance,
+  ProfilerScreenController profiler,
   DebuggerController debugger,
   NetworkController network,
   BannerMessagesController bannerMessages,
@@ -67,8 +67,8 @@ Widget wrapWithControllers(
     if (logging != null) Provider<LoggingController>.value(value: logging),
     if (memory != null) Provider<MemoryController>.value(value: memory),
     if (timeline != null) Provider<TimelineController>.value(value: timeline),
-    if (performance != null)
-      Provider<PerformanceController>.value(value: performance),
+    if (profiler != null)
+      Provider<ProfilerScreenController>.value(value: profiler),
     if (network != null) Provider<NetworkController>.value(value: network),
     if (debugger != null) Provider<DebuggerController>.value(value: debugger),
     if (appSize != null) Provider<AppSizeController>.value(value: appSize),

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -62,8 +62,8 @@ void main() {
           equals([
             // InspectorScreen,
             TimelineScreen,
-            MemoryScreen,
             ProfilerScreen,
+            MemoryScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -80,8 +80,8 @@ void main() {
           equals([
             // InspectorScreen,
             // TimelineScreen,
+            // ProfilerScreen,
             // MemoryScreen,
-            // PerformanceScreen,
             DebuggerScreen,
             // NetworkScreen,
             LoggingScreen,
@@ -99,8 +99,8 @@ void main() {
           equals([
             InspectorScreen,
             TimelineScreen,
-            MemoryScreen,
             ProfilerScreen,
+            MemoryScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -118,8 +118,8 @@ void main() {
           equals([
             // InspectorScreen,
             TimelineScreen,
-            MemoryScreen,
             ProfilerScreen,
+            MemoryScreen,
             // DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -137,8 +137,8 @@ void main() {
           equals([
             InspectorScreen,
             // TimelineScreen,
+            // ProfilerScreen,
             // MemoryScreen,
-            // PerformanceScreen,
             DebuggerScreen,
             // NetworkScreen,
             LoggingScreen,
@@ -156,8 +156,8 @@ void main() {
           equals([
             // InspectorScreen,
             TimelineScreen, // Works offline, so appears regardless of web flag
-            // MemoryScreen,
             ProfilerScreen, // Works offline, so appears regardless of web flag
+            // MemoryScreen,
             // DebuggerScreen,
             // NetworkScreen,
             // LoggingScreen,
@@ -176,8 +176,8 @@ void main() {
           equals([
             // InspectorScreen,
             TimelineScreen,
-            MemoryScreen,
             ProfilerScreen,
+            MemoryScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -11,7 +11,7 @@ import 'package:devtools_app/src/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/logging/logging_screen.dart';
 import 'package:devtools_app/src/memory/memory_screen.dart';
 import 'package:devtools_app/src/network/network_screen.dart';
-import 'package:devtools_app/src/performance/performance_screen.dart';
+import 'package:devtools_app/src/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/screen.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -63,7 +63,7 @@ void main() {
             // InspectorScreen,
             TimelineScreen,
             MemoryScreen,
-            PerformanceScreen,
+            ProfilerScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -100,7 +100,7 @@ void main() {
             InspectorScreen,
             TimelineScreen,
             MemoryScreen,
-            PerformanceScreen,
+            ProfilerScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -119,7 +119,7 @@ void main() {
             // InspectorScreen,
             TimelineScreen,
             MemoryScreen,
-            PerformanceScreen,
+            ProfilerScreen,
             // DebuggerScreen,
             NetworkScreen,
             LoggingScreen,
@@ -157,7 +157,7 @@ void main() {
             // InspectorScreen,
             TimelineScreen, // Works offline, so appears regardless of web flag
             // MemoryScreen,
-            PerformanceScreen, // Works offline, so appears regardless of web flag
+            ProfilerScreen, // Works offline, so appears regardless of web flag
             // DebuggerScreen,
             // NetworkScreen,
             // LoggingScreen,
@@ -177,7 +177,7 @@ void main() {
             // InspectorScreen,
             TimelineScreen,
             MemoryScreen,
-            PerformanceScreen,
+            ProfilerScreen,
             DebuggerScreen,
             NetworkScreen,
             LoggingScreen,

--- a/packages/devtools_app/test/vm_flag_widgets_test.dart
+++ b/packages/devtools_app/test/vm_flag_widgets_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:devtools_app/src/banner_messages.dart';
 import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/performance/performance_screen.dart';
+import 'package:devtools_app/src/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/profiler/profile_granularity.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/theme.dart';
@@ -27,7 +27,7 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       setGlobal(ServiceConnectionManager, fakeServiceManager);
-      dropdown = const ProfileGranularityDropdown(PerformanceScreen.id);
+      dropdown = const ProfileGranularityDropdown(ProfilerScreen.id);
     });
 
     Future<void> pumpDropdown(WidgetTester tester) async {
@@ -99,7 +99,7 @@ void main() {
       // Verify we are showing the high profile granularity warning.
       expect(
         bannerMessagesController(buildContext)
-            .messagesForScreen(PerformanceScreen.id)
+            .messagesForScreen(ProfilerScreen.id)
             .value
             .length,
         equals(1),
@@ -123,7 +123,7 @@ void main() {
       // Verify we are not showing the high profile granularity warning.
       expect(
         bannerMessagesController(buildContext)
-            .messagesForScreen(PerformanceScreen.id)
+            .messagesForScreen(ProfilerScreen.id)
             .value,
         isEmpty,
       );


### PR DESCRIPTION
Addresses part of https://github.com/flutter/devtools/issues/2497:
- [x] move performance tab next to timeline tab
- [x] rename "event details" to CPU profiler on timeline page
- [x] rename performance page to "CPU profiler"
- [x] move bottom up profiler tab to position 0