### PR TITLE
Update to package:vm_service 7.0.0

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   async: ^2.0.0
   codicon: ^0.0.3
   collection: ^1.15.0-nnbd
-  dds: ^1.8.0
+  dds: ^2.0.0
   devtools_shared: 2.3.0
   file: ^6.0.0
   file_selector: ^0.8.0
@@ -52,7 +52,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^6.2.0
+  vm_service: ^7.0.0
   vm_snapshot_analysis: ^0.6.0
   web_socket_channel: ^2.0.0
 

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
   shelf_static: ^1.0.0
   http_multi_server: ^3.0.0
   usage: ^4.0.0
-  vm_service: ^6.2.0
+  vm_service: ^7.0.0
   collection: ^1.15.0-nullsafety.4
 
 dependency_overrides:

--- a/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
+++ b/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
@@ -22,9 +22,14 @@ class ClassHeapDetailStats {
   factory ClassHeapDetailStats.fromJson(Map<String, dynamic> json) {
     final classId = json['class']['id'];
     final className = json['class']['name'];
+    final library = json['class']['library'];
 
     return ClassHeapDetailStats(
-      ClassRef(id: classId, name: className),
+      ClassRef(
+        id: classId,
+        name: className,
+        library: LibraryRef.parse(library),
+      ),
       bytes: json['bytesCurrent'] as int,
       deltaBytes: json['bytesDelta'] as int,
       instances: json['instancesCurrent'] as int,

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -11,4 +11,4 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  vm_service: ^6.2.0
+  vm_service: ^7.0.0

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   meta: ^1.3.0
   pedantic: ^1.11.0
   test: any # This version is pinned by Flutter so we don't need to set one explicitly.
-  vm_service: ^6.2.0
+  vm_service: ^7.0.0
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.


### PR DESCRIPTION
Checks will fail until we can publish a new DDS with `vm_service: ^7.0.0` constraints, but we'll need a new `devtools_shared` before we can do that.