### PR TITLE
Listen for logs with event history in logging page and error badge manager

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -16,6 +16,7 @@ import '../auto_dispose.dart';
 import '../core/message_bus.dart';
 import '../globals.dart';
 import '../utils.dart';
+import '../vm_service_wrapper.dart';
 import 'debugger_model.dart';
 
 // TODO(devoncarew): Add some delayed resume value notifiers (to be used to
@@ -38,7 +39,9 @@ class DebuggerController extends DisposableController
         .listen(switchToIsolate));
     autoDispose(_service.onDebugEvent.listen(_handleDebugEvent));
     autoDispose(_service.onIsolateEvent.listen(_handleIsolateEvent));
+    // TODO(kenz): do we want to listen with event history here?
     autoDispose(_service.onStdoutEvent.listen(_handleStdoutEvent));
+    // TODO(kenz): do we want to listen with event history here?
     autoDispose(_service.onStderrEvent.listen(_handleStderrEvent));
 
     _scriptHistoryListener = () {
@@ -47,7 +50,7 @@ class DebuggerController extends DisposableController
     scriptsHistory.addListener(_scriptHistoryListener);
   }
 
-  VmService get _service => serviceManager.service;
+  VmServiceWrapper get _service => serviceManager.service;
 
   final ScriptCache _scriptCache = ScriptCache();
 

--- a/packages/devtools_app/lib/src/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/error_badge_manager.dart
@@ -33,10 +33,10 @@ class ErrorBadgeManager extends DisposableController
     );
 
     // Log Flutter extension events.
-    autoDispose(service.onExtensionEvent.listen(_handleExtensionEvent));
+    autoDispose(service.onExtensionEventWithHistory.listen(_handleExtensionEvent));
 
     // Log stderr events.
-    autoDispose(service.onStderrEvent.listen(_handleStdErr));
+    autoDispose(service.onStderrEventWithHistory.listen(_handleStdErr));
   }
 
   void _handleExtensionEvent(Event e) async {

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -68,6 +68,7 @@ class InspectorService extends DisposableController
     this.inspectorLibrary,
     this.supportedServiceMethods,
   ) : clients = {} {
+    // TODO(kenz): do we want to listen with event history here?
     autoDispose(
         vmService.onExtensionEvent.listen(onExtensionVmServiceRecieved));
     autoDispose(vmService.onDebugEvent.listen(onDebugVmServiceReceived));

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -68,7 +68,8 @@ class InspectorService extends DisposableController
     this.inspectorLibrary,
     this.supportedServiceMethods,
   ) : clients = {} {
-    // TODO(kenz): do we want to listen with event history here?
+    // Note: We do not need to listen to event history here because the
+    // inspector uses a separate API to get the current inspector selection.
     autoDispose(
         vmService.onExtensionEvent.listen(onExtensionVmServiceRecieved));
     autoDispose(vmService.onDebugEvent.listen(onDebugVmServiceReceived));

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -258,21 +258,21 @@ class LoggingController extends DisposableController
     // Log stdout events.
     final _StdoutEventHandler stdoutHandler =
         _StdoutEventHandler(this, 'stdout');
-    autoDispose(service.onStdoutEvent.listen(stdoutHandler.handle));
+    autoDispose(service.onStdoutEventWithHistory.listen(stdoutHandler.handle));
 
     // Log stderr events.
     final _StdoutEventHandler stderrHandler =
         _StdoutEventHandler(this, 'stderr', isError: true);
-    autoDispose(service.onStderrEvent.listen(stderrHandler.handle));
+    autoDispose(service.onStderrEventWithHistory.listen(stderrHandler.handle));
 
     // Log GC events.
     autoDispose(service.onGCEvent.listen(_handleGCEvent));
 
     // Log `dart:developer` `log` events.
-    autoDispose(service.onLoggingEvent.listen(_handleDeveloperLogEvent));
+    autoDispose(service.onLoggingEventWithHistory.listen(_handleDeveloperLogEvent));
 
     // Log Flutter extension events.
-    autoDispose(service.onExtensionEvent.listen(_handleExtensionEvent));
+    autoDispose(service.onExtensionEventWithHistory.listen(_handleExtensionEvent));
 
     if (inspectorService == null) {
       await ensureInspectorServiceDependencies();

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -567,7 +567,8 @@ class MemoryController extends DisposableController
     _memoryTracker.start();
 
     // Log Flutter extension events.
-    // TODO(kenz): do we want to listen with event history here?
+    // Note: We do not need to listen to event history here because we do not
+    // have matching historical data about total memory usage.
     autoDispose(serviceManager.service.onExtensionEvent.listen((Event event) {
       var extensionEventKind = event.extensionKind;
       String customEventKind;
@@ -994,8 +995,6 @@ class MemoryController extends DisposableController
   bool get isGcing => _gcing;
 
   Future<void> gc() async {
-
-    
     _gcing = true;
 
     try {

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -567,6 +567,7 @@ class MemoryController extends DisposableController
     _memoryTracker.start();
 
     // Log Flutter extension events.
+    // TODO(kenz): do we want to listen with event history here?
     autoDispose(serviceManager.service.onExtensionEvent.listen((Event event) {
       var extensionEventKind = event.extensionKind;
       String customEventKind;

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -1092,6 +1092,7 @@ class ServiceExtensionManager extends Disposer {
     cancel();
     _connectedApp = connectedApp;
     _service = service;
+    // TODO(kenz): do we want to listen with event history here?
     autoDispose(service.onExtensionEvent.listen(_handleExtensionEvent));
     addAutoDisposeListener(
       hasServiceExtension(extensions.didSendFirstFrameEvent),

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -156,6 +156,8 @@ class ServiceConnectionManager {
     @required Future<void> onClosed,
   }) async {
     this.service = service;
+    await service.initServiceVersions();
+
     connectedApp = ConnectedApp();
     // It is critical we call vmServiceOpened on each manager class before
     // performing any async operations. Otherwise, we may get end up with

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:dds/vm_service_extensions.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -613,6 +614,8 @@ class VmServiceWrapper implements VmService {
   @override
   Stream<Event> get onExtensionEvent => _vmService.onExtensionEvent;
 
+  Stream<Event> get onExtensionEventWithHistory => _vmService.onExtensionEventWithHistory;
+
   @override
   Stream<Event> get onGCEvent => _vmService.onGCEvent;
 
@@ -621,6 +624,8 @@ class VmServiceWrapper implements VmService {
 
   @override
   Stream<Event> get onLoggingEvent => _vmService.onLoggingEvent;
+
+  Stream<Event> get onLoggingEventWithHistory => _vmService.onLoggingEventWithHistory;
 
   @override
   Stream<Event> get onTimelineEvent => _vmService.onTimelineEvent;
@@ -637,8 +642,12 @@ class VmServiceWrapper implements VmService {
   @override
   Stream<Event> get onStderrEvent => _vmService.onStderrEvent;
 
+  Stream<Event> get onStderrEventWithHistory => _vmService.onStderrEventWithHistory;
+
   @override
   Stream<Event> get onStdoutEvent => _vmService.onStdoutEvent;
+
+  Stream<Event> get onStdoutEventWithHistory => _vmService.onStdoutEventWithHistory;
 
   @override
   Stream<Event> get onVMEvent => _vmService.onVMEvent;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   ansicolor: 1.0.5
   async: ^2.0.0 
   collection: ^1.15.0-nnbd
+  dds: ^1.7.4
   devtools_shared: 0.9.6+3
   file: ^5.1.0
   file_selector: ^0.7.0

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -390,7 +390,13 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   Stream<Event> get onStdoutEvent => const Stream.empty();
 
   @override
+  Stream<Event> get onStdoutEventWithHistory => const Stream.empty();
+
+  @override
   Stream<Event> get onStderrEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onStderrEventWithHistory => const Stream.empty();
 
   @override
   Stream<Event> get onGCEvent => const Stream.empty();
@@ -402,7 +408,13 @@ class FakeVmService extends Fake implements VmServiceWrapper {
   Stream<Event> get onLoggingEvent => const Stream.empty();
 
   @override
+  Stream<Event> get onLoggingEventWithHistory => const Stream.empty();
+
+  @override
   Stream<Event> get onExtensionEvent => const Stream.empty();
+
+  @override
+  Stream<Event> get onExtensionEventWithHistory => const Stream.empty();
 
   @override
   Stream<Event> get onDebugEvent => const Stream.empty();


### PR DESCRIPTION
This uses the vm service extensions from dds: https://github.com/dart-lang/sdk/blob/master/pkg/dds/lib/vm_service_extensions.dart to pull event history from a stream when subscribing a listener. Before these service extensions were added, event history would only be sent to the _first_ subscriber of an event stream. So when we subscribe from different parts of devtools, not all subscribers were getting event history.

Added TODOs throughout other parts of the code where we listen to event streams - tagging owners for input on whether we should listen with history in these parts as well.