### PR TITLE
Increase size of total time column in CPU profiler

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_columns.dart
@@ -3,7 +3,7 @@ import '../url_utils.dart';
 import '../utils.dart';
 import 'cpu_profile_model.dart';
 
-const _timeColumnWidthPx = 160.0;
+const _timeColumnWidthPx = 180.0;
 
 class SelfTimeColumn extends ColumnData<CpuStackFrame> {
   SelfTimeColumn({String titleTooltip})


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/2779

The bigger issue here is that we don't have flexible column widths, but that is a larger fish to fry: https://github.com/flutter/devtools/issues/2047