### PR TITLE
Fix SpanParser handling of 'while' multiline spans

### DIFF
--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -91,14 +91,13 @@ class ScopeSpan {
         _start = start,
         _end = end;
 
-  ScopeSpan.copy(
-      {ScopeSpan span,
-      List<String> scopes,
-      int start,
-      int end,
-      int line,
-      int column})
-      : _start = start ?? span._start,
+  ScopeSpan.copy({
+    List<String> scopes,
+    int start,
+    int end,
+    int line,
+    int column,
+  })  : _start = start ?? span._start,
         _end = end ?? span._end,
         line = line ?? span.line,
         column = column ?? span.column,
@@ -152,7 +151,14 @@ class ScopeSpan {
     );
 
     // Start with a copy of the original span
-    ScopeSpan current = ScopeSpan.copy(span: this);
+    ScopeSpan current = ScopeSpan.copy(
+      scopes: scopes.toList(),
+      start: _start,
+      end: _end,
+      line: line,
+      column: column,
+    );
+
     while (!splitScanner.isDone) {
       if (splitScanner.matches(cond)) {
         // Update the end position for this span as it's been fully processed.
@@ -164,8 +170,9 @@ class ScopeSpan {
 
         // Create a new span based on the current position.
         current = ScopeSpan.copy(
-          span: this,
+          scopes: scopes.toList(),
           start: splitScanner.position,
+          end: -1, // Updated later.
           // Lines and columns are 0-based.
           line: splitScanner.line + 1,
           column: splitScanner.column + 1,

--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -92,16 +92,13 @@ class ScopeSpan {
         _end = end;
 
   ScopeSpan.copy({
-    List<String> scopes,
+    this.scopes,
     int start,
     int end,
-    int line,
-    int column,
-  })  : _start = start ?? span._start,
-        _end = end ?? span._end,
-        line = line ?? span.line,
-        column = column ?? span.column,
-        scopes = scopes ?? span.scopes.toList();
+    this.line,
+    this.column,
+  })  : _start = start,
+        _end = end;
 
   /// Adds [matcher.name] to the scope stack, if non-null. This scope will be
   /// included in each [ScopeSpan] created within [callback].

--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -91,6 +91,19 @@ class ScopeSpan {
         _start = start,
         _end = end;
 
+  ScopeSpan.copy(
+      {ScopeSpan span,
+      List<String> scopes,
+      int start,
+      int end,
+      int line,
+      int column})
+      : _start = start ?? span._start,
+        _end = end ?? span._end,
+        line = line ?? span.line,
+        column = column ?? span.column,
+        scopes = scopes ?? span.scopes.toList();
+
   /// Adds [matcher.name] to the scope stack, if non-null. This scope will be
   /// included in each [ScopeSpan] created within [callback].
   static List<ScopeSpan> applyScope(
@@ -123,6 +136,52 @@ class ScopeSpan {
   final List<String> scopes;
 
   bool contains(int token) => (_start <= token) && (token < _end);
+
+  /// Splits the current [ScopeSpan] into multiple spans separated by [cond].
+  /// This is useful for post-processing the results from a rule with a while
+  /// condition as formatting should not be applied to the characters that
+  /// match the while condition.
+  List<ScopeSpan> split(LineScanner scanner, RegExp cond) {
+    final splitSpans = <ScopeSpan>[];
+
+    // Create a temporary scanner, copying [0, _end] to ensure that line/column
+    // information is consistent with the original scanner.
+    final splitScanner = LineScanner(
+      scanner.substring(0, _end),
+      position: _start,
+    );
+
+    // Start with a copy of the original span
+    ScopeSpan current = ScopeSpan.copy(span: this);
+    while (!splitScanner.isDone) {
+      if (splitScanner.matches(cond)) {
+        // Update the end position for this span as it's been fully processed.
+        current._end = splitScanner.position;
+        splitSpans.add(current);
+
+        // Move the scanner position past the matched condition.
+        splitScanner.scan(cond);
+
+        // Create a new span based on the current position.
+        current = ScopeSpan.copy(
+          span: this,
+          start: splitScanner.position,
+          // Lines and columns are 0-based.
+          line: splitScanner.line + 1,
+          column: splitScanner.column + 1,
+        );
+      } else {
+        // Move scanner position forward.
+        splitScanner.readChar();
+      }
+    }
+    // Finish processing the last span, which will always have the same end
+    // position as the span we're splitting.
+    current._end = _end;
+    splitSpans.add(current);
+
+    return splitSpans;
+  }
 
   @override
   String toString() {
@@ -468,17 +527,41 @@ class _MultilineMatcher extends _Matcher {
         }
         return results;
       } else if (whileCond != null) {
+        // Find the range of the string that is matched by the while condition.
+        final start = scanner.position;
+        _skipLine(scanner);
+        while (!scanner.isDone && scanner.scan(whileCond)) {
+          _skipLine(scanner);
+        }
+        final end = scanner.position;
+
+        // Create a temporary scanner to ensure that rules that don't find an
+        // end match don't try and match all the way to the end of the file.
+        final contentScanner = LineScanner(
+          scanner.substring(0, end),
+          position: start,
+        );
+
+        final contentResults = <ScopeSpan>[];
         // Finish scanning the line matched by `begin`.
-        results.addAll(_scanToEndOfLine(grammar, scanner));
+        contentResults.addAll(_scanToEndOfLine(grammar, contentScanner));
 
         // Process each line until the `while` condition fails.
-        while (!scanner.isDone && scanner.scan(whileCond)) {
-          results.addAll(_scanToEndOfLine(grammar, scanner));
+        while (!contentScanner.isDone && contentScanner.scan(whileCond)) {
+          contentResults.addAll(_scanToEndOfLine(grammar, contentScanner));
         }
+
+        // Split the results on the while condition to ensure that formatting
+        // isn't applied to characters matching the loop condition (e.g.,
+        // comment blocks with inline code samples shouldn't apply inline code
+        // formatting to the leading '///').
+        results.addAll(contentResults.expand(
+          (e) => e.split(scanner, whileCond),
+        ));
 
         if (beginSpans.isNotEmpty) {
           assert(beginSpans.length == 1);
-          beginSpans.first._end = scanner.position;
+          beginSpans.first._end = end;
         }
         return results;
       } else {
@@ -486,6 +569,10 @@ class _MultilineMatcher extends _Matcher {
             "One of 'end' or 'while' must be provided for rule: $name");
       }
     });
+  }
+
+  void _skipLine(LineScanner scanner) {
+    scanner.scan(RegExp('.*\n'));
   }
 
   @override

--- a/packages/devtools_app/test/span_parser_test.dart
+++ b/packages/devtools_app/test/span_parser_test.dart
@@ -173,6 +173,10 @@ const openCodeBlock = '''
 /// ```dart
 ///
 /// This should not cause parsing to fail.
+
+void main() {
+  // But scope should end when parent scope is closed.
+}
 ''';
 
 void spanTester({
@@ -468,6 +472,8 @@ void main() {
 
     test('handles dartdoc', () {
       final spans = SpanParser.parse(grammar, dartdoc);
+
+      // Covers block of lines starting with '///'
       spanTester(
         span: spans[0],
         scopes: ['comment.block.documentation.dart'],
@@ -476,6 +482,7 @@ void main() {
         length: 92,
       );
 
+      // [Foo]
       spanTester(
         span: spans[1],
         scopes: [
@@ -487,6 +494,7 @@ void main() {
         length: 5,
       );
 
+      // Whitespace after ```
       spanTester(
         span: spans[2],
         scopes: [
@@ -495,7 +503,31 @@ void main() {
         ],
         line: 2,
         column: 8,
-        length: 24,
+        length: 1,
+      );
+
+      // Foo.test(bar);
+      spanTester(
+        span: spans[3],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 3,
+        column: 4,
+        length: 16,
+      );
+
+      // Whitespace after ```
+      spanTester(
+        span: spans[4],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 4,
+        column: 4,
+        length: 1,
       );
     });
 
@@ -506,7 +538,7 @@ void main() {
     // the last line that matched the 'while' condition.
     test("handles 'while' rules", () {
       final spans = SpanParser.parse(grammar, whileRuleApplication);
-      expect(spans.length, 2);
+      expect(spans.length, 4);
 
       // /// multiline
       spanTester(
@@ -526,7 +558,29 @@ void main() {
         ],
         line: 2,
         column: 8,
-        length: 13,
+        length: 1,
+      );
+
+      spanTester(
+        span: spans[2],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 3,
+        column: 4,
+        length: 5,
+      );
+
+      spanTester(
+        span: spans[3],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 4,
+        column: 4,
+        length: 1,
       );
     });
 
@@ -1325,7 +1379,9 @@ void main() {
 
     test('handles malformed input', () {
       final spans = SpanParser.parse(grammar, openCodeBlock);
-      expect(spans.length, 2);
+      expect(spans.length, 7);
+
+      // Represents the span covering all lines starting with '///'
       spanTester(
         span: spans[0],
         scopes: ['comment.block.documentation.dart'],
@@ -1333,6 +1389,8 @@ void main() {
         column: 1,
         length: 91,
       );
+
+      // Immediately following '```dart'
       spanTester(
         span: spans[1],
         scopes: [
@@ -1341,7 +1399,64 @@ void main() {
         ],
         line: 2,
         column: 12,
-        length: 48,
+        length: 1,
+      );
+
+      // Whitespace after 3rd '///' line.
+      spanTester(
+        span: spans[2],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 3,
+        column: 4,
+        length: 1,
+      );
+
+      // 'This should not cause parsing to fail.'
+      spanTester(
+        span: spans[3],
+        scopes: [
+          'comment.block.documentation.dart',
+          'variable.other.source.dart',
+        ],
+        line: 4,
+        column: 4,
+        length: 40,
+      );
+
+      // void
+      spanTester(
+        span: spans[4],
+        scopes: [
+          'storage.type.primitive.dart',
+        ],
+        line: 6,
+        column: 1,
+        length: 4,
+      );
+
+      // main
+      spanTester(
+        span: spans[5],
+        scopes: [
+          'entity.name.function.dart',
+        ],
+        line: 6,
+        column: 6,
+        length: 4,
+      );
+
+      // '// But scope should end when parent scope is closed.'
+      spanTester(
+        span: spans[6],
+        scopes: [
+          'comment.line.double-slash.dart',
+        ],
+        line: 7,
+        column: 3,
+        length: 52,
       );
     });
   });


### PR DESCRIPTION
'while' matching rules now create spans which don't include the characters from the 'while' condition (e.g., leading /// in doc comment blocks) and correctly terminate child spans even if the end pattern hasn't been matched (e.g., in-line code in doc comment missing terminating ```).

Fixes https://github.com/flutter/devtools/issues/2822

**Before:**
![Screen Shot 2021-04-26 at 10 43 16 AM](https://user-images.githubusercontent.com/24210656/116127948-3da0c000-a67d-11eb-84a8-9b4839a3d96e.png)

**After:**
![Screen Shot 2021-04-26 at 10 41 41 AM](https://user-images.githubusercontent.com/24210656/116127966-45f8fb00-a67d-11eb-9b06-b9356ce38e73.png)
