### PR TITLE
Remove `maxLines` from `SelectableText` on Network tab

### DIFF
--- a/packages/devtools_app/lib/src/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/network/network_request_inspector_views.dart
@@ -72,7 +72,6 @@ class HttpRequestHeadersView extends StatelessWidget {
             child: SelectableText(
               value,
               minLines: 1,
-              maxLines: 5,
             ),
           ),
         ],
@@ -576,7 +575,6 @@ class NetworkRequestOverviewView extends StatelessWidget {
     return SelectableText(
       value,
       minLines: 1,
-      maxLines: 5,
     );
   }
 }


### PR DESCRIPTION
Fixes #2911
Reason for the fix is also stated in #2911 
Here is a 7-line text fully displayed without `maxLines`

![image](https://user-images.githubusercontent.com/4087388/114912373-720bb500-9e0f-11eb-8a7b-2fc5ad3dde28.png)
