### PR TITLE
auto-populate call frames

### DIFF
--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -8,7 +8,6 @@ import 'package:vm_service/vm_service.dart';
 
 import '../common_widgets.dart';
 import '../theme.dart';
-import '../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
@@ -28,42 +27,31 @@ class _CallStackState extends State<CallStack> {
 
     final newController = Provider.of<DebuggerController>(context);
     if (newController == controller) return;
+
     controller = newController;
   }
 
   @override
   Widget build(BuildContext context) {
-    return Column(children: [
-      ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
-          valueListenable: controller.stackFramesWithLocation,
-          builder: (context, stackFrames, _) {
-            return Expanded(
-                child: ValueListenableBuilder<StackFrameAndSourcePosition>(
-              valueListenable: controller.selectedStackFrame,
-              builder: (context, selectedFrame, _) {
-                return ListView.builder(
-                  itemCount: stackFrames.length,
-                  itemExtent: defaultListItemHeight,
-                  itemBuilder: (_, index) {
-                    final frame = stackFrames[index];
-                    return _buildStackFrame(frame, frame == selectedFrame);
-                  },
-                );
+    return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
+      valueListenable: controller.stackFramesWithLocation,
+      builder: (context, stackFrames, _) {
+        return Expanded(
+            child: ValueListenableBuilder<StackFrameAndSourcePosition>(
+          valueListenable: controller.selectedStackFrame,
+          builder: (context, selectedFrame, _) {
+            return ListView.builder(
+              itemCount: stackFrames.length,
+              itemExtent: defaultListItemHeight,
+              itemBuilder: (_, index) {
+                final frame = stackFrames[index];
+                return _buildStackFrame(frame, frame == selectedFrame);
               },
-            ));
-          }),
-      ValueListenableBuilder<bool>(
-          valueListenable: controller.hasTruncatedFrames,
-          builder: (_, hasTruncatedFrames, __) {
-            if (hasTruncatedFrames) {
-              return TextButton(
-                onPressed: () => controller.getFullStack(),
-                child: const Text('SHOW ALL'),
-              );
-            }
-            return const SizedBox(height: 0, width: 0);
-          })
-    ]);
+            );
+          },
+        ));
+      },
+    );
   }
 
   Widget _buildStackFrame(
@@ -175,16 +163,5 @@ class _CallStackState extends State<CallStack> {
     }
     final file = uri.split('/').last;
     return frame.line == null ? file : '$file ${frame.line}';
-  }
-}
-
-class CallStackCountBadge extends StatelessWidget {
-  const CallStackCountBadge({@required this.stackFrames});
-
-  final List<StackFrameAndSourcePosition> stackFrames;
-
-  @override
-  Widget build(BuildContext context) {
-    return Badge('${nf.format(stackFrames.length)}');
   }
 }

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -36,8 +36,7 @@ class _CallStackState extends State<CallStack> {
     return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
       valueListenable: controller.stackFramesWithLocation,
       builder: (context, stackFrames, _) {
-        return Expanded(
-            child: ValueListenableBuilder<StackFrameAndSourcePosition>(
+        return ValueListenableBuilder<StackFrameAndSourcePosition>(
           valueListenable: controller.selectedStackFrame,
           builder: (context, selectedFrame, _) {
             return ListView.builder(
@@ -49,7 +48,7 @@ class _CallStackState extends State<CallStack> {
               },
             );
           },
-        ));
+        );
       },
     );
   }

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -633,8 +633,11 @@ class DebuggerController extends DisposableController
 
     // We populate the first 12 frames; this ~roughly corresponds to the number
     // of visible stack frames.
-    _getStackOperation =
-        CancelableOperation.fromFuture(_getStackInfo(limit: 12));
+    const initialFrameRequestCount = 12;
+
+    _getStackOperation = CancelableOperation.fromFuture(_getStackInfo(
+      limit: initialFrameRequestCount,
+    ));
     final stackInfo = await _getStackOperation.value;
     _populateFrameInfo(
       stackInfo.frames,

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -31,8 +31,10 @@ final _log = DebugTimingLogger('debugger', mute: true);
 /// well.
 class ConsoleLine {
   factory ConsoleLine.text(String text) => TextConsoleLine(text);
+
   factory ConsoleLine.variable(Variable variable) =>
       VariableConsoleLine(variable);
+
   ConsoleLine._();
 }
 
@@ -258,7 +260,7 @@ class DebuggerController extends DisposableController
       _breakpoints.value = [];
       _breakpointsWithLocation.value = [];
       await _getStackOperation?.cancel();
-      _populateFrameInfo([]);
+      _populateFrameInfo([], truncated: false);
       return;
     }
 
@@ -612,6 +614,7 @@ class DebuggerController extends DisposableController
   }
 
   final _hasTruncatedFrames = ValueNotifier<bool>(false);
+
   ValueListenable<bool> get hasTruncatedFrames => _hasTruncatedFrames;
 
   CancelableOperation<_StackInfo> _getStackOperation;
@@ -624,31 +627,24 @@ class DebuggerController extends DisposableController
 
     // Perform an early exit if we're not paused.
     if (!paused) {
-      _populateFrameInfo([]);
+      _populateFrameInfo([], truncated: false);
       return;
     }
 
-    // First, notify based on the single 'pauseEvent.topFrame' frame.
-    if (pauseEvent?.topFrame != null) {
-      final tempFrames = _framesForCallStack(
-        [pauseEvent.topFrame],
-        reportedException: pauseEvent?.exception,
-      );
-      _populateFrameInfo(
-        [await _createStackFrameWithLocation(tempFrames.first)],
-        truncated: true,
-      );
-      _log.log('created first frame');
-    }
-
-    // We populate the first 10 frames to match the behavior in VS Code.
+    // We populate the first 12 frames; this ~roughly corresponds to the number
+    // of visible stack frames.
     _getStackOperation =
-        CancelableOperation.fromFuture(_getStackInfo(limit: 10));
+        CancelableOperation.fromFuture(_getStackInfo(limit: 12));
     final stackInfo = await _getStackOperation.value;
     _populateFrameInfo(
       stackInfo.frames,
       truncated: stackInfo.truncated ?? false,
     );
+
+    // In the background, populate the rest of the frames.
+    if (stackInfo.truncated) {
+      unawaited(_getFullStack());
+    }
   }
 
   Future<_StackInfo> _getStackInfo({int limit}) async {
@@ -670,9 +666,8 @@ class DebuggerController extends DisposableController
 
   void _populateFrameInfo(
     List<StackFrameAndSourcePosition> frames, {
-    bool truncated,
+    @required final bool truncated,
   }) {
-    truncated ??= false;
     _log.log('populated frame info');
     _stackFramesWithLocation.value = frames;
     _hasTruncatedFrames.value = truncated;
@@ -683,7 +678,7 @@ class DebuggerController extends DisposableController
     }
   }
 
-  Future<void> getFullStack() async {
+  Future<void> _getFullStack() async {
     await _getStackOperation?.cancel();
     _getStackOperation = CancelableOperation.fromFuture(_getStackInfo());
     final stackInfo = await _getStackOperation.value;
@@ -1226,6 +1221,7 @@ class EvalHistory {
 
 class _StackInfo {
   _StackInfo(this.frames, this.truncated);
+
   final List<StackFrameAndSourcePosition> frames;
   final bool truncated;
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -30,10 +30,6 @@ import 'debugger_model.dart';
 import 'scripts.dart';
 import 'variables.dart';
 
-// This is currently a dev-time flag as the overall call depth may not be that
-// interesting to users.
-const bool debugShowCallStackCount = false;
-
 class DebuggerScreen extends Screen {
   const DebuggerScreen()
       : super.conditional(
@@ -220,7 +216,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
               context,
               title: callStackTitle,
               needsTopBorder: false,
-              actions: debugShowCallStackCount ? [_callStackRightChild()] : [],
             ),
             areaPaneHeader(context, title: variablesTitle),
             areaPaneHeader(
@@ -238,15 +233,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             Breakpoints(),
           ],
         );
-      },
-    );
-  }
-
-  Widget _callStackRightChild() {
-    return ValueListenableBuilder(
-      valueListenable: controller.stackFramesWithLocation,
-      builder: (context, stackFrames, _) {
-        return CallStackCountBadge(stackFrames: stackFrames);
       },
     );
   }

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -392,22 +392,6 @@ void main() {
       // Stack frame 4
       expect(find.text('<async break>'), findsOneWidget);
     });
-    testWidgetsWithWindowSize('Call Stack displays "SHOW ALL" when truncated',
-        const Size(1000.0, 4000.0), (WidgetTester tester) async {
-      when(debuggerController.hasTruncatedFrames)
-          .thenReturn(ValueNotifier(true));
-      await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('SHOW ALL'), findsOneWidget);
-    });
-
-    testWidgetsWithWindowSize(
-        'Call Stack does not display "SHOW ALL" when not truncated',
-        const Size(1000.0, 4000.0), (WidgetTester tester) async {
-      when(debuggerController.hasTruncatedFrames)
-          .thenReturn(ValueNotifier(false));
-      await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.text('SHOW ALL'), findsNothing);
-    });
 
     testWidgetsWithWindowSize(
         'Variables shows items', const Size(1000.0, 4000.0),


### PR DESCRIPTION
- auto-populate call frames
- fix https://github.com/flutter/devtools/issues/2664

This removes the 'show all' button from the call frames area and instead auto-populates them. We don't have quite enough info from the vm service protocol to implement a lazy list (the ability to request a set of frames at an offset and knowing the total number of frames for a stack). Instead we request 12 frames, show those once we have the info, and request all the frames in the background. 12 frames roughly corresponds to the number of visible frames.

This PR also removes the code to initially just show one in frame in the UI and populate a small set of frames in the background. That feature was added when retrieving web frames could be very slow. Web frame population is faster now, and, just showing one for a brief time causes flashing on the screen.
