### PR TITLE
Update CPU profiler colors to make them accessible

### DIFF
--- a/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
@@ -466,7 +466,7 @@ class LegacyTimelineFlameChartState
         key: Key('${event.name} ${event.traceEvents.first.wrapperId}'),
         text: event.name,
         rect: Rect.fromLTRB(left, flameChartNodeTop, right, rowHeight),
-        colorPair: colorPair,
+        colorPair: ThemedColorPair.from(colorPair),
         data: event,
         onSelected: (dynamic event) => widget.onDataSelected(event),
         sectionIndex: section,

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -533,7 +533,7 @@ class TimelineFlameChartState
         key: Key('${event.name} ${event.traceEvents.first.wrapperId}'),
         text: event.name,
         rect: Rect.fromLTRB(left, flameChartNodeTop, right, rowHeight),
-        colorPair: colorPair,
+        colorPair: ThemedColorPair.from(colorPair),
         data: event,
         onSelected: (dynamic event) => widget.onDataSelected(event),
         sectionIndex: section,

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_flame_chart.dart
@@ -153,12 +153,10 @@ class _CpuProfileFlameChartState
     return left;
   }
 
-  // TODO(kenz): base colors on categories (Widget, Render, Layer, User code,
-  // etc.)
-  ColorPair _colorPairForStackFrame(CpuStackFrame stackFrame) {
+  ThemedColorPair _colorPairForStackFrame(CpuStackFrame stackFrame) {
     if (stackFrame.isNative) return nativeCodeColor;
     if (stackFrame.isDartCore) return dartCoreColor;
     if (stackFrame.isFlutterCore) return flutterCoreColor;
-    return cpuFlameChartNodeColor;
+    return appCodeColor;
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -181,19 +181,19 @@ class _CpuProfilerState extends State<CpuProfiler>
                             entries: [
                               LegendEntry(
                                 'App code (code from your app and imported packages)',
-                                cpuFlameChartNodeColor.background,
+                                appCodeColor.background.colorFor(context),
                               ),
                               LegendEntry(
                                 'Native code (code from the native runtime - Android, iOS, etc.)',
-                                nativeCodeColor.background,
+                                nativeCodeColor.background.colorFor(context),
                               ),
                               LegendEntry(
                                 'Dart core libraries (code from the Dart SDK)',
-                                dartCoreColor.background,
+                                dartCoreColor.background.colorFor(context),
                               ),
                               LegendEntry(
                                 'Flutter Framework (code from the Flutter SDK)',
-                                flutterCoreColor.background,
+                                flutterCoreColor.background.colorFor(context),
                               ),
                             ],
                           ),

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -77,19 +77,46 @@ const treemapDecreaseColor = Color(0xFF77102F);
 const tableIncreaseColor = Color(0xFF73BF43);
 const tableDecreaseColor = Color(0xFFEE284F);
 
-const dartCoreColor = ColorPair(
-  background: mainRasterColor,
-  foreground: contrastForegroundWhite,
+const appCodeColor = ThemedColorPair(
+  background: ThemedColor(
+    light: Color(0xFFFCAD70),
+    dark: Color(0xFFFCAD70),
+  ),
+  foreground: ThemedColor(
+    light: Color(0xFF202124),
+    dark: Color(0xFF202124),
+  ),
 );
-const flutterCoreColor = ColorPair(
-  background: Color(0xFF027DFD),
-  foreground: contrastForegroundWhite,
+
+const nativeCodeColor = ThemedColorPair(
+  background: ThemedColor(
+    light: Color(0xFF007B83),
+    dark: Color(0xFF72B6C6),
+  ),
+  foreground: ThemedColor(
+    light: Color(0xFFF8F9FA),
+    dark: Color(0xFF202124),
+  ),
 );
-const nativeCodeColor = ColorPair(
-  background: Color(0xFF9E9E9E),
-  foreground: contrastForegroundWhite,
+
+const flutterCoreColor = ThemedColorPair(
+  background: ThemedColor(
+    light: Color(0xFF6864D3),
+    dark: Color(0xFF928EF9),
+  ),
+  foreground: ThemedColor(
+    light: Color(0xFFF8F9FA),
+    dark: Color(0xFF202124),
+  ),
 );
-const cpuFlameChartNodeColor = ColorPair(
-  background: Color(0xFFB8EAFE),
-  foreground: Colors.black,
+
+const dartCoreColor = ThemedColorPair(
+  background: ThemedColor(
+    light: Color(0xFF1D649C),
+    dark: Color(0xFF6887F7),
+  ),
+  foreground: ThemedColor(
+    light: Color(0xFFF8F9FA),
+    dark: Color(0xFF202124),
+  ),
 );

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -77,15 +77,12 @@ const treemapDecreaseColor = Color(0xFF77102F);
 const tableIncreaseColor = Color(0xFF73BF43);
 const tableDecreaseColor = Color(0xFFEE284F);
 
-const appCodeColor = ThemedColorPair(
-  background: ThemedColor(
-    light: Color(0xFFFCAD70),
+final appCodeColor = ThemedColorPair(
+  background: const ThemedColor(
+    light: Color(0xFFFA7B17),
     dark: Color(0xFFFCAD70),
   ),
-  foreground: ThemedColor(
-    light: Color(0xFF202124),
-    dark: Color(0xFF202124),
-  ),
+  foreground: ThemedColor.fromSingle(Color(0xFF202124)),
 );
 
 const nativeCodeColor = ThemedColorPair(

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import '../auto_dispose_mixin.dart';
+import '../theme.dart';
 
 /// Stateful Checkbox Widget class using a [ValueNotifier].
 ///
@@ -226,4 +227,40 @@ class ColorPair {
   final Color foreground;
 
   final Color background;
+}
+
+class ThemedColorPair {
+  const ThemedColorPair({@required this.background, @required this.foreground});
+
+  factory ThemedColorPair.from(ColorPair colorPair) {
+    return ThemedColorPair(
+      foreground: ThemedColor.fromSingle(colorPair.foreground),
+      background: ThemedColor.fromSingle(colorPair.background),
+    );
+  }
+
+  final ThemedColor foreground;
+
+  final ThemedColor background;
+}
+
+/// A theme-dependent color.
+///
+/// When possible, themed colors should be specified in an extension on
+/// [ColorScheme] using the [ColorScheme.isLight] getter. However, this class
+/// may be used when access to the [BuildContext] is not available at the time
+/// the color needs to be specified.
+class ThemedColor {
+  const ThemedColor({this.light, this.dark});
+
+  factory ThemedColor.fromSingle(Color color) =>
+      ThemedColor(light: color, dark: color);
+
+  final Color light;
+
+  final Color dark;
+
+  Color colorFor(BuildContext context) {
+    return Theme.of(context).colorScheme.isLight ? light : dark;
+  }
 }

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -294,16 +294,21 @@ void main() {
       double zoom = defaultZoom,
     }) async {
       node ??= testNode;
-      await tester.pumpWidget(Directionality(
-        textDirection: TextDirection.ltr,
-        child: node.buildWidget(
-          selected: selected,
-          searchMatch: false,
-          activeSearchMatch: false,
-          hovered: hovered,
-          zoom: zoom,
+      await tester.pumpWidget(
+        Builder(
+          builder: (context) => Directionality(
+            textDirection: TextDirection.ltr,
+            child: node.buildWidget(
+              context,
+              selected: selected,
+              searchMatch: false,
+              activeSearchMatch: false,
+              hovered: hovered,
+              zoom: zoom,
+            ),
+          ),
         ),
-      ));
+      );
     }
 
     Future<void> pumpFlameChartNodeWithOverlay(
@@ -320,6 +325,7 @@ void main() {
             OverlayEntry(
               builder: (BuildContext context) {
                 return testNode.buildWidget(
+                  context,
                   selected: _selected,
                   searchMatch: false,
                   activeSearchMatch: false,
@@ -559,7 +565,9 @@ final narrowNode = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Narrow test node',
   rect: Rect.fromLTWH(23.0, 0.0, 21.9, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;
@@ -570,7 +578,9 @@ final testNode = FlameChartNode<TimelineEvent>(
   text: 'Test node 1',
   // 30.0 is the minimum node width for text.
   rect: Rect.fromLTWH(70.0, 0.0, 30.0, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;
@@ -578,8 +588,10 @@ final testNode = FlameChartNode<TimelineEvent>(
 final testNode2 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 2',
-  rect:  Rect.fromLTWH(120.0, 0.0, 50.0, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  rect: Rect.fromLTWH(120.0, 0.0, 50.0, rowHeight),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;
@@ -587,8 +599,10 @@ final testNode2 = FlameChartNode<TimelineEvent>(
 final testNode3 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 3',
-  rect:  Rect.fromLTWH(180.0, 0.0, 50.0, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  rect: Rect.fromLTWH(180.0, 0.0, 50.0, rowHeight),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;
@@ -597,7 +611,9 @@ final testNode4 = FlameChartNode<TimelineEvent>(
   key: narrowNodeKey,
   text: 'Test node 4',
   rect: Rect.fromLTWH(240.0, 0.0, 300.0, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;
@@ -613,8 +629,10 @@ const noWidthNodeKey = Key('no-width node');
 final negativeWidthNode = FlameChartNode<TimelineEvent>(
   key: noWidthNodeKey,
   text: 'No-width node',
-  rect:  Rect.fromLTWH(1.0, 0.0, -0.1, rowHeight),
-  colorPair: const ColorPair(background: Colors.blue, foreground: Colors.white),
+  rect: Rect.fromLTWH(1.0, 0.0, -0.1, rowHeight),
+  colorPair: ThemedColorPair.from(
+    const ColorPair(background: Colors.blue, foreground: Colors.white),
+  ),
   data: goldenAsyncTimelineEvent,
   onSelected: (_) {},
 )..sectionIndex = 0;


### PR DESCRIPTION
Color changes per UX guidance in discussion on https://github.com/flutter/devtools/pull/3310

This required some refactoring to support theme dependent colors where `context` is not available (`initState`). 