### PR TITLE
make our toast UI more compact

### DIFF
--- a/packages/devtools_app/lib/src/banner_messages.dart
+++ b/packages/devtools_app/lib/src/banner_messages.dart
@@ -150,14 +150,24 @@ class BannerMessage extends StatelessWidget {
           children: [
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
                   headerText,
                   style: Theme.of(context)
                       .textTheme
-                      .headline6
+                      .bodyText1
                       .copyWith(color: foregroundColor),
                 ),
+                const SizedBox(width: defaultSpacing),
+                Expanded(
+                  child: RichText(
+                    text: TextSpan(
+                      children: textSpans,
+                    ),
+                  ),
+                ),
+                const SizedBox(width: defaultSpacing),
                 CircularIconButton(
                   icon: Icons.close,
                   backgroundColor: backgroundColor,
@@ -169,12 +179,6 @@ class BannerMessage extends StatelessWidget {
                       .removeMessage(this, dismiss: true),
                 ),
               ],
-            ),
-            const SizedBox(height: defaultSpacing),
-            RichText(
-              text: TextSpan(
-                children: textSpans,
-              ),
             ),
           ],
         ),

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -1028,8 +1028,8 @@ class CircularIconButton extends StatelessWidget {
       elevation: 0.0,
       materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
       constraints: const BoxConstraints.tightFor(
-        width: 24.0,
-        height: 24.0,
+        width: actionsIconSize,
+        height: actionsIconSize,
       ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20.0),


### PR DESCRIPTION
- make our toast UI more compact
- fix https://github.com/flutter/devtools/issues/3156

Here's the after:

<img width="1347" alt="Screen Shot 2021-06-23 at 3 53 09 PM" src="https://user-images.githubusercontent.com/1269969/123178140-71108880-d43b-11eb-8f31-a79568bbfe8d.png">
