### PR TITLE
Cleanup some UI in the debugger page

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -413,10 +413,13 @@ class Gutter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final bpLineSet = Set.from(breakpoints.map((bp) => bp.line));
-
+    final theme = Theme.of(context);
     return Container(
       width: gutterWidth,
-      color: titleSolidBackgroundColor(Theme.of(context)),
+      decoration: BoxDecoration(
+        border: Border(right: defaultBorderSide(theme)),
+        color: titleSolidBackgroundColor(theme),
+      ),
       child: ListView.builder(
         controller: scrollController,
         itemExtent: CodeView.rowHeight,

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -131,8 +131,10 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
                 decoration: const InputDecoration(
                   contentPadding: EdgeInsets.all(denseSpacing),
                   border: OutlineInputBorder(),
-                  focusedBorder: OutlineInputBorder(borderSide: evalBorder),
-                  enabledBorder: OutlineInputBorder(borderSide: evalBorder),
+                  focusedBorder:
+                      OutlineInputBorder(borderSide: BorderSide.none),
+                  enabledBorder:
+                      OutlineInputBorder(borderSide: BorderSide.none),
                   labelText: 'Eval',
                 ),
               ),

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -366,8 +366,6 @@ const wideSearchTextWidth = 400.0;
 const defaultSearchTextWidth = 200.0;
 const defaultTextFieldHeight = 32.0;
 
-const evalBorder = BorderSide(color: Colors.white, width: 2);
-
 /// Default color of cursor and color used by search's TextField.
 /// Guarantee that the Search TextField on all platforms renders in the same
 /// color for border, label text, and cursor. Primarly, so golden screen


### PR DESCRIPTION
- Add right side border to gutter to match rest of page
- Remove Eval field border. The double border looked a little busy. This is what it looks like now.
<img width="880" alt="Screen Shot 2021-05-21 at 11 28 36 AM" src="https://user-images.githubusercontent.com/43759233/119183674-493b9880-ba29-11eb-8168-6eebe259782d.png">
<img width="887" alt="Screen Shot 2021-05-21 at 11 28 44 AM" src="https://user-images.githubusercontent.com/43759233/119183679-4a6cc580-ba29-11eb-923c-21353149d2b0.png">

Fixes https://github.com/flutter/devtools/issues/3050