### PR TITLE
Cancel timeline polling timer when the vmService is closed

### DIFF
--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -216,7 +216,8 @@ class PerformanceController extends DisposableController
       }));
 
       autoDispose(serviceManager.onConnectionClosed.listen((_) {
-        dispose();
+        _pollingTimer?.cancel();
+        _timelinePollingRateLimiter?.dispose();
       }));
 
       // Load available timeline events.

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -215,6 +215,10 @@ class PerformanceController extends DisposableController
         }
       }));
 
+      autoDispose(serviceManager.onConnectionClosed.listen((_) {
+        dispose();
+      }));
+
       // Load available timeline events.
       await _pullTraceEventsFromVmTimeline(shouldPrimeThreadIds: true);
 


### PR DESCRIPTION
Without this call, the timeline polling timer is never cancelled when the vm service disconnects.