### PR TITLE
Update vm_service dependency.

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -271,7 +271,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
 
     try {
       // Init the inspector service, or return null.
-      await ensureInspectorServiceDependencies();
       inspectorService =
           await InspectorService.create(service).catchError((e) => null);
     } finally {

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -29,18 +29,6 @@ const inspectorLibraryUriCandidates = [
   'package:flutter_web/src/widgets/widget_inspector.dart',
 ];
 
-bool _inspectorDependenciesLoaded = false;
-
-/// This method must be called before any methods on the Inspector are used.
-Future<void> ensureInspectorServiceDependencies() async {
-  if (_inspectorDependenciesLoaded) {
-    return;
-  }
-  // TODO(jacobr): consider also loading common icons needed by the inspector
-  // to avoid flicker on icon load.
-  _inspectorDependenciesLoaded = true;
-}
-
 class RegistrableServiceExtension {
   const RegistrableServiceExtension(this.name);
 
@@ -93,12 +81,10 @@ class InspectorService extends DisposableController
     VmService vmService,
     String groupName,
   ) async {
-    assert(_inspectorDependenciesLoaded);
     return (await create(vmService)).createObjectGroup(groupName);
   }
 
   static Future<InspectorService> create(VmService vmService) async {
-    assert(_inspectorDependenciesLoaded);
     assert(serviceManager.connectedAppInitialized);
     assert(serviceManager.service != null);
     final inspectorLibrary = EvalOnDartLibrary(

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -276,13 +276,10 @@ class LoggingController extends DisposableController
     autoDispose(
         service.onExtensionEventWithHistory.listen(_handleExtensionEvent));
 
-    if (inspectorService == null) {
-      await ensureInspectorServiceDependencies();
-
-      inspectorService = await InspectorService.create(service).catchError(
-          (e) => null,
-          test: (e) => e is FlutterInspectorLibraryNotFound);
-    }
+    inspectorService ??= await InspectorService.create(service).catchError(
+      (e) => null,
+      test: (e) => e is FlutterInspectorLibraryNotFound,
+    );
 
     if (inspectorService != null) {
       objectGroup = inspectorService.createObjectGroup('console-group');

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -973,6 +973,18 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
+  Future<Breakpoint> setBreakpointState(
+      String isolateId, String breakpointId, bool enable) {
+    return trackFuture(
+        'setBreakpointState',
+        _vmService.setBreakpointState(
+          isolateId,
+          breakpointId,
+          enable,
+        ),);
+  }
+
+  @override
   Future<ProtocolList> getSupportedProtocols() async {
     if (await isProtocolVersionSupported(
         supportedVersion: SemanticVersion(major: 3, minor: 35))) {

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -976,12 +976,13 @@ class VmServiceWrapper implements VmService {
   Future<Breakpoint> setBreakpointState(
       String isolateId, String breakpointId, bool enable) {
     return trackFuture(
-        'setBreakpointState',
-        _vmService.setBreakpointState(
-          isolateId,
-          breakpointId,
-          enable,
-        ),);
+      'setBreakpointState',
+      _vmService.setBreakpointState(
+        isolateId,
+        breakpointId,
+        enable,
+      ),
+    );
   }
 
   @override

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   async: ^2.0.0
   codicon: ^0.0.3
   collection: ^1.15.0-nnbd
-  dds: ^1.8.0
+  dds: ^2.0.1
   devtools_shared: 2.3.0
   file: ^6.0.0
   file_selector: ^0.8.0
@@ -52,9 +52,9 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^6.2.0
+  vm_service: ^7.1.0
   vm_snapshot_analysis: ^0.6.0
-  web_socket_channel: ^2.0.0
+  web_socket_channel: ^2.1.0
 
 dev_dependencies:
   build_runner: ^2.0.4
@@ -64,7 +64,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.9
-  test: any # This version is pinned by Flutter so we don't need to set one explicitly.
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 
 flutter:
@@ -130,3 +129,5 @@ dependency_overrides:
     path: ../devtools_shared #OVERRIDE_FOR_DEVELOPMENT
   devtools_testing: #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_testing #OVERRIDE_FOR_DEVELOPMENT
+  devtools:  #OVERRIDE_FOR_DEVELOPMENT
+    path: ../devtools  #OVERRIDE_FOR_DEVELOPMENT

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -58,8 +58,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.4
-  devtools:
-    path: ../devtools
+  devtools: 2.2.4
   devtools_testing: 2.2.4
   flutter_test:
     sdk: flutter

--- a/packages/devtools_app/test/ansi_up_test.dart
+++ b/packages/devtools_app/test/ansi_up_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:ansi_up/ansi_up.dart';
 import 'package:ansicolor/ansicolor.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('ansi_up', () {

--- a/packages/devtools_app/test/association_variable_test.dart
+++ b/packages/devtools_app/test/association_variable_test.dart
@@ -13,6 +13,12 @@ import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';
 
+final libraryRef = LibraryRef(
+  name: 'some library',
+  uri: 'package:foo/foo.dart',
+  id: 'lib-id-1',
+);
+
 void main() {
   ServiceConnectionManager manager;
   DebuggerController debuggerController;
@@ -150,7 +156,7 @@ void main() {
       associations: [
         MapAssociation(
           key: InstanceRef(
-            classRef: ClassRef(id: 'a', name: 'Foo'),
+            classRef: ClassRef(id: 'a', name: 'Foo', library: libraryRef),
             id: '4',
             kind: InstanceKind.kPlainInstance,
             identityHashCode: null,

--- a/packages/devtools_app/test/association_variable_test.dart
+++ b/packages/devtools_app/test/association_variable_test.dart
@@ -6,9 +6,9 @@ import 'package:devtools_app/src/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/auto_complete_test.dart
+++ b/packages/devtools_app/test/auto_complete_test.dart
@@ -1,6 +1,6 @@
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:flutter/material.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('AutoComplete', () {

--- a/packages/devtools_app/test/core/filtering_test.dart
+++ b/packages/devtools_app/test/core/filtering_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/core/filtering.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   defineTests();

--- a/packages/devtools_app/test/core/message_bus_test.dart
+++ b/packages/devtools_app/test/core/message_bus_test.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:devtools_app/src/core/message_bus.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   defineTests();

--- a/packages/devtools_app/test/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profile_model_test.dart
@@ -4,7 +4,7 @@
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('CpuProfileData', () {

--- a/packages/devtools_app/test/cpu_profile_transformer_test.dart
+++ b/packages/devtools_app/test/cpu_profile_transformer_test.dart
@@ -4,7 +4,7 @@
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_transformer.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('CpuProfileTransformer', () {

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -7,7 +7,7 @@ import 'package:devtools_app/src/profiler/cpu_profile_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/mocks.dart';
 import 'support/utils.dart';

--- a/packages/devtools_app/test/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger_controller_test.dart
@@ -5,8 +5,8 @@
 import 'package:devtools_app/src/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger_evalution_test.dart
@@ -12,6 +12,12 @@ import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';
 
+final libraryRef = LibraryRef(
+  name: 'some library',
+  uri: 'package:foo/foo.dart',
+  id: 'lib-id-1',
+);
+
 void main() {
   MockDebuggerController debuggerController;
 
@@ -148,7 +154,7 @@ void main() {
       }
       if (obj is InstanceRef) {
         return Instance(
-          classRef: ClassRef(id: '', name: 'FooClass'),
+          classRef: ClassRef(id: '', name: 'FooClass', library: libraryRef),
           id: '',
           fields: [
             BoundField(

--- a/packages/devtools_app/test/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger_evalution_test.dart
@@ -6,8 +6,8 @@ import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/debugger/evaluate.dart';
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/debugger_model_test.dart
+++ b/packages/devtools_app/test/debugger_model_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/debugger/debugger_model.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';
 
 void main() {

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -240,6 +240,7 @@ void main() {
             scriptUri: 'package:test/script.dart',
             line: 10,
           ),
+          enabled: true,
         )
       ];
 
@@ -606,6 +607,12 @@ String _ansiCodesOutput() {
   return sb.toString();
 }
 
+final libraryRef = LibraryRef(
+  name: 'some library',
+  uri: 'package:foo/foo.dart',
+  id: 'lib-id-1',
+);
+
 final testVariables = [
   Variable.create(BoundVariable(
     name: 'Root 1',
@@ -615,6 +622,7 @@ final testVariables = [
       classRef: ClassRef(
         name: '_GrowableList',
         id: 'ref2',
+        library: libraryRef,
       ),
       length: 2,
       identityHashCode: null,
@@ -629,7 +637,7 @@ final testVariables = [
         value: InstanceRef(
           id: 'ref3',
           kind: InstanceKind.kInt,
-          classRef: ClassRef(name: 'Integer', id: 'ref4'),
+          classRef: ClassRef(name: 'Integer', id: 'ref4', library: libraryRef),
           valueAsString: '3',
           valueAsStringIsTruncated: false,
           identityHashCode: null,
@@ -643,7 +651,7 @@ final testVariables = [
         value: InstanceRef(
           id: 'ref5',
           kind: InstanceKind.kInt,
-          classRef: ClassRef(name: 'Integer', id: 'ref6'),
+          classRef: ClassRef(name: 'Integer', id: 'ref6', library: libraryRef),
           valueAsString: '4',
           valueAsStringIsTruncated: false,
           identityHashCode: null,
@@ -658,7 +666,8 @@ final testVariables = [
     value: InstanceRef(
       id: 'ref7',
       kind: InstanceKind.kMap,
-      classRef: ClassRef(name: '_InternalLinkedHashmap', id: 'ref8'),
+      classRef: ClassRef(
+          name: '_InternalLinkedHashmap', id: 'ref8', library: libraryRef),
       length: 2,
       identityHashCode: null,
     ),
@@ -672,7 +681,7 @@ final testVariables = [
         value: InstanceRef(
           id: 'ref9',
           kind: InstanceKind.kDouble,
-          classRef: ClassRef(name: 'Double', id: 'ref10'),
+          classRef: ClassRef(name: 'Double', id: 'ref10', library: libraryRef),
           valueAsString: '1.0',
           valueAsStringIsTruncated: false,
           identityHashCode: null,
@@ -686,7 +695,7 @@ final testVariables = [
         value: InstanceRef(
           id: 'ref11',
           kind: InstanceKind.kDouble,
-          classRef: ClassRef(name: 'Double', id: 'ref12'),
+          classRef: ClassRef(name: 'Double', id: 'ref12', library: libraryRef),
           valueAsString: '1.1',
           valueAsStringIsTruncated: false,
           identityHashCode: null,
@@ -701,7 +710,7 @@ final testVariables = [
     value: InstanceRef(
       id: 'ref13',
       kind: InstanceKind.kString,
-      classRef: ClassRef(name: 'String', id: 'ref14'),
+      classRef: ClassRef(name: 'String', id: 'ref14', library: libraryRef),
       valueAsString: 'test str',
       valueAsStringIsTruncated: true,
       identityHashCode: null,
@@ -715,7 +724,7 @@ final testVariables = [
     value: InstanceRef(
       id: 'ref15',
       kind: InstanceKind.kBool,
-      classRef: ClassRef(name: 'Boolean', id: 'ref16'),
+      classRef: ClassRef(name: 'Boolean', id: 'ref16', library: libraryRef),
       valueAsString: 'true',
       valueAsStringIsTruncated: false,
       identityHashCode: null,

--- a/packages/devtools_app/test/eval_integration_test.dart
+++ b/packages/devtools_app/test/eval_integration_test.dart
@@ -6,7 +6,7 @@ import 'package:devtools_app/src/eval_on_dart_library.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_testing/support/flutter_test_driver.dart';
 import 'package:devtools_testing/support/flutter_test_environment.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   final FlutterTestEnvironment env = FlutterTestEnvironment(
@@ -116,5 +116,5 @@ void main() {
         expect(error.valueAsString, 'foo');
       });
     });
-  }, timeout: const Timeout.factor(8));
+  });
 }

--- a/packages/devtools_app/test/geometry_test.dart
+++ b/packages/devtools_app/test/geometry_test.dart
@@ -5,8 +5,7 @@
 import 'dart:ui';
 
 import 'package:devtools_app/src/geometry.dart';
-
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('LineSegment', () {

--- a/packages/devtools_app/test/history_manager_test.dart
+++ b/packages/devtools_app/test/history_manager_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/history_manager.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';
 
 void main() {

--- a/packages/devtools_app/test/hover_test.dart
+++ b/packages/devtools_app/test/hover_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:devtools_app/src/debugger/hover.dart';
 import 'package:flutter/widgets.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 const _textSpan = TextSpan(children: [
   TextSpan(text: 'hello', style: TextStyle(fontWeight: FontWeight.bold)),

--- a/packages/devtools_app/test/import_export_test.dart
+++ b/packages/devtools_app/test/import_export_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/utils.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/wrappers.dart';
 

--- a/packages/devtools_app/test/inspector_integration_test.dart
+++ b/packages/devtools_app/test/inspector_integration_test.dart
@@ -32,10 +32,6 @@ void main() async {
 
   InspectorService inspectorService;
 
-  env.afterNewSetup = () async {
-    await ensureInspectorServiceDependencies();
-  };
-
   env.afterEverySetup = () async {
     inspectorService = await InspectorService.create(env.service);
     if (env.reuseTestEnvironment) {

--- a/packages/devtools_app/test/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector_service_test.dart
@@ -7,7 +7,7 @@ import 'package:devtools_testing/support/flutter_test_driver.dart'
     show FlutterRunConfiguration;
 import 'package:devtools_testing/support/flutter_test_environment.dart';
 @TestOn('vm')
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/utils.dart';
 

--- a/packages/devtools_app/test/integration_tests/app.dart
+++ b/packages/devtools_app/test/integration_tests/app.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import '../support/cli_test_driver.dart';
 import 'integration.dart';

--- a/packages/devtools_app/test/integration_tests/debugger.dart
+++ b/packages/devtools_app/test/integration_tests/debugger.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import '../support/cli_test_driver.dart';
 import '../support/utils.dart';

--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -7,8 +7,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter_test/flutter_test.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:test/test.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     show ConsoleAPIEvent, RemoteObject;
 

--- a/packages/devtools_app/test/integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/integration_tests/integration_test.dart
@@ -6,7 +6,7 @@
 import 'dart:io';
 
 import 'package:devtools_testing/support/file_utils.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'app.dart';
 import 'debugger.dart';
@@ -38,5 +38,5 @@ void main() {
       // Temporarily skip tests. See https://github.com/flutter/devtools/issues/1343.
       group('debugging', debuggingTests, skip: true);
     }
-  }, timeout: const Timeout.factor(8));
+  });
 }

--- a/packages/devtools_app/test/integration_tests/logging.dart
+++ b/packages/devtools_app/test/integration_tests/logging.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import '../support/cli_test_driver.dart';
 import 'integration.dart';

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -9,8 +9,8 @@ import 'dart:io';
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:devtools_testing/support/file_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../support/chrome.dart';

--- a/packages/devtools_app/test/logging_controller_fixture_test.dart
+++ b/packages/devtools_app/test/logging_controller_fixture_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /*
 import 'package:devtools_testing/logging_controller_test.dart';

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/inspector/inspector_service.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/filter.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'inspector_screen_test.dart';
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/memory_service_test.dart
+++ b/packages/devtools_app/test/memory_service_test.dart
@@ -7,7 +7,7 @@ import 'package:devtools_testing/memory_service_test.dart';
 import 'package:devtools_testing/support/flutter_test_driver.dart'
     show FlutterRunConfiguration;
 import 'package:devtools_testing/support/flutter_test_environment.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   // TODO(https://github.com/flutter/devtools/issues/2053): rewrite.

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/network/network_model.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/filter.dart';
 import 'package:devtools_app/src/version.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/network_model_test.dart
+++ b/packages/devtools_app/test/network_model_test.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:devtools_app/src/utils.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/network_test_data.dart';
 

--- a/packages/devtools_app/test/network_table_test.dart
+++ b/packages/devtools_app/test/network_table_test.dart
@@ -7,7 +7,7 @@ import 'package:devtools_app/src/http/http_request_data.dart';
 import 'package:devtools_app/src/network/network_controller.dart';
 import 'package:devtools_app/src/network/network_model.dart';
 import 'package:devtools_app/src/network/network_screen.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/utils.dart';
 

--- a/packages/devtools_app/test/performance_controller_test.dart
+++ b/packages/devtools_app/test/performance_controller_test.dart
@@ -7,9 +7,13 @@ import 'package:devtools_testing/performance_controller_test.dart';
 import 'package:devtools_testing/support/flutter_test_driver.dart'
     show FlutterRunConfiguration;
 import 'package:devtools_testing/support/flutter_test_environment.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'support/utils.dart';
 
 void main() async {
+  initializeLiveTestWidgetsFlutterBindingWithAssets();
+
   final FlutterTestEnvironment env = FlutterTestEnvironment(
     const FlutterRunConfiguration(withDebugger: true),
   );

--- a/packages/devtools_app/test/performance_model_test.dart
+++ b/packages/devtools_app/test/performance_model_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_testing/support/cpu_profile_test_data.dart';
 import 'package:devtools_testing/support/performance_test_data.dart';
 import 'package:devtools_testing/support/test_utils.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PerformanceData', () {

--- a/packages/devtools_app/test/performance_utils_test.dart
+++ b/packages/devtools_app/test/performance_utils_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:devtools_app/src/performance/performance_utils.dart';
 import 'package:devtools_testing/support/performance_test_data.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PerformanceUtils', () {

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/preferences.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('PreferencesController', () {

--- a/packages/devtools_app/test/profiler_screen_controller_test.dart
+++ b/packages/devtools_app/test/profiler_screen_controller_test.dart
@@ -4,7 +4,7 @@
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/mocks.dart';
 

--- a/packages/devtools_app/test/service_manager_test.dart
+++ b/packages/devtools_app/test/service_manager_test.dart
@@ -7,7 +7,7 @@ import 'package:devtools_testing/service_manager_test.dart';
 import 'package:devtools_testing/support/flutter_test_driver.dart'
     show FlutterRunConfiguration;
 import 'package:devtools_testing/support/flutter_test_environment.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() async {
   final FlutterTestEnvironment env = FlutterTestEnvironment(

--- a/packages/devtools_app/test/span_parser_test.dart
+++ b/packages/devtools_app/test/span_parser_test.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:devtools_app/src/debugger/span_parser.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
-import 'package:test/test.dart';
 
 const helloWorld = '''
 void main() {

--- a/packages/devtools_app/test/survey_test.dart
+++ b/packages/devtools_app/test/survey_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/survey.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('DevToolsSurvey', () {

--- a/packages/devtools_app/test/theme_test.dart
+++ b/packages/devtools_app/test/theme_test.dart
@@ -7,7 +7,7 @@ import 'dart:ui';
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/theme.dart';
 import 'package:flutter/material.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Theme', () {

--- a/packages/devtools_app/test/timeline_processor_test.dart
+++ b/packages/devtools_app/test/timeline_processor_test.dart
@@ -9,8 +9,8 @@ import 'package:devtools_app/src/trace_event.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_testing/support/performance_test_data.dart';
 import 'package:devtools_testing/support/test_utils.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 
 void main() {
   final originalGoldenUiEvent = goldenUiTimelineEvent.deepCopy();

--- a/packages/devtools_app/test/trees_test.dart
+++ b/packages/devtools_app/test/trees_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/trees.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('TreeNode', () {

--- a/packages/devtools_app/test/typed_data_variable_test.dart
+++ b/packages/devtools_app/test/typed_data_variable_test.dart
@@ -10,9 +10,9 @@ import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/url_utils_test.dart
+++ b/packages/devtools_app/test/url_utils_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/url_utils.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('url utils', () {

--- a/packages/devtools_app/test/version_test.dart
+++ b/packages/devtools_app/test/version_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/version.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('FlutterVersion', () {

--- a/packages/devtools_app/test/vm_service_private_test.dart
+++ b/packages/devtools_app/test/vm_service_private_test.dart
@@ -1,8 +1,8 @@
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/vm_service_wrapper.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
-import 'package:test/test.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_server/pubspec.yaml
+++ b/packages/devtools_server/pubspec.yaml
@@ -3,7 +3,7 @@ description: A server that supports Dart DevTools.
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of packages from packages/devtools.
-version: 2.3.0
+version: 2.3.1
 
 homepage: https://github.com/flutter/devtools
 
@@ -22,7 +22,7 @@ dependencies:
   shelf_static: ^1.0.0
   http_multi_server: ^3.0.0
   usage: ^4.0.0
-  vm_service: ^6.2.0
+  vm_service: ^7.1.0
   collection: ^1.15.0-nullsafety.4
 
 dependency_overrides:

--- a/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
+++ b/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
@@ -24,7 +24,7 @@ class ClassHeapDetailStats {
     final className = json['class']['name'];
 
     return ClassHeapDetailStats(
-      ClassRef(id: classId, name: className),
+      ClassRef(id: classId, name: className, library: null),
       bytes: json['bytesCurrent'] as int,
       deltaBytes: json['bytesDelta'] as int,
       instances: json['instancesCurrent'] as int,

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package of shared structures between devtools_app and devtools_serv
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of packages from packages/devtools.
-version: 2.3.0
+version: 2.3.1
 
 homepage: https://github.com/flutter/devtools
 
@@ -11,4 +11,4 @@ environment:
   sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  vm_service: ^6.2.0
+  vm_service: ^7.1.0

--- a/packages/devtools_testing/lib/inspector_service_test.dart
+++ b/packages/devtools_testing/lib/inspector_service_test.dart
@@ -9,8 +9,7 @@ import 'dart:async';
 
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
-import 'package:flutter_test/flutter_test.dart' show equalsIgnoringHashCodes;
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'matchers/matchers.dart';
 import 'support/flutter_test_driver.dart' show FlutterRunConfiguration;
@@ -18,10 +17,6 @@ import 'support/flutter_test_environment.dart';
 
 Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
   InspectorService inspectorService;
-
-  env.afterNewSetup = () async {
-    await ensureInspectorServiceDependencies();
-  };
 
   env.afterEverySetup = () async {
     inspectorService = await InspectorService.create(env.service);
@@ -446,7 +441,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
 
       // TODO(jacobr): add tests verifying that we can stop the running device
       // without the InspectorService spewing a bunch of errors.
-    }, timeout: const Timeout.factor(8));
+    });
   } catch (e, s) {
     print(s);
   }

--- a/packages/devtools_testing/lib/memory_service_test.dart
+++ b/packages/devtools_testing/lib/memory_service_test.dart
@@ -10,7 +10,7 @@ import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/memory/memory_protocol.dart';
 import 'package:devtools_app/src/memory/memory_timeline.dart';
 import 'package:devtools_shared/devtools_shared.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/flutter_test_environment.dart';
 

--- a/packages/devtools_testing/lib/performance_controller_test.dart
+++ b/packages/devtools_testing/lib/performance_controller_test.dart
@@ -9,7 +9,7 @@
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_model.dart';
 import 'package:devtools_app/src/ui/search.dart';
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 import 'support/flutter_test_environment.dart';
 import 'support/performance_test_data.dart';
@@ -188,9 +188,9 @@ bool isPerformanceDataEqual(PerformanceData a, PerformanceData b) {
 // should re-evaluate the purpose of the devtools_testing package and move some
 // of these tests back into the main devtools_app package if possible.
 void verifyIsSearchMatch(
-    List<DataSearchStateMixin> data,
-    List<DataSearchStateMixin> matches,
-    ) {
+  List<DataSearchStateMixin> data,
+  List<DataSearchStateMixin> matches,
+) {
   for (final request in data) {
     if (matches.contains(request)) {
       expect(request.isSearchMatch, isTrue);

--- a/packages/devtools_testing/lib/support/file_utils.dart
+++ b/packages/devtools_testing/lib/support/file_utils.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 import 'dart:io' as io;
 
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 /// Finds the path to a given package.
 ///

--- a/packages/devtools_testing/pubspec.yaml
+++ b/packages/devtools_testing/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   matcher: ^0.12.3
   meta: ^1.3.0
   pedantic: ^1.11.0
-  test: any # This version is pinned by Flutter so we don't need to set one explicitly.
-  vm_service: ^6.2.0
+  vm_service: ^7.1.0
 
 dependency_overrides:
 # The "#OVERRIDE_FOR_DEVELOPMENT" lines are stripped out when we publish.
@@ -29,7 +28,5 @@ dependency_overrides:
 # in treating them like they are part of a mono-repo while developing.
   devtools_app:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_app  #OVERRIDE_FOR_DEVELOPMENT
-  devtools_server:  #OVERRIDE_FOR_DEVELOPMENT
-    path: ../devtools_server  #OVERRIDE_FOR_DEVELOPMENT
   devtools_shared:  #OVERRIDE_FOR_DEVELOPMENT
     path: ../devtools_shared  #OVERRIDE_FOR_DEVELOPMENT


### PR DESCRIPTION
To make rolling in the future easier, removed the dependency on package:test from package:devtools_app. This avoids problems in cases where there isn't a version of package:test that is compatible with all of the other packages required by devtools_app. All of the tests from devtools_app can be run with flutter_test anyway so there isn't much of a loss of functionality by switching to flutter_test.