### PR TITLE
Add previous/next event in thread buttons to the Timeline

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -924,14 +924,16 @@ class RoundedOutlinedBorder extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      decoration: BoxDecoration(
-        border: Border.all(color: Theme.of(context).focusColor),
-        borderRadius: BorderRadius.circular(defaultBorderRadius),
-      ),
+      decoration: roundedBorderDecoration(context),
       child: child,
     );
   }
 }
+
+BoxDecoration roundedBorderDecoration(BuildContext context) => BoxDecoration(
+      border: Border.all(color: Theme.of(context).focusColor),
+      borderRadius: BorderRadius.circular(defaultBorderRadius),
+    );
 
 class LeftBorder extends StatelessWidget {
   const LeftBorder({this.child});

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -172,6 +172,18 @@ class TimelineEventGroup {
 
   final rowIndexForEvent = <TimelineEvent, int>{};
 
+  int earliestTimestampMicros;
+
+  int latestTimestampMicros;
+
+  List<TimelineEvent> get sortedEventRoots =>
+      _sortedEventRoots ??= List<TimelineEvent>.from(rowIndexForEvent.keys)
+          .where((event) => event.isRoot)
+          .toList()
+            ..sort((a, b) => a.time.start.inMicroseconds
+                .compareTo(b.time.start.inMicroseconds));
+  List<TimelineEvent> _sortedEventRoots;
+
   int get displayDepth => rows.length;
 
   // TODO(kenz): prevent guideline "elbows" from overlapping other events.
@@ -229,6 +241,14 @@ class TimelineEventGroup {
     for (int i = 0; i < event.displayDepth; i++) {
       final displayRow = event.displayRows[i];
       for (var e in displayRow) {
+        earliestTimestampMicros = math.min(
+          e.time.start.inMicroseconds,
+          earliestTimestampMicros ?? e.time.start.inMicroseconds,
+        );
+        latestTimestampMicros = math.max(
+          e.time.end.inMicroseconds,
+          latestTimestampMicros ?? e.time.end.inMicroseconds,
+        );
         rows[row + i].events.add(e);
         rowIndexForEvent[e] = row + i;
         if (e.time.end >

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -298,6 +298,7 @@ class TimelineFlameChartState
       compare: (TimelineEvent a, TimelineEvent b) =>
           a.time.start.compareTo(b.time.start),
     );
+  }
 
   Future<void> _viewPreviousEventInGroup(TimelineEventGroup group) async {
     final firstInViewIndex = _indexOfFirstEventInView(group);

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -126,6 +126,8 @@ bool isValidLightColor(Color color) {
 const defaultToolbarHeight = 32.0;
 
 const defaultButtonHeight = 32.0;
+const smallButtonHeight = 20.0;
+
 const buttonMinWidth = 36.0;
 
 const defaultIconSize = 16.0;


### PR DESCRIPTION
When the timeline has a lot of events, it can be difficult to see where events are because the width of each event is so small. Because of how much time can pass between events on any thread, it can also be challenging to know when the next event happens. These previous and next buttons help with this and let a user jump to the previous/next event on any thread.

![Screen Shot 2021-04-08 at 1 31 41 PM](https://user-images.githubusercontent.com/43759233/114093260-bc20f380-986f-11eb-9b68-604b1aa98bd8.png)

Previous buttons are shorter when a group is small, as to not overlap with the group label:
![Screen Shot 2021-04-08 at 1 32 06 PM](https://user-images.githubusercontent.com/43759233/114093270-be834d80-986f-11eb-9cad-e02d099698d4.png)

@jacob314 @InMatrix 