### PR TITLE
Stop checking flutter version for connected app in flutter web apps

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -57,13 +57,13 @@ dependencies:
   web_socket_channel: ^2.0.0
 
 dev_dependencies:
-  build_runner: ^1.3.0
+  build_runner: ^2.0.4
   devtools:
     path: ../devtools
   devtools_testing: 2.2.4
   flutter_test:
     sdk: flutter
-  mockito: ^4.0.0
+  mockito: ^5.0.9
   test: any # This version is pinned by Flutter so we don't need to set one explicitly.
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 


### PR DESCRIPTION
This also makes the version checking code more safe by ensuring that the flutter version service is available before attempting to make a call to it.