### PR TITLE
Support copying file in the debugger

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -7,6 +7,7 @@ import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart' hide Stack;
 
@@ -347,6 +348,11 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                   scriptRef?.uri ?? ' ',
                   style: theme.textTheme.subtitle2,
                 ),
+              ),
+              ToolbarAction(
+                icon: Icons.copy,
+                onPressed: () =>
+                    Clipboard.setData(ClipboardData(text: scriptRef?.uri)),
               ),
               const SizedBox(width: denseSpacing),
               PopupMenuButton<ScriptRef>(

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -379,6 +379,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
               ),
               PopupMenuButton<ScriptRef>(
                 itemBuilder: _buildScriptMenuFromHistory,
+                tooltip: 'Select recent script',
                 enabled: scriptsHistory.hasScripts,
                 onSelected: (scriptRef) {
                   widget.controller
@@ -389,7 +390,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                   buttonMinWidth + denseSpacing,
                 ),
                 child: const Icon(
-                  Icons.keyboard_arrow_down,
+                  Icons.history,
                   size: actionsIconSize,
                 ),
               ),

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -349,12 +349,34 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                   style: theme.textTheme.subtitle2,
                 ),
               ),
-              ToolbarAction(
-                icon: Icons.copy,
-                onPressed: () =>
-                    Clipboard.setData(ClipboardData(text: scriptRef?.uri)),
-              ),
               const SizedBox(width: denseSpacing),
+              PopupMenuButton<_ScriptPopupMenuOptions>(
+                onSelected: (item) {
+                  if (item == _ScriptPopupMenuOptions.Copy) {
+                    Clipboard.setData(ClipboardData(text: scriptRef?.uri));
+                  }
+                },
+                itemBuilder: (_) => [
+                  PopupMenuItem(
+                    value: _ScriptPopupMenuOptions.Copy,
+                    child: Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        Text('Copy filename',
+                            style: Theme.of(context).regularTextStyle),
+                        const Icon(
+                          Icons.copy,
+                          size: actionsIconSize,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+                child: const Icon(
+                  Icons.more_vert,
+                  size: actionsIconSize,
+                ),
+              ),
               PopupMenuButton<ScriptRef>(
                 itemBuilder: _buildScriptMenuFromHistory,
                 enabled: scriptsHistory.hasScripts,
@@ -730,3 +752,5 @@ class _LineItemState extends State<LineItem> {
         ),
       );
 }
+
+enum _ScriptPopupMenuOptions { Copy }

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -350,33 +350,7 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
                 ),
               ),
               const SizedBox(width: denseSpacing),
-              PopupMenuButton<_ScriptPopupMenuOptions>(
-                onSelected: (item) {
-                  if (item == _ScriptPopupMenuOptions.Copy) {
-                    Clipboard.setData(ClipboardData(text: scriptRef?.uri));
-                  }
-                },
-                itemBuilder: (_) => [
-                  PopupMenuItem(
-                    value: _ScriptPopupMenuOptions.Copy,
-                    child: Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceAround,
-                      children: [
-                        Text('Copy filename',
-                            style: Theme.of(context).regularTextStyle),
-                        const Icon(
-                          Icons.copy,
-                          size: actionsIconSize,
-                        ),
-                      ],
-                    ),
-                  ),
-                ],
-                child: const Icon(
-                  Icons.more_vert,
-                  size: actionsIconSize,
-                ),
-              ),
+              ScriptPopupMenu(scriptRef),
               PopupMenuButton<ScriptRef>(
                 itemBuilder: _buildScriptMenuFromHistory,
                 tooltip: 'Select recent script',
@@ -755,3 +729,39 @@ class _LineItemState extends State<LineItem> {
 }
 
 enum _ScriptPopupMenuOptions { Copy }
+
+class ScriptPopupMenu extends StatelessWidget {
+  const ScriptPopupMenu(this._scriptRef);
+
+  final ScriptRef _scriptRef;
+
+  @override
+  Widget build(BuildContext context) =>
+      PopupMenuButton<_ScriptPopupMenuOptions>(
+        onSelected: (item) {
+          if (item == _ScriptPopupMenuOptions.Copy) {
+            Clipboard.setData(ClipboardData(text: _scriptRef?.uri));
+          }
+        },
+        itemBuilder: (_) => [
+          PopupMenuItem(
+            value: _ScriptPopupMenuOptions.Copy,
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                Text('Copy filename',
+                    style: Theme.of(context).regularTextStyle),
+                const Icon(
+                  Icons.copy,
+                  size: actionsIconSize,
+                ),
+              ],
+            ),
+          ),
+        ],
+        child: const Icon(
+          Icons.more_vert,
+          size: actionsIconSize,
+        ),
+      );
+}


### PR DESCRIPTION
This comes from an internal request. Add  a simple copy button to copy the file's name. 

<img width="956" alt="Screen Shot 2021-04-08 at 11 38 59 AM" src="https://user-images.githubusercontent.com/1840773/114079486-1b2a3c80-985f-11eb-9d1b-0116acc251f6.png">
