### PR TITLE
Fix bug where settings widgets were not centered by using a shared widget

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -254,30 +254,24 @@ class StopRecordingButton extends StatelessWidget {
 class SettingsOutlinedButton extends StatelessWidget {
   const SettingsOutlinedButton({
     @required this.onPressed,
-    @required this.tooltip,
+    @required this.label,
   });
 
   final VoidCallback onPressed;
 
-  final String tooltip;
+  final String label;
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      // TODO(kenz): this height should be unnecessary once
-      // https://github.com/flutter/flutter/issues/79894 is fixed.
-      height: defaultButtonHeight,
-      width: defaultButtonHeight, // This will result in a square button.
-      child: DevToolsTooltip(
-        tooltip: tooltip,
-        child: OutlinedButton(
-          onPressed: onPressed,
-          child: const Icon(
-            Icons.settings,
-            size: defaultIconSize,
-          ),
-        ),
-      ),
+    return IconLabelButton(
+      onPressed: onPressed,
+      icon: Icons.settings,
+      label: label,
+      // TODO(jacobr): consider a more conservative min-width. To minimize the
+      // impact on the existing UI and deal with the fact that some of the
+      // existing label names are fairly verbose, we set a width that will
+      // never be hit.
+      includeTextWidth: 20000,
     );
   }
 }

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -21,7 +21,6 @@ import '../theme.dart';
 import '../ui/icons.dart';
 import '../ui/utils.dart';
 import '../utils.dart';
-
 import 'memory_android_chart.dart' as android;
 import 'memory_charts.dart';
 import 'memory_controller.dart';
@@ -606,7 +605,7 @@ class MemoryBodyState extends State<MemoryBody>
         const SizedBox(width: denseSpacing),
         SettingsOutlinedButton(
           onPressed: _openSettingsDialog,
-          tooltip: 'Memory Configuration',
+          label: 'Memory Configuration',
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -250,7 +250,7 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
         const SizedBox(width: defaultSpacing),
         SettingsOutlinedButton(
           onPressed: _openSettingsDialog,
-          tooltip: 'Performance Settings',
+          label: 'Performance Settings',
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/provider/provider_screen.dart
+++ b/packages/devtools_app/lib/src/provider/provider_screen.dart
@@ -108,7 +108,7 @@ class ProviderScreenBody extends ConsumerWidget {
                           builder: (_) => _StateInspectorSettingsDialog(),
                         );
                       },
-                      tooltip: _StateInspectorSettingsDialog.title,
+                      label: _StateInspectorSettingsDialog.title,
                     ),
                   ],
                 ),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3015

![Screen Shot 2021-05-13 at 10 50 18 AM](https://user-images.githubusercontent.com/1226812/118165344-08b09f00-b3d9-11eb-9074-95b91eeefd8c.png)
