### PR TITLE
convert the repo tool lib to null safety

### DIFF
--- a/packages/devtools/analysis_options.yaml
+++ b/packages/devtools/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: ../../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - build/**

--- a/tool/analysis_options.yaml
+++ b/tool/analysis_options.yaml
@@ -1,0 +1,8 @@
+include: package:lints/recommended.yaml
+
+linter:
+  rules:
+    # - avoid_dynamic_calls
+    - depend_on_referenced_packages
+    - directives_ordering
+    - sort_pub_dependencies

--- a/tool/bin/repo_tool.dart
+++ b/tool/bin/repo_tool.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:args/command_runner.dart';
-import 'package:tool/repo_tool.dart';
+import 'package:devtools_repo/repo_tool.dart';
 
 void main(List<String> args) async {
   final runner = DevToolsCommandRunner();

--- a/tool/bin/repo_tool.dart
+++ b/tool/bin/repo_tool.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart=2.10
+
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -27,7 +27,7 @@ class AnalyzeCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     final packages = repo.getPackages();
 
     log.stdout('Running flutter analyze...');

--- a/tool/lib/commands/generate_changelog.dart
+++ b/tool/lib/commands/generate_changelog.dart
@@ -67,16 +67,16 @@ class GenerateChangelogCommand extends Command {
   Future run() async {
     final repo = DevToolsRepo.getInstance();
     final devtoolsVersionFile =
-    await File('${repo.repoPath}/packages/devtools_app/lib/devtools.dart')
-        .readAsString();
+        await File('${repo.repoPath}/packages/devtools_app/lib/devtools.dart')
+            .readAsString();
     const versionDeclarationPrefix = 'const String version = \'';
     final versionDeclaration =
-    devtoolsVersionFile.indexOf(versionDeclarationPrefix);
+        devtoolsVersionFile.indexOf(versionDeclarationPrefix);
     final versionEnd = devtoolsVersionFile.indexOf('\';');
     final version = devtoolsVersionFile.substring(
         versionDeclaration + versionDeclarationPrefix.length, versionEnd);
     final List tags = jsonDecode((await http.get(
-        Uri.https('${auth}api.github.com', '/repos/flutter/devtools/tags')))
+            Uri.https('${auth}api.github.com', '/repos/flutter/devtools/tags')))
         .body);
 
     print('Current Devtools version is $version.  Retrieving the tagged commit '
@@ -91,11 +91,11 @@ class GenerateChangelogCommand extends Command {
       }
       final tagVersion = getVersion(nameOf(tag));
       final closestTagVersion =
-      closestTag == null ? null : getVersion(nameOf(closestTag));
+          closestTag == null ? null : getVersion(nameOf(closestTag));
       // TODO(djshuckerow): The script does not process dev versioning, so
       // ignore if the version file reports a dev version.
       final versionFileVersion =
-      isDevBuild(version) ? null : getVersion(version);
+          isDevBuild(version) ? null : getVersion(version);
       if ((versionFileVersion == null || tagVersion < versionFileVersion) &&
           (closestTagVersion == null || tagVersion > closestTagVersion)) {
         closestTag = tag;
@@ -140,9 +140,9 @@ class GenerateChangelogCommand extends Command {
         'inserted to any files other than changelog.');
     final versionDate = DateTime.now().toIso8601String().split('T').first;
     final changelogFile =
-    File('${repo.repoPath}/packages/devtools/CHANGELOG.md');
+        File('${repo.repoPath}/packages/devtools/CHANGELOG.md');
     final output = '## $nextVersionNumber '
-        '$versionDate\n' +
+            '$versionDate\n' +
         changes.join('\n') +
         '\n\n';
     await changelogFile.writeAsString(

--- a/tool/lib/commands/generate_changelog.dart
+++ b/tool/lib/commands/generate_changelog.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart=2.10
+
 import 'dart:async';
 import 'dart:convert' show jsonDecode;
 import 'dart:io';
@@ -63,54 +65,49 @@ class GenerateChangelogCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.getInstance();
     final devtoolsVersionFile =
-        await File('${repo.repoPath}/packages/devtools_app/lib/devtools.dart')
-            .readAsString();
+    await File('${repo.repoPath}/packages/devtools_app/lib/devtools.dart')
+        .readAsString();
     const versionDeclarationPrefix = 'const String version = \'';
     final versionDeclaration =
-        devtoolsVersionFile.indexOf(versionDeclarationPrefix);
+    devtoolsVersionFile.indexOf(versionDeclarationPrefix);
     final versionEnd = devtoolsVersionFile.indexOf('\';');
     final version = devtoolsVersionFile.substring(
         versionDeclaration + versionDeclarationPrefix.length, versionEnd);
-    final tags = (jsonDecode((await http.get(Uri.https(
-                '${auth}api.github.com', '/repos/flutter/devtools/tags')))
-            .body) as List)
-        .cast<Map<String, dynamic>>();
+    final List tags = jsonDecode((await http.get(
+        Uri.https('${auth}api.github.com', '/repos/flutter/devtools/tags')))
+        .body);
 
     print('Current Devtools version is $version.  Retrieving the tagged commit '
         'with the closest version number to this version.');
-
     bool isDevBuild(String tagName) => tagName.split('-').length > 1;
-
-    String? nameOf(Map tag) => tag['name'];
-
-    var closestTag = tags.skipWhile((tag) => isDevBuild(nameOf(tag)!)).first;
-
+    String nameOf(tag) => tag['name'];
+    var closestTag = tags.skipWhile((tag) => isDevBuild(nameOf(tag))).first;
     for (var tag in tags) {
-      if (isDevBuild(nameOf(tag)!)) {
+      if (isDevBuild(nameOf(tag))) {
         // This was a dev build.
         continue;
       }
-      final tagVersion = getVersion(nameOf(tag)!);
-      final closestTagVersion = getVersion(nameOf(closestTag)!);
+      final tagVersion = getVersion(nameOf(tag));
+      final closestTagVersion =
+      closestTag == null ? null : getVersion(nameOf(closestTag));
       // TODO(djshuckerow): The script does not process dev versioning, so
       // ignore if the version file reports a dev version.
       final versionFileVersion =
-          isDevBuild(version) ? null : getVersion(version);
+      isDevBuild(version) ? null : getVersion(version);
       if ((versionFileVersion == null || tagVersion < versionFileVersion) &&
-          tagVersion > closestTagVersion) {
+          (closestTagVersion == null || tagVersion > closestTagVersion)) {
         closestTag = tag;
       }
     }
 
-    final commitInfo = closestTag['commit'] as Map<String, dynamic>;
-    print('Getting the date of the tagged commit for ${closestTag['name']}.');
+    print('Getting the date of the tagged commit for ${closestTag["name"]}.');
     final taggedCommit = jsonDecode((await http.get(Uri.https(
       '${auth}api.github.com',
-      '/repos/flutter/devtools/commits/${commitInfo['sha']}',
+      '/repos/flutter/devtools/commits/${closestTag["commit"]["sha"]}',
     )))
-        .body) as Map<String, dynamic>;
+        .body);
 
     final commitDate = taggedCommit['commit']['author']['date'];
     print('getting commits since $commitDate');
@@ -134,7 +131,7 @@ class GenerateChangelogCommand extends Command {
 
     print('Incrementing version number');
     // TODO(djshuckerow): Support overriding the nextVersionNumber with a flag.
-    String nextVersionNumber = nameOf(closestTag)!.replaceFirst('v', '');
+    String nextVersionNumber = nameOf(closestTag).replaceFirst('v', '');
     final List parts = nextVersionNumber.split('.');
     parts[2] = '${int.parse(parts[2]) + 1}';
     nextVersionNumber = parts.join('.');
@@ -143,9 +140,9 @@ class GenerateChangelogCommand extends Command {
         'inserted to any files other than changelog.');
     final versionDate = DateTime.now().toIso8601String().split('T').first;
     final changelogFile =
-        File('${repo.repoPath}/packages/devtools/CHANGELOG.md');
+    File('${repo.repoPath}/packages/devtools/CHANGELOG.md');
     final output = '## $nextVersionNumber '
-            '$versionDate\n' +
+        '$versionDate\n' +
         changes.join('\n') +
         '\n\n';
     await changelogFile.writeAsString(

--- a/tool/lib/commands/list.dart
+++ b/tool/lib/commands/list.dart
@@ -17,7 +17,7 @@ class ListCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     print('DevTools repo at ${repo.repoPath}.');
 
     final packages = repo.getPackages();

--- a/tool/lib/commands/packages_get.dart
+++ b/tool/lib/commands/packages_get.dart
@@ -34,10 +34,10 @@ class PackagesGetCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     final packages = repo.getPackages();
 
-    final upgrade = argResults['upgrade'];
+    final upgrade = argResults!['upgrade'];
     final command = upgrade ? 'upgrade' : 'get';
 
     log.stdout('Running flutter pub $command...');

--- a/tool/lib/commands/repo_check.dart
+++ b/tool/lib/commands/repo_check.dart
@@ -17,7 +17,7 @@ class RepoCheckCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     print('DevTools repo at ${repo.repoPath}.');
 
     final checks = <Check>[

--- a/tool/lib/commands/rollback.dart
+++ b/tool/lib/commands/rollback.dart
@@ -22,7 +22,7 @@ class RollbackCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     print('DevTools repo at ${repo.repoPath}.');
 
     final tempDir =
@@ -35,7 +35,7 @@ class RollbackCommand extends Command {
     final extractDir =
         await io.Directory('${tempDir.path}/extract/').absolute.create();
     final client = io.HttpClient();
-    final version = argResults['to-version'];
+    final version = argResults!['to-version'];
     print('downloading tarball to ${tarball.path}');
     final tarballRequest = await client.getUrl(Uri.http(
         'storage.googleapis.com',

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -19,7 +19,7 @@ class DevToolsRepo {
   ///
   /// This can fail and return null if the current working directory is not
   /// contained within a git checkout of DevTools.
-  static DevToolsRepo getInstance() {
+  static DevToolsRepo? getInstance() {
     final repoPath = _findRepoRoot(Directory.current);
     return repoPath == null ? null : DevToolsRepo._create(repoPath);
   }
@@ -41,7 +41,7 @@ class DevToolsRepo {
     return result;
   }
 
-  static String _findRepoRoot(Directory dir) {
+  static String? _findRepoRoot(Directory dir) {
     // Look for README.md, packages, tool.
     if (_fileExists(dir, 'README.md') &&
         _dirExists(dir, 'packages') &&
@@ -61,8 +61,7 @@ class DevToolsRepo {
       result.add(Package._(this, dir.path));
     }
 
-    for (FileSystemEntity entity
-        in dir.listSync(recursive: false, followLinks: false)) {
+    for (FileSystemEntity entity in dir.listSync(followLinks: false)) {
       final name = path.basename(entity.path);
       if (entity is Directory && !name.startsWith('.') && name != 'build') {
         _collectPackages(entity, result);
@@ -81,7 +80,7 @@ class FlutterSdk {
   /// Return the Flutter SDK.
   ///
   /// This can return null if the Flutter SDK can't be found.
-  static FlutterSdk getSdk() {
+  static FlutterSdk? getSdk() {
     // Look for it relative to the current Dart process.
     final dartVmPath = Platform.resolvedExecutable;
     final pathSegments = path.split(dartVmPath);
@@ -148,8 +147,7 @@ class Package {
   }
 
   void _collectDartFiles(Directory dir, List<String> result) {
-    for (FileSystemEntity entity
-        in dir.listSync(recursive: false, followLinks: false)) {
+    for (FileSystemEntity entity in dir.listSync(followLinks: false)) {
       final name = path.basename(entity.path);
       if (entity is Directory && !name.startsWith('.') && name != 'build') {
         _collectDartFiles(entity, result);

--- a/tool/lib/repo_tool.dart
+++ b/tool/lib/repo_tool.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// @dart=2.10
+
 import 'package:args/command_runner.dart';
 
 import 'commands/analyze.dart';

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -1,11 +1,12 @@
-name: tool
+name: devtools_repo
 description: A repo management tool for DevTools.
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
-  args: any
-  cli_util: any
-  path: any
-  http: any
+  args: ^2.0.0
+  cli_util: ^0.3.0
+  http: ^0.13.3
+  lints: any
+  path: ^1.8.0

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -16,7 +16,7 @@ void main(List<String> args) async {
 
   final version = args.isNotEmpty
       ? args.first
-      : incrementVersion(versionFromPubspecFile(pubspecs.first));
+      : incrementVersion(versionFromPubspecFile(pubspecs.first)!);
 
   if (version == null) {
     print('Something went wrong. Could not resolve version number.');
@@ -43,8 +43,8 @@ void main(List<String> args) async {
   });
 }
 
-String incrementVersion(String oldVersion) {
-  final semVer = RegExp('[0-9]+\.[0-9]\.[0-9]+').firstMatch(oldVersion)[0];
+String? incrementVersion(String oldVersion) {
+  final semVer = RegExp(r'[0-9]+\.[0-9]\.[0-9]+').firstMatch(oldVersion)![0];
 
   const devTag = '-dev';
   final isDevVersion = oldVersion.contains(devTag);
@@ -52,9 +52,9 @@ String incrementVersion(String oldVersion) {
     return semVer;
   }
 
-  final parts = semVer.split('.');
+  final parts = semVer!.split('.');
 
-  // Versions should have the form x.y.z
+  // Versions should have the form 'x.y.z'.
   if (parts.length != 3) return null;
 
   final patch = int.parse(parts.last);
@@ -62,7 +62,7 @@ String incrementVersion(String oldVersion) {
   return [parts[0], parts[1], nextPatch].join('.');
 }
 
-String versionFromPubspecFile(File pubspec) {
+String? versionFromPubspecFile(File pubspec) {
   final lines = pubspec.readAsLinesSync();
   for (final line in lines) {
     if (line.startsWith(pubspecVersionPrefix)) {
@@ -75,12 +75,12 @@ String versionFromPubspecFile(File pubspec) {
 void writeVersionToPubspec(File pubspec, String version) {
   final lines = pubspec.readAsLinesSync();
   final revisedLines = <String>[];
-  var currentSection = '';
+  String? currentSection = '';
   final sectionRegExp = RegExp('([a-z]|_)+:');
   for (var line in lines) {
     if (line.startsWith(sectionRegExp)) {
       // This is a top level section of the pubspec.
-      currentSection = sectionRegExp.firstMatch(line)[0];
+      currentSection = sectionRegExp.firstMatch(line)![0];
     }
     if (editablePubspecSections.contains(currentSection)) {
       if (line.startsWith(pubspecVersionPrefix)) {
@@ -130,7 +130,7 @@ void writeVersionToChangelog(File changelog, String version) {
     return;
   }
   changelog.writeAsString([
-    '$versionString',
+    versionString,
     'TODO: update changelog\n',
     ...lines,
   ].joinWithNewLine());


### PR DESCRIPTION
- convert the repo `tool/` lib to null safety


If the `generate_changelog.dart` command is not used (I'm guessing not?), we should just delete the command.