### PR TITLE
bundle canvaskit when releasing

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -10,6 +10,9 @@ set -ex #echo on
 # This URL should be updated to keep in sync with the version from the engine.
 # See https://github.com/flutter/engine/blob/353efcdf3c0ec0ecf0275d55e4a22329397f899f/lib/web_ui/lib/src/engine/canvaskit/initialization.dart#L51-L79,
 # but compare with the code in master for getting the current version.
+# A better solution would be to either upstream this functionality into the flutter_tools,
+# (https://github.com/flutter/flutter/issues/74936), or to read this from a manifest 
+# provided (https://github.com/flutter/flutter/issues/74934).
 function download_canvaskit() {
   local canvaskit_url=https://unpkg.com/canvaskit-wasm@0.22.0/bin
 

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -10,15 +10,41 @@ pushd packages/devtools_app
 
 rm -rf build
 rm -rf ../devtools/build
+
+# This avoids requiring an internet connection for CanvasKit at runtime.
+# This URL should be updated to keep in sync with the version from the engine.
+# See https://github.com/flutter/engine/blob/353efcdf3c0ec0ecf0275d55e4a22329397f899f/lib/web_ui/lib/src/engine/canvaskit/initialization.dart#L51-L79,
+# but compare with the code in master for getting the current version.
+mkdir -p build/web/assets/canvaskit/profiling
+
+CANVASKIT_URL=https://unpkg.com/canvaskit-wasm@0.22.0/bin
+curl $CANVASKIT_URL/canvaskit.js -o build/web/assets/canvaskit/canvaskit.js
+curl $CANVASKIT_URL/canvaskit.wasm -o build/web/assets/canvaskit/canvaskit.wasm
+curl $CANVASKIT_URL/profiling/canvaskit.js -o build/web/assets/canvaskit/profiling/canvaskit.js
+curl $CANVASKIT_URL/profiling/canvaskit.wasm -o build/web/assets/canvaskit/profiling/canvaskit.wasm
+
 flutter pub get
 
 # Build a profile build rather than a release build to avoid minification
 # as code size doesn't matter very much for us as minification makes some
 # crashes harder to debug. For example, https://github.com/flutter/devtools/issues/2125
 
-flutter build web --pwa-strategy=none --profile --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=true --no-tree-shake-icons
+flutter build web \
+  --pwa-strategy=none \
+  --profile \
+  --dart-define=FLUTTER_WEB_USE_EXPERIMENTAL_CANVAS_TEXT=true \
+  --dart-define=FLUTTER_WEB_CANVASKIT_URL=assets/canvaskit/ \
+  --no-tree-shake-icons
+
 cp build/web/main.dart.js build/web/main_fallback.dart.js
-flutter build web --pwa-strategy=none --profile --dart-define=FLUTTER_WEB_USE_SKIA=true --no-tree-shake-icons
+
+flutter build web \
+  --pwa-strategy=none \
+  --profile \
+  --dart-define=FLUTTER_WEB_USE_SKIA=true \
+  --dart-define=FLUTTER_WEB_CANVASKIT_URL=assets/canvaskit/ \
+  --no-tree-shake-icons
+
 mv build/web ../devtools/build
 
 popd

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -15,7 +15,7 @@ function download_canvaskit() {
 
   local flutter_bin=$(which flutter)
   local canvaskit_dart_file=$(dirname $flutter_bin)/cache/flutter_web_sdk/lib/_engine/engine/canvaskit/initialization.dart
-  if ! grep -q "$canvaskit_url" "$canvaskit_dart_file"; then
+  if ! grep -q "defaultValue: \'$canvaskit_url" "$canvaskit_dart_file"; then
     echo "CanvasKit $canvaskit_url does not match local web engine copy. Please update before continuing."
     exit -1
   fi

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -4,24 +4,36 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
-set -x #echo on
+set -ex #echo on
+
+# This avoids requiring an internet connection for CanvasKit at runtime.
+# This URL should be updated to keep in sync with the version from the engine.
+# See https://github.com/flutter/engine/blob/353efcdf3c0ec0ecf0275d55e4a22329397f899f/lib/web_ui/lib/src/engine/canvaskit/initialization.dart#L51-L79,
+# but compare with the code in master for getting the current version.
+function download_canvaskit() {
+  local canvaskit_url=https://unpkg.com/canvaskit-wasm@0.22.0/bin
+
+  local flutter_bin=$(which flutter)
+  local canvaskit_dart_file=$(dirname $flutter_bin)/cache/flutter_web_sdk/lib/_engine/engine/canvaskit/initialization.dart
+  if ! grep -q "$canvaskit_url" "$canvaskit_dart_file"; then
+    echo "CanvasKit $canvaskit_url does not match local web engine copy. Please update before continuing."
+    exit -1
+  fi
+
+  mkdir -p build/web/assets/canvaskit/profiling
+
+  curl $canvaskit_url/canvaskit.js -o build/web/assets/canvaskit/canvaskit.js
+  curl $canvaskit_url/canvaskit.wasm -o build/web/assets/canvaskit/canvaskit.wasm
+  curl $canvaskit_url/profiling/canvaskit.js -o build/web/assets/canvaskit/profiling/canvaskit.js
+  curl $canvaskit_url/profiling/canvaskit.wasm -o build/web/assets/canvaskit/profiling/canvaskit.wasm
+}
 
 pushd packages/devtools_app
 
 rm -rf build
 rm -rf ../devtools/build
 
-# This avoids requiring an internet connection for CanvasKit at runtime.
-# This URL should be updated to keep in sync with the version from the engine.
-# See https://github.com/flutter/engine/blob/353efcdf3c0ec0ecf0275d55e4a22329397f899f/lib/web_ui/lib/src/engine/canvaskit/initialization.dart#L51-L79,
-# but compare with the code in master for getting the current version.
-mkdir -p build/web/assets/canvaskit/profiling
-
-CANVASKIT_URL=https://unpkg.com/canvaskit-wasm@0.22.0/bin
-curl $CANVASKIT_URL/canvaskit.js -o build/web/assets/canvaskit/canvaskit.js
-curl $CANVASKIT_URL/canvaskit.wasm -o build/web/assets/canvaskit/canvaskit.wasm
-curl $CANVASKIT_URL/profiling/canvaskit.js -o build/web/assets/canvaskit/profiling/canvaskit.js
-curl $CANVASKIT_URL/profiling/canvaskit.wasm -o build/web/assets/canvaskit/profiling/canvaskit.wasm
+download_canvaskit
 
 flutter pub get
 


### PR DESCRIPTION
This would fix https://github.com/flutter/devtools/issues/2420

This approach works, but has a couple downsides:

- Someone has to manually update the `CANVASKIT_URL` when it gets bumped in the engine (or when DevTools wants to use a different build anyway).
- This is not necessarily the same version as used in local development

I did it this way to avoid:

- Checking in binary blobs/large minified JS files to this repo
- Having `assets` entries in the pubspec that get populated by a script

I'm not strongly committed to doing it this way. This also lacks automated testing (I've tested it out locally and it works). If there's somewhere that this build script is tested I could update that test, or we could do something like build the app, serve it up and make sure we can load it in a (headless?) browser without any HTTP errors from the server.

At any rate, providing the dart defines like this and packaging up the WASM blobs in some shape or form is the right way to make it all available offline.