### PR TITLE
Flame chart scrolling polish

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -276,6 +276,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
 
   Widget _buildFlameChart(BoxConstraints constraints) {
     return ExtentDelegateListView(
+      physics: const ClampingScrollPhysics(),
       controller: verticalController,
       extentDelegate: verticalExtentDelegate,
       customPointerSignalHandler: _handlePointerSignal,
@@ -361,7 +362,13 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       double deltaY = event.scrollDelta.dy;
       if (deltaY.abs() >= deltaX.abs()) {
         if (_altKeyPressed) {
-          verticalController.jumpTo(verticalController.offset + deltaY);
+          verticalController.jumpTo(math.max(
+            math.min(
+              verticalController.offset + deltaY,
+              verticalController.position.maxScrollExtent,
+            ),
+            0.0,
+          ));
         } else {
           deltaY = deltaY.clamp(
             -FlameChart.maxScrollWheelDelta,


### PR DESCRIPTION
This makes it so you cannot scroll beyond the bounds of the scroll view. Without this, there is a distracting bounce back effect.