### PR TITLE
Improve search and build performance in flame charts

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -17,6 +17,7 @@ import '../dialogs.dart';
 import '../extent_delegate_list.dart';
 import '../flutter_widgets/linked_scroll_controller.dart';
 import '../theme.dart';
+import '../trees.dart';
 import '../ui/colors.dart';
 import '../ui/search.dart';
 import '../utils.dart';
@@ -87,7 +88,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
 // grouping nodes that are close together until they are zoomed in (quad tree
 // like implementation).
 abstract class FlameChartState<T extends FlameChart,
-        V extends SearchableTreeDataMixin<V>> extends State<T>
+        V extends FlameChartDataMixin<V>> extends State<T>
     with AutoDisposeMixin, FlameChartColorMixin, TickerProviderStateMixin {
   int get rowOffsetForTopPadding => 2;
 
@@ -576,7 +577,7 @@ abstract class FlameChartState<T extends FlameChart,
   double startXForData(V data);
 }
 
-class ScrollingFlameChartRow<V extends SearchableTreeDataMixin<V>>
+class ScrollingFlameChartRow<V extends FlameChartDataMixin<V>>
     extends StatefulWidget {
   const ScrollingFlameChartRow({
     @required this.linkedScrollControllerGroup,
@@ -616,7 +617,7 @@ class ScrollingFlameChartRow<V extends SearchableTreeDataMixin<V>>
       ScrollingFlameChartRowState<V>();
 }
 
-class ScrollingFlameChartRowState<V extends SearchableTreeDataMixin<V>>
+class ScrollingFlameChartRowState<V extends FlameChartDataMixin<V>>
     extends State<ScrollingFlameChartRow> with AutoDisposeMixin {
   ScrollController scrollController;
 
@@ -942,7 +943,7 @@ class FlameChartSection {
   final int endRow;
 }
 
-class FlameChartRow<T extends SearchableTreeDataMixin<T>> {
+class FlameChartRow<T extends FlameChartDataMixin<T>> {
   FlameChartRow(this.index);
 
   final List<FlameChartNode<T>> nodes = [];
@@ -963,9 +964,14 @@ class FlameChartRow<T extends SearchableTreeDataMixin<T>> {
   }
 }
 
+mixin FlameChartDataMixin<T extends TreeNode<T>>
+    on TreeDataSearchStateMixin<T> {
+  String get tooltip;
+}
+
 // TODO(kenz): consider de-coupling this API from the dual background color
 // scheme.
-class FlameChartNode<T extends SearchableTreeDataMixin<T>> {
+class FlameChartNode<T extends FlameChartDataMixin<T>> {
   FlameChartNode({
     this.key,
     @required this.text,

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -7,6 +7,7 @@ import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../trees.dart';
+import '../ui/search.dart';
 import '../utils.dart';
 
 /// A tuple of a script and an optional location.
@@ -55,7 +56,7 @@ class SourcePosition {
   String toString() => '$line:$column';
 }
 
-class SourceToken {
+class SourceToken with SearchableDataMixin {
   SourceToken({@required this.position, @required this.length});
 
   final SourcePosition position;

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -56,7 +56,7 @@ class SourcePosition {
   String toString() => '$line:$column';
 }
 
-class SourceToken with SearchableDataMixin {
+class SourceToken with DataSearchStateMixin {
   SourceToken({@required this.position, @required this.length});
 
   final SourcePosition position;

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -630,6 +630,11 @@ class LoggingController extends DisposableController
           (log.details != null &&
               log.details.toLowerCase().contains(caseInsensitiveSearch))) {
         matches.add(log);
+        // TODO(kenz): use the value of this property in the logs table to
+        // improve performance. This will require some refactoring of FlatTable.
+        log.isSearchMatch = true;
+      } else {
+        log.isSearchMatch = false;
       }
     }
     return matches;
@@ -764,7 +769,7 @@ String _valueAsString(InstanceRef ref) {
 /// case, this log entry will have a non-null `detailsComputer` field. After the
 /// data is calculated, the log entry will be modified to contain the calculated
 /// `details` data.
-class LogData {
+class LogData with SearchableDataMixin {
   LogData(
     this.kind,
     this._details,

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -769,7 +769,7 @@ String _valueAsString(InstanceRef ref) {
 /// case, this log entry will have a non-null `detailsComputer` field. After the
 /// data is calculated, the log entry will be modified to contain the calculated
 /// `details` data.
-class LogData with SearchableDataMixin {
+class LogData with DataSearchStateMixin {
   LogData(
     this.kind,
     this._details,

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -367,6 +367,12 @@ class NetworkController
     for (final request in currentRequests) {
       if (request.uri.toLowerCase().contains(caseInsensitiveSearch)) {
         matches.add(request);
+        // TODO(kenz): use the value of this property in the network requests
+        // table to improve performance. This will require some refactoring of
+        // FlatTable.
+        request.isSearchMatch = true;
+      } else {
+        request.isSearchMatch = false;
       }
     }
     return matches;

--- a/packages/devtools_app/lib/src/network/network_model.dart
+++ b/packages/devtools_app/lib/src/network/network_model.dart
@@ -4,7 +4,7 @@ import '../http/http_request_data.dart';
 import '../ui/search.dart';
 import '../utils.dart';
 
-abstract class NetworkRequest with SearchableDataMixin {
+abstract class NetworkRequest with DataSearchStateMixin {
   NetworkRequest(this._timelineMicrosBase);
 
   final int _timelineMicrosBase;

--- a/packages/devtools_app/lib/src/network/network_model.dart
+++ b/packages/devtools_app/lib/src/network/network_model.dart
@@ -1,9 +1,10 @@
 import 'package:vm_service/vm_service.dart';
 
 import '../http/http_request_data.dart';
+import '../ui/search.dart';
 import '../utils.dart';
 
-abstract class NetworkRequest {
+abstract class NetworkRequest with SearchableDataMixin {
   NetworkRequest(this._timelineMicrosBase);
 
   final int _timelineMicrosBase;

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -442,6 +442,9 @@ class PerformanceController
       breadthFirstTraversal<TimelineEvent>(event, action: (TimelineEvent e) {
         if (e.name.caseInsensitiveContains(search)) {
           matches.add(e);
+          e.isSearchMatch = true;
+        } else {
+          e.isSearchMatch = false;
         }
       });
     }

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -10,6 +10,7 @@ import '../profiler/cpu_profile_model.dart';
 import '../service_manager.dart';
 import '../trace_event.dart';
 import '../trees.dart';
+import '../ui/search.dart';
 import '../utils.dart';
 import 'performance_utils.dart';
 import 'timeline_event_processor.dart';
@@ -511,7 +512,8 @@ class FlutterFrame {
   }
 }
 
-abstract class TimelineEvent extends TreeNode<TimelineEvent> {
+abstract class TimelineEvent extends TreeNode<TimelineEvent>
+    with SearchableDataMixin, SearchableTreeDataMixin<TimelineEvent> {
   TimelineEvent(TraceEventWrapper firstTraceEvent)
       : traceEvents = [firstTraceEvent],
         type = firstTraceEvent.event.type {
@@ -567,6 +569,9 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent> {
   bool get isWellFormedDeep => _isWellFormedDeep(this);
 
   int get threadId => traceEvents.first.event.threadId;
+
+  @override
+  String get tooltip => '$name - ${msText(time.duration)}';
 
   bool _isWellFormedDeep(TimelineEvent event) {
     return !subtreeHasNodeWithCondition((e) => !e.isWellFormed);

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -6,6 +6,7 @@ import 'dart:math' as math;
 
 import 'package:meta/meta.dart';
 
+import '../charts/flame_chart.dart';
 import '../profiler/cpu_profile_model.dart';
 import '../service_manager.dart';
 import '../trace_event.dart';
@@ -513,7 +514,10 @@ class FlutterFrame {
 }
 
 abstract class TimelineEvent extends TreeNode<TimelineEvent>
-    with SearchableDataMixin, SearchableTreeDataMixin<TimelineEvent> {
+    with
+        DataSearchStateMixin,
+        TreeDataSearchStateMixin<TimelineEvent>,
+        FlameChartDataMixin {
   TimelineEvent(TraceEventWrapper firstTraceEvent)
       : traceEvents = [firstTraceEvent],
         type = firstTraceEvent.event.type {

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -88,7 +88,7 @@ class _TimelineFlameChartContainerState
             selectionNotifier: controller.selectedTimelineEvent,
             searchMatchesNotifier: controller.searchMatches,
             activeSearchMatchNotifier: controller.activeSearchMatch,
-            onSelection: (e) => controller.selectTimelineEvent(e),
+            onDataSelected: (e) => controller.selectTimelineEvent(e),
           );
         },
       );
@@ -156,7 +156,7 @@ class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
     @required ValueListenable<TimelineEvent> selectionNotifier,
     @required ValueListenable<List<TimelineEvent>> searchMatchesNotifier,
     @required ValueListenable<TimelineEvent> activeSearchMatchNotifier,
-    @required Function(TimelineEvent event) onSelection,
+    @required Function(TimelineEvent event) onDataSelected,
   }) : super(
           data,
           time: data.time,
@@ -166,7 +166,7 @@ class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
           selectionNotifier: selectionNotifier,
           searchMatchesNotifier: searchMatchesNotifier,
           activeSearchMatchNotifier: activeSearchMatchNotifier,
-          onSelected: onSelection,
+          onDataSelected: onDataSelected,
         );
 
   static double _calculateStartInset(PerformanceData data) {
@@ -456,12 +456,11 @@ class TimelineFlameChartState
       final node = FlameChartNode<TimelineEvent>(
         key: Key('${event.name} ${event.traceEvents.first.id}'),
         text: event.name,
-        tooltip: '${event.name} - ${msText(event.time.duration)}',
         rect: Rect.fromLTRB(left, flameChartNodeTop, right, rowHeight),
         backgroundColor: backgroundColor,
         textColor: textColor,
         data: event,
-        onSelected: (dynamic event) => widget.onSelected(event),
+        onSelected: (dynamic event) => widget.onDataSelected(event),
         sectionIndex: section,
       );
       chartNodesByEvent[event] = node;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -19,7 +19,7 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
   static CpuProfileData baseStateCpuProfileData = CpuProfileData.empty();
 
   /// Notifies that new cpu profile data is available.
-  ValueListenable get dataNotifier => _dataNotifier;
+  ValueListenable<CpuProfileData> get dataNotifier => _dataNotifier;
   final _dataNotifier = ValueNotifier<CpuProfileData>(baseStateCpuProfileData);
 
   /// Notifies that CPU profile data is currently being processed.
@@ -96,6 +96,9 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
     for (final frame in currentStackFrames) {
       if (frame.name.caseInsensitiveContains(search)) {
         matches.add(frame);
+        frame.isSearchMatch = true;
+      } else {
+        frame.isSearchMatch = false;
       }
     }
     return matches;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 import '../charts/flame_chart.dart';
 import '../ui/colors.dart';
-import '../utils.dart';
 import 'cpu_profile_controller.dart';
 import 'cpu_profile_model.dart';
 
@@ -19,7 +18,7 @@ class CpuProfileFlameChart extends FlameChart<CpuProfileData, CpuStackFrame> {
     @required ValueListenable<CpuStackFrame> selectionNotifier,
     @required ValueListenable<List<CpuStackFrame>> searchMatchesNotifier,
     @required ValueListenable<CpuStackFrame> activeSearchMatchNotifier,
-    @required Function(CpuStackFrame stackFrame) onSelected,
+    @required Function(CpuStackFrame stackFrame) onDataSelected,
   }) : super(
           data,
           time: data.profileMetaData.time,
@@ -30,7 +29,7 @@ class CpuProfileFlameChart extends FlameChart<CpuProfileData, CpuStackFrame> {
           selectionNotifier: selectionNotifier,
           searchMatchesNotifier: searchMatchesNotifier,
           activeSearchMatchNotifier: activeSearchMatchNotifier,
-          onSelected: onSelected,
+          onDataSelected: onDataSelected,
         );
 
   final CpuProfilerController controller;
@@ -64,12 +63,11 @@ class _CpuProfileFlameChartState
       final node = FlameChartNode<CpuStackFrame>(
         key: Key('${stackFrame.id}'),
         text: stackFrame.name,
-        tooltip: '${stackFrame.name} - ${msText(stackFrame.totalTime)}',
         rect: Rect.fromLTWH(left, flameChartNodeTop, width, rowHeight),
         backgroundColor: backgroundColor,
         textColor: Colors.black,
         data: stackFrame,
-        onSelected: (dynamic frame) => widget.onSelected(frame),
+        onSelected: (CpuStackFrame frame) => widget.onDataSelected(frame),
       )..sectionIndex = 0;
 
       rows[row].addNode(node);

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:meta/meta.dart';
 
+import '../charts/flame_chart.dart';
 import '../trace_event.dart';
 import '../trees.dart';
 import '../ui/search.dart';
@@ -158,7 +159,10 @@ class CpuProfileMetaData {
 }
 
 class CpuStackFrame extends TreeNode<CpuStackFrame>
-    with SearchableDataMixin, SearchableTreeDataMixin<CpuStackFrame> {
+    with
+        DataSearchStateMixin,
+        TreeDataSearchStateMixin<CpuStackFrame>,
+        FlameChartDataMixin {
   CpuStackFrame({
     @required this.id,
     @required this.name,
@@ -212,8 +216,11 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
   Duration _selfTime;
 
   @override
-  String get tooltip =>
-      '$name - ${msText(totalTime)}${url != null ? ' - $url' : ''}';
+  String get tooltip => [
+        name,
+        msText(totalTime),
+        if (url != null) url,
+      ].join(' - ');
 
   /// Returns the number of cpu samples this stack frame is a part of.
   ///

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -8,6 +8,7 @@ import 'package:meta/meta.dart';
 
 import '../trace_event.dart';
 import '../trees.dart';
+import '../ui/search.dart';
 import '../utils.dart';
 
 /// Data model for DevTools CPU profile.
@@ -156,7 +157,8 @@ class CpuProfileMetaData {
   final TimeRange time;
 }
 
-class CpuStackFrame extends TreeNode<CpuStackFrame> {
+class CpuStackFrame extends TreeNode<CpuStackFrame>
+    with SearchableDataMixin, SearchableTreeDataMixin<CpuStackFrame> {
   CpuStackFrame({
     @required this.id,
     @required this.name,
@@ -208,6 +210,10 @@ class CpuStackFrame extends TreeNode<CpuStackFrame> {
               .round());
 
   Duration _selfTime;
+
+  @override
+  String get tooltip =>
+      '$name - ${msText(totalTime)}${url != null ? ' - $url' : ''}';
 
   /// Returns the number of cpu samples this stack frame is a part of.
   ///

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -208,7 +208,7 @@ class _CpuProfilerState extends State<CpuProfiler>
           selectionNotifier: widget.controller.selectedCpuStackFrameNotifier,
           searchMatchesNotifier: widget.controller.searchMatches,
           activeSearchMatchNotifier: widget.controller.activeSearchMatch,
-          onSelected: (sf) => widget.controller.selectCpuStackFrame(sf),
+          onDataSelected: (sf) => widget.controller.selectCpuStackFrame(sf),
         );
       },
     );

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -15,7 +15,7 @@ import '../utils.dart';
 /// Top 10 matches to display in auto-complete overlay.
 const topMatchesLimit = 10;
 
-mixin SearchControllerMixin<T extends SearchableDataMixin> {
+mixin SearchControllerMixin<T extends DataSearchStateMixin> {
   final _searchNotifier = ValueNotifier<String>('');
 
   /// Notify that the search has changed.
@@ -458,13 +458,12 @@ class SearchNavigationControls extends StatelessWidget {
   }
 }
 
-mixin SearchableDataMixin {
+mixin DataSearchStateMixin {
   bool isSearchMatch = false;
   bool isActiveSearchMatch = false;
-  String get tooltip => '';
 }
 
 // This mixin is used to get around the type system where a type `T` needs to
 // both extend `TreeNode<T>` and mixin `SearchableDataMixin`.
-mixin SearchableTreeDataMixin<T extends TreeNode<T>>
-    on TreeNode<T>, SearchableDataMixin {}
+mixin TreeDataSearchStateMixin<T extends TreeNode<T>>
+    on TreeNode<T>, DataSearchStateMixin {}

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -9,12 +9,13 @@ import 'package:flutter/widgets.dart';
 
 import '../common_widgets.dart';
 import '../theme.dart';
+import '../trees.dart';
 import '../utils.dart';
 
 /// Top 10 matches to display in auto-complete overlay.
 const topMatchesLimit = 10;
 
-mixin SearchControllerMixin<T> {
+mixin SearchControllerMixin<T extends SearchableDataMixin> {
   final _searchNotifier = ValueNotifier<String>('');
 
   /// Notify that the search has changed.
@@ -79,7 +80,9 @@ mixin SearchControllerMixin<T> {
       return;
     }
     assert(activeMatchIndex < searchMatches.value.length);
-    _activeSearchMatch.value = searchMatches.value[activeMatchIndex];
+    _activeSearchMatch.value?.isActiveSearchMatch = false;
+    _activeSearchMatch.value = searchMatches.value[activeMatchIndex]
+      ..isActiveSearchMatch = true;
   }
 
   List<T> matchesForSearch(String search) => [];
@@ -454,3 +457,14 @@ class SearchNavigationControls extends StatelessWidget {
     );
   }
 }
+
+mixin SearchableDataMixin {
+  bool isSearchMatch = false;
+  bool isActiveSearchMatch = false;
+  String get tooltip => '';
+}
+
+// This mixin is used to get around the type system where a type `T` needs to
+// both extend `TreeNode<T>` and mixin `SearchableDataMixin`.
+mixin SearchableTreeDataMixin<T extends TreeNode<T>>
+    on TreeNode<T>, SearchableDataMixin {}

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -9,6 +9,7 @@ import 'package:devtools_testing/support/cpu_profile_test_data.dart';
 import 'package:test/test.dart';
 
 import 'support/mocks.dart';
+import 'support/utils.dart';
 
 void main() {
   group('CpuProfileController', () {
@@ -74,6 +75,38 @@ void main() {
 
       await controller.clear();
       expect(controller.selectedCpuStackFrameNotifier.value, isNull);
+    });
+
+    test('matchesForSearch', () async {
+      // [startMicros] and [extentMicros] are arbitrary for testing.
+      await controller.pullAndProcessProfile(startMicros: 0, extentMicros: 100);
+      expect(
+          controller.dataNotifier.value.stackFrames.values.length, equals(17));
+
+      expect(controller.matchesForSearch(null).length, equals(0));
+      expect(controller.matchesForSearch('').length, equals(0));
+      expect(controller.matchesForSearch('render').length, equals(9));
+      expect(controller.matchesForSearch('THREAD').length, equals(2));
+      expect(controller.matchesForSearch('paint').length, equals(7));
+    });
+
+    test('matchesForSearch sets isSearchMatch property', () async {
+      // [startMicros] and [extentMicros] are arbitrary for testing.
+      await controller.pullAndProcessProfile(startMicros: 0, extentMicros: 100);
+      expect(
+          controller.dataNotifier.value.stackFrames.values.length, equals(17));
+
+      var matches = controller.matchesForSearch('render');
+      verifyIsSearchMatch(
+        controller.dataNotifier.value.stackFrames.values.toList(),
+        matches,
+      );
+
+      matches = controller.matchesForSearch('THREAD');
+      verifyIsSearchMatch(
+        controller.dataNotifier.value.stackFrames.values.toList(),
+        matches,
+      );
     });
 
     test('reset', () async {

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -32,7 +32,7 @@ void main() {
       selectionNotifier: ValueNotifier<CpuStackFrame>(null),
       searchMatchesNotifier: controller.searchMatches,
       activeSearchMatchNotifier: controller.activeSearchMatch,
-      onSelected: (_) {},
+      onDataSelected: (_) {},
     );
 
     Future<void> pumpFlameChart(WidgetTester tester) async {
@@ -158,25 +158,25 @@ void main() {
   group('ScrollingFlameChartRow', () {
     ScrollingFlameChartRow currentRow;
     final linkedScrollControllerGroup = LinkedScrollControllerGroup();
-    final testRow = ScrollingFlameChartRow(
+    final testRow = ScrollingFlameChartRow<TimelineEvent>(
       linkedScrollControllerGroup: linkedScrollControllerGroup,
       nodes: testNodes,
       width: 680.0, // 680.0 fits all test nodes and sideInsets of 70.0.
       startInset: sideInset,
-      selectionNotifier: ValueNotifier<CpuStackFrame>(null),
+      selectionNotifier: ValueNotifier<TimelineEvent>(null),
       searchMatchesNotifier: null,
       activeSearchMatchNotifier: null,
       onTapUp: () {},
       backgroundColor: Colors.transparent,
       zoom: FlameChart.minZoomLevel,
     );
-    final zoomedTestRow = ScrollingFlameChartRow(
+    final zoomedTestRow = ScrollingFlameChartRow<TimelineEvent>(
       linkedScrollControllerGroup: linkedScrollControllerGroup,
       nodes: testNodes,
       // 1080.0 fits all test nodes at zoom level 2.0 and sideInsets of 70.0.
       width: 1080.0,
       startInset: sideInset,
-      selectionNotifier: ValueNotifier<CpuStackFrame>(null),
+      selectionNotifier: ValueNotifier<TimelineEvent>(null),
       searchMatchesNotifier: null,
       activeSearchMatchNotifier: null,
       onTapUp: () {},
@@ -222,7 +222,7 @@ void main() {
     });
 
     testWidgets('builds for empty nodes list', (WidgetTester tester) async {
-      final emptyRow = ScrollingFlameChartRow(
+      final emptyRow = ScrollingFlameChartRow<CpuStackFrame>(
         linkedScrollControllerGroup: linkedScrollControllerGroup,
         nodes: const [],
         width: 500.0, // 500.0 is arbitrary.
@@ -554,7 +554,6 @@ const narrowNodeKey = Key('narrow node');
 final narrowNode = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Narrow test node',
-  tooltip: 'Narrow test node tooltip',
   rect: const Rect.fromLTWH(23.0, 0.0, 21.9, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,
@@ -566,7 +565,6 @@ const Key testNodeKey = Key('test node');
 final testNode = FlameChartNode<TimelineEvent>(
   key: testNodeKey,
   text: 'Test node 1',
-  tooltip: 'Test node 1 tooltip',
   // 30.0 is the minimum node width for text.
   rect: const Rect.fromLTWH(70.0, 0.0, 30.0, rowHeight),
   backgroundColor: Colors.blue,
@@ -578,7 +576,6 @@ final testNode = FlameChartNode<TimelineEvent>(
 final testNode2 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 2',
-  tooltip: 'Test node 2 tooltip',
   rect: const Rect.fromLTWH(120.0, 0.0, 50.0, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,
@@ -589,7 +586,6 @@ final testNode2 = FlameChartNode<TimelineEvent>(
 final testNode3 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 3',
-  tooltip: 'Test node 3 tooltip',
   rect: const Rect.fromLTWH(180.0, 0.0, 50.0, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,
@@ -600,7 +596,6 @@ final testNode3 = FlameChartNode<TimelineEvent>(
 final testNode4 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 4',
-  tooltip: 'Test node 4 tooltip',
   rect: const Rect.fromLTWH(240.0, 0.0, 300.0, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,
@@ -619,7 +614,6 @@ const noWidthNodeKey = Key('no-width node');
 final negativeWidthNode = FlameChartNode<TimelineEvent>(
   key: noWidthNodeKey,
   text: 'No-width node',
-  tooltip: 'no-width node tooltip',
   rect: const Rect.fromLTWH(1.0, 0.0, -0.1, rowHeight),
   backgroundColor: Colors.blue,
   textColor: Colors.white,

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:test/test.dart';
 
 import 'inspector_screen_test.dart';
 import 'support/mocks.dart';
+import 'support/utils.dart';
 
 void main() {
   group('LoggingController', () {
@@ -96,6 +97,23 @@ void main() {
 
       // Search with incorrect case.
       expect(controller.matchesForSearch('STDOUT').length, equals(3));
+    });
+
+    test('matchesForSearch sets isSearchMatch property', () {
+      addStdoutData('abc');
+      addStdoutData('def');
+      addStdoutData('abc ghi');
+      addGcData('gc1');
+      addGcData('gc2');
+
+      expect(controller.filteredData.value, hasLength(5));
+      var matches = controller.matchesForSearch('abc');
+      expect(matches.length, equals(2));
+      verifyIsSearchMatch(controller.filteredData.value, matches);
+
+      matches = controller.matchesForSearch('gc');
+      expect(matches.length, equals(2));
+      verifyIsSearchMatch(controller.filteredData.value, matches);
     });
 
     test('filterData', () {

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -155,6 +155,25 @@ void main() {
       expect(controller.matchesForSearch('YEAR').length, equals(5));
     });
 
+    test('matchesForSearch sets isSearchMatch property', () async {
+      // The number of valid requests recorded in the test data.
+      const numRequests = 16;
+
+      final requestsNotifier = controller.requests;
+      // Refresh network data and ensure requests are populated.
+      await controller.networkService.refreshNetworkData();
+      final profile = requestsNotifier.value;
+      expect(profile.requests.length, numRequests);
+
+      var matches = controller.matchesForSearch('year=2019');
+      expect(matches.length, equals(5));
+      verifyIsSearchMatch(profile.requests, matches);
+
+      matches = controller.matchesForSearch('IPv6');
+      expect(matches.length, equals(2));
+      verifyIsSearchMatch(profile.requests, matches);
+    });
+
     test('filterData', () async {
       // The number of valid requests recorded in the test data.
       const numRequests = 16;

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:devtools_app/src/charts/treemap.dart';
+import 'package:devtools_app/src/ui/search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -252,3 +253,16 @@ Future<void> loadFonts() async {
 ///
 /// E.g. `find.byType(typeOf<MyTypeWithAGeneric<String>>());`
 Type typeOf<T>() => T;
+
+void verifyIsSearchMatch(
+  List<SearchableDataMixin> data,
+  List<SearchableDataMixin> matches,
+) {
+  for (final request in data) {
+    if (matches.contains(request)) {
+      expect(request.isSearchMatch, isTrue);
+    } else {
+      expect(request.isSearchMatch, isFalse);
+    }
+  }
+}

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -255,8 +255,8 @@ Future<void> loadFonts() async {
 Type typeOf<T>() => T;
 
 void verifyIsSearchMatch(
-  List<SearchableDataMixin> data,
-  List<SearchableDataMixin> matches,
+  List<DataSearchStateMixin> data,
+  List<DataSearchStateMixin> matches,
 ) {
   for (final request in data) {
     if (matches.contains(request)) {

--- a/packages/devtools_testing/lib/performance_controller_test.dart
+++ b/packages/devtools_testing/lib/performance_controller_test.dart
@@ -8,6 +8,7 @@
 @TestOn('vm')
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_model.dart';
+import 'package:devtools_app/src/ui/search.dart';
 import 'package:test/test.dart';
 
 import 'support/flutter_test_environment.dart';
@@ -155,6 +156,22 @@ Future<void> runPerformanceControllerTests(FlutterTestEnvironment env) async {
 
       await env.tearDownEnvironment();
     });
+
+    test('matchesForSearch sets isSearchMatch property', () async {
+      await env.setupEnvironment();
+
+      await performanceController.clearData(clearVmTimeline: false);
+      performanceController.addTimelineEvent(goldenUiTimelineEvent);
+      var matches = performanceController.matchesForSearch('frame');
+      expect(matches.length, equals(4));
+      verifyIsSearchMatch(performanceController.data.timelineEvents, matches);
+
+      matches = performanceController.matchesForSearch('begin');
+      expect(matches.length, equals(2));
+      verifyIsSearchMatch(performanceController.data.timelineEvents, matches);
+
+      await env.tearDownEnvironment();
+    });
   });
 }
 
@@ -165,4 +182,20 @@ bool isPerformanceDataEqual(PerformanceData a, PerformanceData b) {
       a.selectedEvent.name == b.selectedEvent.name &&
       a.selectedEvent.time == b.selectedEvent.time &&
       a.cpuProfileData == b.cpuProfileData;
+}
+
+// TODO(kenz): this is copied from devtools_app/test/support/utils.dart. We
+// should re-evaluate the purpose of the devtools_testing package and move some
+// of these tests back into the main devtools_app package if possible.
+void verifyIsSearchMatch(
+    List<SearchableDataMixin> data,
+    List<SearchableDataMixin> matches,
+    ) {
+  for (final request in data) {
+    if (matches.contains(request)) {
+      expect(request.isSearchMatch, isTrue);
+    } else {
+      expect(request.isSearchMatch, isFalse);
+    }
+  }
 }

--- a/packages/devtools_testing/lib/performance_controller_test.dart
+++ b/packages/devtools_testing/lib/performance_controller_test.dart
@@ -188,8 +188,8 @@ bool isPerformanceDataEqual(PerformanceData a, PerformanceData b) {
 // should re-evaluate the purpose of the devtools_testing package and move some
 // of these tests back into the main devtools_app package if possible.
 void verifyIsSearchMatch(
-    List<SearchableDataMixin> data,
-    List<SearchableDataMixin> matches,
+    List<DataSearchStateMixin> data,
+    List<DataSearchStateMixin> matches,
     ) {
   for (final request in data) {
     if (matches.contains(request)) {


### PR DESCRIPTION
Improve flame chart search performance by **~27x** by caching the values isSearchMatch and isActiveSearch. We were performing very expensive calls to `List.contains` in the process of building each flame chart node. 

Before:
![Screen Shot 2021-04-29 at 9 17 36 AM](https://user-images.githubusercontent.com/43759233/116605328-20215f80-a8e4-11eb-93a7-8b0c0e0378e1.png)

After:
![Screen Shot 2021-04-29 at 9 36 53 AM](https://user-images.githubusercontent.com/43759233/116605269-0f70e980-a8e4-11eb-8849-be11271d9612.png)

Fixes https://github.com/flutter/devtools/issues/2941