### PR TITLE
rev. the dep on package:vm_service

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^5.0.0
   url_launcher_web: ^0.1.1+6
-  vm_service: ^7.1.0
+  vm_service: ^7.1.1
   vm_snapshot_analysis: ^0.6.0
   web_socket_channel: ^2.1.0
 


### PR DESCRIPTION
- rev the dep on package:vm_service

It looks like need at least 7.1.1 (where `onProfilerEvent` was introduced)
