### PR TITLE
fix icon positions in the eval console

### DIFF
--- a/packages/devtools_app/lib/src/banner_messages.dart
+++ b/packages/devtools_app/lib/src/banner_messages.dart
@@ -236,7 +236,6 @@ class DebugModePerformanceMessage {
         const TextSpan(
           text: '''
 You are running your app in debug mode. Debug mode performance is not indicative of release performance.
-
 Relaunch your application with the '--profile' argument, or ''',
           style: TextStyle(color: _BannerError.foreground),
         ),
@@ -378,7 +377,6 @@ class DebugModeMemoryMessage {
         const TextSpan(
           text: '''
 You are running your app in debug mode. Absolute memory usage may be higher in a debug build than in a release build.
-
 For the most accurate absolute memory stats, relaunch your application with the '--profile' argument, or ''',
           style: TextStyle(color: _BannerWarning.foreground),
         ),

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -701,8 +701,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
               child: title,
             ),
             ...leftActions,
-            if (leftActions.isNotEmpty && rightActions.isNotEmpty)
-              const Spacer(),
+            if (rightActions.isNotEmpty) const Spacer(),
             ...rightActions,
           ],
         ),


### PR DESCRIPTION
- fix icon positions in the eval console
- make the 'wrong run mode' warnings slightly less tall

This address an issue where the action buttons in the debugger's eval console where next to that area's text, when they should have been docked to the right hand side of the view.

before:
<img width="387" alt="Screen Shot 2021-07-21 at 11 50 43 AM" src="https://user-images.githubusercontent.com/1269969/126562715-efb4c29e-27e4-45ff-8fe5-89bf640931c1.png">
