### PR TITLE
Fix noisy assertion error in timeline processing code

### DIFF
--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -938,7 +938,7 @@ class AsyncTimelineEvent extends TimelineEvent {
   /// The return value will be used to stop the recursion early.
   bool endAsyncEvent(TraceEventWrapper eventWrapper) {
     assert(
-      parentId == null ? asyncId == eventWrapper.event.id : true,
+      parentId != null || asyncId == eventWrapper.event.id,
       'asyncId = $asyncId, but endEventId = ${eventWrapper.event.id}',
     );
     if (endTraceEventJson != null) {

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -932,23 +932,29 @@ class AsyncTimelineEvent extends TimelineEvent {
     }
   }
 
-  void endAsyncEvent(TraceEventWrapper eventWrapper) {
+  /// End the async event with [eventWrapper] and return whether or not the
+  /// end event was successfully added.
+  ///
+  /// The return value will be used to stop the recursion early.
+  bool endAsyncEvent(TraceEventWrapper eventWrapper) {
     assert(
-      asyncId == eventWrapper.event.id,
+      parentId == null ? asyncId == eventWrapper.event.id : true,
       'asyncId = $asyncId, but endEventId = ${eventWrapper.event.id}',
     );
     if (endTraceEventJson != null) {
       // This event has already ended and [eventWrapper] is a duplicate trace
       // event.
-      return;
+      return false;
     }
     if (name == eventWrapper.event.name) {
       addEndEvent(eventWrapper);
-      return;
+      return true;
     }
 
     for (AsyncTimelineEvent child in children) {
-      child.endAsyncEvent(eventWrapper);
+      final added = child.endAsyncEvent(eventWrapper);
+      if (added) return true;
     }
+    return false;
   }
 }

--- a/packages/devtools_app/test/timeline_processor_test.dart
+++ b/packages/devtools_app/test/timeline_processor_test.dart
@@ -244,6 +244,14 @@ void main() {
       );
     });
 
+    test(
+        'processes trace with children with different ids does not throw assert',
+        () async {
+      // This test should complete without throwing an assert from
+      // `AsyncTimelineEvent.endAsyncEvent`.
+      await processor.processTimeline(asyncEventsWithChildrenWithDifferentIds);
+    });
+
     test('inferEventType', () {
       expect(
         processor.inferEventType(asyncStartATrace.event),

--- a/packages/devtools_testing/lib/support/performance_test_data.dart
+++ b/packages/devtools_testing/lib/support/performance_test_data.dart
@@ -1029,6 +1029,81 @@ final durationEventsWithDuplicateTraces = [
   endGpuRasterizerDrawTrace,
 ];
 
+final asyncEventsWithChildrenWithDifferentIds = [
+  testTraceEventWrapper({
+    'name': 'PipelineItem',
+    'cat': 'Embedder',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294235082,
+    'ph': 'b',
+    'id': '1',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+  testTraceEventWrapper({
+    'name': 'PipelineProduce',
+    'cat': 'Embedder',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294235082,
+    'ph': 'b',
+    'id': '1',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+  testTraceEventWrapper({
+    'name': 'PipelineProduce',
+    'cat': 'Embedder',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294236800,
+    'ph': 'e',
+    'id': '1',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+  // Child of PipelineItem with id '1'
+  testTraceEventWrapper({
+    'name': 'ImageCache.putIfAbsent',
+    'cat': 'Dart',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294246630,
+    'ph': 'b',
+    'id': '1',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+  // Child of PipelineItem with id '2' (parent manually specified)
+  testTraceEventWrapper({
+    'name': 'listener',
+    'cat': 'Dart',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294251242,
+    'ph': 'b',
+    'id': '2',
+    'args': {'parentId': '1'}
+  }),
+  testTraceEventWrapper({
+    'name': 'listener',
+    'cat': 'Dart',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294272684,
+    'ph': 'e',
+    'id': '2',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+  testTraceEventWrapper({
+    'name': 'ImageCache.putIfAbsent',
+    'cat': 'Dart',
+    'tid': 22019,
+    'pid': 18510,
+    'ts': 5294272706,
+    'ph': 'e',
+    'id': '1',
+    'args': {'isolateId': 'isolates/677008524697083'}
+  }),
+];
+
 final testTimelineJson = {
   'type': 'Timeline',
   'traceEvents': [


### PR DESCRIPTION
A child can have a different id than its parent if the parent-child relationship was specified via the "parentId" arg. This assertion was firing in part because of what the assertion was checking, and also because we were not returning from the recursion once the event was added. This PR cleans both those issues up and adds a test to verify that the assertion does not fire for cases like this.