### PR TITLE
Use font size from IDE theme

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -34,6 +34,7 @@ void main() async {
 
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
+  setGlobal(IdeTheme, ideTheme);
 
   // Now run the app.
   runApp(

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -18,8 +18,6 @@ import 'src/preferences.dart';
 import 'src/provider/riverpod_error_logger_observer.dart';
 
 void main() async {
-  final ideTheme = getIdeTheme();
-
   // Initialize the framework before we do anything else, otherwise the
   // StorageController won't be initialized and preferences won't be loaded.
   await initializeFramework();
@@ -34,13 +32,13 @@ void main() async {
 
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
-  setGlobal(IdeTheme, ideTheme);
+  setGlobal(IdeTheme, getIdeTheme());
 
   // Now run the app.
   runApp(
     ProviderScope(
       observers: const [ErrorLoggerObserver()],
-      child: DevToolsApp(defaultScreens, ideTheme, await analyticsProvider),
+      child: DevToolsApp(defaultScreens, await analyticsProvider),
     ),
   );
 }

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -292,9 +292,9 @@ class DevToolsAppState extends State<DevToolsApp> {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
       theme: themeFor(
-          isDarkTheme: isDarkThemeEnabled,
-          ideTheme: ideTheme,
-          theme: Theme.of(context),
+        isDarkTheme: isDarkThemeEnabled,
+        ideTheme: ideTheme,
+        theme: Theme.of(context),
       ),
       builder: (context, child) => Notifications(child: child),
       routerDelegate: DevToolsRouterDelegate(_getPage),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -64,12 +64,10 @@ bool isExternalBuild = true;
 class DevToolsApp extends StatefulWidget {
   const DevToolsApp(
     this.screens,
-    this.ideTheme,
     this.analyticsProvider,
   );
 
   final List<DevToolsScreen> screens;
-  final IdeTheme ideTheme;
   final AnalyticsProvider analyticsProvider;
 
   @override
@@ -84,8 +82,6 @@ class DevToolsApp extends StatefulWidget {
 // navigate the full app.
 class DevToolsAppState extends State<DevToolsApp> {
   List<Screen> get _screens => widget.screens.map((s) => s.screen).toList();
-
-  IdeTheme get ideTheme => widget.ideTheme;
 
   bool get isDarkThemeEnabled => _isDarkThemeEnabled;
   bool _isDarkThemeEnabled;

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -294,7 +294,8 @@ class DevToolsAppState extends State<DevToolsApp> {
       theme: themeFor(
           isDarkTheme: isDarkThemeEnabled,
           ideTheme: ideTheme,
-          theme: Theme.of(context)),
+          theme: Theme.of(context),
+      ),
       builder: (context, child) => Notifications(child: child),
       routerDelegate: DevToolsRouterDelegate(_getPage),
       routeInformationParser: DevToolsRouteInformationParser(),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -296,7 +296,7 @@ class DevToolsAppState extends State<DevToolsApp> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      theme: themeFor(isDarkTheme: isDarkThemeEnabled, ideTheme: ideTheme),
+      theme: themeFor(isDarkTheme: isDarkThemeEnabled, ideTheme: ideTheme, theme: Theme.of(context)),
       builder: (context, child) => Notifications(child: child),
       routerDelegate: DevToolsRouterDelegate(_getPage),
       routeInformationParser: DevToolsRouteInformationParser(),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -291,7 +291,10 @@ class DevToolsAppState extends State<DevToolsApp> {
   Widget build(BuildContext context) {
     return MaterialApp.router(
       debugShowCheckedModeBanner: false,
-      theme: themeFor(isDarkTheme: isDarkThemeEnabled, ideTheme: ideTheme, theme: Theme.of(context)),
+      theme: themeFor(
+          isDarkTheme: isDarkThemeEnabled,
+          ideTheme: ideTheme,
+          theme: Theme.of(context)),
       builder: (context, child) => Notifications(child: child),
       routerDelegate: DevToolsRouterDelegate(_getPage),
       routeInformationParser: DevToolsRouteInformationParser(),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -15,7 +15,6 @@ import 'analytics/provider.dart';
 import 'app_size/app_size_controller.dart';
 import 'app_size/app_size_screen.dart';
 import 'common_widgets.dart';
-import 'config_specific/ide_theme/ide_theme.dart';
 import 'config_specific/server/server.dart';
 import 'debugger/debugger_controller.dart';
 import 'debugger/debugger_screen.dart';

--- a/packages/devtools_app/lib/src/config_specific/ide_theme/ide_theme.dart
+++ b/packages/devtools_app/lib/src/config_specific/ide_theme/ide_theme.dart
@@ -15,4 +15,8 @@ class IdeTheme {
   Color backgroundColor;
   Color foregroundColor;
   double fontSize;
+
+  double fontSizeFactor() {
+    return fontSize != null ? fontSize / 14.0 : 1.0;
+  }
 }

--- a/packages/devtools_app/lib/src/config_specific/ide_theme/ide_theme.dart
+++ b/packages/devtools_app/lib/src/config_specific/ide_theme/ide_theme.dart
@@ -12,11 +12,9 @@ export 'ide_theme_stub.dart'
 class IdeTheme {
   IdeTheme({this.backgroundColor, this.foregroundColor, this.fontSize});
 
-  Color backgroundColor;
-  Color foregroundColor;
-  double fontSize;
+  final Color backgroundColor;
+  final Color foregroundColor;
+  final double fontSize;
 
-  double fontSizeFactor() {
-    return fontSize != null ? fontSize / 14.0 : 1.0;
-  }
+  double get fontSizeFactor => fontSize != null ? fontSize / 14.0 : 1.0;
 }

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -45,8 +45,8 @@ class CodeView extends StatefulWidget {
     this.onSelected,
   }) : super(key: key);
 
-  static double get rowHeight => 20.0 * ideTheme.fontSizeFactor();
-  static double get assumedCharacterWidth => 16.0 * ideTheme.fontSizeFactor();
+  static double get rowHeight => scaleByFontFactor(20.0);
+  static double get assumedCharacterWidth => scaleByFontFactor(16.0);
 
   final DebuggerController controller;
   final ScriptRef scriptRef;

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -45,8 +45,8 @@ class CodeView extends StatefulWidget {
     this.onSelected,
   }) : super(key: key);
 
-  static const rowHeight = 20.0;
-  static const assumedCharacterWidth = 16.0;
+  static double get rowHeight => 20.0 * ideTheme.fontSizeFactor();
+  static double get assumedCharacterWidth => 16.0 * ideTheme.fontSizeFactor();
 
   final DebuggerController controller;
   final ScriptRef scriptRef;

--- a/packages/devtools_app/lib/src/globals.dart
+++ b/packages/devtools_app/lib/src/globals.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'config_specific/ide_theme/ide_theme.dart';
 import 'core/message_bus.dart';
 import 'extension_points/extensions_base.dart';
 import 'framework_controller.dart';
@@ -34,6 +35,8 @@ PreferencesController get preferences => globals[PreferencesController];
 
 DevToolsExtensionPoints get devToolsExtensionPoints =>
     globals[DevToolsExtensionPoints];
+
+IdeTheme get ideTheme => globals[IdeTheme];
 
 void setGlobal(Type clazz, dynamic instance) {
   globals[clazz] = instance;

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -11,6 +11,7 @@
 /// and will help simplify porting this code to work with Hummingbird.
 library inspector_tree;
 
+import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
@@ -42,8 +43,8 @@ extension InspectorColorScheme on ColorScheme {
 const double iconPadding = 5.0;
 const double chartLineStrokeWidth = 1.0;
 const double columnWidth = 16.0;
-const double verticalPadding = 10.0;
-const double rowHeight = 24.0;
+double get verticalPadding => 10.0 * ideTheme.fontSizeFactor();
+double get rowHeight => 24.0 * ideTheme.fontSizeFactor();
 
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -16,8 +16,8 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import '../config_specific/logger/logger.dart';
-import '../globals.dart';
 import '../theme.dart';
+import '../utils.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service.dart';
 
@@ -43,8 +43,8 @@ extension InspectorColorScheme on ColorScheme {
 const double iconPadding = 5.0;
 const double chartLineStrokeWidth = 1.0;
 const double columnWidth = 16.0;
-double get verticalPadding => 10.0 * ideTheme.fontSizeFactor();
-double get rowHeight => 24.0 * ideTheme.fontSizeFactor();
+double get verticalPadding => scaleByFontFactor(10.0);
+double get rowHeight => scaleByFontFactor(24.0);
 
 /// This class could be refactored out to be a reasonable generic collapsible
 /// tree ui node class but we choose to instead make it widget inspector

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -11,12 +11,12 @@
 /// and will help simplify porting this code to work with Hummingbird.
 library inspector_tree;
 
-import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import '../config_specific/logger/logger.dart';
+import '../globals.dart';
 import '../theme.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service.dart';

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -32,11 +32,11 @@ ThemeData themeFor({
     primaryTextTheme: (theme != null
             ? theme.primaryTextTheme.merge(colorTheme.primaryTextTheme)
             : colorTheme.primaryTextTheme)
-        .apply(fontSizeFactor: ideTheme?.fontSizeFactor),
+        .apply(fontSizeFactor: ideTheme?.fontSizeFactor ?? 1.0),
     textTheme: (theme != null
             ? theme.textTheme.merge(colorTheme.textTheme)
             : colorTheme.textTheme)
-        .apply(fontSizeFactor: ideTheme?.fontSizeFactor),
+        .apply(fontSizeFactor: ideTheme?.fontSizeFactor ?? 1.0),
   );
 }
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -29,8 +29,8 @@ ThemeData themeFor({
   }
 
   return colorTheme.copyWith(
-    primaryTextTheme: theme.primaryTextTheme.merge(colorTheme.primaryTextTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor()),
-    textTheme: theme.textTheme.merge(colorTheme.textTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor()),
+    primaryTextTheme: theme.primaryTextTheme.merge(colorTheme.primaryTextTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor),
+    textTheme: theme.textTheme.merge(colorTheme.textTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor),
   );
 }
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -16,15 +16,22 @@ const contrastForegroundWhite = _contrastForegroundWhite;
 ThemeData themeFor({
   @required bool isDarkTheme,
   @required IdeTheme ideTheme,
+  ThemeData theme,
 }) {
+  ThemeData colorTheme;
   // If the theme specifies a background color, use it to infer a theme.
   if (isValidDarkColor(ideTheme?.backgroundColor)) {
-    return _darkTheme(ideTheme);
+    colorTheme = _darkTheme(ideTheme);
   } else if (isValidLightColor(ideTheme?.backgroundColor)) {
-    return _lightTheme(ideTheme);
+    colorTheme = _lightTheme(ideTheme);
+  } else {
+    colorTheme = isDarkTheme ? _darkTheme(ideTheme) : _lightTheme(ideTheme);
   }
 
-  return isDarkTheme ? _darkTheme(ideTheme) : _lightTheme(ideTheme);
+  return colorTheme.copyWith(
+    primaryTextTheme: theme.primaryTextTheme.merge(colorTheme.primaryTextTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor()),
+    textTheme: theme.textTheme.merge(colorTheme.textTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor()),
+  );
 }
 
 ThemeData _darkTheme(IdeTheme ideTheme) {

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -29,11 +29,11 @@ ThemeData themeFor({
   }
 
   return colorTheme.copyWith(
-    primaryTextTheme: theme.primaryTextTheme
-        .merge(colorTheme.primaryTextTheme)
+    primaryTextTheme: (theme != null ? theme.primaryTextTheme
+        .merge(colorTheme.primaryTextTheme) : colorTheme.primaryTextTheme)
         .apply(fontSizeFactor: ideTheme.fontSizeFactor),
-    textTheme: theme.textTheme
-        .merge(colorTheme.textTheme)
+    textTheme: (theme != null ? theme.textTheme
+        .merge(colorTheme.textTheme) : colorTheme.textTheme)
         .apply(fontSizeFactor: ideTheme.fontSizeFactor),
   );
 }

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -29,11 +29,13 @@ ThemeData themeFor({
   }
 
   return colorTheme.copyWith(
-    primaryTextTheme: (theme != null ? theme.primaryTextTheme
-        .merge(colorTheme.primaryTextTheme) : colorTheme.primaryTextTheme)
+    primaryTextTheme: (theme != null
+            ? theme.primaryTextTheme.merge(colorTheme.primaryTextTheme)
+            : colorTheme.primaryTextTheme)
         .apply(fontSizeFactor: ideTheme.fontSizeFactor),
-    textTheme: (theme != null ? theme.textTheme
-        .merge(colorTheme.textTheme) : colorTheme.textTheme)
+    textTheme: (theme != null
+            ? theme.textTheme.merge(colorTheme.textTheme)
+            : colorTheme.textTheme)
         .apply(fontSizeFactor: ideTheme.fontSizeFactor),
   );
 }

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -32,11 +32,11 @@ ThemeData themeFor({
     primaryTextTheme: (theme != null
             ? theme.primaryTextTheme.merge(colorTheme.primaryTextTheme)
             : colorTheme.primaryTextTheme)
-        .apply(fontSizeFactor: ideTheme.fontSizeFactor),
+        .apply(fontSizeFactor: ideTheme?.fontSizeFactor),
     textTheme: (theme != null
             ? theme.textTheme.merge(colorTheme.textTheme)
             : colorTheme.textTheme)
-        .apply(fontSizeFactor: ideTheme.fontSizeFactor),
+        .apply(fontSizeFactor: ideTheme?.fontSizeFactor),
   );
 }
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -29,8 +29,12 @@ ThemeData themeFor({
   }
 
   return colorTheme.copyWith(
-    primaryTextTheme: theme.primaryTextTheme.merge(colorTheme.primaryTextTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor),
-    textTheme: theme.textTheme.merge(colorTheme.textTheme).apply(fontSizeFactor: ideTheme.fontSizeFactor),
+    primaryTextTheme: theme.primaryTextTheme
+        .merge(colorTheme.primaryTextTheme)
+        .apply(fontSizeFactor: ideTheme.fontSizeFactor),
+    textTheme: theme.textTheme
+        .merge(colorTheme.textTheme)
+        .apply(fontSizeFactor: ideTheme.fontSizeFactor),
   );
 }
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -9,7 +9,6 @@ import 'dart:math';
 
 import 'package:ansi_up/ansi_up.dart';
 import 'package:collection/collection.dart';
-import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -18,8 +17,8 @@ import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:vm_service/vm_service.dart';
 
-import 'config_specific/ide_theme/ide_theme.dart';
 import 'config_specific/logger/logger.dart' as logger;
+import 'globals.dart';
 import 'notifications.dart';
 
 /// Public properties first, then sort alphabetically

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 
 import 'package:ansi_up/ansi_up.dart';
 import 'package:collection/collection.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -17,6 +18,7 @@ import 'package:intl/intl.dart';
 import 'package:url_launcher/url_launcher.dart' as url_launcher;
 import 'package:vm_service/vm_service.dart';
 
+import 'config_specific/ide_theme/ide_theme.dart';
 import 'config_specific/logger/logger.dart' as logger;
 import 'notifications.dart';
 
@@ -1271,4 +1273,8 @@ class ImmutableList<T> with ListMixin<T> implements List<T> {
   void shuffle([Random random]) {
     throw Exception('Cannot modify the content of ImmutableList');
   }
+}
+
+double scaleByFontFactor(double original) {
+  return (original * ideTheme.fontSizeFactor).roundToDouble();
 }

--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -56,7 +56,6 @@ Future<void> main() async {
         bundle: _DiskAssetBundle(),
         child: DevToolsApp(
           const [],
-          null,
           await analyticsProvider,
         ),
       );


### PR DESCRIPTION
https://github.com/flutter/devtools/pull/2459 was the original attempt to implement variable font size (see for more context), but this PR uses a global variable set from main instead of setting a factor based on theme later. We were originally going to refactor some controller classes to enable passing font size through (see https://github.com/flutter/devtools/issues/2482), but this is easier and seems like a reasonable method. 