### PR TITLE
Set the correct dart:io service extension protocol version for the new HTTP profiler logic

### DIFF
--- a/packages/devtools_app/lib/src/network/network_service.dart
+++ b/packages/devtools_app/lib/src/network/network_service.dart
@@ -43,7 +43,7 @@ class NetworkService {
     List<HttpProfileRequest> httpRequests;
     Timeline timeline;
     if (await serviceManager.service.isDartIoVersionSupported(
-      supportedVersion: SemanticVersion(major: 1, minor: 3),
+      supportedVersion: SemanticVersion(major: 1, minor: 6),
       isolateId: serviceManager.isolateManager.selectedIsolate.id,
     )) {
       httpRequests = await _refreshHttpProfile();


### PR DESCRIPTION
Currently set to try and use the new network profiler RPCs if dart:io
service protocol version is 1.3 or above, but the new RPCs were
introduced in 1.6.