### PR TITLE
Do not log eval error for _connectedToProfileBuild check

### DIFF
--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -70,7 +70,13 @@ class ConnectedApp {
 
     // If eval works we're not a profile build.
     final io = EvalOnDartLibrary(['dart:io'], serviceManager.service);
-    final value = await io.eval('Platform.isAndroid', isAlive: null);
+    // Do not log the error if this eval fails - we expect it to fail for a
+    // profile build.
+    final value = await io.eval(
+      'Platform.isAndroid',
+      isAlive: null,
+      shouldLogError: false,
+    );
     return !(value?.kind == 'Bool');
 
     // TODO(terry): Disabled below code, it will hang if flutter run --start-paused

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -117,8 +117,16 @@ class EvalOnDartLibrary {
     String expression, {
     @required Disposable isAlive,
     Map<String, String> scope,
+    bool shouldLogError = true,
   }) {
-    return addRequest(isAlive, () => _eval(expression, scope: scope));
+    return addRequest(
+      isAlive,
+      () => _eval(
+        expression,
+        scope: scope,
+        shouldLogError: shouldLogError,
+      ),
+    );
   }
 
   Future<LibraryRef> _waitForLibraryRef() async {
@@ -136,6 +144,7 @@ class EvalOnDartLibrary {
   Future<InstanceRef> _eval(
     String expression, {
     @required Map<String, String> scope,
+    bool shouldLogError = true,
   }) async {
     if (_disposed) return null;
 
@@ -157,7 +166,9 @@ class EvalOnDartLibrary {
       }
       return result;
     } catch (e, stack) {
-      _handleError('$e - $expression', stack);
+      if (shouldLogError) {
+        _handleError('$e - $expression', stack);
+      }
     }
     return null;
   }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/2953. This error is expected because we are using eval to determine whether or not the connected app is a profile build. 