### PR TITLE
Revert "Don't wait on stream listening in DevTools start up"

### DIFF
--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -273,7 +273,7 @@ class ServiceConnectionManager {
       serviceStreamName,
     ];
 
-    unawaited(Future.wait(streamIds.map((String id) async {
+    await Future.wait(streamIds.map((String id) async {
       try {
         await service.streamListen(id);
       } catch (e) {
@@ -287,7 +287,7 @@ class ServiceConnectionManager {
           );
         }
       }
-    })));
+    }));
     if (service != this.service) {
       // A different service has been opened.
       return;


### PR DESCRIPTION
Temporarily reverts flutter/devtools#3320 so that it doesn't sneak into the release.