### PR TITLE
Don't wait on stream listening in DevTools start up

### DIFF
--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -273,7 +273,7 @@ class ServiceConnectionManager {
       serviceStreamName,
     ];
 
-    await Future.wait(streamIds.map((String id) async {
+    unawaited(Future.wait(streamIds.map((String id) async {
       try {
         await service.streamListen(id);
       } catch (e) {
@@ -287,7 +287,7 @@ class ServiceConnectionManager {
           );
         }
       }
-    }));
+    })));
     if (service != this.service) {
       // A different service has been opened.
       return;


### PR DESCRIPTION
We are currently `awaiting` setting up listeners on all the streams in the `vmServiceOpened` method. This can take ~300 ms to complete. I don't think it's necessary for us to block on getting the listeners registered.


Note: I've also opened https://github.com/dart-lang/sdk/issues/47042 to investigate the weird throttling behavior I'm seeing on these requests.