### PR TITLE
Remove dependencies on nullsafe versions of packages from devtools.

### DIFF
--- a/packages/devtools/pubspec.lock
+++ b/packages/devtools/pubspec.lock
@@ -29,13 +29,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
@@ -98,7 +91,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0-nullsafety.2"
+    version: "0.16.1"
   logging:
     dependency: transitive
     description:
@@ -126,7 +119,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.7.0"
   pedantic:
     dependency: transitive
     description:
@@ -154,7 +147,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+1"
   source_span:
     dependency: transitive
     description:
@@ -233,4 +226,4 @@ packages:
     source: hosted
     version: "0.7.4"
 sdks:
-  dart: ">=2.12.0-0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   build_config:
     dependency: transitive
     description:
@@ -84,21 +84,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.4"
+    version: "1.5.1"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.9"
+    version: "1.10.11"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.4"
+    version: "6.1.5"
   built_collection:
     dependency: transitive
     description:
@@ -295,7 +295,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0-nullsafety.2"
+    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -477,7 +477,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+1"
   shelf_web_socket:
     dependency: transitive
     description:
@@ -496,7 +496,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.10"
+    version: "0.9.10+1"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   http: ^0.12.0+1
-  intl: ^0.17.0-nullsafety.1
+  intl: ^0.16.1
   js: ^0.6.1+1
   meta: ^1.1.0
   mime: ^0.9.7

--- a/packages/devtools_server/pubspec.lock
+++ b/packages/devtools_server/pubspec.lock
@@ -29,13 +29,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.3"
-  clock:
-    dependency: transitive
-    description:
-      name: clock
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
@@ -91,7 +84,7 @@ packages:
       name: intl
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.17.0-nullsafety.2"
+    version: "0.16.1"
   logging:
     dependency: transitive
     description:
@@ -119,7 +112,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.3"
+    version: "1.7.0"
   pedantic:
     dependency: transitive
     description:
@@ -147,7 +140,7 @@ packages:
       name: shelf_static
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.8"
+    version: "0.2.9+1"
   source_span:
     dependency: transitive
     description:
@@ -226,4 +219,4 @@ packages:
     source: hosted
     version: "0.7.4"
 sdks:
-  dart: ">=2.12.0-0 <3.0.0"
+  dart: ">=2.6.0 <3.0.0"

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   args: ^1.5.1
   browser_launcher: ^0.1.5
   devtools_shared: 0.9.6
-  intl: ^0.17.0-nullsafety.1
+  intl: ^0.16.1
   meta: ^1.1.0
   path: ^1.6.0
   sse: ^3.1.2


### PR DESCRIPTION
devtools_server needs to be compatible with old Dart versions.
Fixes https://github.com/flutter/devtools/issues/2559