### PR TITLE
Add a clear method to history_manager

### DIFF
--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -17,7 +17,6 @@ class HistoryManager<T> {
 
   void clear() {
     _history.clear();
-    _historyIndex = null;
     _historyIndex = -1;
     _current.value = null;
   }

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -15,6 +15,13 @@ class HistoryManager<T> {
   final _history = <T>[];
   int _historyIndex = -1;
 
+  void clear() {
+    _history.clear();
+    _historyIndex = null;
+    _historyIndex = -1;
+    _current.value = null;
+  }
+
   /// Returns true if there is a previous historical item available on the
   /// stack.
   bool get hasPrevious {


### PR DESCRIPTION
Moving this off to reduce the # of non-noop things in a big refactor CL.