### PR TITLE
Add `reportLines` parameter to the `getSourceReport` override

### DIFF
--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -414,6 +414,7 @@ class VmServiceWrapper implements VmService {
     int tokenPos,
     int endTokenPos,
     bool forceCompile,
+    bool reportLines,
   }) async {
     // Workaround for https://github.com/flutter/devtools/issues/2981.
     // TODO(bkonyi): remove after Flutter stable is on Dart SDK > 2.12.
@@ -434,6 +435,7 @@ class VmServiceWrapper implements VmService {
           tokenPos: tokenPos,
           endTokenPos: endTokenPos,
           forceCompile: forceCompile,
+          reportLines: reportLines,
         ));
   }
 


### PR DESCRIPTION
This optional parameter was added to the VM Service recently: https://github.com/dart-lang/sdk/commit/011068f8242b1f9f6ce9dcd96551591bdd585b25
