### PR TITLE
Support filtering CPU profiles by UserTags

### DIFF
--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -418,8 +418,9 @@ class PerformanceController
     }
 
     if (offlinePerformanceData.cpuProfileData != null) {
-      cpuProfilerController
-          .loadProcessedData(offlinePerformanceData.cpuProfileData);
+      cpuProfilerController.loadProcessedData(
+        offlinePerformanceData.cpuProfileData,
+      );
     }
   }
 

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -418,7 +418,8 @@ class PerformanceController
     }
 
     if (offlinePerformanceData.cpuProfileData != null) {
-      cpuProfilerController.loadData(offlinePerformanceData.cpuProfileData);
+      cpuProfilerController
+          .loadProcessedData(offlinePerformanceData.cpuProfileData);
     }
   }
 

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -143,7 +143,6 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
     _processingNotifier.value = true;
 
     try {
-      assert(false);
       _dataNotifier.value = await processDataForTag(tag);
     } catch (e) {
       // In the event of an error, reset the data to the original CPU profile.

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -34,6 +34,12 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
       _selectedCpuStackFrameNotifier;
   final _selectedCpuStackFrameNotifier = ValueNotifier<CpuStackFrame>(null);
 
+  int selectedProfilerTabIndex = 0;
+
+  void changeSelectedProfilerTab(int index) {
+    selectedProfilerTabIndex = index;
+  }
+
   final transformer = CpuProfileTransformer();
 
   /// Notifies that the vm profiler flag has changed.

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -15,6 +15,10 @@ import 'cpu_profile_service.dart';
 import 'cpu_profile_transformer.dart';
 
 class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
+  /// Tag to represent when no user tag filters are applied.
+  ///
+  /// The word 'none' is not a magic word - just a user-friendly name to convey
+  /// the message that no filters are applied.
   static const userTagNone = 'none';
 
   /// Data for the initial value and reset value of [_dataNotifier].
@@ -138,8 +142,16 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
     _dataNotifier.value = null;
     _processingNotifier.value = true;
 
-    _dataNotifier.value = await processDataForTag(tag);
-    _processingNotifier.value = false;
+    try {
+      assert(false);
+      _dataNotifier.value = await processDataForTag(tag);
+    } catch (e) {
+      // In the event of an error, reset the data to the original CPU profile.
+      _dataNotifier.value = _dataByTag[userTagNone];
+      throw Exception('Error loading data with tag "$tag": ${e.toString()}');
+    } finally {
+      _processingNotifier.value = false;
+    }
   }
 
   Future<CpuProfileData> processDataForTag(String tag) async {

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -253,13 +253,13 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
   /// can be part of multiple samples.
   final _userTagSampleCount = <String, int>{};
 
-  void incrementTag(String userTag, {int increment = 1}) {
+  void incrementTagSampleCount(String userTag, {int increment = 1}) {
     assert(userTag != null);
     final currentCount = _userTagSampleCount.putIfAbsent(userTag, () => 0);
     _userTagSampleCount[userTag] = currentCount + increment;
 
     if (parent != null) {
-      parent.incrementTag(userTag);
+      parent.incrementTagSampleCount(userTag);
     }
   }
 
@@ -328,7 +328,7 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
       ..inclusiveSampleCount =
           resetInclusiveSampleCount ? null : inclusiveSampleCount;
     for (final entry in _userTagSampleCount.entries) {
-      copy.incrementTag(entry.key, increment: entry.value);
+      copy.incrementTagSampleCount(entry.key, increment: entry.value);
     }
     return copy;
   }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
@@ -143,7 +143,7 @@ class CpuProfileTransformer {
       stackFrame?.exclusiveSampleCount++;
       final userTag = (traceEvent['args'] ?? {})['userTag'];
       if (userTag != null) {
-        stackFrame.incrementTag(userTag);
+        stackFrame.incrementTagSampleCount(userTag);
       }
     }
   }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
@@ -106,10 +106,11 @@ class CpuProfileTransformer {
     final batchEnd =
         math.min(_stackFramesProcessed + batchSize, _stackFramesCount);
     for (int i = _stackFramesProcessed; i < batchEnd; i++) {
-      final k = _stackFrameKeys[i];
-      final v = _stackFrameValues[i];
-      final stackFrame = cpuProfileData.stackFrames[k];
-      final parent = cpuProfileData.stackFrames[v[CpuProfileData.parentIdKey]];
+      final key = _stackFrameKeys[i];
+      final value = _stackFrameValues[i];
+      final stackFrame = cpuProfileData.stackFrames[key];
+      final parent =
+          cpuProfileData.stackFrames[value[CpuProfileData.parentIdKey]];
       _processStackFrame(stackFrame, parent, cpuProfileData);
       _stackFramesProcessed++;
     }

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import '../auto_dispose_mixin.dart';
 import '../charts/flame_chart.dart';
 import '../common_widgets.dart';
+import '../notifications.dart';
 import '../theme.dart';
 import '../ui/search.dart';
 import 'cpu_profile_bottom_up.dart';
@@ -268,7 +269,6 @@ class CpuProfilerDisabled extends StatelessWidget {
   }
 }
 
-
 /// DropdownButton that controls the value of
 /// [ProfilerScreenController.userTagFilter].
 class UserTagDropdown extends StatelessWidget {
@@ -314,7 +314,9 @@ class UserTagDropdown extends StatelessWidget {
                         value: tag,
                       ),
                 ],
-                onChanged: userTags.isNotEmpty ? _onUserTagChanged : null,
+                onChanged: userTags.isNotEmpty
+                    ? (String tag) => _onUserTagChanged(tag, context)
+                    : null,
               ),
             );
           },
@@ -333,7 +335,11 @@ class UserTagDropdown extends StatelessWidget {
     );
   }
 
-  void _onUserTagChanged(String newTag) {
-    controller.loadDataWithTag(newTag);
+  void _onUserTagChanged(String newTag, BuildContext context) async {
+    try {
+      await controller.loadDataWithTag(newTag);
+    } catch (e) {
+      Notifications.of(context).push(e.toString());
+    }
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -42,8 +42,6 @@ class CpuProfiler extends StatefulWidget {
 
   final bool standaloneProfiler;
 
-  static const Key expandButtonKey = Key('CpuProfiler - Expand Button');
-  static const Key collapseButtonKey = Key('CpuProfiler - Collapse Button');
   static const Key dataProcessingKey = Key('CpuProfiler - data is processing');
 
   // When content of the selected tab from thee tab controller has this key,
@@ -102,7 +100,8 @@ class _CpuProfilerState extends State<CpuProfiler>
     final currentTab = CpuProfiler.tabs[_tabController.index];
     final hasData =
         widget.data != CpuProfilerController.baseStateCpuProfileData &&
-            widget.data != null;
+            widget.data != null &&
+            !widget.data.isEmpty;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -118,47 +117,49 @@ class _CpuProfilerState extends State<CpuProfiler>
                 tabs: CpuProfiler.tabs,
               ),
               const Spacer(),
-              UserTagDropdown(widget.controller),
-              const SizedBox(width: defaultSpacing),
-              // TODO(kenz): support search for call tree and bottom up tabs as
-              // well. This will require implementing search for tree tables.
-              if (currentTab.key == CpuProfiler.flameChartTab &&
-                  widget.searchFieldKey != null)
-                Row(
-                  children: [
-                    _buildSearchField(hasData),
-                    FlameChartHelpButton(),
-                  ],
-                ),
-              if (currentTab.key != CpuProfiler.flameChartTab)
-                Row(children: [
-                  // TODO(kenz): add a switch to order samples by user tag here
-                  // instead of using the filter control. This will allow users
-                  // to see all the tags side by side in the tree tables.
-                  ExpandAllButton(
-                    key: CpuProfiler.expandButtonKey,
-                    onPressed: () {
-                      _performOnDataRoots(
-                        (root) => root.expandCascading(),
-                        currentTab,
-                      );
-                    },
+              if (hasData) ...[
+                UserTagDropdown(widget.controller),
+                const SizedBox(width: defaultSpacing),
+                // TODO(kenz): support search for call tree and bottom up tabs as
+                // well. This will require implementing search for tree tables.
+                if (currentTab.key == CpuProfiler.flameChartTab)
+                  Row(
+                    children: [
+                      if (widget.searchFieldKey != null)
+                        _buildSearchField(hasData),
+                      FlameChartHelpButton(),
+                    ],
                   ),
-                  const SizedBox(width: denseSpacing),
-                  CollapseAllButton(
-                    key: CpuProfiler.collapseButtonKey,
-                    onPressed: () {
-                      _performOnDataRoots(
-                        (root) => root.collapseCascading(),
-                        currentTab,
-                      );
-                    },
+                if (currentTab.key != CpuProfiler.flameChartTab)
+                  Row(
+                    children: [
+                      // TODO(kenz): add a switch to order samples by user tag here
+                      // instead of using the filter control. This will allow users
+                      // to see all the tags side by side in the tree tables.
+                      ExpandAllButton(
+                        onPressed: () {
+                          _performOnDataRoots(
+                            (root) => root.expandCascading(),
+                            currentTab,
+                          );
+                        },
+                      ),
+                      const SizedBox(width: denseSpacing),
+                      CollapseAllButton(
+                        onPressed: () {
+                          _performOnDataRoots(
+                            (root) => root.collapseCascading(),
+                            currentTab,
+                          );
+                        },
+                      ),
+                      // The standaloneProfiler does not need padding because it is
+                      // not wrapped in a bordered container.
+                      if (!widget.standaloneProfiler)
+                        const SizedBox(width: denseSpacing),
+                    ],
                   ),
-                  // The standaloneProfiler does not need padding because it is
-                  // not wrapped in a bordered container.
-                  if (!widget.standaloneProfiler)
-                    const SizedBox(width: denseSpacing),
-                ]),
+              ],
             ],
           ),
         ),

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -261,3 +261,72 @@ class CpuProfilerDisabled extends StatelessWidget {
   }
 }
 
+
+/// DropdownButton that controls the value of
+/// [ProfilerScreenController.userTagFilter].
+class UserTagDropdown extends StatelessWidget {
+  const UserTagDropdown(this.controller);
+
+  final CpuProfilerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    const filterByTag = 'Filter by tag:';
+    // This needs to rebuild whenever there is new CPU profile data because the
+    // user tags will change with the data.
+    return ValueListenableBuilder<CpuProfileData>(
+      valueListenable: controller.dataNotifier,
+      builder: (context, cpuProfileData, _) {
+        return ValueListenableBuilder<String>(
+          valueListenable: controller.userTagFilter,
+          builder: (context, userTag, _) {
+            final userTags = controller.userTags ?? [];
+            final tooltip = userTags.isNotEmpty
+                ? 'Filter the CPU profile by the given UserTag'
+                : 'No UserTags found for this CPU profile';
+            return DevToolsTooltip(
+              tooltip: tooltip,
+              child: RoundedDropDownButton<String>(
+                isDense: true,
+                style: Theme.of(context).textTheme.bodyText2,
+                value: userTag,
+                items: [
+                  _buildMenuItem(
+                    display:
+                        '$filterByTag ${CpuProfilerController.userTagNone}',
+                    value: CpuProfilerController.userTagNone,
+                  ),
+                  // We don't want to show the 'Default' tag if it is the only
+                  // tag available. The 'none' tag above is equivalent in this
+                  // case.
+                  if (!(userTags.length == 1 &&
+                      userTags.first == UserTag.defaultTag.label))
+                    for (final tag in userTags)
+                      _buildMenuItem(
+                        display: '$filterByTag $tag',
+                        value: tag,
+                      ),
+                ],
+                onChanged: userTags.isNotEmpty ? _onUserTagChanged : null,
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  DropdownMenuItem _buildMenuItem({
+    @required String display,
+    @required String value,
+  }) {
+    return DropdownMenuItem<String>(
+      value: value,
+      child: Text(display),
+    );
+  }
+
+  void _onUserTagChanged(String newTag) {
+    controller.loadDataWithTag(newTag);
+  }
+}

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -79,9 +79,15 @@ class _CpuProfilerState extends State<CpuProfiler>
   void initState() {
     super.initState();
 
-    _tabController =
-        TabController(length: CpuProfiler.tabs.length, vsync: this);
-    addAutoDisposeListener(_tabController);
+    _tabController = TabController(
+      length: CpuProfiler.tabs.length,
+      vsync: this,
+    )..index = widget.controller.selectedProfilerTabIndex;
+    addAutoDisposeListener(_tabController, () {
+      setState(() {
+        widget.controller.changeSelectedProfilerTab(_tabController.index);
+      });
+    });
   }
 
   @override

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -1,6 +1,8 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
 
 import '../auto_dispose_mixin.dart';
@@ -102,7 +104,6 @@ class _CpuProfilerState extends State<CpuProfiler>
         SizedBox(
           height: defaultButtonHeight,
           child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               TabBar(
                 labelColor: textTheme.bodyText1.color,
@@ -110,6 +111,9 @@ class _CpuProfilerState extends State<CpuProfiler>
                 controller: _tabController,
                 tabs: CpuProfiler.tabs,
               ),
+              const Spacer(),
+              UserTagDropdown(widget.controller),
+              const SizedBox(width: defaultSpacing),
               // TODO(kenz): support search for call tree and bottom up tabs as
               // well. This will require implementing search for tree tables.
               if (currentTab.key == CpuProfiler.flameChartTab &&
@@ -122,6 +126,9 @@ class _CpuProfilerState extends State<CpuProfiler>
                 ),
               if (currentTab.key != CpuProfiler.flameChartTab)
                 Row(children: [
+                  // TODO(kenz): add a switch to order samples by user tag here
+                  // instead of using the filter control. This will allow users
+                  // to see all the tags side by side in the tree tables.
                   ExpandAllButton(
                     key: CpuProfiler.expandButtonKey,
                     onPressed: () {
@@ -253,3 +260,4 @@ class CpuProfilerDisabled extends StatelessWidget {
     );
   }
 }
+

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -281,6 +281,8 @@ class UserTagDropdown extends StatelessWidget {
     const filterByTag = 'Filter by tag:';
     // This needs to rebuild whenever there is new CPU profile data because the
     // user tags will change with the data.
+    // TODO(kenz): remove the nested ValueListenableBuilders
+    // https://github.com/flutter/devtools/issues/2989.
     return ValueListenableBuilder<CpuProfileData>(
       valueListenable: controller.dataNotifier,
       builder: (context, cpuProfileData, _) {

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -192,7 +192,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   @override
   FutureOr<void> processOfflineData(CpuProfileData offlineData) async {
     await controller.cpuProfilerController.transformer.processData(offlineData);
-    controller.cpuProfilerController.loadData(offlineData);
+    controller.cpuProfilerController.loadProcessedData(offlineData);
   }
 
   @override

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -316,6 +316,10 @@ class VmServiceWrapper implements VmService {
           'ts': sample.timestamp,
           'cat': 'Dart',
           CpuProfileData.stackFrameIdKey: '$isolateId-${tree.frameId}',
+          'args': {
+            if (sample.userTag != null) 'userTag': sample.userTag,
+            if (sample.vmTag != null) 'vmTag': sample.vmTag,
+          },
         });
       }
       return CpuProfileData.parse(traceObject);

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -121,9 +121,9 @@ void main() {
               .duration.inMicroseconds,
           equals(250));
       expect(
-          controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
-          equals(
-            '''
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
   all - children: 1 - excl: 0 - incl: 5
     Frame1 - children: 2 - excl: 0 - incl: 5
       Frame2 - children: 2 - excl: 0 - incl: 2
@@ -132,44 +132,48 @@ void main() {
       Frame5 - children: 1 - excl: 2 - incl: 3
         Frame6 - children: 0 - excl: 1 - incl: 1
 ''',
-          ));
+        ),
+      );
 
       await controller.loadDataWithTag('userTagA');
       expect(
-          controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
-          equals(
-            '''
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
   all - children: 1 - excl: 0 - incl: 2
     Frame1 - children: 2 - excl: 0 - incl: 2
       Frame2 - children: 1 - excl: 0 - incl: 1
         Frame3 - children: 0 - excl: 1 - incl: 1
       Frame5 - children: 0 - excl: 1 - incl: 1
 ''',
-          ));
+        ),
+      );
 
       await controller.loadDataWithTag('userTagB');
       expect(
-          controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
-          equals(
-            '''
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
   all - children: 1 - excl: 0 - incl: 1
     Frame1 - children: 1 - excl: 0 - incl: 1
       Frame2 - children: 1 - excl: 0 - incl: 1
         Frame4 - children: 0 - excl: 1 - incl: 1
 ''',
-          ));
+        ),
+      );
 
       await controller.loadDataWithTag('userTagC');
       expect(
-          controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
-          equals(
-            '''
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
   all - children: 1 - excl: 0 - incl: 2
     Frame1 - children: 1 - excl: 0 - incl: 2
       Frame5 - children: 1 - excl: 1 - incl: 2
         Frame6 - children: 0 - excl: 1 - incl: 1
 ''',
-          ));
+        ),
+      );
     });
 
     test('reset', () async {

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -199,7 +199,7 @@ void main() {
       }
     });
 
-    group('User tag filters', () {
+    group('UserTag filters', () {
       ProfilerScreenController controller;
 
       setUp(() async {

--- a/packages/devtools_app/test/profiler_screen_test.dart
+++ b/packages/devtools_app/test/profiler_screen_test.dart
@@ -67,7 +67,7 @@ void main() {
       expect(find.text('CPU Profiler'), findsOneWidget);
     });
 
-    const windowSize = Size(1000.0, 1000.0);
+    const windowSize = Size(2000.0, 1000.0);
 
     testWidgetsWithWindowSize(
       'builds proper content for recording state',

--- a/packages/devtools_testing/lib/support/cpu_profile_test_data.dart
+++ b/packages/devtools_testing/lib/support/cpu_profile_test_data.dart
@@ -29,6 +29,119 @@ final Map<String, dynamic> emptyCpuProfileDataJson = {
   'traceEvents': [],
 };
 
+final Map<String, dynamic> cpuProfileDataWithUserTagsJson = {
+  'type': '_CpuProfileTimeline',
+  'samplePeriod': 50,
+  'sampleCount': 5,
+  'stackDepth': 128,
+  'timeOriginMicros': 0,
+  'timeExtentMicros': 250,
+  'stackFrames': {
+    '140357727781376-1': {
+      'category': 'Dart',
+      'name': 'Frame1',
+      'resolvedUrl': '',
+    },
+    '140357727781376-2': {
+      'category': 'Dart',
+      'name': 'Frame2',
+      'parent': '140357727781376-1',
+      'resolvedUrl': '',
+    },
+    '140357727781376-3': {
+      'category': 'Dart',
+      'name': 'Frame3',
+      'parent': '140357727781376-2',
+      'resolvedUrl': '',
+    },
+    '140357727781376-4': {
+      'category': 'Dart',
+      'name': 'Frame4',
+      'parent': '140357727781376-2',
+      'resolvedUrl': '',
+    },
+    '140357727781376-5': {
+      'category': 'Dart',
+      'name': 'Frame5',
+      'parent': '140357727781376-1',
+      'resolvedUrl': '',
+    },
+    '140357727781376-6': {
+      'category': 'Dart',
+      'name': 'Frame6',
+      'parent': '140357727781376-5',
+      'resolvedUrl': '',
+    },
+  },
+  'traceEvents': [
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 50,
+      'cat': 'Dart',
+      'args': {
+        'mode': 'basic',
+        'userTag': 'userTagA',
+      },
+      'sf': '140357727781376-3'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 100,
+      'cat': 'Dart',
+      'args': {
+        'mode': 'basic',
+        'userTag': 'userTagB',
+      },
+      'sf': '140357727781376-4'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 150,
+      'cat': 'Dart',
+      'args': {
+        'mode': 'basic',
+        'userTag': 'userTagA',
+      },
+      'sf': '140357727781376-5'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 200,
+      'cat': 'Dart',
+      'args': {
+        'mode': 'basic',
+        'userTag': 'userTagC',
+      },
+      'sf': '140357727781376-5'
+    },
+    {
+      'ph': 'P',
+      'name': '',
+      'pid': 77616,
+      'tid': 42247,
+      'ts': 250,
+      'cat': 'Dart',
+      'args': {
+        'mode': 'basic',
+        'userTag': 'userTagC',
+      },
+      'sf': '140357727781376-6'
+    },
+  ],
+};
+
 const goldenCpuProfileString = '''
   all - children: 2 - excl: 0 - incl: 8
     thread_start - children: 1 - excl: 0 - incl: 2


### PR DESCRIPTION
If a user specifies [UserTag](https://api.dart.dev/stable/2.12.4/dart-developer/UserTag/UserTag.html)s in their code, those tags will show up in the DevTools CPU profiler as filter options.
![filter-by-user-tag](https://user-images.githubusercontent.com/43759233/117358832-74d85380-ae6b-11eb-81c1-3973f270682c.gif)
Fixes https://github.com/flutter/devtools/issues/2964
Fixes https://github.com/flutter/devtools/issues/947