### PR TITLE
Handle bad source input during syntax highlighting

### DIFF
--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -462,7 +462,8 @@ class _MultilineMatcher extends _Matcher {
             (captures ?? endCaptures ?? beginCaptures) == null) {
           assert(beginSpans.length == 1);
           beginSpans.first._end = scanner.position;
-        } else {
+        } else if (endSpans != null) {
+          // endSpans can be null if we reach EOF and haven't completed a match.
           results.addAll(endSpans);
         }
         return results;

--- a/packages/devtools_app/test/span_parser_test.dart
+++ b/packages/devtools_app/test/span_parser_test.dart
@@ -168,6 +168,13 @@ void
 var
 ''';
 
+const openCodeBlock = '''
+/// This is an open code block:
+/// ```dart
+///
+/// This should not cause parsing to fail.
+''';
+
 void spanTester({
   @required ScopeSpan span,
   @required List<String> scopes,
@@ -1313,6 +1320,28 @@ void main() {
         line: 3,
         column: 1,
         length: 1,
+      );
+    });
+
+    test('handles malformed input', () {
+      final spans = SpanParser.parse(grammar, openCodeBlock);
+      expect(spans.length, 2);
+      spanTester(
+          span: spans[0],
+          scopes: ['comment.block.documentation.dart'],
+          line: 1,
+          column: 1,
+          length: 91,
+      );
+      spanTester(
+        span: spans[1],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 2,
+        column: 12,
+        length: 48,
       );
     });
   });


### PR DESCRIPTION
If the end condition of a syntax highlighting rule isn't met (i.e., a
code block in a comment is missing a closing ```) it's possible for the
end spans for a rule to be null. Handle this case instead of throwing an
exception.

Fixes b/178035326