### PR TITLE
Surface shader time per frame in the Performance page

### DIFF
--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -226,7 +226,10 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
           sum +
           math.max(
             1000 / widget.displayRefreshRate,
-            math.max(frame.uiDurationMs, frame.rasterDurationMs),
+            math.max(
+              frame.uiDuration.inMilliseconds,
+              frame.rasterDuration.inMilliseconds,
+            ),
           ),
     );
     final avgFrameTime = sumFrameTimesMs / widget.frames.length;
@@ -275,14 +278,15 @@ class FlutterFramesChartItem extends StatelessWidget {
     final ui = Container(
       key: Key('frame ${frame.id} - ui'),
       width: defaultFrameWidth / 2,
-      height: (frame.uiDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      height: (frame.uiDuration.inMilliseconds / msPerPx)
+          .clamp(0.0, availableChartHeight),
       color: uiJanky ? uiJankColor : mainUiColor,
     );
     final raster = Container(
       key: Key('frame ${frame.id} - raster'),
       width: defaultFrameWidth / 2,
-      height:
-          (frame.rasterDurationMs / msPerPx).clamp(0.0, availableChartHeight),
+      height: (frame.rasterDuration.inMilliseconds / msPerPx)
+          .clamp(0.0, availableChartHeight),
       color: rasterJanky ? rasterJankColor : mainRasterColor,
     );
     return Stack(
@@ -315,13 +319,23 @@ class FlutterFramesChartItem extends StatelessWidget {
             color: defaultSelectionColor,
             height: selectedIndicatorHeight,
           ),
+        if (frame.hasShaderTime)
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Icon(Icons.warning_amber_rounded),
+            ],
+          ),
       ],
     );
   }
 
   String _tooltipText(FlutterFrame frame) {
-    return 'UI: ${msText(frame.uiEventFlow.time.duration)}\n'
-        'Raster: ${msText(frame.rasterEventFlow.time.duration)}';
+    return [
+      'UI: ${msText(frame.uiEventFlow.time.duration)}',
+      'Raster: ${msText(frame.rasterEventFlow.time.duration)}',
+      if (frame.hasShaderTime) 'Skia.Shaders: ${msText(frame.shaderDuration)}',
+    ].join('\n');
   }
 }
 

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -311,7 +311,7 @@ class FlutterFramesChartItem extends StatelessWidget {
           width: defaultFrameWidth / 2,
           height: (frame.shaderDuration.inMilliseconds / msPerPx)
               .clamp(0.0, availableChartHeight * shaderToRasterRatio),
-          color: Colors.amber,
+          color: shaderCompilationColor,
         ),
     ]);
     return Stack(

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -434,6 +434,10 @@ class FlutterFrame {
   Duration get shaderDuration {
     if (_shaderTime != null) return _shaderTime;
     int sumShaderMicros = 0;
+    // TODO(kenz): add a helper class for performing efficient time interval
+    // union computation. This code is currently broken if there were non-shader
+    // events interleaved with shader events. The time reported would be
+    // inaccurately large.
     breadthFirstTraversal<TimelineEvent>(
       rasterEventFlow,
       action: (TimelineEvent event) {

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -427,14 +427,30 @@ class FlutterFrame {
       pipelineItemTime.start?.inMicroseconds != null &&
       pipelineItemTime.end?.inMicroseconds != null;
 
-  int get uiDuration => uiEventFlow?.time?.duration?.inMicroseconds;
+  Duration get uiDuration => uiEventFlow?.time?.duration;
 
-  double get uiDurationMs => uiDuration != null ? uiDuration / 1000 : null;
+  Duration get rasterDuration => rasterEventFlow?.time?.duration;
 
-  int get rasterDuration => rasterEventFlow?.time?.duration?.inMicroseconds;
+  Duration get shaderDuration {
+    if (_shaderTime != null) return _shaderTime;
+    int sumShaderMicros = 0;
+    breadthFirstTraversal<TimelineEvent>(
+      rasterEventFlow,
+      action: (TimelineEvent event) {
+        // Shader events with a shader event parent should not be included in the
+        // sum because the parent event will encompass the time of [event].
+        if (event.isShaderEvent &&
+            (event.parent == null || !event.parent.isShaderEvent)) {
+          sumShaderMicros += event.time.duration.inMicroseconds;
+        }
+      },
+    );
+    return _shaderTime = Duration(microseconds: sumShaderMicros);
+  }
 
-  double get rasterDurationMs =>
-      rasterDuration != null ? rasterDuration / 1000 : null;
+  Duration _shaderTime;
+
+  bool get hasShaderTime => shaderDuration != Duration.zero;
 
   void setEventFlow(SyncTimelineEvent event, {TimelineEventType type}) {
     type ??= event?.type;
@@ -482,11 +498,12 @@ class FlutterFrame {
   }
 
   bool isUiJanky(double displayRefreshRate) {
-    return uiDurationMs > _targetMsPerFrame(displayRefreshRate);
+    return uiDuration.inMilliseconds > _targetMsPerFrame(displayRefreshRate);
   }
 
   bool isRasterJanky(double displayRefreshRate) {
-    return rasterDurationMs > _targetMsPerFrame(displayRefreshRate);
+    return rasterDuration.inMilliseconds >
+        _targetMsPerFrame(displayRefreshRate);
   }
 
   double _targetMsPerFrame(double displayRefreshRate) {
@@ -554,6 +571,9 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent>
 
   bool get isGCEvent =>
       traceEvents.first.event.category == TraceEvent.gcCategory;
+
+  bool get isShaderEvent =>
+      traceEvents.first.isShaderEvent || traceEvents.last.isShaderEvent;
 
   bool get isWellFormed => time.start != null && time.end != null;
 

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -52,7 +52,8 @@ class PerformanceScreen extends Screen {
     // TODO(kenz): once https://github.com/flutter/flutter/commit/78a96b09d64dc2a520e5b269d5cea1b9dde27d3f
     // makes it into flutter dev channel, track the version number and use that
     // here. We may have to add functionality to [SemanticVersion] to support
-    // versions beyond the patch number (e.g.  2.3.0-12.1.pre).
+    // versions beyond the patch number (e.g.  2.3.0-12.1.pre). The supported
+    // version for this commit is 2.3.0-16.0.pre.
     return currentVersion != null &&
         currentVersion >= SemanticVersion(major: 2, minor: 3, patch: 1);
   }

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -435,7 +435,9 @@ class TimelineFlameChartState
       }
 
       Color backgroundColor;
-      if (event.isAsyncEvent) {
+      if (event.isShaderEvent) {
+        backgroundColor = rasterJankColor;
+      } else if (event.isAsyncEvent) {
         backgroundColor = nextAsyncColor(row);
       } else if (event.isGCEvent) {
         // TODO(kenz): should we have a different color palette for GC events?

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -436,7 +436,7 @@ class TimelineFlameChartState
 
       Color backgroundColor;
       if (event.isShaderEvent) {
-        backgroundColor = rasterJankColor;
+        backgroundColor = shaderCompilationColor;
       } else if (event.isAsyncEvent) {
         backgroundColor = nextAsyncColor(row);
       } else if (event.isGCEvent) {

--- a/packages/devtools_app/lib/src/trace_event.dart
+++ b/packages/devtools_app/lib/src/trace_event.dart
@@ -127,6 +127,8 @@ class TraceEventWrapper implements Comparable<TraceEventWrapper> {
 
   bool processed = false;
 
+  bool get isShaderEvent => event.args['devtoolsTag'] == 'shaders';
+
   @override
   int compareTo(TraceEventWrapper other) {
     // Order events based on their timestamps. If the events share a timestamp,

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -59,7 +59,7 @@ const unknownColorPalette = [
 
 const uiJankColor = Color(0xFFF5846B);
 const rasterJankColor = Color(0xFFC3595A);
-const shaderCompilationColor = Colors.amber;
+const shaderCompilationColor = Color(0xFF77102F);
 
 const treemapIncreaseColor = Color(0xFF3FB549);
 const treemapDecreaseColor = Color(0xFF77102F);

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -59,6 +59,7 @@ const unknownColorPalette = [
 
 const uiJankColor = Color(0xFFF5846B);
 const rasterJankColor = Color(0xFFC3595A);
+const shaderCompilationColor = Colors.amber;
 
 const treemapIncreaseColor = Color(0xFF3FB549);
 const treemapDecreaseColor = Color(0xFF77102F);


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3043. This PR:

- Adds logic to calculate the amount of time spent on Shader compilation for a single frame.
- Adds a warning icon on flutter frames that have Shader compilation time
- Adds info about shader compilation time to the tooltip for a flutter frame
- Colors shader events in the timeline with the Raster Jank Color we use in the flutter frames chart

<img width="1161" alt="Screen Shot 2021-06-14 at 4 15 26 PM" src="https://user-images.githubusercontent.com/43759233/121971276-37e66300-cd2d-11eb-92fa-cdbf26b3437d.png">
<img width="322" alt="Screen Shot 2021-06-14 at 4 12 03 PM" src="https://user-images.githubusercontent.com/43759233/121971281-3ae15380-cd2d-11eb-8582-6eb2f8682dfb.png">

**[EDIT with some UI changes from review comments]**
@InMatrix for some UX input on colors here

![shader-compilation](https://user-images.githubusercontent.com/43759233/122109565-5ce0e180-cdd2-11eb-97a6-0f80a73d72c2.gif)
<img width="892" alt="Screen Shot 2021-06-15 at 12 10 01 PM" src="https://user-images.githubusercontent.com/43759233/122109841-ae896c00-cdd2-11eb-90bb-98efa75ec016.png">
<img width="237" alt="Screen Shot 2021-06-15 at 12 10 20 PM" src="https://user-images.githubusercontent.com/43759233/122109848-b0532f80-cdd2-11eb-88d5-a9368285eed4.png">
