### PR TITLE
Remove use of Flutter service worker

### DIFF
--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -352,6 +352,7 @@ class WebBuildFixture {
     cliArgs.addAll([
       'build',
       'web',
+      '--pwa-strategy=none',
       '--dart-define=FLUTTER_WEB_USE_SKIA=true',
       '--no-tree-shake-icons'
     ]);

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -55,14 +55,15 @@
 </head>
 
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
+    // Remove any previously registered service workers as DevTools does not use them anymore.
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
+      navigator.serviceWorker.getRegistrations()
+        .then(function(registrations) {
+          for(let registration of registrations) {
+            registration.unregister();
+          }
+        });
     }
   </script>
 

--- a/packages/devtools_app/web/index_fallback.html
+++ b/packages/devtools_app/web/index_fallback.html
@@ -42,14 +42,15 @@
 </head>
 
 <body>
-  <!-- This script installs service_worker.js to provide PWA functionality to
-       application. For more information, see:
-       https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
+    // Remove any previously registered service workers as DevTools does not use them anymore.
     if ('serviceWorker' in navigator) {
-      window.addEventListener('load', function () {
-        navigator.serviceWorker.register('flutter_service_worker.js');
-      });
+      navigator.serviceWorker.getRegistrations()
+        .then(function(registrations) {
+          for(let registration of registrations) {
+            registration.unregister();
+          }
+        });
     }
   </script>
   <script src="main_fallback.dart.js" type="application/javascript"></script>

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -106,7 +106,7 @@ elif [ "$BOT" = "test_ddc" ]; then
 
     # TODO(https://github.com/flutter/flutter/issues/43538): Remove workaround.
     flutter config --enable-web
-    flutter build web --no-tree-shake-icons
+    flutter build web --pwa-strategy=none --no-tree-shake-icons
 
     # Run every test except for integration_tests.
     # The flutter tool doesn't support excluding a specific set of targets,
@@ -124,7 +124,7 @@ elif [ "$BOT" = "test_dart2js" ]; then
 
     # TODO(https://github.com/flutter/flutter/issues/43538): Remove workaround.
     flutter config --enable-web
-    flutter build web --no-tree-shake-icons
+    flutter build web --pwa-strategy=none --no-tree-shake-icons
 
     # Run every test except for integration_tests.
     # The flutter tool doesn't support excluding a specific set of targets,

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -16,9 +16,9 @@ flutter pub get
 # as code size doesn't matter very much for us as minification makes some
 # crashes harder to debug. For example, https://github.com/flutter/devtools/issues/2125
 
-flutter build web --profile --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=true --no-tree-shake-icons
+flutter build web --pwa-strategy=none --profile --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=true --no-tree-shake-icons
 cp build/web/main.dart.js build/web/main_fallback.dart.js
-flutter build web --profile --dart-define=FLUTTER_WEB_USE_SKIA=true --no-tree-shake-icons
+flutter build web --pwa-strategy=none --profile --dart-define=FLUTTER_WEB_USE_SKIA=true --no-tree-shake-icons
 mv build/web ../devtools/build
 
 popd


### PR DESCRIPTION
Setting `--pwa-strategy=none` just writes an empty service worker file and didn't seem to unregister it, so I wasn't sure if that would cause any issues and added code to explicitly unregister it (I don't know if this is necessary, but it seemed safest).

@jacob314