### PR TITLE
Add support for system isolates to isolate selector while in VM developer mode

### DIFF
--- a/packages/devtools_app/lib/src/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/controls.dart
@@ -39,7 +39,8 @@ class _DebuggingControlsState extends State<DebuggingControls>
     final isPaused = controller.isPaused.value;
     final resuming = controller.resuming.value;
     final hasStackFrames = controller.stackFramesWithLocation.value.isNotEmpty;
-    final canStep = isPaused && !resuming && hasStackFrames;
+    final isSystemIsolate = controller.isolateRef.isSystemIsolate;
+    final canStep = isPaused && !resuming && hasStackFrames && !isSystemIsolate;
     return SizedBox(
       height: defaultButtonHeight,
       child: Row(
@@ -60,6 +61,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
     @required bool isPaused,
     @required bool resuming,
   }) {
+    final isSystemIsolate = controller.isolateRef.isSystemIsolate;
     return RoundedOutlinedBorder(
       child: Row(
         children: [
@@ -67,13 +69,18 @@ class _DebuggingControlsState extends State<DebuggingControls>
             title: 'Pause',
             icon: Codicons.debugPause,
             autofocus: true,
-            onPressed: isPaused ? null : controller.pause,
+            // Disable when paused or selected isolate is a system isolate.
+            onPressed: (isPaused || isSystemIsolate) ? null : controller.pause,
           ),
           LeftBorder(
             child: DebuggerButton(
               title: 'Resume',
               icon: Codicons.debugContinue,
-              onPressed: (isPaused && !resuming) ? controller.resume : null,
+              // Enable while paused + not resuming and selected isolate is not
+              // a system isolate.
+              onPressed: ((isPaused && !resuming) && !isSystemIsolate)
+                  ? controller.resume
+                  : null,
             ),
           ),
         ],
@@ -143,9 +150,12 @@ class BreakOnExceptionsControl extends StatelessWidget {
       builder: (BuildContext context, String modeId, _) {
         return RoundedDropDownButton<ExceptionMode>(
           value: ExceptionMode.from(modeId),
-          onChanged: (ExceptionMode mode) {
-            controller.setExceptionPauseMode(mode.id);
-          },
+          // Cannot set exception pause mode for system isolates.
+          onChanged: controller.isolateRef.isSystemIsolate
+              ? null
+              : (ExceptionMode mode) {
+                  controller.setExceptionPauseMode(mode.id);
+                },
           isDense: true,
           items: [
             for (var mode in ExceptionMode.modes)

--- a/packages/devtools_app/lib/src/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/controls.dart
@@ -39,7 +39,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
     final isPaused = controller.isPaused.value;
     final resuming = controller.resuming.value;
     final hasStackFrames = controller.stackFramesWithLocation.value.isNotEmpty;
-    final isSystemIsolate = controller.isolateRef.isSystemIsolate;
+    final isSystemIsolate = controller.isSystemIsolate;
     final canStep = isPaused && !resuming && hasStackFrames && !isSystemIsolate;
     return SizedBox(
       height: defaultButtonHeight,
@@ -61,7 +61,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
     @required bool isPaused,
     @required bool resuming,
   }) {
-    final isSystemIsolate = controller.isolateRef.isSystemIsolate;
+    final isSystemIsolate = controller.isSystemIsolate;
     return RoundedOutlinedBorder(
       child: Row(
         children: [
@@ -151,7 +151,7 @@ class BreakOnExceptionsControl extends StatelessWidget {
         return RoundedDropDownButton<ExceptionMode>(
           value: ExceptionMode.from(modeId),
           // Cannot set exception pause mode for system isolates.
-          onChanged: controller.isolateRef.isSystemIsolate
+          onChanged: controller.isSystemIsolate
               ? null
               : (ExceptionMode mode) {
                   controller.setExceptionPauseMode(mode.id);

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -250,7 +250,7 @@ class DebuggerController extends DisposableController
   ValueListenable<List<ConsoleLine>> get stdio => _stdio;
 
   IsolateRef isolateRef;
-  bool get isSystemIsolate => isolateRef.isSystemIsolate;
+  bool get isSystemIsolate => isolateRef?.isSystemIsolate ?? false;
 
   /// Clears the contents of stdio.
   void clearStdio() {

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -1325,7 +1325,7 @@ class ParsedScript {
     @required this.highlighter,
     @required this.executableLines,
   })  : assert(script != null),
-        lines = script.source.split('\n').toList();
+        lines = (script.source?.split('\n') ?? const []).toList();
 
   final Script script;
 

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -250,6 +250,7 @@ class DebuggerController extends DisposableController
   ValueListenable<List<ConsoleLine>> get stdio => _stdio;
 
   IsolateRef isolateRef;
+  bool get isSystemIsolate => isolateRef.isSystemIsolate;
 
   /// Clears the contents of stdio.
   void clearStdio() {

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:codicon/codicon.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:flutter/services.dart';
@@ -107,6 +108,13 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   }
 
   Future<void> _toggleBreakpoint(ScriptRef script, int line) async {
+    // The VM doesn't support debugging for system isolates and will crash on
+    // a failed assert in debug mode. Disable the toggle breakpoint
+    // functionality for system isolates.
+    if (serviceManager.isolateManager.selectedIsolate.isSystemIsolate) {
+      return;
+    }
+
     final bp = controller.breakpointsWithLocation.value.firstWhere((bp) {
       return bp.scriptRef == script && bp.line == line;
     }, orElse: () => null);

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:codicon/codicon.dart';
-import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:flutter/services.dart';
@@ -17,6 +16,7 @@ import '../common_widgets.dart';
 import '../config_specific/host_platform/host_platform.dart';
 import '../dialogs.dart';
 import '../flex_split_column.dart';
+import '../globals.dart';
 import '../listenable.dart';
 import '../screen.dart';
 import '../split.dart';

--- a/packages/devtools_app/lib/src/status_line.dart
+++ b/packages/devtools_app/lib/src/status_line.dart
@@ -152,22 +152,36 @@ class StatusLine extends StatelessWidget {
 
         String isolateName(IsolateRef ref) {
           final name = ref.name;
-          return 'Isolate $name #${isolateManager.isolateIndex(ref)}';
+          return '$name #${isolateManager.isolateIndex(ref)}';
         }
 
-        return DropdownButtonHideUnderline(
-          child: DropdownButton<IsolateRef>(
-            value: snapshot.data,
-            onChanged: (IsolateRef ref) {
-              isolateManager.selectIsolate(ref?.id);
-            },
-            isDense: true,
-            items: isolates.map((IsolateRef ref) {
-              return DropdownMenuItem<IsolateRef>(
-                value: ref,
-                child: Text(isolateName(ref), style: textTheme.bodyText2),
-              );
-            }).toList(),
+        return DevToolsTooltip(
+          tooltip: 'Selected Isolate',
+          child: DropdownButtonHideUnderline(
+            child: DropdownButton<IsolateRef>(
+              value: snapshot.data,
+              onChanged: (IsolateRef ref) {
+                isolateManager.selectIsolate(ref?.id);
+              },
+              isDense: true,
+              items: isolates.map((IsolateRef ref) {
+                return DropdownMenuItem<IsolateRef>(
+                  value: ref,
+                  child: Row(
+                    children: [
+                      ref.isSystemIsolate
+                          ? const Icon(Icons.settings_applications)
+                          : const Icon(Icons.call_split),
+                      const SizedBox(width: denseSpacing),
+                      Text(
+                        isolateName(ref),
+                        style: textTheme.bodyText2,
+                      ),
+                    ],
+                  ),
+                );
+              }).toList(),
+            ),
           ),
         );
       },

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -48,6 +48,7 @@ void main() {
       when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
       when(debuggerController.resuming).thenReturn(ValueNotifier(false));
       when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
+      when(debuggerController.isSystemIsolate).thenReturn(false);
       when(debuggerController.breakpointsWithLocation)
           .thenReturn(ValueNotifier([]));
       when(debuggerController.librariesVisible)

--- a/packages/devtools_testing/lib/support/flutter_test_environment.dart
+++ b/packages/devtools_testing/lib/support/flutter_test_environment.dart
@@ -8,6 +8,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/vm_service_wrapper.dart';
 
@@ -101,7 +102,10 @@ class FlutterTestEnvironment {
       await _flutter.run(runConfig: _runConfig);
 
       _service = _flutter.vmService;
+            final preferencesController = PreferencesController();
+      await preferencesController.init();
       setGlobal(ServiceConnectionManager, ServiceConnectionManager());
+      setGlobal(PreferencesController, preferencesController);
       await serviceManager.vmServiceOpened(
         _service,
         onClosed: Completer().future,


### PR DESCRIPTION
- Removed 'Isolate' from the isolate selector, replaced with 'forking' icon for isolates and 'gear' for system isolates.
- Added tooltip for the isolate selector: 'Selected Isolate'.
- Added 'No source available' path for CodeView.
- Disable various debugger controls for system isolates.

**Tooltip**
![Screen Shot 2021-04-27 at 12 33 58 PM](https://user-images.githubusercontent.com/24210656/116302129-aa878900-a755-11eb-8518-74e537baef03.png)

**Isolates + system isolates with icons**
![Screen Shot 2021-04-27 at 12 34 07 PM](https://user-images.githubusercontent.com/24210656/116302137-abb8b600-a755-11eb-982b-dc171957857f.png)

**System isolate with source available**
![Screen Shot 2021-04-27 at 12 34 15 PM](https://user-images.githubusercontent.com/24210656/116302141-ace9e300-a755-11eb-9764-160b6b03fd0f.png)

**System isolate with no source available**
![Screen Shot 2021-04-27 at 12 34 20 PM](https://user-images.githubusercontent.com/24210656/116302147-ad827980-a755-11eb-82f3-6614f8118a2e.png)
