### PR TITLE
Add a key set command for opening a file

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -5,7 +5,6 @@
 import 'package:codicon/codicon.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
-import 'package:flutter/services.dart';
 import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -13,7 +12,6 @@ import '../analytics/analytics_stub.dart'
     if (dart.library.html) '../analytics/analytics.dart' as ga;
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
-import '../config_specific/host_platform/host_platform.dart';
 import '../dialogs.dart';
 import '../flex_split_column.dart';
 import '../listenable.dart';
@@ -27,6 +25,7 @@ import 'codeview.dart';
 import 'controls.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
+import 'key_sets.dart';
 import 'scripts.dart';
 import 'variables.dart';
 
@@ -247,33 +246,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     );
   }
 }
-
-// TODO(kenz): consider breaking out the key binding logic out into a separate
-// file so it is easy to find.
-final LogicalKeySet focusLibraryFilterKeySet = LogicalKeySet(
-  HostPlatform.instance.isMacOS
-      ? LogicalKeyboardKey.meta
-      : LogicalKeyboardKey.control,
-  LogicalKeyboardKey.keyP,
-);
-
-final LogicalKeySet goToLineNumberKeySet = LogicalKeySet(
-  HostPlatform.instance.isMacOS
-      ? LogicalKeyboardKey.meta
-      : LogicalKeyboardKey.control,
-  LogicalKeyboardKey.keyG,
-);
-
-final LogicalKeySet searchInFileKeySet = LogicalKeySet(
-  HostPlatform.instance.isMacOS
-      ? LogicalKeyboardKey.meta
-      : LogicalKeyboardKey.control,
-  LogicalKeyboardKey.keyF,
-);
-
-final LogicalKeySet escapeKeySet = LogicalKeySet(
-  LogicalKeyboardKey.escape,
-);
 
 class FocusLibraryFilterIntent extends Intent {
   const FocusLibraryFilterIntent(

--- a/packages/devtools_app/lib/src/debugger/key_sets.dart
+++ b/packages/devtools_app/lib/src/debugger/key_sets.dart
@@ -32,5 +32,5 @@ final LogicalKeySet openFileKeySet = LogicalKeySet(
   HostPlatform.instance.isMacOS
       ? LogicalKeyboardKey.meta
       : LogicalKeyboardKey.control,
-  LogicalKeyboardKey.keyP,
+  LogicalKeyboardKey.keyO,
 );

--- a/packages/devtools_app/lib/src/debugger/key_sets.dart
+++ b/packages/devtools_app/lib/src/debugger/key_sets.dart
@@ -28,6 +28,7 @@ final LogicalKeySet escapeKeySet = LogicalKeySet(
   LogicalKeyboardKey.escape,
 );
 
+// TODO(elliette): Change to cmd/ctrl + P once focus library filter is removed.
 final LogicalKeySet openFileKeySet = LogicalKeySet(
   HostPlatform.instance.isMacOS
       ? LogicalKeyboardKey.meta

--- a/packages/devtools_app/lib/src/debugger/key_sets.dart
+++ b/packages/devtools_app/lib/src/debugger/key_sets.dart
@@ -1,0 +1,36 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import '../config_specific/host_platform/host_platform.dart';
+
+final LogicalKeySet focusLibraryFilterKeySet = LogicalKeySet(
+  HostPlatform.instance.isMacOS
+      ? LogicalKeyboardKey.meta
+      : LogicalKeyboardKey.control,
+  LogicalKeyboardKey.keyP,
+);
+
+final LogicalKeySet goToLineNumberKeySet = LogicalKeySet(
+  HostPlatform.instance.isMacOS
+      ? LogicalKeyboardKey.meta
+      : LogicalKeyboardKey.control,
+  LogicalKeyboardKey.keyG,
+);
+
+final LogicalKeySet searchInFileKeySet = LogicalKeySet(
+  HostPlatform.instance.isMacOS
+      ? LogicalKeyboardKey.meta
+      : LogicalKeyboardKey.control,
+  LogicalKeyboardKey.keyF,
+);
+
+final LogicalKeySet escapeKeySet = LogicalKeySet(
+  LogicalKeyboardKey.escape,
+);
+
+final LogicalKeySet openFileKeySet = LogicalKeySet(
+  HostPlatform.instance.isMacOS
+      ? LogicalKeyboardKey.meta
+      : LogicalKeyboardKey.control,
+  LogicalKeyboardKey.keyP,
+);

--- a/packages/devtools_app/lib/src/debugger/scripts.dart
+++ b/packages/devtools_app/lib/src/debugger/scripts.dart
@@ -12,7 +12,7 @@ import '../tree.dart';
 import '../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
-import 'debugger_screen.dart';
+import 'key_sets.dart';
 
 const containerIcon = Icons.folder;
 const libraryIcon = Icons.insert_chart;


### PR DESCRIPTION
Adds `CTRL + P` / `CMD + P` as a key set, which will be used to open the file opener dialog. 

Also pulls the key sets definitions out into their own file within the debugger directory.