### PR TITLE
Use "Command" instead of special character ⌘ on web

### DIFF
--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -966,7 +966,8 @@ extension LogicalKeySetExtension on LogicalKeySet {
     return sortedKeys.map((key) {
       if (_modifiers.contains(key)) {
         if (isMacOS && key == LogicalKeyboardKey.meta) {
-          return '⌘';
+          // TODO(issue #3352) Switch back to using ⌘ once supported on web.
+          return kIsWeb ? 'Command-' : '⌘';
         }
         return '${_modifierNames[key]}-';
       } else {

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -966,7 +966,7 @@ extension LogicalKeySetExtension on LogicalKeySet {
     return sortedKeys.map((key) {
       if (_modifiers.contains(key)) {
         if (isMacOS && key == LogicalKeyboardKey.meta) {
-          // TODO(issue #3352) Switch back to using ⌘ once supported on web.
+          // TODO(elliette) Switch back to using ⌘ once supported on web.
           return kIsWeb ? 'Command-' : '⌘';
         }
         return '${_modifierNames[key]}-';

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -966,7 +966,7 @@ extension LogicalKeySetExtension on LogicalKeySet {
     return sortedKeys.map((key) {
       if (_modifiers.contains(key)) {
         if (isMacOS && key == LogicalKeyboardKey.meta) {
-          // TODO(elliette) Switch back to using ⌘ once supported on web.
+          // TODO(#3352) Switch back to using ⌘ once supported on web.
           return kIsWeb ? 'Command-' : '⌘';
         }
         return '${_modifierNames[key]}-';

--- a/packages/devtools_app/lib/src/utils.dart
+++ b/packages/devtools_app/lib/src/utils.dart
@@ -966,7 +966,8 @@ extension LogicalKeySetExtension on LogicalKeySet {
     return sortedKeys.map((key) {
       if (_modifiers.contains(key)) {
         if (isMacOS && key == LogicalKeyboardKey.meta) {
-          // TODO(#3352) Switch back to using ⌘ once supported on web.
+          // TODO(https://github.com/flutter/devtools/issues/3352) Switch back
+          // to using ⌘ once supported on web.
           return kIsWeb ? 'Command-' : '⌘';
         }
         return '${_modifierNames[key]}-';


### PR DESCRIPTION
See https://github.com/flutter/devtools/issues/3352 for details

Temporary workaround until rendering issue is fixed in Flutter.