### PR TITLE
Request focus from flame chart keyboard listener

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -247,6 +247,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       onExit: _handleMouseExit,
       onHover: _handleMouseHover,
       child: RawKeyboardListener(
+        autofocus: true,
         focusNode: focusNode,
         onKey: (event) => _handleKeyEvent(event),
         // Scrollbar needs to wrap [LayoutBuilder] so that the scroll bar is


### PR DESCRIPTION
Fixes a bug where the keyboard navigation in the flame chart was inconsistently focused, and therefore did not always work.