### PR TITLE
Adding missing async / await code in the debugger controller

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -169,7 +169,9 @@ class _CodeViewState extends State<CodeView>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
 
-    if (scriptRef == null) {
+    // Only show the 'No script selected' text when the controller has already
+    // been initialized.
+    if (scriptRef == null && widget.controller.initialized) {
       return Center(
         child: Text(
           'No script selected',

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -75,7 +75,7 @@ class DebuggerController extends DisposableController
 
   VmServiceWrapper _lastService;
 
-  void _handleConnectionAvailable(VmServiceWrapper service) async {
+  Future<void> _handleConnectionAvailable(VmServiceWrapper service) async {
     if (service == _lastService) return;
     _lastService = service;
     onServiceShutdown();

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -206,8 +206,10 @@ void main() {
         // TODO(elliette): https://github.com/flutter/flutter/pull/88152 fixes
         // this so that forcing a scroll event is no longer necessary. Remove
         // once the change is in the stable release.
-        debuggerController.showScriptLocation(ScriptLocation(mockScriptRef,
-            location: SourcePosition(line: 50, column: 50)));
+        await debuggerController.showScriptLocation(ScriptLocation(
+          mockScriptRef,
+          location: SourcePosition(line: 50, column: 50),
+        ));
         await tester.pumpAndSettle();
 
         expect(find.byType(Scrollbar), findsNWidgets(2));

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -649,6 +649,7 @@ class MockDebuggerController extends Mock implements DebuggerController {
     when(debuggerController.variables).thenReturn(ValueNotifier([]));
     when(debuggerController.currentParsedScript)
         .thenReturn(ValueNotifier<ParsedScript>(null));
+    when(debuggerController.initialized).thenReturn(true);
     return debuggerController;
   }
 }


### PR DESCRIPTION
We'd like to be able to measure when the debugger page has finished initializing and is ready for user interaction. The end of the `initialize` method seems like a natural spot for this, but there were several unawaited futures that were still executing at the time that the `initialize` method ended. 