### PR TITLE
Some syntax modifications to the analytics dimensions

### DIFF
--- a/packages/devtools_app/lib/src/analytics/analytics.dart
+++ b/packages/devtools_app/lib/src/analytics/analytics.dart
@@ -442,7 +442,7 @@ void computeDevToolsQueryParams() {
   }
 }
 
-void computeFlutterClientId() async {
+Future<void> computeFlutterClientId() async {
   flutterClientId = await server.flutterGAClientID();
 }
 
@@ -475,12 +475,12 @@ void setupAndGaScreen(String screenName) async {
   }
 }
 
-void setupDimensions() {
+Future<void> setupDimensions() async {
   if (isGtagsEnabled() && !_analyticsComputed && !_computingDimensions) {
     _computingDimensions = true;
     computeDevToolsCustomGTagsData();
     computeDevToolsQueryParams();
-    computeFlutterClientId();
+    await computeFlutterClientId();
     _analyticsComputed = true;
   }
 }

--- a/packages/devtools_app/web/devtools_analytics.js
+++ b/packages/devtools_app/web/devtools_analytics.js
@@ -25,7 +25,7 @@ let _gtagsEnabled = _gtagsValue == null || _gtagsValue == 'enabled';
 let _gtagsDisabled = _gtagsValue == 'disabled';
 
 function gtagsEnabled() {
-  return _gtagsEnabled
+  return _gtagsEnabled;
 }
 
 function gtagsReset() {
@@ -44,18 +44,18 @@ function initializeGA() {
     gtag('config', GA_DEVTOOLS_PROPERTY, {
       'custom_map': {
         // Custom dimensions:
-        dimension1: 'user_app',
-        dimension2: 'user_build',
-        dimension3: 'user_platform',
-        dimension4: 'devtools_platform',
-        dimension5: 'devtools_chrome',
-        dimension6: 'devtools_version',
-        dimension7: 'ide_launched',
-        dimension8: 'flutter_client_id',
+        'dimension1': 'user_app',
+        'dimension2': 'user_build',
+        'dimension3': 'user_platform',
+        'dimension4': 'devtools_platform',
+        'dimension5': 'devtools_chrome',
+        'dimension6': 'devtools_version',
+        'dimension7': 'ide_launched',
+        'dimension8': 'flutter_client_id',
 
         // Custom metrics:
-        metric1: 'gpu_duration',
-        metric2: 'ui_duration',
+        'metric1': 'raster_duration',
+        'metric2': 'ui_duration',
       }
     });
 


### PR DESCRIPTION
From the gtags documentation, it appears the dimensions should be in quotes: https://developers.google.com/analytics/devguides/collection/gtagjs/custom-dims-mets