### PR TITLE
Add support for serving a custom DevTools build

### DIFF
--- a/packages/devtools_server/lib/src/external_handlers.dart
+++ b/packages/devtools_server/lib/src/external_handlers.dart
@@ -27,18 +27,23 @@ import 'server_api.dart';
 /// DevTools project.
 Future<shelf.Handler> defaultHandler(
   ClientManager clients, {
+  String customDevToolsPath,
   bool debugMode = false,
 }) async {
-  final resourceUri = await Isolate.resolvePackageUri(
-      Uri(scheme: 'package', path: 'devtools/devtools.dart'));
+  String buildDir = customDevToolsPath;
+  if (buildDir == null) {
+    final resourceUri = await Isolate.resolvePackageUri(
+        Uri(scheme: 'package', path: 'devtools/devtools.dart'));
 
-  final packageDir = path.dirname(path.dirname(resourceUri.toFilePath()));
+    final packageDir = path.dirname(path.dirname(resourceUri.toFilePath()));
+    buildDir = path.join(packageDir, 'build');
+  }
 
   // Default static handler for all non-package requests.
   Handler buildDirHandler;
   if (!debugMode) {
     buildDirHandler = createStaticHandler(
-      path.join(packageDir, 'build'),
+      buildDir,
       defaultDocument: 'index.html',
     );
   }

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -145,7 +145,12 @@ Future<void> _serveDevToolsWithArgs(
 ///
 /// `handler` is the [shelf.Handler] that the server will use for all requests.
 /// If null, [defaultHandler] will be used. Defaults to null.
-// Note: this method is used by the Flutter CLI and by package:dwds.
+///
+/// `customDevToolsPath` is a path to a directory containing a pre-built
+/// DevTools application. If not provided, the pre-built DevTools application
+/// shipped via pub will be used.
+///
+// Note: this method is used by the Dart CLI, Flutter CLI, and by package:dwds.
 Future<HttpServer> serveDevTools({
   bool enableStdinCommands = true,
   bool machineMode = false,
@@ -156,6 +161,7 @@ Future<HttpServer> serveDevTools({
   bool headlessMode = false,
   bool verboseMode = false,
   String hostname,
+  String customDevToolsPath,
   int port = 0,
   int numPortsToTry = defaultTryPorts,
   shelf.Handler handler,
@@ -180,7 +186,11 @@ Future<HttpServer> serveDevTools({
 
   clients = ClientManager(enableNotifications);
 
-  handler ??= await defaultHandler(clients, debugMode: debugMode);
+  handler ??= await defaultHandler(
+    clients,
+    customBuildDir: customDevToolsPath,
+    debugMode: debugMode,
+  );
 
   HttpServer server;
   SocketException ex;

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -188,7 +188,7 @@ Future<HttpServer> serveDevTools({
 
   handler ??= await defaultHandler(
     clients,
-    customBuildDir: customDevToolsPath,
+    customDevToolsPath: customDevToolsPath,
     debugMode: debugMode,
   );
 


### PR DESCRIPTION
The Dart SDK will use a pinned version pre-built version of DevTools. This means that DDS requires a way to provide a path to the pinned build to devtools_server in order to correctly serve the application.