### PR TITLE
finish converting tool/ to null safety

### DIFF
--- a/tool/bin/repo_tool.dart
+++ b/tool/bin/repo_tool.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:io';
 
 import 'package:args/command_runner.dart';

--- a/tool/lib/commands/generate_changelog.dart
+++ b/tool/lib/commands/generate_changelog.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.10
-
 import 'dart:async';
 import 'dart:convert' show jsonDecode;
 import 'dart:io';
@@ -65,7 +63,7 @@ class GenerateChangelogCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance();
+    final repo = DevToolsRepo.getInstance()!;
     final devtoolsVersionFile =
         await File('${repo.repoPath}/packages/devtools_app/lib/devtools.dart')
             .readAsString();

--- a/tool/lib/repo_tool.dart
+++ b/tool/lib/repo_tool.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.10
-
 import 'package:args/command_runner.dart';
 
 import 'commands/analyze.dart';


### PR DESCRIPTION
finish converting tool/ to null safety:
- remove the `@dart=` nnbd excludes
- fix a null unsafe reference in `tool/lib/commands/generate_changelog.dart`
