### PR TITLE
Fix bug with flame chart tooltips

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -775,7 +775,7 @@ class ScrollingFlameChartRowState<V extends FlameChartDataMixin<V>>
 
   void _handleMouseHover(PointerHoverEvent event) {
     final hoverNodeData =
-        binarySearchForNode(event.localPosition.dx - scrollController.offset)
+        binarySearchForNode(event.localPosition.dx + scrollController.offset)
             ?.data;
 
     if (hoverNodeData != hovered) {


### PR DESCRIPTION
We want to search for the nodes at local mouse x + scroll offset because the nodes are absolutely positioned.

Fixes https://github.com/flutter/devtools/issues/2983