### PR TITLE
Remove thread information on Isolates page

### DIFF
--- a/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view.dart
@@ -59,7 +59,9 @@ class IsolateStatisticsViewBody extends StatelessWidget {
                     child: _buildTopRow(),
                   ),
                   Flexible(
-                    child: _buildBottomRow(),
+                    child: IsolatePortsWidget(
+                      controller: controller,
+                    ),
                   ),
                 ],
               ),
@@ -74,8 +76,19 @@ class IsolateStatisticsViewBody extends StatelessWidget {
     return Row(
       children: [
         Flexible(
-          child: GeneralIsolateStatisticsWidget(
-            controller: controller,
+          child: Column(
+            children: [
+              Flexible(
+                child: GeneralIsolateStatisticsWidget(
+                  controller: controller,
+                ),
+              ),
+              Flexible(
+                child: IsolateMemoryStatisticsWidget(
+                  controller: controller,
+                ),
+              ),
+            ],
           ),
         ),
         Flexible(
@@ -85,24 +98,6 @@ class IsolateStatisticsViewBody extends StatelessWidget {
         ),
         Flexible(
           child: ServiceExtensionsWidget(
-            controller: controller,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildBottomRow() {
-    return Row(
-      children: [
-        Flexible(
-          child: IsolateMemoryStatisticsWidget(
-            controller: controller,
-          ),
-        ),
-        Flexible(
-          flex: 2,
-          child: IsolatePortsWidget(
             controller: controller,
           ),
         ),
@@ -166,8 +161,6 @@ class GeneralIsolateStatisticsWidget extends StatelessWidget {
 /// Displays memory statistics for the isolate, including:
 ///   - Total Dart heap size
 ///   - New + Old space capacity and usage
-///   - Handle counts (zone + scoped)
-///   - Per-thread zone memory usage
 class IsolateMemoryStatisticsWidget extends StatelessWidget {
   const IsolateMemoryStatisticsWidget({@required this.controller});
 
@@ -211,21 +204,7 @@ class IsolateMemoryStatisticsWidget extends StatelessWidget {
                   isolate?.oldSpaceCapacity,
                 ),
               ),
-              MapEntry(
-                'Max Zone Capacity',
-                prettyPrintBytes(
-                  controller.zoneCapacityHighWatermark,
-                  includeUnit: true,
-                ),
-              ),
-              MapEntry('# of Zone Handles', isolate?.zoneHandleCount),
-              MapEntry('# of Scoped Handles', isolate?.scopedHandleCount),
             ],
-            table: Flexible(
-              child: ThreadMemoryTable(
-                controller: controller,
-              ),
-            ),
           ),
         ),
       ],
@@ -282,88 +261,6 @@ class _PercentageColumn extends ColumnData<VMTag> {
 
   @override
   String getDisplayValue(VMTag dataObject) => percent2(dataObject.percentage);
-}
-
-/// Displays a table of threads associated with a given isolate with the
-/// following information:
-///   - Thread kind (e.g., mutator, background compiler, etc.)
-///   - Maximum zone capacity (aka "high watermark")
-///   - Current zone capacity
-class ThreadMemoryTable extends StatelessWidget {
-  ThreadMemoryTable({@required this.controller});
-
-  final id = _IDColumn();
-  final kind = _KindColumn();
-  final watermark = _HighWatermarkColumn();
-  final capacity = _ZoneCapacityColumn();
-
-  List<ColumnData<Thread>> get columns => [
-        id,
-        kind,
-        watermark,
-        capacity,
-      ];
-  final IsolateStatisticsViewController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    final threads = controller.isolate?.threads ?? [];
-    return Column(
-      children: [
-        areaPaneHeader(context, title: 'Threads (${threads.length})'),
-        Expanded(
-          child: FlatTable<Thread>(
-            columns: columns,
-            data: threads,
-            keyFactory: (Thread thread) => ValueKey<String>(thread.id),
-            sortColumn: id,
-            sortDirection: SortDirection.ascending,
-            onItemSelected: (_) => null,
-          ),
-        ),
-      ],
-    );
-  }
-}
-
-class _IDColumn extends ColumnData<Thread> {
-  _IDColumn() : super.wide('ID');
-
-  @override
-  String getValue(Thread thread) => thread.id;
-}
-
-class _KindColumn extends ColumnData<Thread> {
-  _KindColumn() : super.wide('Kind');
-
-  @override
-  String getValue(Thread thread) => thread.kind;
-}
-
-class _HighWatermarkColumn extends ColumnData<Thread> {
-  _HighWatermarkColumn() : super.wide('Max Zone Capacity');
-
-  @override
-  int getValue(Thread thread) => thread.zoneHighWatermark;
-
-  @override
-  String getDisplayValue(Thread thread) => prettyPrintBytes(
-        thread.zoneHighWatermark,
-        includeUnit: true,
-      );
-}
-
-class _ZoneCapacityColumn extends ColumnData<Thread> {
-  _ZoneCapacityColumn() : super.wide('Current Zone Capacity');
-
-  @override
-  int getValue(Thread thread) => thread.zoneCapacity;
-
-  @override
-  String getDisplayValue(Thread thread) => prettyPrintBytes(
-        thread.zoneCapacity,
-        includeUnit: true,
-      );
 }
 
 class _PortIDColumn extends ColumnData<InstanceRef> {

--- a/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view_controller.dart
+++ b/packages/devtools_app/lib/src/vm_developer/isolate_statistics_view_controller.dart
@@ -46,9 +46,6 @@ class IsolateStatisticsViewController extends DisposableController
       UnmodifiableListView(_serviceExtensions);
   List<String> _serviceExtensions = [];
 
-  int get zoneCapacityHighWatermark => _zoneCapacityHighWatermark;
-  int _zoneCapacityHighWatermark = 0;
-
   Future<void> refresh() async => await switchToIsolate(isolate);
 
   Future<void> switchToIsolate(IsolateRef isolateRef) async {
@@ -57,7 +54,6 @@ class IsolateStatisticsViewController extends DisposableController
     // Retrieve updated isolate information and refresh the page.
     _isolate = await _service.getIsolate(isolateRef.id);
     _updateTagCounters(isolate);
-    _updateZoneUsageData(isolate);
     _ports = (await _service.getPorts(_isolate.id)).ports;
     _serviceExtensions = isolate.extensionRPCs ?? [];
     _serviceExtensions.sort();
@@ -85,14 +81,6 @@ class IsolateStatisticsViewController extends DisposableController
         for (final name in percentages.keys)
           VMTag(name, percentages[name] / totalTickCount),
       ];
-    }
-  }
-
-  void _updateZoneUsageData(Isolate isolate) {
-    final currentWatermark =
-        isolate.threads.fold(0, (p, t) => p + t.zoneHighWatermark);
-    if (currentWatermark > _zoneCapacityHighWatermark) {
-      _zoneCapacityHighWatermark = currentWatermark;
     }
   }
 }

--- a/packages/devtools_app/lib/src/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_service_private_extensions.dart
@@ -22,13 +22,6 @@ extension VMPrivateViewExtension on VM {
 
 /// An extension on [Isolate] which allows for access to VM internal fields.
 extension IsolatePrivateViewExtension on Isolate {
-  List<Thread> get threads {
-    return (json['_threads'].cast<Map<String, dynamic>>())
-        .map((e) => Thread.parse(e))
-        .toList()
-        .cast<Thread>();
-  }
-
   Map<String, dynamic> get tagCounters => json['_tagCounters'];
 
   int get dartHeapSize => newSpaceUsage + oldSpaceUsage;
@@ -39,31 +32,4 @@ extension IsolatePrivateViewExtension on Isolate {
 
   int get newSpaceCapacity => json['_heaps']['new']['capacity'];
   int get oldSpaceCapacity => json['_heaps']['old']['capacity'];
-
-  int get zoneHandleCount => json['_numZoneHandles'];
-  int get scopedHandleCount => json['_numScopedHandles'];
-}
-
-/// An internal representation of a thread running within an isolate.
-class Thread {
-  const Thread({
-    @required this.id,
-    @required this.kind,
-    @required this.zoneHighWatermark,
-    @required this.zoneCapacity,
-  });
-
-  factory Thread.parse(Map<String, dynamic> json) {
-    return Thread(
-      id: json['id'],
-      kind: json['kind'],
-      zoneHighWatermark: int.parse(json['_zoneHighWatermark']),
-      zoneCapacity: int.parse(json['_zoneCapacity']),
-    );
-  }
-
-  final String id;
-  final String kind;
-  final int zoneHighWatermark;
-  final int zoneCapacity;
 }

--- a/packages/devtools_app/lib/src/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_service_private_extensions.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 /// NOTE: this file contains extensions to classes provided by


### PR DESCRIPTION
The private field reporting threads and their zone memory usage are no
longer provided by the VM.

Updated page:

![image](https://user-images.githubusercontent.com/24210656/109044886-cbfdc300-7687-11eb-8526-bf6380de753e.png)
