### PR TITLE
Use widgets for flame chart group labels instead of custom painters

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -1097,12 +1097,6 @@ extension ColorExtension on Color {
 }
 
 /// Gets an alternating color to use for indexed UI elements.
-Color alternatingColorForIndexWithContext(int index, BuildContext context) {
-  final theme = Theme.of(context);
-  final color = theme.canvasColor;
-  return _colorForIndex(color, index, theme.colorScheme);
-}
-
 Color alternatingColorForIndex(int index, ColorScheme colorScheme) {
   final color = colorScheme.defaultBackgroundColor;
   return _colorForIndex(color, index, colorScheme);

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -1,7 +1,6 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-import 'dart:collection';
 import 'dart:math' as math;
 import 'dart:ui';
 

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -217,8 +217,16 @@ class TimelineFlameChartState
 
   FlutterFrame _selectedFrame;
 
+  ScrollController _groupLabelScrollController;
+
   @override
   int get rowOffsetForTopPadding => TimelineFlameChart.rowOffsetForTopPadding;
+
+  @override
+  void initState() {
+    super.initState();
+    _groupLabelScrollController = verticalControllerGroup.addAndGet();
+  }
 
   @override
   void didChangeDependencies() {
@@ -236,7 +244,7 @@ class TimelineFlameChartState
   @override
   bool isDataVerticallyInView(TimelineEvent data) {
     final eventTopY = topYForData(data);
-    final verticalScrollOffset = verticalController.offset;
+    final verticalScrollOffset = verticalControllerGroup.offset;
     return eventTopY > verticalScrollOffset &&
         eventTopY + rowHeightWithPadding <
             verticalScrollOffset + widget.containerHeight;
@@ -421,7 +429,7 @@ class TimelineFlameChartState
   }
 
   @override
-  List<CustomPaint> buildCustomPaints(
+  List<Widget> buildChartOverlays(
     BoxConstraints constraints,
     BuildContext buildContext,
   ) {
@@ -432,8 +440,8 @@ class TimelineFlameChartState
         painter: AsyncGuidelinePainter(
           zoom: zoom,
           constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
+          verticalController: verticalControllerGroup,
+          horizontalController: horizontalControllerGroup,
           verticalGuidelines: verticalGuidelines,
           horizontalGuidelines: horizontalGuidelines,
           chartStartInset: widget.startInset,
@@ -444,8 +452,8 @@ class TimelineFlameChartState
         painter: TimelineGridPainter(
           zoom: zoom,
           constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
+          verticalController: verticalControllerGroup,
+          horizontalController: horizontalControllerGroup,
           chartStartInset: widget.startInset,
           chartEndInset: widget.endInset,
           flameChartWidth: widthWithZoom,
@@ -458,8 +466,8 @@ class TimelineFlameChartState
           _selectedFrame,
           zoom: zoom,
           constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
+          verticalController: verticalControllerGroup,
+          horizontalController: horizontalControllerGroup,
           chartStartInset: widget.startInset,
           startTimeOffsetMicros: startTimeOffset,
           startingPxPerMicro: startingPxPerMicro,
@@ -471,18 +479,75 @@ class TimelineFlameChartState
           colorScheme: colorScheme,
         ),
       ),
-      CustomPaint(
-        painter: SectionLabelPainter(
-          _timelineController.data.eventGroups,
-          zoom: zoom,
-          constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
-          chartStartInset: widget.startInset,
-          colorScheme: colorScheme,
+      _buildSectionLabels(constraints: constraints),
+    ];
+  }
+
+  Widget _buildSectionLabels({@required BoxConstraints constraints}) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final eventGroups = _timelineController.data.eventGroups;
+
+    final children = <Widget>[];
+    for (int i = 0; i < eventGroups.length; i++) {
+      var topSpacer = 0.0;
+      var bottomSpacer = 0.0;
+      if (i == 0) {
+        // Add spacing to account for timestamps at top of chart.
+        topSpacer +=
+            sectionSpacing * TimelineFlameChart.rowOffsetForTopPadding -
+                rowHeight;
+      }
+      if (i == eventGroups.length - 1) {
+        // Add spacing to account for bottom row of padding.
+        bottomSpacer = rowHeight;
+      }
+
+      final groupName = eventGroups.keys.elementAt(i);
+      final group = eventGroups[groupName];
+      final backgroundColor = alternatingColorForIndex(
+        eventGroups.values.toList().indexOf(group),
+        colorScheme,
+      );
+      final backgroundWithOpacity = Color.fromRGBO(
+        backgroundColor.red,
+        backgroundColor.green,
+        backgroundColor.blue,
+        0.85,
+      );
+      children.addAll([
+        SizedBox(height: topSpacer),
+        Container(
+          alignment: Alignment.topLeft,
+          height: group.displaySizePx,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: densePadding,
+              vertical: rowPadding,
+            ),
+            color: backgroundWithOpacity,
+            child: Text(
+              groupName,
+              style: TextStyle(color: colorScheme.chartTextColor),
+            ),
+          ),
+        ),
+        SizedBox(height: bottomSpacer),
+      ]);
+    }
+
+    return Positioned(
+      top: rowHeight, // Adjust for row of timestamps
+      left: 0.0,
+      height: constraints.maxHeight,
+      width: widget.startInset,
+      child: IgnorePointer(
+        child: ListView(
+          physics: const ClampingScrollPhysics(),
+          controller: _groupLabelScrollController,
+          children: children,
         ),
       ),
-    ];
+    );
   }
 
   void _calculateAsyncGuidelines() {
@@ -638,97 +703,11 @@ class TimelineFlameChartState
   }
 }
 
-class SectionLabelPainter extends FlameChartPainter {
-  SectionLabelPainter(
-    this.eventGroups, {
-    @required double zoom,
-    @required BoxConstraints constraints,
-    @required ScrollController verticalController,
-    @required LinkedScrollControllerGroup horizontalController,
-    @required double chartStartInset,
-    @required ColorScheme colorScheme,
-  }) : super(
-          zoom: zoom,
-          constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
-          chartStartInset: chartStartInset,
-          colorScheme: colorScheme,
-        );
-
-  final SplayTreeMap<String, TimelineEventGroup> eventGroups;
-
-  @override
-  void paint(Canvas canvas, Size size) {
-    final verticalScrollOffset = verticalController.offset;
-    canvas.clipRect(Rect.fromLTWH(
-      0.0,
-      rowHeight, // We do not want to paint inside the timestamp section.
-      constraints.maxWidth,
-      constraints.maxHeight - rowHeight,
-    ));
-
-    // Start at row height to account for timestamps at top of chart.
-    var startSectionPx =
-        sectionSpacing * TimelineFlameChart.rowOffsetForTopPadding;
-    for (String groupName in eventGroups.keys) {
-      final group = eventGroups[groupName];
-      final labelTop = startSectionPx - verticalScrollOffset;
-
-      final textPainter = TextPainter(
-        text: TextSpan(
-          text: groupName,
-          style: TextStyle(color: colorScheme.chartTextColor),
-        ),
-        textDirection: TextDirection.ltr,
-      )..layout();
-
-      final labelWidth = textPainter.width + 2 * densePadding;
-      final backgroundColor = alternatingColorForIndex(
-        eventGroups.values.toList().indexOf(group),
-        colorScheme,
-      );
-      final backgroundWithOpacity = Color.fromRGBO(
-        backgroundColor.red,
-        backgroundColor.green,
-        backgroundColor.blue,
-        0.85,
-      );
-
-      canvas.drawRect(
-        Rect.fromLTWH(
-          0.0,
-          labelTop,
-          labelWidth,
-          rowHeightWithPadding,
-        ),
-        Paint()..color = backgroundWithOpacity,
-      );
-
-      textPainter.paint(
-        canvas,
-        Offset(densePadding, labelTop + rowPadding),
-      );
-
-      startSectionPx += group.displaySizePx;
-    }
-  }
-
-  @override
-  bool shouldRepaint(CustomPainter oldDelegate) {
-    if (oldDelegate is SectionLabelPainter) {
-      return eventGroups != oldDelegate.eventGroups ||
-          super.shouldRepaint(oldDelegate);
-    }
-    return true;
-  }
-}
-
 class AsyncGuidelinePainter extends FlameChartPainter {
   AsyncGuidelinePainter({
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup verticalController,
     @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required this.verticalGuidelines,
@@ -866,7 +845,7 @@ class SelectedFrameBracketPainter extends FlameChartPainter {
     this.selectedFrame, {
     @required double zoom,
     @required BoxConstraints constraints,
-    @required ScrollController verticalController,
+    @required LinkedScrollControllerGroup verticalController,
     @required LinkedScrollControllerGroup horizontalController,
     @required double chartStartInset,
     @required this.startTimeOffsetMicros,

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -514,11 +514,11 @@ class TimelineFlameChartState
         backgroundColor.blue,
         0.85,
       );
-      children.addAll([
-        SizedBox(height: topSpacer),
+      children.add(
         Container(
+          padding: EdgeInsets.only(top: topSpacer, bottom: bottomSpacer),
           alignment: Alignment.topLeft,
-          height: group.displaySizePx,
+          height: group.displaySizePx + topSpacer + bottomSpacer,
           child: Container(
             padding: const EdgeInsets.symmetric(
               horizontal: densePadding,
@@ -531,8 +531,7 @@ class TimelineFlameChartState
             ),
           ),
         ),
-        SizedBox(height: bottomSpacer),
-      ]);
+      );
     }
 
     return Positioned(

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -83,7 +83,7 @@ class _CpuProfileFlameChartState
   }
 
   @override
-  List<CustomPaint> buildCustomPaints(
+  List<Widget> buildChartOverlays(
     BoxConstraints constraints,
     BuildContext buildContext,
   ) {
@@ -94,8 +94,8 @@ class _CpuProfileFlameChartState
         painter: TimelineGridPainter(
           zoom: zoom,
           constraints: constraints,
-          verticalController: verticalController,
-          horizontalController: horizontalController,
+          verticalController: verticalControllerGroup,
+          horizontalController: horizontalControllerGroup,
           chartStartInset: widget.startInset,
           chartEndInset: widget.endInset,
           flameChartWidth: widthWithZoom,
@@ -108,7 +108,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataVerticallyInView(CpuStackFrame data) {
-    final verticalScrollOffset = verticalController.offset;
+    final verticalScrollOffset = verticalControllerGroup.offset;
     final stackFrameTopY = topYForData(data);
     return stackFrameTopY > verticalScrollOffset &&
         stackFrameTopY + rowHeightWithPadding <
@@ -117,7 +117,7 @@ class _CpuProfileFlameChartState
 
   @override
   bool isDataHorizontallyInView(CpuStackFrame data) {
-    final horizontalScrollOffset = horizontalController.offset;
+    final horizontalScrollOffset = horizontalControllerGroup.offset;
     final startX = startXForData(data);
     return startX >= horizontalScrollOffset &&
         startX <= horizontalScrollOffset + widget.containerWidth;

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -238,7 +238,10 @@ class FlatTableState<T> extends State<FlatTable<T>>
       onPressed: widget.onItemSelected,
       columns: widget.columns,
       columnWidths: columnWidths,
-      backgroundColor: alternatingColorForIndexWithContext(index, context),
+      backgroundColor: alternatingColorForIndex(
+        index,
+        Theme.of(context).colorScheme,
+      ),
       isSelected: widget.selectionNotifier != null
           ? node == widget.selectionNotifier.value
           : false,
@@ -546,7 +549,10 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
         linkedScrollControllerGroup: linkedScrollControllerGroup,
         node: node,
         onPressed: (item) => _onItemPressed(item, index),
-        backgroundColor: alternatingColorForIndexWithContext(index, context),
+        backgroundColor: alternatingColorForIndex(
+          index,
+          Theme.of(context).colorScheme,
+        ),
         columns: widget.columns,
         columnWidths: columnWidths,
         expandableColumn: widget.treeColumn,

--- a/packages/devtools_app/lib/src/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_developer_common_widgets.dart
@@ -98,7 +98,7 @@ class VMInfoList extends StatelessWidget {
 
   Widget _buildAlternatingRow(BuildContext context, int index, Widget row) {
     return Container(
-      color: alternatingColorForIndexWithContext(index, context),
+      color: alternatingColorForIndex(index, Theme.of(context).colorScheme),
       height: defaultRowHeight,
       padding: const EdgeInsets.symmetric(
         horizontal: defaultSpacing,

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -54,7 +54,7 @@ void main() {
       final FlameChartState state = tester.state(find.byWidget(flameChart));
 
       expect(state.zoomController.value, equals(1.0));
-      expect(state.horizontalController.offset, equals(0.0));
+      expect(state.horizontalControllerGroup.offset, equals(0.0));
       state.mouseHoverX = 100.0;
       state.focusNode.requestFocus();
       await tester.pumpAndSettle();
@@ -66,31 +66,31 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.horizontalController.offset, equals(20.0));
+      expect(state.horizontalControllerGroup.offset, equals(20.0));
 
       // Zoom in further.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.horizontalController.offset, equals(50.0));
+      expect(state.horizontalControllerGroup.offset, equals(50.0));
 
       // Zoom out.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.horizontalController.offset, equals(20.0));
+      expect(state.horizontalControllerGroup.offset, equals(20.0));
 
       // Zoom out further.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.0));
-      expect(state.horizontalController.offset, equals(0.0));
+      expect(state.horizontalControllerGroup.offset, equals(0.0));
 
       // Zoom out and verify we cannot go beyond the minimum zoom level (1.0);
       await tester.sendKeyEvent(LogicalKeyboardKey.keyS, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.0));
-      expect(state.horizontalController.offset, equals(0.0));
+      expect(state.horizontalControllerGroup.offset, equals(0.0));
 
       // Verify that the scroll position does not change when the mouse is
       // positioned in an unzoomable area (start or end inset).
@@ -98,7 +98,7 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(1.5));
-      expect(state.horizontalController.offset, equals(0.0));
+      expect(state.horizontalControllerGroup.offset, equals(0.0));
     });
 
     testWidgets('WASD keys pan chart', (WidgetTester tester) async {
@@ -107,7 +107,7 @@ void main() {
       final FlameChartState state = tester.state(find.byWidget(flameChart));
 
       expect(state.zoomController.value, equals(1.0));
-      expect(state.horizontalController.offset, equals(0.0));
+      expect(state.horizontalControllerGroup.offset, equals(0.0));
       state.mouseHoverX = 500.0;
       state.focusNode.requestFocus();
       await tester.pumpAndSettle();
@@ -121,37 +121,37 @@ void main() {
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.horizontalController.offset, equals(550.0));
+      expect(state.horizontalControllerGroup.offset, equals(550.0));
 
       // Pan left. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyA, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.horizontalController.offset, equals(300.0));
+      expect(state.horizontalControllerGroup.offset, equals(300.0));
 
       // Pan right. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyD, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(2.25));
-      expect(state.horizontalController.offset, equals(550.0));
+      expect(state.horizontalControllerGroup.offset, equals(550.0));
 
       // Zoom in.
       await tester.sendKeyEvent(LogicalKeyboardKey.keyW, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(state.horizontalController.offset, equals(1045.0));
+      expect(state.horizontalControllerGroup.offset, equals(1045.0));
 
       // Pan left. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyA, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(state.horizontalController.offset, equals(795.0));
+      expect(state.horizontalControllerGroup.offset, equals(795.0));
 
       // Pan right. Pan unit should equal 1/4th of the original width (1000.0).
       await tester.sendKeyEvent(LogicalKeyboardKey.keyD, platform: 'macos');
       await tester.pumpAndSettle();
       expect(state.zoomController.value, equals(3.375));
-      expect(state.horizontalController.offset, equals(1045.0));
+      expect(state.horizontalControllerGroup.offset, equals(1045.0));
     });
   });
 


### PR DESCRIPTION
This will allow us to do things like make the labels clickable and implement expandable and collapsible threads in the timeline flame chart