### PR TITLE
Fix Memory panel hover overlay leak.

### DIFF
--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -384,6 +384,12 @@ class MemoryBodyState extends State<MemoryBody>
     );
   }
 
+  @override
+  void dispose() {
+    hideHover(); // hover will leak if not hide
+    super.dispose();
+  }
+
   void _refreshCharts() {
     // Remove history of all plotted data in all charts.
     eventChartController?.reset();


### PR DESCRIPTION
switching out of Memory panel when hover overlay is visible will trigger UI leak.

override dispose() to call hideHover() in time.