### PR TITLE
Run all integration tests.

### DIFF
--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -72,13 +72,17 @@ Future<void> main() async {
 
         try {
           final workingDirectory = Directory.current.path;
+          // This command matches the command used by
+          // packages:flutter_tools/lib/src/drive/drive_service.dart
+          // If you change this command, make sure you also update
+          // package:flutter_tools.
           final Process process = await Process.start(
             'dart',
             [
               '../devtools/bin/devtools.dart',
               '--vm-uri',
               '$vmUri',
-              '--profile-memory',
+              '--record-memory-profile',
               '${ParseStdout.jsonFilename}',
               '--verbose',
             ],

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -150,6 +150,8 @@ elif [ "$BOT" = "integration_ddc" ]; then
     # We need to run integration tests with -j1 to run with no concurrency.
     flutter test -j1 test/integration_tests/
 
+    flutter test -j1 test/integration/
+
 elif [ "$BOT" = "integration_dart2js" ]; then
 
     flutter pub get


### PR DESCRIPTION
If this test had been running, we would have avoided breaking flutter_tools.
Related PR:
https://github.com/flutter/flutter/pull/86122