### PR TITLE
Updated buildViewportChrome

### DIFF
--- a/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
@@ -655,10 +655,13 @@ class _CustomPointerScrollableState extends State<CustomPointerScrollable>
       );
     }
 
-    // TODO: https://github.com/flutter/devtools/issues/2858
-    // ignore: deprecated_member_use
-    return _configuration.buildViewportChrome(
-        context, result, widget.axisDirection);
+    // In contrast to scrollable.dart, _configuration.buildScrollbar is not
+    // called since scrollbars are added manually where needed.
+    return _configuration.buildOverscrollIndicator(
+        context,
+        result,
+        ScrollableDetails(
+            controller: widget.controller, direction: axisDirection));
   }
 
   @override


### PR DESCRIPTION
Noticed this while investigating https://github.com/flutter/devtools/issues/2012 :)

I think this fixes https://github.com/flutter/devtools/issues/2858 without needing to re-fork or refactor everything else.

The replacement for `ScrollBehavior.buildViewportChrome` is
- `ScrollBehavior.buildScrollbar` (which is new functionality) and 
- `ScrollBehavior.buildOverscrollIndicator` (which is the same as the deprecated `buildViewportChrome`)

It appears that `Scrollbar`s are applied as needed already, so I left the former out.