### PR TITLE
Show correct mouse cursor for splitters

### DIFF
--- a/packages/devtools_app/lib/src/split.dart
+++ b/packages/devtools_app/lib/src/split.dart
@@ -253,7 +253,9 @@ class _SplitState extends State<Split> {
         ),
         if (i < widget.children.length - 1)
           MouseRegion(
-            cursor: SystemMouseCursors.grab,
+            cursor: isHorizontal
+                ? SystemMouseCursors.resizeColumn
+                : SystemMouseCursors.resizeRow,
             child: GestureDetector(
               key: widget.dividerKey(i),
               behavior: HitTestBehavior.translucent,


### PR DESCRIPTION
This changes the cursor from the grab hand to a proper resize double-arrow. I've tested this change in my app (I stole `split.dart` from here since there isn't an official one) and it works there. I haven't actually built the dev tools.