### PR TITLE
Remove unused dart: imports

### DIFF
--- a/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
@@ -4,7 +4,6 @@
 
 import 'dart:collection';
 import 'dart:convert';
-import 'dart:ui';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/devtools_app/lib/src/memory/memory_timeline.dart
+++ b/packages/devtools_app/lib/src/memory/memory_timeline.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:math';
-
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';


### PR DESCRIPTION
Remove unused dart: import. A bug in the analyzer is causing it to not report this unused import currently. This PR is part of a cleanup to allow fixing the bug. See dart-lang/sdk#45028.