### PR TITLE
Support wide vm_service range

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   string_scanner: ^1.1.0-nullsafety.3
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: '^6.0.0-nullsafety.3'
+  vm_service: ^6.0.0-nullsafety.3
   vm_snapshot_analysis: ^0.5.5
   web_socket_channel: ^1.1.0
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   string_scanner: ^1.1.0-nullsafety.3
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^6.0.0-nullsafety.3
+  vm_service: ^6.0.1-nullsafety.0
   vm_snapshot_analysis: ^0.5.5
   web_socket_channel: ^1.1.0
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   string_scanner: ^1.1.0-nullsafety.3
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: '6.0.0-nullsafety.1'
+  vm_service: '^6.0.0-nullsafety.3'
   vm_snapshot_analysis: ^0.5.5
   web_socket_channel: ^1.1.0
 


### PR DESCRIPTION
We incorrectly pinned the version in https://github.com/flutter/devtools/pull/2617 when we actually can support a wide range.