### PR TITLE
Fix some render overflow errors and cleanup

### DIFF
--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -92,6 +92,7 @@ class IconLabelButton extends StatelessWidget {
     this.color,
     this.includeTextWidth,
     this.elevatedButton = false,
+    this.tooltip,
   }) : super(key: key);
 
   final IconData icon;
@@ -107,6 +108,8 @@ class IconLabelButton extends StatelessWidget {
   /// Whether this icon label button should use an elevated button style.
   final bool elevatedButton;
 
+  final String tooltip;
+
   @override
   Widget build(BuildContext context) {
     final iconLabel = MaterialIconLabel(
@@ -116,20 +119,26 @@ class IconLabelButton extends StatelessWidget {
       color: color,
     );
     if (elevatedButton) {
-      return ElevatedButton(
-        onPressed: onPressed,
-        child: iconLabel,
+      return maybeWrapWithTooltip(
+        tooltip,
+        ElevatedButton(
+          onPressed: onPressed,
+          child: iconLabel,
+        ),
       );
     }
     // TODO(kenz): this SizedBox wrapper should be unnecessary once
     // https://github.com/flutter/flutter/issues/79894 is fixed.
-    return SizedBox(
-      height: defaultButtonHeight,
-      width: !includeText(context, includeTextWidth) ? buttonMinWidth : null,
-      child: OutlinedButton(
-        style: denseAwareOutlinedButtonStyle(context, includeTextWidth),
-        onPressed: onPressed,
-        child: iconLabel,
+    return maybeWrapWithTooltip(
+      tooltip,
+      SizedBox(
+        height: defaultButtonHeight,
+        width: !includeText(context, includeTextWidth) ? buttonMinWidth : null,
+        child: OutlinedButton(
+          style: denseAwareOutlinedButtonStyle(context, includeTextWidth),
+          onPressed: onPressed,
+          child: iconLabel,
+        ),
       ),
     );
   }
@@ -139,11 +148,13 @@ class PauseButton extends IconLabelButton {
   const PauseButton({
     Key key,
     double includeTextWidth,
+    String tooltip = 'Pause',
     @required VoidCallback onPressed,
   }) : super(
           key: key,
           icon: Icons.pause,
           label: 'Pause',
+          tooltip: tooltip,
           includeTextWidth: includeTextWidth,
           onPressed: onPressed,
         );
@@ -153,11 +164,13 @@ class ResumeButton extends IconLabelButton {
   const ResumeButton({
     Key key,
     double includeTextWidth,
+    String tooltip = 'Resume',
     @required VoidCallback onPressed,
   }) : super(
           key: key,
           icon: Icons.play_arrow,
           label: 'Resume',
+          tooltip: tooltip,
           includeTextWidth: includeTextWidth,
           onPressed: onPressed,
         );
@@ -167,11 +180,13 @@ class ClearButton extends IconLabelButton {
   const ClearButton({
     Key key,
     double includeTextWidth,
+    String tooltip = 'Clear',
     @required VoidCallback onPressed,
   }) : super(
           key: key,
           icon: Icons.block,
           label: 'Clear',
+          tooltip: tooltip,
           includeTextWidth: includeTextWidth,
           onPressed: onPressed,
         );
@@ -182,12 +197,14 @@ class RefreshButton extends IconLabelButton {
     Key key,
     String label = 'Refresh',
     double includeTextWidth,
+    String tooltip,
     @required VoidCallback onPressed,
   }) : super(
           key: key,
           icon: Icons.refresh,
           label: label,
           includeTextWidth: includeTextWidth,
+          tooltip: tooltip,
           onPressed: onPressed,
         );
 }
@@ -199,32 +216,22 @@ class RefreshButton extends IconLabelButton {
 ///    omitted.
 /// * `labelOverride`: Optional alternative text to use for the button.
 /// * `onPressed`: The callback to be called upon pressing the button.
-class RecordButton extends StatelessWidget {
+class RecordButton extends IconLabelButton {
   const RecordButton({
     Key key,
-    @required this.recording,
-    this.includeTextWidth,
-    this.labelOverride,
-    @required this.onPressed,
-  }) : super(key: key);
-
-  final bool recording;
-
-  final double includeTextWidth;
-
-  final String labelOverride;
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconLabelButton(
-      onPressed: recording ? null : onPressed,
-      icon: Icons.fiber_manual_record,
-      label: labelOverride ?? 'Record',
-      includeTextWidth: includeTextWidth,
-    );
-  }
+    @required bool recording,
+    @required VoidCallback onPressed,
+    double includeTextWidth,
+    String labelOverride,
+    String tooltip = 'Start recording',
+  }) : super(
+          key: key,
+          onPressed: recording ? null : onPressed,
+          icon: Icons.fiber_manual_record,
+          label: labelOverride ?? 'Record',
+          tooltip: tooltip,
+          includeTextWidth: includeTextWidth,
+        );
 }
 
 /// Button to stop recording data.
@@ -233,54 +240,39 @@ class RecordButton extends StatelessWidget {
 /// * `includeTextWidth`: The minimum width the button can be before the text is
 ///    omitted.
 /// * `onPressed`: The callback to be called upon pressing the button.
-class StopRecordingButton extends StatelessWidget {
+class StopRecordingButton extends IconLabelButton {
   const StopRecordingButton({
     Key key,
-    @required this.recording,
-    this.includeTextWidth,
-    @required this.onPressed,
-  }) : super(key: key);
-
-  final bool recording;
-
-  final double includeTextWidth;
-
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconLabelButton(
-      onPressed: !recording ? null : onPressed,
-      icon: Icons.stop,
-      label: 'Stop',
-      includeTextWidth: includeTextWidth,
-    );
-  }
+    @required bool recording,
+    @required VoidCallback onPressed,
+    double includeTextWidth,
+    String tooltip = 'Stop recording',
+  }) : super(
+          key: key,
+          onPressed: !recording ? null : onPressed,
+          icon: Icons.stop,
+          label: 'Stop',
+          tooltip: tooltip,
+          includeTextWidth: includeTextWidth,
+        );
 }
 
-class SettingsOutlinedButton extends StatelessWidget {
+class SettingsOutlinedButton extends IconLabelButton {
   const SettingsOutlinedButton({
-    @required this.onPressed,
-    @required this.label,
-  });
-
-  final VoidCallback onPressed;
-
-  final String label;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconLabelButton(
-      onPressed: onPressed,
-      icon: Icons.settings,
-      label: label,
-      // TODO(jacobr): consider a more conservative min-width. To minimize the
-      // impact on the existing UI and deal with the fact that some of the
-      // existing label names are fairly verbose, we set a width that will
-      // never be hit.
-      includeTextWidth: 20000,
-    );
-  }
+    @required VoidCallback onPressed,
+    @required String label,
+    String tooltip,
+  }) : super(
+          onPressed: onPressed,
+          icon: Icons.settings,
+          label: label,
+          tooltip: tooltip,
+          // TODO(jacobr): consider a more conservative min-width. To minimize the
+          // impact on the existing UI and deal with the fact that some of the
+          // existing label names are fairly verbose, we set a width that will
+          // never be hit.
+          includeTextWidth: 20000,
+        );
 }
 
 class HelpButton extends StatelessWidget {
@@ -499,22 +491,14 @@ class ProcessingInfo extends StatelessWidget {
 /// setState(() {
 ///   offlineMode = false;
 /// }
-class ExitOfflineButton extends StatelessWidget {
-  const ExitOfflineButton({@required this.onPressed});
-
-  final FutureOr<void> Function() onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return OutlinedButton(
-      key: const Key('exit offline button'),
-      onPressed: onPressed,
-      child: const MaterialIconLabel(
-        label: 'Exit offline mode',
-        iconData: Icons.clear,
-      ),
-    );
-  }
+class ExitOfflineButton extends IconLabelButton {
+  const ExitOfflineButton({@required VoidCallback onPressed})
+      : super(
+          key: const Key('exit offline button'),
+          onPressed: onPressed,
+          label: 'Exit offline mode',
+          icon: Icons.clear,
+        );
 }
 
 /// Display a single bullet character in order to act as a stylized spacer
@@ -762,26 +746,20 @@ class ToggleButton extends StatelessWidget {
 /// * `includeTextWidth`: The minimum width the button can be before the text is
 ///    omitted.
 /// * `onPressed`: The callback to be called upon pressing the button.
-class ExportButton extends StatelessWidget {
+class ExportButton extends IconLabelButton {
   const ExportButton({
     Key key,
-    @required this.includeTextWidth,
-    @required this.onPressed,
-  }) : super(key: key);
-
-  final double includeTextWidth;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return IconLabelButton(
-      key: key,
-      onPressed: onPressed,
-      icon: Icons.file_download,
-      label: 'Export',
-      includeTextWidth: includeTextWidth,
-    );
-  }
+    @required VoidCallback onPressed,
+    @required double includeTextWidth,
+    String tooltip = 'Export data',
+  }) : super(
+          key: key,
+          onPressed: onPressed,
+          icon: Icons.file_download,
+          label: 'Export',
+          tooltip: tooltip,
+          includeTextWidth: includeTextWidth,
+        );
 }
 
 class FilterButton extends StatelessWidget {
@@ -1289,4 +1267,14 @@ class Link {
   final String display;
 
   final String url;
+}
+
+Widget maybeWrapWithTooltip(String tooltip, Widget child) {
+  if (tooltip != null) {
+    return DevToolsTooltip(
+      tooltip: tooltip,
+      child: child,
+    );
+  }
+  return child;
 }

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 

--- a/packages/devtools_app/lib/src/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/debugger/span_parser.dart
@@ -7,6 +7,7 @@ import 'dart:convert';
 
 import 'package:string_scanner/string_scanner.dart';
 
+// ignore: avoid_classes_with_only_static_members
 abstract class SpanParser {
   /// Takes a TextMate [Grammar] and a [String] and outputs a list of
   /// [ScopeSpan]s corresponding to the parsed input.

--- a/packages/devtools_app/lib/src/http/_http_date.dart
+++ b/packages/devtools_app/lib/src/http/_http_date.dart
@@ -22,6 +22,7 @@ part of http;
  * Utility functions for working with dates with HTTP specific date
  * formats.
  */
+// ignore: avoid_classes_with_only_static_members
 class HttpDate {
   // From RFC-2616 section "3.3.1 Full Date",
   // http://tools.ietf.org/html/rfc2616#section-3.3.1

--- a/packages/devtools_app/lib/src/http/_http_date.dart
+++ b/packages/devtools_app/lib/src/http/_http_date.dart
@@ -18,11 +18,8 @@
 
 part of http;
 
-/**
- * Utility functions for working with dates with HTTP specific date
- * formats.
- */
 // ignore: avoid_classes_with_only_static_members
+/// Utility functions for working with dates with HTTP specific date formats.
 class HttpDate {
   // From RFC-2616 section "3.3.1 Full Date",
   // http://tools.ietf.org/html/rfc2616#section-3.3.1

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -587,11 +587,9 @@ class MemoryBodyState extends State<MemoryBody>
                 ],
               )
             : const SizedBox(),
-        IconLabelButton(
+        ExportButton(
           key: MemoryScreen.exportButtonKey,
           onPressed: controller.offline ? null : _exportToFile,
-          icon: Icons.file_download,
-          label: 'Export',
           includeTextWidth: _primaryControlsMinVerboseWidth,
         ),
         const SizedBox(width: denseSpacing),
@@ -600,6 +598,7 @@ class MemoryBodyState extends State<MemoryBody>
           onPressed: controller.toggleLegendVisibility,
           icon: legendOverlayEntry == null ? Icons.storage : Icons.close,
           label: 'Legend',
+          tooltip: 'Legend',
           includeTextWidth: _primaryControlsMinVerboseWidth,
         ),
         const SizedBox(width: denseSpacing),

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -159,54 +159,32 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
   /// Builds the row of buttons that control the Network profiler (e.g., record,
   /// pause, etc.)
   Widget _buildProfilerControls() {
-    const double includeTextWidth = 600;
     final hasRequests = filteredRequests.isNotEmpty;
-    return ValueListenableBuilder(
-      valueListenable: _networkController.recordingNotifier,
-      builder: (context, recording, _) {
-        return Row(
-          children: [
-            PauseButton(
-              includeTextWidth: includeTextWidth,
-              onPressed: recording
-                  ? () => _networkController.togglePolling(false)
-                  : null,
-            ),
-            const SizedBox(width: denseSpacing),
-            ResumeButton(
-              includeTextWidth: includeTextWidth,
-              onPressed: recording
-                  ? null
-                  : () => _networkController.togglePolling(true),
-            ),
-            const SizedBox(width: denseSpacing),
-            ClearButton(
-              onPressed: () {
-                _networkController.clear();
-              },
-            ),
-            const Expanded(child: SizedBox()),
-            // TODO(kenz): fix focus issue when state is refreshed
-            Container(
-              width: wideSearchTextWidth,
-              height: defaultTextFieldHeight,
-              child: buildSearchField(
-                controller: _networkController,
-                searchFieldKey: networkSearchFieldKey,
-                searchFieldEnabled: hasRequests,
-                shouldRequestFocus: false,
-                supportsNavigation: true,
-              ),
-            ),
-            const SizedBox(width: denseSpacing),
-            FilterButton(
-              onPressed: _showFilterDialog,
-              isFilterActive:
-                  filteredRequests.length != requests.requests.length,
-            ),
-          ],
-        );
-      },
+    return Row(
+      children: [
+        _NetworkProfilerControls(
+          controller: _networkController,
+        ),
+        const SizedBox(width: defaultSpacing),
+        const Expanded(child: SizedBox()),
+        // TODO(kenz): fix focus issue when state is refreshed
+        Container(
+          width: wideSearchTextWidth,
+          height: defaultTextFieldHeight,
+          child: buildSearchField(
+            controller: _networkController,
+            searchFieldKey: networkSearchFieldKey,
+            searchFieldEnabled: hasRequests,
+            shouldRequestFocus: false,
+            supportsNavigation: true,
+          ),
+        ),
+        const SizedBox(width: denseSpacing),
+        FilterButton(
+          onPressed: _showFilterDialog,
+          isFilterActive: filteredRequests.length != requests.requests.length,
+        ),
+      ],
     );
   }
 
@@ -263,6 +241,52 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
         const SizedBox(height: denseRowSpacing),
         _buildProfilerBody(),
       ],
+    );
+  }
+}
+
+/// The row of controls that control the Network profiler (e.g., record, pause,
+/// clear).
+class _NetworkProfilerControls extends StatelessWidget {
+  const _NetworkProfilerControls({
+    Key key,
+    @required this.controller,
+  }) : super(key: key);
+
+  static const _includeTextWidth = 810.0;
+
+  final NetworkController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: controller.recordingNotifier,
+      builder: (context, recording, _) {
+        return Row(
+          children: [
+            PauseButton(
+              includeTextWidth: _includeTextWidth,
+              tooltip: 'Pause recording network traffic',
+              onPressed:
+                  recording ? () => controller.togglePolling(false) : null,
+            ),
+            const SizedBox(width: denseSpacing),
+            ResumeButton(
+              includeTextWidth: _includeTextWidth,
+              tooltip: 'Resume recording network traffic',
+              onPressed:
+                  recording ? null : () => controller.togglePolling(true),
+            ),
+            const SizedBox(width: denseSpacing),
+            ClearButton(
+              includeTextWidth: _includeTextWidth,
+              onPressed: () {
+                controller.clear();
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -206,6 +206,7 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
         _PrimaryControls(
           controller: controller,
           processing: processing,
+          onClear: () => setState(() {}),
         ),
         const SizedBox(width: defaultSpacing),
         _SecondaryControls(controller: controller),
@@ -232,6 +233,7 @@ class _PrimaryControls extends StatelessWidget {
     Key key,
     @required this.controller,
     @required this.processing,
+    this.onClear,
   }) : super(key: key);
 
   static const _primaryControlsMinIncludeTextWidth = 760.0;
@@ -239,6 +241,8 @@ class _PrimaryControls extends StatelessWidget {
   final PerformanceController controller;
 
   final bool processing;
+
+  final VoidCallback onClear;
 
   @override
   Widget build(BuildContext context) {
@@ -277,6 +281,9 @@ class _PrimaryControls extends StatelessWidget {
 
   Future<void> _clearPerformanceData() async {
     await controller.clearData();
+    if (onClear != null) {
+      onClear();
+    }
   }
 }
 

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -222,6 +222,7 @@ class ProfilerScreenControls extends StatelessWidget {
           controller: controller,
           recording: recording,
         ),
+        const SizedBox(width: defaultSpacing),
         _SecondaryControls(
           controller: controller,
           recording: recording,
@@ -237,7 +238,7 @@ class _PrimaryControls extends StatelessWidget {
     @required this.recording,
   });
 
-  static const _primaryControlsMinIncludeTextWidth = 600.0;
+  static const _primaryControlsMinIncludeTextWidth = 880.0;
 
   final ProfilerScreenController controller;
 
@@ -258,7 +259,7 @@ class _PrimaryControls extends StatelessWidget {
           includeTextWidth: _primaryControlsMinIncludeTextWidth,
           onPressed: controller.stopRecording,
         ),
-        const SizedBox(width: defaultSpacing),
+        const SizedBox(width: denseSpacing),
         ClearButton(
           includeTextWidth: _primaryControlsMinIncludeTextWidth,
           onPressed: recording ? null : controller.clear,
@@ -274,7 +275,9 @@ class _SecondaryControls extends StatelessWidget {
     @required this.recording,
   });
 
-  static const _secondaryControlsMinIncludeTextWidth = 1100.0;
+  static const _secondaryControlsMinIncludeTextWidth = 880.0;
+
+  static const _loadAllCpuSamplesMinIncludeTextWidth = 660.0;
 
   final ProfilerScreenController controller;
 
@@ -287,15 +290,17 @@ class _SecondaryControls extends StatelessWidget {
       children: [
         RefreshButton(
           label: 'Load all CPU samples',
+          tooltip: 'Load all available CPU samples from the profiler',
+          includeTextWidth: _loadAllCpuSamplesMinIncludeTextWidth,
           onPressed: !recording ? controller.loadAllSamples : null,
         ),
-        const SizedBox(width: defaultSpacing),
+        const SizedBox(width: denseSpacing),
         ProfileGranularityDropdown(
           screenId: ProfilerScreen.id,
           profileGranularityFlagNotifier:
               controller.cpuProfilerController.profileGranularityFlagNotifier,
         ),
-        const SizedBox(width: defaultSpacing),
+        const SizedBox(width: denseSpacing),
         ExportButton(
           onPressed: !recording &&
                   controller.cpuProfileData != null &&


### PR DESCRIPTION
Just some styling / layout changes and some helpful refactors:

This PR
- Refactors some `_buildXYZ` methods into their own widget classes
- Fixes some render overflow errors caused by buttons including text at narrow widths
- Cleans up some code in common_widgets.dart to use existing utilities.