### PR TITLE
add a package:args Command implementation

### DIFF
--- a/packages/devtools_server/lib/devtools_server.dart
+++ b/packages/devtools_server/lib/devtools_server.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/devtools_command.dart' show DevToolsCommand;
 export 'src/external_handlers.dart';
 export 'src/server.dart'
     show launchDevTools, serveDevTools, serveDevToolsWithArgs;

--- a/packages/devtools_server/lib/src/devtools_command.dart
+++ b/packages/devtools_server/lib/src/devtools_command.dart
@@ -1,0 +1,39 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:args/command_runner.dart';
+
+import '../devtools_server.dart';
+import 'server.dart';
+
+class DevToolsCommand extends Command<int> {
+  DevToolsCommand({
+    this.customDevToolsPath,
+    bool verbose = false,
+  }) {
+    configureArgsParser(argParser, verbose);
+  }
+
+  final String? customDevToolsPath;
+
+  @override
+  String get name => 'devtools';
+
+  @override
+  String get description =>
+      'Open a DevTools instance in a browser and optionally connect to an existing application.';
+
+  @override
+  String get invocation => '${super.invocation} [service protocol uri]';
+
+  @override
+  Future<int> run() async {
+    final server = await serveDevToolsWithArgs(
+      argResults!.arguments,
+      customDevToolsPath: customDevToolsPath,
+    );
+
+    return server == null ? -1 : 0;
+  }
+}


### PR DESCRIPTION
- add a package:args Command implementation

This will make it easier to implement something like `dart devtools` - we can delegate to the package:devtools and package:devtools_server implementation instead of doing something like copying CLI args and calling `serveDevToolsWithArgs`.

