### PR TITLE
Fix a null pointer exception if keypress fires before app is initialized

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -56,7 +56,7 @@ void _sendKeyPressToParent(KeyboardEvent event) {
   // Check we have a connection and we appear to be embedded somewhere expected
   // because we can't use targetOrigin in postMessage as only the scheme is fixed
   // for VS Code (vscode-webview://[some guid]).
-  if (!serviceManager.hasConnection) return;
+  if (serviceManager == null || !serviceManager.hasConnection) return;
   if (!window.navigator.userAgent.contains('Electron')) return;
 
   final data = {


### PR DESCRIPTION
While hot reloading, I saw null references here a few times. I can't reliably reproduce it, nor can I explain it (`FrameworkCore.initGlobals()` always runs before `initializePlatform` so it seems like it should never be null) - my guess is something strange happens during a reload or when the app initialises  a second time, but it seems save to just not pass the keypress on in this case (even if only to prevent the debugger pausing while working on the DevTools code itself).