### PR TITLE
Added tracking when a class is constructed (new).

### DIFF
--- a/case_study/memory_leaks/images_1/lib/main.dart
+++ b/case_study/memory_leaks/images_1/lib/main.dart
@@ -38,16 +38,16 @@ class MyHomePage extends StatefulWidget {
 
 int globalObjectId = 0;
 
-class Tracker {
-  Tracker()
+class ObjectWithUniqueId {
+  ObjectWithUniqueId()
       : now = DateTime.now(),
-        trackerId = globalObjectId++;
+        uniqueId = globalObjectId++;
 
   DateTime now = DateTime.now();
-  int trackerId = globalObjectId++;
+  int uniqueId = globalObjectId++;
 
   @override
-  String toString() => 'Collected @ $now, id=$trackerId';
+  String toString() => 'Collected @ $now, id=$uniqueId';
 }
 
 class MyHomePageState extends State<MyHomePage>
@@ -62,12 +62,12 @@ class MyHomePageState extends State<MyHomePage>
     _tabController = TabController(length: tabs.length, vsync: this);
   }
 
-  final trackers = <Tracker>[];
+  final objects = <ObjectWithUniqueId>[];
 
   void devToolsPostEvent(String eventName, Map<String, Object> eventData) {
     developer.postEvent('DevTools.Event_$eventName', eventData);
 
-    trackers.add(Tracker());
+    objects.add(ObjectWithUniqueId());
   }
 
   Widget recordLoadedImage(ImageChunkEvent imageChunkEvent, String imageUrl) {

--- a/case_study/memory_leaks/images_1/lib/main.dart
+++ b/case_study/memory_leaks/images_1/lib/main.dart
@@ -36,6 +36,20 @@ class MyHomePage extends StatefulWidget {
   MyHomePageState createState() => MyHomePageState();
 }
 
+int globalObjectId = 0;
+
+class Tracker {
+  Tracker()
+      : now = DateTime.now(),
+        trackerId = globalObjectId++;
+
+  DateTime now = DateTime.now();
+  int trackerId = globalObjectId++;
+
+  @override
+  String toString() => 'Collected @ ${now}, id=$trackerId';
+}
+
 class MyHomePageState extends State<MyHomePage>
     with SingleTickerProviderStateMixin {
   TabController _tabController;
@@ -48,8 +62,12 @@ class MyHomePageState extends State<MyHomePage>
     _tabController = TabController(length: tabs.length, vsync: this);
   }
 
+  final trackers = <Tracker>[];
+
   void devToolsPostEvent(String eventName, Map<String, Object> eventData) {
     developer.postEvent('DevTools.Event_$eventName', eventData);
+
+    trackers.add(Tracker());
   }
 
   Widget recordLoadedImage(ImageChunkEvent imageChunkEvent, String imageUrl) {

--- a/case_study/memory_leaks/images_1/lib/main.dart
+++ b/case_study/memory_leaks/images_1/lib/main.dart
@@ -47,7 +47,7 @@ class Tracker {
   int trackerId = globalObjectId++;
 
   @override
-  String toString() => 'Collected @ ${now}, id=$trackerId';
+  String toString() => 'Collected @ $now, id=$trackerId';
 }
 
 class MyHomePageState extends State<MyHomePage>

--- a/packages/devtools_app/lib/src/charts/chart.dart
+++ b/packages/devtools_app/lib/src/charts/chart.dart
@@ -11,6 +11,7 @@ import 'package:flutter/material.dart';
 import '../auto_dispose_mixin.dart';
 import '../config_specific/logger/logger.dart' as logger;
 import '../theme.dart';
+import '../utils.dart';
 import 'chart_controller.dart';
 import 'chart_trace.dart';
 

--- a/packages/devtools_app/lib/src/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/charts/chart_controller.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:intl/intl.dart' as intl;
 
 import '../auto_dispose.dart';
 

--- a/packages/devtools_app/lib/src/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/charts/chart_controller.dart
@@ -10,21 +10,6 @@ import '../auto_dispose.dart';
 
 import 'chart_trace.dart';
 
-/// Displays timestamp using locale's timezone HH:MM:SS, if isUtc is false.
-/// @param isUTC - if true for testing, the UTC locale is used (instead of
-/// the user's locale). Tests will then pass when run in any timezone. All
-/// formatted timestamps are displayed using the UTC locale.
-String prettyTimestamp(
-  int timestamp, {
-  bool isUtc = false,
-}) {
-  final timestampDT = DateTime.fromMillisecondsSinceEpoch(
-    timestamp,
-    isUtc: isUtc,
-  );
-  return intl.DateFormat.Hms().format(timestampDT); // HH:mm:ss
-}
-
 ///_____________________________________________________________________
 ///
 ///                                       xPaddingRight

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
@@ -9,6 +9,28 @@ import 'memory_protocol.dart';
 
 const defaultNumberFieldWidth = 100.0;
 
+class FieldTrace extends ColumnData<ClassHeapDetailStats> {
+  FieldTrace() : super('✔', fixedWidthPx: 50.0);
+
+  @override
+  int getValue(ClassHeapDetailStats dataObject) =>
+      dataObject.isStacktraced ? 1 : 0;
+
+  @override
+  String getDisplayValue(ClassHeapDetailStats dataObject) =>
+        dataObject.isStacktraced ? '✔' : ' '; // U+2714 ✔ HEAVY CHECK MARK
+
+  @override
+  bool get supportsSorting => true;
+
+  @override
+  int compare(ClassHeapDetailStats a, ClassHeapDetailStats b) {
+    final Comparable valueA = getValue(a);
+    final Comparable valueB = getValue(b);
+    return valueA.compareTo(valueB);
+  }
+}
+
 class FieldClassName extends ColumnData<ClassHeapDetailStats> {
   FieldClassName() : super('Class', fixedWidthPx: 200.0);
 

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
@@ -4,21 +4,29 @@
 
 import 'dart:math';
 
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../table.dart';
 import '../table_data.dart';
+import 'memory_controller.dart';
 import 'memory_protocol.dart';
 
 const defaultNumberFieldWidth = 100.0;
 
-class FieldTrace extends ColumnData<ClassHeapDetailStats> {
-  FieldTrace() : super('✔', fixedWidthPx: 50.0);
+class FieldTrack extends ColumnData<ClassHeapDetailStats>
+    implements ColumnRenderer<ClassHeapDetailStats> {
+  FieldTrack()
+      : super(
+          'Track',
+          titleTooltip: 'Track Class Allocations',
+          fixedWidthPx: 55.0,
+          alignment: ColumnAlignment.left,
+        );
 
   @override
   int getValue(ClassHeapDetailStats dataObject) =>
       dataObject.isStacktraced ? 1 : 0;
-
-  @override
-  String getDisplayValue(ClassHeapDetailStats dataObject) =>
-        dataObject.isStacktraced ? '✔' : ' '; // U+2714 ✔ HEAVY CHECK MARK
 
   @override
   bool get supportsSorting => true;
@@ -28,6 +36,24 @@ class FieldTrace extends ColumnData<ClassHeapDetailStats> {
     final Comparable valueA = getValue(a);
     final Comparable valueB = getValue(b);
     return valueA.compareTo(valueB);
+  }
+
+  @override
+  Widget build(
+    BuildContext context,
+    ClassHeapDetailStats item, {
+    bool isRowSelected = false,
+  }) {
+    final controller = Provider.of<MemoryController>(context);
+
+    return Checkbox(
+      value: item.isStacktraced,
+      onChanged: (value) {
+        item.isStacktraced = value;
+        controller.setTracking(item.classRef, value);
+        controller.changeStackTraces();
+      },
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
@@ -4,10 +4,13 @@
 
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../auto_dispose_mixin.dart';
+import '../split.dart';
 import '../table.dart';
 import '../table_data.dart';
+import '../theme.dart';
 import '../utils.dart';
 import 'memory_allocation_table_data.dart';
 import 'memory_controller.dart';
@@ -25,12 +28,15 @@ class AllocationTableViewState extends State<AllocationTableView>
 
   final List<ColumnData<ClassHeapDetailStats>> columns = [];
 
+  var samplesProcessed = <ClassRef, CpuSamples>{};
+
   @override
   void initState() {
     super.initState();
 
     // Setup the columns.
     columns.addAll([
+      FieldTrace(),
       FieldClassName(),
       FieldInstanceCountColumn(),
       FieldInstanceDeltaColumn(),
@@ -58,28 +64,173 @@ class AllocationTableViewState extends State<AllocationTableView>
         controller.computeAllLibraries(rebuild: true);
       });
     });
+
+    addAutoDisposeListener(controller.updateClassStackTraces, () {
+      setState(() {});
+    });
+
+    addAutoDisposeListener(controller.treeChangedNotifier, () {
+      if (controller.isTreeChanged) {
+        setState(() {});
+      }
+    });
+  }
+
+  /// Construct all objects tracked and their stacktraces.
+  List<Widget> allTrackedCreations(ClassRef classRef) {
+    final fixFontStyle = fixedFontStyle(context);
+
+    final allocationSample = controller.allocationSamples.singleWhere(
+      (element) => element.classRef.id == classRef.id,
+      orElse: () => null,
+    );
+
+    // Nothing tracked.
+    if (allocationSample == null) {
+      return [
+        Padding(
+          padding: const EdgeInsets.only(bottom: 5),
+          child: Text('empty', style: fixFontStyle),
+        )
+      ];
+    }
+
+    final smallerFixedFont = smallerFixedFontStyle(context);
+
+    final subTitles = <ExpansionTile>[];
+
+    for (var stacktrace in allocationSample.stacktraces) {
+      final callStackEntries = <Widget>[];
+
+      callStackEntries.add(Text(
+        '${stacktrace.stacktraceDisplay(maxLines: stacktrace.showFullStacktrace ? -1 : 4)}',
+        style: smallerFixedFont,
+      ));
+      if (stacktrace.stackDepth > 4 && !stacktrace.showFullStacktrace) {
+        callStackEntries.add(
+          InkWell(
+            onTap: () {
+              stacktrace.showFullStacktrace = true;
+              // TODO(terry): Use a value notifier.
+              setState(() {});
+            },
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 10),
+              child: Text('More ...', style: smallerFixedFont),
+            ),
+          ),
+        );
+      }
+
+      final stackTraceWidget = Container(
+        padding: const EdgeInsets.symmetric(horizontal: 80),
+        alignment: Alignment.topLeft,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: callStackEntries,
+        ),
+      );
+
+      subTitles.add(
+        ExpansionTile(
+          tilePadding: const EdgeInsets.only(left: 80, right: 20),
+          childrenPadding: EdgeInsets.zero,
+          title: Text(
+            '${allocationSample.classRef.name} '
+            '@${prettyTimestamp(stacktrace.timestamp)}',
+            style: fixFontStyle,
+          ),
+          children: [stackTraceWidget],
+        ),
+      );
+    }
+
+    return subTitles;
+  }
+
+  ExpansionTile _createExpansionTile(int index) {
+    final fixFontStyle = fixedFontStyle(context);
+
+    if (controller.trackAllocations.isNotEmpty) {
+      // Show what is to be tracked.
+      final trackingClasses = controller.trackAllocations.keys.toList();
+      final className = trackingClasses[index];
+      final classRef = controller.trackAllocations[className];
+      final childWidgets = allTrackedCreations(classRef);
+      return ExpansionTile(
+        leading: const Icon(Icons.track_changes),
+        tilePadding: const EdgeInsets.symmetric(horizontal: 20),
+        childrenPadding: EdgeInsets.zero,
+        title: Text(className, style: fixFontStyle),
+        children: childWidgets,
+      );
+    } else {
+      return null;
+    }
+  }
+
+  Widget trackedClassesList() {
+    return controller.trackAllocations.isEmpty
+        ? const Padding(
+            padding: EdgeInsets.only(top: 15),
+            child: Text('No classes tracked.', textAlign: TextAlign.center),
+          )
+        : ListView.builder(
+            padding: const EdgeInsets.all(0),
+            itemCount: controller.trackAllocations.length,
+            itemBuilder: (BuildContext context, int index) =>
+                _createExpansionTile(index),
+          );
   }
 
   @override
   Widget build(BuildContext context) {
     if (controller.allocationsFieldsTable == null) {
-      controller.sortedMonitorColumn = columns[0];
+      // Sort by class name.
+      controller.sortedMonitorColumn = columns[1];
       controller.sortedMonitorDirection = SortDirection.ascending;
+    }
+
+    if (controller.monitorAllocations.isEmpty) {
+      return const SizedBox(height: defaultSpacing);
     }
 
     controller.allocationsFieldsTable = FlatTable<ClassHeapDetailStats>(
       columns: columns,
       data: controller.monitorAllocations,
       keyFactory: (d) => Key(d.classRef.name),
-      onItemSelected: (ref) {},
+      onItemSelected: (ref) {
+        final isTraced = !ref.isStacktraced;
+        ref.isStacktraced = isTraced;
+
+        controller
+            .setTracking(
+              ref.classRef,
+              isTraced,
+            )
+            .then((success) => true)
+            .catchError((e) => debugLogger('ERROR: ${e.message}'))
+            .whenComplete(() => controller.changeStackTraces());
+      },
       sortColumn: controller.sortedMonitorColumn,
       sortDirection: controller.sortedMonitorDirection,
-      onSortChanged: (column, direction) {
+      onSortChanged: (
+        column,
+        direction,
+      ) {
         controller.sortedMonitorColumn = column;
         controller.sortedMonitorDirection = direction;
       },
     );
 
-    return controller.allocationsFieldsTable;
+    return Split(
+      initialFractions: const [0.9, 0.1],
+      minSizes: const [200, 0],
+      axis: Axis.vertical,
+      children: [
+        controller.allocationsFieldsTable,
+        trackedClassesList(),
+      ],
+    );
   }
 }

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
@@ -203,14 +203,7 @@ class AllocationTableViewState extends State<AllocationTableView>
         final isTraced = !ref.isStacktraced;
         ref.isStacktraced = isTraced;
 
-        controller
-            .setTracking(
-              ref.classRef,
-              isTraced,
-            )
-            .then((success) => true)
-            .catchError((e) => debugLogger('ERROR: ${e.message}'))
-            .whenComplete(() => controller.changeStackTraces());
+        controller.setTracking(ref.classRef, isTraced);
       },
       sortColumn: controller.sortedMonitorColumn,
       sortDirection: controller.sortedMonitorDirection,

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
@@ -78,9 +78,7 @@ class AllocationTableViewState extends State<AllocationTableView>
     });
 
     addAutoDisposeListener(controller.treeChangedNotifier, () {
-      if (controller.isTreeChanged) {
-        setState(() {});
-      }
+      setState(() {});
     });
 
     addAutoDisposeListener(trackerData.selectionNotifier, () {
@@ -117,7 +115,8 @@ class AllocationTableViewState extends State<AllocationTableView>
         controller.sortedMonitorColumn = column;
         controller.sortedMonitorDirection = direction;
       },
-      activeSearchMatchNotifier: controller.searchMatchMonitorAllocationsNotifier,
+      activeSearchMatchNotifier:
+          controller.searchMatchMonitorAllocationsNotifier,
     );
 
     return Split(

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -567,13 +567,11 @@ class MemoryController extends DisposableController
     if (foundClass != null) {
       foundClass.isStacktraced = true;
 
-      _setTracking(
-        foundClass.classRef,
-        true,
-      )
+      _setTracking(foundClass.classRef, true)
           .then((success) => true)
-          .catchError((e) => debugLogger('ERROR: ${e.message}'))
-          .whenComplete(
+          .catchError((e) {
+        debugLogger('ERROR: ${e.message}');
+      }).whenComplete(
         () {
           changeStackTraces();
           treeChanged();

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -567,12 +567,14 @@ class MemoryController extends DisposableController
     if (foundClass != null) {
       foundClass.isStacktraced = enable;
 
-      _setTracking(foundClass.classRef, enable).catchError((e) {
+      final classRef = foundClass.classRef;
+      _setTracking(classRef, enable).catchError((e) {
         debugLogger('ERROR: ${e.message}');
       }).whenComplete(
         () {
           changeStackTraces();
           treeChanged();
+          // TODO(terry): Add a toast popup.
         },
       );
     }

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -567,9 +567,7 @@ class MemoryController extends DisposableController
     if (foundClass != null) {
       foundClass.isStacktraced = true;
 
-      _setTracking(foundClass.classRef, true)
-          .then((success) => true)
-          .catchError((e) {
+      _setTracking(foundClass.classRef, true).catchError((e) {
         debugLogger('ERROR: ${e.message}');
       }).whenComplete(
         () {

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -687,20 +687,8 @@ class HeapTreeViewState extends State<HeapTree>
                     orElse: () => null,
                   );
                   foundClass.isStacktraced = true;
-                  controller
-                      .setTracking(
-                        foundClass.classRef,
-                        true,
-                      )
-                      .then((success) => true)
-                      .catchError((e) => debugLogger('ERROR: ${e.message}'))
-                      .whenComplete(
-                    () {
-                      controller.changeStackTraces();
-                      textController.clear();
-                      controller.treeChanged();
-                    },
-                  );
+                  controller.setTracking(foundClass.classRef, true);
+                  textController.clear();
                 }
               },
               decoration: InputDecoration(

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -141,6 +141,8 @@ class HeapTreeViewState extends State<HeapTree>
   @visibleForTesting
   static const allocationMonitorResetKey = Key('Accumulators Reset Button');
   @visibleForTesting
+  static const trackAllocationKey = Key('Track Class');
+  @visibleForTesting
   static const searchButtonKey = Key('Snapshot Search');
   @visibleForTesting
   static const filterButtonKey = Key('Snapshot Filter');
@@ -662,6 +664,7 @@ class HeapTreeViewState extends State<HeapTree>
             width: defaultSearchTextWidth,
             height: defaultTextFieldHeight,
             child: TextField(
+              key: trackAllocationKey,
               controller: textController,
               inputFormatters: [
                 // Valid Dart class name.

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -380,6 +380,7 @@ class ClassHeapDetailStats {
 
   final Map<String, dynamic> json;
 
+  bool isStacktraced = false;
   int instancesCurrent = 0;
   int instancesDelta = 0;
   int bytesCurrent = 0;

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -1230,8 +1230,11 @@ class MemoryBodyState extends State<MemoryBody>
 
     controller.memoryTimeline.reset();
 
+
     // Clear any current Allocation Profile collected.
     controller.monitorAllocations = [];
+    controller.trackAllocations.clear();
+    controller.allocationSamples.clear();
 
     // Clear all analysis and snapshots collected too.
     controller.clearAllSnapshots();

--- a/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
+++ b/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
@@ -1,0 +1,259 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../table.dart';
+import '../table_data.dart';
+import '../trees.dart';
+import '../utils.dart';
+import 'memory_controller.dart';
+
+class Tracker extends TreeNode<Tracker> {
+  factory Tracker({String className}) {
+    return Tracker._internal(name: className);
+  }
+
+  Tracker._internal({this.name});
+
+  /// Used for both class name and call stack entry value.
+  final String name;
+}
+
+class TrackerClass extends Tracker {
+  TrackerClass(String className) : super._internal(name: className);
+
+  @override
+  String toString() => name;
+}
+
+class TrackerAllocation extends Tracker {
+  TrackerAllocation(this.timestamp) : super._internal(name: null);
+
+  final int timestamp;
+
+  bool displayAll = false;
+
+  /// If displayAll is false then depth of callstack is:
+  final callDepthDisplay = 4;
+
+  @override
+  String toString() => '$timestamp';
+}
+
+class TrackerCall extends Tracker {
+  TrackerCall(String entry) : super._internal(name: entry);
+
+  @override
+  String toString() => name;
+}
+
+class TrackerMore extends Tracker {
+  TrackerMore(this.stacktrace) : super._internal(name: 'More ...');
+
+  final List<String> stacktrace;
+
+  @override
+  String toString() => name;
+}
+
+class _TrackerClassColumn extends TreeColumnData<Tracker> {
+  _TrackerClassColumn() : super('Tracking');
+
+  @override
+  dynamic getValue(Tracker dataObject) {
+    if (dataObject is TrackerClass || dataObject is TrackerMore) {
+      return dataObject.name;
+    } else if (dataObject is TrackerCall) {
+      final TrackerCall call = dataObject;
+      return call.name;
+    } else if (dataObject is TrackerAllocation) {
+      final TrackerAllocation allocation = dataObject;
+      return '${dataObject.parent.name} @ ${prettyTimestamp(allocation.timestamp)}';
+    }
+
+    assert(false, 'Unknown dataObject');
+  }
+
+  @override
+  int compare(Tracker a, Tracker b) {
+    Comparable valueA = getValue(a);
+    Comparable valueB = getValue(b);
+    if (a is TrackerCall) {
+      // Sort is always by child index for the stacktrace, call stack should not reorder.
+      valueA = a.children.indexOf(a);
+      valueB = b.children.indexOf(a);
+    }
+    return valueA.compareTo(valueB);
+  }
+
+  @override
+  double get fixedWidthPx => 640;
+
+  @override
+  bool get supportsSorting => true;
+}
+
+class _TrackerCountColumn extends ColumnData<Tracker> {
+  _TrackerCountColumn()
+      : super(
+          'Count',
+          alignment: ColumnAlignment.right,
+          fixedWidthPx: 100.0,
+        );
+
+  @override
+  String getValue(Tracker dataObject) {
+    if (dataObject is TrackerClass) {
+      return '${dataObject.children.length}';
+    }
+
+    assert(dataObject is TrackerAllocation ||
+        dataObject is TrackerCall ||
+        dataObject is TrackerMore);
+    return '';
+  }
+
+  @override
+  double get fixedWidthPx => 50.0;
+
+  @override
+  bool get supportsSorting => true;
+}
+
+class TreeTracker {
+  TrackerClass tree1;
+
+  TreeColumnData<Tracker> treeColumn = _TrackerClassColumn();
+
+  final selectionNotifier =
+      ValueNotifier<Selection<Tracker>>(Selection<Tracker>());
+
+  /// Rebuild list of classes to track.
+  void createTrackerTree(
+    Map<String, ClassRef> classesTracked,
+    List<AllocationSamples> allocationSamples,
+  ) {
+    tree1 = TrackerClass('_ROOT_tracking');
+
+    tree1.children.clear();
+
+    final classesName = classesTracked.keys;
+    for (var className in classesName) {
+      final classEntry = TrackerClass(className);
+      tree1.addChild(classEntry);
+
+      final trackedClassId = classesTracked[className].id;
+
+      final allocationSample = allocationSamples.singleWhere((sample) {
+        // If no stacktraces, then nothing to handle.
+        if (sample.totalStacktraces == 0) return false;
+
+        // Match the sample to the class being tracked.
+        final allocationClassRef = sample.classRef;
+        final allocationClassId = allocationClassRef.id;
+        return allocationClassId == trackedClassId;
+      }, orElse: () => null);
+
+      if (allocationSample != null) {
+        for (var stacktrace in allocationSample.stacktraces) {
+          final allocation = TrackerAllocation(stacktrace.timestamp);
+          classEntry.addChild(allocation);
+          int displayDepth = 0;
+          for (var callStackEntry in stacktrace.stacktrace) {
+            if (allocation.displayAll ||
+                displayDepth++ < allocation.callDepthDisplay) {
+              allocation.addChild(TrackerCall(callStackEntry));
+            }
+          }
+          if (!allocation.displayAll) {
+            allocation.addChild(TrackerMore(stacktrace.stacktrace));
+          }
+        }
+      }
+    }
+  }
+
+  /// Remove the "More ..." and show the entire call stack.
+  void expandCallStack(TrackerMore item) {
+    final TrackerAllocation allocation = item.parent;
+
+    // Show the entire call stack for this instance.
+    allocation.displayAll = true;
+
+    // Re-construct the callstack for this instance.
+    final leafNodesCount = allocation.children.length;
+
+    assert(allocation.children.last is TrackerMore);
+    allocation.removeLastChild();   // Remove "More ..."
+
+    // Add the entire call stack as leaf nodes.
+    final totalCallStack = item.stacktrace.length;
+    for (var index = leafNodesCount - 1; index < totalCallStack; index++) {
+      allocation.addChild(TrackerCall(item.stacktrace[index]));
+    }
+    allocation.expandCascading();
+  }
+
+  void createTrackerTreeSample() {
+    treeColumn = _TrackerClassColumn();
+    tree1 = TrackerClass('_ROOT_tracking');
+
+    var classEntry = TrackerClass('Foo');
+    tree1.addChild(classEntry);
+
+    var allocation = TrackerAllocation(1);
+    classEntry.addChild(allocation);
+    allocation.addChild(TrackerCall('foo.call1a()'));
+    allocation.addChild(TrackerCall('foo.call2a()'));
+    allocation.addChild(TrackerCall('parent.call0a()'));
+
+    allocation = TrackerAllocation(2);
+    classEntry.addChild(allocation);
+    allocation.addChild(TrackerCall('foo.call1b()'));
+    allocation.addChild(TrackerCall('foo.call2b()'));
+    allocation.addChild(TrackerCall('parent.call0b()'));
+
+    classEntry = TrackerClass('Bar');
+    tree1.addChild(classEntry);
+
+    allocation = TrackerAllocation(3);
+    classEntry.addChild(allocation);
+    allocation.addChild(TrackerCall('bar.call1a()'));
+    allocation.addChild(TrackerCall('xyzzy.call2a()'));
+    allocation.addChild(TrackerCall('xyzzy.call0a()'));
+
+    allocation = TrackerAllocation(4);
+    classEntry.addChild(allocation);
+    allocation.addChild(TrackerCall('bar.call1b()'));
+    allocation.addChild(TrackerCall('xyzzy.call2b()'));
+    allocation.addChild(TrackerCall('xyzzy.call0b()'));
+
+//      ..expandCascading();
+  }
+
+  Widget createTrackingTable(MemoryController controller) {
+    final widget = controller.trackAllocations.isEmpty
+        ? const Padding(
+            padding: EdgeInsets.only(top: 15),
+            child: Text('No classes tracked.', textAlign: TextAlign.center),
+          )
+        : TreeTable<Tracker>(
+            columns: [
+              treeColumn,
+              _TrackerCountColumn(),
+            ],
+            dataRoots: tree1.children,
+            treeColumn: treeColumn,
+            keyFactory: (d) {
+              return Key(d.name);
+            },
+            sortColumn: treeColumn,
+            sortDirection: SortDirection.ascending,
+            selectionNotifier: selectionNotifier,
+          );
+    return widget;
+  }
+}

--- a/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
+++ b/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
@@ -83,8 +83,8 @@ class _TrackerClassColumn extends TreeColumnData<Tracker> {
     Comparable valueB = getValue(b);
     if (a is TrackerCall) {
       // Sort is always by child index for the stacktrace, call stack should not reorder.
-      valueA = a.children.indexOf(a);
-      valueB = b.children.indexOf(a);
+      valueA = a.parent.children.indexOf(a);
+      valueB = b.parent.children.indexOf(b);
     }
     return valueA.compareTo(valueB);
   }
@@ -195,43 +195,6 @@ class TreeTracker {
       allocation.addChild(TrackerCall(item.stacktrace[index]));
     }
     allocation.expandCascading();
-  }
-
-  void createTrackerTreeSample() {
-    treeColumn = _TrackerClassColumn();
-    tree1 = TrackerClass('_ROOT_tracking');
-
-    var classEntry = TrackerClass('Foo');
-    tree1.addChild(classEntry);
-
-    var allocation = TrackerAllocation(1);
-    classEntry.addChild(allocation);
-    allocation.addChild(TrackerCall('foo.call1a()'));
-    allocation.addChild(TrackerCall('foo.call2a()'));
-    allocation.addChild(TrackerCall('parent.call0a()'));
-
-    allocation = TrackerAllocation(2);
-    classEntry.addChild(allocation);
-    allocation.addChild(TrackerCall('foo.call1b()'));
-    allocation.addChild(TrackerCall('foo.call2b()'));
-    allocation.addChild(TrackerCall('parent.call0b()'));
-
-    classEntry = TrackerClass('Bar');
-    tree1.addChild(classEntry);
-
-    allocation = TrackerAllocation(3);
-    classEntry.addChild(allocation);
-    allocation.addChild(TrackerCall('bar.call1a()'));
-    allocation.addChild(TrackerCall('xyzzy.call2a()'));
-    allocation.addChild(TrackerCall('xyzzy.call0a()'));
-
-    allocation = TrackerAllocation(4);
-    classEntry.addChild(allocation);
-    allocation.addChild(TrackerCall('bar.call1b()'));
-    allocation.addChild(TrackerCall('xyzzy.call2b()'));
-    allocation.addChild(TrackerCall('xyzzy.call0b()'));
-
-//      ..expandCascading();
   }
 
   Widget createTrackingTable(MemoryController controller) {

--- a/packages/devtools_app/lib/src/memory/memory_vm_chart.dart
+++ b/packages/devtools_app/lib/src/memory/memory_vm_chart.dart
@@ -65,7 +65,7 @@ class VMChartController extends ChartController {
       trace.Data(timestamp, capacityValue),
     );
 
-    final rssValue = sample.rss.toDouble();
+    final rssValue = sample.rss?.toDouble();
     addDataToTrace(TraceName.rSS.index, trace.Data(timestamp, rssValue));
 
     final rasterLayerValue = sample.rasterCache.layerBytes.toDouble();

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -25,7 +25,6 @@ import '../theme.dart';
 import '../ui/service_extension_widgets.dart';
 import '../ui/utils.dart';
 import '../ui/vm_flag_widgets.dart';
-import '../utils.dart';
 import 'event_details.dart';
 import 'flutter_frames_chart.dart';
 import 'performance_controller.dart';

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -335,3 +335,11 @@ TextStyle fixedFontStyle(BuildContext context) {
       .bodyText2
       .copyWith(fontFamily: 'RobotoMono', fontSize: 13.0);
 }
+
+TextStyle smallerFixedFontStyle(BuildContext context) {
+  return Theme.of(context)
+      .textTheme
+      .bodyText2
+      .copyWith(fontFamily: 'RobotoMono', fontSize: 10.0);
+}
+

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -141,6 +141,9 @@ const defaultListItemHeight = 28.0;
 
 const defaultChartHeight = 150.0;
 
+/// Width of all settings dialogs.
+const dialogSettingsWidth = 700.0;
+
 const defaultScrollBarOffset = 10.0;
 
 const defaultTabBarViewPhysics = NeverScrollableScrollPhysics();

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import '../common_widgets.dart';
 import '../dialogs.dart';
 import '../theme.dart';
-import '../utils.dart';
 import 'label.dart';
 
 mixin FilterControllerMixin<T> {

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -129,8 +129,8 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
         ListTile(
           title: Text(matchedName),
           onTap: () {
-            selectTheSearch = true;
             search = matchedName;
+            selectTheSearch = true;
           },
         ),
       );

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -1039,9 +1039,6 @@ double safePositiveDouble(double value) {
   return max(value, 0.0);
 }
 
-/// Width of all settings dialogs.
-const dialogSettingsWidth = 700.0;
-
 /// Displays timestamp using locale's timezone HH:MM:SS, if isUtc is false.
 /// @param isUTC - if true for testing, the UTC locale is used (instead of
 /// the user's locale). Tests will then pass when run in any timezone. All

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -1041,3 +1041,18 @@ double safePositiveDouble(double value) {
 
 /// Width of all settings dialogs.
 const dialogSettingsWidth = 700.0;
+
+/// Displays timestamp using locale's timezone HH:MM:SS, if isUtc is false.
+/// @param isUTC - if true for testing, the UTC locale is used (instead of
+/// the user's locale). Tests will then pass when run in any timezone. All
+/// formatted timestamps are displayed using the UTC locale.
+String prettyTimestamp(
+  int timestamp, {
+  bool isUtc = false,
+}) {
+  final timestampDT = DateTime.fromMillisecondsSinceEpoch(
+    timestamp,
+    isUtc: isUtc,
+  );
+  return DateFormat.Hms().format(timestampDT); // HH:mm:ss
+}

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -220,7 +220,7 @@ class VmServiceWrapper implements VmService {
     if (await isProtocolVersionSupported(
         supportedVersion: SemanticVersion(major: 3, minor: 18))) {
       return trackFuture(
-        'getAllocationProfile',
+        '_getAllocationProfile',
         _vmService.getAllocationProfile(isolateId, reset: reset, gc: gc),
       );
     } else {
@@ -237,6 +237,44 @@ class VmServiceWrapper implements VmService {
       );
       return AllocationProfile.parse(response.json);
     }
+  }
+
+  //{ "_setTraceClassAllocation", SetTraceClassAllocation,
+  Future<Success> setTraceClassAllocation(
+    String isolateId, {
+    String classId,
+    bool enable,
+  }) async {
+    final Map<String, dynamic> args = {};
+    if (classId != null) {
+      args['classId'] = classId;
+    }
+    if (enable != null) {
+      args['enable'] = enable ? true : false;
+    }
+
+    final response = await trackFuture(
+      '_setTraceClassAllocation',
+      callMethod('_setTraceClassAllocation', isolateId: isolateId, args: args),
+    );
+
+    return response as Success;
+  }
+
+  Future<CpuSamples> getAllocationSamples(
+    String isolateId, {
+    String classId,
+  }) async {
+    final Map<String, dynamic> args = {};
+    if (classId != null) {
+      args['classId'] = classId;
+    }
+    final response = await trackFuture(
+      '_getAllocationSamples',
+      callMethod('_getAllocationSamples', isolateId: isolateId, args: args),
+    );
+
+    return CpuSamples.parse(response.json);
   }
 
   @override

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -220,7 +220,7 @@ class VmServiceWrapper implements VmService {
     if (await isProtocolVersionSupported(
         supportedVersion: SemanticVersion(major: 3, minor: 18))) {
       return trackFuture(
-        '_getAllocationProfile',
+        'getAllocationProfile',
         _vmService.getAllocationProfile(isolateId, reset: reset, gc: gc),
       );
     } else {

--- a/packages/devtools_app/test/chart_test.dart
+++ b/packages/devtools_app/test/chart_test.dart
@@ -1,6 +1,7 @@
 import 'package:devtools_app/src/charts/chart_controller.dart';
 import 'package:devtools_app/src/charts/chart_trace.dart';
 import 'package:devtools_app/src/charts/chart.dart';
+import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:devtools_testing/support/memory_test_data.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -242,10 +242,7 @@ void main() {
     await pumpMemoryScreen(tester);
 
     expect(find.byKey(HeapTreeViewState.snapshotButtonKey), findsOneWidget);
-    expect(
-      find.byKey(HeapTreeViewState.allocationMonitorResetKey),
-      findsOneWidget,
-    );
+    expect(find.byKey(HeapTreeViewState.allocationMonitorKey), findsOneWidget);
     expect(
       find.byKey(HeapTreeViewState.allocationMonitorResetKey),
       findsOneWidget,
@@ -319,5 +316,22 @@ void main() {
       controller.selectedSnapshotTimestamp.millisecondsSinceEpoch,
       lessThan(DateTime.now().millisecondsSinceEpoch),
     );
+  });
+
+  testWidgetsWithWindowSize('allocation monitor/class tracking', windowSize,
+      (WidgetTester tester) async {
+    await pumpMemoryScreen(tester);
+
+    expect(find.byKey(HeapTreeViewState.allocationMonitorKey), findsOneWidget);
+
+    // TODO(terry): Need to mock up allocation data (ClassHeapStats) and CpuSamples for
+    //              further tracking tests.
+/*
+    await tester.tap(find.byKey(HeapTreeViewState.allocationMonitorKey));
+    await tester.pump();
+
+    // Tracker TextField should now exist.
+    expect(find.byKey(HeapTreeViewState.trackAllocationKey), findsOneWidget);
+*/
   });
 }


### PR DESCRIPTION
Sometimes it is difficult to know which code is leaking or causing too much memory to be allocated. Allocation monitoring was created to see the delta of objects between two points in time.  However, even this useful tool can be hard to pinpoint who or what is causing the memory explosion.

To monitor a particular allocation first start the allocation monitoring by pressing

![image](https://user-images.githubusercontent.com/2055873/106134799-e477cd80-611b-11eb-91d6-7414b30f22e4.png)

Using the Search field, type in the name of a class to track e.g., ObjectWithUniqueId

![image](https://user-images.githubusercontent.com/2055873/107390172-489b7980-6aac-11eb-9824-7918162cac59.png)

Adding one of your known classes in your application being profiled in this example "ObjectWithUniqueId" is typed in

![image](https://user-images.githubusercontent.com/2055873/107389948-14c05400-6aac-11eb-8b2c-b848ec87302c.png)

Selecting the class to the tracking will scroll the class into view and enable the checkbox will add the class to the list of classes to track:

![image](https://user-images.githubusercontent.com/2055873/107390483-99ab6d80-6aac-11eb-9a5d-e0299228dd31.png)

now interact with the application your profiling to track the class(es) that might be constructed.

now press the monitor button ![image](https://user-images.githubusercontent.com/2055873/106134799-e477cd80-611b-11eb-91d6-7414b30f22e4.png) again

At the bottom on the monitor pane (right side) are the track classes, expanding the tracked class will display all instances of  classes that were constructed (between when the class to added to tracking list and the monitor button was pressed). In the below example, 14 instances where constructed.

![image](https://user-images.githubusercontent.com/2055873/107390902-06266c80-6aad-11eb-8295-78a6196441e6.png)

Expanding on when (timestamp) the construction occurred will display the call stack of the top 4 entries when the constructor was called:

![image](https://user-images.githubusercontent.com/2055873/107391313-6d442100-6aad-11eb-94c7-77a6210ecc0e.png)

Clicking on "More ..." will display the entire call stack.

![image](https://user-images.githubusercontent.com/2055873/107391522-9fee1980-6aad-11eb-9686-702dada0e311.png)
