### PR TITLE
Restructure analytics code so that the AnalyticsController can be tested

### DIFF
--- a/packages/devtools_app/lib/src/analytics/_analytics_controller_stub.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_controller_stub.dart
@@ -4,9 +4,8 @@
 
 import 'dart:async';
 
-import 'analytics_common.dart';
+import 'analytics_controller.dart';
 
-FutureOr<AnalyticsController> get analyticsController => _controller;
-AnalyticsController _controller = AnalyticsController();
-
-class AnalyticsController extends AnalyticsControllerBase {}
+FutureOr<AnalyticsController> get devToolsAnalyticsController => _controller;
+AnalyticsController _controller =
+    AnalyticsController(enabled: false, firstRun: false);

--- a/packages/devtools_app/lib/src/analytics/_analytics_controller_web.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_controller_web.dart
@@ -4,71 +4,11 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
-
 import '../config_specific/server/server.dart' as server;
-// It is okay to import the web analytics here because this file is a web
-// specific implementation itself.
-import '_analytics_web.dart' as ga;
-import 'analytics_common.dart';
+import 'analytics.dart' as ga;
+import 'analytics_controller.dart';
 
-class AnalyticsController implements AnalyticsControllerBase {
-  AnalyticsController(
-    bool enabled,
-    bool firstRun,
-  )   : _analyticsEnabled = ValueNotifier<bool>(enabled),
-        _shouldPrompt = ValueNotifier<bool>(firstRun && !enabled) {
-    if (_shouldPrompt.value) {
-      toggleAnalyticsEnabled(true);
-    }
-    if (_analyticsEnabled.value) {
-      setUpAnalytics();
-    }
-  }
-
-  @override
-  ValueListenable<bool> get analyticsEnabled => _analyticsEnabled;
-  final ValueNotifier<bool> _analyticsEnabled;
-
-  @override
-  ValueListenable<bool> get shouldPrompt => _shouldPrompt;
-  final ValueNotifier<bool> _shouldPrompt;
-
-  @override
-  bool get analyticsInitialized => _analyticsInitialized;
-  bool _analyticsInitialized = false;
-
-  @override
-  Future<void> toggleAnalyticsEnabled(bool enable) async {
-    if (enable) {
-      _analyticsEnabled.value = true;
-      if (!_analyticsInitialized) {
-        setUpAnalytics();
-      }
-      await ga.enableAnalytics();
-    } else {
-      _analyticsEnabled.value = false;
-      hidePrompt();
-      await ga.disableAnalytics();
-    }
-  }
-
-  @override
-  void setUpAnalytics() {
-    if (_analyticsInitialized) return;
-    assert(_analyticsEnabled.value = true);
-    ga.initializeGA();
-    ga.jsHookupListenerForGA();
-    _analyticsInitialized = true;
-  }
-
-  @override
-  void hidePrompt() {
-    _shouldPrompt.value = false;
-  }
-}
-
-Future<AnalyticsController> get analyticsController async {
+Future<AnalyticsController> get devToolsAnalyticsController async {
   if (_controllerCompleter != null) return _controllerCompleter.future;
   _controllerCompleter = Completer<AnalyticsController>();
   var enabled = false;
@@ -83,8 +23,19 @@ Future<AnalyticsController> get analyticsController async {
   } catch (_) {
     // Ignore issues if analytics could not be initialized.
   }
-  _controllerCompleter.complete(AnalyticsController(enabled, firstRun));
+  _controllerCompleter.complete(
+    AnalyticsController(
+      enabled: enabled,
+      firstRun: firstRun,
+      onEnableAnalytics: ga.enableAnalytics,
+      onDisableAnalytics: ga.disableAnalytics,
+      onSetupAnalytics: () {
+        ga.initializeGA();
+        ga.jsHookupListenerForGA();
+      },
+    ),
+  );
   return _controllerCompleter.future;
 }
 
-Completer<AnalyticsControllerBase> _controllerCompleter;
+Completer<AnalyticsController> _controllerCompleter;

--- a/packages/devtools_app/lib/src/analytics/_analytics_stub.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_stub.dart
@@ -13,6 +13,14 @@ Future<void> setAnalyticsEnabled(bool value) async {}
 
 FutureOr<bool> isAnalyticsEnabled() => false;
 
+void initializeGA() {}
+
+void jsHookupListenerForGA() {}
+
+Future<void> enableAnalytics() async {}
+
+Future<void> disableAnalytics() async {}
+
 void screen(
   String screenName, [
   int value = 0,

--- a/packages/devtools_app/lib/src/analytics/analytics_common.dart
+++ b/packages/devtools_app/lib/src/analytics/analytics_common.dart
@@ -5,8 +5,6 @@
 // Code in this file should be able to be imported by both dart:html and
 // dart:io dependent libraries.
 
-import 'package:flutter/foundation.dart';
-
 /// Base class for all screen metrics classes.
 ///
 /// Create a subclass of this class to store custom metrics for a screen. All
@@ -25,13 +23,3 @@ import 'package:flutter/foundation.dart';
 /// Then, add your fields to the `GtagEventDevTools.withScreenMetrics` factory
 /// constructor.
 abstract class ScreenAnalyticsMetrics {}
-
-@protected
-abstract class AnalyticsControllerBase {
-  final ValueListenable<bool> analyticsEnabled = ValueNotifier<bool>(false);
-  final ValueListenable<bool> shouldPrompt = ValueNotifier<bool>(false);
-  bool get analyticsInitialized => false;
-  Future<void> toggleAnalyticsEnabled(bool enable) async {}
-  void setUpAnalytics() {}
-  void hidePrompt() {}
-}

--- a/packages/devtools_app/lib/src/analytics/analytics_controller.dart
+++ b/packages/devtools_app/lib/src/analytics/analytics_controller.dart
@@ -2,5 +2,78 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export '_analytics_controller_stub.dart'
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '_analytics_controller_stub.dart'
     if (dart.library.html) '_analytics_controller_web.dart';
+
+Future<AnalyticsController> get analyticsController async =>
+    await devToolsAnalyticsController;
+
+typedef AsyncAnalyticsCallback = FutureOr<void> Function();
+
+class AnalyticsController {
+  AnalyticsController({
+    @required bool enabled,
+    @required bool firstRun,
+    this.onEnableAnalytics,
+    this.onDisableAnalytics,
+    this.onSetupAnalytics,
+  })  : _analyticsEnabled = ValueNotifier<bool>(enabled),
+        _shouldPrompt = ValueNotifier<bool>(firstRun && !enabled) {
+    if (_shouldPrompt.value) {
+      toggleAnalyticsEnabled(true);
+    }
+    if (_analyticsEnabled.value) {
+      setUpAnalytics();
+    }
+  }
+
+  ValueListenable<bool> get analyticsEnabled => _analyticsEnabled;
+  final ValueNotifier<bool> _analyticsEnabled;
+
+  ValueListenable<bool> get shouldPrompt => _shouldPrompt;
+  final ValueNotifier<bool> _shouldPrompt;
+
+  bool get analyticsInitialized => _analyticsInitialized;
+  bool _analyticsInitialized = false;
+
+  final AsyncAnalyticsCallback onEnableAnalytics;
+
+  final AsyncAnalyticsCallback onDisableAnalytics;
+
+  final VoidCallback onSetupAnalytics;
+
+  Future<void> toggleAnalyticsEnabled(bool enable) async {
+    if (enable) {
+      _analyticsEnabled.value = true;
+      if (!_analyticsInitialized) {
+        setUpAnalytics();
+      }
+      if (onEnableAnalytics != null) {
+        await onEnableAnalytics();
+      }
+    } else {
+      _analyticsEnabled.value = false;
+      hidePrompt();
+      if (onDisableAnalytics != null) {
+        await onDisableAnalytics();
+      }
+    }
+  }
+
+  void setUpAnalytics() {
+    if (_analyticsInitialized) return;
+    assert(_analyticsEnabled.value = true);
+    if (onSetupAnalytics != null) {
+      onSetupAnalytics();
+    }
+    _analyticsInitialized = true;
+  }
+
+  void hidePrompt() {
+    _shouldPrompt.value = false;
+  }
+}

--- a/packages/devtools_app/test/scaffold_test.dart
+++ b/packages/devtools_app/test/scaffold_test.dart
@@ -138,7 +138,7 @@ void main() {
             ideTheme: null,
           ),
           debugger: mockDebuggerController,
-          analytics: AnalyticsController(),
+          analytics: AnalyticsController(enabled: false, firstRun: false),
         ),
       );
       expect(find.byKey(k1), findsOneWidget);
@@ -174,7 +174,7 @@ void main() {
             ideTheme: null,
           ),
           debugger: mockDebuggerController,
-          analytics: AnalyticsController(),
+          analytics: AnalyticsController(enabled: false, firstRun: false),
         ),
       );
       expect(find.byKey(debuggerScreenKey), findsOneWidget);

--- a/packages/devtools_app/test/support/wrappers.dart
+++ b/packages/devtools_app/test/support/wrappers.dart
@@ -54,7 +54,7 @@ Widget wrapWithAnalytics(
   Widget widget, {
   AnalyticsController controller,
 }) {
-  controller ??= AnalyticsController();
+  controller ??= AnalyticsController(enabled: false, firstRun: false);
   return Provider<AnalyticsController>.value(
     value: controller,
     child: widget,


### PR DESCRIPTION
This allows the core functionality of AnalyticsController to be used for desktop and web platforms, and breaks out the platform specific code into callbacks. This also allows for better testing in that we can actually use a real controller in tests instead of a fake controller that was a copy of the web implementation. This was fragile and easy to fall out of date with the real controller code.