### PR TITLE
Eliminate spurious test output spam on missing taps.

### DIFF
--- a/packages/devtools_app/test/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/service_extension_widgets_test.dart
@@ -71,7 +71,7 @@ void main() {
       expect(find.byWidget(button), findsOneWidget);
       await tester.pumpAndSettle();
       expect(reloads, 0);
-      await tester.tap(find.byWidget(button));
+      await tester.tap(find.byWidget(button), warnIfMissed: false);
       await tester.pumpAndSettle();
       expect(reloads, 0);
     });
@@ -118,7 +118,7 @@ void main() {
       expect(find.byWidget(button), findsOneWidget);
       await tester.pumpAndSettle();
       expect(restarts, 0);
-      await tester.tap(find.byWidget(button));
+      await tester.tap(find.byWidget(button), warnIfMissed: false);
       await tester.pumpAndSettle();
       expect(restarts, 0);
     });


### PR DESCRIPTION
This eliminates multiple warnings of the following form in the test output. 
```

Warning: A call to tap() with finder "exactly one widget with the given widget (HotReloadButton) (ignoring offstage widgets): HotReloadButton" derived an Offset (Offset(400.0, 300.0)) that would not hit test on the specified widget.
Maybe the widget is actually off-screen, or another widget is obscuring it, or the widget cannot receive pointer events.
The finder corresponds to this RenderBox: RenderPointerListener#017c3 relayoutBoundary=up2
The hit test result at that offset is: HitTestResult(_RenderInkFeatures#9fe35@Offset(400.0, 300.0), RenderPhysicalModel#d66ac@Offset(400.0, 300.0), _RenderInkFeatures#04a69@Offset(400.0, 300.0), RenderPhysicalModel#e00b0@Offset(400.0, 300.0), RenderSemanticsAnnotations#46a05@Offset(400.0, 300.0), RenderRepaintBoundary#d62d1@Offset(400.0, 300.0), RenderIgnorePointer#bc88d@Offset(400.0, 300.0), RenderAnimatedOpacity#f5da7@Offset(400.0, 300.0), RenderRepaintBoundary#77863@Offset(400.0, 300.0), _RenderFocusTrap#52e37@Offset(400.0, 300.0), RenderSemanticsAnnotations#1c28e@Offset(400.0, 300.0), RenderOffstage#ebcd6@Offset(400.0, 300.0), RenderSemanticsAnnotations#f7943@Offset(400.0, 300.0), _RenderTheatre#bb152@Offset(400.0, 300.0), RenderSemanticsAnnotations#b6f95@Offset(400.0, 300.0), RenderAbsorbPointer#0c917@Offset(400.0, 300.0), RenderPointerListener#e29c8@Offset(400.0, 300.0), RenderCustomPaint#92b6b@Offset(400.0, 300.0), RenderSemanticsAnnotations#aeddc@Offset(400.0, 300.0), RenderSemanticsAnnotations#3808f@Offset(400.0, 300.0), RenderSemanticsAnnotations#94a0e@Offset(400.0, 300.0), RenderSemanticsAnnotations#a5666@Offset(400.0, 300.0), HitTestEntry#0d71e(RenderView#d5ba7), HitTestEntry#d4d81(<AutomatedTestWidgetsFlutterBinding>))
#0      WidgetController._getElementPoint (package:flutter_test/src/controller.dart:958:25)
#1      WidgetController.getCenter (package:flutter_test/src/controller.dart:841:12)
#2      WidgetController.tap (package:flutter_test/src/controller.dart:273:18)
#3      main.<anonymous closure>.<anonymous closure> (file:///home/runner/work/devtools/devtools/packages/devtools_app/test/service_extension_widgets_test.dart:74:20)
<asynchronous suspension>
#4      StackZoneSpecification._registerUnaryCallback.<anonymous closure> (package:stack_trace/src/stack_zone_specification.dart)
<asynchronous suspension>
To silence this warning, pass "warnIfMissed: false" to "tap()".
To make this warning fatal, set WidgetController.hitTestWarningShouldBeFatal to true.
```