### PR TITLE
ignore use of a deprecated parameter

### DIFF
--- a/case_study/memory_leak/lib/tabs/http_data.dart
+++ b/case_study/memory_leak/lib/tabs/http_data.dart
@@ -87,6 +87,7 @@ class MyGetHttpDataState extends State<MyGetHttpData> {
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(48.0),
           child: Theme(
+            // ignore: deprecated_member_use
             data: Theme.of(context).copyWith(accentColor: Colors.white),
             child: Container(
               child: Text(


### PR DESCRIPTION
- ignore use of a deprecated parameter

This will address a CI failure in https://github.com/flutter/devtools/pull/3161.