### PR TITLE
Don't wait for stream registration in `openVmService`

### DIFF
--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -317,6 +317,9 @@ class ServiceConnectionManager {
     }
 
     _connectionAvailableController.add(service);
+
+    // Clear the isolates cache:
+    isolateManager.clearIsolateIdCache();
   }
 
   void manuallyDisconnect() {
@@ -744,6 +747,10 @@ class IsolateManager extends Disposer {
 
   Future<Isolate> getIsolateCachedById(String isolateId) async {
     return _isolatesCache[isolateId] ??= await _service.getIsolate(isolateId);
+  }
+
+  void clearIsolateIdCache() {
+    _isolatesCache.clear();
   }
 
   void _handleDebugEvent(Event event) {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -275,7 +275,7 @@ class ServiceConnectionManager {
       serviceStreamName,
     ];
 
-    await Future.wait(streamIds.map((String id) async {
+    unawaited(Future.wait(streamIds.map((String id) async {
       try {
         await service.streamListen(id);
       } catch (e) {
@@ -289,7 +289,7 @@ class ServiceConnectionManager {
           );
         }
       }
-    }));
+    })));
     if (service != this.service) {
       // A different service has been opened.
       return;

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -372,13 +372,16 @@ class VmServiceWrapper implements VmService {
 
   @override
   Future<Isolate> getIsolate(String isolateId) async {
-    if (_isolatesCache.containsKey(isolateId)) {
-      return Future.value(_isolatesCache[isolateId]);
-    }
-    final isolate =
+    return _isolatesCache[isolateId] ??=
         await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
-    _isolatesCache[isolateId] = isolate;
-    return isolate;
+
+    // if (_isolatesCache.containsKey(isolateId)) {
+    //   return Future.value(_isolatesCache[isolateId]);
+    // }
+    // final isolate =
+    //     await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
+    // _isolatesCache[isolateId] = isolate;
+    // return isolate;
   }
 
   @override
@@ -647,8 +650,10 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Version> getVersion() =>
-      trackFuture('getVersion', _vmService.getVersion());
+  Future<Version> getVersion() async {
+    return _protocolVersion ??=
+        await trackFuture('getVersion', _vmService.getVersion());
+  }
 
   Future<Version> getDartIOVersion(String isolateId) =>
       trackFuture('_getDartIOVersion', _vmService.getDartIOVersion(isolateId));

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -39,6 +39,7 @@ class VmServiceWrapper implements VmService {
   Version _protocolVersion;
   Version _dartIoVersion;
   Version _ddsVersion;
+  final _isolatesCache = <String, Isolate>{};
 
   Future<void> initServiceVersions() async {
     // Note: We cannot init [_dartIoVersion] here because it requires an
@@ -370,8 +371,14 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Isolate> getIsolate(String isolateId) {
-    return trackFuture('getIsolate', _vmService.getIsolate(isolateId));
+  Future<Isolate> getIsolate(String isolateId) async {
+    if (_isolatesCache.containsKey(isolateId)) {
+      return Future.value(_isolatesCache[isolateId]);
+    }
+    final isolate =
+        await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
+    _isolatesCache[isolateId] = isolate;
+    return isolate;
   }
 
   @override

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -39,7 +39,6 @@ class VmServiceWrapper implements VmService {
   Version _protocolVersion;
   Version _dartIoVersion;
   Version _ddsVersion;
-  final _isolatesCache = <String, Isolate>{};
 
   Future<void> initServiceVersions() async {
     // Note: We cannot init [_dartIoVersion] here because it requires an
@@ -371,9 +370,8 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Isolate> getIsolate(String isolateId) async {
-    return _isolatesCache[isolateId] ??=
-        await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
+  Future<Isolate> getIsolate(String isolateId) {
+    return trackFuture('getIsolate', _vmService.getIsolate(isolateId));
   }
 
   @override

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -374,14 +374,6 @@ class VmServiceWrapper implements VmService {
   Future<Isolate> getIsolate(String isolateId) async {
     return _isolatesCache[isolateId] ??=
         await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
-
-    // if (_isolatesCache.containsKey(isolateId)) {
-    //   return Future.value(_isolatesCache[isolateId]);
-    // }
-    // final isolate =
-    //     await trackFuture('getIsolate', _vmService.getIsolate(isolateId));
-    // _isolatesCache[isolateId] = isolate;
-    // return isolate;
   }
 
   @override


### PR DESCRIPTION
The streams take a fair amount of time to load. I don't think we need to block loading the app on listening to all the streams.