### PR TITLE
Support multi-line eval output

### DIFF
--- a/packages/devtools_app/lib/src/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/debugger/variables.dart
@@ -146,7 +146,6 @@ Widget displayProvider(
         ],
       ),
       onTap: onTap,
-      maxLines: 1,
     ),
   );
 }

--- a/packages/devtools_app/lib/src/tree.dart
+++ b/packages/devtools_app/lib/src/tree.dart
@@ -14,7 +14,7 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
     this.dataDisplayProvider,
     this.onItemPressed,
     this.shrinkWrap = false,
-    this.itemExtent = defaultListItemHeight,
+    this.itemExtent,
     this.onTraverse,
   });
 
@@ -68,6 +68,7 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
     if (items.isEmpty) return const SizedBox();
     return ListView.builder(
       itemCount: items.length,
+      itemExtent: widget.itemExtent,
       shrinkWrap: widget.shrinkWrap,
       physics: widget.shrinkWrap ? const ClampingScrollPhysics() : null,
       itemBuilder: (context, index) {

--- a/packages/devtools_app/lib/src/tree.dart
+++ b/packages/devtools_app/lib/src/tree.dart
@@ -68,7 +68,6 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
     if (items.isEmpty) return const SizedBox();
     return ListView.builder(
       itemCount: items.length,
-      itemExtent: widget.itemExtent,
       shrinkWrap: widget.shrinkWrap,
       physics: widget.shrinkWrap ? const ClampingScrollPhysics() : null,
       itemBuilder: (context, index) {


### PR DESCRIPTION
The `toString()` of an eval result can be multi-line. For example `'\n ${[0,0]} \n'`. Prior to this change this would not render correctly. I also believe, but I'm not certain, that this was the root cause of the flaky overlapping console lines.