### PR TITLE
Cleanup console with eval that scrolls and less busy splitter.

### DIFF
--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -25,9 +25,11 @@ class Console extends StatelessWidget {
     this.controls,
     @required this.lines,
     this.title,
+    this.footer,
   }) : super();
 
   final Widget title;
+  final Widget footer;
   final List<Widget> controls;
   final ValueListenable<List<ConsoleLine>> lines;
 
@@ -39,7 +41,7 @@ class Console extends StatelessWidget {
     return ConsoleFrame(
       controls: controls,
       title: title,
-      child: _ConsoleOutput(lines: lines),
+      child: _ConsoleOutput(lines: lines, footer: footer),
     );
   }
 }
@@ -108,9 +110,12 @@ class _ConsoleOutput extends StatefulWidget {
   const _ConsoleOutput({
     Key key,
     @required this.lines,
+    this.footer,
   }) : super(key: key);
 
   final ValueListenable<List<ConsoleLine>> lines;
+
+  final Widget footer;
 
   @override
   _ConsoleOutputState createState() => _ConsoleOutputState();
@@ -218,7 +223,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
       key: _scrollBarKey,
       child: ListView.separated(
         padding: const EdgeInsets.all(denseSpacing),
-        itemCount: _currentLines.length,
+        itemCount: _currentLines.length + (widget.footer != null ? 1 : 0),
         controller: _scroll,
         // Scroll physics to try to keep content within view and avoid bouncing.
         physics: const ClampingScrollPhysics(
@@ -228,6 +233,9 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
           return const Divider();
         },
         itemBuilder: (context, index) {
+          if (index == _currentLines.length && widget.footer != null) {
+            return widget.footer;
+          }
           final line = _currentLines[index];
           if (line is TextConsoleLine) {
             return SelectableText.rich(

--- a/packages/devtools_app/lib/src/debugger/console.dart
+++ b/packages/devtools_app/lib/src/debugger/console.dart
@@ -10,7 +10,6 @@ import '../console.dart';
 import '../console_service.dart';
 import '../globals.dart';
 import '../theme.dart';
-import '../utils.dart';
 import 'debugger_controller.dart';
 import 'evaluate.dart';
 

--- a/packages/devtools_app/lib/src/debugger/console.dart
+++ b/packages/devtools_app/lib/src/debugger/console.dart
@@ -6,10 +6,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../common_widgets.dart';
 import '../console.dart';
 import '../console_service.dart';
 import '../globals.dart';
+import '../utils.dart';
 import 'debugger_controller.dart';
 import 'evaluate.dart';
 
@@ -30,34 +30,21 @@ class DebuggerConsole extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return OutlineDecoration(
-      child: Column(
-        children: [
-          Expanded(
-            child: Console(
-              title: AreaPaneHeader(
-                title: const Text('Console'),
-                needsTopBorder: false,
-                rightActions: [
-                  CopyToClipboardControl(
-                    dataProvider: () => stdio.value?.join('\n') ?? '',
-                    buttonKey: DebuggerConsole.copyToClipboardButtonKey,
-                  ),
-                  DeleteControl(
-                    buttonKey: DebuggerConsole.clearStdioButtonKey,
-                    tooltip: 'Clear console output',
-                    onPressed: () => serviceManager.consoleService.clearStdio(),
-                  ),
-                ],
+    return Column(
+      children: [
+        Expanded(
+          child: Console(
+            lines: stdio,
+            footer: SizedBox(
+              height: scaleByFontFactor(18.0),
+              child: ExpressionEvalField(
+                controller:
+                    Provider.of<DebuggerController>(context, listen: false),
               ),
-              lines: stdio,
             ),
           ),
-          ExpressionEvalField(
-            controller: Provider.of<DebuggerController>(context, listen: false),
-          ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/console.dart
+++ b/packages/devtools_app/lib/src/debugger/console.dart
@@ -9,6 +9,7 @@ import 'package:provider/provider.dart';
 import '../console.dart';
 import '../console_service.dart';
 import '../globals.dart';
+import '../theme.dart';
 import '../utils.dart';
 import 'debugger_controller.dart';
 import 'evaluate.dart';
@@ -36,7 +37,7 @@ class DebuggerConsole extends StatelessWidget {
           child: Console(
             lines: stdio,
             footer: SizedBox(
-              height: scaleByFontFactor(18.0),
+              height: consoleLineHeight,
               child: ExpressionEvalField(
                 controller:
                     Provider.of<DebuggerController>(context, listen: false),

--- a/packages/devtools_app/lib/src/debugger/console.dart
+++ b/packages/devtools_app/lib/src/debugger/console.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../common_widgets.dart';
 import '../console.dart';
 import '../console_service.dart';
 import '../globals.dart';
@@ -43,6 +44,25 @@ class DebuggerConsole extends StatelessWidget {
               ),
             ),
           ),
+        ),
+      ],
+    );
+  }
+
+  static PreferredSizeWidget buildHeader() {
+    return AreaPaneHeader(
+      title: const Text('Console'),
+      needsTopBorder: false,
+      rightActions: [
+        CopyToClipboardControl(
+          dataProvider: () =>
+              serviceManager.consoleService.stdio.value?.join('\n') ?? '',
+          buttonKey: DebuggerConsole.copyToClipboardButtonKey,
+        ),
+        DeleteControl(
+          buttonKey: DebuggerConsole.clearStdioButtonKey,
+          tooltip: 'Clear console output',
+          onPressed: () => serviceManager.consoleService.clearStdio(),
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -103,57 +103,45 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
+    return Row(
+      children: [
+        const Text('>'),
+        const SizedBox(width: 8.0),
+        Expanded(
+          child: Focus(
+            onKey: (_, RawKeyEvent event) {
+              if (event.isKeyPressed(LogicalKeyboardKey.arrowUp)) {
+                _historyNavUp();
+                return KeyEventResult.handled;
+              } else if (event.isKeyPressed(LogicalKeyboardKey.arrowDown)) {
+                _historyNavDown();
+                return KeyEventResult.handled;
+              } else if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
+                _handleExpressionEval();
+                return KeyEventResult.handled;
+              }
 
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(
-          top: BorderSide(color: theme.focusColor),
-        ),
-      ),
-      padding: const EdgeInsets.all(8.0),
-      child: Row(
-        children: [
-          const Text('>'),
-          const SizedBox(width: 8.0),
-          Expanded(
-            child: Focus(
-              onKey: (_, RawKeyEvent event) {
-                if (event.isKeyPressed(LogicalKeyboardKey.arrowUp)) {
-                  _historyNavUp();
-                  return KeyEventResult.handled;
-                } else if (event.isKeyPressed(LogicalKeyboardKey.arrowDown)) {
-                  _historyNavDown();
-                  return KeyEventResult.handled;
-                } else if (event.isKeyPressed(LogicalKeyboardKey.enter)) {
-                  _handleExpressionEval();
-                  return KeyEventResult.handled;
-                }
-
-                return KeyEventResult.ignored;
-              },
-              child: buildAutoCompleteSearchField(
-                controller: _autoCompleteController,
-                searchFieldKey: evalTextFieldKey,
-                searchFieldEnabled: true,
-                shouldRequestFocus: false,
-                supportClearField: true,
-                onSelection: _onSelection,
-                tracking: true,
-                decoration: const InputDecoration(
-                  contentPadding: EdgeInsets.all(denseSpacing),
-                  border: OutlineInputBorder(),
-                  focusedBorder:
-                      OutlineInputBorder(borderSide: BorderSide.none),
-                  enabledBorder:
-                      OutlineInputBorder(borderSide: BorderSide.none),
-                  labelText: 'Eval',
-                ),
+              return KeyEventResult.ignored;
+            },
+            child: buildAutoCompleteSearchField(
+              controller: _autoCompleteController,
+              searchFieldKey: evalTextFieldKey,
+              searchFieldEnabled: true,
+              shouldRequestFocus: false,
+              supportClearField: true,
+              onSelection: _onSelection,
+              tracking: true,
+              decoration: const InputDecoration(
+                contentPadding: EdgeInsets.all(denseSpacing),
+                border: OutlineInputBorder(),
+                focusedBorder: OutlineInputBorder(borderSide: BorderSide.none),
+                enabledBorder: OutlineInputBorder(borderSide: BorderSide.none),
+                labelText: 'Eval',
               ),
             ),
           ),
-        ],
-      ),
+        ),
+      ],
     );
   }
 

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -77,9 +77,9 @@ class DevToolsScaffold extends StatefulWidget {
   /// The border around the content in the DevTools UI.
   EdgeInsets get appPadding => EdgeInsets.fromLTRB(
         horizontalPadding.left,
-        isEmbedded() ? 2.0 : 16.0,
+        isEmbedded() ? 2.0 : defaultSpacing,
         horizontalPadding.right,
-        isEmbedded() ? 0.0 : 8.0,
+        isEmbedded() ? 0.0 : denseSpacing,
       );
 
   // Note: when changing this value, also update `flameChartContainerOffset`

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -19,7 +19,6 @@ import 'common_widgets.dart';
 import 'config_specific/drag_and_drop/drag_and_drop.dart';
 import 'config_specific/ide_theme/ide_theme.dart';
 import 'config_specific/import_export/import_export.dart';
-import 'console.dart';
 import 'debugger/console.dart';
 import 'debugger/debugger_screen.dart';
 import 'framework_controller.dart';
@@ -364,26 +363,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
                           ),
                         ],
                         splitters: [
-                          AreaPaneHeader(
-                            title: const Text('Console'),
-                            needsTopBorder: false,
-                            rightActions: [
-                              CopyToClipboardControl(
-                                dataProvider: () =>
-                                    serviceManager.consoleService.stdio.value
-                                        ?.join('\n') ??
-                                    '',
-                                buttonKey:
-                                    DebuggerConsole.copyToClipboardButtonKey,
-                              ),
-                              DeleteControl(
-                                buttonKey: DebuggerConsole.clearStdioButtonKey,
-                                tooltip: 'Clear console output',
-                                onPressed: () =>
-                                    serviceManager.consoleService.clearStdio(),
-                              ),
-                            ],
-                          )
+                          DebuggerConsole.buildHeader(),
                         ],
                         initialFractions: const [0.8, 0.2],
                       )

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -19,6 +19,7 @@ import 'common_widgets.dart';
 import 'config_specific/drag_and_drop/drag_and_drop.dart';
 import 'config_specific/ide_theme/ide_theme.dart';
 import 'config_specific/import_export/import_export.dart';
+import 'console.dart';
 import 'debugger/console.dart';
 import 'debugger/debugger_screen.dart';
 import 'framework_controller.dart';
@@ -78,7 +79,7 @@ class DevToolsScaffold extends StatefulWidget {
         horizontalPadding.left,
         isEmbedded() ? 2.0 : 16.0,
         horizontalPadding.right,
-        0.0,
+        isEmbedded() ? 0.0 : 8.0,
       );
 
   // Note: when changing this value, also update `flameChartContainerOffset`
@@ -361,6 +362,28 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
                             padding: DevToolsScaffold.horizontalPadding,
                             child: const DebuggerConsole(),
                           ),
+                        ],
+                        splitters: [
+                          AreaPaneHeader(
+                            title: const Text('Console'),
+                            needsTopBorder: false,
+                            rightActions: [
+                              CopyToClipboardControl(
+                                dataProvider: () =>
+                                    serviceManager.consoleService.stdio.value
+                                        ?.join('\n') ??
+                                    '',
+                                buttonKey:
+                                    DebuggerConsole.copyToClipboardButtonKey,
+                              ),
+                              DeleteControl(
+                                buttonKey: DebuggerConsole.clearStdioButtonKey,
+                                tooltip: 'Clear console output',
+                                onPressed: () =>
+                                    serviceManager.consoleService.clearStdio(),
+                              ),
+                            ],
+                          )
                         ],
                         initialFractions: const [0.8, 0.2],
                       )

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import 'common_widgets.dart';
 import 'config_specific/ide_theme/ide_theme.dart';
+import 'utils.dart';
 
 const _contrastForegroundWhite = Color.fromARGB(255, 240, 240, 240);
 
@@ -175,6 +176,8 @@ const defaultTabBarViewPhysics = NeverScrollableScrollPhysics();
 const defaultDialogWidth = 700.0;
 
 const defaultFontSize = 14.0;
+
+double get consoleLineHeight => scaleByFontFactor(18.0);
 
 /// Branded grey color.
 ///

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -42,7 +42,12 @@ void main() {
     Future<void> pumpConsole(
         WidgetTester tester, DebuggerController controller) async {
       await tester.pumpWidget(wrapWithControllers(
-        const DebuggerConsole(),
+        Row(
+          children: [
+            Flexible(child: DebuggerConsole.buildHeader()),
+            const Expanded(child: DebuggerConsole()),
+          ],
+        ),
         debugger: controller,
       ));
     }


### PR DESCRIPTION
![Screen Shot 2021-08-20 at 3 28 15 PM](https://user-images.githubusercontent.com/1226812/130299411-76f2becd-60e7-448a-abba-fa68f95043a2.png)
New implicit splitter that doubles as the title line better matches the rest of the debugger page.
Eval line is now just another line in the console leaving more room to view content when scrolling.
![small_gif](https://user-images.githubusercontent.com/1226812/130299670-6c858efe-37f6-43bb-b045-34e639ce4932.gif)
