### PR TITLE
Allow embedding unless specified

### DIFF
--- a/packages/devtools_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/devtools_app/macos/Runner.xcodeproj/project.pbxproj
@@ -308,14 +308,9 @@
 			files = (
 			);
 			inputPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/file_selector_macos/file_selector_macos.framework",
-				"${BUILT_PRODUCTS_DIR}/url_launcher_macos/url_launcher_macos.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/file_selector_macos.framework",
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/url_launcher_macos.framework",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -126,7 +126,7 @@ void main() {
     }
   }, timeout: const Timeout.factor(10));
 
-  test('does not allow embedding without flag', () async {
+  test('allows embedding without flag', () async {
     final server = await DevToolsServerDriver.create();
     final httpClient = HttpClient();
     try {
@@ -137,16 +137,16 @@ void main() {
 
       final req = await httpClient.get(host, port, '/');
       final resp = await req.close();
-      expect(resp.headers.value('x-frame-options'), equals('SAMEORIGIN'));
+      expect(resp.headers.value('x-frame-options'), isNull);
     } finally {
       httpClient.close();
       server.kill();
     }
   }, timeout: const Timeout.factor(10));
 
-  test('allows embedding with flag', () async {
+  test('does not allow embedding with flag', () async {
     final server = await DevToolsServerDriver.create(
-        additionalArgs: ['--allow-embedding']);
+        additionalArgs: ['--no-allow-embedding']);
     final httpClient = HttpClient();
     try {
       final startedEvent = await server.stdout
@@ -156,7 +156,7 @@ void main() {
 
       final req = await httpClient.get(host, port, '/');
       final resp = await req.close();
-      expect(resp.headers.value('x-frame-options'), isNull);
+      expect(resp.headers.value('x-frame-options'), equals('SAMEORIGIN'));
     } finally {
       httpClient.close();
       server.kill();

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -572,7 +572,6 @@ ArgParser _createArgsParser(bool verbose) {
     )
     ..addFlag(
       argAllowEmbedding,
-      negatable: true,
       help: 'Allow embedding DevTools inside an iframe.',
       hide: !verbose,
     )

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -572,7 +572,7 @@ ArgParser _createArgsParser(bool verbose) {
     )
     ..addFlag(
       argAllowEmbedding,
-      negatable: false,
+      negatable: true,
       help: 'Allow embedding DevTools inside an iframe.',
       hide: !verbose,
     )

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -81,7 +81,8 @@ Future<HttpServer?> _serveDevToolsWithArgs(
   final bool launchBrowser =
       args.wasParsed(argLaunchBrowser) ? args[argLaunchBrowser] : !machineMode;
   final bool enableNotifications = args[argEnableNotifications];
-  final bool allowEmbedding = args[argAllowEmbedding];
+  final bool allowEmbedding =
+      args.wasParsed(argAllowEmbedding) ? args[argAllowEmbedding] : true;
 
   final port = args[argPort] != null ? int.tryParse(args[argPort]) ?? 0 : 0;
 


### PR DESCRIPTION
We want DevTools to default to allow embedding so that it can be shown in the VSCode iframe consistently.

CC @DanTup 