### PR TITLE
remove some older crash handling support

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -66,26 +66,6 @@
         });
     }
   </script>
-
-  <!-- Script to fail gracefully when CanvasKit crashes. -->
-  <script>
-    var realWarn = window.console.warn.bind(console);
-    var tryingToClose = false;
-    window.console.warn = function(obj) {
-      if( typeof obj == "string" && obj.indexOf("CanvasKit") != -1 && obj.indexOf("font") != -1) {
-        if (!tryingToClose) {
-          tryingToClose = true;
-          window.alert(
-            "The Flutter web backend ('CanvasKit') has encountered a fatal error and needs to restart. \n" +
-            "Press OK to restart devtools. We are aware of this bug and working hard on a fix.\n" + obj
-          );
-        }
-        window.location.reload();
-        return;
-      }
-      realWarn(obj);
-    }
-  </script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
 </html>


### PR DESCRIPTION
- remove some older crash handling support

I don't believe this crash handling is used anymore; I believe this had been added to handle a specific crash in canvaskit when it was in alpha.

