### PR TITLE
Make a copy of performance page files under performance/legacy

### DIFF
--- a/packages/devtools_app/lib/src/performance/legacy/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/flutter_frames_chart.dart
@@ -1,0 +1,519 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auto_dispose_mixin.dart';
+import '../../common_widgets.dart';
+import '../../theme.dart';
+import '../../ui/colors.dart';
+import '../../utils.dart';
+import 'performance_controller.dart';
+import 'performance_model.dart';
+
+class FlutterFramesChart extends StatefulWidget {
+  const FlutterFramesChart(
+    this.frames,
+    this.displayRefreshRate,
+  );
+
+  static const chartLegendKey = Key('Flutter frames chart legend');
+
+  final List<FlutterFrame> frames;
+
+  final double displayRefreshRate;
+
+  @override
+  _FlutterFramesChartState createState() => _FlutterFramesChartState();
+}
+
+class _FlutterFramesChartState extends State<FlutterFramesChart>
+    with AutoDisposeMixin {
+  static const defaultFrameWidthWithPadding =
+      FlutterFramesChartItem.defaultFrameWidth + densePadding * 2;
+
+  static const yAxisUnitsSpace = 48.0;
+
+  static const legendSquareSize = 16.0;
+
+  static const outlineBorderWidth = 1.0;
+
+  PerformanceController _controller;
+
+  ScrollController scrollController;
+
+  FlutterFrame _selectedFrame;
+
+  double horizontalScrollOffset = 0.0;
+
+  double get availableChartHeight => defaultChartHeight - defaultSpacing;
+
+  /// Milliseconds per pixel value for the y-axis.
+  ///
+  /// This value will result in a y-axis time range spanning two times the
+  /// target frame time for a single frame (e.g. 16.6 * 2 for a 60 FPS device).
+  double get msPerPx =>
+      // Multiply by two to reach two times the target frame time.
+      1 / widget.displayRefreshRate * 1000 * 2 / availableChartHeight;
+
+  @override
+  void initState() {
+    super.initState();
+    scrollController = ScrollController()
+      ..addListener(() {
+        horizontalScrollOffset = scrollController.offset;
+      });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newController = Provider.of<PerformanceController>(context);
+    if (newController == _controller) return;
+    _controller = newController;
+
+    cancel();
+    addAutoDisposeListener(_controller.selectedFrame, () {
+      setState(() {
+        _selectedFrame = _controller.selectedFrame.value;
+      });
+    });
+  }
+
+  @override
+  void didUpdateWidget(FlutterFramesChart oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (scrollController.hasClients && scrollController.atScrollBottom) {
+      scrollController.autoScrollToBottom();
+    }
+  }
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.only(
+        left: denseSpacing,
+        right: denseSpacing,
+        bottom: defaultSpacing,
+      ),
+      height: defaultChartHeight + defaultScrollBarOffset,
+      child: Row(
+        children: [
+          Expanded(child: _buildChart()),
+          const SizedBox(width: defaultSpacing),
+          Padding(
+            padding: const EdgeInsets.only(bottom: defaultScrollBarOffset),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildChartLegend(),
+                if (widget.frames.isNotEmpty) _buildAverageFps(),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChart() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final themeData = Theme.of(context);
+        final chart = Scrollbar(
+          isAlwaysShown: true,
+          controller: scrollController,
+          child: Padding(
+            padding: const EdgeInsets.only(bottom: defaultScrollBarOffset),
+            child: RoundedOutlinedBorder(
+              child: ListView.builder(
+                controller: scrollController,
+                scrollDirection: Axis.horizontal,
+                itemCount: widget.frames.length,
+                itemExtent: defaultFrameWidthWithPadding,
+                itemBuilder: (context, index) =>
+                    _buildFrame(widget.frames[index]),
+              ),
+            ),
+          ),
+        );
+        final chartAxisPainter = CustomPaint(
+          painter: ChartAxisPainter(
+            constraints: constraints,
+            displayRefreshRate: widget.displayRefreshRate,
+            msPerPx: msPerPx,
+            themeData: themeData,
+          ),
+        );
+        final fpsLinePainter = CustomPaint(
+          painter: FPSLinePainter(
+            constraints: constraints,
+            displayRefreshRate: widget.displayRefreshRate,
+            msPerPx: msPerPx,
+            themeData: themeData,
+          ),
+        );
+        return Stack(
+          children: [
+            chartAxisPainter,
+            Padding(
+              padding: const EdgeInsets.only(left: yAxisUnitsSpace),
+              child: chart,
+            ),
+            fpsLinePainter,
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildFrame(FlutterFrame frame) {
+    return InkWell(
+      onTap: () => _controller.toggleSelectedFrame(frame),
+      child: FlutterFramesChartItem(
+        frame: frame,
+        selected: frame == _selectedFrame,
+        msPerPx: msPerPx,
+        availableChartHeight: availableChartHeight - 2 * outlineBorderWidth,
+        displayRefreshRate: widget.displayRefreshRate,
+      ),
+    );
+  }
+
+  Widget _buildChartLegend() {
+    return Column(
+      key: FlutterFramesChart.chartLegendKey,
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        _legendItem('Frame Time (UI)', mainUiColor),
+        const SizedBox(height: denseRowSpacing),
+        _legendItem('Frame Time (Raster)', mainRasterColor),
+        const SizedBox(height: denseRowSpacing),
+        _legendItem('Jank (slow frame)', uiJankColor),
+      ],
+    );
+  }
+
+  Widget _legendItem(String description, Color color) {
+    return Row(
+      children: [
+        Container(
+          height: legendSquareSize,
+          width: legendSquareSize,
+          color: color,
+        ),
+        const SizedBox(width: denseSpacing),
+        Text(description),
+      ],
+    );
+  }
+
+  Widget _buildAverageFps() {
+    final double sumFrameTimesMs = widget.frames.fold(
+      0.0,
+      (sum, frame) =>
+          sum +
+          math.max(
+            1000 / widget.displayRefreshRate,
+            math.max(frame.uiDurationMs, frame.rasterDurationMs),
+          ),
+    );
+    final avgFrameTime = sumFrameTimesMs / widget.frames.length;
+    final avgFps = (1 / avgFrameTime * 1000).round();
+    return Text(
+      '$avgFps FPS (average)',
+      maxLines: 2,
+    );
+  }
+}
+
+class FlutterFramesChartItem extends StatelessWidget {
+  const FlutterFramesChartItem({
+    @required this.frame,
+    @required this.selected,
+    @required this.msPerPx,
+    @required this.availableChartHeight,
+    @required this.displayRefreshRate,
+  });
+
+  static const defaultFrameWidth = 32.0;
+
+  static const selectedIndicatorHeight = 8.0;
+
+  static const selectedFrameIndicatorKey =
+      Key('flutter frames chart - selected frame indicator');
+
+  final FlutterFrame frame;
+
+  final bool selected;
+
+  final double msPerPx;
+
+  final double availableChartHeight;
+
+  final double displayRefreshRate;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final bool uiJanky = frame.isUiJanky(displayRefreshRate);
+    final bool rasterJanky = frame.isRasterJanky(displayRefreshRate);
+    // TODO(kenz): add some indicator when a frame is so janky that it exceeds the
+    // available axis space.
+    final ui = Container(
+      key: Key('frame ${frame.id} - ui'),
+      width: defaultFrameWidth / 2,
+      height: (frame.uiDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      color: uiJanky ? uiJankColor : mainUiColor,
+    );
+    final raster = Container(
+      key: Key('frame ${frame.id} - raster'),
+      width: defaultFrameWidth / 2,
+      height:
+          (frame.rasterDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      color: rasterJanky ? rasterJankColor : mainRasterColor,
+    );
+    return Stack(
+      children: [
+        // TODO(kenz): make tooltip to persist if the frame is selected.
+        DevToolsTooltip(
+          tooltip: _tooltipText(frame),
+          padding: const EdgeInsets.all(denseSpacing),
+          child: Container(
+            padding: const EdgeInsets.symmetric(horizontal: densePadding),
+            color: selected ? colorScheme.selectedFrameBackgroundColor : null,
+            child: Column(
+              children: [
+                // Dummy child so that the InkWell does not take up the entire column.
+                const Expanded(child: SizedBox()),
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.end,
+                  children: [
+                    ui,
+                    raster,
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+        if (selected)
+          Container(
+            key: selectedFrameIndicatorKey,
+            color: defaultSelectionColor,
+            height: selectedIndicatorHeight,
+          ),
+      ],
+    );
+  }
+
+  String _tooltipText(FlutterFrame frame) {
+    return 'UI: ${msText(frame.uiEventFlow.time.duration)}\n'
+        'Raster: ${msText(frame.rasterEventFlow.time.duration)}';
+  }
+}
+
+class ChartAxisPainter extends CustomPainter {
+  ChartAxisPainter({
+    @required this.constraints,
+    @required this.displayRefreshRate,
+    @required this.msPerPx,
+    @required this.themeData,
+  });
+
+  static const yAxisTickWidth = 8.0;
+
+  final BoxConstraints constraints;
+
+  final double displayRefreshRate;
+
+  final double msPerPx;
+
+  final ThemeData themeData;
+
+  ColorScheme get colorScheme => themeData.colorScheme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // The absolute coordinates of the chart's visible area.
+    final chartArea = Rect.fromLTWH(
+      _FlutterFramesChartState.yAxisUnitsSpace,
+      0.0,
+      constraints.maxWidth - _FlutterFramesChartState.yAxisUnitsSpace,
+      constraints.maxHeight - defaultScrollBarOffset,
+    );
+
+    _paintYAxisLabels(canvas, chartArea);
+  }
+
+  void _paintYAxisLabels(
+    Canvas canvas,
+    Rect chartArea,
+  ) {
+    const yAxisLabelCount = 6;
+    final totalMs = msPerPx * constraints.maxHeight;
+
+    // Subtract 1 because one of the labels will be 0.0 ms.
+    final int timeUnitMs = totalMs ~/ (yAxisLabelCount - 1);
+
+    // Max FPS non-jank value in ms. E.g., 16.6 for 60 FPS, 8.3 for 120 FPS.
+    final targetMsPerFrame = 1 / displayRefreshRate * 1000;
+    final targetMsPerFrameRounded = targetMsPerFrame.round();
+
+    // TODO(kenz): maybe we should consider making these round values in
+    // multiples of 5 or 10?
+    // Y axis time units centered around [targetMsPerFrameRounded].
+    final yAxisTimes = [
+      0,
+      for (int timeMs = targetMsPerFrameRounded - timeUnitMs;
+          timeMs > 0;
+          timeMs -= timeUnitMs)
+        timeMs,
+      targetMsPerFrameRounded,
+      for (int timeMs = targetMsPerFrameRounded + timeUnitMs;
+          timeMs < totalMs;
+          timeMs += timeUnitMs)
+        timeMs,
+    ];
+
+    for (final timeMs in yAxisTimes) {
+      _paintYAxisLabel(canvas, chartArea, timeMs: timeMs);
+    }
+  }
+
+  void _paintYAxisLabel(
+    Canvas canvas,
+    Rect chartArea, {
+    @required int timeMs,
+  }) {
+    final labelText = msText(
+      Duration(milliseconds: timeMs),
+      fractionDigits: 0,
+    );
+
+    // Paint a tick on the axis.
+    final tickY = chartArea.height - timeMs / msPerPx;
+    canvas.drawLine(
+      Offset(chartArea.left - yAxisTickWidth / 2, tickY),
+      Offset(chartArea.left + yAxisTickWidth / 2, tickY),
+      Paint()..color = colorScheme.chartAccentColor,
+    );
+
+    // Paint the axis label.
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: labelText,
+        style: TextStyle(
+          color: colorScheme.chartSubtleColor,
+          fontSize: chartFontSizeSmall,
+        ),
+      ),
+      textAlign: TextAlign.end,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    const baselineAdjust = 2.0;
+
+    textPainter.paint(
+      canvas,
+      Offset(
+        _FlutterFramesChartState.yAxisUnitsSpace -
+            yAxisTickWidth / 2 -
+            densePadding - // Padding between y axis tick and label
+            textPainter.width,
+        chartArea.height -
+            timeMs / msPerPx -
+            textPainter.height / 2 -
+            baselineAdjust,
+      ),
+    );
+  }
+
+  @override
+  bool shouldRepaint(ChartAxisPainter oldDelegate) {
+    return themeData.isDarkTheme != oldDelegate.themeData.isDarkTheme;
+  }
+}
+
+class FPSLinePainter extends CustomPainter {
+  FPSLinePainter({
+    @required this.constraints,
+    @required this.displayRefreshRate,
+    @required this.msPerPx,
+    @required this.themeData,
+  });
+
+  static const fpsTextSpace = 45.0;
+
+  final BoxConstraints constraints;
+
+  final double displayRefreshRate;
+
+  final double msPerPx;
+
+  final ThemeData themeData;
+
+  ColorScheme get colorScheme => themeData.colorScheme;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // The absolute coordinates of the chart's visible area.
+    final chartArea = Rect.fromLTWH(
+      _FlutterFramesChartState.yAxisUnitsSpace,
+      0.0,
+      constraints.maxWidth - _FlutterFramesChartState.yAxisUnitsSpace,
+      constraints.maxHeight - defaultScrollBarOffset,
+    );
+
+    // Max FPS non-jank value in ms. E.g., 16.6 for 60 FPS, 8.3 for 120 FPS.
+    final targetMsPerFrame = 1000 / displayRefreshRate;
+    final targetLineY = chartArea.height - targetMsPerFrame / msPerPx;
+
+    canvas.drawLine(
+      Offset(chartArea.left, targetLineY),
+      Offset(chartArea.right, targetLineY),
+      Paint()..color = colorScheme.chartAccentColor,
+    );
+
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: '${displayRefreshRate.toStringAsFixed(0)} FPS',
+        style: TextStyle(
+          color: colorScheme.chartSubtleColor,
+          fontSize: chartFontSizeSmall,
+        ),
+      ),
+      textAlign: TextAlign.right,
+      textDirection: TextDirection.ltr,
+    )..layout();
+
+    textPainter.paint(
+      canvas,
+      Offset(
+        chartArea.right - fpsTextSpace,
+        targetLineY + borderPadding,
+      ),
+    );
+  }
+
+  @override
+  bool shouldRepaint(FPSLinePainter oldDelegate) {
+    return themeData.isDarkTheme != oldDelegate.themeData.isDarkTheme;
+  }
+}

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -1,0 +1,526 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:pedantic/pedantic.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
+
+import '../../auto_dispose.dart';
+import '../../config_specific/import_export/import_export.dart';
+import '../../config_specific/logger/allowed_error.dart';
+import '../../config_specific/logger/logger.dart';
+import '../../globals.dart';
+import '../../http/http_service.dart';
+import '../../profiler/cpu_profile_controller.dart';
+import '../../profiler/cpu_profile_service.dart';
+import '../../profiler/cpu_profile_transformer.dart';
+import '../../profiler/profile_granularity.dart';
+import '../../service_manager.dart';
+import '../../trace_event.dart';
+import '../../trees.dart';
+import '../../ui/search.dart';
+import '../../utils.dart';
+import '../performance_screen.dart';
+import '../timeline_streams.dart';
+import 'performance_model.dart';
+import 'timeline_event_processor.dart';
+
+/// This class contains the business logic for [performance_screen.dart].
+///
+/// The controller manages the timeline data model and communicates with the
+/// view to give and receive data updates. It also manages data processing via
+/// [TimelineEventProcessor] and [CpuProfileTransformer].
+///
+/// This class must not have direct dependencies on dart:html. This allows tests
+/// of the complicated logic in this class to run on the VM and will help
+/// simplify porting this code to work with Hummingbird.
+class PerformanceController
+    with
+        CpuProfilerControllerProviderMixin,
+        SearchControllerMixin<TimelineEvent>
+    implements DisposableController {
+  PerformanceController() {
+    processor = TimelineEventProcessor(this);
+    _init();
+  }
+
+  final _exportController = ExportController();
+
+  /// The currently selected timeline event.
+  ValueListenable<TimelineEvent> get selectedTimelineEvent =>
+      _selectedTimelineEventNotifier;
+  final _selectedTimelineEventNotifier = ValueNotifier<TimelineEvent>(null);
+
+  /// The currently selected timeline frame.
+  ValueListenable<FlutterFrame> get selectedFrame => _selectedFrameNotifier;
+  final _selectedFrameNotifier = ValueNotifier<FlutterFrame>(null);
+
+  /// The flutter frames in the current timeline.
+  ValueListenable<List<FlutterFrame>> get flutterFrames => _flutterFrames;
+  final _flutterFrames = ValueNotifier<List<FlutterFrame>>([]);
+
+  /// Whether an empty timeline recording was just recorded.
+  ValueListenable<bool> get emptyTimeline => _emptyTimeline;
+  final _emptyTimeline = ValueNotifier<bool>(false);
+
+  /// Whether the timeline is currently being recorded.
+  ValueListenable<bool> get refreshing => _refreshing;
+  final _refreshing = ValueNotifier<bool>(false);
+
+  /// Whether the recorded timeline data is currently being processed.
+  ValueListenable<bool> get processing => _processing;
+  final _processing = ValueNotifier<bool>(false);
+
+  // TODO(jacobr): this isn't accurate. Another page of DevTools
+  // or a different instance of DevTools could change this value. We need to
+  // sync the value with the server like we do for other vm service extensions
+  // that we track with the vm service extension manager.
+  // See https://github.com/dart-lang/sdk/issues/41823.
+  /// Whether http timeline logging is enabled.
+  ValueListenable<bool> get httpTimelineLoggingEnabled =>
+      _httpTimelineLoggingEnabled;
+  final _httpTimelineLoggingEnabled = ValueNotifier<bool>(false);
+
+  ValueListenable<bool> get badgeTabForJankyFrames => _badgeTabForJankyFrames;
+  final _badgeTabForJankyFrames = ValueNotifier<bool>(false);
+
+  // TODO(kenz): switch to use VmFlagManager-like pattern once
+  // https://github.com/dart-lang/sdk/issues/41822 is fixed.
+  /// Recorded timeline stream values.
+  final recordedStreams = [
+    dartTimelineStream,
+    embedderTimelineStream,
+    gcTimelineStream,
+    apiTimelineStream,
+    compilerTimelineStream,
+    compilerVerboseTimelineStream,
+    debuggerTimelineStream,
+    isolateTimelineStream,
+    vmTimelineStream,
+  ];
+
+  final threadNamesById = <int, String>{};
+
+  /// Active timeline data.
+  ///
+  /// This is the true source of data for the UI. In the case of an offline
+  /// import, this will begin as a copy of [offlinePerformanceData] (the original
+  /// data from the imported file). If any modifications are made while the data
+  /// is displayed (e.g. change in selected timeline event, selected frame,
+  /// etc.), those changes will be tracked here.
+  PerformanceData data;
+
+  /// Timeline data loaded via import.
+  ///
+  /// This is expected to be null when we are not in [offlineMode].
+  ///
+  /// This will contain the original data from the imported file, regardless of
+  /// any selection modifications that occur while the data is displayed. [data]
+  /// will start as a copy of offlineTimelineData in this case, and will track
+  /// any data modifications that occur while the data is displayed (e.g. change
+  /// in selected timeline event, selected frame, etc.).
+  PerformanceData offlinePerformanceData;
+
+  TimelineEventProcessor processor;
+
+  /// Trace events in the current timeline.
+  ///
+  /// This list is cleared and repopulated each time "Refresh" is clicked.
+  List<TraceEventWrapper> allTraceEvents = [];
+
+  Future<void> _initialized;
+  Future<void> get initialized => _initialized;
+
+  Future<void> _init() {
+    return _initialized = _initHelper();
+  }
+
+  Future<void> _initHelper() async {
+    await serviceManager.onServiceAvailable;
+
+    // Default to true for profile builds only.
+    _badgeTabForJankyFrames.value =
+        await serviceManager.connectedApp.isProfileBuild;
+
+    unawaited(allowedError(
+      serviceManager.service.setProfilePeriod(mediumProfilePeriod),
+      logError: false,
+    ));
+    await setTimelineStreams([
+      dartTimelineStream,
+      embedderTimelineStream,
+      gcTimelineStream,
+    ]);
+    await toggleHttpRequestLogging(true);
+
+    // Initialize displayRefreshRate.
+    _displayRefreshRate.value =
+        await serviceManager.queryDisplayRefreshRate ?? defaultRefreshRate;
+    data?.displayRefreshRate = _displayRefreshRate.value;
+  }
+
+  Future<void> selectTimelineEvent(TimelineEvent event) async {
+    if (event == null || data.selectedEvent == event) return;
+
+    data.selectedEvent = event;
+    _selectedTimelineEventNotifier.value = event;
+
+    cpuProfilerController.reset();
+
+    // Fetch a profile if not in offline mode and if the profiler is enabled.
+    if ((!offlineMode || offlinePerformanceData == null) &&
+        cpuProfilerController.profilerEnabled) {
+      await getCpuProfileForSelectedEvent();
+    }
+  }
+
+  Future<void> getCpuProfileForSelectedEvent() async {
+    final selectedEvent = data.selectedEvent;
+    if (!selectedEvent.isUiEvent) return;
+
+    await cpuProfilerController.pullAndProcessProfile(
+      startMicros: selectedEvent.time.start.inMicroseconds,
+      extentMicros: selectedEvent.time.duration.inMicroseconds,
+      processId: '${selectedEvent.traceEvents.first.id}',
+    );
+    data.cpuProfileData = cpuProfilerController.dataNotifier.value;
+  }
+
+  ValueListenable<double> get displayRefreshRate => _displayRefreshRate;
+  final _displayRefreshRate = ValueNotifier<double>(defaultRefreshRate);
+
+  Future<void> toggleSelectedFrame(FlutterFrame frame) async {
+    if (frame == null || data == null) {
+      return;
+    }
+
+    // Unselect [frame] if is already selected.
+    if (data.selectedFrame == frame) {
+      data.selectedFrame = null;
+      _selectedFrameNotifier.value = null;
+      return;
+    }
+
+    data.selectedFrame = frame;
+    _selectedFrameNotifier.value = frame;
+
+    await selectTimelineEvent(frame.uiEventFlow);
+
+    if (debugTimeline && frame != null) {
+      final buf = StringBuffer();
+      buf.writeln('UI timeline event for frame ${frame.id}:');
+      frame.uiEventFlow.format(buf, '  ');
+      buf.writeln('\nUI trace for frame ${frame.id}');
+      frame.uiEventFlow.writeTraceToBuffer(buf);
+      buf.writeln('\Raster timeline event frame ${frame.id}:');
+      frame.rasterEventFlow.format(buf, '  ');
+      buf.writeln('\nRaster trace for frame ${frame.id}');
+      frame.rasterEventFlow.writeTraceToBuffer(buf);
+      log(buf.toString());
+    }
+  }
+
+  void addFrame(FlutterFrame frame) {
+    data.frames.add(frame);
+  }
+
+  Future<void> refreshData() async {
+    await clearData(clearVmTimeline: false);
+    data = serviceManager.connectedApp.isFlutterAppNow
+        ? PerformanceData(
+            displayRefreshRate: await serviceManager.queryDisplayRefreshRate)
+        : PerformanceData();
+
+    _emptyTimeline.value = false;
+    _refreshing.value = true;
+    allTraceEvents.clear();
+    final timeline = await serviceManager.service.getVMTimeline();
+    primeThreadIds(timeline);
+    for (final event in timeline.traceEvents) {
+      final eventWrapper = TraceEventWrapper(
+        TraceEvent(event.json),
+        DateTime.now().millisecondsSinceEpoch,
+      );
+      allTraceEvents.add(eventWrapper);
+    }
+
+    _refreshing.value = false;
+
+    if (allTraceEvents.isEmpty) {
+      _emptyTimeline.value = true;
+      return;
+    }
+
+    _processing.value = true;
+    await processTraceEvents(allTraceEvents);
+    _processing.value = false;
+
+    _flutterFrames.value = data.frames;
+
+    _maybeBadgeTabForJankyFrames();
+  }
+
+  void _maybeBadgeTabForJankyFrames() {
+    if (_badgeTabForJankyFrames.value) {
+      for (final frame in _flutterFrames.value) {
+        if (frame.isJanky(_displayRefreshRate.value)) {
+          serviceManager.errorBadgeManager
+              .incrementBadgeCount(PerformanceScreen.id);
+        }
+      }
+    }
+  }
+
+  void primeThreadIds(vm_service.Timeline timeline) {
+    threadNamesById.clear();
+    final threadNameEvents = timeline.traceEvents
+        .map((event) => TraceEvent(event.json))
+        .where((TraceEvent event) {
+      return event.phase == 'M' && event.name == 'thread_name';
+    }).toList();
+
+    // TODO(kenz): Remove this logic once ui/raster distinction changes are
+    // available in the engine.
+    int uiThreadId;
+    int rasterThreadId;
+    for (TraceEvent event in threadNameEvents) {
+      final name = event.args['name'];
+
+      // Android: "1.ui (12652)"
+      // iOS: "io.flutter.1.ui (12652)"
+      // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
+      if (name.contains('.ui')) {
+        uiThreadId = event.threadId;
+      }
+
+      // Android: "1.raster (12651)"
+      // iOS: "io.flutter.1.raster (12651)"
+      // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
+      // MacOS: Does not exist
+      // Also look for .gpu here for older versions of Flutter.
+      // TODO(kenz): remove check for .gpu name in April 2021.
+      if (name.contains('.raster') || name.contains('.gpu')) {
+        rasterThreadId = event.threadId;
+      }
+
+      // Android: "1.platform (22585)"
+      // iOS: "io.flutter.1.platform (22585)"
+      // MacOS, Linux, Windows, Dream (g3): "io.flutter.platform (22596)"
+      if (name.contains('.platform')) {
+        // MacOS and Flutter apps with platform views do not have a .gpu thread.
+        // In these cases, the "Raster" events will come on the .platform thread
+        // instead.
+        rasterThreadId ??= event.threadId;
+      }
+
+      threadNamesById[event.threadId] = name;
+    }
+
+    if (uiThreadId == null || rasterThreadId == null) {
+      log('Could not find UI thread and / or Raster thread from names: '
+          '${threadNamesById.values}');
+    }
+
+    processor.primeThreadIds(
+      uiThreadId: uiThreadId,
+      rasterThreadId: rasterThreadId,
+    );
+  }
+
+  void addTimelineEvent(TimelineEvent event) {
+    data.addTimelineEvent(event);
+  }
+
+  FutureOr<void> processTraceEvents(List<TraceEventWrapper> traceEvents) async {
+    await processor.processTimeline(traceEvents);
+    data.initializeEventGroups(threadNamesById);
+    if (data.eventGroups.isEmpty) {
+      _emptyTimeline.value = true;
+    }
+  }
+
+  FutureOr<void> processOfflineData(OfflinePerformanceData offlineData) async {
+    await clearData();
+    final traceEvents = [
+      for (var trace in offlineData.traceEvents)
+        TraceEventWrapper(
+          TraceEvent(trace),
+          DateTime.now().microsecondsSinceEpoch,
+        )
+    ];
+
+    // TODO(kenz): once each trace event has a ui/raster distinction bit added to
+    // the trace, we will not need to infer thread ids. This is not robust.
+    final uiThreadId = _threadIdForEvents({uiEventName}, traceEvents);
+    final rasterThreadId = _threadIdForEvents({rasterEventName}, traceEvents);
+
+    offlinePerformanceData = offlineData.shallowClone();
+    data = offlineData.shallowClone();
+
+    // Process offline data.
+    processor.primeThreadIds(
+      uiThreadId: uiThreadId,
+      rasterThreadId: rasterThreadId,
+    );
+    await processTraceEvents(traceEvents);
+    if (data.cpuProfileData != null) {
+      await cpuProfilerController.transformer
+          .processData(offlinePerformanceData.cpuProfileData);
+    }
+
+    // Set offline data.
+    setOfflineData();
+  }
+
+  int _threadIdForEvents(
+    Set<String> targetEventNames,
+    List<TraceEventWrapper> traceEvents,
+  ) {
+    const invalidThreadId = -1;
+    return traceEvents
+            .firstWhere(
+              (trace) => targetEventNames.contains(trace.event.name),
+              orElse: () => null,
+            )
+            ?.event
+            ?.threadId ??
+        invalidThreadId;
+  }
+
+  void setOfflineData() {
+    _flutterFrames.value = offlinePerformanceData.frames;
+    final frameToSelect = offlinePerformanceData.frames.firstWhere(
+      (frame) => frame.id == offlinePerformanceData.selectedFrameId,
+      orElse: () => null,
+    );
+    if (frameToSelect != null) {
+      data.selectedFrame = frameToSelect;
+      // TODO(kenz): frames bar chart should listen to this stream and
+      // programmatially select the frame from the offline snapshot.
+      _selectedFrameNotifier.value = frameToSelect;
+    }
+    if (offlinePerformanceData.selectedEvent != null) {
+      for (var timelineEvent in data.timelineEvents) {
+        final eventToSelect = timelineEvent.firstChildWithCondition((event) {
+          return event.name == offlinePerformanceData.selectedEvent.name &&
+              event.time == offlinePerformanceData.selectedEvent.time;
+        });
+        if (eventToSelect != null) {
+          data
+            ..selectedEvent = eventToSelect
+            ..cpuProfileData = offlinePerformanceData.cpuProfileData;
+          _selectedTimelineEventNotifier.value = eventToSelect;
+          break;
+        }
+      }
+    }
+
+    if (offlinePerformanceData.cpuProfileData != null) {
+      cpuProfilerController.loadProcessedData(
+        offlinePerformanceData.cpuProfileData,
+      );
+    }
+  }
+
+  /// Exports the current timeline data to a .json file.
+  ///
+  /// This method returns the name of the file that was downloaded.
+  String exportData() {
+    final encodedData =
+        _exportController.encode(PerformanceScreen.id, data.json);
+    return _exportController.downloadFile(encodedData);
+  }
+
+  @override
+  List<TimelineEvent> matchesForSearch(String search) {
+    if (search?.isEmpty ?? true) return [];
+    final matches = <TimelineEvent>[];
+    for (final event in data.timelineEvents) {
+      breadthFirstTraversal<TimelineEvent>(event, action: (TimelineEvent e) {
+        if (e.name.caseInsensitiveContains(search)) {
+          matches.add(e);
+          e.isSearchMatch = true;
+        } else {
+          e.isSearchMatch = false;
+        }
+      });
+    }
+    return matches;
+  }
+
+  Future<void> toggleHttpRequestLogging(bool state) async {
+    await HttpService.toggleHttpRequestLogging(state);
+    _httpTimelineLoggingEnabled.value = state;
+  }
+
+  Future<void> setTimelineStreams(List<RecordedTimelineStream> streams) async {
+    for (final stream in streams) {
+      assert(recordedStreams.contains(stream));
+      stream.toggle(true);
+    }
+    await serviceManager.service
+        .setVMTimelineFlags(streams.map((s) => s.name).toList());
+  }
+
+  // TODO(kenz): this is not as robust as we'd like. Revisit once
+  // https://github.com/dart-lang/sdk/issues/41822 is addressed.
+  Future<void> toggleTimelineStream(RecordedTimelineStream stream) async {
+    final newValue = !stream.enabled.value;
+    final timelineFlags =
+        (await serviceManager.service.getVMTimelineFlags()).recordedStreams;
+    if (timelineFlags.contains(stream.name) && !newValue) {
+      timelineFlags.remove(stream.name);
+    } else if (!timelineFlags.contains(stream.name) && newValue) {
+      timelineFlags.add(stream.name);
+    }
+    await serviceManager.service.setVMTimelineFlags(timelineFlags);
+    stream.toggle(newValue);
+  }
+
+  /// Clears the timeline data currently stored by the controller.
+  ///
+  /// [clearVmTimeline] defaults to true, but should be set to false if you want
+  /// to clear the data stored by the controller, but do not want to clear the
+  /// data currently stored by the VM.
+  Future<void> clearData({bool clearVmTimeline = true}) async {
+    if (clearVmTimeline && serviceManager.hasConnection) {
+      await serviceManager.service.clearVMTimeline();
+    }
+    allTraceEvents.clear();
+    offlinePerformanceData = null;
+    cpuProfilerController.reset();
+    data?.clear();
+    processor?.reset();
+    _emptyTimeline.value = true;
+    _flutterFrames.value = [];
+    _selectedTimelineEventNotifier.value = null;
+    _selectedFrameNotifier.value = null;
+    _processing.value = false;
+    serviceManager.errorBadgeManager.clearErrors(PerformanceScreen.id);
+  }
+
+  void recordTrace(Map<String, dynamic> trace) {
+    data?.traceEvents?.add(trace);
+  }
+
+  void recordTraceForTimelineEvent(TimelineEvent event) {
+    recordTrace(event.beginTraceEventJson);
+    event.children.forEach(recordTraceForTimelineEvent);
+    if (event.endTraceEventJson != null) {
+      recordTrace(event.endTraceEventJson);
+    }
+  }
+
+  @override
+  void dispose() {
+    cpuProfilerController.dispose();
+    _selectedTimelineEventNotifier.dispose();
+  }
+}

--- a/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
@@ -1,0 +1,1026 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'dart:collection';
+import 'dart:math' as math;
+
+import 'package:meta/meta.dart';
+
+import '../../charts/flame_chart.dart';
+import '../../profiler/cpu_profile_model.dart';
+import '../../service_manager.dart';
+import '../../trace_event.dart';
+import '../../trees.dart';
+import '../../ui/search.dart';
+import '../../utils.dart';
+import 'performance_utils.dart';
+import 'timeline_event_processor.dart';
+
+class PerformanceData {
+  PerformanceData({
+    List<Map<String, dynamic>> traceEvents,
+    List<FlutterFrame> frames,
+    this.selectedFrame,
+    this.selectedEvent,
+    this.cpuProfileData,
+    double displayRefreshRate,
+    List<TimelineEvent> timelineEvents,
+  })  : traceEvents = traceEvents ?? [],
+        frames = frames ?? [],
+        displayRefreshRate = displayRefreshRate ?? defaultRefreshRate,
+        timelineEvents = timelineEvents ?? [];
+
+  static const traceEventsKey = 'traceEvents';
+
+  static const cpuProfileKey = 'cpuProfile';
+
+  static const selectedEventKey = 'selectedEvent';
+
+  static const timelineModeKey = 'timelineMode';
+
+  static const uiKey = 'UI';
+
+  static const rasterKey = 'Raster';
+
+  static const gcKey = 'GC';
+
+  static const unknownKey = 'Unknown';
+
+  static const displayRefreshRateKey = 'displayRefreshRate';
+
+  static const selectedFrameIdKey = 'selectedFrameId';
+
+  final List<TimelineEvent> timelineEvents;
+
+  final SplayTreeMap<String, TimelineEventGroup> eventGroups =
+      SplayTreeMap(eventGroupComparator);
+
+  /// List that will store trace events in the order we process them.
+  ///
+  /// These events are scrubbed so that bad data from the engine does not hinder
+  /// event processing or trace viewing. When the export timeline button is
+  /// clicked, this will be part of the output.
+  List<Map<String, dynamic>> traceEvents = [];
+
+  bool get isEmpty => traceEvents.isEmpty;
+
+  TimelineEvent selectedEvent;
+
+  CpuProfileData cpuProfileData;
+
+  double displayRefreshRate;
+
+  /// All frames currently visible in the timeline.
+  List<FlutterFrame> frames = [];
+
+  FlutterFrame selectedFrame;
+
+  String get selectedFrameId => selectedFrame?.id;
+
+  TimeRange time = TimeRange();
+
+  /// The end timestamp for the data in this timeline.
+  ///
+  /// Track it here so that we can cache the value as we add timeline events,
+  /// and eventually set [time.end] to this value after the data is processed.
+  int get endTimestampMicros => _endTimestampMicros;
+  int _endTimestampMicros = -1;
+
+  void initializeEventGroups(Map<int, String> threadNamesById) {
+    for (TimelineEvent event in timelineEvents) {
+      eventGroups.putIfAbsent(computeEventGroupKey(event, threadNamesById),
+          () => TimelineEventGroup())
+        ..addEventAtCalculatedRow(event);
+    }
+  }
+
+  void addTimelineEvent(TimelineEvent event) {
+    assert(event.isWellFormedDeep);
+    timelineEvents.add(event);
+    _endTimestampMicros = math.max(_endTimestampMicros, event.maxEndMicros);
+  }
+
+  bool hasCpuProfileData() {
+    return cpuProfileData != null && cpuProfileData.stackFrames.isNotEmpty;
+  }
+
+  void clear() {
+    traceEvents.clear();
+    selectedEvent = null;
+    cpuProfileData = null;
+    timelineEvents.clear();
+    eventGroups.clear();
+    time = TimeRange();
+    _endTimestampMicros = -1;
+    frames.clear();
+    selectedFrame = null;
+  }
+
+  // TODO(kenz): simplify this comparator if possible.
+  @visibleForTesting
+  static int eventGroupComparator(String a, String b) {
+    if (a == b) return 0;
+
+    // Order Unknown buckets last.
+    if (a == unknownKey) return 1;
+    if (b == unknownKey) return -1;
+
+    // Order the Raster event bucket after the UI event bucket.
+    if ((a == uiKey && b == rasterKey) || (a == rasterKey && b == uiKey)) {
+      return -1 * a.compareTo(b);
+    }
+
+    // Order non-UI and non-raster buckets after the UI / Raster buckets.
+    if (a == uiKey || a == rasterKey) return -1;
+    if (b == uiKey || b == rasterKey) return 1;
+
+    // Alphabetize all other buckets.
+    return a.compareTo(b);
+  }
+
+  Map<String, dynamic> get json => {
+        selectedFrameIdKey: selectedFrame?.id,
+        displayRefreshRateKey: displayRefreshRate,
+        traceEventsKey: traceEvents,
+        cpuProfileKey: cpuProfileData?.json ?? {},
+        selectedEventKey: selectedEvent?.json ?? {},
+      };
+}
+
+// TODO(kenz): add tests for this class.
+class TimelineEventGroup {
+  /// At each index in the list, this stores row data for the row at index.
+  ///
+  /// We store data by row within the group in order to display events with
+  /// overlapping timestamps in the flame chart UI. This allows us to reuse
+  /// space where possible and avoid collisions.  We will draw overlapping
+  /// events on a new flame chart row.
+  ///
+  /// If we have events A, B, C, and D, where all belong in a single
+  /// [TimelineEventGroup] but some overlap, the UI will look
+  /// like this:
+  ///
+  ///    [timeline_event_A]    [timeline_event_C]    <-- row 0
+  ///               [timeline_event_B]               <-- row 1
+  ///                            [timeline_event_D]  <-- row 2
+  ///
+  /// The contents of [eventsByRow] would look like this:
+  /// [
+  ///   [timeline_event_A, timeline_event_C],
+  ///   [timeline_event_B],
+  ///   [timeline_event_D],
+  /// ]
+  final rows = <TimelineRowData>[];
+
+  final rowIndexForEvent = <TimelineEvent, int>{};
+
+  int earliestTimestampMicros;
+
+  int latestTimestampMicros;
+
+  List<TimelineEvent> get sortedEventRoots =>
+      _sortedEventRoots ??= List<TimelineEvent>.from(rowIndexForEvent.keys)
+          .where((event) => event.isRoot)
+          .toList()
+            ..sort((a, b) => a.time.start.inMicroseconds
+                .compareTo(b.time.start.inMicroseconds));
+  List<TimelineEvent> _sortedEventRoots;
+
+  int get displayDepth => rows.length;
+
+  // TODO(kenz): prevent guideline "elbows" from overlapping other events.
+  void addEventAtCalculatedRow(TimelineEvent event, {int displayRow = 0}) {
+    final currentLargestRowIndex = rows.length;
+    while (displayRow < currentLargestRowIndex) {
+      // Ensure that [event] and its children do not overlap with events at all
+      // current offsets.
+      final eventFitsAtDisplayRow = _eventFitsAtDisplayRow(
+        event,
+        displayRow,
+        currentLargestRowIndex,
+      );
+      if (eventFitsAtDisplayRow) break;
+      displayRow++;
+    }
+    _addEventAtDisplayRow(event, row: displayRow);
+  }
+
+  bool _eventFitsAtDisplayRow(
+    TimelineEvent event,
+    int displayRow,
+    int currentLargestRowIndex,
+  ) {
+    final maxLevelToVerify =
+        math.min(event.displayDepth, currentLargestRowIndex - displayRow);
+    for (int level = 0; level < maxLevelToVerify; level++) {
+      final lastEventAtLevel = displayRow + level < rows.length
+          ? rows[displayRow + level].lastEvent
+          : null;
+      final firstNewEventAtLevel = event.displayRows[level].safeFirst;
+      if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
+        // Events overlap one another, so [event] does not fit at [displayRow].
+        if (lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time)) {
+          return false;
+        }
+
+        // [firstNewEventAtLevel] ends before [lastEventAtLevel] begins, so
+        // [event] does not fit at [displayRow].
+        if (firstNewEventAtLevel.time.end < lastEventAtLevel.time.start) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  void _addEventAtDisplayRow(TimelineEvent event, {@required int row}) {
+    if (row + event.displayDepth >= rows.length) {
+      for (int i = rows.length; i < row + event.displayDepth; i++) {
+        rows.add(TimelineRowData());
+      }
+    }
+
+    for (int i = 0; i < event.displayDepth; i++) {
+      final displayRow = event.displayRows[i];
+      for (var e in displayRow) {
+        earliestTimestampMicros = math.min(
+          e.time.start.inMicroseconds,
+          earliestTimestampMicros ?? e.time.start.inMicroseconds,
+        );
+        latestTimestampMicros = math.max(
+          e.time.end.inMicroseconds,
+          latestTimestampMicros ?? e.time.end.inMicroseconds,
+        );
+        rows[row + i].events.add(e);
+        rowIndexForEvent[e] = row + i;
+        if (e.time.end >
+            (rows[row + i].lastEvent?.time?.end ?? const Duration())) {
+          rows[row + i].lastEvent = e;
+        }
+      }
+    }
+  }
+}
+
+class TimelineRowData {
+  /// Timeline events that will be displayed in this row in a visualization of a
+  /// [TimelineEventGroup].
+  final List<TimelineEvent> events = [];
+
+  /// The last event for this row, where last means the event has the latest end
+  /// time in the row.
+  ///
+  /// The most recently added event for the row is not guaranteed to be the last
+  /// event for the row, which is why we cannot just call [events.last] to get
+  /// [lastEvent].
+  TimelineEvent lastEvent;
+}
+
+class OfflinePerformanceData extends PerformanceData {
+  OfflinePerformanceData._({
+    List<Map<String, dynamic>> traceEvents,
+    List<FlutterFrame> frames,
+    FlutterFrame selectedFrame,
+    String selectedFrameId,
+    TimelineEvent selectedEvent,
+    double displayRefreshRate,
+    CpuProfileData cpuProfileData,
+  })  : _selectedFrameId = selectedFrameId,
+        super(
+          traceEvents: traceEvents,
+          frames: frames,
+          selectedFrame: selectedFrame,
+          selectedEvent: selectedEvent,
+          displayRefreshRate: displayRefreshRate,
+          cpuProfileData: cpuProfileData,
+        );
+
+  static OfflinePerformanceData parse(Map<String, dynamic> json) {
+    final List<dynamic> traceEvents =
+        (json[PerformanceData.traceEventsKey] ?? [])
+            .cast<Map<String, dynamic>>();
+
+    final Map<String, dynamic> cpuProfileJson =
+        json[PerformanceData.cpuProfileKey] ?? {};
+    final CpuProfileData cpuProfileData =
+        cpuProfileJson.isNotEmpty ? CpuProfileData.parse(cpuProfileJson) : null;
+
+    final String selectedFrameId = json[PerformanceData.selectedFrameIdKey];
+
+    final Map<String, dynamic> selectedEventJson =
+        json[PerformanceData.selectedEventKey] ?? {};
+    final OfflineTimelineEvent selectedEvent = selectedEventJson.isNotEmpty
+        ? OfflineTimelineEvent(
+            (selectedEventJson[TimelineEvent.firstTraceKey] ?? {})
+                .cast<String, dynamic>())
+        : null;
+
+    final displayRefreshRate =
+        json[PerformanceData.displayRefreshRateKey] ?? defaultRefreshRate;
+
+    return OfflinePerformanceData._(
+      traceEvents: traceEvents,
+      selectedFrameId: selectedFrameId,
+      selectedEvent: selectedEvent,
+      displayRefreshRate: displayRefreshRate.toDouble(),
+      cpuProfileData: cpuProfileData,
+    );
+  }
+
+  @override
+  String get selectedFrameId => _selectedFrameId;
+  final String _selectedFrameId;
+
+  /// Creates a new instance of [OfflinePerformanceData] with references to the
+  /// same objects contained in this instance.
+  ///
+  /// This is not a deep copy. We are not modifying the before-mentioned
+  /// objects, only pointing our reference variables at different objects.
+  /// Therefore, we do not need to store a copy of all these objects (and the
+  /// objects they contain) in memory.
+  OfflinePerformanceData shallowClone() {
+    return OfflinePerformanceData._(
+      traceEvents: traceEvents,
+      frames: frames,
+      selectedFrame: selectedFrame,
+      selectedFrameId: selectedFrameId,
+      selectedEvent: selectedEvent,
+      displayRefreshRate: displayRefreshRate,
+      cpuProfileData: cpuProfileData,
+    );
+  }
+}
+
+/// Wrapper class for [TimelineEvent] that only includes information we need for
+/// importing and exporting snapshots.
+///
+/// * name
+/// * start time
+/// * duration
+/// * type
+///
+/// We extend TimelineEvent so that our CPU profiler code requiring a selected
+/// timeline event will work as it does when we are not loading from offline.
+class OfflineTimelineEvent extends TimelineEvent {
+  OfflineTimelineEvent(Map<String, dynamic> firstTrace)
+      : super(TraceEventWrapper(
+          TraceEvent(firstTrace),
+          0, // 0 is an arbitrary value for [TraceEventWrapper.timeReceived].
+        )) {
+    time.end = Duration(
+        microseconds: firstTrace[TraceEvent.timestampKey] +
+            firstTrace[TraceEvent.durationKey]);
+    type = TimelineEventType.values.firstWhere(
+        (t) =>
+            t.toString() ==
+            firstTrace[TraceEvent.argsKey][TraceEvent.typeKey].toString(),
+        orElse: () => TimelineEventType.unknown);
+  }
+
+  // The following methods should never be called on an instance of
+  // [OfflineTimelineEvent]. The intended use for this class is to wrap a
+  // [TimelineEvent] for the purpose of importing and exporting timeline
+  // snapshots.
+
+  @override
+  bool couldBeParentOf(TimelineEvent e) {
+    throw UnimplementedError('This method should never be called for an '
+        'instance of OfflineTimelineEvent');
+  }
+
+  @override
+  int get maxEndMicros =>
+      throw UnimplementedError('This method should never be called for an '
+          'instance of OfflineTimelineEvent');
+
+  @override
+  List<List<TimelineEvent>> _calculateDisplayRows() =>
+      throw UnimplementedError('This method should never be called for an '
+          'instance of OfflineTimelineEvent');
+}
+
+/// Data describing a single Flutter frame.
+///
+/// Each [FlutterFrame] should have 2 distinct pieces of data:
+/// * [uiEventFlow] : flow of events showing the UI work for the frame.
+/// * [rasterEventFlow] : flow of events showing the Raster work for the frame.
+class FlutterFrame {
+  FlutterFrame(this.id);
+
+  final String id;
+
+  /// Event flows for the UI and Raster work for the frame.
+  final List<SyncTimelineEvent> eventFlows = List.generate(2, (_) => null);
+
+  /// Flow of events describing the UI work for the frame.
+  SyncTimelineEvent get uiEventFlow => eventFlows[TimelineEventType.ui.index];
+
+  /// Flow of events describing the Raster work for the frame.
+  SyncTimelineEvent get rasterEventFlow =>
+      eventFlows[TimelineEventType.raster.index];
+
+  /// Whether the frame is ready for the timeline.
+  ///
+  /// A frame is ready once it has both required event flows as well as
+  /// [_pipelineItemStartTime] and [_pipelineItemEndTime].
+  bool get isReadyForTimeline {
+    return uiEventFlow != null &&
+        rasterEventFlow != null &&
+        pipelineItemTime.start?.inMicroseconds != null &&
+        pipelineItemTime.end?.inMicroseconds != null;
+  }
+
+  // Stores frame start time, end time, and duration.
+  final time = TimeRange();
+
+  /// Pipeline item time range in micros.
+  ///
+  /// This stores the start and end times for the pipeline item event for this
+  /// frame. We use this value to determine whether a TimelineEvent fits within
+  /// the frame's time boundaries.
+  final pipelineItemTime = TimeRange(singleAssignment: false);
+
+  TraceEvent pipelineItemStartTrace;
+
+  TraceEvent pipelineItemEndTrace;
+
+  bool get isWellFormed =>
+      pipelineItemTime.start?.inMicroseconds != null &&
+      pipelineItemTime.end?.inMicroseconds != null;
+
+  int get uiDuration => uiEventFlow?.time?.duration?.inMicroseconds;
+
+  double get uiDurationMs => uiDuration != null ? uiDuration / 1000 : null;
+
+  int get rasterDuration => rasterEventFlow?.time?.duration?.inMicroseconds;
+
+  double get rasterDurationMs =>
+      rasterDuration != null ? rasterDuration / 1000 : null;
+
+  CpuProfileData cpuProfileData;
+
+  void setEventFlow(SyncTimelineEvent event, {TimelineEventType type}) {
+    type ??= event?.type;
+    if (type == TimelineEventType.ui) {
+      time.start = event?.time?.start;
+      // If [rasterEventFlow] has already completed, set the end time for this
+      // frame to [event]'s end time.
+      if (rasterEventFlow != null) {
+        time.end = event?.time?.end;
+      }
+    }
+    if (type == TimelineEventType.raster) {
+      // If [uiEventFlow] is null, that means that this raster event flow
+      // completed before the ui event flow did for this frame. This means one
+      // of two things: 1) there will never be a [uiEventFlow] for this frame
+      // because the UI events are not present in the available timeline
+      // events, or 2) the [uiEventFlow] has started but not completed yet. In
+      // the event that 2) is true, do not set the frame end time here because
+      // the end time for this frame will be set to the the end time for
+      // [uiEventFlow] once it finishes.
+      if (uiEventFlow != null) {
+        time.end = Duration(
+          microseconds: math.max(
+            uiEventFlow.time.end.inMicroseconds,
+            event?.time?.end?.inMicroseconds ?? 0,
+          ),
+        );
+      }
+    }
+    eventFlows[type.index] = event;
+    event?.frameId = id;
+  }
+
+  TimelineEvent findTimelineEvent(TimelineEvent event) {
+    if (event.type == TimelineEventType.ui ||
+        event.type == TimelineEventType.raster) {
+      return eventFlows[event.type.index].firstChildWithCondition(
+          (e) => e.name == event.name && e.time == event.time);
+    }
+    return null;
+  }
+
+  bool isJanky(double displayRefreshRate) {
+    return isUiJanky(displayRefreshRate) || isRasterJanky(displayRefreshRate);
+  }
+
+  bool isUiJanky(double displayRefreshRate) {
+    return uiDurationMs > _targetMsPerFrame(displayRefreshRate);
+  }
+
+  bool isRasterJanky(double displayRefreshRate) {
+    return rasterDurationMs > _targetMsPerFrame(displayRefreshRate);
+  }
+
+  double _targetMsPerFrame(double displayRefreshRate) {
+    return 1 / displayRefreshRate * 1000;
+  }
+
+  @override
+  String toString() {
+    return 'Frame $id - $time, ui: ${uiEventFlow.time}, '
+        'raster: ${rasterEventFlow.time}';
+  }
+}
+
+abstract class TimelineEvent extends TreeNode<TimelineEvent>
+    with
+        DataSearchStateMixin,
+        TreeDataSearchStateMixin<TimelineEvent>,
+        FlameChartDataMixin {
+  TimelineEvent(TraceEventWrapper firstTraceEvent)
+      : traceEvents = [firstTraceEvent],
+        type = firstTraceEvent.event.type {
+    time.start = Duration(microseconds: firstTraceEvent.event.timestampMicros);
+  }
+
+  static const firstTraceKey = 'firstTrace';
+  static const eventNameKey = 'name';
+  static const eventTypeKey = 'type';
+  static const eventStartTimeKey = 'startMicros';
+  static const eventDurationKey = 'durationMicros';
+
+  /// Trace events associated with this [TimelineEvent].
+  ///
+  /// There will either be one entry in the list (for DurationComplete events)
+  /// or two (one for the associated DurationBegin event and one for the
+  /// associated DurationEnd event).
+  final List<TraceEventWrapper> traceEvents;
+
+  TimelineEventType type;
+
+  TimeRange time = TimeRange();
+
+  String get frameId => _frameId ?? root._frameId;
+
+  String _frameId;
+
+  set frameId(String id) => _frameId = id;
+
+  String get name => traceEvents.first.event.name;
+
+  String get groupKey => traceEvents.first.event.args['filterKey'];
+
+  Map<String, dynamic> get beginTraceEventJson => traceEvents.first.json;
+
+  Map<String, dynamic> get endTraceEventJson =>
+      traceEvents.length > 1 ? traceEvents.last.json : null;
+
+  bool get isUiEvent => type == TimelineEventType.ui;
+
+  bool get isRasterEvent => type == TimelineEventType.raster;
+
+  bool get isAsyncEvent => type == TimelineEventType.async;
+
+  bool get isAsyncInstantEvent =>
+      traceEvents.first.event.phase == TraceEvent.asyncInstantPhase;
+
+  bool get isGCEvent =>
+      traceEvents.first.event.category == TraceEvent.gcCategory;
+
+  bool get isWellFormed => time.start != null && time.end != null;
+
+  bool get isWellFormedDeep => _isWellFormedDeep(this);
+
+  int get threadId => traceEvents.first.event.threadId;
+
+  @override
+  String get tooltip => '$name - ${msText(time.duration)}';
+
+  bool _isWellFormedDeep(TimelineEvent event) {
+    return !subtreeHasNodeWithCondition((e) => !e.isWellFormed);
+  }
+
+  /// Maximum end micros for the event.
+  ///
+  /// This value could come from the end time of [this] event or from the end
+  /// time of any of its descendant events.
+  int get maxEndMicros;
+
+  /// Whether [this] event could be the parent of [e] based on criteria such as
+  /// timestamps and event ids.
+  bool couldBeParentOf(TimelineEvent e);
+
+  /// Tracks the start row for the lowest visual child in the display for this
+  /// TimelineEvent.
+  int _lowestDisplayChildRow = 1;
+
+  /// The child that is nearest the bottom of the visualization for this
+  /// TimelineEvent.
+  TimelineEvent get lowestDisplayChild => _lowestDisplayChild;
+  TimelineEvent _lowestDisplayChild;
+
+  int get displayDepth => displayRows.length;
+
+  List<List<TimelineEvent>> _displayRows;
+  List<List<TimelineEvent>> get displayRows =>
+      _displayRows ??= _calculateDisplayRows();
+
+  List<List<TimelineEvent>> _calculateDisplayRows();
+
+  void _expandDisplayRows(int newRowLength) {
+    _displayRows ??= [];
+    final currentLength = _displayRows.length;
+    for (int i = currentLength; i < newRowLength; i++) {
+      _displayRows.add([]);
+    }
+  }
+
+  void _mergeChildDisplayRows(int mergeStartLevel, TimelineEvent child) {
+    assert(
+      mergeStartLevel <= _displayRows.length,
+      'mergeStartLevel $mergeStartLevel is greater than _displayRows.length'
+      ' ${_displayRows.length}',
+    );
+    final childDisplayRows = child.displayRows;
+    _expandDisplayRows(mergeStartLevel + childDisplayRows.length);
+    for (int i = 0; i < childDisplayRows.length; i++) {
+      displayRows[mergeStartLevel + i].addAll(childDisplayRows[i]);
+    }
+    if (mergeStartLevel >= _lowestDisplayChildRow) {
+      _lowestDisplayChildRow = mergeStartLevel;
+      _lowestDisplayChild = child;
+    }
+  }
+
+  void addEndEvent(TraceEventWrapper eventWrapper) {
+    time.end = Duration(microseconds: eventWrapper.event.timestampMicros);
+    traceEvents.add(eventWrapper);
+  }
+
+  void maybeRemoveDuplicate() {
+    void _maybeRemoveDuplicate({@required TimelineEvent parent}) {
+      if (parent.children.length == 1 &&
+          // [parent]'s DurationBegin trace is equal to that of its only child.
+          collectionEquals(
+            parent.beginTraceEventJson,
+            parent.children.first.beginTraceEventJson,
+          ) &&
+          // [parent]'s DurationEnd trace is equal to that of its only child.
+          collectionEquals(
+            parent.endTraceEventJson,
+            parent.children.first.endTraceEventJson,
+          )) {
+        parent.removeChild(parent.children.first);
+      }
+    }
+
+    // Remove [this] event's child if it is a duplicate of [this].
+    if (children.isNotEmpty) {
+      _maybeRemoveDuplicate(parent: this);
+    }
+    // Remove [this] event if it is a duplicate of [parent].
+    if (parent != null) {
+      _maybeRemoveDuplicate(parent: parent);
+    }
+  }
+
+  void removeChild(TimelineEvent childToRemove) {
+    assert(children.contains(childToRemove));
+    final List<TimelineEvent> newChildren = List.from(childToRemove.children);
+    newChildren.forEach(_addChild);
+    children.remove(childToRemove);
+  }
+
+  @override
+  void addChild(TimelineEvent child) {
+    void _putChildInTree(TimelineEvent root) {
+      // [root] is a leaf. Add child here.
+      if (root.children.isEmpty) {
+        root._addChild(child);
+        return;
+      }
+
+      final _children = root.children.toList();
+
+      // If [child] is the parent of some or all of the members in [_children],
+      // those members will need to be reordered in the tree.
+      final childrenToReorder = [];
+      for (TimelineEvent otherChild in _children) {
+        if (child.couldBeParentOf(otherChild)) {
+          childrenToReorder.add(otherChild);
+        }
+      }
+
+      if (childrenToReorder.isNotEmpty) {
+        root._addChild(child);
+
+        for (TimelineEvent otherChild in childrenToReorder) {
+          // Link [otherChild] with its correct parent [child].
+          child._addChild(otherChild);
+
+          // Unlink [otherChild] from its incorrect parent [root].
+          root.children.remove(otherChild);
+        }
+        return;
+      }
+
+      // Check if a member of [_children] is the parent of [child]. If multiple
+      // children in [_children] share a timestamp, they both could be the
+      // parent of [child]. We reverse [_children] so that we will pick the last
+      // received candidate as the new parent of [child].
+      for (TimelineEvent otherChild in _children.reversed) {
+        if (otherChild.couldBeParentOf(child)) {
+          // Recurse on [otherChild]'s subtree.
+          _putChildInTree(otherChild);
+          return;
+        }
+      }
+
+      // If we have not returned at this point, [child] belongs in
+      // [root.children].
+      root._addChild(child);
+    }
+
+    _putChildInTree(this);
+  }
+
+  void _addChild(TimelineEvent child) {
+    assert(!children.contains(child));
+    children.add(child);
+    child.parent = this;
+  }
+
+  void format(StringBuffer buf, String indent) {
+    buf.writeln('$indent$name $time');
+    for (TimelineEvent child in children) {
+      child.format(buf, '  $indent');
+    }
+  }
+
+  void formatFromRoot(StringBuffer buf, String indent) {
+    root.format(buf, indent);
+  }
+
+  void writeTraceToBuffer(StringBuffer buf) {
+    buf.writeln(beginTraceEventJson);
+    for (TimelineEvent child in children) {
+      child.writeTraceToBuffer(buf);
+    }
+    if (endTraceEventJson != null) {
+      buf.writeln(endTraceEventJson);
+    }
+  }
+
+  Map<String, dynamic> get json {
+    final modifiedTrace = Map.from(beginTraceEventJson);
+    modifiedTrace[TraceEvent.argsKey]
+        .addAll({TraceEvent.typeKey: type.toString()});
+    if (!modifiedTrace.containsKey(TraceEvent.durationKey)) {
+      modifiedTrace
+          .addAll({TraceEvent.durationKey: time.duration.inMicroseconds});
+    }
+    return {firstTraceKey: modifiedTrace};
+  }
+
+  @visibleForTesting
+  TimelineEvent deepCopy() {
+    final copy = isAsyncEvent
+        ? AsyncTimelineEvent(traceEvents.first)
+        : SyncTimelineEvent(traceEvents.first);
+    copy.time.end = time.end;
+    copy.parent = parent;
+    for (TimelineEvent child in children) {
+      copy._addChild(child.deepCopy());
+    }
+    return copy;
+  }
+
+  // TODO(kenz): use DiagnosticableTreeMixin instead.
+  @override
+  String toString() {
+    final buf = StringBuffer();
+    format(buf, '  ');
+    return buf.toString();
+  }
+}
+
+class SyncTimelineEvent extends TimelineEvent {
+  SyncTimelineEvent(TraceEventWrapper firstTraceEvent) : super(firstTraceEvent);
+
+  bool get isUiEventFlow => subtreeHasNodeWithCondition(
+      (TimelineEvent event) => event.name.contains(uiEventName));
+
+  bool get isRasterEventFlow => subtreeHasNodeWithCondition(
+      (TimelineEvent event) => event.name.contains('PipelineConsume'));
+
+  @override
+  int get maxEndMicros => time.end.inMicroseconds;
+
+  @override
+  List<List<TimelineEvent>> _calculateDisplayRows() {
+    assert(_displayRows == null);
+    _expandDisplayRows(depth);
+
+    _displayRows[0].add(this);
+    for (final child in children) {
+      _mergeChildDisplayRows(1, child);
+    }
+    return _displayRows;
+  }
+
+  @override
+  bool couldBeParentOf(TimelineEvent e) {
+    final startTime = time.start.inMicroseconds;
+    final endTime = time.end?.inMicroseconds;
+    final eStartTime = e.time.start.inMicroseconds;
+    final eEndTime = e.time.end?.inMicroseconds;
+
+    if (endTime != null && eEndTime != null) {
+      if (startTime == eStartTime && endTime == eEndTime) {
+        return traceEvents.first.id < e.traceEvents.first.id;
+      }
+      return startTime <= eStartTime && endTime >= eEndTime;
+    } else if (endTime != null) {
+      // We don't use >= to compare [endTime] and [e.startTime] here because we
+      // don't want to falsely make [this] the parent of [e]. We do not know
+      // [e.endTime], meaning [e] could start at [endTime] and end later than
+      // [endTime] (unless e has a duration of 0). In this case, [this] would
+      // not be the parent of [e].
+      return startTime <= eStartTime && endTime > eStartTime;
+    } else if (startTime == eStartTime) {
+      return traceEvents.first.id < e.traceEvents.first.id;
+    } else {
+      return startTime < eStartTime;
+    }
+  }
+}
+
+// TODO(kenz): calculate and store async guidelines here instead of in the UI
+// code.
+class AsyncTimelineEvent extends TimelineEvent {
+  AsyncTimelineEvent(TraceEventWrapper firstTraceEvent)
+      : asyncId = firstTraceEvent.event.id,
+        parentId = firstTraceEvent.event.args[parentIdKey],
+        super(firstTraceEvent) {
+    type = TimelineEventType.async;
+  }
+
+  static const parentIdKey = 'parentId';
+
+  final String asyncId;
+
+  /// Unique id for this async event's parent event.
+  ///
+  /// This field is not guaranteed to be non-null.
+  final String parentId;
+
+  int _maxEndMicros;
+  @override
+  int get maxEndMicros => _maxEndMicros ?? _calculateMaxEndMicros();
+
+  int _calculateMaxEndMicros() {
+    if (children.isEmpty) {
+      return time.end.inMicroseconds;
+    }
+    var maxEnd = time.end.inMicroseconds;
+    for (AsyncTimelineEvent child in children) {
+      maxEnd = math.max(maxEnd, child._calculateMaxEndMicros());
+    }
+    return _maxEndMicros = maxEnd;
+  }
+
+  @override
+  List<List<TimelineEvent>> _calculateDisplayRows() {
+    assert(_displayRows == null);
+    _expandDisplayRows(1);
+
+    const currentRow = 0;
+    _displayRows[currentRow].add(this);
+
+    const mainChildRow = currentRow + 1;
+    for (int i = 0; i < children.length; i++) {
+      final AsyncTimelineEvent child = children[i];
+      if (i == 0 ||
+          _eventFitsAtDisplayRow(child, mainChildRow, _displayRows.length)) {
+        _mergeChildDisplayRows(mainChildRow, child);
+      } else {
+        // If [child] does not fit on the target row, add it below the current
+        // deepest display row.
+        _mergeChildDisplayRows(displayRows.length, child);
+      }
+    }
+    return _displayRows;
+  }
+
+  bool _eventFitsAtDisplayRow(
+    AsyncTimelineEvent event,
+    int displayRow,
+    int currentLargestRowIndex,
+  ) {
+    final maxLevelToVerify =
+        math.min(event.displayDepth, currentLargestRowIndex - displayRow);
+    for (int level = 0; level < maxLevelToVerify; level++) {
+      final lastEventAtLevel = _displayRows[displayRow + level].safeLast;
+      final firstNewEventAtLevel = event.displayRows[level].safeFirst;
+      if (lastEventAtLevel != null && firstNewEventAtLevel != null) {
+        // Events overlap one another, so [event] does not fit at [displayRow].
+        if (lastEventAtLevel.time.overlaps(firstNewEventAtLevel.time)) {
+          return false;
+        }
+
+        // [firstNewEventAtLevel] ends before [lastEventAtLevel] begins, so
+        // [event] does not fit at [displayRow].
+        if (firstNewEventAtLevel.time.end < lastEventAtLevel.time.start) {
+          return false;
+        }
+
+        final lastEventParent = lastEventAtLevel.parent;
+        final firstNewEventParent = firstNewEventAtLevel.parent;
+        // If the two events are non-overlapping siblings and their parent ends
+        // before [lastEventAtLevel], drawing a subsequent guideline from
+        // [lastEventParent] to [firstNewEventAtLevel] would overlap
+        // [lastEventAtLevel], so we cannot place [event] on this row.
+        if (lastEventParent != null &&
+            firstNewEventParent != null &&
+            lastEventParent == firstNewEventParent &&
+            lastEventAtLevel.time.end >= lastEventParent.time.end) {
+          return false;
+        }
+      }
+    }
+    return true;
+  }
+
+  @override
+  void addChild(TimelineEvent child) {
+    final AsyncTimelineEvent _child = child;
+    // Short circuit if we are using an explicit parentId.
+    if (_child.parentId != null &&
+        _child.parentId == traceEvents.first.event.id) {
+      _addChild(child);
+    } else {
+      super.addChild(child);
+    }
+  }
+
+  @override
+  bool couldBeParentOf(TimelineEvent e) {
+    final AsyncTimelineEvent asyncEvent = e;
+
+    // If [asyncEvent] has an explicit parentId, use that as the truth.
+    if (asyncEvent.parentId != null) return asyncId == asyncEvent.parentId;
+
+    // Without an explicit parentId, two events must share an asyncId to be
+    // part of the same event tree.
+    if (asyncId != asyncEvent.asyncId) return false;
+
+    // When two events share an asyncId, determine parent / child relationships
+    // based on timestamps.
+    final startTime = time.start.inMicroseconds;
+    final endTime = time.end?.inMicroseconds;
+    final eStartTime = e.time.start.inMicroseconds;
+    final eEndTime = e.time.end?.inMicroseconds;
+
+    if (endTime != null && eEndTime != null) {
+      if (startTime == eStartTime && endTime == eEndTime) {
+        return int.parse(asyncId, radix: 16) <
+            int.parse(asyncEvent.asyncId, radix: 16);
+      }
+      return startTime <= eStartTime && endTime >= eEndTime;
+    } else if (endTime != null) {
+      // We don't use >= to compare [endTime] and [eStartTime] here because we
+      // don't want to falsely make [this] the parent of [e]. We do not know
+      // [eEndTime], meaning [e] could start at [endTime] and end later than
+      // [endTime] (unless e has a duration of 0). In this case, [this] would
+      // not be the parent of [e].
+      return startTime <= eStartTime && endTime > eStartTime;
+    } else if (startTime == eStartTime) {
+      return int.parse(asyncId, radix: 16) <
+          int.parse(asyncEvent.asyncId, radix: 16);
+    } else {
+      return startTime < eStartTime;
+    }
+  }
+
+  /// End the async event with [eventWrapper] and return whether or not the
+  /// end event was successfully added.
+  ///
+  /// The return value will be used to stop the recursion early.
+  bool endAsyncEvent(TraceEventWrapper eventWrapper) {
+    assert(
+      parentId != null || asyncId == eventWrapper.event.id,
+      'asyncId = $asyncId, but endEventId = ${eventWrapper.event.id}',
+    );
+    if (endTraceEventJson != null) {
+      // This event has already ended and [eventWrapper] is a duplicate trace
+      // event.
+      return false;
+    }
+    if (name == eventWrapper.event.name) {
+      addEndEvent(eventWrapper);
+      return true;
+    }
+
+    for (AsyncTimelineEvent child in children) {
+      final added = child.endAsyncEvent(eventWrapper);
+      if (added) return true;
+    }
+    return false;
+  }
+}

--- a/packages/devtools_app/lib/src/performance/legacy/performance_utils.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_utils.dart
@@ -1,0 +1,28 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'performance_model.dart';
+
+String computeEventGroupKey(
+  TimelineEvent event,
+  Map<int, String> threadNamesById,
+) {
+  if (event.groupKey != null) {
+    return event.groupKey;
+  } else if (event.isAsyncEvent) {
+    return event.root.name;
+  } else if (event.isUiEvent) {
+    return PerformanceData.uiKey;
+  } else if (event.isRasterEvent) {
+    return PerformanceData.rasterKey;
+  } else if (threadNamesById[event.threadId] != null) {
+    return threadNamesById[event.threadId];
+  } else {
+    return PerformanceData.unknownKey;
+  }
+}

--- a/packages/devtools_app/lib/src/performance/legacy/timeline_event_processor.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_event_processor.dart
@@ -1,0 +1,635 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
+
+import '../../config_specific/logger/logger.dart';
+import '../../trace_event.dart';
+import '../../utils.dart';
+//import '../../simple_trace_example.dart';
+import 'performance_controller.dart';
+import 'performance_model.dart';
+
+// For documentation, see the Chrome "Trace Event Format" document:
+// https://docs.google.com/document/d/1CvAClvFfyA5R-PhYUmn5OOQtYMH4h6I0nSsKchNAySU.
+// This class depends on the stability of event names we receive from the
+// engine. That dependency is tracked at
+// https://github.com/flutter/flutter/issues/27609.
+
+/// Switch this flag to true collect debug info from the timeline protocol.
+///
+/// This will add a button to the timeline page that will download files with
+/// debug info on click.
+bool debugTimeline = false;
+
+/// List that will store trace event json in the order we handle the events.
+///
+/// This list is for debug purposes. When [debugTimeline] is true, we will be
+/// able to dump this data to a downloadable text file.
+List<Map<String, dynamic>> debugHandledTraceEvents = [];
+
+/// Buffer that will store significant events in the frame tracking process.
+///
+/// This buffer is for debug purposes. When [debugTimeline] is true, we will
+/// be able to dump this buffer to a downloadable text file.
+StringBuffer debugFrameTracking = StringBuffer();
+
+const String rasterEventName = 'GPURasterizer::Draw';
+
+const String uiEventName = 'Engine::BeginFrame';
+
+const String messageLoopFlushTasks = 'MessageLoop::FlushTasks';
+
+// For Flutter apps, PipelineItem flow events signal frame start and end events.
+const String pipelineItem = 'PipelineItem';
+
+/// Processor for composing a recorded list of trace events into a timeline of
+/// [AsyncTimelineEvent]s, [SyncTimelineEvent]s, and [FlutterFrame]s.
+class TimelineEventProcessor {
+  TimelineEventProcessor(this.timelineController);
+
+  /// Number of traceEvents we will process in each batch.
+  static const _defaultBatchSize = 2000;
+
+  final PerformanceController timelineController;
+
+  /// Notifies with the current progress value of processing Timeline data.
+  ///
+  /// This value should sit between 0.0 and 1.0.
+  ValueListenable get progressNotifier => _progressNotifier;
+  final _progressNotifier = ValueNotifier<double>(0.0);
+
+  int _traceEventsProcessed = 0;
+
+  /// Async timeline events we have processed, mapped to their respective async
+  /// ids.
+  final _asyncEventsById = <String, AsyncTimelineEvent>{};
+
+  /// The current timeline event nodes for duration events.
+  ///
+  /// The events are mapped to their thread id. As we process duration events,
+  /// a timeline event on a single thread will be formed and completed before
+  /// another timeline event on the same thread begins.
+  @visibleForTesting
+  final currentDurationEventNodes = <int, SyncTimelineEvent>{};
+
+  /// The previously handled DurationEnd events for each thread.
+  ///
+  /// We need this information to balance the tree structures of our event nodes
+  /// if they fall out of balance due to duplicate trace events.
+  ///
+  /// Bug tracking dupes: https://github.com/flutter/flutter/issues/47020.
+  final _previousDurationEndEvents = <int, TraceEvent>{};
+
+  /// Frames we are in the process of assembling.
+  ///
+  /// Once frames have a start and end time, we will remove them from this Map
+  /// and add them to the timeline.
+  @visibleForTesting
+  final pendingFrames = <String, FlutterFrame>{};
+
+  /// Pending root duration complete event that has not yet been added to the
+  /// timeline.
+  ///
+  /// A DC event is a root if we do not have a current duration event tracked
+  /// for the given thread.
+  ///
+  /// We keep this event around to avoid prematurely adding a root DC event to
+  /// the timeline. Once we have processed events beyond a DC event's end
+  /// timestamp, we know that the DC event has no more unprocessed children.
+  /// This is guaranteed because we process the events in timestamp order.
+  SyncTimelineEvent _pendingRootCompleteEvent;
+
+  // TODO(kenz): Remove the [uiThreadId] and [rasterThreadId] once ui/raster
+  //  distinction changes and frame ids are available in the engine.
+  int uiThreadId;
+
+  int rasterThreadId;
+
+  Future<void> processTimeline(
+    List<TraceEventWrapper> traceEvents, {
+    bool resetAfterProcessing = true,
+  }) async {
+    // Reset the processor before processing.
+    reset();
+
+// Uncomment this code for testing the timeline.
+//    traceEvents = simpleTraceEvents['traceEvents']
+//        .where((json) =>
+//            json.containsKey(TraceEvent.timestampKey)) // thread_name events
+//        .map((e) => TraceEventWrapper(
+//            TraceEvent(e), DateTime.now().microsecondsSinceEpoch))
+//        .toList();
+    const sixteenHoursMicros = 57600000000;
+    int firstTimestampMicros;
+    final _traceEvents = (traceEvents.where((event) {
+      // Throw out 'MessageLoop::FlushTasks' events. A single
+      // 'MessageLoop::FlushTasks' event can parent multiple Flutter frame event
+      // sequences and complicates the frame detection logic.
+      final isMessageLoopFlushTasks =
+          event.event.name.contains(messageLoopFlushTasks);
+      // Throw out timeline events that do not have a timestamp
+      // (e.g. thread_name events) as well as events from before we started
+      // recording.
+      final ts = event.event.timestampMicros;
+      final shouldProcess = ts != null && !isMessageLoopFlushTasks;
+
+      // TODO(kenz): remove this code once
+      // https://github.com/flutter/flutter/issues/76875 is resolved. We are
+      // getting extreme outlier events with timestamps ~1 day after the
+      // expected time range. Using sixteen hours as a threshold is arbitrary,
+      // but should catch the outliers without triggering false positives.
+      if (shouldProcess) {
+        firstTimestampMicros ??= ts;
+        if ((ts - firstTimestampMicros).abs() > sixteenHoursMicros) {
+          return false;
+        }
+      }
+      return shouldProcess;
+    }).toList())
+      // Events need to be in increasing timestamp order.
+      ..sort()
+      ..map((event) => event.event.json)
+          .toList()
+          .forEach(timelineController.recordTrace);
+
+    // At minimum, process the data in 4 batches to smooth the appearance of
+    // the progress indicator.
+    final batchSize = math
+        .min(_defaultBatchSize, math.max(1, _traceEvents.length / 4))
+        .round();
+
+    while (_traceEventsProcessed < _traceEvents.length) {
+      _processBatch(batchSize, _traceEvents);
+      _progressNotifier.value = _traceEventsProcessed / _traceEvents.length;
+
+      // Await a small delay to give the UI thread a chance to update the
+      // progress indicator.
+      await delayForBatchProcessing();
+    }
+
+    for (var rootEvent in _asyncEventsById.values.where((e) => e.isRoot)) {
+      // Do not add incomplete async trees to the timeline.
+      // TODO(kenz): infer missing end times based on other end times in the
+      // async event tree. Add these "repaired" events to the timeline.
+      if (!rootEvent.isWellFormedDeep) continue;
+
+      timelineController.addTimelineEvent(rootEvent);
+    }
+
+    _addPendingCompleteRootToTimeline(force: true);
+
+    pendingFrames.values.forEach(_maybeAddCompletedFrame);
+
+    timelineController.data.timelineEvents.sort((a, b) =>
+        a.time.start.inMicroseconds.compareTo(b.time.start.inMicroseconds));
+    if (timelineController.data.timelineEvents.isNotEmpty) {
+      timelineController.data.time
+        // We process trace events in timestamp order, so we can ensure the first
+        // trace event has the earliest starting timestamp.
+        ..start = Duration(
+            microseconds: timelineController
+                .data.timelineEvents.first.time.start.inMicroseconds)
+        // We cannot guarantee that the last trace event is the latest timestamp
+        // in the timeline. DurationComplete events' timestamps refer to their
+        // starting timestamp, but their end time is derived from the same trace
+        // via the "dur" field. For this reason, we use the cached value stored in
+        // [timelineController.fullTimeline].
+        ..end =
+            Duration(microseconds: timelineController.data.endTimestampMicros);
+    } else {
+      timelineController.data.time
+        ..start = Duration.zero
+        ..end = Duration.zero;
+    }
+
+    if (resetAfterProcessing) {
+      reset();
+    }
+  }
+
+  void _processBatch(int batchSize, List<TraceEventWrapper> traceEvents) {
+    final batchEnd =
+        math.min(_traceEventsProcessed + batchSize, traceEvents.length);
+    for (int i = _traceEventsProcessed; i < batchEnd; i++) {
+      final eventWrapper = traceEvents[i];
+      _traceEventsProcessed++;
+
+      // TODO(kenz): stop manually setting the type once we have that data
+      // from the engine.
+      eventWrapper.event.type = inferEventType(eventWrapper.event);
+
+      // Add [pendingRootCompleteEvent] to the timeline if it is ready.
+      _addPendingCompleteRootToTimeline(
+          currentProcessingTime: eventWrapper.event.timestampMicros);
+
+      switch (eventWrapper.event.phase) {
+        case TraceEvent.asyncBeginPhase:
+        case TraceEvent.asyncInstantPhase:
+          _addAsyncEvent(eventWrapper);
+          break;
+        case TraceEvent.asyncEndPhase:
+          _endAsyncEvent(eventWrapper);
+          break;
+        case TraceEvent.durationBeginPhase:
+          _handleDurationBeginEvent(eventWrapper);
+          break;
+        case TraceEvent.durationEndPhase:
+          _handleDurationEndEvent(eventWrapper);
+          break;
+        case TraceEvent.durationCompletePhase:
+          _handleDurationCompleteEvent(eventWrapper);
+          break;
+        // TODO(kenz): add additional support for flows.
+        case TraceEvent.flowStartPhase:
+          if (eventWrapper.event.name.contains(pipelineItem)) {
+            _handleFrameStartEvent(eventWrapper.event);
+          }
+          break;
+        case TraceEvent.flowEndPhase:
+          if (eventWrapper.event.name.contains(pipelineItem)) {
+            _handleFrameEndEvent(eventWrapper.event);
+          }
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  void _addPendingCompleteRootToTimeline({
+    int currentProcessingTime,
+    bool force = false,
+  }) {
+    assert(currentProcessingTime != null || force);
+    if (_pendingRootCompleteEvent != null &&
+        (force ||
+            currentProcessingTime >
+                _pendingRootCompleteEvent.time.end.inMicroseconds)) {
+      timelineController.addTimelineEvent(_pendingRootCompleteEvent);
+      _pendingRootCompleteEvent = null;
+    }
+  }
+
+  void _addAsyncEvent(TraceEventWrapper eventWrapper) {
+    final timelineEvent = AsyncTimelineEvent(eventWrapper);
+    if (eventWrapper.event.phase == TraceEvent.asyncInstantPhase) {
+      timelineEvent.time.end = timelineEvent.time.start;
+    }
+
+    // If parentId is specified, use it to define the async tree structure.
+    final parentId = timelineEvent.parentId;
+    if (parentId != null) {
+      final parent = _asyncEventsById[parentId];
+      if (parent != null) {
+        parent.addChild(timelineEvent);
+      }
+      _asyncEventsById[eventWrapper.event.id] = timelineEvent;
+      return;
+    }
+
+    final currentEventWithId = _asyncEventsById[eventWrapper.event.id];
+
+    // If we already have a timeline event with the same async id as
+    // [timelineEvent] (e.g. [currentEventWithId]), then [timelineEvent] is
+    // either a child of [currentEventWithId] or a new root event with this id.
+    if (currentEventWithId != null) {
+      if (currentEventWithId.isWellFormedDeep) {
+        // [timelineEvent] is a new root with the same id as
+        // [currentEventWithId]. Since [currentEventWithId] is well formed, add
+        // it to the timeline.
+        timelineController.addTimelineEvent(currentEventWithId);
+        _asyncEventsById[eventWrapper.event.id] = timelineEvent;
+      } else {
+        if (currentEventWithId.isWellFormed) {
+          // Since parent id was not explicitly passed in the event args and
+          // since we process events in timestamp order, if [currentEventWithId]
+          // is well formed, [timelineEvent] cannot be a child of
+          // [currentEventWithId]. This is an illegal id collision that we need
+          // to handle gracefully, so throw this event away.
+          // Bug tracking collisions:
+          // https://github.com/flutter/flutter/issues/47019.
+          log('Id collision on id ${eventWrapper.event.id}', LogLevel.warning);
+        } else {
+          // We know it must be a child because we process events in timestamp
+          // order.
+          currentEventWithId.addChild(timelineEvent);
+        }
+      }
+    } else {
+      _asyncEventsById[eventWrapper.event.id] = timelineEvent;
+    }
+  }
+
+  void _endAsyncEvent(TraceEventWrapper eventWrapper) {
+    final AsyncTimelineEvent root = _asyncEventsById[eventWrapper.event.id];
+    if (root == null) {
+      // Since we process trace events in timestamp order, we can guarantee that
+      // we have not already processed the matching begin event. Discard the end
+      // event in this case.
+      return;
+    }
+    root.endAsyncEvent(eventWrapper);
+  }
+
+  void _handleDurationBeginEvent(TraceEventWrapper eventWrapper) {
+    final current = currentDurationEventNodes[eventWrapper.event.threadId];
+    final timelineEvent = SyncTimelineEvent(eventWrapper);
+    if (current != null) {
+      current.addChild(timelineEvent);
+    }
+    currentDurationEventNodes[eventWrapper.event.threadId] = timelineEvent;
+  }
+
+  void _handleDurationEndEvent(TraceEventWrapper eventWrapper) {
+    final TraceEvent event = eventWrapper.event;
+    SyncTimelineEvent current = currentDurationEventNodes[event.threadId];
+
+    if (current == null) return;
+
+    // If the names of [event] and [current] do not match, our event nesting is
+    // off balance due to duplicate events from the engine. Balance the tree so
+    // we can continue processing trace events for [current].
+    if (event.name != current.name) {
+      if (collectionEquals(
+        event.json,
+        _previousDurationEndEvents[event.threadId]?.json,
+      )) {
+        // This is a duplicate of the previous DurationEnd event we received.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        // Animator::BeginFrame - DurationBegin
+        // ...
+        // Animator::BeginFrame - DurationEnd [previousDurationEndEvent]
+        // Animator::BeginFrame - DurationEnd ([event] - duplicate)
+        // VSYNC - DurationEnd
+        //
+        if (debugTimeline) {
+          debugFrameTracking
+              .writeln('Duplicate duration end event: ${event.json}');
+        }
+        return;
+      } else if (current.name ==
+              _previousDurationEndEvents[event.threadId]?.name &&
+          current.parent?.name == event.name &&
+          current.children.length == 1 &&
+          collectionEquals(
+            current.beginTraceEventJson,
+            current.children.first.beginTraceEventJson,
+          )) {
+        // There was a duplicate DurationBegin event associated with
+        // [previousDurationEndEvent]. [event] is actually the DurationEnd event
+        // for [current.parent]. Trim the extra layer created by the duplicate.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        // Animator::BeginFrame - DurationBegin (duplicate - remove this node)
+        // Animator::BeginFrame - DurationBegin
+        // ...
+        // Animator::BeginFrame - DurationEnd [previousDurationEndEvent]
+        // VSYNC - DurationEnd [event]
+        //
+        if (debugTimeline) {
+          debugFrameTracking.writeln(
+              'Duplicate duration begin event: ${current.beginTraceEventJson}');
+        }
+
+        current.parent.removeChild(current);
+        current = current.parent;
+        currentDurationEventNodes[event.threadId] = current;
+      } else {
+        // The current event node has fallen into an unrecoverable state. Reset
+        // the tracking node.
+        //
+        // Trace example:
+        // VSYNC - DurationBegin
+        //  Animator::BeginFrame - DurationBegin
+        //   VSYNC - DurationBegin (duplicate)
+        //    Animator::BeginFrame - DurationBegin (duplicate)
+        //     ...
+        //  Animator::BeginFrame - DurationEnd
+        // VSYNC - DurationEnd
+        if (debugTimeline) {
+          debugFrameTracking.writeln('Cannot recover unbalanced event tree.');
+          debugFrameTracking.writeln('Event: ${event.json}');
+          debugFrameTracking
+              .writeln('Current: ${currentDurationEventNodes[event.threadId]}');
+        }
+        currentDurationEventNodes[event.threadId] = null;
+        return;
+      }
+    }
+
+    _previousDurationEndEvents[event.threadId] = event;
+
+    current.addEndEvent(eventWrapper);
+
+    // Even if the event is well nested, we could still have a duplicate in the
+    // tree that needs to be removed. Ex:
+    //   VSYNC - StartTime 123
+    //      VSYNC - StartTime 123 (duplicate)
+    //      VSYNC - EndTime 234 (duplicate)
+    //   VSYNC - EndTime 234
+    current.maybeRemoveDuplicate();
+
+    // Since this event is complete, move back up the tree to the nearest
+    // incomplete event.
+    while (current.parent != null &&
+        current.parent.time.end?.inMicroseconds != null) {
+      current = current.parent;
+    }
+    currentDurationEventNodes[event.threadId] = current.parent;
+
+    // If we have reached a null parent, this event is fully formed - add it to
+    // the timeline and try to assign it to a Flutter frame.
+    if (current.parent == null) {
+      if (debugTimeline) {
+        debugFrameTracking.writeln('Trying to add event after DurationEnd:');
+        current.format(debugFrameTracking, '   ');
+      }
+      timelineController.addTimelineEvent(current);
+      // TODO(kenz): only make this call if we are connected to a Flutter app.
+      _maybeAddFlutterFrameEvent(current);
+    }
+  }
+
+  void _handleDurationCompleteEvent(TraceEventWrapper eventWrapper) {
+    final event = eventWrapper.event;
+    final timelineEvent = SyncTimelineEvent(eventWrapper)
+      ..time.end =
+          Duration(microseconds: event.timestampMicros + event.duration);
+
+    final current = currentDurationEventNodes[event.threadId];
+    if (current != null) {
+      if (current.subtreeHasNodeWithCondition(
+          (TimelineEvent event) => collectionEquals(
+                event.beginTraceEventJson,
+                timelineEvent.beginTraceEventJson,
+              ))) {
+        // This is a duplicate DurationComplete event. Return early.
+        return;
+      }
+      current.addChild(timelineEvent);
+    } else {
+      // Since we do not have a current duration event for this thread, this DC
+      // event is either a timeline root event or a child of
+      // [pendingRootCompleteEvent].
+      if (_pendingRootCompleteEvent == null) {
+        _pendingRootCompleteEvent = timelineEvent;
+      } else {
+        _pendingRootCompleteEvent.addChild(timelineEvent);
+      }
+    }
+  }
+
+  void _handleFrameStartEvent(TraceEvent event) {
+    if (event.id == null) return;
+    final pendingFrame = _frameFromEvent(event);
+    pendingFrame.pipelineItemTime.start = Duration(
+      microseconds: nullSafeMin(
+        pendingFrame.pipelineItemTime.start?.inMicroseconds,
+        event.timestampMicros,
+      ),
+    );
+    if (pendingFrame.pipelineItemTime.start.inMicroseconds ==
+        event.timestampMicros) {
+      pendingFrame.pipelineItemStartTrace = event;
+    }
+    _maybeAddCompletedFrame(pendingFrame);
+  }
+
+  void _handleFrameEndEvent(TraceEvent event) async {
+    if (event.id == null) return;
+    // Since we handle events in ascending timestamp order, we should ignore
+    // frame end events that we receive before the corresponding frame start
+    // event.
+    if (!pendingFrames.containsKey(_frameId(event))) return;
+    final pendingFrame = _frameFromEvent(event);
+    pendingFrame.pipelineItemTime.end = Duration(
+      microseconds: nullSafeMax(
+        pendingFrame.pipelineItemTime.end?.inMicroseconds,
+        event.timestampMicros,
+      ),
+    );
+    if (pendingFrame.pipelineItemTime.end.inMicroseconds ==
+        event.timestampMicros) {
+      pendingFrame.pipelineItemEndTrace = event;
+    }
+    _maybeAddCompletedFrame(pendingFrame);
+  }
+
+  /// Add event to an available frame in [pendingFrames] if we can.
+  void _maybeAddFlutterFrameEvent(SyncTimelineEvent event) {
+    if (!(event.isUiEventFlow &&
+            event.traceEvents.first.event.threadId == uiThreadId) &&
+        !(event.isRasterEventFlow &&
+            event.traceEvents.first.event.threadId == rasterThreadId)) {
+      // We do not care about events that are neither the main flow of UI
+      // events nor the main flow of Raster events.
+      return;
+    }
+
+    final frames = pendingFrames.values
+        .where((frame) => frame.pipelineItemTime.start != null)
+        .toList()
+          ..sort((FlutterFrame a, FlutterFrame b) {
+            return a.pipelineItemTime.start.inMicroseconds
+                .compareTo(b.pipelineItemTime.start.inMicroseconds);
+          });
+    for (FlutterFrame frame in frames) {
+      final eventAdded = _maybeAddEventToFrame(event, frame);
+      if (eventAdded) {
+        break;
+      }
+    }
+  }
+
+  /// Attempts to add [event] to [frame], and returns a bool indicating whether
+  /// the attempt was successful.
+  bool _maybeAddEventToFrame(SyncTimelineEvent event, FlutterFrame frame) {
+    // Ensure the frame does not already have an event of this type and that
+    // the event fits within the frame's time boundaries.
+    if (frame.eventFlows[event.type.index] != null ||
+        !satisfiesUiRasterOrder(event, frame)) return false;
+
+    frame.setEventFlow(event);
+
+    // Adding event [e] could mean we have completed the frame. Check if we
+    // should add the completed frame to [_frameCompleteController].
+    _maybeAddCompletedFrame(frame);
+
+    return true;
+  }
+
+  // The [rasterEventFlow] should always start after the [uiEventFlow].
+  @visibleForTesting
+  bool satisfiesUiRasterOrder(SyncTimelineEvent e, FlutterFrame f) {
+    if (e.isUiEventFlow && f.rasterEventFlow != null) {
+      return e.time.start.inMicroseconds <
+          f.rasterEventFlow.time.start.inMicroseconds;
+    } else if (e.isRasterEventFlow && f.uiEventFlow != null) {
+      return e.time.start.inMicroseconds >
+          f.uiEventFlow.time.start.inMicroseconds;
+    }
+    // We do not have enough information about the frame to compare UI and
+    // Raster start times, so return true.
+    return true;
+  }
+
+  void _maybeAddCompletedFrame(FlutterFrame frame) {
+    assert(pendingFrames.containsKey(frame.id));
+    if (frame.isReadyForTimeline) {
+      timelineController.addFrame(frame);
+      pendingFrames.remove(frame.id);
+    }
+  }
+
+  FlutterFrame _frameFromEvent(TraceEvent event) {
+    final id = _frameId(event);
+    return pendingFrames.putIfAbsent(id, () => FlutterFrame(id));
+  }
+
+  String _frameId(TraceEvent event) {
+    return '${event.name}-${event.id}';
+  }
+
+  void reset() {
+    _asyncEventsById.clear();
+    currentDurationEventNodes.clear();
+    _previousDurationEndEvents.clear();
+    pendingFrames.clear();
+    _pendingRootCompleteEvent = null;
+    _traceEventsProcessed = 0;
+    _progressNotifier.value = 0.0;
+  }
+
+  void primeThreadIds(
+      {@required int uiThreadId, @required int rasterThreadId}) {
+    this.uiThreadId = uiThreadId;
+    this.rasterThreadId = rasterThreadId;
+  }
+
+  @visibleForTesting
+  TimelineEventType inferEventType(TraceEvent event) {
+    if (event.phase == TraceEvent.asyncBeginPhase ||
+        event.phase == TraceEvent.asyncInstantPhase ||
+        event.phase == TraceEvent.asyncEndPhase) {
+      return TimelineEventType.async;
+    } else if (event.threadId == uiThreadId) {
+      return TimelineEventType.ui;
+    } else if (event.threadId == rasterThreadId) {
+      return TimelineEventType.raster;
+    } else {
+      return TimelineEventType.unknown;
+    }
+  }
+}

--- a/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
@@ -1,0 +1,1317 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// TODO(kenz): delete this legacy implementation after
+// https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
+// hits flutter stable.
+
+import 'dart:math' as math;
+import 'dart:ui';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import '../../auto_dispose_mixin.dart';
+import '../../charts/flame_chart.dart';
+import '../../common_widgets.dart';
+import '../../flutter_widgets/linked_scroll_controller.dart';
+import '../../geometry.dart';
+import '../../notifications.dart';
+import '../../theme.dart';
+import '../../trace_event.dart';
+import '../../ui/colors.dart';
+import '../../ui/search.dart';
+import '../../utils.dart';
+import 'performance_controller.dart';
+import 'performance_model.dart';
+import 'performance_utils.dart';
+
+final timelineSearchFieldKey = GlobalKey(debugLabel: 'TimelineSearchFieldKey');
+
+class TimelineFlameChartContainer extends StatefulWidget {
+  const TimelineFlameChartContainer({
+    @required this.processing,
+    @required this.processingProgress,
+  });
+
+  @visibleForTesting
+  static const emptyTimelineKey = Key('Empty Timeline');
+
+  final bool processing;
+
+  final double processingProgress;
+
+  @override
+  _TimelineFlameChartContainerState createState() =>
+      _TimelineFlameChartContainerState();
+}
+
+class _TimelineFlameChartContainerState
+    extends State<TimelineFlameChartContainer>
+    with AutoDisposeMixin, SearchFieldMixin<TimelineFlameChartContainer> {
+  PerformanceController controller;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final newController = Provider.of<PerformanceController>(context);
+    if (newController == controller) return;
+    controller = newController;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    Widget content;
+    final timelineEmpty = (controller.data?.isEmpty ?? true) ||
+        controller.data.eventGroups.isEmpty;
+    if (widget.processing || timelineEmpty) {
+      content = ValueListenableBuilder<bool>(
+        valueListenable: controller.emptyTimeline,
+        builder: (context, emptyRecording, _) {
+          return emptyRecording
+              ? Center(
+                  key: TimelineFlameChartContainer.emptyTimelineKey,
+                  child: Text(
+                    'No timeline events',
+                    style: Theme.of(context).subtleTextStyle,
+                  ),
+                )
+              : _buildProcessingInfo();
+        },
+      );
+    } else {
+      content = LayoutBuilder(
+        builder: (context, constraints) {
+          return TimelineFlameChart(
+            controller.data,
+            width: constraints.maxWidth,
+            height: constraints.maxHeight,
+            selectionNotifier: controller.selectedTimelineEvent,
+            searchMatchesNotifier: controller.searchMatches,
+            activeSearchMatchNotifier: controller.activeSearchMatch,
+            onDataSelected: (e) => controller.selectTimelineEvent(e),
+          );
+        },
+      );
+    }
+
+    final searchFieldEnabled =
+        !(controller.data?.isEmpty ?? true) && !widget.processing;
+    return OutlineDecoration(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          AreaPaneHeader(
+            title: const Text('Timeline Events'),
+            tall: true,
+            needsTopBorder: false,
+            rightPadding: 0.0,
+            actions: [
+              _buildSearchField(searchFieldEnabled),
+              FlameChartHelpButton(),
+            ],
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: content,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSearchField(bool searchFieldEnabled) {
+    return Container(
+      width: wideSearchTextWidth,
+      height: defaultTextFieldHeight,
+      child: buildSearchField(
+        controller: controller,
+        searchFieldKey: timelineSearchFieldKey,
+        searchFieldEnabled: searchFieldEnabled,
+        shouldRequestFocus: false,
+        supportsNavigation: true,
+      ),
+    );
+  }
+
+  Widget _buildProcessingInfo() {
+    return ProcessingInfo(
+      progressValue: widget.processingProgress,
+      processedObject: 'timeline trace',
+    );
+  }
+}
+
+// TODO(kenz): for sections with more than one row deep, add empty row for
+// section label.
+
+// TODO(kenz): make flame chart sections collapsible.
+
+class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
+  TimelineFlameChart(
+    PerformanceData data, {
+    @required double width,
+    @required double height,
+    @required ValueListenable<TimelineEvent> selectionNotifier,
+    @required ValueListenable<List<TimelineEvent>> searchMatchesNotifier,
+    @required ValueListenable<TimelineEvent> activeSearchMatchNotifier,
+    @required Function(TimelineEvent event) onDataSelected,
+  }) : super(
+          data,
+          time: data.time,
+          containerWidth: width,
+          containerHeight: height,
+          startInset: _calculateStartInset(data),
+          selectionNotifier: selectionNotifier,
+          searchMatchesNotifier: searchMatchesNotifier,
+          activeSearchMatchNotifier: activeSearchMatchNotifier,
+          onDataSelected: onDataSelected,
+        );
+
+  static double _calculateStartInset(PerformanceData data) {
+    const spaceFor0msText = 55.0;
+    const maxStartInset = 300.0;
+    var maxMeasuredWidth = 0.0;
+    for (String groupName in data.eventGroups.keys) {
+      final textPainter = TextPainter(
+        text: TextSpan(text: groupName),
+        textDirection: TextDirection.ltr,
+      )..layout();
+      maxMeasuredWidth =
+          math.max(maxMeasuredWidth, textPainter.width + 2 * densePadding);
+    }
+    return math.min(maxStartInset, maxMeasuredWidth) + spaceFor0msText;
+  }
+
+  /// Offset for drawing async guidelines.
+  static const int asyncGuidelineOffset = 1;
+
+  // Rows of top padding needed to create room for the timestamp labels and the
+  // selected frame brackets.
+  static const int rowOffsetForTopPadding = 3;
+
+  @override
+  TimelineFlameChartState createState() => TimelineFlameChartState();
+}
+
+class TimelineFlameChartState
+    extends FlameChartState<TimelineFlameChart, TimelineEvent> {
+  /// Stores the [FlameChartNode] for each [TimelineEvent] in the chart.
+  ///
+  /// We need to be able to look up a [FlameChartNode] based on its
+  /// corresponding [TimelineEvent] when we traverse the event tree.
+  final chartNodesByEvent = <TimelineEvent, FlameChartNode>{};
+
+  /// Async guideline segments drawn in the direction of the x-axis.
+  final horizontalGuidelines = <HorizontalLineSegment>[];
+
+  /// Async guideline segments drawn in the direction of the y-axis.
+  final verticalGuidelines = <VerticalLineSegment>[];
+
+  final eventGroupStartYValues = Expando<double>();
+
+  int widestRow = -1;
+
+  PerformanceController _performanceController;
+
+  FlutterFrame _selectedFrame;
+
+  ScrollController _groupLabelScrollController;
+
+  ScrollController _previousInGroupButtonsScrollController;
+
+  ScrollController _nextInGroupButtonsScrollController;
+
+  @override
+  int get rowOffsetForTopPadding => TimelineFlameChart.rowOffsetForTopPadding;
+
+  @override
+  void initState() {
+    super.initState();
+    _groupLabelScrollController = verticalControllerGroup.addAndGet();
+    _previousInGroupButtonsScrollController =
+        verticalControllerGroup.addAndGet();
+    _nextInGroupButtonsScrollController = verticalControllerGroup.addAndGet();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final newController = Provider.of<PerformanceController>(context);
+    if (newController == _performanceController) return;
+    _performanceController = newController;
+
+    addAutoDisposeListener(
+      _performanceController.selectedFrame,
+      _handleSelectedFrame,
+    );
+  }
+
+  @override
+  bool isDataVerticallyInView(TimelineEvent data) {
+    final eventTopY = topYForData(data);
+    final verticalScrollOffset = verticalControllerGroup.offset;
+    return eventTopY > verticalScrollOffset &&
+        eventTopY + rowHeightWithPadding <
+            verticalScrollOffset + widget.containerHeight;
+  }
+
+  @override
+  bool isDataHorizontallyInView(TimelineEvent data) {
+    return (visibleTimeRange.contains(data.time.start) &&
+            visibleTimeRange.contains(data.time.end)) ||
+        (data.time.start <= visibleTimeRange.start &&
+            data.time.end >= visibleTimeRange.end);
+  }
+
+  @override
+  double topYForData(TimelineEvent data) {
+    final eventGroup = widget.data.eventGroups[computeEventGroupKey(
+      data,
+      _performanceController.threadNamesById,
+    )];
+    assert(eventGroup != null);
+    final rowOffsetInGroup = eventGroup.rowIndexForEvent[data];
+    return eventGroupStartYValues[eventGroup] +
+        rowOffsetInGroup * rowHeightWithPadding;
+  }
+
+  @override
+  double startXForData(TimelineEvent data) {
+    final timeMicros = data.time.start.inMicroseconds;
+    // Horizontally scroll to the frame.
+    final relativeStartTime = timeMicros - startTimeOffset;
+    final ratio = relativeStartTime / widget.data.time.duration.inMicroseconds;
+    return contentWidthWithZoom * ratio;
+  }
+
+  int _indexOfFirstEventInView(TimelineEventGroup group) {
+    final boundEvent = SyncTimelineEvent(
+      TraceEventWrapper(
+        TraceEvent({'ts': visibleTimeRange.start.inMicroseconds})
+          ..type = TimelineEventType.unknown,
+        0, // This is arbitrary
+      ),
+    )..time = visibleTimeRange;
+    return lowerBound(
+      group.sortedEventRoots,
+      boundEvent,
+      compare: (TimelineEvent a, TimelineEvent b) =>
+          a.time.start.compareTo(b.time.start),
+    );
+  }
+
+  Future<void> _viewPreviousEventInGroup(TimelineEventGroup group) async {
+    final firstInViewIndex = _indexOfFirstEventInView(group);
+    if (firstInViewIndex > 0) {
+      final event = group.sortedEventRoots[firstInViewIndex - 1];
+      await zoomAndScrollToData(
+        startMicros: event.time.start.inMicroseconds,
+        durationMicros: event.time.duration.inMicroseconds,
+        data: event,
+        scrollVertically: false,
+        jumpZoom: true,
+      );
+      return;
+    }
+    // This notification should not be shown, as we are disabling the previous
+    // button when there are no more events out of view for the group. Leave
+    // this here as a fallback though, so that we do not give the user a
+    // completely broken experience if we regress or if there is a race.
+    Notifications.of(context).push(
+      'There are no events on this thread that occurred before this time range.',
+    );
+  }
+
+  Future<void> _viewNextEventInGroup(TimelineEventGroup group) async {
+    final boundEvent = SyncTimelineEvent(
+      TraceEventWrapper(
+        TraceEvent({'ts': visibleTimeRange.end.inMicroseconds})
+          ..type = TimelineEventType.unknown,
+        0, // This is arbitrary
+      ),
+    )..time = (TimeRange()
+      ..start = visibleTimeRange.end
+      ..end = visibleTimeRange.end);
+    final firstOutOfViewIndex = lowerBound(
+      group.sortedEventRoots,
+      boundEvent,
+      compare: (TimelineEvent a, TimelineEvent b) =>
+          a.time.end.compareTo(b.time.end),
+    );
+
+    TimelineEvent zoomTo;
+    // If there are no events in this group that occur after the visible time
+    // range, and the first event in the visible time range is the first event
+    // in the group, zoom to this event. This covers the case where a user is
+    // viewing a very zoomed out chart and would like to jump to the first in
+    // view. If the first event in the group occurs before the visible time
+    // range, then the user will be able to use the previous button to navigate
+    // to that event.
+    if (firstOutOfViewIndex == group.sortedEventRoots.length) {
+      final firstInViewIndex = _indexOfFirstEventInView(group);
+      if (firstInViewIndex == 0) {
+        zoomTo = group.sortedEventRoots.first;
+      }
+    } else if (firstOutOfViewIndex < group.sortedEventRoots.length) {
+      zoomTo = group.sortedEventRoots[firstOutOfViewIndex];
+    }
+
+    if (zoomTo != null) {
+      await zoomAndScrollToData(
+        startMicros: zoomTo.time.start.inMicroseconds,
+        durationMicros: zoomTo.time.duration.inMicroseconds,
+        data: zoomTo,
+        scrollVertically: false,
+        jumpZoom: true,
+      );
+      return;
+    }
+
+    // TODO(kenz): once the performance view records live frame data, perform
+    // a refresh of timeline events here if we know there are more events we
+    // have yet to render.
+
+    // This notification should not be shown, as we are disabling the next
+    // button when there are no more events out of view for the group. Leave
+    // this here as a fallback though, so that we do not give the user a
+    // completely broken experience if we regress or if there is a race.
+    Notifications.of(context).push(
+      'There are no events on this thread that occurred after this time range.',
+    );
+  }
+
+  void _handleSelectedFrame() async {
+    final selectedFrame = _performanceController.selectedFrame.value;
+    if (selectedFrame == _selectedFrame) return;
+
+    setState(() {
+      _selectedFrame = selectedFrame;
+    });
+
+    // TODO(kenz): consider using jumpTo for some of these animations to
+    // improve performance.
+
+    if (_selectedFrame != null) {
+      // Zoom and scroll to the frame's UI event.
+      await zoomAndScrollToData(
+        startMicros: selectedFrame.time.start.inMicroseconds,
+        durationMicros: selectedFrame.time.duration.inMicroseconds,
+        data: selectedFrame.uiEventFlow,
+      );
+    }
+  }
+
+  @override
+  void initFlameChartElements() {
+    super.initFlameChartElements();
+
+    double leftForEvent(TimelineEvent event) {
+      return (event.time.start.inMicroseconds - startTimeOffset) *
+              startingPxPerMicro +
+          widget.startInset;
+    }
+
+    double rightForEvent(TimelineEvent event) {
+      return (event.time.end.inMicroseconds - startTimeOffset) *
+              startingPxPerMicro +
+          widget.startInset;
+    }
+
+    double maxRight = -1;
+    void createChartNode(TimelineEvent event, int row, int section) {
+      // TODO(kenz): we should do something more clever here by inferring the
+      // missing start/end time based on ancestors/children. Skip for now.
+      if (!event.isWellFormed) return;
+
+      final double left = leftForEvent(event);
+      final double right = rightForEvent(event);
+      if (right > maxRight) {
+        maxRight = right;
+        widestRow = row;
+      }
+
+      Color backgroundColor;
+      if (event.isAsyncEvent) {
+        backgroundColor = nextAsyncColor(row);
+      } else if (event.isGCEvent) {
+        // TODO(kenz): should we have a different color palette for GC events?
+        backgroundColor = nextUnknownColor(row);
+      } else if (event.isUiEvent) {
+        backgroundColor = nextUiColor(row);
+      } else if (event.isRasterEvent) {
+        backgroundColor = nextRasterColor(row);
+      } else {
+        backgroundColor = nextUnknownColor(row);
+      }
+
+      Color textColor;
+      if (event.isRasterEvent) {
+        textColor = contrastForegroundWhite;
+      } else {
+        textColor = Colors.black;
+      }
+
+      final node = FlameChartNode<TimelineEvent>(
+        key: Key('${event.name} ${event.traceEvents.first.id}'),
+        text: event.name,
+        rect: Rect.fromLTRB(left, flameChartNodeTop, right, rowHeight),
+        backgroundColor: backgroundColor,
+        textColor: textColor,
+        data: event,
+        onSelected: (dynamic event) => widget.onDataSelected(event),
+        sectionIndex: section,
+      );
+      chartNodesByEvent[event] = node;
+
+      rows[row].addNode(node);
+    }
+
+    expandRows(rowOffsetForTopPadding);
+    int currentRowIndex = rowOffsetForTopPadding;
+    int currentSectionIndex = 0;
+    double yOffset = rowOffsetForTopPadding * sectionSpacing;
+    for (String groupName in widget.data.eventGroups.keys) {
+      final TimelineEventGroup group = widget.data.eventGroups[groupName];
+      // Expand rows to fit nodes in [group].
+      assert(rows.length == currentRowIndex);
+      expandRows(rows.length + group.displaySize);
+      eventGroupStartYValues[group] = yOffset;
+      for (int i = 0; i < group.rows.length; i++) {
+        for (var event in group.rows[i].events) {
+          createChartNode(
+            event,
+            currentRowIndex + i,
+            currentSectionIndex,
+          );
+        }
+      }
+
+      final section = FlameChartSection(
+        currentSectionIndex,
+        startRow: currentRowIndex,
+        endRow: currentRowIndex + group.displayDepth,
+      );
+      sections.add(section);
+
+      // Increment for next section.
+      currentRowIndex += group.displaySize;
+      currentSectionIndex++;
+      yOffset += group.displaySizePx;
+    }
+
+    // Ensure the nodes in each row are sorted in ascending positional order.
+    for (var row in rows) {
+      row.nodes.sort((a, b) => a.rect.left.compareTo(b.rect.left));
+    }
+
+    _calculateAsyncGuidelines();
+  }
+
+  @override
+  List<Widget> buildChartOverlays(
+    BoxConstraints constraints,
+    BuildContext buildContext,
+  ) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final zoom = zoomController.value;
+    return [
+      CustomPaint(
+        painter: AsyncGuidelinePainter(
+          zoom: zoom,
+          constraints: constraints,
+          verticalScrollOffset: verticalScrollOffset,
+          horizontalScrollOffset: horizontalScrollOffset,
+          verticalGuidelines: verticalGuidelines,
+          horizontalGuidelines: horizontalGuidelines,
+          chartStartInset: widget.startInset,
+          colorScheme: colorScheme,
+        ),
+      ),
+      CustomPaint(
+        painter: TimelineGridPainter(
+          zoom: zoom,
+          constraints: constraints,
+          verticalScrollOffset: verticalScrollOffset,
+          horizontalScrollOffset: horizontalScrollOffset,
+          chartStartInset: widget.startInset,
+          chartEndInset: widget.endInset,
+          flameChartWidth: widthWithZoom,
+          duration: widget.time.duration,
+          colorScheme: colorScheme,
+        ),
+      ),
+      CustomPaint(
+        painter: SelectedFrameBracketPainter(
+          _selectedFrame,
+          zoom: zoom,
+          constraints: constraints,
+          verticalScrollOffset: verticalScrollOffset,
+          horizontalScrollOffset: horizontalScrollOffset,
+          chartStartInset: widget.startInset,
+          startTimeOffsetMicros: startTimeOffset,
+          startingPxPerMicro: startingPxPerMicro,
+          // Subtract [rowHeight] because [_calculateVerticalGuidelineStartY]
+          // returns the Y value at the bottom of the flame chart node, and we
+          // want the Y value at the top of the node.
+          yForEvent: (event) =>
+              _calculateVerticalGuidelineStartY(event) - rowHeight,
+          colorScheme: colorScheme,
+        ),
+      ),
+      _buildSectionLabels(constraints: constraints),
+      ..._buildEventThreadNavigationButtons(constraints: constraints),
+    ];
+  }
+
+  Widget _buildSectionLabels({@required BoxConstraints constraints}) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final eventGroups = _performanceController.data.eventGroups;
+
+    final children = <Widget>[];
+    for (int i = 0; i < eventGroups.length; i++) {
+      var topSpacer = 0.0;
+      var bottomSpacer = 0.0;
+      if (i == 0) {
+        // Add spacing to account for timestamps at top of chart.
+        topSpacer +=
+            sectionSpacing * TimelineFlameChart.rowOffsetForTopPadding -
+                rowHeight;
+      }
+      if (i == eventGroups.length - 1) {
+        // Add spacing to account for bottom row of padding.
+        bottomSpacer = rowHeight;
+      }
+
+      final groupName = eventGroups.keys.elementAt(i);
+      final group = eventGroups[groupName];
+      final backgroundColor = alternatingColorForIndex(i, colorScheme);
+      final backgroundWithOpacity = Color.fromRGBO(
+        backgroundColor.red,
+        backgroundColor.green,
+        backgroundColor.blue,
+        0.85,
+      );
+      children.add(
+        Container(
+          padding: EdgeInsets.only(top: topSpacer, bottom: bottomSpacer),
+          alignment: Alignment.topLeft,
+          height: group.displaySizePx + topSpacer + bottomSpacer,
+          child: Container(
+            padding: const EdgeInsets.symmetric(
+              horizontal: densePadding,
+              vertical: rowPadding,
+            ),
+            color: backgroundWithOpacity,
+            child: Text(
+              groupName,
+              style: TextStyle(color: colorScheme.chartTextColor),
+            ),
+          ),
+        ),
+      );
+    }
+
+    return Positioned(
+      top: rowHeight, // Adjust for row of timestamps
+      left: 0.0,
+      height: constraints.maxHeight,
+      width: widget.startInset,
+      child: IgnorePointer(
+        child: ListView(
+          physics: const ClampingScrollPhysics(),
+          controller: _groupLabelScrollController,
+          children: children,
+        ),
+      ),
+    );
+  }
+
+  List<Widget> _buildEventThreadNavigationButtons({
+    @required BoxConstraints constraints,
+  }) {
+    const threadButtonContainerWidth = buttonMinWidth + defaultSpacing;
+    final eventGroups = _performanceController.data.eventGroups;
+
+    Widget buildNavigatorButton(int index, {@required bool isNext}) {
+      // Add spacing to account for timestamps at top of chart.
+      final topSpacer = index == 0
+          ? sectionSpacing * TimelineFlameChart.rowOffsetForTopPadding -
+              rowHeight
+          : 0.0;
+      // Add spacing to account for bottom row of padding.
+      final bottomSpacer = index == eventGroups.length - 1 ? rowHeight : 0.0;
+
+      final groupName = eventGroups.keys.elementAt(index);
+      final group = eventGroups[groupName];
+      final backgroundColor = alternatingColorForIndex(
+        // Add 1 so that the color of the button contrasts with the group
+        // background color.
+        index + 1,
+        Theme.of(context).colorScheme,
+      );
+      final backgroundWithOpacity = Color.fromRGBO(
+        backgroundColor.red,
+        backgroundColor.green,
+        backgroundColor.blue,
+        0.85,
+      );
+      return NavigateInThreadInButton(
+        group: group,
+        isNext: isNext,
+        topSpacer: topSpacer,
+        bottomSpacer: bottomSpacer,
+        backgroundColor: backgroundWithOpacity,
+        threadButtonContainerWidth: threadButtonContainerWidth,
+        onPressed: () => isNext
+            ? _viewNextEventInGroup(group)
+            : _viewPreviousEventInGroup(group),
+        shouldEnableButton: (g) => isNext
+            ? _shouldEnableNextInThreadButton(g)
+            : _shouldEnablePrevInThreadButton(g),
+        horizontalController: horizontalControllerGroup,
+      );
+    }
+
+    return [
+      Positioned(
+        top: rowHeight, // Adjust for row of timestamps
+        left: 0.0,
+        height: constraints.maxHeight,
+        width: threadButtonContainerWidth,
+        child: ListView.builder(
+          physics: const ClampingScrollPhysics(),
+          controller: _previousInGroupButtonsScrollController,
+          itemCount: eventGroups.length,
+          itemBuilder: (context, i) => buildNavigatorButton(i, isNext: false),
+        ),
+      ),
+      Positioned(
+        top: rowHeight, // Adjust for row of timestamps
+        right: 0.0,
+        height: constraints.maxHeight,
+        width: threadButtonContainerWidth,
+        child: ListView.builder(
+          physics: const ClampingScrollPhysics(),
+          controller: _nextInGroupButtonsScrollController,
+          itemCount: eventGroups.length,
+          itemBuilder: (context, i) => buildNavigatorButton(i, isNext: true),
+        ),
+      ),
+    ];
+  }
+
+  bool _shouldEnablePrevInThreadButton(TimelineEventGroup group) {
+    return horizontalControllerGroup.hasAttachedControllers &&
+        group.earliestTimestampMicros < visibleTimeRange.start.inMicroseconds;
+  }
+
+  bool _shouldEnableNextInThreadButton(TimelineEventGroup group) {
+    final firstEventInView = _indexOfFirstEventInView(group);
+    final noEventsAfterVisibleTimeRange =
+        horizontalControllerGroup.hasAttachedControllers &&
+            group.latestTimestampMicros <= visibleTimeRange.end.inMicroseconds;
+    return (firstEventInView == 0 && noEventsAfterVisibleTimeRange) ||
+        horizontalControllerGroup.hasAttachedControllers &&
+            group.latestTimestampMicros > visibleTimeRange.end.inMicroseconds;
+  }
+
+  void _calculateAsyncGuidelines() {
+    // Padding to be added between a subsequent guideline and the child event
+    // it is connecting.
+    const subsequentChildGuidelinePadding = 8.0;
+    assert(rows.isNotEmpty);
+    assert(chartNodesByEvent.isNotEmpty);
+    verticalGuidelines.clear();
+    horizontalGuidelines.clear();
+    for (var row in rows) {
+      for (var node in row.nodes) {
+        if (node.data is AsyncTimelineEvent) {
+          final event = node.data as AsyncTimelineEvent;
+          bool allChildrenAreAsyncInstantEvents = true;
+          for (var child in event.children) {
+            if (!child.isAsyncInstantEvent) {
+              allChildrenAreAsyncInstantEvents = false;
+              break;
+            }
+          }
+          // Continue if there are no children we should draw async guidelines
+          // to.
+          if (event.children.isEmpty || allChildrenAreAsyncInstantEvents) {
+            continue;
+          }
+
+          // Vertical guideline that will connect [node] with its children
+          // nodes. The line will end at [node]'s last child.
+          final verticalGuidelineX =
+              node.rect.left + TimelineFlameChart.asyncGuidelineOffset;
+          final verticalGuidelineStartY =
+              _calculateVerticalGuidelineStartY(event);
+          final verticalGuidelineEndY =
+              _calculateHorizontalGuidelineY(event.lowestDisplayChild);
+          verticalGuidelines.add(VerticalLineSegment(
+            Offset(verticalGuidelineX, verticalGuidelineStartY),
+            Offset(verticalGuidelineX, verticalGuidelineEndY),
+          ));
+
+          // Draw the horizontal guideline to the first child event that is not
+          // an instant event, since it is guaranteed to be connected to
+          // the main vertical we just created.
+          final firstChild = event.children
+              .firstWhere((TimelineEvent e) => !e.isAsyncInstantEvent);
+          final horizontalGuidelineEndX =
+              chartNodesByEvent[firstChild].rect.left;
+          final horizontalGuidelineY =
+              _calculateHorizontalGuidelineY(firstChild);
+          horizontalGuidelines.add(HorizontalLineSegment(
+            Offset(verticalGuidelineX, horizontalGuidelineY),
+            Offset(horizontalGuidelineEndX, horizontalGuidelineY),
+          ));
+
+          // Horizontal guidelines connecting each child to the vertical
+          // guideline above.
+          for (int i = 1; i < event.children.length; i++) {
+            double horizontalGuidelineStartX = verticalGuidelineX;
+
+            final child = event.children[i];
+            if (child.isAsyncInstantEvent) continue;
+
+            final childNode = chartNodesByEvent[child];
+
+            // Helper method to generate a vertical guideline for subsequent
+            // children after the first child. We will create a new guideline
+            // if it can be created without intersecting previous children.
+            void generateSubsequentVerticalGuideline(double previousXInRow) {
+              double newVerticalGuidelineX;
+
+              // If [child] started after [event] ended, use the right edge of
+              // event's [node] as the x coordinate for the guideline.
+              // Otherwise, take the minimum of
+              // [subsequentChildGuidelineOffset] and half the distance
+              // between [previousXInRow] and child's left edge.
+              if (event.time.end < child.time.start) {
+                newVerticalGuidelineX = node.rect.right;
+              } else {
+                newVerticalGuidelineX = childNode.rect.left -
+                    math.min(
+                      subsequentChildGuidelinePadding,
+                      (childNode.rect.left - previousXInRow) / 2,
+                    );
+              }
+              final newVerticalGuidelineEndY =
+                  _calculateHorizontalGuidelineY(child);
+              verticalGuidelines.add(VerticalLineSegment(
+                Offset(newVerticalGuidelineX, verticalGuidelineStartY),
+                Offset(newVerticalGuidelineX, newVerticalGuidelineEndY),
+              ));
+
+              horizontalGuidelineStartX = newVerticalGuidelineX;
+            }
+
+            FlameChartNode previousSiblingInRow(FlameChartNode child) {
+              final previousNodeIndex = child.row.nodes.indexOf(child) - 1;
+              final previousNode = previousNodeIndex >= 0
+                  ? child.row.nodes[previousNodeIndex]
+                  : null;
+              final isSibling = previousNode?.data?.parent == node.data;
+              return isSibling ? previousNode : null;
+            }
+
+            if (childNode.row.index == node.row.index + 1) {
+              FlameChartNode previousSibling = previousSiblingInRow(childNode);
+              // Look back until we find the first sibling in this row that is
+              // not an instant event (if present).
+              while (previousSibling != null &&
+                  (previousSibling.data as AsyncTimelineEvent)
+                      .isAsyncInstantEvent) {
+                previousSibling = previousSiblingInRow(previousSibling);
+              }
+              if (previousSibling != null) {
+                generateSubsequentVerticalGuideline(previousSibling.rect.right);
+              }
+            }
+
+            final horizontalGuidelineEndX = childNode.rect.left;
+            final horizontalGuidelineY = _calculateHorizontalGuidelineY(child);
+            horizontalGuidelines.add(HorizontalLineSegment(
+              Offset(horizontalGuidelineStartX, horizontalGuidelineY),
+              Offset(horizontalGuidelineEndX, horizontalGuidelineY),
+            ));
+          }
+        }
+      }
+    }
+
+    // Sort the lists in ascending order based on their cross axis coordinate.
+    verticalGuidelines.sort();
+    horizontalGuidelines.sort();
+  }
+
+  int _spacerRowsBeforeEvent(TimelineEvent event) {
+    // Add 1 to account for the first spacer row before section 0 begins.
+    return chartNodesByEvent[event].sectionIndex + rowOffsetForTopPadding;
+  }
+
+  double _calculateVerticalGuidelineStartY(TimelineEvent event) {
+    final spacerRowsBeforeEvent = _spacerRowsBeforeEvent(event);
+    return spacerRowsBeforeEvent * sectionSpacing +
+        (chartNodesByEvent[event].row.index - spacerRowsBeforeEvent) *
+            rowHeightWithPadding +
+        rowHeight;
+  }
+
+  double _calculateHorizontalGuidelineY(TimelineEvent event) {
+    final spacerRowsBeforeEvent = _spacerRowsBeforeEvent(event);
+    return spacerRowsBeforeEvent * sectionSpacing +
+        (chartNodesByEvent[event].row.index - spacerRowsBeforeEvent) *
+            rowHeightWithPadding +
+        rowHeight / 2;
+  }
+}
+
+class AsyncGuidelinePainter extends FlameChartPainter {
+  AsyncGuidelinePainter({
+    @required double zoom,
+    @required BoxConstraints constraints,
+    @required double verticalScrollOffset,
+    @required double horizontalScrollOffset,
+    @required double chartStartInset,
+    @required this.verticalGuidelines,
+    @required this.horizontalGuidelines,
+    @required ColorScheme colorScheme,
+  }) : super(
+          zoom: zoom,
+          constraints: constraints,
+          verticalScrollOffset: verticalScrollOffset,
+          horizontalScrollOffset: horizontalScrollOffset,
+          chartStartInset: chartStartInset,
+          colorScheme: colorScheme,
+        );
+
+  final List<VerticalLineSegment> verticalGuidelines;
+
+  final List<HorizontalLineSegment> horizontalGuidelines;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    // The guideline objects are calculated with a base zoom level of 1.0. We
+    // need to convert the zoomed left offset into the unzoomed left offset for
+    // proper calculation of the first vertical guideline index.
+    final visible = visibleRect;
+    final unzoomedOffset = math.max(0.0, visible.left - chartStartInset) / zoom;
+    final leftBoundWithoutZoom = chartStartInset + unzoomedOffset;
+
+    final firstVerticalGuidelineIndex = lowerBound(
+      verticalGuidelines,
+      VerticalLineSegment(
+        Offset(leftBoundWithoutZoom, visible.top),
+        Offset(leftBoundWithoutZoom, visible.bottom),
+      ),
+    );
+    final firstHorizontalGuidelineIndex = lowerBound(
+      horizontalGuidelines,
+      HorizontalLineSegment(visible.topLeft, visible.topRight),
+    );
+
+    if (firstVerticalGuidelineIndex != -1) {
+      _paintGuidelines(
+        canvas,
+        visible,
+        verticalGuidelines,
+        firstVerticalGuidelineIndex,
+      );
+    }
+
+    if (firstHorizontalGuidelineIndex != -1) {
+      _paintGuidelines(
+        canvas,
+        visible,
+        horizontalGuidelines,
+        firstHorizontalGuidelineIndex,
+      );
+    }
+  }
+
+  void _paintGuidelines(
+    Canvas canvas,
+    Rect visible,
+    List<LineSegment> guidelines,
+    int firstLineIndex,
+  ) {
+    final paint = Paint()..color = colorScheme.treeGuidelineColor;
+    var lastOpacity = 1.0;
+    for (int i = firstLineIndex; i < guidelines.length; i++) {
+      final line = guidelines[i];
+      // Take [chartStartInset] and
+      // [FullTimelineFlameChart.asyncGuidelineOffset] into account when
+      // calculating [zoomedLine] because these units of space should not scale.
+      final unzoomableOffsetLineStart =
+          TimelineFlameChart.asyncGuidelineOffset + chartStartInset;
+
+      LineSegment zoomedLine;
+      if (line is VerticalLineSegment) {
+        // The unzoomable offset will be the same for start and end because this
+        // is a vertical line, so line.start.dx == line.end.dx.
+        zoomedLine = line.toZoomed(
+          zoom: zoom,
+          unzoomableOffsetLineStart: unzoomableOffsetLineStart,
+          unzoomableOffsetLineEnd: unzoomableOffsetLineStart,
+        );
+      } else {
+        // The unzoomable end offset for a horizontal line is unaffected by
+        // [FullTimelineFlameChart.asyncGuidelineOffset], so we only need to
+        // consider [chartStartInset].
+        zoomedLine = line.toZoomed(
+          zoom: zoom,
+          unzoomableOffsetLineStart: unzoomableOffsetLineStart,
+          unzoomableOffsetLineEnd: chartStartInset,
+        );
+      }
+
+      // We are out of range on the cross axis.
+      if (!zoomedLine.crossAxisIntersects(visible)) break;
+
+      // Only paint lines that intersect [visible] along both axes.
+      if (zoomedLine.intersects(visible)) {
+        final opacity = zoomedLine.opacity;
+        if (opacity != lastOpacity) {
+          paint.color = colorScheme.treeGuidelineColor.withOpacity(opacity);
+          lastOpacity = opacity;
+        }
+        canvas.drawLine(
+          Offset(
+            (zoomedLine.start.dx - horizontalScrollOffset)
+                .clamp(0.0, constraints.maxWidth),
+            (zoomedLine.start.dy - verticalScrollOffset)
+                .clamp(0.0, constraints.maxHeight),
+          ),
+          Offset(
+            (zoomedLine.end.dx - horizontalScrollOffset)
+                .clamp(0.0, constraints.maxWidth),
+            (zoomedLine.end.dy - verticalScrollOffset)
+                .clamp(0.0, constraints.maxHeight),
+          ),
+          paint,
+        );
+      }
+    }
+  }
+
+  // TODO(kenz): does this have to return true all the time? Is it cheaper to
+  // compare delegates or to just paint?
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) => true;
+}
+
+class SelectedFrameBracketPainter extends FlameChartPainter {
+  SelectedFrameBracketPainter(
+    this.selectedFrame, {
+    @required double zoom,
+    @required BoxConstraints constraints,
+    @required double verticalScrollOffset,
+    @required double horizontalScrollOffset,
+    @required double chartStartInset,
+    @required this.startTimeOffsetMicros,
+    @required this.startingPxPerMicro,
+    @required this.yForEvent,
+    @required ColorScheme colorScheme,
+  }) : super(
+          zoom: zoom,
+          constraints: constraints,
+          verticalScrollOffset: verticalScrollOffset,
+          horizontalScrollOffset: horizontalScrollOffset,
+          chartStartInset: chartStartInset,
+          colorScheme: colorScheme,
+        );
+
+  static const strokeWidth = 4.0;
+  static const bracketWidth = 24.0;
+  static const bracketCurveWidth = 8.0;
+  static const bracketVerticalPadding = 8.0;
+
+  final FlutterFrame selectedFrame;
+
+  final int startTimeOffsetMicros;
+
+  final double startingPxPerMicro;
+
+  final double Function(TimelineEvent) yForEvent;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    if (selectedFrame == null) return;
+
+    canvas.clipRect(Rect.fromLTWH(
+      0.0,
+      rowHeight, // We do not want to paint inside the timestamp section.
+      constraints.maxWidth,
+      constraints.maxHeight - rowHeight,
+    ));
+
+    final paint = Paint()
+      ..color = defaultSelectionColor
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = strokeWidth;
+
+    _paintBrackets(canvas, paint, event: selectedFrame.uiEventFlow);
+    _paintBrackets(canvas, paint, event: selectedFrame.rasterEventFlow);
+  }
+
+  void _paintBrackets(
+    Canvas canvas,
+    Paint paint, {
+    @required TimelineEvent event,
+  }) {
+    final visible = visibleRect;
+    final startMicros = event.time.start.inMicroseconds - startTimeOffsetMicros;
+    final endMicros = event.time.end.inMicroseconds - startTimeOffsetMicros;
+    final startPx = startMicros * startingPxPerMicro * zoom + chartStartInset;
+    final endPx = endMicros * startingPxPerMicro * zoom + chartStartInset;
+
+    final startBracketX =
+        startPx - visible.left + (bracketWidth - bracketCurveWidth);
+    final endBracketX =
+        endPx - visible.left - (bracketWidth - bracketCurveWidth);
+    final bracketTopY = yForEvent(event) - visible.top - bracketVerticalPadding;
+    final bracketBottomY = bracketTopY +
+        event.depth * rowHeightWithPadding -
+        rowPadding +
+        bracketVerticalPadding * 2;
+
+    // Draw the start bracket.
+    canvas.drawPath(
+      Path()
+        ..moveTo(startBracketX, bracketTopY)
+        ..lineTo(startBracketX - bracketWidth + bracketCurveWidth, bracketTopY)
+        ..arcTo(
+          Rect.fromLTWH(
+            startBracketX - bracketWidth,
+            bracketTopY,
+            bracketCurveWidth * 2,
+            bracketCurveWidth * 2,
+          ),
+          degToRad(270),
+          degToRad(-90),
+          false,
+        )
+        ..lineTo(
+          startBracketX - bracketWidth,
+          bracketBottomY - bracketWidth,
+        )
+        ..arcTo(
+          Rect.fromLTWH(
+            startBracketX - bracketWidth,
+            bracketBottomY - bracketVerticalPadding * 2,
+            bracketCurveWidth * 2,
+            bracketCurveWidth * 2,
+          ),
+          degToRad(180),
+          degToRad(-90),
+          false,
+        )
+        ..lineTo(startBracketX, bracketBottomY),
+      paint,
+    );
+
+    // Draw the end bracket.
+    // TODO(kenz): reuse the path of the start bracket and transform it to draw
+    // the end bracket.
+    canvas.drawPath(
+      Path()
+        ..moveTo(endBracketX, bracketTopY)
+        ..lineTo(endBracketX + bracketWidth - bracketCurveWidth, bracketTopY)
+        ..arcTo(
+          Rect.fromLTWH(
+            endBracketX + bracketWidth - bracketCurveWidth * 2,
+            bracketTopY,
+            bracketCurveWidth * 2,
+            bracketCurveWidth * 2,
+          ),
+          degToRad(270),
+          degToRad(90),
+          false,
+        )
+        ..lineTo(
+          endBracketX + bracketWidth,
+          bracketBottomY - bracketWidth,
+        )
+        ..arcTo(
+          Rect.fromLTWH(
+            endBracketX + bracketWidth - bracketCurveWidth * 2,
+            bracketBottomY - bracketVerticalPadding * 2,
+            bracketCurveWidth * 2,
+            bracketCurveWidth * 2,
+          ),
+          degToRad(0),
+          degToRad(90),
+          false,
+        )
+        ..lineTo(endBracketX, bracketBottomY),
+      paint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(SelectedFrameBracketPainter oldDelegate) =>
+      this != oldDelegate;
+
+  @override
+  bool operator ==(Object other) {
+    return other is SelectedFrameBracketPainter &&
+        selectedFrame == other.selectedFrame &&
+        zoom == other.zoom &&
+        constraints == other.constraints &&
+        verticalScrollOffset == other.verticalScrollOffset &&
+        horizontalScrollOffset == other.horizontalScrollOffset &&
+        colorScheme == other.colorScheme;
+  }
+
+  @override
+  int get hashCode => hashValues(
+        selectedFrame,
+        zoom,
+        constraints,
+        verticalScrollOffset,
+        horizontalScrollOffset,
+        colorScheme,
+      );
+}
+
+class NavigateInThreadInButton extends StatefulWidget {
+  const NavigateInThreadInButton({
+    @required this.group,
+    @required this.isNext,
+    @required this.topSpacer,
+    @required this.bottomSpacer,
+    @required this.backgroundColor,
+    @required this.threadButtonContainerWidth,
+    @required this.onPressed,
+    @required this.shouldEnableButton,
+    @required this.horizontalController,
+  });
+
+  final TimelineEventGroup group;
+
+  final bool isNext;
+
+  final double topSpacer;
+
+  final double bottomSpacer;
+
+  final Color backgroundColor;
+
+  final double threadButtonContainerWidth;
+
+  final VoidCallback onPressed;
+
+  final bool Function(TimelineEventGroup) shouldEnableButton;
+
+  final LinkedScrollControllerGroup horizontalController;
+
+  static const topPaddingForMediumGroups = 20.0;
+
+  @override
+  _NavigateInThreadInButtonState createState() =>
+      _NavigateInThreadInButtonState();
+}
+
+class _NavigateInThreadInButtonState extends State<NavigateInThreadInButton>
+    with AutoDisposeMixin {
+  @override
+  void initState() {
+    super.initState();
+    // Call set state each time the horizontal offset is updated. This will
+    // ensure we are properly enabling/disabling the navigator button based on
+    // the visible time range.
+    addAutoDisposeListener(widget.horizontalController.offsetNotifier);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final useSmallButton = !widget.isNext && widget.group.displayDepth <= 1;
+    final topPadding = !widget.isNext && widget.group.displayDepth == 2
+        ? NavigateInThreadInButton.topPaddingForMediumGroups
+        : 0.0;
+    return Container(
+      margin: EdgeInsets.only(
+        top: widget.topSpacer,
+        bottom: widget.bottomSpacer,
+      ),
+      padding: EdgeInsets.only(
+        top: topPadding,
+        bottom: useSmallButton ? borderPadding : 0.0,
+        right: widget.isNext ? defaultSpacing : 0.0,
+        left: widget.isNext ? 0.0 : defaultSpacing,
+      ),
+      height: widget.group.displaySizePx,
+      width: widget.threadButtonContainerWidth,
+      alignment: useSmallButton ? Alignment.bottomCenter : Alignment.center,
+      child: ThreadNavigatorButton(
+        useSmallButton: useSmallButton,
+        backgroundColor: widget.backgroundColor,
+        tooltip:
+            widget.isNext ? 'Next event in thread' : 'Previous event in thread',
+        icon: widget.isNext ? Icons.chevron_right : Icons.chevron_left,
+        onPressed:
+            widget.shouldEnableButton(widget.group) ? widget.onPressed : null,
+      ),
+    );
+  }
+}
+
+class ThreadNavigatorButton extends StatelessWidget {
+  const ThreadNavigatorButton({
+    @required this.useSmallButton,
+    @required this.backgroundColor,
+    @required this.tooltip,
+    @required this.icon,
+    @required this.onPressed,
+  });
+
+  final bool useSmallButton;
+
+  final Color backgroundColor;
+
+  final String tooltip;
+
+  final IconData icon;
+
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: roundedBorderDecoration(context).copyWith(
+        color: backgroundColor,
+      ),
+      // Using [buttonMinWidth] will result in a square button.
+      height: useSmallButton ? smallButtonHeight : buttonMinWidth,
+      width: buttonMinWidth,
+      child: DevToolsTooltip(
+        tooltip: tooltip,
+        child: IconButton(
+          padding: EdgeInsets.zero,
+          icon: Icon(
+            icon,
+            size: actionsIconSize,
+          ),
+          onPressed: onPressed,
+        ),
+      ),
+    );
+  }
+}
+
+extension TimelineEventGroupDisplayExtension on TimelineEventGroup {
+  int get displaySize => rows.length + FlameChart.rowOffsetForSectionSpacer;
+
+  double get displaySizePx =>
+      rows.length * rowHeightWithPadding +
+      FlameChart.rowOffsetForSectionSpacer * sectionSpacing;
+}


### PR DESCRIPTION
We will have to support two versions of the performance page: the current implementation that calculates flutter frames based off of timeline events, and a new version that uses the flutter FrameTiming API. Until the engine and framework changes related to flutter frame ids in timeline events and flutter.frame events are present in flutter stable (https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f is the latest), we need to support both of these impls in the performance page.

No functional changes here, just copying current code into legacy/ to prepare for the migration to using the FrameTiming api.