### PR TITLE
dumpsys meminfo is a heavy action(trigger native GC), only fetch when android memory chart visible

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -106,7 +106,9 @@ class MemoryTracker {
 
     // Polls for current Android meminfo using:
     //    > adb shell dumpsys meminfo -d <package_name>
-    if (hasConnection && serviceManager.vm.operatingSystem == 'android') {
+    // This is a heavy action(trigger native GC), only fetch when chart visible
+    if (hasConnection && serviceManager.vm.operatingSystem == 'android' &&
+        memoryController.isAndroidChartVisible) {
       adbMemoryInfo = await _fetchAdbInfo();
     } else {
       // TODO(terry): TBD alternative for iOS memory info - all values zero.


### PR DESCRIPTION
This makes the performance more accurate when the android part of the memory data is not needed.