### PR TITLE
Improve eval autocomplete

### DIFF
--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -296,8 +296,10 @@ Future<List<String>> autoCompleteResultsFor(
         );
         // TODO(grouma) - This shouldn't be necessary but package:dwds does
         // not properly provide superclass information.
-        result.addAll(instance.fields.map((field) => field.decl.name).where(
-            (member) => !_isAccessible(member, instance.classRef, controller)));
+        final clazz = await controller.getObject(instance.classRef);
+        result.addAll(instance.fields
+            .map((field) => field.decl.name)
+            .where((member) => _isAccessible(member, clazz, controller)));
       }
     } catch (_) {}
   }

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -580,6 +580,12 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
             return KeyEventResult.handled;
           }
         }
+
+        // We don't support tabs in the search input. Swallow to prevent a
+        // change of focus.
+        if (key == tab || key == tabMac) {
+          return KeyEventResult.handled;
+        }
       }
 
       return KeyEventResult.ignored;

--- a/packages/devtools_app/test/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger_evalution_test.dart
@@ -163,6 +163,18 @@ void main() {
               ),
               value: null,
             ),
+            BoundField(
+              decl: FieldRef(
+                name: '_privateFieldBound',
+                owner: null,
+                declaredType: null,
+                isConst: false,
+                isFinal: false,
+                isStatic: false,
+                id: '',
+              ),
+              value: null,
+            ),
           ],
           identityHashCode: null,
           kind: '',


### PR DESCRIPTION
- Don't change focus with tab as that can be frustrating, especially in slow autocomplete environments
  - Note that tab to select is already supported
- Prevent showing inaccessible members from a superclass on the web
- Swallow `getObject` issues in the recursive walk of the class hierarchy.