### PR TITLE
Fix regression where the BulletSpacer was rendered on top of the code size tab.

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -405,7 +405,7 @@ class BulletSpacer extends StatelessWidget {
 
   final bool useAccentColor;
 
-  static final width = DevToolsScaffold.actionWidgetSize / 2;
+  static const width = DevToolsScaffold.actionWidgetSize / 2;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -405,6 +405,8 @@ class BulletSpacer extends StatelessWidget {
 
   final bool useAccentColor;
 
+  static final width = DevToolsScaffold.actionWidgetSize / 2;
+
   @override
   Widget build(BuildContext context) {
     final ThemeData theme = Theme.of(context);
@@ -420,7 +422,7 @@ class BulletSpacer extends StatelessWidget {
     final mutedColor = textStyle?.color?.withAlpha(0x90);
 
     return Container(
-      width: DevToolsScaffold.actionWidgetSize / 2,
+      width: width,
       height: DevToolsScaffold.actionWidgetSize,
       alignment: Alignment.center,
       child: Text(

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -342,7 +342,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           : const Size.fromHeight(kToolbarHeight);
       final alignment = isNarrow ? Alignment.bottomLeft : Alignment.centerRight;
 
-      final rightAdjust = isNarrow ? 0.0 : DevToolsScaffold.actionWidgetSize;
+      final rightAdjust = isNarrow ? 0.0 : BulletSpacer.width;
       final rightPadding = isNarrow
           ? 0.0
           : math.max(


### PR DESCRIPTION
We were using the wrong offset causing the content to overlap.
Broken:
<img width="111" alt="Screen Shot 2021-01-08 at 1 16 22 PM" src="https://user-images.githubusercontent.com/1226812/104067423-ff5bbf80-51b7-11eb-9e5b-b5437e2bdf4a.png">

Fixed:
<img width="1385" alt="Screen Shot 2021-01-08 at 1 41 46 PM" src="https://user-images.githubusercontent.com/1226812/104067385-ee12b300-51b7-11eb-8498-8c8f4a202512.png">
