### PR TITLE
Fix bug where you could trigger simultaneous connects by accidentally clicking or pressing return twice

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -202,7 +202,10 @@ class DevToolsAppState extends State<DevToolsApp> {
             if (tabs.isEmpty) {
               return DevToolsScaffold.withChild(
                 child: CenteredMessage(
-                    'The "$page" screen is not available for this application.'),
+                  page != null
+                      ? 'The "$page" screen is not available for this application.'
+                      : 'No tabs available for this application.',
+                ),
                 ideTheme: ideTheme,
                 analyticsProvider: widget.analyticsProvider,
               );

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -117,7 +117,7 @@ class _InitializerState extends State<Initializer>
 
   /// Shows a "disconnected" overlay if the [service.serviceManager] is not currently connected.
   void _handleNoConnection() {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance.scheduleFrameCallback((_) {
       if (!_checkLoaded() &&
           ModalRoute.of(context).isCurrent &&
           currentDisconnectedOverlay == null) {

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -765,30 +765,6 @@ bool equalsWithinEpsilon(double a, double b) {
   return (a - b).abs() < defaultEpsilon;
 }
 
-/// Have a quiet period after a callback to ensure that rapid invocations of a
-/// callback only result in one call.
-class CallbackDwell {
-  CallbackDwell(
-    this.callback, {
-    this.dwell = const Duration(milliseconds: 250),
-  });
-
-  final VoidCallback callback;
-  final Duration dwell;
-
-  Timer _timer;
-
-  void invoke() {
-    if (_timer == null) {
-      _timer = Timer(dwell, () {
-        _timer = null;
-      });
-
-      callback();
-    }
-  }
-}
-
 /// A dev time class to help trace DevTools application events.
 class DebugTimingLogger {
   DebugTimingLogger(this.name, {this.mute});
@@ -1304,4 +1280,19 @@ extension BoolExtension on bool {
     if (other) return 1;
     return -1;
   }
+}
+
+Future<T> whenValueNonNull<T>(ValueListenable<T> listenable) {
+  if (listenable.value != null) return Future.value(listenable.value);
+  final completer = Completer<T>();
+  void listener() {
+    final value = listenable.value;
+    if (value != null) {
+      completer.complete(value);
+    }
+    listenable.removeListener(listener);
+  }
+
+  listenable.addListener(listener);
+  return completer.future;
 }

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -1289,8 +1289,8 @@ Future<T> whenValueNonNull<T>(ValueListenable<T> listenable) {
     final value = listenable.value;
     if (value != null) {
       completer.complete(value);
+      listenable.removeListener(listener);
     }
-    listenable.removeListener(listener);
   }
 
   listenable.addListener(listener);


### PR DESCRIPTION
The previous approach of delaying by 250ms was insufficient. This matches other UI in DevTools where we block actions while the current action is in progress.