### PR TITLE
Add an Error banner with a link to documentation when shader jank is detected

### DIFF
--- a/packages/devtools_app/lib/src/banner_messages.dart
+++ b/packages/devtools_app/lib/src/banner_messages.dart
@@ -19,6 +19,9 @@ const _runInProfileModeDocsUrl =
 const _profileGranularityDocsUrl =
     'https://flutter.dev/docs/development/tools/devtools/performance#profile-granularity';
 
+const preCompileShadersDocsUrl =
+    'https://flutter.dev/docs/perf/rendering/shader#how-to-use-sksl-warmup';
+
 class BannerMessagesController {
   final _messages = <String, ValueNotifier<List<BannerMessage>>>{};
   final _dismissedMessageKeys = <Key>{};
@@ -272,6 +275,51 @@ This could be caused by an older version of package:provider; please make sure t
           style: TextStyle(color: _BannerError.foreground),
         ),
       ],
+    );
+  }
+}
+
+class ShaderJankMessage {
+  const ShaderJankMessage(
+    this.screenId, {
+    @required this.jankyFramesCount,
+    @required this.jankDuration,
+  });
+
+  final String screenId;
+
+  final int jankyFramesCount;
+
+  final Duration jankDuration;
+
+  Widget build(BuildContext context) {
+    return _BannerError(
+      key: Key('ShaderJankMessage - $screenId'),
+      textSpans: [
+        TextSpan(
+          text: '''
+Shader compilation jank detected. $jankyFramesCount ${pluralize('frame', jankyFramesCount)} janked with a total of ${msText(jankDuration)} spent in shader compilation.
+
+To pre-compile shaders, see the instructions at ''',
+          style: const TextStyle(color: _BannerError.foreground),
+        ),
+        TextSpan(
+          text: preCompileShadersDocsUrl,
+          style: const TextStyle(
+            decoration: TextDecoration.underline,
+            color: _BannerError.linkColor,
+          ),
+          recognizer: TapGestureRecognizer()
+            ..onTap = () async {
+              await launchUrl(preCompileShadersDocsUrl, context);
+            },
+        ),
+        const TextSpan(
+          text: '.',
+          style: TextStyle(color: _BannerError.foreground),
+        ),
+      ],
+      screenId: screenId,
     );
   }
 }

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -5,14 +5,14 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:devtools_app/src/globals.dart';
-import 'package:devtools_app/src/scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../auto_dispose_mixin.dart';
 import '../banner_messages.dart';
 import '../common_widgets.dart';
+import '../globals.dart';
+import '../scaffold.dart';
 import '../theme.dart';
 import '../ui/colors.dart';
 import '../utils.dart';

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -5,16 +5,20 @@
 import 'dart:async';
 import 'dart:math' as math;
 
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/scaffold.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../auto_dispose_mixin.dart';
+import '../banner_messages.dart';
 import '../common_widgets.dart';
 import '../theme.dart';
 import '../ui/colors.dart';
 import '../utils.dart';
 import 'performance_controller.dart';
 import 'performance_model.dart';
+import 'performance_screen.dart';
 
 class FlutterFramesChart extends StatefulWidget {
   const FlutterFramesChart(
@@ -83,6 +87,8 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
         _selectedFrame = _controller.selectedFrame.value;
       });
     });
+
+    _maybeShowShaderJankMessage();
   }
 
   @override
@@ -90,6 +96,29 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     super.didUpdateWidget(oldWidget);
     if (scrollController.hasClients && scrollController.atScrollBottom) {
       scrollController.autoScrollToBottom();
+    }
+
+    if (!collectionEquals(oldWidget.frames, widget.frames)) {
+      _maybeShowShaderJankMessage();
+    }
+  }
+
+  void _maybeShowShaderJankMessage() {
+    final shaderJankFrames = widget.frames
+        .where((frame) => frame.hasShaderJank(widget.displayRefreshRate))
+        .toList();
+    if (shaderJankFrames.isNotEmpty) {
+      final Duration shaderJankDuration = shaderJankFrames.fold(
+        Duration.zero,
+        (prev, frame) => prev + frame.shaderDuration,
+      );
+      Provider.of<BannerMessagesController>(context).addMessage(
+        ShaderJankMessage(
+          offlineMode ? SimpleScreen.id : PerformanceScreen.id,
+          jankyFramesCount: shaderJankFrames.length,
+          jankDuration: shaderJankDuration,
+        ).build(context),
+      );
     }
   }
 
@@ -260,10 +289,6 @@ class FlutterFramesChartItem extends StatelessWidget {
   static const selectedFrameIndicatorKey =
       Key('flutter frames chart - selected frame indicator');
 
-  // TODO(kenz): instead of hard coding 4, factor in the display refresh rate to
-  // calculate 1/4 of the target frame time.
-  static const shaderTimeThreshold = Duration(milliseconds: 4);
-
   final FlutterFrame frame;
 
   final bool selected;
@@ -280,9 +305,7 @@ class FlutterFramesChartItem extends StatelessWidget {
 
     final bool uiJanky = frame.isUiJanky(displayRefreshRate);
     final bool rasterJanky = frame.isRasterJanky(displayRefreshRate);
-    final bool hasShaderJank = frame.hasShaderTime &&
-        rasterJanky &&
-        frame.shaderDuration > shaderTimeThreshold;
+    final bool hasShaderJank = frame.hasShaderJank(displayRefreshRate);
 
     // TODO(kenz): add some indicator when a frame is so janky that it exceeds the
     // available axis space.
@@ -355,8 +378,6 @@ class FlutterFramesChartItem extends StatelessWidget {
     );
   }
 
-  // TODO(kenz): make this a rich tooltip that can support a clickable link to
-  // shader compilation jank docs.
   String _tooltipText(FlutterFrame frame, bool hasShaderJank) {
     return [
       'UI: ${msText(frame.uiEventFlow.time.duration)}',

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -510,6 +510,13 @@ class FlutterFrame {
         _targetMsPerFrame(displayRefreshRate);
   }
 
+  bool hasShaderJank(double displayRefreshRate) {
+    final quarterFrame = (_targetMsPerFrame(displayRefreshRate) / 4).round();
+    return isRasterJanky(displayRefreshRate) &&
+        hasShaderTime &&
+        shaderDuration > Duration(milliseconds: quarterFrame);
+  }
+
   double _targetMsPerFrame(double displayRefreshRate) {
     return 1 / displayRefreshRate * 1000;
   }


### PR DESCRIPTION
<img width="897" alt="Screen Shot 2021-06-15 at 2 02 25 PM" src="https://user-images.githubusercontent.com/43759233/122123252-a0dbe280-cde2-11eb-807b-daee6f28f0d9.png">

part of https://github.com/flutter/devtools/issues/3043