### PR TITLE
Stop using rounded and sharp icons.

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -779,9 +779,10 @@ class MemoryBodyState extends State<MemoryBody>
             primary: false,
             children: [
               listItem(
-                  events: chartsValues.extensionEvents,
-                  title: entry.key,
-                  icon: Icons.dashboard_rounded),
+                events: chartsValues.extensionEvents,
+                title: entry.key,
+                icon: Icons.dashboard,
+              ),
             ],
           ),
         ));

--- a/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view.dart
@@ -24,7 +24,7 @@ class IsolateStatisticsView extends VMDeveloperView {
       : super(
           id,
           title: 'Isolates',
-          icon: Icons.bar_chart_sharp,
+          icon: Icons.bar_chart,
         );
   static const id = 'isolate-statistics';
 

--- a/packages/devtools_app/lib/src/vm_developer/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_statistics_view.dart
@@ -19,7 +19,7 @@ class VMStatisticsView extends VMDeveloperView {
       : super(
           id,
           title: 'VM',
-          icon: Icons.devices_sharp,
+          icon: Icons.devices,
         );
   static const id = 'vm-statistics';
 


### PR DESCRIPTION
This will avoid roll failures in g3.