### PR TITLE
Make debugger gutter background color extend to bottom of view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -414,8 +414,9 @@ class Gutter extends StatelessWidget {
   Widget build(BuildContext context) {
     final bpLineSet = Set.from(breakpoints.map((bp) => bp.line));
 
-    return SizedBox(
+    return Container(
       width: gutterWidth,
+      color: titleSolidBackgroundColor(Theme.of(context)),
       child: ListView.builder(
         controller: scrollController,
         itemExtent: CodeView.rowHeight,
@@ -473,7 +474,6 @@ class GutterItem extends StatelessWidget {
       child: Container(
         height: CodeView.rowHeight,
         padding: const EdgeInsets.only(right: 4.0),
-        decoration: BoxDecoration(color: titleSolidBackgroundColor(theme)),
         child: Stack(
           alignment: AlignmentDirectional.centerStart,
           fit: StackFit.expand,


### PR DESCRIPTION
Before:
<img width="133" alt="Screen Shot 2021-02-26 at 8 15 17 AM" src="https://user-images.githubusercontent.com/43759233/109325456-cd0b2d80-780a-11eb-817a-b5319a2709ae.png">

After:
<img width="432" alt="Screen Shot 2021-02-26 at 8 14 15 AM" src="https://user-images.githubusercontent.com/43759233/109325355-acdb6e80-780a-11eb-8423-beb4ae3674bf.png">
