### PR TITLE
Improve hover logic

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -591,12 +591,10 @@ class _LineItemState extends State<LineItem> {
     _removeTimer?.cancel();
     if (!_debuggerController.isPaused.value) return;
     _showTimer = Timer(LineItem._hoverDelay, () async {
-      final theme = Theme.of(context);
       _hoverCard?.remove();
       final word = wordForHover(
         event.localPosition.dx,
         widget.lineContents,
-        theme.fixedFontStyle,
       );
       if (word != '') {
         try {

--- a/packages/devtools_app/lib/src/debugger/hover.dart
+++ b/packages/devtools_app/lib/src/debugger/hover.dart
@@ -55,7 +55,8 @@ String wordForHover(double dx, TextSpan line) {
 /// located.
 int _hoverIndexFor(double dx, TextSpan line) {
   int hoverIndex = -1;
-  for (var i = 0; i < line.toPlainText().length; i++) {
+  final length = line.toPlainText().length;
+  for (var i = 0; i < length; i++) {
     final painter = TextPainter(
       text: truncateTextSpan(line, i + 1),
       textDirection: TextDirection.ltr,

--- a/packages/devtools_app/test/hover_test.dart
+++ b/packages/devtools_app/test/hover_test.dart
@@ -7,15 +7,15 @@ import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
 const _textSpan = TextSpan(children: [
-  TextSpan(text: 'hello'),
+  TextSpan(text: 'hello', style: TextStyle(fontWeight: FontWeight.bold)),
   TextSpan(text: ' '),
   TextSpan(text: 'world'),
   TextSpan(text: ' '),
-  TextSpan(text: 'foo'),
+  TextSpan(text: 'foo', style: TextStyle(fontWeight: FontWeight.bold)),
   TextSpan(text: '.'),
   TextSpan(text: 'bar'),
   TextSpan(text: '.'),
-  TextSpan(text: 'baz'),
+  TextSpan(text: 'baz', style: TextStyle(fontWeight: FontWeight.w100)),
   TextSpan(text: ' '),
   TextSpan(text: 'blah'),
 ]);

--- a/packages/devtools_app/test/hover_test.dart
+++ b/packages/devtools_app/test/hover_test.dart
@@ -9,12 +9,15 @@ import 'package:test/test.dart';
 const _defaultStyle = TextStyle();
 const _textSpan = TextSpan(children: [
   TextSpan(text: 'hello'),
+  TextSpan(text: ' '),
   TextSpan(text: 'world'),
+  TextSpan(text: ' '),
   TextSpan(text: 'foo'),
   TextSpan(text: '.'),
   TextSpan(text: 'bar'),
   TextSpan(text: '.'),
   TextSpan(text: 'baz'),
+  TextSpan(text: ' '),
   TextSpan(text: 'blah'),
 ]);
 
@@ -31,8 +34,8 @@ void main() {
   });
 
   test('wordForHover merges words linked with `.`', () {
-    expect(wordForHover(150, _textSpan, _defaultStyle), 'foo');
-    expect(wordForHover(200, _textSpan, _defaultStyle), 'foo.bar');
-    expect(wordForHover(255, _textSpan, _defaultStyle), 'foo.bar.baz');
+    expect(wordForHover(200, _textSpan, _defaultStyle), 'foo');
+    expect(wordForHover(250, _textSpan, _defaultStyle), 'foo.bar');
+    expect(wordForHover(300, _textSpan, _defaultStyle), 'foo.bar.baz');
   });
 }

--- a/packages/devtools_app/test/hover_test.dart
+++ b/packages/devtools_app/test/hover_test.dart
@@ -6,7 +6,6 @@ import 'package:devtools_app/src/debugger/hover.dart';
 import 'package:flutter/widgets.dart';
 import 'package:test/test.dart';
 
-const _defaultStyle = TextStyle();
 const _textSpan = TextSpan(children: [
   TextSpan(text: 'hello'),
   TextSpan(text: ' '),
@@ -23,19 +22,19 @@ const _textSpan = TextSpan(children: [
 
 void main() {
   test('wordForHover returns the correct word given the provided x offset', () {
-    expect(wordForHover(10, _textSpan, _defaultStyle), 'hello');
-    expect(wordForHover(100, _textSpan, _defaultStyle), 'world');
-    expect(wordForHover(5000, _textSpan, _defaultStyle), '');
+    expect(wordForHover(10, _textSpan), 'hello');
+    expect(wordForHover(100, _textSpan), 'world');
+    expect(wordForHover(5000, _textSpan), '');
   });
 
   test('wordForHover returns an empty string if there is no underlying word',
       () {
-    expect(wordForHover(5000, _textSpan, _defaultStyle), '');
+    expect(wordForHover(5000, _textSpan), '');
   });
 
   test('wordForHover merges words linked with `.`', () {
-    expect(wordForHover(200, _textSpan, _defaultStyle), 'foo');
-    expect(wordForHover(250, _textSpan, _defaultStyle), 'foo.bar');
-    expect(wordForHover(300, _textSpan, _defaultStyle), 'foo.bar.baz');
+    expect(wordForHover(200, _textSpan), 'foo');
+    expect(wordForHover(250, _textSpan), 'foo.bar');
+    expect(wordForHover(300, _textSpan), 'foo.bar.baz');
   });
 }


### PR DESCRIPTION
Closes https://github.com/flutter/devtools/issues/2797

This gets us in a better place but isn't perfect. If you hover inside a quoted string then the entire string isn't considered a single entity for evaluation. Today at HEAD, if the string doesn't contain interpolation, the entire string is considered for evaluation. However that's not very useful as the result is obvious. I think it makes sense to move forward with this change that improves the overall hover experience for useful cases.