### PR TITLE
Update 2.2.2 versions to latest version 2.2.4

### DIFF
--- a/packages/devtools/CHANGELOG.md
+++ b/packages/devtools/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.2.4
+* Fix bug in devtools_server by calling proper vm service API [#3040](https://github.com/flutter/devtools/pull/3040)
+
 ## 2.2.3
 * Enable the provider screen [#2998](https://github.com/flutter/devtools/pull/2998) [#3010](https://github.com/flutter/devtools/pull/3010) [#3006](https://github.com/flutter/devtools/pull/23006) [#2992](https://github.com/flutter/devtools/pull/2992)
 * Support filtering CPU profiles by UserTags [#2988](https://github.com/flutter/devtools/pull/2988)

--- a/packages/devtools/pubspec.yaml
+++ b/packages/devtools/pubspec.yaml
@@ -8,7 +8,7 @@ description: A suite of web-based performance tooling for Dart and Flutter.
 # package remaining purely as a container for the compiled copy of the devtools
 # app. That ensures that version constraints for the devtools_app do not impact
 # this package.
-version: 2.2.2
+version: 2.2.4
 
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.dart matches the following line so
 // if you change it you must also modify tools/update_version.dart.
-const String version = '2.2.2';
+const String version = '2.2.4';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -6,7 +6,7 @@ description: Web-based performance tooling for Dart and Flutter.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 2.2.2
+version: 2.2.4
 
 homepage: https://github.com/flutter/devtools
 
@@ -58,9 +58,9 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^1.3.0
-  devtools: #^0.1.7
+  devtools:
     path: ../devtools
-  devtools_testing: 2.2.2
+  devtools_testing: 2.2.4
   flutter_test:
     sdk: flutter
   mockito: ^4.0.0

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -2,7 +2,7 @@ name: devtools_testing
 description: Package of shared testing code for Dart DevTools.
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of packages from packages/devtools.
-version: 2.2.2
+version: 2.2.4
 
 homepage: https://github.com/flutter/devtools
 
@@ -10,7 +10,7 @@ environment:
   sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
-  devtools_app: 2.2.2
+  devtools_app: 2.2.4
   devtools_shared: 2.3.0
   flutter:
     sdk: flutter

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -130,8 +130,8 @@ void writeVersionToChangelog(File changelog, String version) {
     return;
   }
   changelog.writeAsString([
-    '$versionString\n',
-    'TODO: update changelog',
+    '$versionString',
+    'TODO: update changelog\n',
     ...lines,
   ].joinWithNewLine());
 }


### PR DESCRIPTION
this does not bump the 2.3.0 packages or dependencies on those packages (devtools_server, devtools_shared)