### PR TITLE
Add a loading message when loading app size data from file paths

### DIFF
--- a/packages/devtools_app/lib/src/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/app_size/app_size_screen.dart
@@ -15,6 +15,7 @@ import '../config_specific/drag_and_drop/drag_and_drop.dart';
 import '../config_specific/server/server.dart' as server;
 import '../config_specific/url/url.dart';
 import '../file_import.dart';
+import '../globals.dart';
 import '../notifications.dart';
 import '../screen.dart';
 import '../split.dart';
@@ -163,7 +164,14 @@ class _AppSizeBodyState extends State<AppSizeBody>
   @override
   Widget build(BuildContext context) {
     if (preLoadingData) {
-      return const CenteredCircularProgressIndicator();
+      return Center(
+        child: Column(
+          children: [
+            Text(devToolsExtensionPoints.loadingAppSizeDataMessage()),
+            const CircularProgressIndicator(),
+          ],
+        ),
+      );
     }
     final currentTab = tabs[_tabController.index];
     return Column(

--- a/packages/devtools_app/lib/src/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/app_size/app_size_screen.dart
@@ -166,8 +166,14 @@ class _AppSizeBodyState extends State<AppSizeBody>
     if (preLoadingData) {
       return Center(
         child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(devToolsExtensionPoints.loadingAppSizeDataMessage()),
+            Text(
+              devToolsExtensionPoints.loadingAppSizeDataMessage(),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: defaultSpacing),
             const CircularProgressIndicator(),
           ],
         ),
@@ -298,6 +304,7 @@ class _AnalysisViewState extends State<AnalysisView> with AutoDisposeMixin {
         children: [
           AreaPaneHeader(
             title: Text(_generateSingleFileHeaderText()),
+            maxLines: 2,
             needsTopBorder: false,
           ),
           Expanded(
@@ -452,6 +459,7 @@ class _DiffViewState extends State<DiffView> with AutoDisposeMixin {
         children: [
           AreaPaneHeader(
             title: Text(_generateDualFileHeaderText()),
+            maxLines: 2,
             needsTopBorder: false,
           ),
           Expanded(

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -649,6 +649,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
   const AreaPaneHeader({
     Key key,
     @required this.title,
+    this.maxLines = 1,
     this.needsTopBorder = true,
     this.needsBottomBorder = true,
     this.needsLeftBorder = false,
@@ -658,6 +659,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
   }) : super(key: key);
 
   final Widget title;
+  final int maxLines;
   final bool needsTopBorder;
   final bool needsBottomBorder;
   final bool needsLeftBorder;
@@ -686,7 +688,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
           children: [
             Expanded(
               child: DefaultTextStyle(
-                maxLines: 1,
+                maxLines: maxLines,
                 overflow: TextOverflow.ellipsis,
                 style: theme.textTheme.subtitle2,
                 child: title,

--- a/packages/devtools_app/lib/src/extension_points/extensions_base.dart
+++ b/packages/devtools_app/lib/src/extension_points/extensions_base.dart
@@ -9,4 +9,6 @@ abstract class DevToolsExtensionPoints {
   List<ScriptPopupMenuOption> buildExtraDebuggerScriptPopupMenuOptions();
 
   Link issueTrackerLink();
+
+  String loadingAppSizeDataMessage();
 }

--- a/packages/devtools_app/lib/src/extension_points/extensions_external.dart
+++ b/packages/devtools_app/lib/src/extension_points/extensions_external.dart
@@ -16,4 +16,9 @@ class ExternalDevToolsExtensionPoints implements DevToolsExtensionPoints {
     const githubLink = 'github.com/flutter/devtools/issues';
     return const Link(display: githubLink, url: 'https://$githubLink');
   }
+
+  @override
+  String loadingAppSizeDataMessage() {
+    return 'Loading app size data. Please wait.';
+  }
 }

--- a/packages/devtools_app/lib/src/extension_points/extensions_external.dart
+++ b/packages/devtools_app/lib/src/extension_points/extensions_external.dart
@@ -19,6 +19,6 @@ class ExternalDevToolsExtensionPoints implements DevToolsExtensionPoints {
 
   @override
   String loadingAppSizeDataMessage() {
-    return 'Loading app size data. Please wait.';
+    return 'Loading app size data. Please wait...';
   }
 }


### PR DESCRIPTION
This message is provided as an extension point so that we can customize the message in google3. Internally, there is high latency due to the file store and we should warn users that it could a little while.