### PR TITLE
Use a different copy icon

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -752,7 +752,7 @@ class ScriptPopupMenu extends StatelessWidget {
                 Text('Copy filename',
                     style: Theme.of(context).regularTextStyle),
                 const Icon(
-                  Icons.copy,
+                  Icons.file_copy,
                   size: actionsIconSize,
                 ),
               ],


### PR DESCRIPTION
Use this icon for consistency with other usages inside Dart DevTools.