### PR TITLE
Add tooltips to CPU profiler column titles.

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_bottom_up.dart
@@ -15,9 +15,9 @@ import 'cpu_profile_model.dart';
 class CpuBottomUpTable extends StatelessWidget {
   factory CpuBottomUpTable(List<CpuStackFrame> bottomUpRoots, {Key key}) {
     final treeColumn = MethodNameColumn();
-    final startingSortColumn = SelfTimeColumn();
+    final startingSortColumn = SelfTimeColumn(titleTooltip: selfTimeTooltip);
     final columns = List<ColumnData<CpuStackFrame>>.unmodifiable([
-      TotalTimeColumn(),
+      TotalTimeColumn(titleTooltip: totalTimeTooltip),
       startingSortColumn,
       treeColumn,
       // TODO(kenz): add source column for flutter apps once
@@ -45,6 +45,17 @@ class CpuBottomUpTable extends StatelessWidget {
   final ColumnData<CpuStackFrame> sortColumn;
   final List<ColumnData<CpuStackFrame>> columns;
   final List<CpuStackFrame> bottomUpRoots;
+
+  static const totalTimeTooltip =
+      'Time that a method spent executing its own code as well as the code for '
+      'the\nmethod that it called (which is displayed as an ancestor in the '
+      'bottom up tree).';
+
+  static const selfTimeTooltip =
+      'For top-level methods in the bottom-up tree (leaf stack frames in the '
+      'CPU profile),\nthis is the time the method spent executing only its own '
+      'code. For sub nodes (the\ncallers in the CPU profile), this is the self '
+      'time of the callee when being called by\nthe caller. ';
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_call_tree.dart
@@ -15,10 +15,10 @@ import 'cpu_profile_model.dart';
 class CpuCallTreeTable extends StatelessWidget {
   factory CpuCallTreeTable(List<CpuStackFrame> dataRoots, {Key key}) {
     final treeColumn = MethodNameColumn();
-    final startingSortColumn = TotalTimeColumn();
+    final startingSortColumn = TotalTimeColumn(titleTooltip: totalTimeTooltip);
     final columns = List<ColumnData<CpuStackFrame>>.unmodifiable([
       startingSortColumn,
-      SelfTimeColumn(),
+      SelfTimeColumn(titleTooltip: selfTimeTooltip),
       treeColumn,
       // TODO(kenz): add source column for flutter apps once
       // https://github.com/dart-lang/sdk/issues/37553 is fixed.
@@ -40,6 +40,13 @@ class CpuCallTreeTable extends StatelessWidget {
     this.sortColumn,
     this.columns,
   ) : super(key: key);
+
+  static const totalTimeTooltip =
+      'Time that a method spent executing its own code\nas well as the code for '
+      'any methods it called.';
+
+  static const selfTimeTooltip =
+      'Time that a method spent executing only its own code.';
 
   final TreeColumnData<CpuStackFrame> treeColumn;
   final ColumnData<CpuStackFrame> sortColumn;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
@@ -6,9 +6,10 @@ import 'cpu_profile_model.dart';
 const _timeColumnWidthPx = 160.0;
 
 class SelfTimeColumn extends ColumnData<CpuStackFrame> {
-  SelfTimeColumn()
+  SelfTimeColumn({String titleTooltip})
       : super(
           'Self Time',
+          titleTooltip: titleTooltip,
           fixedWidthPx: _timeColumnWidthPx,
         );
 
@@ -36,9 +37,10 @@ class SelfTimeColumn extends ColumnData<CpuStackFrame> {
 }
 
 class TotalTimeColumn extends ColumnData<CpuStackFrame> {
-  TotalTimeColumn()
+  TotalTimeColumn({String titleTooltip})
       : super(
           'Total Time',
+          titleTooltip: titleTooltip,
           fixedWidthPx: _timeColumnWidthPx,
         );
 

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -1260,6 +1260,11 @@ class _TableRowState<T> extends State<TableRow<T>>
       if (node == null) {
         final isSortColumn = column == widget.sortColumn;
 
+        final title = Text(
+          column.title,
+          overflow: TextOverflow.ellipsis,
+        );
+
         content = InkWell(
           canRequestFocus: false,
           onTap: () => _handleSortChange(column),
@@ -1277,10 +1282,15 @@ class _TableRowState<T> extends State<TableRow<T>>
               // TODO: This Flexible wrapper was added to get the
               // network_profiler_test.dart tests to pass.
               Flexible(
-                child: Text(
-                  column.title,
-                  overflow: TextOverflow.ellipsis,
-                ),
+                child: column.titleTooltip != null
+                    ? Tooltip(
+                        message: column.titleTooltip,
+                        padding: const EdgeInsets.all(denseSpacing),
+                        waitDuration: tooltipWait,
+                        preferBelow: false,
+                        child: title,
+                      )
+                    : title,
               ),
             ],
           ),

--- a/packages/devtools_app/lib/src/table_data.dart
+++ b/packages/devtools_app/lib/src/table_data.dart
@@ -327,6 +327,7 @@ class TreeTableData<T extends TreeNode<T>> extends TableData<T> {
 abstract class ColumnData<T> {
   ColumnData(
     this.title, {
+    this.titleTooltip,
     @required this.fixedWidthPx,
     this.alignment = ColumnAlignment.left,
   })  : assert(fixedWidthPx != null),
@@ -334,11 +335,14 @@ abstract class ColumnData<T> {
 
   ColumnData.wide(
     this.title, {
+    this.titleTooltip,
     this.minWidthPx,
     this.alignment = ColumnAlignment.left,
   }) : fixedWidthPx = null;
 
   final String title;
+
+  final String titleTooltip;
 
   /// Width of the column expressed as a fixed number of pixels.
   final double fixedWidthPx;


### PR DESCRIPTION
Call Tree Total and Self time
![Screen Shot 2021-01-12 at 1 21 54 PM](https://user-images.githubusercontent.com/43759233/104376728-46102900-54da-11eb-8439-2a2460649ffe.png)
![Screen Shot 2021-01-12 at 1 21 48 PM](https://user-images.githubusercontent.com/43759233/104376719-414b7500-54da-11eb-8e5f-55aa8b13b35f.png)

Bottom up Total and Self time
![Screen Shot 2021-01-12 at 1 21 40 PM](https://user-images.githubusercontent.com/43759233/104376759-56c09f00-54da-11eb-9519-2ba28057d86e.png)
![Screen Shot 2021-01-12 at 1 21 34 PM](https://user-images.githubusercontent.com/43759233/104376769-5922f900-54da-11eb-9cdf-75034f26595f.png)

Definitions taken straight from public docs: https://flutter.dev/docs/development/tools/devtools/cpu-profiler