### PR TITLE
remove some unused top level variables

### DIFF
--- a/packages/devtools_app/lib/src/analytics/analytics.dart
+++ b/packages/devtools_app/lib/src/analytics/analytics.dart
@@ -22,7 +22,7 @@ import '../config_specific/url/url.dart';
 import '../globals.dart';
 import '../ui/gtags.dart';
 import '../version.dart';
-import 'constants.dart';
+import 'constants.dart' as analytics_constants;
 
 // Dimensions1 AppType values:
 const String appTypeFlutter = 'flutter';
@@ -200,7 +200,7 @@ void screen(
   GTag.event(
     screenName,
     GtagEventDevTools(
-      event_category: screenViewEvent,
+      event_category: analytics_constants.screenViewEvent,
       value: value,
       user_app: userAppType,
       user_build: userBuildType,
@@ -222,7 +222,7 @@ void select(
   GTag.event(
     screenName,
     GtagEventDevTools(
-      event_category: selectEvent,
+      event_category: analytics_constants.selectEvent,
       event_label: selectedItem,
       value: value,
       user_app: userAppType,
@@ -247,7 +247,7 @@ void selectFrame(
   GTag.event(
     screenName,
     GtagEventDevTools(
-      event_category: selectEvent,
+      event_category: analytics_constants.selectEvent,
       event_label: selectedItem,
       raster_duration: rasterDuration,
       ui_duration: uiDuration,

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -3,38 +3,27 @@
 // found in the LICENSE file.
 
 // Type of events (event_category):
-const String applicationEvent = 'application'; // visible/hidden
+
 const String screenViewEvent = 'screen'; // Active screen (tab selected).
 const String selectEvent = 'select'; // User selected something.
 
-const String errorError = 'onerror'; // Browser onError detected in DevTools
-const String exceptionEvent = 'exception'; // Any Dart exception in DevTools
+//const String exceptionEvent = 'exception'; // Any Dart exception in DevTools
 
 // DevTools GA screenNames:
 
 // GA events not associated with a any screen e.g., hotReload, hotRestart, etc
 const String devToolsMain = 'main';
-const String debugger = 'debugger';
 const String inspector = 'inspector';
 const String logging = 'logging';
-const String memory = 'memory';
 const String performance = 'performance';
-const String timeline = 'timeline';
 
 // DevTools UI action selected (clicked).
 
 // Main bar UX actions:
-const String hotReload = 'hotReload';
-const String hotRestart = 'hotRestart';
 const String feedbackLink = 'feedback';
 const String feedbackButton = 'feedbackButton';
 
-// Common UX actions:
-const String pause = 'pause'; // Memory, Timeline, Debugger
-const String resume = 'resume'; // Memory, Timeline, Debugger
-
 // Inspector UX actions:
-const String widgetMode = 'widgetMode';
 const String refresh = 'refresh';
 const String performanceOverlay = 'performanceOverlay';
 const String debugPaint = 'debugPaint';
@@ -48,29 +37,5 @@ const String selectWidgetMode = 'selectWidgetMode';
 const String enableOnDeviceInspector = 'enableOnDeviceInspector';
 const String showOnDeviceInspector = 'showInspector';
 
-// Timeline UX actions:
-const String timelineFrame = 'frame'; // Frame selected in frame chart
-const String timelineFlameRaster = 'flameRaster'; // Selected a Raster flame
-const String timelineFlameUi = 'flameUI'; // Selected a UI flame
-
-// Memory UX actions:
-const String search = 'search';
-const String snapshot = 'snapshot';
-const String reset = 'reset';
-const String gC = 'gc';
-const String inspectClass = 'inspectClass'; // inspect a class from snapshot
-const String inspectInstance = 'inspectInstance'; // inspect an instance
-const String inspectData = 'inspectData'; // inspect data of the instance
-
-// Debugger UX actions:
-const String openShortcut = 'openShortcut';
-const String stepIn = 'stepIn';
-const String stepOver = 'stepOver';
-const String stepOut = 'stepOut';
-const String bP = 'bp';
-const String unhandledExceptions = 'unhandledExceptions';
-const String allExceptions = 'allExceptions';
-
 // Logging UX actions:
-const String clearLogs = 'clearLogs';
 const String structuredErrors = 'structuredErrors';

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -7,6 +7,7 @@
 const String screenViewEvent = 'screen'; // Active screen (tab selected).
 const String selectEvent = 'select'; // User selected something.
 
+// TODO(devoncarew): Add exception reporting - #3079.
 //const String exceptionEvent = 'exception'; // Any Dart exception in DevTools
 
 // DevTools GA screenNames:

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -10,7 +10,7 @@ import 'package:provider/provider.dart';
 import '../devtools.dart' as devtools;
 import 'analytics/analytics_stub.dart'
     if (dart.library.html) 'analytics/analytics.dart' as ga;
-import 'analytics/constants.dart';
+import 'analytics/constants.dart' as analytics_constants;
 import 'analytics/provider.dart';
 import 'app_size/app_size_controller.dart';
 import 'app_size/app_size_screen.dart';
@@ -448,7 +448,8 @@ class ReportFeedbackButton extends StatelessWidget {
       tooltip: 'Report feedback',
       child: InkWell(
         onTap: () async {
-          ga.select(devToolsMain, feedbackButton);
+          ga.select(analytics_constants.devToolsMain,
+              analytics_constants.feedbackButton);
           await launchUrl(
               devToolsExtensionPoints.issueTrackerLink().url, context);
         },
@@ -504,7 +505,8 @@ class DevToolsAboutDialog extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     return InkWell(
       onTap: () async {
-        ga.select(devToolsMain, feedbackLink);
+        ga.select(
+            analytics_constants.devToolsMain, analytics_constants.feedbackLink);
         await launchUrl(reportIssuesLink.url, context);
       },
       child: Text(reportIssuesLink.display, style: linkTextStyle(colorScheme)),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -448,8 +448,10 @@ class ReportFeedbackButton extends StatelessWidget {
       tooltip: 'Report feedback',
       child: InkWell(
         onTap: () async {
-          ga.select(analytics_constants.devToolsMain,
-              analytics_constants.feedbackButton);
+          ga.select(
+            analytics_constants.devToolsMain,
+            analytics_constants.feedbackButton,
+          );
           await launchUrl(
               devToolsExtensionPoints.issueTrackerLink().url, context);
         },
@@ -506,7 +508,9 @@ class DevToolsAboutDialog extends StatelessWidget {
     return InkWell(
       onTap: () async {
         ga.select(
-            analytics_constants.devToolsMain, analytics_constants.feedbackLink);
+          analytics_constants.devToolsMain,
+          analytics_constants.feedbackLink,
+        );
         await launchUrl(reportIssuesLink.url, context);
       },
       child: Text(reportIssuesLink.display, style: linkTextStyle(colorScheme)),

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -10,7 +10,7 @@ import 'package:vm_service/vm_service.dart' hide Stack;
 
 import '../analytics/analytics_stub.dart'
     if (dart.library.html) '../analytics/analytics.dart' as ga;
-import '../analytics/constants.dart';
+import '../analytics/constants.dart' as analytics_constants;
 import '../auto_dispose_mixin.dart';
 import '../blocking_action_mixin.dart';
 import '../common_widgets.dart';
@@ -329,7 +329,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   }
 
   void _refreshInspector() {
-    ga.select(inspector, refresh);
+    ga.select(analytics_constants.inspector, analytics_constants.refresh);
     blockWhileInProgress(() async {
       await inspectorController?.onForceRefresh();
     });

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -10,7 +10,6 @@ import 'package:intl/intl.dart';
 import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../analytics/constants.dart';
 import '../auto_dispose.dart';
 import '../config_specific/file/file.dart';
 import '../config_specific/logger/logger.dart';

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -7,7 +7,7 @@ library service_extensions;
 import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
-import 'analytics/constants.dart' as ga;
+import 'analytics/constants.dart' as analytics_constants;
 import 'theme.dart';
 import 'ui/icons.dart';
 
@@ -90,8 +90,8 @@ final debugAllowBanner = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Debug Banner',
   disabledTooltip: 'Show Debug Banner',
-  gaScreenName: ga.inspector,
-  gaItem: ga.debugBanner,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.debugBanner,
 );
 
 final invertOversizedImages = ToggleableServiceExtensionDescription<bool>._(
@@ -102,8 +102,8 @@ final invertOversizedImages = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Disable Invert Oversized Images',
   disabledTooltip: 'Enable Invert Oversized Images',
-  gaScreenName: ga.inspector,
-  gaItem: ga.debugBanner,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.debugBanner,
 );
 
 final debugPaint = ToggleableServiceExtensionDescription<bool>._(
@@ -114,8 +114,8 @@ final debugPaint = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Debug Paint',
   disabledTooltip: 'Show Debug Paint',
-  gaScreenName: ga.inspector,
-  gaItem: ga.debugPaint,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.debugPaint,
 );
 
 final debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
@@ -126,8 +126,8 @@ final debugPaintBaselines = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Paint Baselines',
   disabledTooltip: 'Show Paint Baselines',
-  gaScreenName: ga.inspector,
-  gaItem: ga.paintBaseline,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.paintBaseline,
 );
 
 final performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
@@ -138,8 +138,8 @@ final performanceOverlay = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Performance Overlay',
   disabledTooltip: 'Show Performance Overlay',
-  gaScreenName: ga.inspector,
-  gaItem: ga.performanceOverlay,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.performanceOverlay,
 );
 
 final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
@@ -150,8 +150,8 @@ final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Disable tracking widget builds',
   disabledTooltip: 'Enable tracking widget builds',
-  gaScreenName: ga.performance,
-  gaItem: ga.trackRebuilds,
+  gaScreenName: analytics_constants.performance,
+  gaItem: analytics_constants.trackRebuilds,
 );
 
 final repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
@@ -162,8 +162,8 @@ final repaintRainbow = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Hide Repaint Rainbow',
   disabledTooltip: 'Show Repaint Rainbow',
-  gaScreenName: ga.inspector,
-  gaItem: ga.repaintRainbow,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.repaintRainbow,
 );
 
 final slowAnimations = ToggleableServiceExtensionDescription<num>._(
@@ -174,8 +174,8 @@ final slowAnimations = ToggleableServiceExtensionDescription<num>._(
   disabledValue: 1.0,
   enabledTooltip: 'Disable Slow Animations',
   disabledTooltip: 'Enable Slow Animations',
-  gaScreenName: ga.inspector,
-  gaItem: ga.slowAnimation,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.slowAnimation,
 );
 
 final togglePlatformMode = ServiceExtensionDescription<String>(
@@ -191,8 +191,8 @@ final togglePlatformMode = ServiceExtensionDescription<String>(
     'Platform: Linux'
   ],
   tooltips: ['Override Target Platform'],
-  gaScreenName: ga.inspector,
-  gaItem: ga.togglePlatform,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.togglePlatform,
 );
 
 final httpEnableTimelineLogging = ToggleableServiceExtensionDescription<bool>._(
@@ -232,8 +232,8 @@ final toggleOnDeviceWidgetInspector =
   disabledValue: false,
   enabledTooltip: 'Disable select widget mode',
   disabledTooltip: 'Enable select widget mode',
-  gaScreenName: ga.inspector,
-  gaItem: ga.showOnDeviceInspector,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.showOnDeviceInspector,
 );
 
 /// Toggle whether interacting with the device selects widgets or triggers
@@ -246,8 +246,8 @@ final toggleSelectWidgetMode = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Exit select widget mode',
   disabledTooltip: 'Enter select widget mode',
-  gaScreenName: ga.inspector,
-  gaItem: ga.selectWidgetMode,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.selectWidgetMode,
 );
 
 /// Toggle whether the inspector on-device overlay is enabled.
@@ -263,8 +263,8 @@ final enableOnDeviceInspector = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Exit on-device inspector',
   disabledTooltip: 'Enter on-device inspector',
-  gaScreenName: ga.inspector,
-  gaItem: ga.enableOnDeviceInspector,
+  gaScreenName: analytics_constants.inspector,
+  gaItem: analytics_constants.enableOnDeviceInspector,
 );
 
 final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
@@ -275,8 +275,8 @@ final structuredErrors = ToggleableServiceExtensionDescription<bool>._(
   disabledValue: false,
   enabledTooltip: 'Disable structured errors for Flutter framework issues',
   disabledTooltip: 'Show structured errors for Flutter framework issues',
-  gaScreenName: ga.logging,
-  gaItem: ga.structuredErrors,
+  gaScreenName: analytics_constants.logging,
+  gaItem: analytics_constants.structuredErrors,
 );
 
 // This extension should never be displayed as a button so does not need a


### PR DESCRIPTION
- remove some unused top level variables from analytics/constants.dart

This PR removes a number of unused top-level fields from the `lib/src/analytics/constants.dart` library. I believe these were used in a previous iteration of the analytics impl.? I changed the imports of this library to use an import prefix - constants.dart has a number of symbols w/ short names, and it's useful to know where they come from.
