### PR TITLE
Lighten the area pane header color for light theme

### DIFF
--- a/packages/devtools_app/lib/src/app_size/code_size_attribution.dart
+++ b/packages/devtools_app/lib/src/app_size/code_size_attribution.dart
@@ -129,7 +129,7 @@ class _CallGraphViewState extends State<CallGraphView> {
                 Container(
                   height: constraints.maxHeight,
                   width: densePadding,
-                  color: titleSolidBackgroundColor(Theme.of(context)),
+                  color: Theme.of(context).titleSolidBackgroundColor,
                 ),
                 Flexible(
                   child: _buildToTable(),

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -1107,16 +1107,9 @@ extension ColorExtension on Color {
 
 /// Gets an alternating color to use for indexed UI elements.
 Color alternatingColorForIndex(int index, ColorScheme colorScheme) {
-  final color = colorScheme.defaultBackgroundColor;
-  return _colorForIndex(color, index, colorScheme);
-}
-
-Color _colorForIndex(Color color, int index, ColorScheme colorScheme) {
-  if (index % 2 == 1) {
-    return color;
-  } else {
-    return colorScheme.isLight ? color.darken() : color.brighten();
-  }
+  return index % 2 == 1
+      ? colorScheme.defaultBackgroundColor
+      : colorScheme.alternatingBackgroundColor;
 }
 
 class BreadcrumbNavigator extends StatelessWidget {

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -678,7 +678,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
                 needsBottomBorder ? defaultBorderSide(theme) : BorderSide.none,
             left: needsLeftBorder ? defaultBorderSide(theme) : BorderSide.none,
           ),
-          color: titleSolidBackgroundColor(theme),
+          color: theme.titleSolidBackgroundColor,
         ),
         padding: EdgeInsets.only(left: defaultSpacing, right: rightPadding),
         alignment: Alignment.centerLeft,

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -418,7 +418,7 @@ class Gutter extends StatelessWidget {
       width: gutterWidth,
       decoration: BoxDecoration(
         border: Border(right: defaultBorderSide(theme)),
-        color: titleSolidBackgroundColor(theme),
+        color: Theme.of(context).titleSolidBackgroundColor,
       ),
       child: ListView.builder(
         controller: scrollController,

--- a/packages/devtools_app/lib/src/debugger/common.dart
+++ b/packages/devtools_app/lib/src/debugger/common.dart
@@ -19,7 +19,7 @@ Container debuggerSectionTitle(ThemeData theme, {String text, Widget child}) {
       border: Border(
         bottom: BorderSide(color: theme.focusColor),
       ),
-      color: titleSolidBackgroundColor(theme),
+      color: theme.titleSolidBackgroundColor,
     ),
     padding: const EdgeInsets.only(left: defaultSpacing),
     alignment: Alignment.centerLeft,

--- a/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
+++ b/packages/devtools_app/lib/src/memory/memory_tracker_model.dart
@@ -208,7 +208,7 @@ class TreeTracker {
     final callstackLength = stackTrace.length;
     assert(sources.length == callstackLength);
 
-    final titleBackground = titleSolidBackgroundColor(Theme.of(context));
+    final titleBackground = Theme.of(context).titleSolidBackgroundColor;
 
     return Column(
       children: [

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -1294,7 +1294,7 @@ class _TableRowState<T> extends State<TableRow<T>>
 
   Color _searchAwareBackgroundColor() {
     final backgroundColor =
-        widget.backgroundColor ?? titleSolidBackgroundColor(Theme.of(context));
+        widget.backgroundColor ?? Theme.of(context).titleSolidBackgroundColor;
     if (widget.isSelected) {
       return Theme.of(context).selectedRowColor;
     }

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -352,12 +352,16 @@ extension ThemeDataExtension on ThemeData {
   TextStyle get fixedFontStyle =>
       textTheme.bodyText2.copyWith(fontFamily: 'RobotoMono');
 
-  TextStyle get subtleFixedFontStyle {
-    return fixedFontStyle.copyWith(color: unselectedWidgetColor);
-  }
+  TextStyle get subtleFixedFontStyle =>
+      fixedFontStyle.copyWith(color: unselectedWidgetColor);
 
   TextStyle get devToolsTitleStyle =>
       textTheme.headline6.copyWith(color: Colors.white);
+
+  Color get titleSolidBackgroundColor => colorScheme.isLight
+      // This matches the color for alternating row background colors in tables.
+      ? colorScheme.defaultBackgroundColor.darken()
+      : canvasColor.darken(0.2);
 }
 
 TextStyle linkTextStyle(ColorScheme colorScheme) => TextStyle(
@@ -439,13 +443,6 @@ const defaultCurve = Curves.easeInOutCubic;
 /// This is the standard curve for animations in DevTools.
 CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
-
-Color titleSolidBackgroundColor(ThemeData theme) {
-  return theme.colorScheme.isLight
-      // This matches the color for alternating row background colors in tables.
-      ? theme.colorScheme.defaultBackgroundColor.darken()
-      : theme.canvasColor.darken(0.2);
-}
 
 const chartFontSizeSmall = 12.0;
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -224,6 +224,10 @@ extension DevToolsColorScheme on ColorScheme {
   // this in places where we do not have access to the context.
   Color get defaultBackgroundColor =>
       isLight ? Colors.grey[50] : Colors.grey[850];
+  Color get alternatingBackgroundColor => isLight
+      ? defaultBackgroundColor.darken()
+      : defaultBackgroundColor.brighten();
+
   Color get chartAccentColor =>
       isLight ? const Color(0xFFCCCCCC) : const Color(0xFF585858);
   Color get chartTextColor => isLight ? Colors.black : Colors.white;
@@ -359,8 +363,7 @@ extension ThemeDataExtension on ThemeData {
       textTheme.headline6.copyWith(color: Colors.white);
 
   Color get titleSolidBackgroundColor => colorScheme.isLight
-      // This matches the color for alternating row background colors in tables.
-      ? colorScheme.defaultBackgroundColor.darken()
+      ? colorScheme.alternatingBackgroundColor
       : canvasColor.darken(0.2);
 }
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -440,7 +440,10 @@ CurvedAnimation defaultCurvedAnimation(AnimationController parent) =>
     CurvedAnimation(curve: defaultCurve, parent: parent);
 
 Color titleSolidBackgroundColor(ThemeData theme) {
-  return theme.canvasColor.darken(0.2);
+  return theme.colorScheme.isLight
+      // This matches the color for alternating row background colors in tables.
+      ? theme.colorScheme.defaultBackgroundColor.darken()
+      : theme.canvasColor.darken(0.2);
 }
 
 const chartFontSizeSmall = 12.0;


### PR DESCRIPTION
before: <img width="1191" alt="Screen Shot 2021-05-21 at 10 53 51 AM" src="https://user-images.githubusercontent.com/43759233/119179446-c19f5b00-ba23-11eb-811b-ddd2e334ed6e.png">
<img width="308" alt="Screen Shot 2021-05-21 at 11 02 15 AM" src="https://user-images.githubusercontent.com/43759233/119179645-075c2380-ba24-11eb-9a2d-97420787541b.png">

after: <img width="1191" alt="Screen Shot 2021-05-21 at 10 54 35 AM" src="https://user-images.githubusercontent.com/43759233/119179468-cbc15980-ba23-11eb-9020-2267f2a3e592.png">
<img width="309" alt="Screen Shot 2021-05-21 at 10 55 23 AM" src="https://user-images.githubusercontent.com/43759233/119179540-e267b080-ba23-11eb-9ced-2dd7e4c34425.png">

Fixes https://github.com/flutter/devtools/issues/3019
