### PR TITLE
Memory page UX polish

### DIFF
--- a/packages/devtools_app/lib/src/app_size/file_import_container.dart
+++ b/packages/devtools_app/lib/src/app_size/file_import_container.dart
@@ -166,8 +166,8 @@ class _FileImportContainerState extends State<FileImportContainer> {
                   ? () => widget.onAction(importedFile)
                   : null,
               child: MaterialIconLabel(
-                Icons.highlight,
-                widget.actionText,
+                label: widget.actionText,
+                iconData: Icons.highlight,
               ),
             ),
           ],
@@ -303,8 +303,8 @@ class _DualFileImportContainerState extends State<DualFileImportContainer> {
                       )
                   : null,
               child: MaterialIconLabel(
-                Icons.highlight,
-                widget.actionText,
+                label: widget.actionText,
+                iconData: Icons.highlight,
               ),
             ),
           ],

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -105,8 +105,8 @@ class IconLabelButton extends StatelessWidget {
     return FixedHeightOutlinedButton(
       onPressed: onPressed,
       child: MaterialIconLabel(
-        icon,
-        label,
+        label: label,
+        iconData: icon,
         includeTextWidth: includeTextWidth,
       ),
     );
@@ -276,6 +276,35 @@ class HelpButton extends StatelessWidget {
           size: defaultIconSize,
         ),
       ),
+    );
+  }
+}
+
+class ExpandAllButton extends StatelessWidget {
+  const ExpandAllButton({Key key, @required this.onPressed}) : super(key: key);
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FixedHeightOutlinedButton(
+      onPressed: onPressed,
+      child: const Text('Expand All'),
+    );
+  }
+}
+
+class CollapseAllButton extends StatelessWidget {
+  const CollapseAllButton({Key key, @required this.onPressed})
+      : super(key: key);
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return FixedHeightOutlinedButton(
+      onPressed: onPressed,
+      child: const Text('Collapse All'),
     );
   }
 }
@@ -511,8 +540,8 @@ class ExitOfflineButton extends StatelessWidget {
       buttonKey: const Key('exit offline button'),
       onPressed: onPressed,
       child: const MaterialIconLabel(
-        Icons.clear,
-        'Exit offline mode',
+        label: 'Exit offline mode',
+        iconData: Icons.clear,
       ),
     );
   }
@@ -722,8 +751,8 @@ class ToggleButton extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
         child: MaterialIconLabel(
-          icon,
-          text,
+          label: text,
+          iconData: icon,
           includeTextWidth: includeTextWidth,
         ),
       ),

--- a/packages/devtools_app/lib/src/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/controls.dart
@@ -241,8 +241,8 @@ class DebuggerButton extends StatelessWidget {
       ),
       onPressed: onPressed,
       child: MaterialIconLabel(
-        icon,
-        title,
+        label: title,
+        iconData: icon,
         includeTextWidth: mediumDeviceWidth,
       ),
     );

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_data.dart
@@ -49,9 +49,7 @@ class FieldTrack extends ColumnData<ClassHeapDetailStats>
     return Checkbox(
       value: item.isStacktraced,
       onChanged: (value) {
-        item.isStacktraced = value;
-        controller.setTracking(item.classRef, value);
-        controller.changeStackTraces();
+        controller.toggleAllocationTracking(item, value);
       },
     );
   }

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
@@ -178,7 +178,8 @@ class AllocationTableViewState extends State<AllocationTableView>
       columns: columns,
       data: controller.monitorAllocations,
       keyFactory: (d) => Key(d.classRef.name),
-      onItemSelected: (ref) {},
+      onItemSelected: (ref) =>
+          controller.toggleAllocationTracking(ref, !ref.isStacktraced),
       sortColumn: controller.sortedMonitorColumn,
       sortDirection: controller.sortedMonitorDirection,
       onSortChanged: (

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -388,9 +388,13 @@ class MemoryController extends DisposableController
     return null;
   }
 
-  final treeMapVisible = ValueNotifier<bool>(false);
+  ValueListenable get treeMapVisible => _treeMapVisible;
 
-  ValueListenable get treeMapVisibleNotifier => treeMapVisible;
+  final _treeMapVisible = ValueNotifier<bool>(false);
+
+  void toggleTreeMapVisible(bool value) {
+    _treeMapVisible.value = value;
+  }
 
   bool isAnalyzeButtonEnabled() => computeSnapshotToAnalyze != null;
 
@@ -941,6 +945,12 @@ class MemoryController extends DisposableController
         setTracking(trackedClass.value, true);
       }
     }
+  }
+
+  void toggleAllocationTracking(ClassHeapDetailStats item, bool isStacktraced) {
+    item.isStacktraced = isStacktraced;
+    setTracking(item.classRef, isStacktraced);
+    changeStackTraces();
   }
 
   Future<List<ClassHeapDetailStats>> resetAllocationProfile() =>

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -120,9 +120,25 @@ class _CpuProfilerState extends State<CpuProfiler>
               ),
             if (currentTab.key != CpuProfiler.flameChartTab)
               Row(children: [
-                _expandAllButton(currentTab),
+                ExpandAllButton(
+                  key: CpuProfiler.expandButtonKey,
+                  onPressed: () {
+                    _performOnDataRoots(
+                      (root) => root.expandCascading(),
+                      currentTab,
+                    );
+                  },
+                ),
                 const SizedBox(width: denseSpacing),
-                _collapseAllButton(currentTab),
+                CollapseAllButton(
+                  key: CpuProfiler.collapseButtonKey,
+                  onPressed: () {
+                    _performOnDataRoots(
+                      (root) => root.collapseCascading(),
+                      currentTab,
+                    );
+                  },
+                ),
                 // The standaloneProfiler does not need padding because it is
                 // not wrapped in a bordered container.
                 if (!widget.standaloneProfiler)
@@ -195,26 +211,6 @@ class _CpuProfilerState extends State<CpuProfiler>
     );
     // TODO(kenz): make this order configurable.
     return [bottomUp, callTree, cpuFlameChart];
-  }
-
-  Widget _expandAllButton(Tab currentTab) {
-    return FixedHeightOutlinedButton(
-      buttonKey: CpuProfiler.expandButtonKey,
-      onPressed: () {
-        _performOnDataRoots((root) => root.expandCascading(), currentTab);
-      },
-      child: const Text('Expand All'),
-    );
-  }
-
-  Widget _collapseAllButton(Tab currentTab) {
-    return FixedHeightOutlinedButton(
-      buttonKey: CpuProfiler.collapseButtonKey,
-      onPressed: () {
-        _performOnDataRoots((root) => root.collapseCascading(), currentTab);
-      },
-      child: const Text('Collapse All'),
-    );
   }
 
   void _performOnDataRoots(

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -90,8 +90,8 @@ class _FilterDialogState extends State<FilterDialog> {
         TextButton(
           onPressed: queryTextFieldController.clear,
           child: const MaterialIconLabel(
-            Icons.replay,
-            'Reset to default',
+            label: 'Reset to default',
+            iconData: Icons.replay,
           ),
         ),
       ],

--- a/packages/devtools_app/lib/src/ui/label.dart
+++ b/packages/devtools_app/lib/src/ui/label.dart
@@ -29,10 +29,16 @@ class ImageIconLabel extends StatelessWidget {
 }
 
 class MaterialIconLabel extends StatelessWidget {
-  const MaterialIconLabel(this.iconData, this.text, {this.includeTextWidth});
+  const MaterialIconLabel({
+    @required this.label,
+    this.iconData,
+    this.imageIcon,
+    this.includeTextWidth,
+  }) : assert((iconData == null) != (imageIcon == null));
 
   final IconData iconData;
-  final String text;
+  final Image imageIcon;
+  final String label;
   final double includeTextWidth;
 
   @override
@@ -41,15 +47,17 @@ class MaterialIconLabel extends StatelessWidget {
     // when the text is not shown.
     return Row(
       children: [
-        Icon(
-          iconData,
-          size: defaultIconSize,
-        ),
+        iconData != null
+            ? Icon(
+                iconData,
+                size: defaultIconSize,
+              )
+            : imageIcon,
         // TODO(jacobr): animate showing and hiding the text.
         if (_showLabelText(context, includeTextWidth))
           Padding(
-            padding: const EdgeInsets.only(left: 8.0),
-            child: Text(text),
+            padding: const EdgeInsets.only(left: denseSpacing),
+            child: Text(label),
           ),
       ],
     );


### PR DESCRIPTION
- allocation icons are now the same size as other icons (refactored the MaterialIconLabel utility for this)
- normalize padding around buttons and tables
- replace expand all / collapse all icon buttons with the Expand All / Collapse All buttons used elsewhere in DevTools
- selecting a row in the accumulator table toggles the checkbox for that row (@terrylucas is there another use for selecting a row? I found myself expecting the checkbox would change when I selected a row)
- general cleanup