### PR TITLE
Ignore a deprecated member in custom_pointer_scroll_view.dart

### DIFF
--- a/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
@@ -655,6 +655,8 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
       );
     }
 
+    // TODO: https://github.com/flutter/devtools/issues/2858
+    // ignore: deprecated_member_use
     return _configuration.buildViewportChrome(
         context, result, widget.axisDirection);
   }


### PR DESCRIPTION
See https://github.com/flutter/devtools/issues/2858 for details. Fixing this issue will be a larger task, and this lint is breaking the bots.