### PR TITLE
Fix lifecycle bug in network page

### DIFF
--- a/packages/devtools_app/lib/src/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/auto_dispose_mixin.dart
@@ -22,9 +22,9 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
   final Disposer _delegate = Disposer();
 
   @override
-  void deactivate() {
+  void dispose() {
     cancel();
-    super.deactivate();
+    super.dispose();
   }
 
   void _refresh() => setState(() {});

--- a/packages/devtools_app/lib/src/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/auto_dispose_mixin.dart
@@ -22,9 +22,9 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
   final Disposer _delegate = Disposer();
 
   @override
-  void dispose() {
+  void deactivate() {
     cancel();
-    super.dispose();
+    super.deactivate();
   }
 
   void _refresh() => setState(() {});

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -158,8 +158,8 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   void dispose() {
-    _networkController?.stopRecording();
     super.dispose();
+    _networkController?.stopRecording();
   }
 
   /// Builds the row of buttons that control the Network profiler (e.g., record,

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -158,8 +158,8 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   void dispose() {
-    super.dispose();
     _networkController?.stopRecording();
+    super.dispose();
   }
 
   /// Builds the row of buttons that control the Network profiler (e.g., record,


### PR DESCRIPTION
In `didChangeDependencies` we have several calls to `addAutoDisposeListener`, provided by a mixin. In `dispose` we called `_networkController?.stopRecording()`, which causes one of these listeners to fire, before we called `super.dispose()`. `super.dispose()` will dispose of the listeners because dispose will be called on the mixin, so we need to call `super.dispose()` first, before we do anything else that may cause some of these listeners to fire (the listeners call `setState` so this created a lifecycle bug where we were calling `setState` on an already-disposed state.

@pq is there a way we can warn users of this sort of thing with a lint?