### PR TITLE
Rev sse version

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/sse/_fake_sse.dart
+++ b/packages/devtools_app/lib/src/config_specific/sse/_fake_sse.dart
@@ -14,7 +14,5 @@ class SseClient {
 
   Stream get stream => null;
 
-  Stream get onOpen => null;
-
   StreamSink get sink => null;
 }

--- a/packages/devtools_app/lib/src/service.dart
+++ b/packages/devtools_app/lib/src/service.dart
@@ -23,19 +23,17 @@ Future<VmServiceWrapper> _connectWithSse(
       : uri.replace(scheme: 'https');
   final client = SseClient('$uri');
   final Stream<String> stream = client.stream?.asBroadcastStream();
-  client.onOpen?.listen((_) {
-    final service = VmServiceWrapper.fromNewVmService(
-      stream,
-      client.sink.add,
-      uri,
-    );
+  final service = VmServiceWrapper.fromNewVmService(
+    stream,
+    client.sink.add,
+    uri,
+  );
 
-    client.sink?.done?.whenComplete(() {
-      finishedCompleter.complete();
-      service.dispose();
-    });
-    serviceCompleter.complete(service);
-  });
+  unawaited(client.sink?.done?.whenComplete(() {
+    finishedCompleter.complete();
+    service.dispose();
+  }));
+  serviceCompleter.complete(service);
 
   unawaited(stream?.drain()?.catchError(onError));
   return serviceCompleter.future;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -46,7 +46,7 @@ dependencies:
   path: ^1.6.0
   pedantic: ^1.7.0
   provider: ^4.0.0
-  sse: ^3.1.2
+  sse: ^3.7.0
   string_scanner: ^1.1.0-nullsafety.3
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6


### PR DESCRIPTION
Version `3.7.0` of `package:sse` now buffers requests before the connection is established. `onOpen` is now deprecated. This fixes an issue where we were trying to complete the service upon reconnects.