### PR TITLE
Fix issue where first build of the VM Tools status bar would cause a null pointer exception

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -273,7 +273,7 @@ class DevToolsAppState extends State<DevToolsApp> {
   Widget _providedControllers({@required Widget child, bool offline = false}) {
     final _providers = widget.screens
         .where((s) =>
-            s.createController != null && (offline ? s.supportsOffline : true))
+            s.providesController && (offline ? s.supportsOffline : true))
         .map((s) => s.controllerProvider)
         .toList();
 
@@ -303,7 +303,8 @@ class DevToolsAppState extends State<DevToolsApp> {
 class DevToolsScreen<C> {
   const DevToolsScreen(
     this.screen, {
-    @required this.createController,
+    this.createController,
+    this.controller,
     this.supportsOffline = false,
   });
 
@@ -315,9 +316,23 @@ class DevToolsScreen<C> {
   /// widgets depending on this controller can access it by calling
   /// `Provider<C>.of(context)`.
   ///
-  /// If null, [screen] will be responsible for creating and maintaining its own
-  /// controller.
+  /// If [createController] and [controller] are both null, [screen] will be
+  /// responsible for creating and maintaining its own controller.
   final C Function() createController;
+
+  /// A provided controller for this screen, if non-null.
+  ///
+  /// The controller will then be provided via [controllerProvider], and
+  /// widgets depending on this controller can access it by calling
+  /// `Provider<C>.of(context)`.
+  ///
+  /// If [createController] and [controller] are both null, [screen] will be
+  /// responsible for creating and maintaining its own controller.
+  final C controller;
+
+  /// Returns true if a controller was provided for [screen]. If false,
+  /// [screen] is responsible for creating and maintaining its own controller.
+  bool get providesController => createController != null || controller != null;
 
   /// Whether this screen has implemented offline support.
   ///
@@ -325,7 +340,11 @@ class DevToolsScreen<C> {
   final bool supportsOffline;
 
   Provider<C> get controllerProvider {
-    assert(createController != null);
+    assert((createController != null && controller == null) ||
+        (createController == null && controller != null));
+    if (controller != null) {
+      return Provider<C>.value(value: controller);
+    }
     return Provider<C>(create: (_) => createController());
   }
 }
@@ -526,49 +545,54 @@ class SettingsDialog extends StatelessWidget {
 ///
 /// Conditional screens can be added to this list, and they will automatically
 /// be shown or hidden based on the [Screen.conditionalLibrary] provided.
-List<DevToolsScreen> get defaultScreens => <DevToolsScreen>[
-      DevToolsScreen<InspectorSettingsController>(
-        const InspectorScreen(),
-        createController: () => InspectorSettingsController(),
+List<DevToolsScreen> get defaultScreens {
+  final vmDeveloperToolsController = VMDeveloperToolsController();
+  return <DevToolsScreen>[
+    DevToolsScreen<InspectorSettingsController>(
+      const InspectorScreen(),
+      createController: () => InspectorSettingsController(),
+    ),
+    DevToolsScreen<PerformanceController>(
+      const PerformanceScreen(),
+      createController: () => PerformanceController(),
+      supportsOffline: true,
+    ),
+    DevToolsScreen<ProfilerScreenController>(
+      const ProfilerScreen(),
+      createController: () => ProfilerScreenController(),
+      supportsOffline: true,
+    ),
+    DevToolsScreen<MemoryController>(
+      const MemoryScreen(),
+      createController: () => MemoryController(),
+    ),
+    DevToolsScreen<DebuggerController>(
+      const DebuggerScreen(),
+      createController: () => DebuggerController(),
+    ),
+    DevToolsScreen<NetworkController>(
+      const NetworkScreen(),
+      createController: () => NetworkController(),
+    ),
+    DevToolsScreen<LoggingController>(
+      const LoggingScreen(),
+      createController: () => LoggingController(),
+    ),
+    DevToolsScreen<AppSizeController>(
+      const AppSizeScreen(),
+      createController: () => AppSizeController(),
+    ),
+    DevToolsScreen<VMDeveloperToolsController>(
+      VMDeveloperToolsScreen(
+        controller: vmDeveloperToolsController
       ),
-      DevToolsScreen<PerformanceController>(
-        const PerformanceScreen(),
-        createController: () => PerformanceController(),
-        supportsOffline: true,
-      ),
-      DevToolsScreen<ProfilerScreenController>(
-        const ProfilerScreen(),
-        createController: () => ProfilerScreenController(),
-        supportsOffline: true,
-      ),
-      DevToolsScreen<MemoryController>(
-        const MemoryScreen(),
-        createController: () => MemoryController(),
-      ),
-      DevToolsScreen<DebuggerController>(
-        const DebuggerScreen(),
-        createController: () => DebuggerController(),
-      ),
-      DevToolsScreen<NetworkController>(
-        const NetworkScreen(),
-        createController: () => NetworkController(),
-      ),
-      DevToolsScreen<LoggingController>(
-        const LoggingScreen(),
-        createController: () => LoggingController(),
-      ),
-      DevToolsScreen<AppSizeController>(
-        const AppSizeScreen(),
-        createController: () => AppSizeController(),
-      ),
-      DevToolsScreen<VMDeveloperToolsController>(
-        const VMDeveloperToolsScreen(),
-        createController: () => VMDeveloperToolsController(),
-      ),
+      controller: vmDeveloperToolsController,
+    ),
 // Uncomment to see a sample implementation of a conditional screen.
 //      DevToolsScreen<ExampleController>(
 //        const ExampleConditionalScreen(),
 //        createController: () => ExampleController(),
 //        supportsOffline: true,
 //      ),
-    ];
+  ];
+}

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -306,7 +306,7 @@ class DevToolsScreen<C> {
     this.createController,
     this.controller,
     this.supportsOffline = false,
-  });
+  }) : assert(createController == null || controller == null);
 
   final Screen screen;
 

--- a/packages/devtools_app/lib/src/status_line.dart
+++ b/packages/devtools_app/lib/src/status_line.dart
@@ -47,9 +47,6 @@ class StatusLine extends StatelessWidget {
 
     // Optionally display an isolate selector.
     if (currentScreen != null) {
-      // Ensure that the current screen's state is initialized. In particular,
-      // make sure that the screen's controller is available before calling
-      // `currentScreen.showIsolateSelector`.
       children.add(
         ValueListenableBuilder<bool>(
           valueListenable: currentScreen.showIsolateSelector,

--- a/packages/devtools_app/lib/src/status_line.dart
+++ b/packages/devtools_app/lib/src/status_line.dart
@@ -47,6 +47,9 @@ class StatusLine extends StatelessWidget {
 
     // Optionally display an isolate selector.
     if (currentScreen != null) {
+      // Ensure that the current screen's state is initialized. In particular,
+      // make sure that the screen's controller is available before calling
+      // `currentScreen.showIsolateSelector`.
       children.add(
         ValueListenableBuilder<bool>(
           valueListenable: currentScreen.showIsolateSelector,

--- a/packages/devtools_app/lib/src/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_developer_tools_screen.dart
@@ -38,8 +38,9 @@ abstract class VMDeveloperView {
 }
 
 class VMDeveloperToolsScreen extends Screen {
-  const VMDeveloperToolsScreen()
-      : super.conditional(
+  const VMDeveloperToolsScreen({
+    @required this.controller,
+  }) : super.conditional(
           id: id,
           title: 'VM Tools',
           icon: Icons.settings_applications,
@@ -48,9 +49,11 @@ class VMDeveloperToolsScreen extends Screen {
 
   static const id = 'vm-tools';
 
+  final VMDeveloperToolsController controller;
+
   @override
   ValueListenable<bool> get showIsolateSelector =>
-      _VMDeveloperToolsScreenState.controller.showIsolateSelector;
+      controller.showIsolateSelector;
 
   @override
   Widget build(BuildContext context) => const VMDeveloperToolsScreenBody();
@@ -70,9 +73,8 @@ class VMDeveloperToolsScreenBody extends StatefulWidget {
 
 class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
     with AutoDisposeMixin {
-  // TODO(bkonyi): do we want this to be static? Currently necessary to provide
-  // access to the `showIsolateSelector` via `VMDeveloperToolsScreen`
-  static VMDeveloperToolsController controller;
+
+  VMDeveloperToolsController controller;
 
   @override
   void didChangeDependencies() {


### PR DESCRIPTION
`VMDeveloperToolsScreen` exposes a `ValueListenable` provided by the `VMDeveloperToolsController` in order to control the visibility of the isolate selector. Given that `VMDeveloperToolsScreen.showIsolateSelector` can be invoked before the static controller in `_VMDeveloperToolsScreenState` is initialized, a null pointer exception was being thrown when first building the VM Tools screen.

This change updates `DevToolsScreen` to take either a `createController` callback or a pre-instantiated `controller`, allowing for the same instance of `VMDeveloperToolsController` to be used by `VMDeveloperToolsScreen` while also being exposed via `Provider`.