### PR TITLE
Fix a couple bugs with flame chart styling and zoom.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -660,10 +660,10 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
   @override
   Widget build(BuildContext context) {
     if (nodes.isEmpty) {
-      return Container(
+      return EmptyFlameChartRow(
         height: sectionSpacing,
         width: widget.width,
-        color: widget.backgroundColor,
+        backgroundColor: widget.backgroundColor,
       );
     }
     // Having each row handle gestures and mouse events instead of each node
@@ -1487,6 +1487,29 @@ class _FlameChartHelpDialog extends StatelessWidget {
           ],
         ),
       ],
+    );
+  }
+}
+
+class EmptyFlameChartRow extends StatelessWidget {
+  const EmptyFlameChartRow({
+    @required this.height,
+    @required this.width,
+    @required this.backgroundColor,
+  });
+
+  final double height;
+
+  final double width;
+
+  final Color backgroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: height,
+      width: width,
+      color: backgroundColor,
     );
   }
 }

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -292,7 +292,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
           final nodes = rows[index].nodes;
           Color rowBackgroundColor = Colors.transparent;
           if (index >= rowOffsetForTopPadding && nodes.isEmpty) {
-            // If this is a spacer row, so we should use the background color of
+            // If this is a spacer row, we should use the background color of
             // the previous row with nodes.
             for (int i = index; i > rowOffsetForTopPadding; i--) {
               // Look back until we find the first non-empty row.

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -159,15 +159,15 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
   /// Starting pixels per microsecond in order to fit all the data in view at
   /// start.
   double get startingPxPerMicro =>
-      widget.startingContentWidth / widget.data.time.duration.inMicroseconds;
+      widget.startingContentWidth / widget.time.duration.inMicroseconds;
 
-  int get startTimeOffset => widget.data.time.start.inMicroseconds;
+  int get startTimeOffset => widget.time.start.inMicroseconds;
 
   double get maxZoomLevel {
     // The max zoom level is hit when 1 microsecond is the width of each grid
     // interval (this may bottom out at 2 micros per interval due to rounding).
     return TimelineGridPainter.baseGridIntervalPx *
-        widget.data.time.duration.inMicroseconds /
+        widget.time.duration.inMicroseconds /
         widget.startingContentWidth;
   }
 

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -24,7 +24,7 @@ import '../utils.dart';
 const double rowPadding = 2.0;
 const double rowHeight = 25.0;
 const double rowHeightWithPadding = rowHeight + rowPadding;
-const double sectionSpacing = 15.0;
+const double sectionSpacing = 16.0;
 const double sideInset = 70.0;
 const double sideInsetSmall = 60.0;
 
@@ -48,7 +48,6 @@ abstract class FlameChart<T, V> extends StatefulWidget {
   });
 
   static const minZoomLevel = 1.0;
-  static const maxZoomLevel = double.infinity;
   static const zoomMultiplier = 0.01;
   static const minScrollOffset = 0.0;
   static const rowOffsetForBottomPadding = 1;
@@ -164,6 +163,14 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
 
   int get startTimeOffset => widget.data.time.start.inMicroseconds;
 
+  double get maxZoomLevel {
+    // The max zoom level is hit when 1 microsecond is the width of each grid
+    // interval (this may bottom out at 2 micros per interval due to rounding).
+    return TimelineGridPainter.baseGridIntervalPx *
+        widget.data.time.duration.inMicroseconds /
+        widget.startingContentWidth;
+  }
+
   /// Provides widgets to be layered on top of the flame chart, if overridden.
   ///
   /// The widgets will be layered in a [Stack] in the order that they are
@@ -188,7 +195,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
     zoomController = AnimationController(
       value: FlameChart.minZoomLevel,
       lowerBound: FlameChart.minZoomLevel,
-      upperBound: FlameChart.maxZoomLevel,
+      upperBound: maxZoomLevel,
       vsync: this,
     )..addListener(_handleZoomControllerValueUpdate);
 
@@ -282,14 +289,36 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       customPointerSignalHandler: _handlePointerSignal,
       childrenDelegate: SliverChildBuilderDelegate(
         (context, index) {
+          final nodes = rows[index].nodes;
+          Color rowBackgroundColor = Colors.transparent;
+          if (index >= rowOffsetForTopPadding && nodes.isEmpty) {
+            // If this is a spacer row, so we should use the background color of
+            // the previous row with nodes.
+            for (int i = index; i > rowOffsetForTopPadding; i--) {
+              // Look back until we find the first non-empty row.
+              if (rows[i].nodes.isNotEmpty) {
+                rowBackgroundColor = alternatingColorForIndex(
+                  rows[i].nodes.first.sectionIndex,
+                  Theme.of(context).colorScheme,
+                );
+                break;
+              }
+            }
+          } else if (nodes.isNotEmpty) {
+            rowBackgroundColor = alternatingColorForIndex(
+              nodes.first.sectionIndex,
+              Theme.of(context).colorScheme,
+            );
+          }
           return ScrollingFlameChartRow<V>(
             linkedScrollControllerGroup: horizontalControllerGroup,
-            nodes: rows[index].nodes,
+            nodes: nodes,
             width: math.max(constraints.maxWidth, widthWithZoom),
             startInset: widget.startInset,
             selectionNotifier: widget.selectionNotifier,
             searchMatchesNotifier: widget.searchMatchesNotifier,
             activeSearchMatchNotifier: widget.activeSearchMatchNotifier,
+            backgroundColor: rowBackgroundColor,
             zoom: zoomController.value,
           );
         },
@@ -340,7 +369,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       // if the key is held currently.
       if (keyLabel == 'w') {
         zoomTo(math.min(
-          FlameChart.maxZoomLevel,
+          maxZoomLevel,
           zoomController.value + keyboardZoomInUnit,
         ));
       } else if (keyLabel == 's') {
@@ -381,7 +410,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
           final multiplier = FlameChart.zoomMultiplier * currentZoom;
           final newZoomLevel = (currentZoom + deltaY * multiplier).clamp(
             FlameChart.minZoomLevel,
-            FlameChart.maxZoomLevel,
+            maxZoomLevel,
           );
           await zoomTo(newZoomLevel, jump: true);
           if (newZoomLevel == FlameChart.minZoomLevel &&
@@ -432,7 +461,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       mouseHoverX = forceMouseX;
     }
     await zoomController.animateTo(
-      zoom.clamp(FlameChart.minZoomLevel, FlameChart.maxZoomLevel),
+      zoom.clamp(FlameChart.minZoomLevel, maxZoomLevel),
       duration: jump ? Duration.zero : shortDuration,
     );
   }
@@ -492,6 +521,7 @@ class ScrollingFlameChartRow<V> extends StatefulWidget {
     @required this.selectionNotifier,
     @required this.searchMatchesNotifier,
     @required this.activeSearchMatchNotifier,
+    @required this.backgroundColor,
     @required this.zoom,
   });
 
@@ -508,6 +538,8 @@ class ScrollingFlameChartRow<V> extends StatefulWidget {
   final ValueListenable<List<V>> searchMatchesNotifier;
 
   final ValueListenable<V> activeSearchMatchNotifier;
+
+  final Color backgroundColor;
 
   final double zoom;
 
@@ -628,9 +660,10 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
   @override
   Widget build(BuildContext context) {
     if (nodes.isEmpty) {
-      return SizedBox(
+      return Container(
         height: sectionSpacing,
         width: widget.width,
+        color: widget.backgroundColor,
       );
     }
     // Having each row handle gestures and mouse events instead of each node
@@ -643,10 +676,7 @@ class ScrollingFlameChartRowState<V> extends State<ScrollingFlameChartRow>
         child: Container(
           height: rowHeightWithPadding,
           width: widget.width,
-          color: alternatingColorForIndex(
-            nodes.first.sectionIndex,
-            Theme.of(context).colorScheme,
-          ),
+          color: widget.backgroundColor,
           // TODO(kenz): investigate if `addAutomaticKeepAlives: false` and
           // `addRepaintBoundaries: false` are needed here for perf improvement.
           child: ExtentDelegateListView(
@@ -1282,8 +1312,7 @@ class TimelineGridPainter extends FlameChartPainter {
 
   int _microsPerInterval(double intervalWidth) {
     final contentWidth = flameChartWidth - chartStartInset - chartEndInset;
-    final numCompleteIntervals =
-        (flameChartWidth - chartStartInset - chartEndInset) ~/ intervalWidth;
+    final numCompleteIntervals = contentWidth ~/ intervalWidth;
     final remainderContentWidth =
         contentWidth - (numCompleteIntervals * intervalWidth);
     final remainderMicros =

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -290,7 +290,7 @@ abstract class FlameChartState<T extends FlameChart, V> extends State<T>
       childrenDelegate: SliverChildBuilderDelegate(
         (context, index) {
           final nodes = rows[index].nodes;
-          Color rowBackgroundColor = Colors.transparent;
+          var rowBackgroundColor = Colors.transparent;
           if (index >= rowOffsetForTopPadding && nodes.isEmpty) {
             // If this is a spacer row, we should use the background color of
             // the previous row with nodes.

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -393,12 +393,12 @@ class HeapTreeViewState extends State<HeapTree>
             _isSnapshotStreaming
                 ? 'Processing...'
                 : _isSnapshotGraphing
-                    ? 'Graphing...'
-                    : _isSnapshotGrouping
-                        ? 'Grouping...'
-                        : _isSnapshotComplete
-                            ? 'Done'
-                            : '...',
+                ? 'Graphing...'
+                : _isSnapshotGrouping
+                ? 'Grouping...'
+                : _isSnapshotComplete
+                ? 'Done'
+                : '...',
           ),
         ],
       );
@@ -479,8 +479,8 @@ class HeapTreeViewState extends State<HeapTree>
     final rightSideTable = controller.isLeafSelected
         ? InstanceTreeView()
         : controller.isAnalysisLeafSelected
-            ? Expanded(child: AnalysisInstanceViewTable())
-            : helpScreen();
+        ? Expanded(child: AnalysisInstanceViewTable())
+        : helpScreen();
 
     return treeMapVisible
         ? snapshotDisplay

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -786,8 +786,8 @@ class MemoryBodyState extends State<MemoryBody>
         image == null
             ? const SizedBox()
             : scaleImage
-                ? Image(image: AssetImage(image), width: 20, height: 10)
-                : Image(image: AssetImage(image)),
+            ? Image(image: AssetImage(image), width: 20, height: 10)
+            : Image(image: AssetImage(image)),
         const PaddedDivider(
           padding: EdgeInsets.only(left: denseRowSpacing),
         ),

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -166,6 +166,7 @@ void main() {
       selectionNotifier: ValueNotifier<CpuStackFrame>(null),
       searchMatchesNotifier: null,
       activeSearchMatchNotifier: null,
+      backgroundColor: Colors.transparent,
       zoom: FlameChart.minZoomLevel,
     );
     final zoomedTestRow = ScrollingFlameChartRow(
@@ -177,6 +178,7 @@ void main() {
       selectionNotifier: ValueNotifier<CpuStackFrame>(null),
       searchMatchesNotifier: null,
       activeSearchMatchNotifier: null,
+      backgroundColor: Colors.transparent,
       zoom: 2.0,
     );
 
@@ -226,6 +228,7 @@ void main() {
         selectionNotifier: ValueNotifier<CpuStackFrame>(null),
         searchMatchesNotifier: null,
         activeSearchMatchNotifier: null,
+        backgroundColor: Colors.transparent,
         zoom: FlameChart.minZoomLevel,
       );
 

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -236,9 +236,10 @@ void main() {
       expect(find.byWidget(currentRow), findsOneWidget);
       expect(find.byType(MouseRegion), findsNothing);
 
-      final sizedBoxFinder = find.byType(SizedBox);
-      final SizedBox box = tester.widget(sizedBoxFinder);
-      expect(box.height, equals(sectionSpacing));
+      final emptyRowFinder = find.byType(EmptyFlameChartRow);
+      final EmptyFlameChartRow emptyFlameChartRow =
+          tester.widget(emptyRowFinder);
+      expect(emptyFlameChartRow.height, equals(sectionSpacing));
     });
 
     testWidgets('binary search for node returns correct node',


### PR DESCRIPTION
Styling changes: Sections of the flame chart did not have a consistent height because odd-indexed sections appeared to have both padding on the top and bottom. This was due to the fact that we colored all spacer rows the same instead of making them take on the color of the section they belonged to. This PR fixes that.

Zoom bugs: when zooming the flame chart in as far as it will go, you could reach the point where each interval represented less than 1 microsecond. At this point, all the timestamps in the flame chart would go to 0.0ms because of rounding and the fact that microseconds are as fine grained as we have data for. Setting the max zoom level solves this issue.