### PR TITLE
Add text previews to widget tree

### DIFF
--- a/packages/devtools_app/lib/src/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics.dart
@@ -89,8 +89,9 @@ class DiagnosticsNodeDescription extends StatelessWidget {
 
     final textPreview = diagnostic.json['textPreview'];
     if (textPreview is String) {
+      final preview = textPreview.replaceAll('\n', ' ');
       yield TextSpan(
-        text: ': "$textPreview"',
+        text: ': "$preview"',
         style: textStyle.merge(inspector_text_styles.unimportant(colorScheme)),
       );
     }

--- a/packages/devtools_app/lib/src/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics.dart
@@ -82,8 +82,17 @@ class DiagnosticsNodeDescription extends StatelessWidget {
         return;
       }
     }
+
     if (description?.isNotEmpty == true) {
       yield TextSpan(text: description, style: textStyle);
+    }
+
+    final textPreview = diagnostic.json['textPreview'];
+    if (textPreview is String) {
+      yield TextSpan(
+        text: ': "$textPreview"',
+        style: textStyle.merge(inspector_text_styles.unimportant(colorScheme)),
+      );
     }
   }
 

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -38,6 +38,8 @@ class RegistrableServiceExtension {
   static const setFlexFactor = RegistrableServiceExtension('setFlexFactor');
   static const setFlexProperties =
       RegistrableServiceExtension('setFlexProperties');
+  static const getRootWidgetSummaryTreeWithPreviews =
+      RegistrableServiceExtension('getRootWidgetSummaryTreeWithPreviews');
 
   static const getPubRootDirectories =
       RegistrableServiceExtension('getPubRootDirectories');
@@ -974,7 +976,10 @@ class ObjectGroup implements Disposable {
   }
 
   Future<RemoteDiagnosticsNode> getRootWidget() {
-    return invokeServiceMethodReturningNode('getRootWidgetSummaryTree');
+    return parseDiagnosticsNodeDaemon(invokeServiceExtensionMethod(
+      RegistrableServiceExtension.getRootWidgetSummaryTreeWithPreviews,
+      {'groupName': groupName},
+    ));
   }
 
   Future<RemoteDiagnosticsNode> getRootWidgetFullTree() {

--- a/packages/devtools_app/test/inspector_tree_test.dart
+++ b/packages/devtools_app/test/inspector_tree_test.dart
@@ -9,24 +9,28 @@ import 'package:devtools_app/src/inspector/inspector_tree.dart';
 import 'package:devtools_app/src/inspector/inspector_tree_flutter.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart' hide Fake;
 import 'package:mockito/mockito.dart';
 
+import 'support/inspector_tree.dart';
 import 'support/mocks.dart';
+import 'support/utils.dart';
 import 'support/wrappers.dart';
 
 void main() {
   FakeServiceManager fakeServiceManager;
+
+  setUp(() {
+    fakeServiceManager = FakeServiceManager();
+    when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
+    when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
+
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
+    mockIsFlutterApp(serviceManager.connectedApp);
+  });
+
   group('InspectorTreeController', () {
-    setUp(() {
-      fakeServiceManager = FakeServiceManager();
-      when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
-      when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
-
-      setGlobal(ServiceConnectionManager, fakeServiceManager);
-      mockIsFlutterApp(serviceManager.connectedApp);
-    });
-
     testWidgets('Row with negative index regression test',
         (WidgetTester tester) async {
       final controller = InspectorTreeControllerFlutter()
@@ -62,6 +66,64 @@ void main() {
       // This operation would previously throw an exception in debug builds
       // and infinite loop in release builds.
       controller.scrollToRect(const Rect.fromLTWH(0, -20, 100, 100));
+    });
+  });
+
+  group('Inspector tree content preview', () {
+    testWidgets('Shows simple text preview', (WidgetTester tester) async {
+      final diagnosticNode = await widgetToInspectorTreeDiagnosticsNode(
+        widget: const Text('Content'),
+        tester: tester,
+      );
+
+      final treeController = inspectorTreeControllerFromNode(diagnosticNode);
+      await tester.pumpWidget(wrap(InspectorTree(
+        controller: treeController,
+        debuggerController: DebuggerController(),
+      )));
+
+      expect(find.richText('Text: "Content"'), findsOneWidget);
+    });
+
+    testWidgets('Shows preview from Text.rich', (WidgetTester tester) async {
+      final diagnosticNode = await widgetToInspectorTreeDiagnosticsNode(
+        widget: const Text.rich(
+          TextSpan(
+            children: [
+              TextSpan(text: 'Rich '),
+              TextSpan(text: 'text'),
+            ],
+          ),
+        ),
+        tester: tester,
+      );
+
+      final treeController = inspectorTreeControllerFromNode(diagnosticNode);
+      await tester.pumpWidget(wrap(InspectorTree(
+        controller: treeController,
+        debuggerController: DebuggerController(),
+      )));
+
+      expect(find.richText('Text: "Rich text"'), findsOneWidget);
+    });
+
+    testWidgets('Strips new lines from text preview',
+        (WidgetTester tester) async {
+      final diagnosticNode = await widgetToInspectorTreeDiagnosticsNode(
+        widget: const Text('Multiline\ntext\n\ncontent'),
+        tester: tester,
+      );
+
+      final treeController = inspectorTreeControllerFromNode(diagnosticNode);
+
+      await tester.pumpWidget(
+        wrap(InspectorTree(
+          controller: treeController,
+          debuggerController: DebuggerController(),
+        )),
+      );
+
+      expect(find.richText('Text: "Multiline text  content"'), findsOneWidget);
     });
   });
 }

--- a/packages/devtools_app/test/support/inspector_tree.dart
+++ b/packages/devtools_app/test/support/inspector_tree.dart
@@ -1,3 +1,7 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:devtools_app/src/inspector/inspector_service.dart';
 import 'package:devtools_app/src/inspector/inspector_tree.dart';

--- a/packages/devtools_app/test/support/inspector_tree.dart
+++ b/packages/devtools_app/test/support/inspector_tree.dart
@@ -1,0 +1,63 @@
+import 'package:devtools_app/src/inspector/diagnostics_node.dart';
+import 'package:devtools_app/src/inspector/inspector_service.dart';
+import 'package:devtools_app/src/inspector/inspector_tree.dart';
+import 'package:devtools_app/src/inspector/inspector_tree_flutter.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'wrappers.dart';
+
+/// Create an `InspectorTreeControllerFlutter` from a single `RemoteDiagnosticsNode`
+InspectorTreeControllerFlutter inspectorTreeControllerFromNode(
+    RemoteDiagnosticsNode node) {
+  final controller = InspectorTreeControllerFlutter()
+    ..config = InspectorTreeConfig(
+      summaryTree: false,
+      treeType: FlutterTreeType.widget,
+      onNodeAdded: (_, __) {},
+      onClientActiveChange: (_) {},
+    );
+
+  controller.root = InspectorTreeNode()
+    ..appendChild(
+      InspectorTreeNode()..diagnostic = node,
+    );
+
+  return controller;
+}
+
+/// Replicates the functionality of `getRootWidgetSummaryTreeWithPreviews` from
+/// inspector_polyfill_script.dart
+Future<RemoteDiagnosticsNode> widgetToInspectorTreeDiagnosticsNode({
+  @required Widget widget,
+  @required WidgetTester tester,
+}) async {
+  await tester.pumpWidget(wrap(widget));
+  final element = find.byWidget(widget).evaluate().first;
+  final nodeJson =
+      element.toDiagnosticsNode(style: DiagnosticsTreeStyle.dense).toJsonMap(
+            InspectorSerializationDelegate(
+              service: WidgetInspectorService.instance,
+              subtreeDepth: 1000000,
+              summaryTree: true,
+              addAdditionalPropertiesCallback: (node, delegate) {
+                final additionalJson = <String, Object>{};
+
+                final value = node.value;
+                if (value is Element) {
+                  final renderObject = value.renderObject;
+                  if (renderObject is RenderParagraph) {
+                    additionalJson['textPreview'] =
+                        renderObject.text.toPlainText();
+                  }
+                }
+
+                return additionalJson;
+              },
+            ),
+          );
+
+  return RemoteDiagnosticsNode(nodeJson, null, false, null);
+}


### PR DESCRIPTION
As discussed in #3195.

For now this only brings the text preview for `RenderParagraph` objects, such as `Text` and `RichText`:

<img width="327" alt="Screenshot 2021-07-23 at 22 15 48" src="https://user-images.githubusercontent.com/756862/126830578-c6906b22-8e3c-4950-8971-5c28cce9b7a1.png">

We probably want to support other widgets such as `SelectableText`, but those will require special cases.

Am in the process of adding tests hence the draft, but I wanted to check you're happy with this implementation of adding an extra polyfill script @jacob314 @kenzieschmoll?

