### PR TITLE
Eval autocomplete polish.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -89,6 +89,9 @@ class DebuggerController extends DisposableController
 
   VmServiceWrapper get _service => serviceManager.service;
 
+  Map<ObjRef, Future<Set<String>>> autocompleteCache = {};
+  Map<ObjRef, Future<Set<String>>> autocompleteInclusiveCache = {};
+
   final ScriptCache _scriptCache = ScriptCache();
 
   final ScriptsHistory scriptsHistory = ScriptsHistory();
@@ -202,6 +205,10 @@ class DebuggerController extends DisposableController
 
   ValueListenable<StackFrameAndSourcePosition> get selectedStackFrame =>
       _selectedStackFrame;
+
+  Frame get frameForEval =>
+      _selectedStackFrame.value?.frame ??
+      _stackFramesWithLocation.value.first.frame;
 
   final _variables = ValueNotifier<List<Variable>>([]);
 
@@ -594,6 +601,7 @@ class DebuggerController extends DisposableController
     // ignore: unused_local_variable
     final status = reloadEvent.status;
 
+    _clearAutocompleteCaches();
     // Refresh the list of scripts.
     final scriptRefs = await _retrieveAndSortScripts(isolateRef);
     for (var scriptRef in scriptRefs) {
@@ -769,6 +777,12 @@ class DebuggerController extends DisposableController
     _breakPositionsMap.clear();
     _stdio.value = [];
     _uriToScriptMap.clear();
+    _clearAutocompleteCaches();
+  }
+
+  void _clearAutocompleteCaches() {
+    autocompleteCache.clear();
+    autocompleteInclusiveCache.clear();
   }
 
   /// Get the populated [Obj] object, given an [ObjRef].

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -213,6 +213,10 @@ class DebuggerController extends DisposableController
       return ref;
     }
     if (ref is ClassRef) {
+      if (ref.library != null) {
+        return ref.library;
+      }
+      // Fallback for older VMService versions.
       final clazz = await classFor(ref);
       return clazz?.library;
     }

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -63,8 +63,9 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
         return;
       }
 
-      // No exact match, return the list of possible matches.
-      _autoCompleteController.clearSearchAutoComplete();
+      // We avoid clearing the list of possible matches here even though the
+      // current matches may probably out of data as that results in flicker
+      // as Flutter will render a frame before the new matches are available.
 
       // Find word in TextField to try and match (word breaks).
       final textFieldEditingValue = searchTextFieldController.value;
@@ -77,13 +78,22 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
       );
 
       // Only show pop-up if there's a real variable name or field.
-      if (parts.activeWord.isEmpty && !parts.isField) return;
-
+      if (parts.activeWord.isEmpty && !parts.isField) {
+        _autoCompleteController.clearSearchAutoComplete();
+        return;
+      }
       final matches = await autoCompleteResultsFor(parts, widget.controller);
-      _autoCompleteController.searchAutoComplete.value = matches.sublist(
-        0,
-        min(defaultTopMatchesLimit, matches.length),
-      );
+      if (matches.length == 1 && matches.first == parts.activeWord) {
+        // It is not useful to show a single autocomplete that is exactly what
+        // the already typed.
+        _autoCompleteController.clearSearchAutoComplete();
+      } else {
+        _autoCompleteController.searchAutoComplete.value = matches.sublist(
+          0,
+          min(defaultTopMatchesLimit, matches.length),
+        );
+        _autoCompleteController.currentDefaultIndex = 0;
+      }
     } else {
       _autoCompleteController.closeAutoCompleteOverlay();
     }
@@ -274,14 +284,58 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
   }
 }
 
+// If Dart had union types, ref would be type ClassRef | FuncRef | LibraryRef
+Future<LibraryRef> findOwnerLibrary(
+    Object ref, DebuggerController controller) async {
+  if (ref is LibraryRef) {
+    return ref;
+  }
+  if (ref is ClassRef) {
+    final clazz = await classFor(ref, controller);
+    return clazz?.library;
+  }
+  if (ref is FuncRef) {
+    return findOwnerLibrary(ref.owner, controller);
+  }
+  return null;
+}
+
 Future<List<String>> autoCompleteResultsFor(
   EditingParts parts,
   DebuggerController controller,
 ) async {
   final result = <String>{};
   if (!parts.isField) {
-    result.addAll(
-        controller.variables.value.map((variable) => variable.boundVar.name));
+    final variables = controller.variables.value;
+    result.addAll(variables.map((variable) => variable.boundVar.name));
+
+    final thisVariable = variables.firstWhere(
+        (variable) => variable.boundVar.name == 'this',
+        orElse: () => null);
+    if (thisVariable != null) {
+      final thisValue = thisVariable.boundVar.value;
+      if (thisValue is InstanceRef) {
+        await _addAllInstanceMembersToAutocompleteList(
+          result,
+          thisValue,
+          controller,
+        );
+      }
+    }
+    final frame = controller.frameForEval;
+    if (frame != null) {
+      final function = frame.function;
+      if (function != null) {
+        final libraryRef = await findOwnerLibrary(function, controller);
+        if (libraryRef != null) {
+          controller.autocompleteInclusiveCache.clear();
+          controller.autocompleteCache.clear();
+          result.addAll(await libraryMemberAndImportsAutocompletes(
+              libraryRef, controller));
+        }
+      }
+      // TODO(jacobr): consider
+    }
   } else {
     var left = parts.leftSide.split(' ').last;
     // Removing trailing `.`.
@@ -289,40 +343,173 @@ Future<List<String>> autoCompleteResultsFor(
     try {
       final response = await controller.evalAtCurrentFrame(left);
       if (response is InstanceRef) {
-        final Instance instance = await controller.getObject(response);
-        result.addAll(
-          await _autoCompleteMembersFor(
-            instance.classRef,
+        if (response.typeClass != null) {
+          // Assume we want static members for a type class not members of the
+          // Type object. This is reasonable as Type objects are rarely useful
+          // in dart.
+          result.addAll(await _autoCompleteMembersFor(
+            response.typeClass,
             controller,
-          ),
-        );
-        // TODO(grouma) - This shouldn't be necessary but package:dwds does
-        // not properly provide superclass information.
-        final clazz = await classFor(instance.classRef, controller);
-        result.addAll(instance.fields
-            .map((field) => field.decl.name)
-            .where((member) => _isAccessible(member, clazz, controller)));
+            staticContext: true,
+          ));
+        } else {
+          await _addAllInstanceMembersToAutocompleteList(
+            result,
+            response,
+            controller,
+          );
+        }
       }
     } catch (_) {}
   }
-  return result.where((name) => name.startsWith(parts.activeWord)).toList()
-    ..sort();
+  return result.where((name) => name.startsWith(parts.activeWord)).toList();
+}
+
+// Due to https://github.com/dart-lang/sdk/issues/46221
+// we cannot tell what the show clause for an export was so it is unsafe to
+// surface exports as if they were library members as there tend to be
+// significant false positives for libraries such as Flutter where all of
+// dart:ui shows up as in scope from flutter:foundation when it should not be.
+bool debugIncludeExports = true;
+
+Future<Set<String>> libraryMemberAndImportsAutocompletes(
+    LibraryRef libraryRef, DebuggerController controller) {
+  return controller.autocompleteInclusiveCache.putIfAbsent(libraryRef,
+      () => _libraryMemberAndImportsAutocompletes(libraryRef, controller));
+}
+
+Future<Set<String>> _libraryMemberAndImportsAutocompletes(
+    LibraryRef libraryRef, DebuggerController controller) async {
+  final result = <String>{};
+  try {
+    final futures = <Future<Set<String>>>[];
+    futures.add(libraryMemberAutocompletes(
+      controller,
+      libraryRef,
+      includePrivates: true,
+    ));
+
+    final Library library = await controller.getObject(libraryRef);
+    for (var dependency in library.dependencies) {
+      if (dependency.prefix?.isNotEmpty ?? false) {
+        // We won't give a list of autocompletes once you enter a prefix
+        // but at least we do include the prefix in the autocompletes list.
+        result.add(dependency.prefix);
+      } else {
+        futures.add(libraryMemberAutocompletes(
+          controller,
+          dependency.target,
+          includePrivates: false,
+        ));
+      }
+    }
+    (await Future.wait(futures)).forEach(result.addAll);
+  } catch (_) {
+    // Silently skip library completions if there is a failure.
+  }
+  return result;
+}
+
+Future<Set<String>> libraryMemberAutocompletes(
+  DebuggerController controller,
+  LibraryRef libraryRef, {
+  @required bool includePrivates,
+}) async {
+  var result = await controller.autocompleteCache.putIfAbsent(
+      libraryRef, () => _libraryMemberAutocompletes(controller, libraryRef));
+  if (!includePrivates) {
+    result = result.where((name) => !isPrivate(name)).toSet();
+  }
+  return result;
+}
+
+Future<Set<String>> _libraryMemberAutocompletes(
+  DebuggerController controller,
+  LibraryRef libraryRef,
+) async {
+  final result = <String>{};
+  final Library library = await controller.getObject(libraryRef);
+  result.addAll(library.variables.map((field) => field.name));
+  result.addAll(library.functions
+      // The VM shows setters as `<member>=`.
+      .map((funcRef) => funcRef.name.replaceAll('=', '')));
+  // Autocomplete class names as well
+  result.addAll(library.classes.map((clazz) => clazz.name));
+
+  if (debugIncludeExports) {
+    final futures = <Future<Set<String>>>[];
+    for (var dependency in library.dependencies) {
+      if (!dependency.isImport) {
+        if (dependency.prefix?.isNotEmpty ?? false) {
+          result.add(dependency.prefix);
+        } else {
+          futures.add(libraryMemberAutocompletes(
+            controller,
+            dependency.target,
+            includePrivates: false,
+          ));
+        }
+      }
+    }
+    if (futures.isNotEmpty) {
+      (await Future.wait(futures)).forEach(result.addAll);
+    }
+  }
+  return result;
+}
+
+Future<void> _addAllInstanceMembersToAutocompleteList(
+  Set<String> result,
+  InstanceRef response,
+  DebuggerController controller,
+) async {
+  final Instance instance = await controller.getObject(response);
+  result.addAll(
+    await _autoCompleteMembersFor(
+      instance.classRef,
+      controller,
+      staticContext: false,
+    ),
+  );
+  // TODO(grouma) - This shouldn't be necessary but package:dwds does
+  // not properly provide superclass information.
+  final clazz = await classFor(instance.classRef, controller);
+  result.addAll(instance.fields
+      .where((field) => !field.decl.isStatic)
+      .map((field) => field.decl.name)
+      .where((member) => _isAccessible(member, clazz, controller)));
 }
 
 Future<Set<String>> _autoCompleteMembersFor(
   ClassRef classRef,
-  DebuggerController controller,
-) async {
+  DebuggerController controller, {
+  @required bool staticContext,
+}) async {
+  if (classRef == null) {
+    return {};
+  }
+  // TODO(jacobr): consider using controller.autocompleteCache to cache the list
+  // of autocomplete candidates for each class. The main challenge with caching
+  // is _isAccessible depends on the current source location so makes caching
+  // difficult.
   final result = <String>{};
   final clazz = await classFor(classRef, controller);
   if (clazz != null) {
-    result.addAll(
-        clazz.fields.where((f) => !f.isStatic).map((field) => field.name));
+    result.addAll(clazz.fields
+        .where((f) => f.isStatic == staticContext)
+        .map((field) => field.name));
     result.addAll(clazz.functions
-        .where((funcRef) => _validFunction(funcRef, clazz))
+        .where((funcRef) =>
+            _validFunction(funcRef, clazz) && funcRef.isStatic == staticContext)
         // The VM shows setters as `<member>=`.
         .map((funcRef) => funcRef.name.replaceAll('=', '')));
-    result.addAll(await _autoCompleteMembersFor(clazz.superClass, controller));
+    if (!staticContext) {
+      result.addAll(await _autoCompleteMembersFor(
+        clazz.superClass,
+        controller,
+        staticContext: staticContext,
+      ));
+    }
     result.removeWhere((member) => !_isAccessible(member, clazz, controller));
   }
   return result;
@@ -340,7 +527,7 @@ Future<Class> classFor(ClassRef classRef, DebuggerController controller) async {
 
 bool _validFunction(FuncRef funcRef, Class clazz) {
   return !funcRef.isStatic &&
-      !_isContructor(funcRef, clazz) &&
+      !_isConstructor(funcRef, clazz) &&
       !_isOperator(funcRef);
 }
 
@@ -366,13 +553,13 @@ bool _isOperator(FuncRef funcRef) => [
       'uniary-',
     ].contains(funcRef.name);
 
-bool _isContructor(FuncRef funcRef, Class clazz) =>
+bool _isConstructor(FuncRef funcRef, Class clazz) =>
     funcRef.name == clazz.name || funcRef.name.startsWith('${clazz.name}.');
 
 bool _isAccessible(String member, Class clazz, DebuggerController controller) {
-  final frame = controller.selectedStackFrame.value?.frame ??
-      controller.stackFramesWithLocation.value.first.frame;
+  final frame = controller.frameForEval;
   final currentScript = frame.location.script;
-  return !member.startsWith('_') ||
-      currentScript.id == clazz?.location?.script?.id;
+  return !isPrivate(member) || currentScript.id == clazz?.location?.script?.id;
 }
+
+bool isPrivate(String member) => member.startsWith('_');

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -31,6 +31,7 @@ class EvalOnDartLibrary {
     Iterable<String> candidateLibraryNames,
     this.service, {
     IsolateRef isolateRef,
+    this.disableBreakpoints = true,
     this.oneRequestAtATime = false,
   })  : _candidateLibraryNames = Set.from(candidateLibraryNames),
         _clientId = (Random.secure().nextDouble() * 10000).toInt() {
@@ -66,6 +67,9 @@ class EvalOnDartLibrary {
   /// guarantees but significantly hurts performance particularly when the
   /// VM Service and DevTools are not running on the same machine.
   final bool oneRequestAtATime;
+
+  /// Whether to disable breakpoints triggered while evaluating expressions.
+  final bool disableBreakpoints;
 
   /// An ID unique to this instance, so that [asyncEval] keeps working even if
   /// the devtool is opened on multiple tabs at the same time.
@@ -176,7 +180,7 @@ class EvalOnDartLibrary {
         libraryRef.id,
         expression,
         scope: scope,
-        disableBreakpoints: true,
+        disableBreakpoints: disableBreakpoints,
       );
       if (result is Sentinel) {
         return null;
@@ -400,6 +404,7 @@ class EvalOnDartLibrary {
           libraryRef.id,
           expression,
           scope: scope,
+          disableBreakpoints: disableBreakpoints,
         );
       });
 

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -19,6 +19,7 @@ import 'package:vm_service/vm_service.dart';
 import '../auto_dispose.dart';
 import '../eval_on_dart_library.dart';
 import '../globals.dart';
+import '../utils.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service_polyfill.dart';
 
@@ -1115,7 +1116,7 @@ class ObjectGroup implements Disposable {
     final Map<String, InstanceRef> properties = {};
     for (FieldRef field in clazz.fields) {
       final String name = field.name;
-      if (name.startsWith('_')) {
+      if (isPrivate(name)) {
         // Needed to filter out _deleted_enum_sentinel synthetic property.
         // If showing enum values is useful we could special case
         // just the _deleted_enum_sentinel property name.

--- a/packages/devtools_app/lib/src/memory/memory_graph_model.dart
+++ b/packages/devtools_app/lib/src/memory/memory_graph_model.dart
@@ -5,6 +5,7 @@
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart';
+import '../utils.dart';
 import 'memory_controller.dart';
 
 // TODO(terry): Ask Ben, what is a class name of ::?
@@ -332,8 +333,7 @@ class HeapGraph {
     groupByClass.removeWhere((className, instances) {
       final remove =
           (controller.filterZeroInstances.value && instances.isEmpty) ||
-              (controller.filterPrivateClasses.value &&
-                  className.startsWith('_')) ||
+              (controller.filterPrivateClasses.value && isPrivate(className)) ||
               className == internalClassName;
       if (remove) {
         filteredElements.putIfAbsent(className, () => instances);
@@ -355,8 +355,7 @@ class HeapGraph {
       classes.removeWhere((actual) {
         final result = (controller.filterZeroInstances.value &&
                 actual.getInstances(this).isEmpty) ||
-            (controller.filterPrivateClasses.value &&
-                actual.name.startsWith('_')) ||
+            (controller.filterPrivateClasses.value && isPrivate(actual.name)) ||
             actual.name == internalClassName;
         return result;
       });

--- a/packages/devtools_app/lib/src/ui/icons.dart
+++ b/packages/devtools_app/lib/src/ui/icons.dart
@@ -17,6 +17,7 @@ import 'package:flutter/material.dart';
 import 'package:meta/meta.dart';
 
 import '../theme.dart';
+import '../utils.dart';
 
 class CustomIcon extends StatelessWidget {
   const CustomIcon({
@@ -74,7 +75,6 @@ class CustomIconMaker {
       return null;
     }
 
-    final bool isPrivate = name.startsWith('_');
     while (name.isNotEmpty && !isAlphabetic(name.codeUnitAt(0))) {
       name = name.substring(1);
     }
@@ -85,7 +85,7 @@ class CustomIconMaker {
 
     return getCustomIcon(
       name,
-      kind: isPrivate ? IconKind.method : IconKind.classIcon,
+      kind: isPrivate(name) ? IconKind.method : IconKind.classIcon,
     );
   }
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -21,10 +21,12 @@ import 'config_specific/logger/logger.dart' as logger;
 import 'globals.dart';
 import 'notifications.dart';
 
+bool isPrivate(String member) => member.startsWith('_');
+
 /// Public properties first, then sort alphabetically
 int sortFieldsByName(String a, String b) {
-  final isAPrivate = a.startsWith('_');
-  final isBPrivate = b.startsWith('_');
+  final isAPrivate = isPrivate(a);
+  final isBPrivate = isPrivate(b);
 
   if (isAPrivate && !isBPrivate) {
     return 1;

--- a/packages/devtools_app/test/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger_evalution_test.dart
@@ -2,236 +2,270 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/debugger/debugger_model.dart';
+import 'package:devtools_app/src/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/evaluate.dart';
+import 'package:devtools_app/src/eval_on_dart_library.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/ui/search.dart';
-import 'package:flutter/widgets.dart';
+import 'package:devtools_testing/support/flutter_test_driver.dart';
+import 'package:devtools_testing/support/flutter_test_environment.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:pedantic/pedantic.dart';
 
-import 'support/mocks.dart';
-
-final libraryRef = LibraryRef(
-  name: 'some library',
-  uri: 'package:foo/foo.dart',
-  id: 'lib-id-1',
-);
+import 'support/utils.dart';
 
 void main() {
-  MockDebuggerController debuggerController;
+  final FlutterTestEnvironment env = FlutterTestEnvironment(
+    const FlutterRunConfiguration(withDebugger: true),
+  );
 
+  Disposable isAlive;
+  DebuggerController debuggerController;
+  EvalOnDartLibrary eval;
   setUp(() async {
-    debuggerController = MockDebuggerController();
-
-    when(debuggerController.selectedStackFrame).thenReturn(
-      ValueNotifier(
-        StackFrameAndSourcePosition(
-          Frame(
-            index: 0,
-            location: SourceLocation(
-                script: ScriptRef(id: 'some-script-loc', uri: ''), tokenPos: 0),
-          ),
-        ),
-      ),
-    );
-    when(debuggerController.variables).thenReturn(
-      ValueNotifier(
-        [
-          Variable.create(
-            BoundVariable(
-              name: 'foo',
-              value: null,
-              declarationTokenPos: 0,
-              scopeStartTokenPos: 0,
-              scopeEndTokenPos: 0,
-            ),
-          ),
-          Variable.create(
-            BoundVariable(
-              name: 'foobar',
-              value: null,
-              declarationTokenPos: 0,
-              scopeStartTokenPos: 0,
-              scopeEndTokenPos: 0,
-            ),
-          ),
-          Variable.create(
-            BoundVariable(
-              name: 'bar',
-              value: null,
-              declarationTokenPos: 0,
-              scopeStartTokenPos: 0,
-              scopeEndTokenPos: 0,
-            ),
-          ),
-          Variable.create(
-            BoundVariable(
-              name: 'baz',
-              value: null,
-              declarationTokenPos: 0,
-              scopeStartTokenPos: 0,
-              scopeEndTokenPos: 0,
-            ),
-          ),
-        ],
-      ),
-    );
-    when(debuggerController.evalAtCurrentFrame(any)).thenAnswer(
-      (_) async =>
-          InstanceRef(kind: '', identityHashCode: 0, classRef: null, id: ''),
-    );
-    when(debuggerController.getObject(any)).thenAnswer((inv) async {
-      final obj = inv.positionalArguments.first;
-      if (obj is ClassRef) {
-        return Class(
-          fields: [
-            FieldRef(
-              name: 'field1',
-              owner: null,
-              declaredType: null,
-              isConst: false,
-              isFinal: false,
-              isStatic: false,
-              id: '',
-            ),
-            FieldRef(
-              name: 'field2',
-              owner: null,
-              declaredType: null,
-              isConst: false,
-              isFinal: false,
-              isStatic: false,
-              id: '',
-            ),
-          ],
-          functions: [
-            FuncRef(
-              name: 'func1',
-              owner: null,
-              isStatic: false,
-              isConst: false,
-              id: '',
-            ),
-            FuncRef(
-              name: 'func2',
-              owner: null,
-              isStatic: false,
-              isConst: false,
-              id: '',
-            ),
-            FuncRef(
-              name: 'funcStatic',
-              owner: null,
-              isStatic: true,
-              isConst: false,
-              id: '',
-            ),
-            FuncRef(
-              name: '>=',
-              owner: null,
-              isStatic: true,
-              isConst: false,
-              id: '',
-            ),
-            FuncRef(
-              name: '==',
-              owner: null,
-              isStatic: true,
-              isConst: false,
-              id: '',
-            ),
-          ],
-          id: '',
-          interfaces: [],
-          isAbstract: null,
-          isConst: null,
-          library: null,
-          name: 'FooClass',
-          subclasses: [],
-          traceAllocations: null,
-        );
-      }
-      if (obj is InstanceRef) {
-        return Instance(
-          classRef: ClassRef(id: '', name: 'FooClass', library: libraryRef),
-          id: '',
-          fields: [
-            BoundField(
-              decl: FieldRef(
-                name: 'fieldBound1',
-                owner: null,
-                declaredType: null,
-                isConst: false,
-                isFinal: false,
-                isStatic: false,
-                id: '',
-              ),
-              value: null,
-            ),
-            BoundField(
-              decl: FieldRef(
-                name: '_privateFieldBound',
-                owner: null,
-                declaredType: null,
-                isConst: false,
-                isFinal: false,
-                isStatic: false,
-                id: '',
-              ),
-              value: null,
-            ),
-          ],
-          identityHashCode: null,
-          kind: '',
-        );
-      }
-      return null;
-    });
-  });
-  test('returns scoped variables when EditingParts is not a field', () async {
-    expect(
-        await autoCompleteResultsFor(
-          EditingParts(
-            activeWord: 'foo',
-            leftSide: '',
-            rightSide: '',
-          ),
-          debuggerController,
-        ),
-        equals(['foo', 'foobar']));
-    expect(
-        await autoCompleteResultsFor(
-          EditingParts(
-            activeWord: 'b',
-            leftSide: '',
-            rightSide: '',
-          ),
-          debuggerController,
-        ),
-        equals(['bar', 'baz']));
+    isAlive = Disposable();
+    await env.setupEnvironment();
+    debuggerController = DebuggerController();
+    eval = EvalOnDartLibrary(
+        ['package:flutter_app/src/autocomplete.dart'], serviceManager.service,
+        disableBreakpoints: false);
   });
 
-  test('returns filtered members when EditingParts is a field ', () async {
-    expect(
-        await autoCompleteResultsFor(
-          EditingParts(
-            activeWord: 'f',
-            leftSide: 'foo.',
-            rightSide: '',
-          ),
-          debuggerController,
-        ),
-        equals(['field1', 'field2', 'fieldBound1', 'func1', 'func2']));
-    expect(
-        await autoCompleteResultsFor(
-          EditingParts(
-            activeWord: 'fu',
-            leftSide: 'foo.',
-            rightSide: '',
-          ),
-          debuggerController,
-        ),
-        equals(['func1', 'func2']));
+  tearDown(() async {
+    await debuggerController.resume();
+    isAlive.dispose();
+    debuggerController.dispose();
+    await env.tearDownEnvironment();
   });
+
+  tearDownAll(() async {
+    await env.tearDownEnvironment(force: true);
+  });
+
+  Future<void> runMethodAndWaitForPause(String method) async {
+    unawaited(eval.eval(method, isAlive: isAlive));
+
+    await whenMatches(debuggerController.selectedStackFrame, (f) => f != null);
+  }
+
+  group(
+    'EvalOnDartLibrary',
+    () {
+      test(
+        'returns scoped variables when EditingParts is not a field',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'foo',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals(['foo', 'foobar']),
+          );
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'b',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals(['bar', 'baz']),
+          );
+        },
+        timeout: const Timeout.factor(8),
+      );
+
+      test(
+        'returns filtered members when EditingParts is a field ',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+              await autoCompleteResultsFor(
+                EditingParts(
+                  activeWord: 'f',
+                  leftSide: 'foo.',
+                  rightSide: '',
+                ),
+                debuggerController,
+              ),
+              equals(['field1', 'field2', 'func1', 'func2']));
+          expect(
+              await autoCompleteResultsFor(
+                EditingParts(
+                  activeWord: 'fu',
+                  leftSide: 'foo.',
+                  rightSide: '',
+                ),
+                debuggerController,
+              ),
+              equals(['func1', 'func2']));
+        },
+        timeout: const Timeout.factor(8),
+      );
+
+      test(
+        'returns filtered members when EditingParts is a class name ',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: '',
+                leftSide: 'FooClass.',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              'staticField1',
+              'staticField2',
+              'namedConstructor',
+              'factory1',
+              'staticMethod'
+            ]),
+          );
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'fa',
+                leftSide: 'FooClass.',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals(['factory1']),
+          );
+        },
+        timeout: const Timeout.factor(8),
+      );
+      test(
+        'returns privates only from library',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: '_',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              '_privateField2',
+              '_privateField1',
+              '_PrivateClass',
+            ]),
+          );
+        },
+        timeout: const Timeout.factor(8),
+      );
+      test(
+        'returns exported members from import',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'exportedField',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              'exportedField',
+            ]),
+          );
+
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'ExportedClass',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              'ExportedClass',
+            ]),
+          );
+
+          // Privates are not exported
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: '_privateExportedField',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([]),
+          );
+
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: '_PrivateExportedClass',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([]),
+          );
+        },
+        timeout: const Timeout.factor(8),
+      );
+
+      test(
+        'returns prefixes of libraries imported',
+        () async {
+          await runMethodAndWaitForPause(
+              'AnotherClass().pauseWithScopedVariablesMethod()');
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'developer',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              'developer',
+            ]),
+          );
+
+          expect(
+            await autoCompleteResultsFor(
+              EditingParts(
+                activeWord: 'math',
+                leftSide: '',
+                rightSide: '',
+              ),
+              debuggerController,
+            ),
+            equals([
+              'math',
+            ]),
+          );
+        },
+        timeout: const Timeout.factor(8),
+      );
+    },
+  );
 }

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:devtools_app/src/charts/treemap.dart';
 import 'package:devtools_app/src/ui/search.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -37,6 +39,22 @@ Future<void> addListenerScope({
   await callback();
   expect(listenerCalled, true);
   listenable.removeListener(listenerWrapped);
+}
+
+/// Returns a future that completes when a listenable has a value that satisfies
+/// [condition].
+Future<T> whenMatches<T>(ValueListenable<T> listenable, bool condition(T)) {
+  final completer = Completer<T>();
+  void listener() {
+    if (condition(listenable.value)) {
+      completer.complete(listenable.value);
+      listenable.removeListener(listener);
+    }
+  }
+
+  listenable.addListener(listener);
+  listener();
+  return completer.future;
 }
 
 /// Creates an instance of [Timeline] which contains recorded HTTP events.

--- a/packages/devtools_testing/fixtures/flutter_app/lib/main.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/main.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 // ignore: unused_import

--- a/packages/devtools_testing/fixtures/flutter_app/lib/main.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/main.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 // ignore: unused_import
+import 'src/autocomplete.dart';
+// ignore: unused_import
 import 'src/other_classes.dart';
 
 void main() => runApp(MyApp());

--- a/packages/devtools_testing/fixtures/flutter_app/lib/overflow_errors.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/overflow_errors.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:developer' as developer;
 import 'dart:math' as math;
 

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete.dart
@@ -1,0 +1,66 @@
+import 'dart:developer' as developer;
+import 'dart:math' as math;
+
+// ignore: unused_import
+import 'autocomplete_helper_library.dart';
+
+export 'other_classes.dart';
+
+class FooClass {
+  FooClass();
+  FooClass.namedConstructor();
+  factory FooClass.factory1() => FooClass();
+
+  int field1 = 1;
+  int field2 = 2;
+  static int staticField1 = 3;
+  static int staticField2 = 4;
+  static void staticMethod() {}
+  void func1() {}
+  void func2() {}
+}
+
+// ignore: unused_element
+class _PrivateClass {}
+
+class AnotherClass {
+  int operator [](int index) {
+    return 42;
+  }
+
+  static int someStaticMethod() {
+    return math.max(3, 4);
+  }
+
+  void someInstanceMethod() {}
+
+  void pauseWithScopedVariablesMethod() {
+    // ignore: unused_local_variable, prefer_final_locals
+    var foo = FooClass();
+    // ignore: unused_local_variable, prefer_final_locals
+    var foobar = 2;
+    // ignore: unused_local_variable, prefer_final_locals
+    var baz = 3;
+    // ignore: unused_local_variable, prefer_final_locals
+    var bar = 4;
+    developer.debugger();
+  }
+
+  var someField = 3;
+  static var someStaticField = 2;
+  int get someProperty => 42;
+  set someSomeProperty(v) {}
+}
+
+var someTopLevelField = 9;
+
+int get someTopLevelGetter => 42;
+
+set someTopLevelSetter(v) {}
+
+void someTopLevelMember() {}
+
+// ignore: unused_element
+const _privateField1 = 1;
+// ignore: unused_element
+const _privateField2 = 2;

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_export.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_export.dart
@@ -1,0 +1,11 @@
+void somePublicExportedMethod() {}
+// ignore: unused_element
+void _somePrivateExportedMethod() {}
+int exportedField = 3;
+// ignore: unused_element
+int _privateExportedField = 10;
+
+class ExportedClass {}
+
+// ignore: unused_element
+class _PrivateExportedClass {}

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_export.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_export.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 void somePublicExportedMethod() {}
 // ignore: unused_element
 void _somePrivateExportedMethod() {}

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_helper_library.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_helper_library.dart
@@ -1,0 +1,9 @@
+export 'autocomplete_export.dart';
+
+// ignore: unused_element
+int _privateFieldInOtherLibrary = 2;
+
+int publicFieldInOtherLibrary = 3;
+// ignore: unused_element
+void _privateMethodOtherLibrary() {}
+void publicMethodOtherLibrary() {}

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_helper_library.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/autocomplete_helper_library.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 export 'autocomplete_export.dart';
 
 // ignore: unused_element

--- a/packages/devtools_testing/fixtures/flutter_app/lib/src/other_classes.dart
+++ b/packages/devtools_testing/fixtures/flutter_app/lib/src/other_classes.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 
 // Unused class in the sample application that is a widget.

--- a/packages/devtools_testing/lib/inspector_service_test.dart
+++ b/packages/devtools_testing/lib/inspector_service_test.dart
@@ -78,7 +78,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
         await inspectorService.setPubRootDirectories([]);
         final List<String> rootDirectories =
-            await inspectorService.inferPubRootDirectoryIfNeeded();
+        await inspectorService.inferPubRootDirectoryIfNeeded();
         expect(rootDirectories.length, 1);
         expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
         await group.dispose();
@@ -91,15 +91,24 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
         await inspectorService.setPubRootDirectories([]);
         final List<String> rootDirectories =
-            await inspectorService.inferPubRootDirectoryIfNeeded();
+        await inspectorService.inferPubRootDirectoryIfNeeded();
         expect(rootDirectories.length, 1);
         expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
         final originalRootDirectories = rootDirectories.toList();
         try {
           expect(
-            (inspectorService.localClasses.keys.toList()..sort()),
+            (inspectorService.localClasses.keys.toList()
+              ..sort()),
             equals(
-              ['MyApp', 'MyOtherWidget', 'NotAWidget'],
+              ['AnotherClass',
+                'ExportedClass',
+                'FooClass',
+                'MyApp',
+                'MyOtherWidget',
+                'NotAWidget',
+                '_PrivateClass',
+                '_PrivateExportedClass',
+              ],
             ),
           );
 
@@ -108,9 +117,17 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
           // Adding src does not change the directory as local classes are
           // computed at the library level.
           expect(
-            (inspectorService.localClasses.keys.toList()..sort()),
+            (inspectorService.localClasses.keys.toList()
+              ..sort()),
             equals(
-              ['MyApp', 'MyOtherWidget', 'NotAWidget'],
+              ['AnotherClass',
+                'ExportedClass',
+                'FooClass',
+                'MyApp',
+                'MyOtherWidget',
+                'NotAWidget',
+                '_PrivateClass',
+                '_PrivateExportedClass'],
             ),
           );
 
@@ -173,7 +190,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
         expect(await inspectorService.isWidgetCreationTracked(), isTrue);
         await inspectorService.setPubRootDirectories([]);
         final originalRootDirectories =
-            (await inspectorService.inferPubRootDirectoryIfNeeded()).toList();
+        (await inspectorService.inferPubRootDirectoryIfNeeded()).toList();
         try {
           await inspectorService.setPubRootDirectories(
               ['/usr/me/clients/google3/foo/bar/baz/lib/src/bla']);
@@ -284,37 +301,37 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
         await env.setupEnvironment();
         final group = inspectorService.createObjectGroup('test-group');
         final RemoteDiagnosticsNode root =
-            await group.getRoot(FlutterTreeType.widget);
+        await group.getRoot(FlutterTreeType.widget);
         // Tree only contains widgets from local app.
         expect(
           treeToDebugString(root),
           equalsIgnoringHashCodes(
             '[root]\n'
-            ' └─MyApp\n'
-            '   └─MaterialApp\n'
-            '     └─Scaffold\n'
-            '       ├─Center\n'
-            '       │ └─Text\n'
-            '       └─AppBar\n'
-            '         └─Text\n',
+                ' └─MyApp\n'
+                '   └─MaterialApp\n'
+                '     └─Scaffold\n'
+                '       ├─Center\n'
+                '       │ └─Text\n'
+                '       └─AppBar\n'
+                '         └─Text\n',
           ),
         );
         RemoteDiagnosticsNode nodeInSummaryTree =
-            findNodeMatching(root, 'MaterialApp');
+        findNodeMatching(root, 'MaterialApp');
         expect(nodeInSummaryTree, isNotNull);
         expect(
           treeToDebugString(nodeInSummaryTree),
           equalsIgnoringHashCodes(
             'MaterialApp\n'
-            ' └─Scaffold\n'
-            '   ├─Center\n'
-            '   │ └─Text\n'
-            '   └─AppBar\n'
-            '     └─Text\n',
+                ' └─Scaffold\n'
+                '   ├─Center\n'
+                '   │ └─Text\n'
+                '   └─AppBar\n'
+                '     └─Text\n',
           ),
         );
         RemoteDiagnosticsNode nodeInDetailsTree =
-            await group.getDetailsSubtree(nodeInSummaryTree);
+        await group.getDetailsSubtree(nodeInSummaryTree);
         // When flutter rolls, this string may sometimes change due to
         // implementation details.
         expect(
@@ -348,7 +365,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
           treeToDebugString(selection),
           equalsIgnoringHashCodes(
             'Text\n'
-            ' └─RichText\n',
+                ' └─RichText\n',
           ),
         );
 
@@ -359,7 +376,7 @@ Future<void> runInspectorServiceTests(FlutterTestEnvironment env) async {
           treeToDebugString(selection),
           equalsIgnoringHashCodes(
             'RenderParagraph#00000 relayoutBoundary=up2\n'
-            ' └─text: TextSpan\n',
+                ' └─text: TextSpan\n',
           ),
         );
 


### PR DESCRIPTION
Polish items:
Fix flicker while typing in autocomplete.
Fix missing autocompletes for names in scope from the current class.
Fix missing autocompletes for names in scope for the current library.
Fix missing autocompletes for static members of classes.
Add caching to avoid performing duplicated work looking up autocompletes for librries
Limitations: we show more top level more autocompletes than we should as we can't tell what the show clauses are for library imports and exports.