### PR TITLE
add a hidden arg to the devtools command

### DIFF
--- a/packages/devtools_server/lib/src/devtools_command.dart
+++ b/packages/devtools_server/lib/src/devtools_command.dart
@@ -7,13 +7,20 @@ import 'package:args/command_runner.dart';
 import '../devtools_server.dart';
 import 'server.dart';
 
+const commandDescription =
+    'Open DevTools (optionally connecting to an existing application).';
+
 class DevToolsCommand extends Command<int> {
   DevToolsCommand({
     this.customDevToolsPath,
     bool verbose = false,
+    this.hidden = false,
   }) {
     configureArgsParser(argParser, verbose);
   }
+
+  @override
+  final bool hidden;
 
   final String? customDevToolsPath;
 
@@ -21,8 +28,7 @@ class DevToolsCommand extends Command<int> {
   String get name => 'devtools';
 
   @override
-  String get description =>
-      'Open a DevTools instance in a browser and optionally connect to an existing application.';
+  String get description => commandDescription;
 
   @override
   String get invocation => '${super.invocation} [service protocol uri]';

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -21,6 +21,7 @@ import 'package:vm_service/utils.dart';
 import 'package:vm_service/vm_service.dart' hide Isolate;
 
 import 'client_manager.dart';
+import 'devtools_command.dart';
 import 'external_handlers.dart';
 import 'memory_profile.dart';
 
@@ -618,8 +619,7 @@ ArgParser configureArgsParser(ArgParser parser, bool verbose) {
 void _printUsage(bool verbose) {
   print('usage: devtools <options> [service protocol uri]');
   print('');
-  print('Open a DevTools instance in a browser and optionally connect to an '
-      'existing application.');
+  print(commandDescription);
   print('');
   print(configureArgsParser(ArgParser(), verbose).usage);
 }


### PR DESCRIPTION
- add a `hidden` arg to the devtools command

This gives a caller the ability to make the devtools command hidden. I've tested the current API against dartdev in the sdk repo.