### PR TITLE
Fix spurious new lines

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -219,7 +219,7 @@ class DebuggerController extends DisposableController
     var lines = _stdio.value.toList();
     final newLines = text.split('\n');
 
-    final last = lines.safeLast;
+    var last = lines.safeLast;
     if (lines.isNotEmpty && !_stdioTrailingNewline && last is TextConsoleLine) {
       lines.last = ConsoleLine.text('${last.text}${newLines.first}');
       if (newLines.length > 1) {
@@ -232,6 +232,7 @@ class DebuggerController extends DisposableController
     _stdioTrailingNewline = text.endsWith('\n');
 
     // Don't report trailing blank lines.
+    last = lines.safeLast;
     if (lines.isNotEmpty && (last is TextConsoleLine && last.text.isEmpty)) {
       lines = lines.sublist(0, lines.length - 1);
     }


### PR DESCRIPTION
We correctly remove trailing new lines based off the last element. However we had a stale reference for this logic which caused issues.