### PR TITLE
Prevent most caught exceptions when constraints are unavailable.

### DIFF
--- a/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
+++ b/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
@@ -165,22 +165,25 @@ String addServiceExtensions() {
                 }
 
                 try {
-                  final constraints = renderObject.constraints;
-                  final constraintsProperty = <String, Object>{
-                    'type': constraints.runtimeType.toString(),
-                    'description': constraints.toString(),
-                  };
-                  if (constraints is BoxConstraints) {
-                    constraintsProperty.addAll(<String, Object>{
-                      'minWidth': constraints.minWidth.toString(),
-                      'minHeight': constraints.minHeight.toString(),
-                      'maxWidth': constraints.maxWidth.toString(),
-                      'maxHeight': constraints.maxHeight.toString(),
-                    });
+                  if (!renderObject.debugNeedsLayout) {
+                    final constraints = renderObject.constraints;
+                    final constraintsProperty = <String, Object>{
+                      'type': constraints.runtimeType.toString(),
+                      'description': constraints.toString(),
+                    };
+                    if (constraints is BoxConstraints) {
+                      constraintsProperty.addAll(<String, Object>{
+                        'minWidth': constraints.minWidth.toString(),
+                        'minHeight': constraints.minHeight.toString(),
+                        'maxWidth': constraints.maxWidth.toString(),
+                        'maxHeight': constraints.maxHeight.toString(),
+                      });
+                    }
+                    additionalJson['constraints'] = constraintsProperty;
                   }
-                  additionalJson['constraints'] = constraintsProperty;
                 } catch (e) {
-                  // Not laid out yet.
+                  // Constraints are sometimes unavailable even though
+                  // debugNeedsLayout is false.
                 }
 
                 try {

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -123,6 +123,7 @@ class EvalOnDartLibrary {
         libraryRef.id,
         expression,
         scope: scope,
+        disableBreakpoints: true,
       );
       if (result is Sentinel) {
         return null;


### PR DESCRIPTION
Skip breakpoints (including caught exceptions when performing eval for inspector.