### PR TITLE
Add floating debugger controls when app is paused

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -364,7 +364,7 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
 class OpenAboutAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ActionButton(
+    return DevToolsTooltip(
       tooltip: 'About DevTools',
       child: InkWell(
         onTap: () async {
@@ -390,7 +390,7 @@ class OpenAboutAction extends StatelessWidget {
 class OpenSettingsAction extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
-    return ActionButton(
+    return DevToolsTooltip(
       tooltip: 'Settings',
       child: InkWell(
         onTap: () async {

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -568,8 +568,8 @@ class Badge extends StatelessWidget {
 
 /// A widget, commonly used for icon buttons, that provides a tooltip with a
 /// common delay before the tooltip is shown.
-class ActionButton extends StatelessWidget {
-  const ActionButton({
+class DevToolsTooltip extends StatelessWidget {
+  const DevToolsTooltip({
     @required this.tooltip,
     @required this.child,
   });
@@ -787,6 +787,39 @@ Widget inputDecorationSuffixButton(IconData icon, VoidCallback onPressed) {
       icon: Icon(icon),
     ),
   );
+}
+
+class OutlinedRowGroup extends StatelessWidget {
+  const OutlinedRowGroup({@required this.children, this.borderColor});
+
+  final List<Widget> children;
+
+  final Color borderColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final color = borderColor ?? Theme.of(context).focusColor;
+    final childrenWithOutlines = <Widget>[];
+    for (int i = 0; i < children.length; i++) {
+      childrenWithOutlines.addAll([
+        Container(
+          decoration: BoxDecoration(
+            border: Border(
+              left: i == 0 ? BorderSide(color: color) : BorderSide.none,
+              right: BorderSide(color: color),
+              top: BorderSide(color: color),
+              bottom: BorderSide(color: color),
+            ),
+          ),
+          child: children[i],
+        ),
+      ]);
+    }
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: childrenWithOutlines,
+    );
+  }
 }
 
 class OutlineDecoration extends StatelessWidget {

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -271,7 +271,6 @@ class DebuggerController extends DisposableController
     if (isolate.pauseEvent != null &&
         isolate.pauseEvent.kind != EventKind.kResume) {
       _lastEvent = isolate.pauseEvent;
-      print('pausing from switchToIsolate');
       await _pause(true, pauseEvent: isolate.pauseEvent);
     }
 
@@ -439,7 +438,6 @@ class DebuggerController extends DisposableController
         // Any event we receive here indicates that any resume/step request has been
         // processed.
         _resuming.value = false;
-        print('pausing from kPause debug event');
         _pause(true, pauseEvent: event);
         break;
       // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -271,6 +271,7 @@ class DebuggerController extends DisposableController
     if (isolate.pauseEvent != null &&
         isolate.pauseEvent.kind != EventKind.kResume) {
       _lastEvent = isolate.pauseEvent;
+      print('pausing from switchToIsolate');
       await _pause(true, pauseEvent: isolate.pauseEvent);
     }
 
@@ -438,6 +439,7 @@ class DebuggerController extends DisposableController
         // Any event we receive here indicates that any resume/step request has been
         // processed.
         _resuming.value = false;
+        print('pausing from kPause debug event');
         _pause(true, pauseEvent: event);
         break;
       // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -256,7 +256,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       builder: (context, breakpoints, _) {
         return Row(children: [
           BreakpointsCountBadge(breakpoints: breakpoints),
-          ActionButton(
+          DevToolsTooltip(
             child: ToolbarAction(
               icon: Icons.delete,
               onPressed:
@@ -368,5 +368,75 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
         widget.controller.calculatePosition(script, frame.location.tokenPos);
 
     return 'paused$reason$fileName $pos';
+  }
+}
+
+class FloatingDebuggerControls extends StatelessWidget {
+  @visibleForTesting
+  static const debuggerControlsKey = Key('debugger controls');
+
+  @visibleForTesting
+  static const debuggerControlsResumeKey = Key('debugger controls - resume');
+
+  @visibleForTesting
+  static const debuggerControlsStepKey = Key('debugger controls - step');
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Provider.of<DebuggerController>(context);
+    return ValueListenableBuilder<bool>(
+      valueListenable: controller.isPaused,
+      builder: (context, paused, _) {
+        if (!paused) return const SizedBox();
+        return Container(
+          key: debuggerControlsKey,
+          color: devtoolsWarning,
+          height: defaultButtonHeight,
+          child: OutlinedRowGroup(
+            // Default focus color for the light theme - since the background
+            // color of the controls [devtoolsWarning] is the same for both
+            // themes, we will use the same border color.
+            borderColor: Colors.black.withOpacity(0.12),
+            children: [
+              Container(
+                height: defaultButtonHeight,
+                alignment: Alignment.centerLeft,
+                padding: const EdgeInsets.symmetric(
+                  horizontal: defaultSpacing,
+                ),
+                child: const Text(
+                  'Main isolate is paused in the debugger',
+                  style: TextStyle(color: Colors.black),
+                ),
+              ),
+              DevToolsTooltip(
+                tooltip: 'Resume',
+                child: TextButton(
+                  key: debuggerControlsResumeKey,
+                  onPressed: controller.resume,
+                  child: const Icon(
+                    Icons.play_arrow,
+                    color: Colors.green,
+                    size: defaultIconSize,
+                  ),
+                ),
+              ),
+              DevToolsTooltip(
+                tooltip: 'Step over',
+                child: TextButton(
+                  key: debuggerControlsStepKey,
+                  onPressed: controller.stepOver,
+                  child: const Icon(
+                    Icons.keyboard_arrow_right,
+                    color: Colors.black,
+                    size: defaultIconSize,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -371,60 +371,80 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
   }
 }
 
-class FloatingDebuggerControls extends StatelessWidget {
+class FloatingDebuggerControls extends StatefulWidget {
+  @override
+  _FloatingDebuggerControlsState createState() =>
+      _FloatingDebuggerControlsState();
+}
+
+class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
+    with AutoDisposeMixin {
+  DebuggerController controller;
+
+  bool paused;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    controller = Provider.of<DebuggerController>(context);
+    paused = controller.isPaused.value;
+    addAutoDisposeListener(controller.isPaused, () {
+      setState(() {
+        paused = controller.isPaused.value;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
-    final controller = Provider.of<DebuggerController>(context);
-    return ValueListenableBuilder<bool>(
-      valueListenable: controller.isPaused,
-      builder: (context, paused, _) {
-        if (!paused) return const SizedBox();
-        return Container(
-          color: devtoolsWarning,
-          height: defaultButtonHeight,
-          child: OutlinedRowGroup(
-            // Default focus color for the light theme - since the background
-            // color of the controls [devtoolsWarning] is the same for both
-            // themes, we will use the same border color.
-            borderColor: Colors.black.withOpacity(0.12),
-            children: [
-              Container(
-                height: defaultButtonHeight,
-                alignment: Alignment.centerLeft,
-                padding: const EdgeInsets.symmetric(
-                  horizontal: defaultSpacing,
-                ),
-                child: const Text(
-                  'Main isolate is paused in the debugger',
-                  style: TextStyle(color: Colors.black),
+    return AnimatedOpacity(
+      opacity: paused ? 1.0 : 0.0,
+      duration: longDuration,
+      child: Container(
+        color: devtoolsWarning,
+        height: defaultButtonHeight,
+        child: OutlinedRowGroup(
+          // Default focus color for the light theme - since the background
+          // color of the controls [devtoolsWarning] is the same for both
+          // themes, we will use the same border color.
+          borderColor: Colors.black.withOpacity(0.12),
+          children: [
+            Container(
+              height: defaultButtonHeight,
+              alignment: Alignment.centerLeft,
+              padding: const EdgeInsets.symmetric(
+                horizontal: defaultSpacing,
+              ),
+              child: const Text(
+                'Main isolate is paused in the debugger',
+                style: TextStyle(color: Colors.black),
+              ),
+            ),
+            DevToolsTooltip(
+              tooltip: 'Resume',
+              child: TextButton(
+                onPressed: controller.resume,
+                child: const Icon(
+                  Icons.play_arrow,
+                  color: Colors.green,
+                  size: defaultIconSize,
                 ),
               ),
-              DevToolsTooltip(
-                tooltip: 'Resume',
-                child: TextButton(
-                  onPressed: controller.resume,
-                  child: const Icon(
-                    Icons.play_arrow,
-                    color: Colors.green,
-                    size: defaultIconSize,
-                  ),
+            ),
+            DevToolsTooltip(
+              tooltip: 'Step over',
+              child: TextButton(
+                onPressed: controller.stepOver,
+                child: const Icon(
+                  Icons.keyboard_arrow_right,
+                  color: Colors.black,
+                  size: defaultIconSize,
                 ),
               ),
-              DevToolsTooltip(
-                tooltip: 'Step over',
-                child: TextButton(
-                  onPressed: controller.stepOver,
-                  child: const Icon(
-                    Icons.keyboard_arrow_right,
-                    color: Colors.black,
-                    size: defaultIconSize,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        );
-      },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -372,15 +372,6 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
 }
 
 class FloatingDebuggerControls extends StatelessWidget {
-  @visibleForTesting
-  static const debuggerControlsKey = Key('debugger controls');
-
-  @visibleForTesting
-  static const debuggerControlsResumeKey = Key('debugger controls - resume');
-
-  @visibleForTesting
-  static const debuggerControlsStepKey = Key('debugger controls - step');
-
   @override
   Widget build(BuildContext context) {
     final controller = Provider.of<DebuggerController>(context);
@@ -389,7 +380,6 @@ class FloatingDebuggerControls extends StatelessWidget {
       builder: (context, paused, _) {
         if (!paused) return const SizedBox();
         return Container(
-          key: debuggerControlsKey,
           color: devtoolsWarning,
           height: defaultButtonHeight,
           child: OutlinedRowGroup(
@@ -412,7 +402,6 @@ class FloatingDebuggerControls extends StatelessWidget {
               DevToolsTooltip(
                 tooltip: 'Resume',
                 child: TextButton(
-                  key: debuggerControlsResumeKey,
                   onPressed: controller.resume,
                   child: const Icon(
                     Icons.play_arrow,
@@ -424,7 +413,6 @@ class FloatingDebuggerControls extends StatelessWidget {
               DevToolsTooltip(
                 tooltip: 'Step over',
                 child: TextButton(
-                  key: debuggerControlsStepKey,
                   onPressed: controller.stepOver,
                   child: const Icon(
                     Icons.keyboard_arrow_right,

--- a/packages/devtools_app/lib/src/status_line.dart
+++ b/packages/devtools_app/lib/src/status_line.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../devtools.dart' as devtools;
@@ -26,11 +25,13 @@ const statusLineHeight = 24.0;
 /// This displays information global to the application, as well as gives pages
 /// a mechanism to display page-specific information.
 class StatusLine extends StatelessWidget {
+  const StatusLine(this.currentScreen);
+
+  final Screen currentScreen;
+
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-
-    final Screen currentScreen = Provider.of<Screen>(context);
 
     final List<Widget> children = [];
 
@@ -211,7 +212,7 @@ class StatusLine extends StatelessWidget {
                 },
               ),
               const SizedBox(width: denseSpacing),
-              ActionButton(
+              DevToolsTooltip(
                 tooltip: 'Device Info',
                 child: InkWell(
                   onTap: () async {

--- a/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
@@ -178,7 +178,7 @@ class HotReloadButton extends StatelessWidget {
   Widget build(BuildContext context) {
     // TODO(devoncarew): Show as disabled when reload service calls are in progress.
 
-    return ActionButton(
+    return DevToolsTooltip(
       tooltip: 'Hot reload',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotReload,
@@ -200,7 +200,7 @@ class HotRestartButton extends StatelessWidget {
   Widget build(BuildContext context) {
     // TODO(devoncarew): Show as disabled when reload service calls are in progress.
 
-    return ActionButton(
+    return DevToolsTooltip(
       tooltip: 'Hot restart',
       child: _RegisteredServiceExtensionButton._(
         serviceDescription: hotRestart,

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -535,14 +535,11 @@ void main() {
 
     testWidgets('display as expected', (WidgetTester tester) async {
       await pumpControls(tester);
-      expect(find.byKey(FloatingDebuggerControls.debuggerControlsKey),
-          findsOneWidget);
+      expect(find.byType(OutlinedRowGroup), findsOneWidget);
       expect(
           find.text('Main isolate is paused in the debugger'), findsOneWidget);
-      expect(find.byKey(FloatingDebuggerControls.debuggerControlsResumeKey),
-          findsOneWidget);
-      expect(find.byKey(FloatingDebuggerControls.debuggerControlsStepKey),
-          findsOneWidget);
+      expect(find.byTooltip('Resume'), findsOneWidget);
+      expect(find.byTooltip('Step over'), findsOneWidget);
     });
 
     testWidgets('can resume', (WidgetTester tester) async {
@@ -555,8 +552,7 @@ void main() {
       when(debuggerController.resume()).thenAnswer((_) => resume());
       await pumpControls(tester);
       expect(didResume, isFalse);
-      await tester
-          .tap(find.byKey(FloatingDebuggerControls.debuggerControlsResumeKey));
+      await tester.tap(find.byTooltip('Resume'));
       await tester.pumpAndSettle();
       expect(didResume, isTrue);
     });
@@ -571,8 +567,7 @@ void main() {
       when(debuggerController.stepOver()).thenAnswer((_) => stepOver());
       await pumpControls(tester);
       expect(didStep, isFalse);
-      await tester
-          .tap(find.byKey(FloatingDebuggerControls.debuggerControlsStepKey));
+      await tester.tap(find.byTooltip('Step over'));
       await tester.pumpAndSettle();
       expect(didStep, isTrue);
     });
@@ -581,8 +576,7 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.isPaused).thenReturn(ValueNotifier<bool>(false));
       await pumpControls(tester);
-      expect(find.byKey(FloatingDebuggerControls.debuggerControlsKey),
-          findsNothing);
+      expect(find.byType(OutlinedRowGroup), findsNothing);
     });
   });
 }

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -535,7 +535,11 @@ void main() {
 
     testWidgets('display as expected', (WidgetTester tester) async {
       await pumpControls(tester);
-      expect(find.byType(OutlinedRowGroup), findsOneWidget);
+      final animatedOpacityFinder = find.byType(AnimatedOpacity);
+      expect(animatedOpacityFinder, findsOneWidget);
+      final AnimatedOpacity animatedOpacity =
+          animatedOpacityFinder.evaluate().first.widget;
+      expect(animatedOpacity.opacity, equals(1.0));
       expect(
           find.text('Main isolate is paused in the debugger'), findsOneWidget);
       expect(find.byTooltip('Resume'), findsOneWidget);
@@ -576,7 +580,11 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.isPaused).thenReturn(ValueNotifier<bool>(false));
       await pumpControls(tester);
-      expect(find.byType(OutlinedRowGroup), findsNothing);
+      final animatedOpacityFinder = find.byType(AnimatedOpacity);
+      expect(animatedOpacityFinder, findsOneWidget);
+      final AnimatedOpacity animatedOpacity =
+          animatedOpacityFinder.evaluate().first.widget;
+      expect(animatedOpacity.opacity, equals(0.0));
     });
   });
 }

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -409,6 +409,7 @@ void main() {
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('SHOW ALL'), findsNothing);
     });
+
     testWidgetsWithWindowSize(
         'Variables shows items', const Size(1000.0, 4000.0),
         (WidgetTester tester) async {
@@ -515,6 +516,73 @@ void main() {
         debugger: debuggerController,
       ));
       expect(find.text('Ignore'), findsOneWidget);
+    });
+  });
+
+  group('FloatingDebuggerControls', () {
+    setUp(() {
+      debuggerController = MockDebuggerController();
+      when(debuggerController.isPaused).thenReturn(ValueNotifier<bool>(true));
+    });
+
+    Future<void> pumpControls(WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithControllers(
+        FloatingDebuggerControls(),
+        debugger: debuggerController,
+      ));
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets('display as expected', (WidgetTester tester) async {
+      await pumpControls(tester);
+      expect(find.byKey(FloatingDebuggerControls.debuggerControlsKey),
+          findsOneWidget);
+      expect(
+          find.text('Main isolate is paused in the debugger'), findsOneWidget);
+      expect(find.byKey(FloatingDebuggerControls.debuggerControlsResumeKey),
+          findsOneWidget);
+      expect(find.byKey(FloatingDebuggerControls.debuggerControlsStepKey),
+          findsOneWidget);
+    });
+
+    testWidgets('can resume', (WidgetTester tester) async {
+      bool didResume = false;
+      Future<Success> resume() {
+        didResume = true;
+        return Future.value(Success());
+      }
+
+      when(debuggerController.resume()).thenAnswer((_) => resume());
+      await pumpControls(tester);
+      expect(didResume, isFalse);
+      await tester
+          .tap(find.byKey(FloatingDebuggerControls.debuggerControlsResumeKey));
+      await tester.pumpAndSettle();
+      expect(didResume, isTrue);
+    });
+
+    testWidgets('can step over', (WidgetTester tester) async {
+      bool didStep = false;
+      Future<Success> stepOver() {
+        didStep = true;
+        return Future.value(Success());
+      }
+
+      when(debuggerController.stepOver()).thenAnswer((_) => stepOver());
+      await pumpControls(tester);
+      expect(didStep, isFalse);
+      await tester
+          .tap(find.byKey(FloatingDebuggerControls.debuggerControlsStepKey));
+      await tester.pumpAndSettle();
+      expect(didStep, isTrue);
+    });
+
+    testWidgets('are hidden when app is not paused',
+        (WidgetTester tester) async {
+      when(debuggerController.isPaused).thenReturn(ValueNotifier<bool>(false));
+      await pumpControls(tester);
+      expect(find.byKey(FloatingDebuggerControls.debuggerControlsKey),
+          findsNothing);
     });
   });
 }

--- a/packages/devtools_app/test/scaffold_test.dart
+++ b/packages/devtools_app/test/scaffold_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/analytics/stub_provider.dart';
+import 'package:devtools_app/src/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/framework_controller.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/scaffold.dart';
@@ -120,13 +121,101 @@ void main() {
       expect(find.byKey(k1), findsNothing);
       expect(find.byKey(k2), findsOneWidget);
     });
+
+    testWidgets('displays floating debugger controls',
+        (WidgetTester tester) async {
+      final mockConnectedApp = MockConnectedApp();
+      when(mockConnectedApp.isFlutterAppNow).thenReturn(true);
+      when(mockServiceManager.hasConnection).thenReturn(true);
+      when(mockServiceManager.connectedApp).thenReturn(mockConnectedApp);
+      final mockDebuggerController = MockDebuggerController();
+      when(mockDebuggerController.isPaused)
+          .thenReturn(ValueNotifier<bool>(false));
+
+      await tester.pumpWidget(wrapWithControllers(
+        DevToolsScaffold(
+          tabs: const [screen1, screen2],
+          ideTheme: null,
+          analyticsProvider: await analyticsProvider,
+        ),
+        debugger: mockDebuggerController,
+      ));
+      expect(find.byKey(k1), findsOneWidget);
+      expect(find.byKey(k2), findsNothing);
+      expect(find.byType(FloatingDebuggerControls), findsOneWidget);
+    });
+
+    testWidgets(
+        'does not display floating debugger controls when debugger screen is showing',
+        (WidgetTester tester) async {
+      final mockConnectedApp = MockConnectedApp();
+      when(mockConnectedApp.isFlutterAppNow).thenReturn(true);
+      when(mockServiceManager.hasConnection).thenReturn(true);
+      when(mockServiceManager.connectedApp).thenReturn(mockConnectedApp);
+      final mockDebuggerController = MockDebuggerController();
+      when(mockDebuggerController.isPaused)
+          .thenReturn(ValueNotifier<bool>(false));
+
+      const debuggerScreenKey = Key('debugger screen');
+      const debuggerTabKey = Key('debugger tab');
+      await tester.pumpWidget(wrapWithControllers(
+        DevToolsScaffold(
+          tabs: const [
+            _TestScreen(
+              DebuggerScreen.id,
+              debuggerScreenKey,
+              tabKey: debuggerTabKey,
+            ),
+            screen2,
+          ],
+          ideTheme: null,
+          analyticsProvider: await analyticsProvider,
+        ),
+        debugger: mockDebuggerController,
+      ));
+      expect(find.byKey(debuggerScreenKey), findsOneWidget);
+      expect(find.byKey(k2), findsNothing);
+      expect(find.byType(FloatingDebuggerControls), findsNothing);
+
+      // Tap on the tab for screen 2 and verify the controls are present.
+      await tester.tap(find.byKey(t2));
+      await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
+      expect(find.byKey(debuggerScreenKey), findsNothing);
+      expect(find.byKey(k2), findsOneWidget);
+      expect(find.byType(FloatingDebuggerControls), findsOneWidget);
+
+      // Return to the debugger screen and verify the controls are gone.
+      await tester.tap(find.byKey(debuggerTabKey));
+      await tester.pumpAndSettle();
+      await tester.pumpAndSettle();
+      expect(find.byKey(debuggerScreenKey), findsOneWidget);
+      expect(find.byKey(k2), findsNothing);
+      expect(find.byType(FloatingDebuggerControls), findsNothing);
+    });
+
+    testWidgets(
+        'does not display floating debugger tab controls when no app is connected',
+        (WidgetTester tester) async {
+      when(mockServiceManager.hasConnection).thenReturn(false);
+      await tester.pumpWidget(wrap(
+        DevToolsScaffold(
+          tabs: const [screen1, screen2],
+          ideTheme: null,
+          analyticsProvider: await analyticsProvider,
+        ),
+      ));
+      expect(find.byKey(k1), findsOneWidget);
+      expect(find.byKey(k2), findsNothing);
+      expect(find.byType(FloatingDebuggerControls), findsNothing);
+    });
   });
 }
 
 class _TestScreen extends Screen {
   const _TestScreen(this.name, this.key, {Key tabKey})
       : super(
-          'testScreen$name',
+          name,
           title: name,
           icon: Icons.computer,
           tabKey: tabKey,


### PR DESCRIPTION
This will show up when an app is paused (except when the debugger screen is the current screen)

![Screen Shot 2021-02-04 at 10 53 37 AM](https://user-images.githubusercontent.com/43759233/106957278-ab77c400-66ec-11eb-979c-be44d97355e6.png)

Fixes https://github.com/flutter/devtools/issues/2377
Fixes https://github.com/flutter/devtools/issues/2547