### PR TITLE
Enable the file opener

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -32,8 +32,6 @@ import 'file_search.dart';
 import 'hover.dart';
 import 'variables.dart';
 
-const openFileDialogEnabled = false;
-
 final debuggerCodeViewSearchKey =
     GlobalKey(debugLabel: 'DebuggerCodeViewSearchKey');
 
@@ -172,7 +170,7 @@ class _CodeViewState extends State<CodeView>
     if (scriptRef == null) {
       return Center(
         child: Text(
-          'No script selected',
+          'Open a file: ⌘ P',
           style: theme.textTheme.subtitle1,
         ),
       );
@@ -1059,7 +1057,7 @@ class ScriptPopupMenuOption {
 final defaultScriptPopupMenuOptions = [
   copyScriptNameOption,
   goToLineOption,
-  if (openFileDialogEnabled) openFileOption,
+  openFileOption,
 ];
 
 final copyScriptNameOption = ScriptPopupMenuOption(
@@ -1084,12 +1082,10 @@ const goToLineOption = ScriptPopupMenuOption(
 );
 
 void showOpenFileDialog(BuildContext context, DebuggerController controller) {
-  if (openFileDialogEnabled) {
-    showDialog(
-      context: context,
-      builder: (context) => OpenFileDialog(controller),
-    );
-  }
+  showDialog(
+    context: context,
+    builder: (context) => OpenFileDialog(controller),
+  );
 }
 
 const openFileOption = ScriptPopupMenuOption(

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -30,6 +30,7 @@ import 'debugger_controller.dart';
 import 'debugger_model.dart';
 import 'file_search.dart';
 import 'hover.dart';
+import 'key_sets.dart';
 import 'variables.dart';
 
 final debuggerCodeViewSearchKey =
@@ -170,7 +171,7 @@ class _CodeViewState extends State<CodeView>
     if (scriptRef == null) {
       return Center(
         child: Text(
-          'Open a file: ⌘ P',
+          'Open a file: $openFileKeySetDescription',
           style: theme.textTheme.subtitle1,
         ),
       );
@@ -1075,8 +1076,8 @@ void showGoToLineDialog(BuildContext context, DebuggerController controller) {
   );
 }
 
-const goToLineOption = ScriptPopupMenuOption(
-  label: 'Go to line number (⌘ G)',
+final goToLineOption = ScriptPopupMenuOption(
+  label: 'Go to line number ($goToLineNumberKeySetDescription)',
   icon: Icons.list,
   onSelected: showGoToLineDialog,
 );
@@ -1088,8 +1089,8 @@ void showOpenFileDialog(BuildContext context, DebuggerController controller) {
   );
 }
 
-const openFileOption = ScriptPopupMenuOption(
-  label: 'Open file (⌘ P)',
+final openFileOption = ScriptPopupMenuOption(
+  label: 'Open file ($openFileKeySetDescription)',
   icon: Icons.folder_open,
   onSelected: showOpenFileDialog,
 );

--- a/packages/devtools_app/lib/src/debugger/key_sets.dart
+++ b/packages/devtools_app/lib/src/debugger/key_sets.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../config_specific/host_platform/host_platform.dart';
+import '../utils.dart';
 
 final LogicalKeySet goToLineNumberKeySet = LogicalKeySet(
   HostPlatform.instance.isMacOS
@@ -9,6 +10,9 @@ final LogicalKeySet goToLineNumberKeySet = LogicalKeySet(
       : LogicalKeyboardKey.control,
   LogicalKeyboardKey.keyG,
 );
+
+final String goToLineNumberKeySetDescription =
+    goToLineNumberKeySet.describeKeys(isMacOS: HostPlatform.instance.isMacOS);
 
 final LogicalKeySet searchInFileKeySet = LogicalKeySet(
   HostPlatform.instance.isMacOS
@@ -27,3 +31,6 @@ final LogicalKeySet openFileKeySet = LogicalKeySet(
       : LogicalKeyboardKey.control,
   LogicalKeyboardKey.keyP,
 );
+
+final String openFileKeySetDescription =
+    openFileKeySet.describeKeys(isMacOS: HostPlatform.instance.isMacOS);


### PR DESCRIPTION
Enables the file opener dialog. Since it's now enabled, also changes the text when no file is opened to specify how to open a new file. 