### PR TITLE
Flex layout polish.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/box/box.dart
@@ -179,7 +179,7 @@ class _BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
         final availableHeight = constraints.maxHeight - 2;
         final availableWidth = constraints.maxWidth - 2;
 
-        final minFractions = [0.2, 0.3, 0.2];
+        final minFractions = [0.2, 0.5, 0.2];
         double nullOutZero(double value) => value != 0.0 ? value : null;
         final widths = [
           nullOutZero(offset.offset.dx),


### PR DESCRIPTION
Tweak layout fractions and ensure the selected widget is visible even when view is a bit less tall.
Fix https://github.com/flutter/devtools/issues/2697 where the selected child in the flex layout wouldn't scroll into view.
Fix bug with scrollbars in flex layout. It is safer to manually manage the scroll controller than to hope the right thing will happen.
![fix_scroll_explorer](https://user-images.githubusercontent.com/1226812/107670869-09a22b00-6c48-11eb-9e84-74d9410e139e.gif)
