### PR TITLE
Refactor Debugger history view into HistoryViewport widget

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -257,7 +257,7 @@ class _CodeViewState extends State<CodeView>
           enabled: widget.controller.scriptsHistory.hasScripts,
         ),
       ],
-      buildContents: (context, script) {
+      contentBuilder: (context, script) {
         if (lines.isNotEmpty) {
           return DefaultTextStyle(
             style: theme.fixedFontStyle,

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -18,6 +18,7 @@ import '../config_specific/logger/logger.dart';
 import '../dialogs.dart';
 import '../flutter_widgets/linked_scroll_controller.dart';
 import '../globals.dart';
+import '../history_viewport.dart';
 import '../theme.dart';
 import '../ui/colors.dart';
 import '../ui/search.dart';
@@ -243,81 +244,93 @@ class _CodeViewState extends State<CodeView>
 
     _updateScrollPosition(animate: false);
 
-    return OutlineDecoration(
-      child: Column(
-        children: [
-          buildCodeviewTitle(theme),
-          if (lines.isNotEmpty)
-            DefaultTextStyle(
-              style: theme.fixedFontStyle,
-              child: Expanded(
-                child: Scrollbar(
-                  controller: textController,
-                  child: ValueListenableBuilder<StackFrameAndSourcePosition>(
-                    valueListenable: widget.controller.selectedStackFrame,
-                    builder: (context, frame, _) {
-                      final pausedFrame = frame == null
-                          ? null
-                          : (frame.scriptRef == scriptRef ? frame : null);
+    return HistoryViewport(
+      history: widget.controller.scriptsHistory,
+      generateTitle: (script) => script.uri,
+      buildControls: (context) {
+        return [
+          ScriptPopupMenu(widget.controller),
+          ScriptHistoryPopupMenu(
+            itemBuilder: _buildScriptMenuFromHistory,
+            onSelected: (scriptRef) {
+              widget.controller.showScriptLocation(ScriptLocation(scriptRef));
+            },
+            enabled: widget.controller.scriptsHistory.hasScripts,
+          ),
+        ];
+      },
+      buildContents: (context, script) {
+        if (lines.isNotEmpty) {
+          return DefaultTextStyle(
+            style: theme.fixedFontStyle,
+            child: Expanded(
+              child: Scrollbar(
+                controller: textController,
+                child: ValueListenableBuilder<StackFrameAndSourcePosition>(
+                  valueListenable: widget.controller.selectedStackFrame,
+                  builder: (context, frame, _) {
+                    final pausedFrame = frame == null
+                        ? null
+                        : (frame.scriptRef == scriptRef ? frame : null);
 
-                      return Row(
-                        children: [
-                          ValueListenableBuilder<
-                              List<BreakpointAndSourcePosition>>(
-                            valueListenable:
-                                widget.controller.breakpointsWithLocation,
-                            builder: (context, breakpoints, _) {
-                              return Gutter(
-                                gutterWidth: gutterWidth,
-                                scrollController: gutterController,
-                                lineCount: lines.length,
+                    return Row(
+                      children: [
+                        ValueListenableBuilder<
+                            List<BreakpointAndSourcePosition>>(
+                          valueListenable:
+                              widget.controller.breakpointsWithLocation,
+                          builder: (context, breakpoints, _) {
+                            return Gutter(
+                              gutterWidth: gutterWidth,
+                              scrollController: gutterController,
+                              lineCount: lines.length,
+                              pausedFrame: pausedFrame,
+                              breakpoints: breakpoints
+                                  .where((bp) => bp.scriptRef == scriptRef)
+                                  .toList(),
+                              executableLines: parsedScript.executableLines,
+                              onPressed: _onPressed,
+                              // Disable dots for possible breakpoint locations.
+                              allowInteraction:
+                                  !widget.controller.isSystemIsolate,
+                            );
+                          },
+                        ),
+                        const SizedBox(width: denseSpacing),
+                        Expanded(
+                          child: LayoutBuilder(
+                            builder: (context, constraints) {
+                              return Lines(
+                                constraints: constraints,
+                                scrollController: textController,
+                                lines: lines,
                                 pausedFrame: pausedFrame,
-                                breakpoints: breakpoints
-                                    .where((bp) => bp.scriptRef == scriptRef)
-                                    .toList(),
-                                executableLines: parsedScript.executableLines,
-                                onPressed: _onPressed,
-                                // Disable dots for possible breakpoint locations.
-                                allowInteraction:
-                                    !widget.controller.isSystemIsolate,
+                                searchMatchesNotifier:
+                                    widget.controller.searchMatches,
+                                activeSearchMatchNotifier:
+                                    widget.controller.activeSearchMatch,
                               );
                             },
                           ),
-                          const SizedBox(width: denseSpacing),
-                          Expanded(
-                            child: LayoutBuilder(
-                              builder: (context, constraints) {
-                                return Lines(
-                                  constraints: constraints,
-                                  scrollController: textController,
-                                  lines: lines,
-                                  pausedFrame: pausedFrame,
-                                  searchMatchesNotifier:
-                                      widget.controller.searchMatches,
-                                  activeSearchMatchNotifier:
-                                      widget.controller.activeSearchMatch,
-                                );
-                              },
-                            ),
-                          ),
-                        ],
-                      );
-                    },
-                  ),
-                ),
-              ),
-            )
-          else
-            Expanded(
-              child: Center(
-                child: Text(
-                  'No source available',
-                  style: theme.textTheme.subtitle1,
+                        ),
+                      ],
+                    );
+                  },
                 ),
               ),
             ),
-        ],
-      ),
+          );
+        } else {
+          return Expanded(
+            child: Center(
+              child: Text(
+                'No source available',
+                style: theme.textTheme.subtitle1,
+              ),
+            ),
+          );
+        }
+      },
     );
   }
 
@@ -341,52 +354,6 @@ class _CodeViewState extends State<CodeView>
           onClose: () => widget.controller.toggleSearchInFileVisibility(false),
         ),
       ),
-    );
-  }
-
-  Widget buildCodeviewTitle(ThemeData theme) {
-    return ValueListenableBuilder(
-      valueListenable: widget.controller.scriptsHistory,
-      builder: (context, scriptsHistory, _) {
-        return debuggerSectionTitle(
-          theme,
-          child: Row(
-            children: [
-              ToolbarAction(
-                icon: Icons.chevron_left,
-                onPressed:
-                    scriptsHistory.hasPrevious ? scriptsHistory.moveBack : null,
-              ),
-              ToolbarAction(
-                icon: Icons.chevron_right,
-                onPressed:
-                    scriptsHistory.hasNext ? scriptsHistory.moveForward : null,
-              ),
-              const SizedBox(width: denseSpacing),
-              const VerticalDivider(thickness: 1.0),
-              const SizedBox(width: defaultSpacing),
-              Expanded(
-                child: Text(
-                  scriptRef?.uri ?? ' ',
-                  style: theme.textTheme.subtitle2,
-                ),
-              ),
-              const SizedBox(width: denseSpacing),
-              ScriptPopupMenu(widget.controller),
-              const SizedBox(width: denseSpacing),
-              ScriptHistoryPopupMenu(
-                itemBuilder: _buildScriptMenuFromHistory,
-                onSelected: (scriptRef) {
-                  widget.controller
-                      .showScriptLocation(ScriptLocation(scriptRef));
-                },
-                enabled: scriptsHistory.hasScripts,
-              ),
-              const SizedBox(width: denseSpacing),
-            ],
-          ),
-        );
-      },
     );
   }
 

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -247,18 +247,16 @@ class _CodeViewState extends State<CodeView>
     return HistoryViewport(
       history: widget.controller.scriptsHistory,
       generateTitle: (script) => script.uri,
-      buildControls: (context) {
-        return [
-          ScriptPopupMenu(widget.controller),
-          ScriptHistoryPopupMenu(
-            itemBuilder: _buildScriptMenuFromHistory,
-            onSelected: (scriptRef) {
-              widget.controller.showScriptLocation(ScriptLocation(scriptRef));
-            },
-            enabled: widget.controller.scriptsHistory.hasScripts,
-          ),
-        ];
-      },
+      controls: [
+        ScriptPopupMenu(widget.controller),
+        ScriptHistoryPopupMenu(
+          itemBuilder: _buildScriptMenuFromHistory,
+          onSelected: (scriptRef) {
+            widget.controller.showScriptLocation(ScriptLocation(scriptRef));
+          },
+          enabled: widget.controller.scriptsHistory.hasScripts,
+        ),
+      ],
       buildContents: (context, script) {
         if (lines.isNotEmpty) {
           return DefaultTextStyle(

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -1222,7 +1222,7 @@ class ScriptsHistory extends HistoryManager<ScriptRef> {
   bool get hasScripts => _openedScripts.isNotEmpty;
 
   void pushEntry(ScriptRef ref) {
-    if (ref == current) return;
+    if (ref == current.value) return;
 
     while (hasNext) {
       pop();
@@ -1233,9 +1233,6 @@ class ScriptsHistory extends HistoryManager<ScriptRef> {
 
     push(ref);
   }
-
-  @override
-  ScriptsHistory get value => this;
 
   Iterable<ScriptRef> get openedScripts => _openedScripts.toList().reversed;
 }

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -82,9 +82,9 @@ class DebuggerController extends DisposableController
     autoDispose(_service.onStderrEvent.listen(_handleStderrEvent));
 
     _scriptHistoryListener = () {
-      _showScriptLocation(ScriptLocation(scriptsHistory.current));
+      _showScriptLocation(ScriptLocation(scriptsHistory.current.value));
     };
-    scriptsHistory.addListener(_scriptHistoryListener);
+    scriptsHistory.current.addListener(_scriptHistoryListener);
   }
 
   VmServiceWrapper get _service => serviceManager.service;
@@ -131,9 +131,9 @@ class DebuggerController extends DisposableController
 
     // Update the scripts history (and make sure we don't react to the
     // subsequent event).
-    scriptsHistory.removeListener(_scriptHistoryListener);
+    scriptsHistory.current.removeListener(_scriptHistoryListener);
     scriptsHistory.pushEntry(scriptLocation.scriptRef);
-    scriptsHistory.addListener(_scriptHistoryListener);
+    scriptsHistory.current.addListener(_scriptHistoryListener);
   }
 
   /// Show the given script location (without updating the script navigation

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -5,8 +5,8 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-class HistoryManager<T> extends ChangeNotifier
-    implements ValueListenable<HistoryManager<T>> {
+class HistoryManager<T> {
+  final _current = ValueNotifier<T>(null);
   final _history = <T>[];
   int _historyIndex = -1;
 
@@ -28,10 +28,8 @@ class HistoryManager<T> extends ChangeNotifier
     if (!hasNext) throw StateError('no next history item');
 
     _historyIndex++;
-
-    notifyListeners();
-
-    return current;
+    _current.value = _history[_historyIndex];
+    return _current.value;
   }
 
   /// Return the previous historical item on the stack.
@@ -41,10 +39,8 @@ class HistoryManager<T> extends ChangeNotifier
     if (!hasPrevious) throw StateError('no previous history item');
 
     _historyIndex--;
-
-    notifyListeners();
-
-    return current;
+    _current.value = _history[_historyIndex];
+    return _current.value;
   }
 
   /// Remove and return the most recent historical item on the stack.
@@ -62,7 +58,7 @@ class HistoryManager<T> extends ChangeNotifier
     // last element on the stack and notify the listeners.
     if (_history.length == _historyIndex) {
       --_historyIndex;
-      notifyListeners();
+      _current.value = _history[_historyIndex];
     }
     return value;
   }
@@ -72,16 +68,11 @@ class HistoryManager<T> extends ChangeNotifier
   void push(T value) {
     _history.add(value);
     _historyIndex = _history.length - 1;
-    notifyListeners();
+    _current.value = _history[_historyIndex];
   }
 
   /// The currently selected historical item.
   ///
   /// Returns null if there is no historical items.
-  T get current {
-    return _history.isEmpty ? null : _history[_historyIndex];
-  }
-
-  @override
-  HistoryManager<T> get value => this;
+  ValueListenable<T> get current => _current;
 }

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -6,6 +6,11 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 class HistoryManager<T> {
+  /// The currently selected historical item.
+  ///
+  /// Returns null if there is no historical items.
+  ValueListenable<T> get current => _current;
+
   final _current = ValueNotifier<T>(null);
   final _history = <T>[];
   int _historyIndex = -1;
@@ -21,38 +26,36 @@ class HistoryManager<T> {
     return _history.isNotEmpty && _historyIndex < _history.length - 1;
   }
 
-  /// Return the next historical item on the stack.
+  /// Move to next historical item on the stack.
   ///
   /// Throws [StateError] if there's no next item available.
-  T moveForward() {
+  void moveForward() {
     if (!hasNext) throw StateError('no next history item');
 
     _historyIndex++;
     _current.value = _history[_historyIndex];
-    return _current.value;
   }
 
-  /// Return the previous historical item on the stack.
+  /// Move to previous historical item on the stack.
   ///
   /// Throws [StateError] if there's no previous item available.
-  T moveBack() {
+  void moveBack() {
     if (!hasPrevious) throw StateError('no previous history item');
 
     _historyIndex--;
     _current.value = _history[_historyIndex];
-    return _current.value;
   }
 
-  /// Remove and return the most recent historical item on the stack.
+  /// Remove the most recent historical item on the stack.
   ///
   /// If [current] is the last item on the stack when this method is called,
   /// [current] will be updated to return the new last item.
   ///
   /// Throws [StateError] if there's no historical items.
-  T pop() {
+  void pop() {
     if (_history.isEmpty) throw StateError('no history available');
 
-    final value = _history.removeLast();
+    _history.removeLast();
 
     // If the currently selected item was popped, update the selection to the
     // last element on the stack and notify the listeners.
@@ -60,7 +63,6 @@ class HistoryManager<T> {
       --_historyIndex;
       _current.value = _history[_historyIndex];
     }
-    return value;
   }
 
   /// Insert a new historical item at the end of the stack and set [current] to
@@ -70,9 +72,4 @@ class HistoryManager<T> {
     _historyIndex = _history.length - 1;
     _current.value = _history[_historyIndex];
   }
-
-  /// The currently selected historical item.
-  ///
-  /// Returns null if there is no historical items.
-  ValueListenable<T> get current => _current;
 }

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -1,0 +1,87 @@
+// Copyright 2021. The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+class HistoryManager<T> extends ChangeNotifier
+    implements ValueListenable<HistoryManager<T>> {
+  final _history = <T>[];
+  int _historyIndex = -1;
+
+  /// Returns true if there is a previous historical item available on the
+  /// stack.
+  bool get hasPrevious {
+    return _history.isNotEmpty && _historyIndex > 0;
+  }
+
+  /// Returns true if there is a next historical item available on the stack.
+  bool get hasNext {
+    return _history.isNotEmpty && _historyIndex < _history.length - 1;
+  }
+
+  /// Return the next historical item on the stack.
+  /// 
+  /// Throws [StateError] if there's no next item available.
+  T moveForward() {
+    if (!hasNext) throw StateError('no next history item');
+
+    _historyIndex++;
+
+    notifyListeners();
+
+    return current;
+  }
+
+  /// Return the previous historical item on the stack.
+  /// 
+  /// Throws [StateError] if there's no previous item available.
+  T moveBack() {
+    if (!hasPrevious) throw StateError('no previous history item');
+
+    _historyIndex--;
+
+    notifyListeners();
+
+    return current;
+  }
+
+  /// Remove and return the most recent historical item on the stack.
+  /// 
+  /// If [current] is the last item on the stack when this method is called,
+  /// [current] will be updated to return the new last item.
+  /// 
+  /// Throws [StateError] if there's no historical items.
+  T pop() {
+    if (_history.isEmpty) throw StateError('no history available');
+
+    final value = _history.removeLast();
+
+    // If the currently selected item was popped, update the selection to the
+    // last element on the stack and notify the listeners.
+    if (_history.length == _historyIndex) {
+      --_historyIndex;
+      notifyListeners();
+    }
+    return value;
+  }
+
+  /// Insert a new historical item at the end of the stack and set [current] to
+  /// point to the new item.
+  void push(T value) {
+    _history.add(value);
+    _historyIndex = _history.length - 1;
+    notifyListeners();
+  }
+
+  /// The currently selected historical item.
+  /// 
+  /// Returns null if there is no historical items.
+  T get current {
+    return _history.isEmpty ? null : _history[_historyIndex];
+  }
+
+  @override
+  HistoryManager<T> get value => this;
+}

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -22,7 +22,7 @@ class HistoryManager<T> extends ChangeNotifier
   }
 
   /// Return the next historical item on the stack.
-  /// 
+  ///
   /// Throws [StateError] if there's no next item available.
   T moveForward() {
     if (!hasNext) throw StateError('no next history item');
@@ -35,7 +35,7 @@ class HistoryManager<T> extends ChangeNotifier
   }
 
   /// Return the previous historical item on the stack.
-  /// 
+  ///
   /// Throws [StateError] if there's no previous item available.
   T moveBack() {
     if (!hasPrevious) throw StateError('no previous history item');
@@ -48,10 +48,10 @@ class HistoryManager<T> extends ChangeNotifier
   }
 
   /// Remove and return the most recent historical item on the stack.
-  /// 
+  ///
   /// If [current] is the last item on the stack when this method is called,
   /// [current] will be updated to return the new last item.
-  /// 
+  ///
   /// Throws [StateError] if there's no historical items.
   T pop() {
     if (_history.isEmpty) throw StateError('no history available');
@@ -76,7 +76,7 @@ class HistoryManager<T> extends ChangeNotifier
   }
 
   /// The currently selected historical item.
-  /// 
+  ///
   /// Returns null if there is no historical items.
   T get current {
     return _history.isEmpty ? null : _history[_historyIndex];

--- a/packages/devtools_app/lib/src/history_viewport.dart
+++ b/packages/devtools_app/lib/src/history_viewport.dart
@@ -44,11 +44,10 @@ class HistoryViewport<T> extends StatelessWidget {
         children: [
           _buildTitle(context, theme),
           ValueListenableBuilder(
-            valueListenable: history.current,
-            builder: (context, current, _) {
-              return buildContents(context, current);
-            }
-          ),
+              valueListenable: history.current,
+              builder: (context, current, _) {
+                return buildContents(context, current);
+              }),
         ],
       ),
     );

--- a/packages/devtools_app/lib/src/history_viewport.dart
+++ b/packages/devtools_app/lib/src/history_viewport.dart
@@ -18,8 +18,8 @@ import 'theme.dart';
 /// [buildContents] is invoked with the currently selected historical data
 /// when building the contents of the viewport.
 ///
-/// If [buildControls] is provided, the returned [List<Widget>] will be
-/// inserted at the end of the viewport title bar.
+/// If [controls] is provided, each [Widget] will be inserted with padding
+/// at the end of the viewport title bar.
 ///
 /// If [generateTitle] is provided, the title string will be set to the
 /// returned value. If not provided, the title will be empty.
@@ -27,13 +27,13 @@ class HistoryViewport<T> extends StatelessWidget {
   const HistoryViewport({
     @required this.history,
     @required this.buildContents,
-    this.buildControls,
+    this.controls,
     this.generateTitle,
   });
 
   final HistoryManager<T> history;
   final String Function(T) generateTitle;
-  final List<Widget> Function(BuildContext) buildControls;
+  final List<Widget> controls;
   final Widget Function(BuildContext, T) buildContents;
 
   @override
@@ -43,7 +43,12 @@ class HistoryViewport<T> extends StatelessWidget {
       child: Column(
         children: [
           _buildTitle(context, theme),
-          buildContents(context, history.current),
+          ValueListenableBuilder(
+            valueListenable: history.current,
+            builder: (context, current, _) {
+              return buildContents(context, current);
+            }
+          ),
         ],
       ),
     );
@@ -51,7 +56,7 @@ class HistoryViewport<T> extends StatelessWidget {
 
   Widget _buildTitle(BuildContext context, ThemeData theme) {
     return ValueListenableBuilder(
-      valueListenable: history,
+      valueListenable: history.current,
       builder: (context, history, _) {
         return debuggerSectionTitle(
           theme,
@@ -74,9 +79,9 @@ class HistoryViewport<T> extends StatelessWidget {
                   style: theme.textTheme.subtitle2,
                 ),
               ),
-              if (buildControls != null) ...[
+              if (controls != null) ...[
                 const SizedBox(width: denseSpacing),
-                for (final widget in buildControls(context)) ...[
+                for (final widget in controls) ...[
                   widget,
                   const SizedBox(width: denseSpacing),
                 ],

--- a/packages/devtools_app/lib/src/history_viewport.dart
+++ b/packages/devtools_app/lib/src/history_viewport.dart
@@ -15,7 +15,7 @@ import 'theme.dart';
 ///
 /// [history] is the [HistoryManger] that contains the data to be displayed.
 ///
-/// [buildContents] is invoked with the currently selected historical data
+/// [contentBuilder] is invoked with the currently selected historical data
 /// when building the contents of the viewport.
 ///
 /// If [controls] is provided, each [Widget] will be inserted with padding
@@ -26,7 +26,7 @@ import 'theme.dart';
 class HistoryViewport<T> extends StatelessWidget {
   const HistoryViewport({
     @required this.history,
-    @required this.buildContents,
+    @required this.contentBuilder,
     this.controls,
     this.generateTitle,
   });
@@ -34,61 +34,59 @@ class HistoryViewport<T> extends StatelessWidget {
   final HistoryManager<T> history;
   final String Function(T) generateTitle;
   final List<Widget> controls;
-  final Widget Function(BuildContext, T) buildContents;
+  final Widget Function(BuildContext, T) contentBuilder;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return OutlineDecoration(
-      child: Column(
-        children: [
-          _buildTitle(context, theme),
-          ValueListenableBuilder(
-              valueListenable: history.current,
-              builder: (context, current, _) {
-                return buildContents(context, current);
-              }),
-        ],
+      child: ValueListenableBuilder(
+        valueListenable: history.current,
+        builder: (context, current, _) {
+          return Column(
+            children: [
+              _buildTitle(context, theme),
+              contentBuilder(context, current),
+            ],
+          );
+        },
       ),
     );
   }
 
   Widget _buildTitle(BuildContext context, ThemeData theme) {
-    return ValueListenableBuilder(
-      valueListenable: history.current,
-      builder: (context, history, _) {
-        return debuggerSectionTitle(
-          theme,
-          child: Row(
-            children: [
-              ToolbarAction(
-                icon: Icons.chevron_left,
-                onPressed: history.hasPrevious ? history.moveBack : null,
-              ),
-              ToolbarAction(
-                icon: Icons.chevron_right,
-                onPressed: history.hasNext ? history.moveForward : null,
-              ),
-              const SizedBox(width: denseSpacing),
-              const VerticalDivider(thickness: 1.0),
-              const SizedBox(width: defaultSpacing),
-              Expanded(
-                child: Text(
-                  generateTitle == null ? '  ' : generateTitle(history.current),
-                  style: theme.textTheme.subtitle2,
-                ),
-              ),
-              if (controls != null) ...[
-                const SizedBox(width: denseSpacing),
-                for (final widget in controls) ...[
-                  widget,
-                  const SizedBox(width: denseSpacing),
-                ],
-              ],
-            ],
+    return debuggerSectionTitle(
+      theme,
+      child: Row(
+        children: [
+          ToolbarAction(
+            icon: Icons.chevron_left,
+            onPressed: history.hasPrevious ? history.moveBack : null,
           ),
-        );
-      },
+          ToolbarAction(
+            icon: Icons.chevron_right,
+            onPressed: history.hasNext ? history.moveForward : null,
+          ),
+          const SizedBox(width: denseSpacing),
+          const VerticalDivider(thickness: 1.0),
+          const SizedBox(width: defaultSpacing),
+          Expanded(
+            child: Text(
+              generateTitle == null
+                  ? '  '
+                  : generateTitle(history.current.value),
+              style: theme.textTheme.subtitle2,
+            ),
+          ),
+          if (controls != null) ...[
+            const SizedBox(width: denseSpacing),
+            for (final widget in controls) ...[
+              widget,
+              const SizedBox(width: denseSpacing),
+            ],
+          ],
+        ],
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/history_viewport.dart
+++ b/packages/devtools_app/lib/src/history_viewport.dart
@@ -1,0 +1,90 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'common_widgets.dart';
+import 'debugger/common.dart';
+import 'history_manager.dart';
+import 'theme.dart';
+
+/// A [Widget] that allows for displaying content based on the current state of a
+/// [HistoryManager]. Includes built-in controls for navigating back and forth
+/// through the content stored in the provided [HistoryManager].
+///
+/// [history] is the [HistoryManger] that contains the data to be displayed.
+///
+/// [buildContents] is invoked with the currently selected historical data
+/// when building the contents of the viewport.
+///
+/// If [buildControls] is provided, the returned [List<Widget>] will be
+/// inserted at the end of the viewport title bar.
+///
+/// If [generateTitle] is provided, the title string will be set to the
+/// returned value. If not provided, the title will be empty.
+class HistoryViewport<T> extends StatelessWidget {
+  const HistoryViewport({
+    @required this.history,
+    @required this.buildContents,
+    this.buildControls,
+    this.generateTitle,
+  });
+
+  final HistoryManager<T> history;
+  final String Function(T) generateTitle;
+  final List<Widget> Function(BuildContext) buildControls;
+  final Widget Function(BuildContext, T) buildContents;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return OutlineDecoration(
+      child: Column(
+        children: [
+          _buildTitle(context, theme),
+          buildContents(context, history.current),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTitle(BuildContext context, ThemeData theme) {
+    return ValueListenableBuilder(
+      valueListenable: history,
+      builder: (context, history, _) {
+        return debuggerSectionTitle(
+          theme,
+          child: Row(
+            children: [
+              ToolbarAction(
+                icon: Icons.chevron_left,
+                onPressed: history.hasPrevious ? history.moveBack : null,
+              ),
+              ToolbarAction(
+                icon: Icons.chevron_right,
+                onPressed: history.hasNext ? history.moveForward : null,
+              ),
+              const SizedBox(width: denseSpacing),
+              const VerticalDivider(thickness: 1.0),
+              const SizedBox(width: defaultSpacing),
+              Expanded(
+                child: Text(
+                  generateTitle == null ? '  ' : generateTitle(history.current),
+                  style: theme.textTheme.subtitle2,
+                ),
+              ),
+              if (buildControls != null) ...[
+                const SizedBox(width: denseSpacing),
+                for (final widget in buildControls(context)) ...[
+                  widget,
+                  const SizedBox(width: denseSpacing),
+                ],
+              ],
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/devtools_app/linux/.gitignore
+++ b/packages/devtools_app/linux/.gitignore
@@ -1,1 +1,0 @@
-flutter/ephemeral

--- a/packages/devtools_app/linux/main.cc
+++ b/packages/devtools_app/linux/main.cc
@@ -1,6 +1,0 @@
-#include "my_application.h"
-
-int main(int argc, char** argv) {
-  g_autoptr(MyApplication) app = my_application_new();
-  return g_application_run(G_APPLICATION(app), argc, argv);
-}

--- a/packages/devtools_app/test/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger_controller_test.dart
@@ -73,7 +73,7 @@ void main() {
     test('initial values', () {
       expect(history.hasNext, false);
       expect(history.hasPrevious, false);
-      expect(history.currentScript, isNull);
+      expect(history.current, isNull);
       expect(history.hasScripts, false);
     });
 
@@ -84,19 +84,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.currentScript, ref3);
+      expect(history.current, ref3);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, true);
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.currentScript, ref1);
+      expect(history.current, ref1);
     });
 
     test('moveBack', () {
@@ -105,19 +105,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.currentScript, ref1);
+      expect(history.current, ref1);
 
       history.moveForward();
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
     });
 
     test('openedScripts', () {
@@ -138,26 +138,26 @@ void main() {
       history.pushEntry(ref1);
       history.pushEntry(ref2);
 
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
       history.moveBack();
-      expect(history.currentScript, ref1);
+      expect(history.current, ref1);
       history.moveBack();
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
       history.moveBack();
-      expect(history.currentScript, ref1);
+      expect(history.current, ref1);
     });
 
     test('pushEntry removes next entries', () {
       history.pushEntry(ref1);
       history.pushEntry(ref2);
 
-      expect(history.currentScript, ref2);
+      expect(history.current, ref2);
       expect(history.hasNext, isFalse);
       history.moveBack();
-      expect(history.currentScript, ref1);
+      expect(history.current, ref1);
       expect(history.hasNext, isTrue);
       history.pushEntry(ref3);
-      expect(history.currentScript, ref3);
+      expect(history.current, ref3);
       expect(history.hasNext, isFalse);
     });
   });

--- a/packages/devtools_app/test/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger_controller_test.dart
@@ -73,7 +73,7 @@ void main() {
     test('initial values', () {
       expect(history.hasNext, false);
       expect(history.hasPrevious, false);
-      expect(history.current, isNull);
+      expect(history.current.value, isNull);
       expect(history.hasScripts, false);
     });
 
@@ -84,19 +84,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref3);
+      expect(history.current.value, ref3);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
     });
 
     test('moveBack', () {
@@ -105,19 +105,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
 
       history.moveForward();
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
     });
 
     test('openedScripts', () {
@@ -138,26 +138,26 @@ void main() {
       history.pushEntry(ref1);
       history.pushEntry(ref2);
 
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
       history.moveBack();
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
       history.moveBack();
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
       history.moveBack();
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
     });
 
     test('pushEntry removes next entries', () {
       history.pushEntry(ref1);
       history.pushEntry(ref2);
 
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
       expect(history.hasNext, isFalse);
       history.moveBack();
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
       expect(history.hasNext, isTrue);
       history.pushEntry(ref3);
-      expect(history.current, ref3);
+      expect(history.current.value, ref3);
       expect(history.hasNext, isFalse);
     });
   });

--- a/packages/devtools_app/test/history_manager_test.dart
+++ b/packages/devtools_app/test/history_manager_test.dart
@@ -1,0 +1,85 @@
+// Copyright 2021. The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/history_manager.dart';
+import 'package:test/test.dart';
+import 'package:vm_service/vm_service.dart';
+
+void main() {
+  group('HistoryManager', () {
+    HistoryManager history;
+
+    final ScriptRef ref1 = ScriptRef(uri: 'package:foo/foo.dart', id: 'id-1');
+    final ScriptRef ref2 = ScriptRef(uri: 'package:bar/bar.dart', id: 'id-2');
+    final ScriptRef ref3 = ScriptRef(uri: 'package:baz/baz.dart', id: 'id-3');
+
+    setUp(() {
+      history = HistoryManager<ScriptRef>();
+    });
+
+    test('initial values', () {
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, false);
+      expect(history.current, isNull);
+    });
+
+    test('moveBack', () {
+      history.push(ref1);
+      history.push(ref2);
+      history.push(ref3);
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.current, ref3);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, true);
+      expect(history.current, ref2);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, false);
+      expect(history.current, ref1);
+    });
+
+    test('moveForward', () {
+      history.push(ref1);
+      history.push(ref2);
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.current, ref2);
+
+      history.moveBack();
+
+      expect(history.hasNext, true);
+      expect(history.hasPrevious, false);
+      expect(history.current, ref1);
+
+      history.moveForward();
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.current, ref2);
+    });
+
+    test('ref can be in history twice', () {
+      history.push(ref1);
+      history.push(ref2);
+      history.push(ref1);
+      history.push(ref2);
+
+      expect(history.current, ref2);
+      history.moveBack();
+      expect(history.current, ref1);
+      history.moveBack();
+      expect(history.current, ref2);
+      history.moveBack();
+      expect(history.current, ref1);
+    });
+  });
+}

--- a/packages/devtools_app/test/history_manager_test.dart
+++ b/packages/devtools_app/test/history_manager_test.dart
@@ -21,7 +21,7 @@ void main() {
     test('initial values', () {
       expect(history.hasNext, false);
       expect(history.hasPrevious, false);
-      expect(history.current, isNull);
+      expect(history.current.value, isNull);
     });
 
     test('moveBack', () {
@@ -31,19 +31,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref3);
+      expect(history.current.value, ref3);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
     });
 
     test('moveForward', () {
@@ -52,19 +52,19 @@ void main() {
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
 
       history.moveBack();
 
       expect(history.hasNext, true);
       expect(history.hasPrevious, false);
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
 
       history.moveForward();
 
       expect(history.hasNext, false);
       expect(history.hasPrevious, true);
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
     });
 
     test('ref can be in history twice', () {
@@ -73,13 +73,13 @@ void main() {
       history.push(ref1);
       history.push(ref2);
 
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
       history.moveBack();
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
       history.moveBack();
-      expect(history.current, ref2);
+      expect(history.current.value, ref2);
       history.moveBack();
-      expect(history.current, ref1);
+      expect(history.current.value, ref1);
     });
   });
 }


### PR DESCRIPTION
Will allow for future re-use in VM tools (e.g., object inspector).