### PR TITLE
Cache CPU profiles for selected frames

### DIFF
--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -181,7 +181,7 @@ class LegacyPerformanceController
 
     if (event.isUiEvent && updateProfiler) {
       final storedProfile =
-          cpuProfilerController.cpuProfileStore.storedProfile(event.time);
+          cpuProfilerController.cpuProfileStore.lookupProfile(event.time);
       if (storedProfile != null) {
         await cpuProfilerController.processAndSetData(
           storedProfile,
@@ -228,7 +228,7 @@ class LegacyPerformanceController
     await selectTimelineEvent(frame.uiEventFlow, updateProfiler: false);
 
     final storedProfileForFrame =
-        cpuProfilerController.cpuProfileStore.storedProfile(frame.time);
+        cpuProfilerController.cpuProfileStore.lookupProfile(frame.time);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       await cpuProfilerController.pullAndProcessProfile(

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -68,8 +68,6 @@ class LegacyPerformanceController
   ValueListenable<List<LegacyFlutterFrame>> get flutterFrames => _flutterFrames;
   final _flutterFrames = ValueNotifier<List<LegacyFlutterFrame>>([]);
 
-  final _flutterFramesById = <String, LegacyFlutterFrame>{};
-
   /// Whether an empty timeline recording was just recorded.
   ValueListenable<bool> get emptyTimeline => _emptyTimeline;
   final _emptyTimeline = ValueNotifier<bool>(false);
@@ -174,25 +172,22 @@ class LegacyPerformanceController
 
   Future<void> selectTimelineEvent(
     LegacyTimelineEvent event, {
-    bool pullCpuProfile = true,
+    bool updateProfiler = true,
   }) async {
     if (event == null || data.selectedEvent == event) return;
 
     data.selectedEvent = event;
     _selectedTimelineEventNotifier.value = event;
 
-    if (pullCpuProfile && event.isUiEvent) {
-      if (event.frameId != null) {
-        final frameProfile = _flutterFramesById[event.frameId]?.cpuProfileData;
-        if (frameProfile != null) {
-          cpuProfilerController.reset();
-          await cpuProfilerController.generateSubProfile(
-            frameProfile,
-            event.time,
-            processId: 'subProfile for ${event.name} from ${event.frameId}',
-          );
-          data.cpuProfileData = cpuProfilerController.dataNotifier.value;
-        }
+    if (event.isUiEvent && updateProfiler) {
+      final storedProfile =
+          cpuProfilerController.cpuProfileStore.storedProfile(event.time);
+      if (storedProfile != null) {
+        await cpuProfilerController.processAndSetData(
+          storedProfile,
+          processId: 'Stored profile for ${event.time}',
+        );
+        data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       } else if ((!offlineMode || offlinePerformanceData == null) &&
           cpuProfilerController.profilerEnabled) {
         // Fetch a profile if not in offline mode and if the profiler is enabled
@@ -201,6 +196,10 @@ class LegacyPerformanceController
           startMicros: event.time.start.inMicroseconds,
           extentMicros: event.time.duration.inMicroseconds,
           processId: '${event.traceEvents.first.id}',
+        );
+        cpuProfilerController.cpuProfileStore.storeProfile(
+          event.time,
+          cpuProfilerController.dataNotifier.value,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       }
@@ -230,20 +229,21 @@ class LegacyPerformanceController
     // pulling the CPU profile for the frame (directly below) matters here.
     // If the selected timeline event is null, the event details section will
     // not show the progress bar while we are processing the CPU profile.
-    await selectTimelineEvent(frame.uiEventFlow, pullCpuProfile: false);
+    await selectTimelineEvent(frame.uiEventFlow, updateProfiler: false);
 
-    if (frame.cpuProfileData == null) {
+    final storedProfileForFrame =
+        cpuProfilerController.cpuProfileStore.storedProfile(frame.time);
+    if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       await cpuProfilerController.pullAndProcessProfile(
         startMicros: frame.time.start.inMicroseconds,
         extentMicros: frame.time.duration.inMicroseconds,
         processId: 'Flutter frame ${frame.id}',
       );
-      frame.cpuProfileData = cpuProfilerController.dataNotifier.value;
       data.cpuProfileData = cpuProfilerController.dataNotifier.value;
     } else {
-      data.cpuProfileData = frame.cpuProfileData;
-      cpuProfilerController.loadProcessedData(frame.cpuProfileData);
+      data.cpuProfileData = storedProfileForFrame;
+      cpuProfilerController.loadProcessedData(storedProfileForFrame);
     }
 
     if (debugTimeline) {
@@ -262,7 +262,6 @@ class LegacyPerformanceController
 
   void addFrame(LegacyFlutterFrame frame) {
     data.frames.add(frame);
-    _flutterFramesById.putIfAbsent(frame.id, () => frame);
   }
 
   Future<void> refreshData() async {
@@ -537,7 +536,6 @@ class LegacyPerformanceController
     processor?.reset();
     _emptyTimeline.value = true;
     _flutterFrames.value = [];
-    _flutterFramesById.clear();
     _selectedTimelineEventNotifier.value = null;
     _selectedFrameNotifier.value = null;
     _processing.value = false;

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -68,6 +68,8 @@ class LegacyPerformanceController
   ValueListenable<List<LegacyFlutterFrame>> get flutterFrames => _flutterFrames;
   final _flutterFrames = ValueNotifier<List<LegacyFlutterFrame>>([]);
 
+  final _flutterFramesById = <String, LegacyFlutterFrame>{};
+
   /// Whether an empty timeline recording was just recorded.
   ValueListenable<bool> get emptyTimeline => _emptyTimeline;
   final _emptyTimeline = ValueNotifier<bool>(false);
@@ -170,31 +172,39 @@ class LegacyPerformanceController
     }
   }
 
-  Future<void> selectTimelineEvent(LegacyTimelineEvent event) async {
+  Future<void> selectTimelineEvent(
+    LegacyTimelineEvent event, {
+    bool pullCpuProfile = true,
+  }) async {
     if (event == null || data.selectedEvent == event) return;
 
     data.selectedEvent = event;
     _selectedTimelineEventNotifier.value = event;
 
-    cpuProfilerController.reset();
-
-    // Fetch a profile if not in offline mode and if the profiler is enabled.
-    if ((!offlineMode || offlinePerformanceData == null) &&
-        cpuProfilerController.profilerEnabled) {
-      await getCpuProfileForSelectedEvent();
+    if (pullCpuProfile && event.isUiEvent) {
+      if (event.frameId != null) {
+        final frameProfile = _flutterFramesById[event.frameId]?.cpuProfileData;
+        if (frameProfile != null) {
+          cpuProfilerController.reset();
+          await cpuProfilerController.generateSubProfile(
+            frameProfile,
+            event.time,
+            processId: 'subProfile for ${event.name} from ${event.frameId}',
+          );
+          data.cpuProfileData = cpuProfilerController.dataNotifier.value;
+        }
+      } else if ((!offlineMode || offlinePerformanceData == null) &&
+          cpuProfilerController.profilerEnabled) {
+        // Fetch a profile if not in offline mode and if the profiler is enabled
+        cpuProfilerController.reset();
+        await cpuProfilerController.pullAndProcessProfile(
+          startMicros: event.time.start.inMicroseconds,
+          extentMicros: event.time.duration.inMicroseconds,
+          processId: '${event.traceEvents.first.id}',
+        );
+        data.cpuProfileData = cpuProfilerController.dataNotifier.value;
+      }
     }
-  }
-
-  Future<void> getCpuProfileForSelectedEvent() async {
-    final selectedEvent = data.selectedEvent;
-    if (!selectedEvent.isUiEvent) return;
-
-    await cpuProfilerController.pullAndProcessProfile(
-      startMicros: selectedEvent.time.start.inMicroseconds,
-      extentMicros: selectedEvent.time.duration.inMicroseconds,
-      processId: '${selectedEvent.traceEvents.first.id}',
-    );
-    data.cpuProfileData = cpuProfilerController.dataNotifier.value;
   }
 
   ValueListenable<double> get displayRefreshRate => _displayRefreshRate;
@@ -215,9 +225,28 @@ class LegacyPerformanceController
     data.selectedFrame = frame;
     _selectedFrameNotifier.value = frame;
 
-    await selectTimelineEvent(frame.uiEventFlow);
+    // We do not need to pull the CPU profile because we will pull the profile
+    // for the entire frame. The order of selecting the timeline event and
+    // pulling the CPU profile for the frame (directly below) matters here.
+    // If the selected timeline event is null, the event details section will
+    // not show the progress bar while we are processing the CPU profile.
+    await selectTimelineEvent(frame.uiEventFlow, pullCpuProfile: false);
 
-    if (debugTimeline && frame != null) {
+    if (frame.cpuProfileData == null) {
+      cpuProfilerController.reset();
+      await cpuProfilerController.pullAndProcessProfile(
+        startMicros: frame.time.start.inMicroseconds,
+        extentMicros: frame.time.duration.inMicroseconds,
+        processId: 'Flutter frame ${frame.id}',
+      );
+      frame.cpuProfileData = cpuProfilerController.dataNotifier.value;
+      data.cpuProfileData = cpuProfilerController.dataNotifier.value;
+    } else {
+      data.cpuProfileData = frame.cpuProfileData;
+      cpuProfilerController.loadProcessedData(frame.cpuProfileData);
+    }
+
+    if (debugTimeline) {
       final buf = StringBuffer();
       buf.writeln('UI timeline event for frame ${frame.id}:');
       frame.uiEventFlow.format(buf, '  ');
@@ -233,6 +262,7 @@ class LegacyPerformanceController
 
   void addFrame(LegacyFlutterFrame frame) {
     data.frames.add(frame);
+    _flutterFramesById.putIfAbsent(frame.id, () => frame);
   }
 
   Future<void> refreshData() async {
@@ -351,7 +381,8 @@ class LegacyPerformanceController
   }
 
   FutureOr<void> processOfflineData(
-      LegacyOfflinePerformanceData offlineData) async {
+    LegacyOfflinePerformanceData offlineData,
+  ) async {
     await clearData();
     final traceEvents = [
       for (var trace in offlineData.traceEvents)
@@ -506,6 +537,7 @@ class LegacyPerformanceController
     processor?.reset();
     _emptyTimeline.value = true;
     _flutterFrames.value = [];
+    _flutterFramesById.clear();
     _selectedTimelineEventNotifier.value = null;
     _selectedFrameNotifier.value = null;
     _processing.value = false;

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -197,10 +197,6 @@ class LegacyPerformanceController
           extentMicros: event.time.duration.inMicroseconds,
           processId: '${event.traceEvents.first.id}',
         );
-        cpuProfilerController.cpuProfileStore.storeProfile(
-          event.time,
-          cpuProfilerController.dataNotifier.value,
-        );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       }
     }

--- a/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
@@ -447,8 +447,6 @@ class LegacyFlutterFrame {
   double get rasterDurationMs =>
       rasterDuration != null ? rasterDuration / 1000 : null;
 
-  CpuProfileData cpuProfileData;
-
   void setEventFlow(LegacySyncTimelineEvent event, {TimelineEventType type}) {
     type ??= event?.type;
     if (type == TimelineEventType.ui) {

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -172,7 +172,7 @@ class PerformanceController
 
     if (event.isUiEvent && updateProfiler) {
       final storedProfile =
-          cpuProfilerController.cpuProfileStore.storedProfile(event.time);
+          cpuProfilerController.cpuProfileStore.lookupProfile(event.time);
       if (storedProfile != null) {
         await cpuProfilerController.processAndSetData(
           storedProfile,
@@ -219,7 +219,7 @@ class PerformanceController
     await selectTimelineEvent(frame.uiEventFlow, updateProfiler: false);
 
     final storedProfileForFrame =
-        cpuProfilerController.cpuProfileStore.storedProfile(frame.time);
+        cpuProfilerController.cpuProfileStore.lookupProfile(frame.time);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       await cpuProfilerController.pullAndProcessProfile(

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -188,10 +188,6 @@ class PerformanceController
           extentMicros: event.time.duration.inMicroseconds,
           processId: '${event.traceEvents.first.id}',
         );
-        cpuProfilerController.cpuProfileStore.storeProfile(
-          event.time,
-          cpuProfilerController.dataNotifier.value,
-        );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       }
     }

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -436,8 +436,6 @@ class FlutterFrame {
   double get rasterDurationMs =>
       rasterDuration != null ? rasterDuration / 1000 : null;
 
-  CpuProfileData cpuProfileData;
-
   void setEventFlow(SyncTimelineEvent event, {TimelineEventType type}) {
     type ??= event?.type;
     if (type == TimelineEventType.ui) {

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -100,7 +100,7 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
     );
 
     await processAndSetData(cpuProfileData);
-    cpuProfileStore.storeProfile(
+    cpuProfileStore.addProfile(
       TimeRange()
         ..start = Duration(microseconds: startMicros)
         ..end = Duration(microseconds: startMicros + extentMicros),

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -96,6 +96,24 @@ class CpuProfilerController with SearchControllerMixin<CpuStackFrame> {
       extentMicros: extentMicros,
     );
 
+    await _transformAndSetData(cpuProfileData);
+  }
+
+  Future<void> generateSubProfile(
+    CpuProfileData superProfile,
+    TimeRange subTimeRange, {
+    String processId,
+  }) async {
+    _processingNotifier.value = true;
+    _dataNotifier.value = null;
+    final subProfile = CpuProfileData.subProfile(superProfile, subTimeRange);
+    await _transformAndSetData(subProfile);
+  }
+
+  Future<void> _transformAndSetData(
+    CpuProfileData cpuProfileData, {
+    String processId,
+  }) async {
     try {
       await transformer.processData(cpuProfileData, processId: processId);
       _dataNotifier.value = cpuProfileData;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -11,6 +11,7 @@ import '../trace_event.dart';
 import '../trees.dart';
 import '../ui/search.dart';
 import '../utils.dart';
+import 'cpu_profile_transformer.dart';
 
 /// Data model for DevTools CPU profile.
 class CpuProfileData {
@@ -107,6 +108,21 @@ class CpuProfileData {
 
   /// Marks whether this data has already been processed.
   bool processed = false;
+
+  List<CpuStackFrame> get callTreeRoots {
+    if (!processed) return <CpuStackFrame>[];
+    return _callTreeRoots ??= [_cpuProfileRoot.deepCopy()];
+  }
+
+  List<CpuStackFrame> _callTreeRoots;
+
+  List<CpuStackFrame> get bottomUpRoots {
+    if (!processed) return <CpuStackFrame>[];
+    return _bottomUpRoots ??=
+        BottomUpProfileTransformer.processData(_cpuProfileRoot);
+  }
+
+  List<CpuStackFrame> _bottomUpRoots;
 
   final Map<String, dynamic> stackFramesJson;
 

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -313,9 +313,11 @@ class UserTagDropdown extends StatelessWidget {
                         value: tag,
                       ),
                 ],
-                onChanged: userTags.isNotEmpty
-                    ? (String tag) => _onUserTagChanged(tag, context)
-                    : null,
+                onChanged: userTags.isEmpty ||
+                        (userTags.length == 1 &&
+                            userTags.first == UserTag.defaultTag.label)
+                    ? null
+                    : (String tag) => _onUserTagChanged(tag, context),
               ),
             );
           },

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -16,7 +16,6 @@ import 'cpu_profile_call_tree.dart';
 import 'cpu_profile_controller.dart';
 import 'cpu_profile_flame_chart.dart';
 import 'cpu_profile_model.dart';
-import 'cpu_profile_transformer.dart';
 
 // TODO(kenz): provide useful UI upon selecting a CPU stack frame.
 
@@ -26,10 +25,8 @@ class CpuProfiler extends StatefulWidget {
     @required this.controller,
     this.searchFieldKey,
     this.standaloneProfiler = true,
-  })  : callTreeRoots = data != null ? [data.cpuProfileRoot.deepCopy()] : [],
-        bottomUpRoots = data != null
-            ? BottomUpProfileTransformer.processData(data.cpuProfileRoot)
-            : [];
+  })  : callTreeRoots = data?.callTreeRoots ?? [],
+        bottomUpRoots = data?.bottomUpRoots ?? [];
 
   final CpuProfileData data;
 

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -555,6 +555,8 @@ class TimeRange {
 
   bool contains(Duration target) => target >= start && target <= end;
 
+  bool containsRange(TimeRange t) => contains(t.start) && contains(t.end);
+
   set end(Duration value) {
     if (singleAssignment) {
       assert(_end == null);

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -160,47 +160,78 @@ void main() {
       expect(end - start, lessThan(400));
     });
 
-    test('timeRange', () {
-      final timeRange = TimeRange();
+    group('TimeRange', () {
+      test('toString', () {
+        final timeRange = TimeRange();
 
-      expect(timeRange.toString(), equals('[null μs - null μs]'));
+        expect(timeRange.toString(), equals('[null μs - null μs]'));
 
-      timeRange
-        ..start = const Duration(microseconds: 1000)
-        ..end = const Duration(microseconds: 8000);
+        timeRange
+          ..start = const Duration(microseconds: 1000)
+          ..end = const Duration(microseconds: 8000);
 
-      expect(timeRange.duration.inMicroseconds, equals(7000));
-      expect(timeRange.toString(), equals('[1000 μs - 8000 μs]'));
-      expect(
-        timeRange.toString(unit: TimeUnit.milliseconds),
-        equals('[1 ms - 8 ms]'),
-      );
+        expect(timeRange.duration.inMicroseconds, equals(7000));
+        expect(timeRange.toString(), equals('[1000 μs - 8000 μs]'));
+        expect(
+          timeRange.toString(unit: TimeUnit.milliseconds),
+          equals('[1 ms - 8 ms]'),
+        );
+      });
 
-      final t = TimeRange()
-        ..start = const Duration(milliseconds: 100)
-        ..end = const Duration(milliseconds: 200);
-      final overlapBeginning = TimeRange()
-        ..start = const Duration(milliseconds: 50)
-        ..end = const Duration(milliseconds: 150);
-      final overlapMiddle = TimeRange()
-        ..start = const Duration(milliseconds: 125)
-        ..end = const Duration(milliseconds: 175);
-      final overlapEnd = TimeRange()
-        ..start = const Duration(milliseconds: 150)
-        ..end = const Duration(milliseconds: 250);
-      final overlapAll = TimeRange()
-        ..start = const Duration(milliseconds: 50)
-        ..end = const Duration(milliseconds: 250);
-      final noOverlap = TimeRange()
-        ..start = const Duration(milliseconds: 300)
-        ..end = const Duration(milliseconds: 400);
+      test('overlaps', () {
+        final t = TimeRange()
+          ..start = const Duration(milliseconds: 100)
+          ..end = const Duration(milliseconds: 200);
+        final overlapBeginning = TimeRange()
+          ..start = const Duration(milliseconds: 50)
+          ..end = const Duration(milliseconds: 150);
+        final overlapMiddle = TimeRange()
+          ..start = const Duration(milliseconds: 125)
+          ..end = const Duration(milliseconds: 175);
+        final overlapEnd = TimeRange()
+          ..start = const Duration(milliseconds: 150)
+          ..end = const Duration(milliseconds: 250);
+        final overlapAll = TimeRange()
+          ..start = const Duration(milliseconds: 50)
+          ..end = const Duration(milliseconds: 250);
+        final noOverlap = TimeRange()
+          ..start = const Duration(milliseconds: 300)
+          ..end = const Duration(milliseconds: 400);
 
-      expect(t.overlaps(t), isTrue);
-      expect(t.overlaps(overlapBeginning), isTrue);
-      expect(t.overlaps(overlapMiddle), isTrue);
-      expect(t.overlaps(overlapEnd), isTrue);
-      expect(t.overlaps(overlapAll), isTrue);
-      expect(t.overlaps(noOverlap), isFalse);
+        expect(t.overlaps(t), isTrue);
+        expect(t.overlaps(overlapBeginning), isTrue);
+        expect(t.overlaps(overlapMiddle), isTrue);
+        expect(t.overlaps(overlapEnd), isTrue);
+        expect(t.overlaps(overlapAll), isTrue);
+        expect(t.overlaps(noOverlap), isFalse);
+      });
+
+      test('containsRange', () {
+        final t = TimeRange()
+          ..start = const Duration(milliseconds: 100)
+          ..end = const Duration(milliseconds: 200);
+        final containsStart = TimeRange()
+          ..start = const Duration(milliseconds: 50)
+          ..end = const Duration(milliseconds: 150);
+        final containsStartAndEnd = TimeRange()
+          ..start = const Duration(milliseconds: 125)
+          ..end = const Duration(milliseconds: 175);
+        final containsEnd = TimeRange()
+          ..start = const Duration(milliseconds: 150)
+          ..end = const Duration(milliseconds: 250);
+        final invertedContains = TimeRange()
+          ..start = const Duration(milliseconds: 50)
+          ..end = const Duration(milliseconds: 250);
+        final containsNeither = TimeRange()
+          ..start = const Duration(milliseconds: 300)
+          ..end = const Duration(milliseconds: 400);
+
+        expect(t.containsRange(containsStart), isFalse);
+        expect(t.containsRange(containsStartAndEnd), isTrue);
+        expect(t.containsRange(containsEnd), isFalse);
+        expect(t.containsRange(invertedContains), isFalse);
+        expect(t.containsRange(containsNeither), isFalse);
+      });
     });
 
     test('formatDateTime', () {


### PR DESCRIPTION
This will prevent users from losing CPU profile data for frames they have already selected. We have seen users in user studies hit problems with CPU samples falling out of the CPU sample buffer. 

We now cache profiles with their respective frames in the performance page. For timeline events within that frame, we will generate a sub profile from the frame's cached profile upon selection.

This PR also improves the performance of the CPU profiler by caching the `callTreeRoots` and `bottomUpRoots` for an instance of `CpuProfileData`.

This will improve https://github.com/flutter/devtools/issues/2631