### PR TITLE
Improve file picker UX

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -294,6 +294,13 @@ class FileNode extends TreeNode<FileNode> {
 
   bool get hasScript => scriptRef != null;
 
+  String _fileName = '';
+
+  /// Returns the name of the file.
+  ///
+  /// May be empty.
+  String get fileName => _fileName;
+
   /// Given a flat list of service protocol scripts, return a tree of scripts
   /// representing the best hierarchical grouping.
   static List<FileNode> createRootsFrom(List<ScriptRef> scripts) {
@@ -310,6 +317,7 @@ class FileNode extends TreeNode<FileNode> {
       }
 
       node.scriptRef = script;
+      node._fileName = ScriptRefUtils.fileName(script);
     }
 
     // Clear out the _childrenAsMap map.
@@ -353,6 +361,9 @@ class FileNode extends TreeNode<FileNode> {
 }
 
 class ScriptRefUtils {
+  static String fileName(ScriptRef scriptRef) =>
+      Uri.parse(scriptRef.uri).path.split('/').last;
+
   /// Return the Uri for the given ScriptRef split into path segments.
   ///
   /// This is useful for converting a flat list of scripts into a directory tree

--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -16,6 +16,7 @@ import 'debugger_screen.dart';
 
 const containerIcon = Icons.folder;
 const libraryIcon = Icons.insert_chart;
+const listItemHeight = 40.0;
 
 /// Picker that takes a list of scripts and allows filtering and selection of
 /// items.
@@ -113,6 +114,7 @@ class ScriptPickerState extends State<ScriptPicker> {
           if (!_isLoading)
             Expanded(
               child: TreeView<FileNode>(
+                itemExtent: listItemHeight,
                 dataRoots: _rootScriptNodes,
                 dataDisplayProvider: (item, onTap) =>
                     _displayProvider(context, item, onTap),
@@ -148,10 +150,36 @@ class ScriptPickerState extends State<ScriptPicker> {
               ),
               const SizedBox(width: densePadding),
               Expanded(
-                child: Text(
-                  node.name,
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          if (!node.hasScript)
+                            Text(
+                              node.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          if (node.hasScript) ...[
+                            Text(
+                              node.fileName,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            Text(
+                              node.scriptRef.uri,
+                              style: const TextStyle(color: Colors.grey),
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ]
+                        ],
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],

--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -150,35 +150,29 @@ class ScriptPickerState extends State<ScriptPicker> {
               ),
               const SizedBox(width: densePadding),
               Expanded(
-                child: Row(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Expanded(
-                      child: Column(
-                        mainAxisAlignment: MainAxisAlignment.center,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          if (!node.hasScript)
-                            Text(
-                              node.name,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          if (node.hasScript) ...[
-                            Text(
-                              node.fileName,
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                            Text(
-                              node.scriptRef.uri,
-                              style: const TextStyle(color: Colors.grey),
-                              maxLines: 1,
-                              overflow: TextOverflow.ellipsis,
-                            ),
-                          ]
-                        ],
+                    if (!node.hasScript)
+                      Text(
+                        node.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      )
+                    else ...[
+                      Text(
+                        node.fileName,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                       ),
-                    ),
+                      Text(
+                        node.scriptRef.uri,
+                        style: const TextStyle(color: Colors.grey),
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ]
                   ],
                 ),
               ),

--- a/packages/devtools_app/lib/src/tree.dart
+++ b/packages/devtools_app/lib/src/tree.dart
@@ -14,6 +14,7 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
     this.dataDisplayProvider,
     this.onItemPressed,
     this.shrinkWrap = false,
+    this.itemExtent = defaultListItemHeight,
   });
 
   final List<T> dataRoots;
@@ -29,6 +30,8 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
   final Widget Function(T, VoidCallback) dataDisplayProvider;
 
   final void Function(T) onItemPressed;
+
+  final double itemExtent;
 
   @override
   _TreeViewState<T> createState() => _TreeViewState<T>();
@@ -61,7 +64,7 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
     if (items.isEmpty) return const SizedBox();
     return ListView.builder(
       itemCount: items.length,
-      itemExtent: defaultListItemHeight,
+      itemExtent: widget.itemExtent,
       shrinkWrap: widget.shrinkWrap,
       physics: widget.shrinkWrap ? const ClampingScrollPhysics() : null,
       itemBuilder: (context, index) {


### PR DESCRIPTION
Mirror the file picker UX in Chrome which shows file results in two lines, the first line is simply the file name, the second line is the entire path potentially truncated. This helps for very long files as it's difficult to distinguish between truncated file names.

<img width="1265" alt="Screen Shot 2021-03-10 at 4 10 35 PM" src="https://user-images.githubusercontent.com/1840773/110716840-cd1d0d00-81bc-11eb-8610-8ab35ad16228.png">
