### PR TITLE
Throw RPCError when invoking getSourceReport in profile mode

### DIFF
--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -8,6 +8,7 @@ import 'package:dds/vm_service_extensions.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
+import 'globals.dart';
 import 'profiler/cpu_profile_model.dart';
 import 'version.dart';
 
@@ -409,7 +410,17 @@ class VmServiceWrapper implements VmService {
     int tokenPos,
     int endTokenPos,
     bool forceCompile,
-  }) {
+  }) async {
+    // Workaround for https://github.com/flutter/devtools/issues/2981.
+    // TODO(bkonyi): remove after Flutter stable is on Dart SDK > 2.12.
+    if (await serviceManager.connectedApp.isProfileBuild) {
+      const kFeatureDisabled = 100;
+      throw RPCError(
+        'getSourceReport',
+        kFeatureDisabled,
+        'disabled in AOT mode and PRODUCT.',
+      );
+    }
     return trackFuture(
         'getSourceReport',
         _vmService.getSourceReport(


### PR DESCRIPTION
There was a bug in the VM service where invoking getSourceReport on an application running in profile mode (Dart AOT) would cause the VM to crash (resolved in [this CL](https://dart-review.googlesource.com/c/sdk/+/197241)).

This change adds a guard in vm_service_wrapper.dart to manually check for a profile mode run before invoking the RPC, throwing the correct RPCError that the VM service package would throw if the VM didn't crash.