### PR TITLE
Correctly process large HTTP responses in network profiler

### DIFF
--- a/packages/devtools_app/lib/src/http/http_request_data.dart
+++ b/packages/devtools_app/lib/src/http/http_request_data.dart
@@ -82,7 +82,9 @@ class HttpRequestData extends NetworkRequest {
     }
 
     try {
-      responseBody = utf8.decode(encodedData);
+      if (encodedData.isNotEmpty) {
+        responseBody = utf8.decode(encodedData);
+      }
     } on FormatException {
       // Non-UTF8 response.
     }

--- a/packages/devtools_app/macos/Flutter/Flutter-Debug.xcconfig
+++ b/packages/devtools_app/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/devtools_app/macos/Flutter/Flutter-Release.xcconfig
+++ b/packages/devtools_app/macos/Flutter/Flutter-Release.xcconfig
@@ -1,2 +1,3 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/packages/devtools_app/pubspec.lock
+++ b/packages/devtools_app/pubspec.lock
@@ -554,7 +554,7 @@ packages:
     source: hosted
     version: "1.2.0"
   string_scanner:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
@@ -709,4 +709,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.12.0-0.0 <3.0.0"
-  flutter: ">=1.22.0 <2.0.0"
+  flutter: ">=1.22.0"


### PR DESCRIPTION
The network profiler was assuming that a response body would only ever
consist of a single chunk. This was resulting in us trying to decode a
partial response, causing a FormatException to be thrown and halting
processing of HTTP events.

This change stitches together all of the response body events for a
given response before trying to decode it. In addition, the
FormatException is caught and ignored in order to allow for non-UTF8
responses.

Fixes both https://github.com/flutter/devtools/issues/2398 and https://github.com/flutter/devtools/issues/2480