### PR TITLE
Changes to when analytics dialog appears and how it sets analytics

### DIFF
--- a/packages/devtools_app/lib/src/analytics/analytics.dart
+++ b/packages/devtools_app/lib/src/analytics/analytics.dart
@@ -178,14 +178,14 @@ ValueListenable<bool> get gaEnabledNotifier => _gaEnabledNotifier;
 bool gaEnabled() => _gaEnabledNotifier.value;
 
 /// Request DevTools property value 'enabled' (GA enabled) stored in the file
-/// '~/.devtools'.
+/// '~/.flutter-devtools/.devtools'.
 Future<bool> isAnalyticsEnabled() async {
   _gaEnabledNotifier.value = await server.isAnalyticsEnabled();
   return _gaEnabledNotifier.value;
 }
 
 /// Set the DevTools property 'enabled' (GA enabled) stored in the file
-/// '~/.devtools'.
+/// '~/flutter-devtools/.devtools'.
 Future<void> setAnalyticsEnabled([bool value = true]) async {
   final didSet = await server.setAnalyticsEnabled(value);
   if (didSet) {

--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
+import '../common_widgets.dart';
 import '../theme.dart';
 import '../utils.dart';
 import 'provider.dart';
@@ -21,48 +22,68 @@ class AnalyticsPrompt extends StatefulWidget {
   final AnalyticsProvider provider;
 
   @override
-  State<AnalyticsPrompt> createState() =>
-      _AnalyticsPromptState(provider, child);
+  State<AnalyticsPrompt> createState() => _AnalyticsPromptState();
 }
 
 class _AnalyticsPromptState extends State<AnalyticsPrompt> {
-  _AnalyticsPromptState(this._provider, this._child);
-
-  final Widget _child;
-  final AnalyticsProvider _provider;
+  Widget _child;
+  AnalyticsProvider _provider;
 
   bool _isVisible = false;
 
   @override
   void initState() {
     super.initState();
+    _provider = widget.provider;
+    _child = widget.child;
     if (_provider.isGtagsEnabled) {
       if (_provider.shouldPrompt) {
+        // Enable the analytics and give the user the option to opt out via the
+        // prompt.
+        _provider.setAllowAnalytics();
         _isVisible = true;
-      } else if (_provider.isEnabled) {
-        _provider.setUpAnalytics();
       }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         if (_isVisible)
           Card(
-            margin: const EdgeInsets.only(bottom: denseRowSpacing),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(defaultBorderRadius),
+              side: BorderSide(
+                color: theme.focusColor,
+              ),
+            ),
+            color: theme.canvasColor,
+            margin: const EdgeInsets.only(bottom: denseSpacing),
             child: Padding(
               padding: const EdgeInsets.all(defaultSpacing),
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(
-                    'Send usage statistics for DevTools?',
-                    style: textTheme.headline5,
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Send usage statistics for DevTools?',
+                        style: textTheme.headline5,
+                      ),
+                      CircularIconButton(
+                        icon: Icons.close,
+                        onPressed: _onPromptClosed,
+                        backgroundColor: theme.canvasColor,
+                        foregroundColor: theme.colorScheme.contrastForeground,
+                      ),
+                    ],
                   ),
                   const Padding(
                     padding: EdgeInsets.only(top: defaultSpacing),
@@ -87,11 +108,11 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
             text: 'DevTools reports feature usage statistics and basic '
                 'crash reports to Google in order to help Google improve '
                 'the tool over time. See Google\'s ',
-            style: textTheme.bodyText1,
+            style: textTheme.subtitle1,
           ),
           TextSpan(
             text: 'privacy policy',
-            style: const TextStyle(color: Color(0xFF54C1EF)),
+            style: textTheme.subtitle1.copyWith(color: const Color(0xFF54C1EF)),
             recognizer: TapGestureRecognizer()
               ..onTap = () {
                 launchUrl(
@@ -102,7 +123,7 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
           ),
           TextSpan(
             text: '.',
-            style: textTheme.bodyText1,
+            style: textTheme.subtitle1,
           ),
         ],
       ),
@@ -137,5 +158,11 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
         ),
       ],
     );
+  }
+
+  void _onPromptClosed() {
+    setState(() {
+      _isVisible = false;
+    });
   }
 }

--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -26,16 +26,15 @@ class AnalyticsPrompt extends StatefulWidget {
 }
 
 class _AnalyticsPromptState extends State<AnalyticsPrompt> {
-  Widget _child;
-  AnalyticsProvider _provider;
+  Widget get _child => widget.child;
+
+  AnalyticsProvider get _provider => widget.provider;
 
   bool _isVisible = false;
 
   @override
   void initState() {
     super.initState();
-    _provider = widget.provider;
-    _child = widget.child;
     if (_provider.isGtagsEnabled) {
       if (_provider.shouldPrompt) {
         // Enable the analytics and give the user the option to opt out via the

--- a/packages/devtools_app/lib/src/analytics/remote_provider.dart
+++ b/packages/devtools_app/lib/src/analytics/remote_provider.dart
@@ -15,14 +15,12 @@ class _RemoteAnalyticsProvider implements AnalyticsProvider {
     this._isGtagsEnabled,
   );
 
-  bool _isConfigured = false;
-
   @override
   bool get isEnabled => _isEnabled;
   final bool _isEnabled;
 
   @override
-  bool get shouldPrompt => _isFirstRun && !_isConfigured;
+  bool get shouldPrompt => _isFirstRun;
   final bool _isFirstRun;
 
   @override
@@ -31,13 +29,12 @@ class _RemoteAnalyticsProvider implements AnalyticsProvider {
 
   @override
   void setAllowAnalytics() {
-    _isConfigured = true;
+    setUpAnalytics();
     analytics.setAllowAnalytics();
   }
 
   @override
   void setDontAllowAnalytics() {
-    _isConfigured = true;
     analytics.setDontAllowAnalytics();
   }
 
@@ -70,8 +67,11 @@ Future<AnalyticsProvider> get analyticsProvider async {
   } catch (_) {
     // Ignore issues if analytics could not be initialized.
   }
-  _providerCompleter.complete(
-      _RemoteAnalyticsProvider(isEnabled, isFirstRun, isGtagsEnabled));
+  _providerCompleter.complete(_RemoteAnalyticsProvider(
+    isEnabled,
+    isFirstRun,
+    isGtagsEnabled,
+  ));
   return _providerCompleter.future;
 }
 

--- a/packages/devtools_app/lib/src/config_specific/server/_server_web.dart
+++ b/packages/devtools_app/lib/src/config_specific/server/_server_web.dart
@@ -31,7 +31,7 @@ Future<HttpRequest> _request(String url) async {
 }
 
 /// Request DevTools property value 'firstRun' (GA dialog) stored in the file
-/// '~\.devtools'.
+/// '~/flutter-devtools/.devtools'.
 Future<bool> isFirstRun() async {
   bool firstRun = false;
 
@@ -63,7 +63,7 @@ Future<bool> isAnalyticsEnabled() async {
 }
 
 /// Set the DevTools property 'enabled' (GA enabled) stored in the file
-/// '~/.devtools'.
+/// '~/.flutter-devtools/.devtools'.
 ///
 /// Returns whether the set call was successful.
 Future<bool> setAnalyticsEnabled([bool value = true]) async {
@@ -239,7 +239,7 @@ Future<int> incrementSurveyShownCount() async {
 }
 
 /// Requests all .devtools properties to be reset to their default values in the
-/// file '~/.devtools'.
+/// file '~/.flutter-devtools/.devtools'.
 Future<void> resetDevToolsFile() async {
   if (isDevToolsServerAvailable) {
     final resp = await _request(apiResetDevTools);

--- a/packages/devtools_app/test/analytics_prompt_test.dart
+++ b/packages/devtools_app/test/analytics_prompt_test.dart
@@ -42,6 +42,8 @@ class FakeProvider implements AnalyticsProvider {
   void setUpAnalytics() {}
 }
 
+const windowSize = Size(2000.0, 1000.0);
+
 void main() {
   setUp(() {
     setGlobal(ServiceConnectionManager, FakeServiceManager());
@@ -49,7 +51,8 @@ void main() {
 
   group('AnalyticsPrompt', () {
     group('with gtags enabled', () {
-      testWidgets('displays prompt if provider indicates to do so',
+      testWidgetsWithWindowSize(
+          'displays prompt if provider indicates to do so', windowSize,
           (WidgetTester tester) async {
         final prompt = AnalyticsPrompt(
           provider: FakeProvider(gtagsEnabled: true, prompt: true),
@@ -61,7 +64,8 @@ void main() {
             find.text('Send usage statistics for DevTools?'), findsOneWidget);
       });
 
-      testWidgets('does not display prompt without first run',
+      testWidgetsWithWindowSize(
+          'does not display prompt without first run', windowSize,
           (WidgetTester tester) async {
         final prompt = AnalyticsPrompt(
           provider: FakeProvider(gtagsEnabled: true),
@@ -72,7 +76,8 @@ void main() {
         expect(find.text('Send usage statistics for DevTools?'), findsNothing);
       });
 
-      testWidgets('displays the child', (WidgetTester tester) async {
+      testWidgetsWithWindowSize('displays the child', windowSize,
+          (WidgetTester tester) async {
         final prompt = AnalyticsPrompt(
           provider: FakeProvider(),
           child: const Text('Child Text'),
@@ -84,7 +89,8 @@ void main() {
     });
 
     group('without gtags enabled', () {
-      testWidgets('does not display prompt', (WidgetTester tester) async {
+      testWidgetsWithWindowSize('does not display prompt', windowSize,
+          (WidgetTester tester) async {
         final prompt = AnalyticsPrompt(
           provider: FakeProvider(),
           child: const Text('Child Text'),
@@ -94,7 +100,8 @@ void main() {
         expect(find.text('Send usage statistics for DevTools?'), findsNothing);
       });
 
-      testWidgets('displays the child', (WidgetTester tester) async {
+      testWidgetsWithWindowSize('displays the child', windowSize,
+          (WidgetTester tester) async {
         final prompt = AnalyticsPrompt(
           provider: FakeProvider(),
           child: const Text('Child Text'),

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -58,22 +58,24 @@ class ServerApi {
         _devToolsUsage.reset();
         return api.getCompleted(request, json.encode(true));
       case apiGetDevToolsFirstRun:
-        // Has DevTools been run first time? To bring up welcome screen.
+        // Has DevTools been run first time? To bring up analytics dialog.
         return api.getCompleted(
           request,
           json.encode(_devToolsUsage.isFirstRun),
         );
       case apiGetDevToolsEnabled:
         // Is DevTools Analytics collection enabled?
-        return api.getCompleted(request, json.encode(_devToolsUsage.enabled));
+        return api.getCompleted(
+            request, json.encode(_devToolsUsage.analyticsEnabled));
       case apiSetDevToolsEnabled:
         // Enable or disable DevTools analytics collection.
         final queryParams = request.requestedUri.queryParameters;
         if (queryParams.containsKey(devToolsEnabledPropertyName)) {
-          _devToolsUsage.enabled =
+          _devToolsUsage.analyticsEnabled =
               json.decode(queryParams[devToolsEnabledPropertyName]!);
         }
-        return api.setCompleted(request, json.encode(_devToolsUsage.enabled));
+        return api.setCompleted(
+            request, json.encode(_devToolsUsage.analyticsEnabled));
 
       // ----- DevTools survey store. -----
 
@@ -186,7 +188,7 @@ class ServerApi {
   static final FlutterUsage? _usage =
       FlutterUsage.doesStoreExist ? FlutterUsage() : null;
 
-  // Accessing DevTools usage file e.g., ~/.devtools
+  // Accessing DevTools usage file e.g., ~/.flutter-devtools/.devtools
   static final DevToolsUsage _devToolsUsage = DevToolsUsage();
 
   static DevToolsUsage get devToolsPreferences => _devToolsUsage;

--- a/packages/devtools_shared/lib/src/server/usage.dart
+++ b/packages/devtools_shared/lib/src/server/usage.dart
@@ -63,9 +63,10 @@ class DevToolsUsage {
   static const _surveyShownCount = 'surveyShownCount';
 
   void reset() {
-    // TODO(kenz): remove this in ~6 months. The `firstRun` property has been
-    // replaced by `firstDevToolsRun`. This is to force all users to answer the
-    // analytics dialog again. The 'enabled' property has been replaced by
+    // TODO(kenz): remove this in Feb 2022. See
+    // https://github.com/flutter/devtools/issues/3264. The `firstRun` property
+    // has been replaced by `isFirstRun`. This is to force all users to answer
+    // the analytics dialog again. The 'enabled' property has been replaced by
     // 'analyticsEnabled' for better naming.
     properties.remove('firstRun');
     properties.remove('enabled');
@@ -75,9 +76,10 @@ class DevToolsUsage {
   }
 
   bool get isFirstRun {
-    // TODO(kenz): remove this in ~6 months. The `firstRun` property has been
-    // replaced by `isFirstRun`. This is to force all users to answer the
-    // analytics dialog again.
+    // TODO(kenz): remove this in Feb 2022. See
+    // https://github.com/flutter/devtools/issues/3264.The `firstRun` property
+    // has been replaced by `isFirstRun`. This is to force all users to answer
+    // the analytics dialog again.
     properties.remove('firstRun');
 
     properties['isFirstRun'] = properties['isFirstRun'] == null;
@@ -85,8 +87,9 @@ class DevToolsUsage {
   }
 
   bool get analyticsEnabled {
-    // TODO(kenz): remove this in ~6 months. The `enabled` property has been
-    // replaced by `analyticsEnabled` for better naming.
+    // TODO(kenz): remove this in Feb 2022. See
+    // https://github.com/flutter/devtools/issues/3264. The `enabled` property
+    // has been replaced by `analyticsEnabled` for better naming.
     if (properties['enabled'] != null) {
       properties['analyticsEnabled'] = properties['enabled'];
       properties.remove('enabled');

--- a/packages/devtools_shared/lib/src/server/usage.dart
+++ b/packages/devtools_shared/lib/src/server/usage.dart
@@ -63,26 +63,44 @@ class DevToolsUsage {
   static const _surveyShownCount = 'surveyShownCount';
 
   void reset() {
+    // TODO(kenz): remove this in ~6 months. The `firstRun` property has been
+    // replaced by `firstDevToolsRun`. This is to force all users to answer the
+    // analytics dialog again. The 'enabled' property has been replaced by
+    // 'analyticsEnabled' for better naming.
     properties.remove('firstRun');
-    properties['enabled'] = false;
+    properties.remove('enabled');
+
+    properties.remove('firstDevToolsRun');
+    properties['analyticsEnabled'] = false;
   }
 
   bool get isFirstRun {
-    properties['firstRun'] = properties['firstRun'] == null;
-    return properties['firstRun'];
+    // TODO(kenz): remove this in ~6 months. The `firstRun` property has been
+    // replaced by `isFirstRun`. This is to force all users to answer the
+    // analytics dialog again.
+    properties.remove('firstRun');
+
+    properties['isFirstRun'] = properties['isFirstRun'] == null;
+    return properties['isFirstRun'];
   }
 
-  bool get enabled {
-    if (properties['enabled'] == null) {
-      properties['enabled'] = false;
+  bool get analyticsEnabled {
+    // TODO(kenz): remove this in ~6 months. The `enabled` property has been
+    // replaced by `analyticsEnabled` for better naming.
+    if (properties['enabled'] != null) {
+      properties['analyticsEnabled'] = properties['enabled'];
+      properties.remove('enabled');
     }
 
-    return properties['enabled'];
+    if (properties['analyticsEnabled'] == null) {
+      properties['analyticsEnabled'] = false;
+    }
+    return properties['analyticsEnabled'];
   }
 
-  set enabled(bool value) {
-    properties['enabled'] = value;
-    return properties['enabled'];
+  set analyticsEnabled(bool value) {
+    properties['analyticsEnabled'] = value;
+    return properties['analyticsEnabled'];
   }
 
   bool surveyNameExists(String surveyName) => properties[surveyName] != null;


### PR DESCRIPTION
Changes:
- Changed some prompt styling. Added a close button in the upper right of the prompt (consistent with other banner-type messages in DevTools.
![Screen Shot 2021-08-11 at 10 30 12 AM](https://user-images.githubusercontent.com/43759233/129087105-0f3974f6-5f26-47dd-bf1e-9d9074e0a2e8.png)

- The prompt will show again once for all users because we have changed the 'firstRun' bit in the .devtools storage file to 'isFirstRun' (just to force the prompt to show again). At the time the prompt is shown, analytics will be enabled for a user, and the user will be given the opportunity to opt-out by responding to the dialog. The user can still opt out of analytics at any time through the setting menu.
- The 'enabled' bit in the .devtools storage file has been changed to 'analyticsEnabled' for more clarity.

Here is what the .devtools file will look like after these changes:
```
{
  "analyticsEnabled": true,
  "isFirstRun": false,
  "2020Q4": {
    "surveyActionTaken": false,
    "surveyShownCount": 0
  }
}
```

Verified that these prompts show up as expected in the embedded version of DevTools as well:

IntelliJ
![Screen Shot 2021-08-11 at 11 56 19 AM](https://user-images.githubusercontent.com/43759233/129086999-cca6729a-d6eb-4c5f-b6e1-14dea936d415.png)

VS Code
![Screen Shot 2021-08-11 at 11 32 25 AM](https://user-images.githubusercontent.com/43759233/129086984-5af64c91-ff17-41ca-8ff4-868df10b2e94.png)
