### PR TITLE
Show the event summary view for UI events in the performance page

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -1252,8 +1252,11 @@ class _BreadcrumbPainter extends CustomPainter {
 }
 
 class FormattedJson extends StatelessWidget {
-  const FormattedJson({this.json, this.formattedString})
-      : assert((json == null) != (formattedString == null));
+  const FormattedJson({
+    this.json,
+    this.formattedString,
+    this.useSubtleStyle = false,
+  }) : assert((json == null) != (formattedString == null));
 
   static const encoder = JsonEncoder.withIndent('  ');
 
@@ -1261,12 +1264,15 @@ class FormattedJson extends StatelessWidget {
 
   final String formattedString;
 
+  final bool useSubtleStyle;
+
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     // TODO(kenz): we could consider using a prettier format like YAML.
     return SelectableText(
       json != null ? encoder.convert(json) : formattedString,
-      style: Theme.of(context).fixedFontStyle,
+      style: useSubtleStyle ? theme.subtleFixedFontStyle : theme.fixedFontStyle,
     );
   }
 }

--- a/packages/devtools_app/lib/src/performance/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/event_details.dart
@@ -144,8 +144,7 @@ class EventSummary extends StatelessWidget {
         // affects the hover boundary for the clickable expanding tiles.
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
-          child: _buildDataItem(
-            context: context,
+          child: EventMetaData(
             title: 'Time',
             inlineValue: msText(event.time.duration),
             child: SelectableText(
@@ -164,8 +163,7 @@ class EventSummary extends StatelessWidget {
             children: [
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Category',
                   inlineValue: '${firstTraceEvent.category}',
                 ),
@@ -177,16 +175,14 @@ class EventSummary extends StatelessWidget {
                 ),
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Thread id',
                   inlineValue: '${firstTraceEvent.threadId}',
                 ),
               ),
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Process id',
                   inlineValue: '${firstTraceEvent.processId}',
                 ),
@@ -207,16 +203,14 @@ class EventSummary extends StatelessWidget {
     } else {
       asyncId = (event as AsyncTimelineEvent).asyncId;
     }
-    return _buildDataItem(
-      context: context,
+    return EventMetaData(
       title: 'Async id',
       inlineValue: asyncId,
     );
   }
 
   Widget _buildConnectedEvents(BuildContext context) {
-    return _buildExpandingDataItem(
-      context: context,
+    return ExpandingEventMetaData(
       title: 'Connected events',
       children: [
         for (var e in _connectedEvents) _buildConnectedEvent(context, e),
@@ -229,8 +223,7 @@ class EventSummary extends StatelessWidget {
       'startTime': msText(e.time.start - event.time.start),
       'args': e.traceEvents.first.event.args,
     };
-    return _buildDataItem(
-      context: context,
+    return EventMetaData(
       title: e.name,
       child: FormattedJson(
         json: eventArgs,
@@ -240,8 +233,7 @@ class EventSummary extends StatelessWidget {
   }
 
   Widget _buildArguments(BuildContext context) {
-    return _buildExpandingDataItem(
-      context: context,
+    return ExpandingEventMetaData(
       title: 'Arguments',
       children: [
         FormattedJson(
@@ -251,13 +243,25 @@ class EventSummary extends StatelessWidget {
       ],
     );
   }
+}
 
-  Widget _buildDataItem({
-    @required BuildContext context,
-    @required String title,
-    String inlineValue,
-    Widget child,
-  }) {
+class EventMetaData extends StatelessWidget {
+  const EventMetaData({
+    Key key,
+    @required this.title,
+    this.inlineValue,
+    this.child,
+  })  : assert(inlineValue != null || child != null),
+        super(key: key);
+
+  final String title;
+
+  final String inlineValue;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: denseSpacing),
@@ -286,12 +290,21 @@ class EventSummary extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildExpandingDataItem({
-    @required BuildContext context,
-    @required String title,
-    @required List<Widget> children,
-  }) {
+class ExpandingEventMetaData extends StatelessWidget {
+  const ExpandingEventMetaData({
+    Key key,
+    @required this.title,
+    @required this.children,
+  }) : super(key: key);
+
+  final String title;
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
     return ExpansionTile(
       title: Text(
         title,

--- a/packages/devtools_app/lib/src/performance/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/event_details.dart
@@ -89,6 +89,7 @@ class EventDetails extends StatelessWidget {
         return CpuProfiler(
           data: cpuProfileData,
           controller: cpuProfilerController,
+          summaryView: EventSummary(selectedEvent),
         );
       },
     );
@@ -133,6 +134,7 @@ class EventSummary extends StatelessWidget {
 
   TraceEvent get firstTraceEvent => event.traceEvents.first.event;
 
+  // TODO(kenz): make this view more dense.
   @override
   Widget build(BuildContext context) {
     return ListView(

--- a/packages/devtools_app/lib/src/performance/legacy/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/event_details.dart
@@ -93,6 +93,7 @@ class EventDetails extends StatelessWidget {
         return CpuProfiler(
           data: cpuProfileData,
           controller: cpuProfilerController,
+          summaryView: EventSummary(selectedEvent),
         );
       },
     );

--- a/packages/devtools_app/lib/src/performance/legacy/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/event_details.dart
@@ -148,8 +148,7 @@ class EventSummary extends StatelessWidget {
         // affects the hover boundary for the clickable expanding tiles.
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
-          child: _buildDataItem(
-            context: context,
+          child: EventMetaData(
             title: 'Time',
             inlineValue: msText(event.time.duration),
             child: SelectableText(
@@ -168,8 +167,7 @@ class EventSummary extends StatelessWidget {
             children: [
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Category',
                   inlineValue: '${firstTraceEvent.category}',
                 ),
@@ -181,16 +179,14 @@ class EventSummary extends StatelessWidget {
                 ),
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Thread id',
                   inlineValue: '${firstTraceEvent.threadId}',
                 ),
               ),
               Flexible(
                 fit: FlexFit.tight,
-                child: _buildDataItem(
-                  context: context,
+                child: EventMetaData(
                   title: 'Process id',
                   inlineValue: '${firstTraceEvent.processId}',
                 ),
@@ -211,16 +207,14 @@ class EventSummary extends StatelessWidget {
     } else {
       asyncId = (event as LegacyAsyncTimelineEvent).asyncId;
     }
-    return _buildDataItem(
-      context: context,
+    return EventMetaData(
       title: 'Async id',
       inlineValue: asyncId,
     );
   }
 
   Widget _buildConnectedEvents(BuildContext context) {
-    return _buildExpandingDataItem(
-      context: context,
+    return ExpandingEventMetaData(
       title: 'Connected events',
       children: [
         for (var e in _connectedEvents) _buildConnectedEvent(context, e),
@@ -233,8 +227,7 @@ class EventSummary extends StatelessWidget {
       'startTime': msText(e.time.start - event.time.start),
       'args': e.traceEvents.first.event.args,
     };
-    return _buildDataItem(
-      context: context,
+    return EventMetaData(
       title: e.name,
       child: FormattedJson(
         json: eventArgs,
@@ -244,8 +237,7 @@ class EventSummary extends StatelessWidget {
   }
 
   Widget _buildArguments(BuildContext context) {
-    return _buildExpandingDataItem(
-      context: context,
+    return ExpandingEventMetaData(
       title: 'Arguments',
       children: [
         FormattedJson(
@@ -255,13 +247,25 @@ class EventSummary extends StatelessWidget {
       ],
     );
   }
+}
 
-  Widget _buildDataItem({
-    @required BuildContext context,
-    @required String title,
-    String inlineValue,
-    Widget child,
-  }) {
+class EventMetaData extends StatelessWidget {
+  const EventMetaData({
+    Key key,
+    @required this.title,
+    this.inlineValue,
+    this.child,
+  })  : assert(inlineValue != null || child != null),
+        super(key: key);
+
+  final String title;
+
+  final String inlineValue;
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: denseSpacing),
@@ -290,12 +294,21 @@ class EventSummary extends StatelessWidget {
       ),
     );
   }
+}
 
-  Widget _buildExpandingDataItem({
-    @required BuildContext context,
-    @required String title,
-    @required List<Widget> children,
-  }) {
+class ExpandingEventMetaData extends StatelessWidget {
+  const ExpandingEventMetaData({
+    Key key,
+    @required this.title,
+    @required this.children,
+  }) : super(key: key);
+
+  final String title;
+
+  final List<Widget> children;
+
+  @override
+  Widget build(BuildContext context) {
     return ExpansionTile(
       title: Text(
         title,

--- a/packages/devtools_app/lib/src/performance/legacy/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/event_details.dart
@@ -141,77 +141,169 @@ class EventSummary extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView(
+      padding: const EdgeInsets.symmetric(vertical: denseSpacing),
       children: [
-        ListTile(
-          title: const Text('Time'),
-          subtitle: Text('${event.time.start.inMicroseconds} μs —  '
-              '${event.time.end.inMicroseconds} μs'),
+        // Wrap with horizontal padding so that these items align with the
+        // expanding data items. Adding horizontal padding to the entire list
+        // affects the hover boundary for the clickable expanding tiles.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
+          child: _buildDataItem(
+            context: context,
+            title: 'Time',
+            inlineValue: msText(event.time.duration),
+            child: SelectableText(
+              '[${event.time.start.inMicroseconds} μs —  '
+              '${event.time.end.inMicroseconds} μs]',
+              style: Theme.of(context).subtleFixedFontStyle,
+            ),
+          ),
         ),
-        ListTile(
-          title: const Text('Thread id'),
-          subtitle: Text('${firstTraceEvent.threadId}'),
+        // Wrap with horizontal padding so that these items align with the
+        // expanding data items. Adding horizontal padding to the entire list
+        // affects the hover boundary for the clickable expanding tiles.
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
+          child: Row(
+            children: [
+              Flexible(
+                fit: FlexFit.tight,
+                child: _buildDataItem(
+                  context: context,
+                  title: 'Category',
+                  inlineValue: '${firstTraceEvent.category}',
+                ),
+              ),
+              if (event.isAsyncEvent)
+                Flexible(
+                  fit: FlexFit.tight,
+                  child: _asyncIdTile(context),
+                ),
+              Flexible(
+                fit: FlexFit.tight,
+                child: _buildDataItem(
+                  context: context,
+                  title: 'Thread id',
+                  inlineValue: '${firstTraceEvent.threadId}',
+                ),
+              ),
+              Flexible(
+                fit: FlexFit.tight,
+                child: _buildDataItem(
+                  context: context,
+                  title: 'Process id',
+                  inlineValue: '${firstTraceEvent.processId}',
+                ),
+              ),
+            ],
+          ),
         ),
-        ListTile(
-          title: const Text('Process id'),
-          subtitle: Text('${firstTraceEvent.processId}'),
-        ),
-        ListTile(
-          title: const Text('Category'),
-          subtitle: Text(firstTraceEvent.category),
-        ),
-        if (event.isAsyncEvent) _asyncIdTile(),
-        if (_connectedEvents.isNotEmpty) _buildConnectedEvents(),
-        if (_eventArgs.isNotEmpty) _buildArguments(),
+        if (_connectedEvents.isNotEmpty) _buildConnectedEvents(context),
+        if (_eventArgs.isNotEmpty) _buildArguments(context),
       ],
     );
   }
 
-  Widget _asyncIdTile() {
+  Widget _asyncIdTile(BuildContext context) {
     String asyncId;
     if (event is LegacyOfflineTimelineEvent) {
       asyncId = event.traceEvents.first.event.id;
     } else {
       asyncId = (event as LegacyAsyncTimelineEvent).asyncId;
     }
-    return ListTile(
-      title: const Text('Async id'),
-      subtitle: Text(asyncId),
+    return _buildDataItem(
+      context: context,
+      title: 'Async id',
+      inlineValue: asyncId,
     );
   }
 
-  Widget _buildConnectedEvents() {
-    return ExpansionTile(
-      title: const Text('Connected events'),
+  Widget _buildConnectedEvents(BuildContext context) {
+    return _buildExpandingDataItem(
+      context: context,
+      title: 'Connected events',
       children: [
-        Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            for (var e in _connectedEvents) _buildConnectedEvent(e),
-          ],
-        ),
+        for (var e in _connectedEvents) _buildConnectedEvent(context, e),
       ],
     );
   }
 
-  Widget _buildConnectedEvent(LegacyTimelineEvent e) {
+  Widget _buildConnectedEvent(BuildContext context, LegacyTimelineEvent e) {
     final eventArgs = {
       'startTime': msText(e.time.start - event.time.start),
       'args': e.traceEvents.first.event.args,
     };
-    return ListTile(
-      title: Text(e.name),
-      subtitle: FormattedJson(json: eventArgs),
+    return _buildDataItem(
+      context: context,
+      title: e.name,
+      child: FormattedJson(
+        json: eventArgs,
+        useSubtleStyle: true,
+      ),
     );
   }
 
-  Widget _buildArguments() {
-    return ExpansionTile(
-      title: const Text('Arguments'),
+  Widget _buildArguments(BuildContext context) {
+    return _buildExpandingDataItem(
+      context: context,
+      title: 'Arguments',
       children: [
-        ListTile(
-          subtitle: FormattedJson(json: _eventArgs),
+        FormattedJson(
+          json: _eventArgs,
+          useSubtleStyle: true,
         ),
       ],
+    );
+  }
+
+  Widget _buildDataItem({
+    @required BuildContext context,
+    @required String title,
+    String inlineValue,
+    Widget child,
+  }) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: denseSpacing),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          SelectableText.rich(
+            TextSpan(
+              text: '$title${inlineValue != null ? ':  ' : ''}',
+              style: theme.textTheme.subtitle2,
+              children: [
+                if (inlineValue != null)
+                  TextSpan(
+                    text: inlineValue,
+                    style: theme.subtleFixedFontStyle,
+                  ),
+              ],
+            ),
+          ),
+          if (child != null) ...[
+            const SizedBox(height: densePadding),
+            child,
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildExpandingDataItem({
+    @required BuildContext context,
+    @required String title,
+    @required List<Widget> children,
+  }) {
+    return ExpansionTile(
+      title: Text(
+        title,
+        style: Theme.of(context).textTheme.subtitle2,
+      ),
+      childrenPadding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
+      expandedAlignment: Alignment.topLeft,
+      children: children,
     );
   }
 }

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -49,7 +49,6 @@ void main() {
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsOneWidget);
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);
@@ -59,6 +58,10 @@ void main() {
       expect(find.byType(CollapseAllButton), findsNothing);
       expect(find.byType(FlameChartHelpButton), findsNothing);
       expect(find.byKey(searchFieldKey), findsNothing);
+      expect(find.byKey(CpuProfiler.flameChartTab), findsNothing);
+      expect(find.byKey(CpuProfiler.callTreeTab), findsNothing);
+      expect(find.byKey(CpuProfiler.bottomUpTab), findsNothing);
+      expect(find.byKey(CpuProfiler.summaryTab), findsNothing);
     });
 
     testWidgetsWithWindowSize('builds for empty cpuProfileData', windowSize,
@@ -71,7 +74,6 @@ void main() {
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsOneWidget);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);
@@ -81,6 +83,39 @@ void main() {
       expect(find.byType(CollapseAllButton), findsNothing);
       expect(find.byType(FlameChartHelpButton), findsNothing);
       expect(find.byKey(searchFieldKey), findsNothing);
+      expect(find.byKey(CpuProfiler.flameChartTab), findsNothing);
+      expect(find.byKey(CpuProfiler.callTreeTab), findsNothing);
+      expect(find.byKey(CpuProfiler.bottomUpTab), findsNothing);
+      expect(find.byKey(CpuProfiler.summaryTab), findsNothing);
+    });
+
+    testWidgetsWithWindowSize(
+        'builds for empty cpuProfileData with summary view', windowSize,
+        (WidgetTester tester) async {
+      cpuProfileData = CpuProfileData.parse(emptyCpuProfileDataJson);
+      const summaryViewKey = Key('test summary view');
+      cpuProfiler = CpuProfiler(
+        data: cpuProfileData,
+        controller: controller,
+        searchFieldKey: searchFieldKey,
+        summaryView: const SizedBox(key: summaryViewKey),
+      );
+      await tester.pumpWidget(wrap(cpuProfiler));
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
+      expect(find.byType(CpuProfileFlameChart), findsNothing);
+      expect(find.byType(CpuCallTreeTable), findsNothing);
+      expect(find.byType(CpuBottomUpTable), findsNothing);
+      expect(find.byType(UserTagDropdown), findsNothing);
+      expect(find.byType(ExpandAllButton), findsNothing);
+      expect(find.byType(CollapseAllButton), findsNothing);
+      expect(find.byType(FlameChartHelpButton), findsNothing);
+      expect(find.byKey(searchFieldKey), findsNothing);
+      expect(find.byKey(CpuProfiler.flameChartTab), findsNothing);
+      expect(find.byKey(CpuProfiler.callTreeTab), findsNothing);
+      expect(find.byKey(CpuProfiler.bottomUpTab), findsNothing);
+      expect(find.byKey(CpuProfiler.summaryTab), findsOneWidget);
+      expect(find.byKey(summaryViewKey), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('builds for valid cpuProfileData', windowSize,
@@ -92,7 +127,6 @@ void main() {
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
       expect(find.byType(CpuBottomUpTable), findsOneWidget);
       expect(find.byType(UserTagDropdown), findsOneWidget);
@@ -100,6 +134,35 @@ void main() {
       expect(find.byType(CollapseAllButton), findsOneWidget);
       expect(find.byType(FlameChartHelpButton), findsNothing);
       expect(find.byKey(searchFieldKey), findsNothing);
+      expect(find.byKey(CpuProfiler.flameChartTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.summaryTab), findsNothing);
+    });
+
+    testWidgetsWithWindowSize(
+        'builds for valid cpuProfileData with summaryView', windowSize,
+        (WidgetTester tester) async {
+      const summaryViewKey = Key('test summary view');
+      cpuProfiler = CpuProfiler(
+        data: cpuProfileData,
+        controller: controller,
+        searchFieldKey: searchFieldKey,
+        summaryView: const SizedBox(key: summaryViewKey),
+      );
+      await tester.pumpWidget(wrap(cpuProfiler));
+      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
+      expect(find.byKey(summaryViewKey), findsOneWidget);
+      expect(find.byType(UserTagDropdown), findsNothing);
+      expect(find.byType(ExpandAllButton), findsNothing);
+      expect(find.byType(CollapseAllButton), findsNothing);
+      expect(find.byType(FlameChartHelpButton), findsNothing);
+      expect(find.byKey(searchFieldKey), findsNothing);
+      expect(find.byKey(CpuProfiler.flameChartTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
+      expect(find.byKey(CpuProfiler.summaryTab), findsOneWidget);
     });
 
     testWidgetsWithWindowSize('switches tabs', windowSize,
@@ -111,7 +174,6 @@ void main() {
       );
       await tester.pumpWidget(wrap(cpuProfiler));
       expect(find.byType(TabBar), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsNothing);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);

--- a/packages/devtools_app/test/event_details_test.dart
+++ b/packages/devtools_app/test/event_details_test.dart
@@ -46,7 +46,7 @@ void main() {
       await pumpEventDetails(goldenUiTimelineEvent, tester);
       expect(find.byType(CpuProfiler), findsOneWidget);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
-      expect(find.byType(EventSummary), findsNothing);
+      expect(find.byType(EventSummary), findsOneWidget);
       expect(find.text(EventDetails.noEventSelected), findsNothing);
       expect(find.text(EventDetails.instructions), findsNothing);
     });
@@ -95,9 +95,8 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.byType(CpuProfiler), findsOneWidget);
-      expect(find.text(CpuProfiler.emptyCpuProfile), findsOneWidget);
       expect(find.byType(CpuProfilerDisabled), findsNothing);
-      expect(find.byType(EventSummary), findsNothing);
+      expect(find.byType(EventSummary), findsOneWidget);
     });
   });
 
@@ -108,11 +107,11 @@ void main() {
       eventSummary = EventSummary(asyncEventWithInstantChildren);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
-      expect(find.text('Time'), findsOneWidget);
-      expect(find.text('Thread id'), findsOneWidget);
-      expect(find.text('Process id'), findsOneWidget);
-      expect(find.text('Category'), findsOneWidget);
-      expect(find.text('Async id'), findsOneWidget);
+      expect(find.text('Time:  29.1 ms'), findsOneWidget);
+      expect(find.text('Thread id:  19333'), findsOneWidget);
+      expect(find.text('Process id:  94955'), findsOneWidget);
+      expect(find.text('Category:  Embedder'), findsOneWidget);
+      expect(find.text('Async id:  f1'), findsOneWidget);
       expect(find.text('Connected events'), findsOneWidget);
     });
 
@@ -120,11 +119,11 @@ void main() {
       eventSummary = EventSummary(goldenUiTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
-      expect(find.text('Time'), findsOneWidget);
-      expect(find.text('Thread id'), findsOneWidget);
-      expect(find.text('Process id'), findsOneWidget);
-      expect(find.text('Category'), findsOneWidget);
-      expect(find.text('Async id'), findsNothing);
+      expect(find.text('Time:  1.6 ms'), findsOneWidget);
+      expect(find.text('Thread id:  1'), findsOneWidget);
+      expect(find.text('Process id:  94955'), findsOneWidget);
+      expect(find.text('Category:  Embedder'), findsOneWidget);
+      expect(find.textContaining('Async id'), findsNothing);
       expect(find.text('Connected events'), findsNothing);
     });
 
@@ -132,11 +131,11 @@ void main() {
       eventSummary = EventSummary(goldenRasterTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
-      expect(find.text('Time'), findsOneWidget);
-      expect(find.text('Thread id'), findsOneWidget);
-      expect(find.text('Process id'), findsOneWidget);
-      expect(find.text('Category'), findsOneWidget);
-      expect(find.text('Async id'), findsNothing);
+      expect(find.text('Time:  28.4 ms'), findsOneWidget);
+      expect(find.text('Thread id:  2'), findsOneWidget);
+      expect(find.text('Process id:  94955'), findsOneWidget);
+      expect(find.text('Category:  Embedder'), findsOneWidget);
+      expect(find.textContaining('Async id'), findsNothing);
       expect(find.text('Arguments'), findsOneWidget);
     });
 
@@ -144,11 +143,11 @@ void main() {
       eventSummary = EventSummary(goldenUiTimelineEvent);
       await tester.pumpWidget(wrap(eventSummary));
       expect(find.byType(EventSummary), findsOneWidget);
-      expect(find.text('Time'), findsOneWidget);
-      expect(find.text('Thread id'), findsOneWidget);
-      expect(find.text('Process id'), findsOneWidget);
-      expect(find.text('Category'), findsOneWidget);
-      expect(find.text('Async id'), findsNothing);
+      expect(find.text('Time:  1.6 ms'), findsOneWidget);
+      expect(find.text('Thread id:  1'), findsOneWidget);
+      expect(find.text('Process id:  94955'), findsOneWidget);
+      expect(find.text('Category:  Embedder'), findsOneWidget);
+      expect(find.textContaining('Async id'), findsNothing);
       expect(find.text('Arguments'), findsNothing);
     });
   });


### PR DESCRIPTION
We show this view for non-UI events in the performance page, but we currently only show the CPU profiler for UI events. After this PR, the summary view will be available for all events in the timeline.

![Screen Shot 2021-06-22 at 9 11 14 AM](https://user-images.githubusercontent.com/43759233/122963524-31fb0e00-d33b-11eb-8a09-d40816779f13.png)
