### PR TITLE
Improve scrolling / zooming behavior in flame charts

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -436,7 +436,6 @@ abstract class FlameChartState<T extends FlameChart,
     final newZoom = zoomController.value;
     if (previousZoom == newZoom) return;
 
-
     // Store current scroll values for re-calculating scroll location on zoom.
     final lastScrollOffset = horizontalControllerGroup.offset;
 

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -433,8 +433,8 @@ abstract class FlameChartState<T extends FlameChart,
 
   void _handleZoomControllerValueUpdate() {
     final previousZoom = currentZoom;
-    currentZoom = zoomController.value;
-    if (previousZoom == currentZoom) return;
+    final newZoom = zoomController.value;
+    if (previousZoom == newZoom) return;
 
 
     // Store current scroll values for re-calculating scroll location on zoom.
@@ -446,9 +446,7 @@ abstract class FlameChartState<T extends FlameChart,
 
     // Calculate the new horizontal scroll position.
     final newScrollOffset = fixedX >= 0
-        ? fixedX * currentZoom / previousZoom +
-            widget.startInset -
-            safeMouseHoverX
+        ? fixedX * newZoom / previousZoom + widget.startInset - safeMouseHoverX
         // We are in the fixed portion of the window - no need to transform.
         : lastScrollOffset;
 

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -115,9 +115,10 @@ abstract class FlameChartState<T extends FlameChart,
   ScrollController _flameChartScrollController;
 
   /// Animation controller for animating flame chart zoom changes.
+  @visibleForTesting
   AnimationController zoomController;
 
-  double previousZoom = FlameChart.minZoomLevel;
+  double currentZoom = FlameChart.minZoomLevel;
 
   double horizontalScrollOffset = FlameChart.minScrollOffset;
 
@@ -129,16 +130,15 @@ abstract class FlameChartState<T extends FlameChart,
   // Zooming in via WASD controls will zoom the view in by 50% on each zoom. For
   // example, if the zoom level is 2.0, zooming by one unit would increase the
   // level to 3.0 (e.g. 2 + (2 * 0.5) = 3).
-  double get keyboardZoomInUnit => zoomController.value * 0.5;
+  double get keyboardZoomInUnit => currentZoom * 0.5;
 
   // Zooming out via WASD controls will zoom the view out to the previous zoom
   // level. For example, if the zoom level is 3.0, zooming out by one unit would
   // decrease the level to 2.0 (e.g. 3 - 3 * 1/3 = 2). See [wasdZoomInUnit]
   // for an explanation of how we previously zoomed from level 2.0 to level 3.0.
-  double get keyboardZoomOutUnit => zoomController.value * 1 / 3;
+  double get keyboardZoomOutUnit => currentZoom * 1 / 3;
 
-  double get contentWidthWithZoom =>
-      widget.startingContentWidth * zoomController.value;
+  double get contentWidthWithZoom => widget.startingContentWidth * currentZoom;
 
   double get widthWithZoom =>
       contentWidthWithZoom + widget.startInset + widget.endInset;
@@ -149,12 +149,12 @@ abstract class FlameChartState<T extends FlameChart,
         ? startTimeOffset
         : startTimeOffset +
             (horizontalScrollOffset - widget.startInset) /
-                zoomController.value /
+                currentZoom /
                 startingPxPerMicro;
 
     final endMicros = startTimeOffset +
         (horizontalScrollOffset - widget.startInset + widget.containerWidth) /
-            zoomController.value /
+            currentZoom /
             startingPxPerMicro;
 
     return TimeRange()
@@ -248,7 +248,6 @@ abstract class FlameChartState<T extends FlameChart,
       initFlameChartElements();
       horizontalControllerGroup.resetScroll();
       verticalControllerGroup.resetScroll();
-      previousZoom = FlameChart.minZoomLevel;
       zoomController.reset();
       verticalExtentDelegate.recompute();
     }
@@ -335,7 +334,7 @@ abstract class FlameChartState<T extends FlameChart,
             activeSearchMatchNotifier: widget.activeSearchMatchNotifier,
             onTapUp: focusNode.requestFocus,
             backgroundColor: rowBackgroundColor,
-            zoom: zoomController.value,
+            zoom: currentZoom,
           );
         },
         childCount: rows.length,
@@ -378,12 +377,12 @@ abstract class FlameChartState<T extends FlameChart,
       if (keyLabel == 'w') {
         zoomTo(math.min(
           maxZoomLevel,
-          zoomController.value + keyboardZoomInUnit,
+          currentZoom + keyboardZoomInUnit,
         ));
       } else if (keyLabel == 's') {
         zoomTo(math.max(
           FlameChart.minZoomLevel,
-          zoomController.value - keyboardZoomOutUnit,
+          currentZoom - keyboardZoomOutUnit,
         ));
       } else if (keyLabel == 'a') {
         scrollToX(horizontalControllerGroup.offset - keyboardScrollUnit);
@@ -411,7 +410,6 @@ abstract class FlameChartState<T extends FlameChart,
             -FlameChart.maxScrollWheelDelta,
             FlameChart.maxScrollWheelDelta,
           );
-          final currentZoom = zoomController.value;
           // TODO(kenz): if https://github.com/flutter/flutter/issues/52762 is,
           // resolved, consider adjusting the multiplier based on the scroll device
           // kind (mouse or track pad).
@@ -434,27 +432,28 @@ abstract class FlameChartState<T extends FlameChart,
   }
 
   void _handleZoomControllerValueUpdate() {
+    final previousZoom = currentZoom;
+    currentZoom = zoomController.value;
+    if (previousZoom == currentZoom) return;
+
+
+    // Store current scroll values for re-calculating scroll location on zoom.
+    final lastScrollOffset = horizontalControllerGroup.offset;
+
+    final safeMouseHoverX = mouseHoverX ?? widget.containerWidth / 2;
+    // Position in the zoomable coordinate space that we want to keep fixed.
+    final fixedX = safeMouseHoverX + lastScrollOffset - widget.startInset;
+
+    // Calculate the new horizontal scroll position.
+    final newScrollOffset = fixedX >= 0
+        ? fixedX * currentZoom / previousZoom +
+            widget.startInset -
+            safeMouseHoverX
+        // We are in the fixed portion of the window - no need to transform.
+        : lastScrollOffset;
+
     setState(() {
-      final currentZoom = zoomController.value;
-      if (currentZoom == previousZoom) return;
-
-      // Store current scroll values for re-calculating scroll location on zoom.
-      final lastScrollOffset = horizontalControllerGroup.offset;
-
-      final safeMouseHoverX = mouseHoverX ?? widget.containerWidth / 2;
-      // Position in the zoomable coordinate space that we want to keep fixed.
-      final fixedX = safeMouseHoverX + lastScrollOffset - widget.startInset;
-
-      // Calculate the new horizontal scroll position.
-      final newScrollOffset = fixedX >= 0
-          ? fixedX * currentZoom / previousZoom +
-              widget.startInset -
-              safeMouseHoverX
-          // We are in the fixed portion of the window - no need to transform.
-          : lastScrollOffset;
-
-      previousZoom = currentZoom;
-
+      currentZoom = zoomController.value;
       // TODO(kenz): consult with Flutter team to see if there is a better place
       // to call this that guarantees the scroll controller offsets will be
       // updated for the new zoom level and layout size
@@ -530,27 +529,24 @@ abstract class FlameChartState<T extends FlameChart,
     @required int startMicros,
     @required int durationMicros,
     @required V data,
-    bool scrollHorizontally = true,
     bool scrollVertically = true,
     bool jumpZoom = false,
   }) async {
-    await Future.wait([
-      zoomToTimeRange(
-        startMicros: startMicros,
-        durationMicros: durationMicros,
-        jump: jumpZoom,
-      ),
-      if (scrollVertically) scrollVerticallyToData(data),
-    ]);
-    // Call this in a post frame callback so that the horizontal scroll
-    // controllers have had time to update their scroll extents. Otherwise, we
-    // can hit a race where are trying to scroll to an offset that is beyond
-    // what the scroll controller thinks its max scroll extent is.
-    if (scrollHorizontally) {
-      WidgetsBinding.instance.addPostFrameCallback((_) async {
-        await scrollHorizontallyToData(data);
-      });
-    }
+    await zoomToTimeRange(
+      startMicros: startMicros,
+      durationMicros: durationMicros,
+      jump: jumpZoom,
+    );
+    // Call these in a post frame callback so that the scroll controllers have
+    // had time to update their scroll extents. Otherwise, we can hit a race
+    // where are trying to scroll to an offset that is beyond what the scroll
+    // controller thinks its max scroll extent is.
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await Future.wait([
+        scrollHorizontallyToData(data),
+        if (scrollVertically) scrollVerticallyToData(data),
+      ]);
+    });
   }
 
   Future<void> zoomToTimeRange({
@@ -875,7 +871,7 @@ class FlameChartUtils {
     // the issue described in the bug where the scroll extent is smaller than
     // where we want to `jumpTo`. Smaller values were experimented with but the
     // issue still persisted, so we are using a very large number.
-    if (index == nodes.length - 1) return 10000000.0;
+    if (index == nodes.length - 1) return 1000000000000.0;
     final node = nodes[index];
     final nextNode = index == nodes.length - 1 ? null : nodes[index + 1];
     final nodeZoom = zoomForNode(node, chartZoom);

--- a/packages/devtools_app/lib/src/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/flutter_widgets/linked_scroll_controller.dart
@@ -83,18 +83,25 @@ class LinkedScrollControllerGroup {
     @required Curve curve,
     @required Duration duration,
   }) async {
-    final animations = <Future<void>>[];
-    for (final controller in _attachedControllers) {
-      animations
-          .add(controller.animateTo(offset, duration: duration, curve: curve));
+    // All scroll controllers are already linked with their peers, so we only
+    // need to interact with one controller to mirror the interaction with all
+    // other controllers.
+    if (_attachedControllers.isNotEmpty) {
+      await _attachedControllers.first.animateTo(
+        offset,
+        duration: duration,
+        curve: curve,
+      );
     }
-    return Future.wait<void>(animations).then<void>((List<void> _) => null);
   }
 
   /// Jumps the scroll position of all linked controllers to [value].
   void jumpTo(double value) {
-    for (final controller in _attachedControllers) {
-      controller.jumpTo(value);
+    // All scroll controllers are already linked with their peers, so we only
+    // need to interact with one controller to mirror the interaction with all
+    // other controllers.
+    if (_attachedControllers.isNotEmpty) {
+      _attachedControllers.first.jumpTo(value);
     }
   }
 

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -212,7 +212,6 @@ class LegacyPerformanceController
       return;
     }
 
-    print(frame.time);
     data.selectedFrame = frame;
     _selectedFrameNotifier.value = frame;
 

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -212,6 +212,7 @@ class LegacyPerformanceController
       return;
     }
 
+    print(frame.time);
     data.selectedFrame = frame;
     _selectedFrameNotifier.value = frame;
 

--- a/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
@@ -408,6 +408,7 @@ class LegacyTimelineFlameChartState
         startMicros: selectedFrame.time.start.inMicroseconds,
         durationMicros: selectedFrame.time.duration.inMicroseconds,
         data: selectedFrame.uiEventFlow,
+        jumpZoom: true,
       );
     }
   }
@@ -524,11 +525,10 @@ class LegacyTimelineFlameChartState
     BuildContext buildContext,
   ) {
     final colorScheme = Theme.of(context).colorScheme;
-    final zoom = zoomController.value;
     return [
       CustomPaint(
         painter: LegacyAsyncGuidelinePainter(
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,
@@ -540,7 +540,7 @@ class LegacyTimelineFlameChartState
       ),
       CustomPaint(
         painter: TimelineGridPainter(
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,
@@ -554,7 +554,7 @@ class LegacyTimelineFlameChartState
       CustomPaint(
         painter: LegacySelectedFrameBracketPainter(
           _selectedFrame,
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -400,6 +400,7 @@ class TimelineFlameChartState
         startMicros: selectedFrame.time.start.inMicroseconds,
         durationMicros: selectedFrame.time.duration.inMicroseconds,
         data: selectedFrame.uiEventFlow,
+        jumpZoom: true,
       );
     }
   }
@@ -516,11 +517,10 @@ class TimelineFlameChartState
     BuildContext buildContext,
   ) {
     final colorScheme = Theme.of(context).colorScheme;
-    final zoom = zoomController.value;
     return [
       CustomPaint(
         painter: AsyncGuidelinePainter(
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,
@@ -532,7 +532,7 @@ class TimelineFlameChartState
       ),
       CustomPaint(
         painter: TimelineGridPainter(
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,
@@ -546,7 +546,7 @@ class TimelineFlameChartState
       CustomPaint(
         painter: SelectedFrameBracketPainter(
           _selectedFrame,
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -86,11 +86,10 @@ class _CpuProfileFlameChartState
     BuildContext buildContext,
   ) {
     final colorScheme = Theme.of(context).colorScheme;
-    final zoom = zoomController.value;
     return [
       CustomPaint(
         painter: TimelineGridPainter(
-          zoom: zoom,
+          zoom: currentZoom,
           constraints: constraints,
           verticalScrollOffset: verticalScrollOffset,
           horizontalScrollOffset: horizontalScrollOffset,
@@ -129,7 +128,7 @@ class _CpuProfileFlameChartState
   @override
   double startXForData(CpuStackFrame data) {
     final x = stackFrameLefts[data.id] - widget.startInset;
-    return x * zoomController.value;
+    return x * currentZoom;
   }
 
   double startingLeftForStackFrame(CpuStackFrame stackFrame) {

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -450,7 +450,8 @@ void main() {
       expect(paddedZoomedIntervals[0], equals(const Range(0.0, 120.0)));
       expect(paddedZoomedIntervals[1], equals(const Range(120.0, 180.0)));
       expect(paddedZoomedIntervals[2], equals(const Range(180.0, 240.0)));
-      expect(paddedZoomedIntervals[3], equals(const Range(240.0, 10000540.0)));
+      expect(paddedZoomedIntervals[3],
+          equals(const Range(240.0, 1000000000540.0)));
     });
 
     test('toPaddedZoomedIntervals calculation is accurate for zoomed row', () {
@@ -462,7 +463,8 @@ void main() {
       expect(paddedZoomedIntervals[0], equals(const Range(0.0, 170.0)));
       expect(paddedZoomedIntervals[1], equals(const Range(170.0, 290.0)));
       expect(paddedZoomedIntervals[2], equals(const Range(290.0, 410.0)));
-      expect(paddedZoomedIntervals[3], equals(const Range(410.0, 10001010.0)));
+      expect(paddedZoomedIntervals[3],
+          equals(const Range(410.0, 1000000001010.0)));
     });
   });
 
@@ -502,7 +504,7 @@ void main() {
       expect(
           FlameChartUtils.rightPaddingForNode(3, testNodes,
               chartZoom: 1.0, chartStartInset: sideInset, chartWidth: 610.0),
-          equals(10000000.0));
+          equals(1000000000000.0));
     });
 
     test('leftPaddingForNode returns correct value for zoomed row', () {
@@ -540,7 +542,7 @@ void main() {
       expect(
           FlameChartUtils.rightPaddingForNode(3, testNodes,
               chartZoom: 2.0, chartStartInset: sideInset, chartWidth: 1080.0),
-          equals(10000000.0));
+          equals(1000000000000.0));
     });
 
     test('zoomForNode returns correct values', () {


### PR DESCRIPTION
Some of these changes will reduce the number of rebuilds, and one (increasing size of right padding for the last node in each row) is a band-aid fix for a larger and more difficult to solve issue (https://github.com/flutter/devtools/issues/2012).