### PR TITLE
Added syntax highlighting to CodeView

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -10,6 +10,7 @@ import 'src/app.dart';
 import 'src/config_specific/framework_initialize/framework_initialize.dart';
 import 'src/config_specific/ide_theme/ide_theme.dart';
 import 'src/config_specific/load_fallback_app/load_fallback_app.dart';
+import 'src/debugger/syntax_highlighter.dart';
 import 'src/preferences.dart';
 
 void main() async {
@@ -60,6 +61,9 @@ void main() async {
   await preferences.init();
 
   await initializeFramework();
+
+  // Load the Dart syntax highlighting grammar.
+  await SyntaxHighlighter.initialize();
 
   // Now run the app.
   runApp(

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -213,9 +213,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
     final theme = Theme.of(context);
 
     final lines = <TextSpan>[];
-    final style = theme.textTheme.bodyText2.copyWith(
-      fontFamily: 'RobotoMono',
-    );
+    final style = fixedFontStyle(context);
 
     // Ensure the syntax highlighter has been initialized.
     // TODO(bkonyi): process source for highlighting on a separate thread.

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -57,7 +57,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
   void initState() {
     super.initState();
 
-    SyntaxHighlighter.initialize().then((_) => _initScriptInfo());
+    _initScriptInfo();
     verticalController = LinkedScrollControllerGroup();
     gutterController = verticalController.addAndGet();
     textController = verticalController.addAndGet();

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -213,9 +213,13 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
     final theme = Theme.of(context);
 
     final lines = <TextSpan>[];
+    final style = theme.textTheme.bodyText2.copyWith(
+      fontFamily: 'RobotoMono',
+    );
 
     // Ensure the syntax highlighter has been initialized.
-    if (highlighter != null) {
+    // TODO(bkonyi): process source for highlighting on a separate thread.
+    if (script.source.length < 500000 && highlighter != null) {
       final highlighted = highlighter.highlight(context);
 
       // Look for [TextSpan]s which only contain '\n' to manually break the
@@ -226,9 +230,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
         if (span.toPlainText() == '\n') {
           lines.add(
             TextSpan(
-              style: theme.textTheme.bodyText2.copyWith(
-                fontFamily: 'RobotoMono',
-              ),
+              style: style,
               children: currentLine,
             ),
           );
@@ -238,11 +240,19 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
       });
       lines.add(
         TextSpan(
-          style: theme.textTheme.bodyText2.copyWith(
-            fontFamily: 'RobotoMono',
-          ),
+          style: style,
           children: currentLine,
         ),
+      );
+    } else {
+      lines.addAll(
+        [
+          for (final line in script.source.split('\n'))
+            TextSpan(
+              style: style,
+              text: line,
+            ),
+        ],
       );
     }
 

--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -122,6 +122,8 @@ class ScopeSpan {
 
   final List<String> scopes;
 
+  bool contains(int token) => (_start <= token) && (token < _end);
+
   @override
   String toString() {
     return '[$_start, $_end, $line:$column (len: $length)] = $scopes';

--- a/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
@@ -14,9 +14,7 @@ import '../theme.dart';
 import 'span_parser.dart';
 
 class SyntaxHighlighter {
-  SyntaxHighlighter({
-    this.source,
-  });
+  SyntaxHighlighter({this.source});
 
   SyntaxHighlighter.withGrammar({
     Grammar grammar,

--- a/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
@@ -37,6 +37,9 @@ class SyntaxHighlighter {
 
   static Future<void> initialize() async {
     if (_grammar == null) {
+      // Ensure the framework is initialized before trying to load the syntax
+      // from the bundled assets.
+      WidgetsFlutterBinding.ensureInitialized();
       final grammarJson = json.decode(
         await rootBundle.loadString('assets/dart_syntax.json'),
       );
@@ -60,7 +63,7 @@ class SyntaxHighlighter {
   }
 
   /// Returns the [TextStyle] for the current span based on the current scopes.
-  /// 
+  ///
   /// If there are multiple scopes for a span, styling for each scope is
   /// applied in the order the scopes are listed (i.e., later scope styles take
   /// precidence).

--- a/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
@@ -1,0 +1,297 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file
+
+import 'dart:collection';
+import 'dart:convert';
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter/services.dart' show rootBundle;
+
+import '../theme.dart';
+import 'span_parser.dart';
+
+class SyntaxHighlighter {
+  SyntaxHighlighter({
+    this.source,
+  });
+
+  SyntaxHighlighter.withGrammar({
+    Grammar grammar,
+    this.source,
+  }) {
+    _grammar = grammar;
+  }
+
+  final String source;
+
+  final _spanStack = ListQueue<ScopeSpan>();
+
+  int _currentPosition;
+
+  Map<String, TextStyle> _scopeStyles;
+
+  static Grammar _grammar;
+
+  static Future<void> initialize() async {
+    if (_grammar == null) {
+      final grammarJson = json.decode(
+        await rootBundle.loadString('assets/dart_syntax.json'),
+      );
+      _grammar = Grammar.fromJson(grammarJson);
+    }
+  }
+
+  TextSpan highlight(BuildContext context) {
+    assert(_grammar != null);
+    // Generate the styling for the various scopes based on the current theme.
+    _scopeStyles = _buildSyntaxColorTable(Theme.of(context));
+    _currentPosition = 0;
+
+    return TextSpan(
+      children: _highlightLoopHelper(
+        currentScope: null,
+        loopCondition: () => _currentPosition < source.length,
+        scopes: SpanParser.parse(_grammar, source),
+      ),
+    );
+  }
+
+  /// Returns the [TextStyle] for the current span based on the current scopes.
+  /// 
+  /// If there are multiple scopes for a span, styling for each scope is
+  /// applied in the order the scopes are listed (i.e., later scope styles take
+  /// precidence).
+  TextStyle _getStyleForSpan() {
+    if (_spanStack.isEmpty) {
+      return const TextStyle();
+    }
+    final scopes = _spanStack.last.scopes;
+
+    if (scopes == null || scopes.isEmpty) {
+      return const TextStyle();
+    } else if (scopes.length == 1) {
+      return _scopeStyles[scopes.first] ?? const TextStyle();
+    } else {
+      var style = const TextStyle();
+      for (final scope in scopes) {
+        style = style.merge(_scopeStyles[scope] ?? const TextStyle());
+      }
+      return style;
+    }
+  }
+
+  /// Enters a new scope for a span of text. Returns a [List<TextSpan>]
+  /// containing the stylized text from within the scope.
+  List<TextSpan> _scope(
+    ScopeSpan currentScope,
+    List<ScopeSpan> scopes,
+  ) {
+    return _highlightLoopHelper(
+      currentScope: currentScope,
+      loopCondition: () => currentScope.contains(_currentPosition),
+      scopes: scopes,
+    );
+  }
+
+  List<TextSpan> _highlightLoopHelper({
+    @required ScopeSpan currentScope,
+    @required bool Function() loopCondition,
+    @required List<ScopeSpan> scopes,
+  }) {
+    final sourceSpans = <TextSpan>[];
+    int currentScopeBegin = _currentPosition;
+    if (currentScope != null) {
+      _spanStack.addLast(currentScope);
+    }
+    while (loopCondition()) {
+      if (scopes.isNotEmpty && scopes.first.contains(_currentPosition)) {
+        // Encountered the next scoped span. Close the current span and enter
+        // the next.
+        final text = source.substring(
+          currentScopeBegin,
+          _currentPosition,
+        );
+        if (text.isNotEmpty) {
+          sourceSpans.add(
+            TextSpan(
+              style: _getStyleForSpan(),
+              text: text,
+            ),
+          );
+        }
+        sourceSpans.addAll(
+          _scope(
+            scopes.removeAt(0),
+            scopes,
+          ),
+        );
+        // Reset the beginning of the current span to the first position after
+        // the close of the span that was just processed.
+        currentScopeBegin = _currentPosition;
+      } else if (_atNewline()) {
+        currentScopeBegin = _processNewlines(
+          sourceSpans,
+          currentScopeBegin,
+        );
+      } else {
+        ++_currentPosition;
+      }
+    }
+    // Reached the end of the text covered by the current span. Close the span
+    // and exit the scope.
+    final text = source.substring(
+      currentScopeBegin,
+      _currentPosition,
+    );
+    if (text.isNotEmpty) {
+      sourceSpans.add(
+        TextSpan(
+          style: _getStyleForSpan(),
+          text: text,
+        ),
+      );
+    }
+    if (currentScope != null) {
+      _spanStack.removeLast();
+    }
+    return sourceSpans;
+  }
+
+  bool _atNewline() =>
+      String.fromCharCode(source.codeUnitAt(_currentPosition)) == '\n';
+
+  int _processNewlines(List<TextSpan> sourceSpans, int currentScopeBegin) {
+    final text = source.substring(
+      currentScopeBegin,
+      _currentPosition,
+    );
+    if (text.isNotEmpty) {
+      sourceSpans.add(
+        TextSpan(
+          style: _getStyleForSpan(),
+          text: source.substring(
+            currentScopeBegin,
+            _currentPosition,
+          ),
+        ),
+      );
+    }
+    // We artificially break up spans if they contain a newline so it's easier
+    // to find line boundaries when we try and populate the code view.
+    do {
+      sourceSpans.add(const TextSpan(text: '\n'));
+      ++_currentPosition;
+    } while ((_currentPosition < source.length) &&
+        (String.fromCharCode(source.codeUnitAt(_currentPosition)) == '\n'));
+    return _currentPosition;
+  }
+
+  Map<String, TextStyle> _buildSyntaxColorTable(ThemeData theme) {
+    final commentStyle = TextStyle(
+      color: theme.colorScheme.commentSyntaxColor,
+    );
+    final functionStyle = TextStyle(
+      color: theme.colorScheme.functionSyntaxColor,
+    );
+    final declarationStyle = TextStyle(
+      color: theme.colorScheme.declarationsSyntaxColor,
+    );
+    final modifierStyle = TextStyle(
+      color: theme.colorScheme.modifierSyntaxColor,
+    );
+    final controlFlowStyle = TextStyle(
+      color: theme.colorScheme.controlFlowSyntaxColor,
+    );
+    final variableStyle = TextStyle(
+      color: theme.colorScheme.variableSyntaxColor,
+    );
+    final stringStyle = TextStyle(
+      color: theme.colorScheme.stringSyntaxColor,
+    );
+    final numericConstantStyle = TextStyle(
+      color: theme.colorScheme.numericConstantSyntaxColor,
+    );
+
+    // Note: these scopes are defined in assets/dart_syntax.json
+    const modifierScopes = <String>[
+      'constant.language.dart',
+      'keyword.cast.dart',
+      'keyword.declaration.dart',
+      'keyword.other.import.dart',
+      'storage.modifier.dart',
+      'storage.type.annotation.dart',
+      'storage.type.primitive.dart',
+    ];
+
+    const commentScopes = <String>[
+      'comment.block.dart',
+      'comment.block.documentation.dart',
+      'comment.block.empty.dart',
+      'comment.line.double-slash.dart',
+    ];
+
+    const declarationScopes = <String>[
+      'support.class.dart',
+      'variable.language.dart',
+    ];
+
+    const numericConstantScopes = <String>[
+      'constant.numeric.dart',
+    ];
+
+    const functionScopes = <String>[
+      'entity.name.function.dart',
+    ];
+
+    const controlFlowScopes = <String>[
+      'keyword.control.catch-exception.dart',
+      'keyword.control.dart',
+      // While 'new' is not a control flow keyword, it uses the control flow
+      // color scheme so we include it here.
+      'keyword.control.new.dart',
+    ];
+
+    const stringScopes = <String>[
+      'string.interpolated.double.dart',
+      'string.interpolated.single.dart',
+      'string.interpolated.triple.double.dart',
+      'string.interpolated.triple.single.dart',
+      'string.quoted.double.dart',
+      'string.quoted.single.dart',
+      'string.quoted.triple.double.dart',
+      'string.quoted.triple.single.dart',
+    ];
+
+    const variableScopes = <String>[
+      // DartDoc code reference
+      'variable.name.source.dart',
+      // DartDoc in-line code
+      'variable.other.source.dart',
+      // Highlights code in strings (e.g., '$foo' or '${foo.bar()}')
+      'variable.parameter.dart',
+    ];
+
+    Map<String, TextStyle> _scopeTextStyleMapper(
+      List<String> scopes,
+      TextStyle style,
+    ) {
+      return {
+        for (final scope in scopes) scope: style,
+      };
+    }
+
+    return <String, TextStyle>{
+      ..._scopeTextStyleMapper(modifierScopes, modifierStyle),
+      ..._scopeTextStyleMapper(commentScopes, commentStyle),
+      ..._scopeTextStyleMapper(declarationScopes, declarationStyle),
+      ..._scopeTextStyleMapper(numericConstantScopes, numericConstantStyle),
+      ..._scopeTextStyleMapper(functionScopes, functionStyle),
+      ..._scopeTextStyleMapper(controlFlowScopes, controlFlowStyle),
+      ..._scopeTextStyleMapper(stringScopes, stringStyle),
+      ..._scopeTextStyleMapper(variableScopes, variableStyle),
+    };
+  }
+}

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -159,6 +159,23 @@ extension DevToolsColorScheme on ColorScheme {
       isLight ? const Color(0xFFE0EEFA) : const Color(0xFF2E3C48);
   // [toggleButtonForegroundColor] is the same for light and dark theme.
   Color get toggleButtonForegroundColor => const Color(0xFF2196F3);
+
+  Color get functionSyntaxColor =>
+      isLight ? const Color(0xFF795E26) : const Color(0xFFDCDCAA);
+  Color get declarationsSyntaxColor =>
+      isLight ? const Color(0xFF267f99) : const Color(0xFF4EC9B0);
+  Color get modifierSyntaxColor =>
+      isLight ? const Color(0xFF0000FF) : const Color(0xFF569CD6);
+  Color get controlFlowSyntaxColor =>
+      isLight ? const Color(0xFFAF00DB) : const Color(0xFFC586C0);
+  Color get variableSyntaxColor =>
+      isLight ? const Color(0xFF001080) : const Color(0xFF9CDCFE);
+  Color get commentSyntaxColor =>
+      isLight ? const Color(0xFF008000) : const Color(0xFF6A9955);
+  Color get stringSyntaxColor =>
+      isLight ? const Color(0xFFB20001) : const Color(0xFFD88E73);
+  Color get numericConstantSyntaxColor =>
+      isLight ? const Color(0xFF098658) : const Color(0xFFB5CEA8);
 }
 
 TextStyle linkTextStyle(ColorScheme colorScheme) => TextStyle(

--- a/packages/devtools_app/test/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/syntax_highlighter_test.dart
@@ -1,0 +1,546 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@TestOn('vm')
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/debugger/span_parser.dart';
+import 'package:devtools_app/src/debugger/syntax_highlighter.dart';
+import 'package:devtools_app/src/routing.dart';
+import 'package:devtools_app/src/theme.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
+
+import 'support/wrappers.dart';
+
+const modifierSpans = [
+  // Start multi-capture spans
+  'import "foo";',
+  'export "foo";',
+  'part of "baz";',
+  'part "foo";',
+  'export "foo";',
+  // End multi-capture spans
+  '@annotation',
+  'true',
+  'false',
+  'null',
+  'as',
+  'abstract',
+  'class',
+  'enum',
+  'extends',
+  'extension',
+  'external',
+  'factory',
+  'implements',
+  'get',
+  'mixin',
+  'native',
+  'operator',
+  'set',
+  'typedef',
+  'with',
+  'covariant',
+  'static',
+  'final',
+  'const',
+  'required',
+  'late',
+];
+
+const controlFlowSpans = [
+  'try',
+  'on',
+  'catch',
+  'finally',
+  'throw',
+  'rethrow',
+  'break',
+  'case',
+  'continue',
+  'default',
+  'do',
+  'else',
+  'for',
+  'if',
+  'in',
+  'return',
+  'switch',
+  'while',
+  'sync',
+  'async',
+  'await',
+  'yield',
+  'assert',
+  'new',
+];
+
+const declarationSpans = [
+  'this',
+  'super',
+  'bool',
+  'num',
+  'int',
+  'double',
+  'dynamic',
+  '_PrivateDeclaration',
+  'PublicDeclaration',
+];
+
+const functionSpans = [
+  'foo()',
+  '_foo()',
+  'foo(bar)',
+];
+
+const numericSpans = [
+  '1',
+  '1.1',
+  '0xFF',
+  '0xff',
+  '1.3e5',
+  '1.3E5',
+];
+
+const helloWorld = '''
+Future<void> main() async {
+  print('hello world!');
+}
+''';
+
+const multilineDoc = '''
+/**
+ * Multiline
+ */
+''';
+
+const docCodeReference = '''
+/// This is a code reference for [Foo]
+''';
+
+const variableReferenceInString = '''
+'\$i: \${foo[i] == bar[i]}'
+''';
+
+void main() {
+  Grammar grammar;
+  setUp(() async {
+    final grammarFile = File('assets/dart_syntax.json');
+    expect(grammarFile.existsSync(), true);
+
+    final grammarJson = json.decode(await grammarFile.readAsString());
+    grammar = Grammar.fromJson(grammarJson);
+  });
+
+  Color defaultTextColor(_) => const TextStyle().color;
+  Color commentSyntaxColor(ColorScheme scheme) => scheme.commentSyntaxColor;
+  Color controlFlowSyntaxColor(ColorScheme scheme) =>
+      scheme.controlFlowSyntaxColor;
+  Color declarationSyntaxColor(ColorScheme scheme) =>
+      scheme.declarationsSyntaxColor;
+  Color functionSyntaxColor(ColorScheme scheme) => scheme.functionSyntaxColor;
+  Color modifierSyntaxColor(ColorScheme scheme) => scheme.modifierSyntaxColor;
+  Color numericConstantSyntaxColor(ColorScheme scheme) =>
+      scheme.numericConstantSyntaxColor;
+  Color stringSyntaxColor(ColorScheme scheme) => scheme.stringSyntaxColor;
+  Color variableSyntaxColor(ColorScheme scheme) => scheme.variableSyntaxColor;
+
+  void spanTester(
+    BuildContext context,
+    TextSpan span,
+    String expectedText,
+    Color Function(ColorScheme) expectedColor,
+  ) {
+    expect(span.text, expectedText);
+    expect(
+      span.style,
+      TextStyle(
+        color: expectedColor(Theme.of(context).colorScheme),
+      ),
+    );
+  }
+
+  void runTestsWithTheme({@required bool useDarkTheme}) {
+    group(
+      'Syntax Highlighting (${useDarkTheme ? 'Dark' : 'Light'} Theme)',
+      () {
+        Widget buildSyntaxHighlightingTestContext(
+          Function(BuildContext) callback,
+        ) {
+          return MaterialApp.router(
+            theme: themeFor(
+              isDarkTheme: useDarkTheme,
+              ideTheme: getIdeTheme(),
+            ),
+            routerDelegate: DevToolsRouterDelegate(null),
+            routeInformationParser: DevToolsRouteInformationParser(),
+            builder: (context, _) {
+              callback(context);
+              return Container();
+            },
+          );
+        }
+
+        testWidgetsWithContext(
+          'hello world smoke',
+          (WidgetTester tester) async {
+            final highlighter = SyntaxHighlighter.withGrammar(
+              grammar: grammar,
+              source: helloWorld,
+            );
+
+            await tester.pumpWidget(
+              buildSyntaxHighlightingTestContext(
+                (context) {
+                  final highlighted = highlighter.highlight(context);
+                  final children = highlighted.children;
+
+                  spanTester(
+                    context,
+                    children[0],
+                    'Future',
+                    declarationSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[1],
+                    '<',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[2],
+                    'void',
+                    modifierSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[3],
+                    '>',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[4],
+                    ' ',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[5],
+                    'main',
+                    functionSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[6],
+                    '() ',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[7],
+                    'async',
+                    controlFlowSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[8],
+                    ' {',
+                    defaultTextColor,
+                  );
+
+                  expect(children[9].toPlainText(), '\n');
+
+                  spanTester(
+                    context,
+                    children[10],
+                    '  ',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[11],
+                    'print',
+                    functionSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[12],
+                    '(',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[13],
+                    "'hello world!'",
+                    stringSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[14],
+                    ')',
+                    defaultTextColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[15],
+                    ';',
+                    defaultTextColor,
+                  );
+
+                  expect(children[16].toPlainText(), '\n');
+
+                  spanTester(
+                    context,
+                    children[17],
+                    '}',
+                    defaultTextColor,
+                  );
+
+                  expect(children[18].toPlainText(), '\n');
+
+                  return Container();
+                },
+              ),
+            );
+          },
+        );
+
+        testWidgetsWithContext(
+          'multiline documentation',
+          (WidgetTester tester) async {
+            final highlighter = SyntaxHighlighter.withGrammar(
+              grammar: grammar,
+              source: multilineDoc,
+            );
+
+            await tester.pumpWidget(
+              buildSyntaxHighlightingTestContext(
+                (context) {
+                  final highlighted = highlighter.highlight(context);
+                  final children = highlighted.children;
+
+                  spanTester(
+                    context,
+                    children[0],
+                    '/**',
+                    commentSyntaxColor,
+                  );
+
+                  expect(children[1].toPlainText(), '\n');
+
+                  spanTester(
+                    context,
+                    children[2],
+                    ' * Multiline',
+                    commentSyntaxColor,
+                  );
+
+                  expect(
+                    children[3].toPlainText(),
+                    '\n',
+                  );
+
+                  spanTester(
+                    context,
+                    children[4],
+                    ' */',
+                    commentSyntaxColor,
+                  );
+                },
+              ),
+            );
+          },
+        );
+
+        testWidgetsWithContext(
+          'documentation code reference',
+          (WidgetTester tester) async {
+            final highlighter = SyntaxHighlighter.withGrammar(
+              grammar: grammar,
+              source: docCodeReference,
+            );
+
+            await tester.pumpWidget(
+              buildSyntaxHighlightingTestContext(
+                (context) {
+                  final highlighted = highlighter.highlight(context);
+                  final children = highlighted.children;
+
+                  spanTester(
+                    context,
+                    children[0],
+                    '/// This is a code reference for ',
+                    commentSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[1],
+                    '[Foo]',
+                    variableSyntaxColor,
+                  );
+
+                  expect(children[2].toPlainText(), '\n');
+                },
+              ),
+            );
+          },
+        );
+
+        testWidgetsWithContext(
+          'variable reference in string',
+          (WidgetTester tester) async {
+            final highlighter = SyntaxHighlighter.withGrammar(
+              grammar: grammar,
+              source: variableReferenceInString,
+            );
+
+            await tester.pumpWidget(
+              buildSyntaxHighlightingTestContext(
+                (context) {
+                  final highlighted = highlighter.highlight(context);
+                  final children = highlighted.children;
+
+                  spanTester(
+                    context,
+                    children[0],
+                    "'\$",
+                    stringSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[1],
+                    'i',
+                    variableSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[2],
+                    ': \${',
+                    stringSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[3],
+                    'foo[i] == bar[i]',
+                    variableSyntaxColor,
+                  );
+
+                  spanTester(
+                    context,
+                    children[4],
+                    '}\'',
+                    stringSyntaxColor,
+                  );
+                },
+              ),
+            );
+          },
+        );
+
+        void testSingleSpan(
+          String name,
+          String spanText,
+          Color Function(ColorScheme) colorCallback,
+        ) {
+          testWidgetsWithContext(
+            "$name '$spanText'",
+            (WidgetTester tester) async {
+              final highlighter = SyntaxHighlighter.withGrammar(
+                grammar: grammar,
+                source: spanText,
+              );
+
+              await tester.pumpWidget(
+                buildSyntaxHighlightingTestContext(
+                  (context) {
+                    final highlighted = highlighter.highlight(context);
+                    expect(
+                      highlighted.children.first.style,
+                      TextStyle(
+                        color: colorCallback(Theme.of(context).colorScheme),
+                      ),
+                    );
+                    return Container();
+                  },
+                ),
+              );
+            },
+          );
+        }
+
+        group(
+          'single span highlighting:',
+          () {
+            for (final spanText in modifierSpans) {
+              testSingleSpan(
+                'modifier',
+                spanText,
+                modifierSyntaxColor,
+              );
+            }
+
+            for (final spanText in controlFlowSpans) {
+              testSingleSpan(
+                'control flow',
+                spanText,
+                controlFlowSyntaxColor,
+              );
+            }
+
+            for (final spanText in declarationSpans) {
+              testSingleSpan(
+                'declaration',
+                spanText,
+                declarationSyntaxColor,
+              );
+            }
+
+            for (final spanText in functionSpans) {
+              testSingleSpan(
+                'function',
+                spanText,
+                functionSyntaxColor,
+              );
+            }
+
+            for (final spanText in numericSpans) {
+              testSingleSpan(
+                'numeric',
+                spanText,
+                numericConstantSyntaxColor,
+              );
+            }
+          },
+        );
+      },
+    );
+  }
+
+  runTestsWithTheme(useDarkTheme: false);
+  runTestsWithTheme(useDarkTheme: true);
+}


### PR DESCRIPTION
**Dark theme:**
<img width="3003" alt="Screen Shot 2021-01-05 at 11 42 51 AM" src="https://user-images.githubusercontent.com/24210656/103692145-36c63400-4f4c-11eb-903b-92b45da76c87.png">

**Light theme:**
<img width="3005" alt="Screen Shot 2021-01-05 at 11 43 08 AM" src="https://user-images.githubusercontent.com/24210656/103692167-3d54ab80-4f4c-11eb-8f68-ef7a3173e669.png">

Fixes https://github.com/flutter/devtools/issues/1927