### PR TITLE
Performance improvements for the CPU profiler

### DIFF
--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -63,21 +63,17 @@ class CpuProfilerController
   List<ToggleFilter<CpuStackFrame>> get toggleFilters => _toggleFilters ??= [
         ToggleFilter<CpuStackFrame>(
           name: 'Hide Native code',
-          includeCallback: (stackFrame) => stackFrame.processedUrl.isNotEmpty,
+          includeCallback: (stackFrame) => !stackFrame.isNative,
           enabledByDefault: true,
         ),
         ToggleFilter<CpuStackFrame>(
           name: 'Hide core Dart libraries',
-          includeCallback: (stackFrame) =>
-              !stackFrame.processedUrl.startsWith('dart:'),
+          includeCallback: (stackFrame) => !stackFrame.isDartCore,
         ),
         if (serviceManager.connectedApp?.isFlutterAppNow ?? true)
           ToggleFilter<CpuStackFrame>(
             name: 'Hide core Flutter libraries',
-            includeCallback: (stackFrame) =>
-                !(stackFrame.processedUrl.startsWith('package:flutter/') ||
-                    stackFrame.name.startsWith('flutter::') ||
-                    stackFrame.processedUrl.startsWith('dart:ui')),
+            includeCallback: (stackFrame) => !stackFrame.isFlutterCore,
           ),
       ];
 

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -441,6 +441,18 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
     @required this.profileMetaData,
   });
 
+  /// Prefix for packages from the core Dart libraries.
+  static const dartPackagePrefix = 'dart:';
+
+  /// Prefix for packages from the core Flutter libraries.
+  static const flutterPackagePrefix = 'package:flutter/';
+
+  /// The Flutter namespace in C++ that is part of the Flutter Engine code.
+  static const flutterEnginePrefix = 'flutter::';
+
+  /// dart:ui is the library for the Dart part of the Flutter Engine code.
+  static const dartUiPrefix = 'dart:ui';
+
   final String id;
 
   final String name;
@@ -462,14 +474,15 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
 
   bool _isNative;
 
-  bool get isDartCore => _isDartCore ??= processedUrl.startsWith('dart:');
+  bool get isDartCore =>
+      _isDartCore ??= processedUrl.startsWith(dartPackagePrefix);
 
   bool _isDartCore;
 
   bool get isFlutterCore =>
-      _isFlutterCore ??= processedUrl.startsWith('package:flutter/') ||
-          name.startsWith('flutter::') ||
-          processedUrl.startsWith('dart:ui');
+      _isFlutterCore ??= processedUrl.startsWith(flutterPackagePrefix) ||
+          name.startsWith(flutterEnginePrefix) ||
+          processedUrl.startsWith(dartUiPrefix);
 
   bool _isFlutterCore;
 

--- a/packages/devtools_app/test/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profile_model_test.dart
@@ -91,6 +91,36 @@ void main() {
   });
 
   group('CpuStackFrame', () {
+    test('isNative', () {
+      expect(stackFrameA.isNative, isTrue);
+      expect(stackFrameB.isNative, isFalse);
+      expect(stackFrameC.isNative, isFalse);
+      expect(
+        CpuStackFrame(
+          id: CpuProfileData.rootId,
+          name: CpuProfileData.rootName,
+          verboseName: 'all',
+          category: 'Dart',
+          rawUrl: '',
+          parentId: null,
+          profileMetaData: profileMetaData,
+        ).isNative,
+        isFalse,
+      );
+    });
+
+    test('isDartCore', () {
+      expect(stackFrameA.isDartCore, isFalse);
+      expect(stackFrameB.isDartCore, isTrue);
+      expect(stackFrameC.isDartCore, isFalse);
+    });
+
+    test('isFlutterCore', () {
+      expect(stackFrameA.isFlutterCore, isFalse);
+      expect(stackFrameB.isFlutterCore, isFalse);
+      expect(stackFrameC.isFlutterCore, isTrue);
+    });
+
     test('sampleCount', () {
       expect(testStackFrame.inclusiveSampleCount, equals(10));
     });


### PR DESCRIPTION
The recent introduction of profile filtering added more calls to `getSimplePackageUrl` than we would have liked. This PR improves the performance of the profiler by caching some values:
- the `processedUrl` returned by `getSimplePackageUrl` for a stack frame. We then pass this value as a parameter during stack frame copy operations (we were previously computing it for every copy, which is unnecessary).
- the `isNative`, `isDartCore`, and `isFlutterCore` values for a single stack frame. These no longer have to be re-computed for filter operations.