### PR TITLE
Added settings dialog for memory page.

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -117,6 +117,9 @@ class MemoryController extends DisposableController
 
   static const logFilenamePrefix = 'memory_log_';
 
+  ValueListenable<bool> get androidCollectionEnabled => _androidCollectionEnabled;
+  final _androidCollectionEnabled = ValueNotifier<bool>(true);
+
   final List<Snapshot> snapshots = [];
 
   Snapshot get lastSnapshot => snapshots.safeLast;

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -117,8 +117,13 @@ class MemoryController extends DisposableController
 
   static const logFilenamePrefix = 'memory_log_';
 
-  ValueListenable<bool> get androidCollectionEnabled => _androidCollectionEnabled;
-  final _androidCollectionEnabled = ValueNotifier<bool>(true);
+  // Default state of Android ADB collection.
+  static const androidADBDefault = true;
+
+  ValueListenable<bool> get androidCollectionEnabled =>
+      _androidCollectionEnabled;
+
+  final _androidCollectionEnabled = ValueNotifier<bool>(androidADBDefault);
 
   final List<Snapshot> snapshots = [];
 

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -143,8 +143,6 @@ class HeapTreeViewState extends State<HeapTree>
   static const searchButtonKey = Key('Snapshot Search');
   @visibleForTesting
   static const filterButtonKey = Key('Snapshot Filter');
-  @visibleForTesting
-  static const settingsButtonKey = Key('Snapshot Settings');
 
   MemoryController controller;
 
@@ -685,17 +683,6 @@ class HeapTreeViewState extends State<HeapTree>
           // TODO(kenz): implement isFilterActive
           isFilterActive: false,
         ),
-        // TODO: Add these back in when _settings() is implemented.
-//        const SizedBox(width: denseSpacing),
-//        OutlinedButton(
-//          key: settingsButtonKey,
-//          onPressed: _settings,
-//          child: const MaterialIconLabel(
-//            Icons.tune,
-//            'Settings',
-//            includeTextWidth: 200,
-//          ),
-//        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/memory/memory_protocol.dart
@@ -106,7 +106,9 @@ class MemoryTracker {
 
     // Polls for current Android meminfo using:
     //    > adb shell dumpsys meminfo -d <package_name>
-    if (hasConnection && serviceManager.vm.operatingSystem == 'android') {
+    if (hasConnection &&
+        serviceManager.vm.operatingSystem == 'android' &&
+        memoryController.androidCollectionEnabled.value) {
       adbMemoryInfo = await _fetchAdbInfo();
     } else {
       // TODO(terry): TBD alternative for iOS memory info - all values zero.

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -22,6 +22,7 @@ import '../octicons.dart';
 import '../screen.dart';
 import '../theme.dart';
 import '../ui/label.dart';
+import '../ui/utils.dart';
 import '../utils.dart';
 
 import 'memory_android_chart.dart' as android;
@@ -136,6 +137,9 @@ class MemoryBodyState extends State<MemoryBody>
 
   OverlayEntry hoverOverlayEntry;
   OverlayEntry legendOverlayEntry;
+
+  /// Updated when the MemoryController's _androidCollectionEnabled ValueNotifier changes.
+  bool isAndroidCollection = MemoryController.androidADBDefault;
 
   @override
   void initState() {
@@ -286,9 +290,11 @@ class MemoryBodyState extends State<MemoryBody>
     });
 
     addAutoDisposeListener(controller.androidCollectionEnabled, () {
-      final isAndroidCollection = controller.androidCollectionEnabled.value;
+      isAndroidCollection = controller.androidCollectionEnabled.value;
       setState(() {
         if (!isAndroidCollection && controller.isAndroidChartVisible) {
+          // If we're no longer collecting android stats then hide the
+          // chart and disable the Android Memory button.
           controller.toggleAndroidChartVisibility();
         }
       });
@@ -554,8 +560,7 @@ class MemoryBodyState extends State<MemoryBody>
   OutlinedButton createToggleAdbMemoryButton() {
     return OutlinedButton(
       key: MemoryScreen.androidChartButtonKey,
-      onPressed: controller.isConnectedDeviceAndroid &&
-              controller.androidCollectionEnabled.value
+      onPressed: controller.isConnectedDeviceAndroid && isAndroidCollection
           ? controller.toggleAndroidChartVisibility
           : null,
       child: MaterialIconLabel(

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -4,7 +4,6 @@
 
 import 'dart:math';
 
-import 'package:devtools_app/src/ui/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -287,9 +286,9 @@ class MemoryBodyState extends State<MemoryBody>
     });
 
     addAutoDisposeListener(controller.androidCollectionEnabled, () {
+      final isAndroidCollection = controller.androidCollectionEnabled.value;
       setState(() {
-        if (!controller.androidCollectionEnabled.value &&
-            controller.isAndroidChartVisible) {
+        if (!isAndroidCollection && controller.isAndroidChartVisible) {
           controller.toggleAndroidChartVisibility();
         }
       });
@@ -1457,8 +1456,6 @@ class ChartsValues {
 class MemoryConfigurationsDialog extends StatelessWidget {
   const MemoryConfigurationsDialog(this.controller);
 
-  static const dialogWidth = 700.0;
-
   final MemoryController controller;
 
   @override
@@ -1469,7 +1466,7 @@ class MemoryConfigurationsDialog extends StatelessWidget {
       title: dialogTitleText(theme, 'Memory Settings'),
       includeDivider: false,
       content: Container(
-        width: dialogWidth,
+        width: dialogSettingsWidth,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -25,6 +25,7 @@ import '../theme.dart';
 import '../ui/service_extension_widgets.dart';
 import '../ui/utils.dart';
 import '../ui/vm_flag_widgets.dart';
+import '../utils.dart';
 import 'event_details.dart';
 import 'flutter_frames_chart.dart';
 import 'performance_controller.dart';
@@ -300,8 +301,6 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
 class TimelineConfigurationsDialog extends StatelessWidget {
   const TimelineConfigurationsDialog(this.controller);
 
-  static const dialogWidth = 700.0;
-
   final PerformanceController controller;
 
   @override
@@ -312,7 +311,7 @@ class TimelineConfigurationsDialog extends StatelessWidget {
       title: dialogTitleText(theme, 'Performance Settings'),
       includeDivider: false,
       content: Container(
-        width: dialogWidth,
+        width: dialogSettingsWidth,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import '../common_widgets.dart';
 import '../dialogs.dart';
 import '../theme.dart';
+import '../utils.dart';
 import 'label.dart';
 
 mixin FilterControllerMixin<T> {
@@ -38,8 +39,6 @@ class FilterDialog<FilterControllerMixin> extends StatefulWidget {
 }
 
 class _FilterDialogState extends State<FilterDialog> {
-  static const dialogWidth = 500.0;
-
   TextEditingController queryTextFieldController;
 
   @override
@@ -63,7 +62,7 @@ class _FilterDialogState extends State<FilterDialog> {
         padding: const EdgeInsets.symmetric(
           horizontal: defaultSpacing,
         ),
-        width: dialogWidth,
+        width: dialogSettingsWidth,
         child: Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -1038,3 +1038,6 @@ double safePositiveDouble(double value) {
   if (value.isNaN) return 0.0;
   return max(value, 0.0);
 }
+
+/// Width of all settings dialogs.
+const dialogSettingsWidth = 700.0;


### PR DESCRIPTION
Add ability to disable automatic ADB collection of android memory statistics.  Collecting Android memory metrics will not resemble normal operations while metrics are collected.  ADB metric collection can cause lots of GCs in the Android environment.

![image](https://user-images.githubusercontent.com/2055873/106177179-08073c00-614d-11eb-99cf-b294e0a8ddc0.png)
