### PR TITLE
Add focus node names for debugging.

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -100,7 +100,7 @@ abstract class FlameChartState<T extends FlameChart,
 
   final List<FlameChartSection> sections = [];
 
-  final focusNode = FocusNode();
+  final focusNode = FocusNode(debugLabel: 'flame-chart');
 
   bool _altKeyPressed = false;
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -84,7 +84,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   @override
   void initState() {
     super.initState();
-    _libraryFilterFocusNode = FocusNode();
+    _libraryFilterFocusNode = FocusNode(debugLabel: 'library-filter');
     ga.screen(DebuggerScreen.id);
   }
 

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_flutter.dart
@@ -230,7 +230,7 @@ class _InspectorTreeState extends State<InspectorTree>
     if (isSummaryTree) {
       constraintDisplayController = longAnimationController(this);
     }
-    _focusNode = FocusNode();
+    _focusNode = FocusNode(debugLabel: 'inspector-tree');
     _bindToController();
   }
 

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -336,7 +336,7 @@ class MemoryBodyState extends State<MemoryBody>
 
     // TODO(terry): Can Flutter's focus system be used instead of listening to keyboard?
     return RawKeyboardListener(
-      focusNode: FocusNode(),
+      focusNode: FocusNode(debugLabel: 'memory'),
       onKey: (RawKeyEvent event) {
         if (event.isKeyPressed(LogicalKeyboardKey.escape)) {
           hideHover();

--- a/packages/devtools_app/lib/src/provider/instance_viewer/instance_viewer.dart
+++ b/packages/devtools_app/lib/src/provider/instance_viewer/instance_viewer.dart
@@ -484,8 +484,8 @@ class _EditableField extends StatefulWidget {
 
 class _EditableFieldState extends State<_EditableField> {
   final controller = TextEditingController();
-  final focusNode = FocusNode();
-  final textFieldFocusNode = FocusNode();
+  final focusNode = FocusNode(debugLabel: 'editable-field');
+  final textFieldFocusNode = FocusNode(debugLabel: 'text-field');
   var isHovering = false;
 
   final _isAlive = Disposable();

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -398,7 +398,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     rootsExpanded =
         List.generate(dataRoots.length, (index) => dataRoots[index].isExpanded);
     _updateItems();
-    _focusNode = FocusNode();
+    _focusNode = FocusNode(debugLabel: 'table');
   }
 
   void expandParents(T parent) {

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -477,7 +477,7 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
   @override
   void initState() {
     super.initState();
-    _searchFieldFocusNode = FocusNode();
+    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
     searchTextFieldController = TextEditingController();
   }
 
@@ -533,7 +533,7 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
 
     onHighlightDropdown ??= _highlightDropdown;
 
-    final rawKeyboardFocusNode = FocusNode();
+    final rawKeyboardFocusNode = FocusNode(debugLabel: 'search');
 
     rawKeyboardFocusNode.onKey = (FocusNode node, RawKeyEvent event) {
       if (event is RawKeyDownEvent) {


### PR DESCRIPTION
Add debug labels for all focus nodes to track down focus node bugs more easily. I sometimes see focus node exceptions but it is hard to tell where they are coming from without unique debug labels.