### PR TITLE
Moves the file opener out of a dialog

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -32,7 +32,7 @@ import 'file_search.dart';
 import 'hover.dart';
 import 'variables.dart';
 
-const openFileDialogEnabled = false;
+const openFileDialogEnabled = true;
 
 final debuggerCodeViewSearchKey =
     GlobalKey(debugLabel: 'DebuggerCodeViewSearchKey');
@@ -167,6 +167,28 @@ class _CodeViewState extends State<CodeView>
 
   @override
   Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+        valueListenable: widget.controller.showFileOpener,
+        builder: (context, showFileOpener, _) {
+          return Stack(
+            children: [
+              buildCodeviewContent(context),
+              if (showFileOpener)
+                Positioned(
+                  // top: denseSpacing,
+                  left: 110.0,
+                  child: wrapInElevatedCard(
+                    FileSearchField(
+                      controller: widget.controller,
+                    ),
+                  ),
+                ),
+            ],
+          );
+        });
+  }
+
+  Widget buildCodeviewContent(BuildContext context) {
     final theme = Theme.of(context);
 
     if (scriptRef == null) {
@@ -377,7 +399,7 @@ class _CodeViewState extends State<CodeView>
     );
   }
 
-  Widget buildSearchInFileField() {
+  Widget wrapInElevatedCard(Widget widget) {
     return Card(
       elevation: defaultElevation,
       color: Theme.of(context).scaffoldBackgroundColor,
@@ -388,14 +410,20 @@ class _CodeViewState extends State<CodeView>
         width: wideSearchTextWidth,
         height: defaultTextFieldHeight + 2 * denseSpacing,
         padding: const EdgeInsets.all(denseSpacing),
-        child: buildSearchField(
-          controller: widget.controller,
-          searchFieldKey: debuggerCodeViewSearchKey,
-          searchFieldEnabled: parsedScript != null,
-          shouldRequestFocus: true,
-          supportsNavigation: true,
-          onClose: () => widget.controller.toggleSearchInFileVisibility(false),
-        ),
+        child: widget,
+      ),
+    );
+  }
+
+  Widget buildSearchInFileField() {
+    return wrapInElevatedCard(
+      buildSearchField(
+        controller: widget.controller,
+        searchFieldKey: debuggerCodeViewSearchKey,
+        searchFieldEnabled: parsedScript != null,
+        shouldRequestFocus: true,
+        supportsNavigation: true,
+        onClose: () => widget.controller.toggleSearchInFileVisibility(false),
       ),
     );
   }
@@ -1083,19 +1111,14 @@ const goToLineOption = ScriptPopupMenuOption(
   onSelected: showGoToLineDialog,
 );
 
-void showOpenFileDialog(BuildContext context, DebuggerController controller) {
-  if (openFileDialogEnabled) {
-    showDialog(
-      context: context,
-      builder: (context) => OpenFileDialog(controller),
-    );
-  }
+void showFileOpener(BuildContext context, DebuggerController controller) {
+  controller.toggleFileOpener(true);
 }
 
 const openFileOption = ScriptPopupMenuOption(
   label: 'Open file (⌘ P)',
   icon: Icons.folder_open,
-  onSelected: showOpenFileDialog,
+  onSelected: showFileOpener,
 );
 
 class GoToLineDialog extends StatelessWidget {
@@ -1151,15 +1174,17 @@ class OpenFileDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return DevToolsDialog(
-      title: dialogTitleText(Theme.of(context), 'Open file'),
+      title: FileSearchField(
+        controller: _debuggerController,
+      ),
       includeDivider: false,
-      content: Container(
-        alignment: Alignment.topCenter,
-        height: 325,
+      content: const SizedBox(
+        // alignment: Alignment.topCenter,
+        height: 340,
         width: 500,
-        child: FileSearchField(
-          controller: _debuggerController,
-        ),
+        // child: FileSearchField(
+        //   controller: _debuggerController,
+        // ),
       ),
       actions: const [
         DialogCancelButton(),

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -174,7 +174,6 @@ class _CodeViewState extends State<CodeView>
               buildCodeviewContent(context),
               if (showFileOpener)
                 Positioned(
-                  // top: denseSpacing,
                   left: 110.0,
                   child: wrapInElevatedCard(
                     FileSearchField(
@@ -1157,33 +1156,6 @@ class GoToLineDialog extends StatelessWidget {
             ],
           )
         ],
-      ),
-      actions: const [
-        DialogCancelButton(),
-      ],
-    );
-  }
-}
-
-class OpenFileDialog extends StatelessWidget {
-  const OpenFileDialog(this._debuggerController);
-
-  final DebuggerController _debuggerController;
-
-  @override
-  Widget build(BuildContext context) {
-    return DevToolsDialog(
-      title: FileSearchField(
-        controller: _debuggerController,
-      ),
-      includeDivider: false,
-      content: const SizedBox(
-        // alignment: Alignment.topCenter,
-        height: 340,
-        width: 500,
-        // child: FileSearchField(
-        //   controller: _debuggerController,
-        // ),
       ),
       actions: const [
         DialogCancelButton(),

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -68,6 +68,7 @@ class CodeView extends StatefulWidget {
 
 class _CodeViewState extends State<CodeView>
     with AutoDisposeMixin, SearchFieldMixin<CodeView> {
+  static const fileOpenerLeftPadding = 110.0;
   static const searchFieldRightPadding = 75.0;
 
   LinkedScrollControllerGroup verticalController;
@@ -166,55 +167,35 @@ class _CodeViewState extends State<CodeView>
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder(
-        valueListenable: widget.controller.showFileOpener,
-        builder: (context, showFileOpener, _) {
-          return Stack(
-            children: [
-              buildCodeviewContent(context),
-              if (showFileOpener)
-                Positioned(
-                  left: 110.0,
-                  child: wrapInElevatedCard(
-                    FileSearchField(
-                      controller: widget.controller,
-                    ),
-                  ),
-                ),
-            ],
-          );
-        });
-  }
-
-  Widget buildCodeviewContent(BuildContext context) {
-    final theme = Theme.of(context);
-
-    if (scriptRef == null) {
-      return Center(
-        child: Text(
-          'Open a file: $openFileKeySetDescription',
-          style: theme.textTheme.subtitle1,
-        ),
-      );
-    }
-
     if (parsedScript == null) {
       return const CenteredCircularProgressIndicator();
     }
 
     return ValueListenableBuilder(
-      valueListenable: widget.controller.showSearchInFileField,
-      builder: (context, showSearch, _) {
-        return Stack(
-          children: [
-            buildCodeArea(context),
-            if (showSearch)
-              Positioned(
-                top: denseSpacing,
-                right: searchFieldRightPadding,
-                child: buildSearchInFileField(),
-              ),
-          ],
+      valueListenable: widget.controller.showFileOpener,
+      builder: (context, showFileOpener, _) {
+        return ValueListenableBuilder(
+          valueListenable: widget.controller.showSearchInFileField,
+          builder: (context, showSearch, _) {
+            return Stack(
+              children: [
+                scriptRef == null
+                    ? buildEmptyState(context)
+                    : buildCodeArea(context),
+                if (showFileOpener)
+                  Positioned(
+                    left: fileOpenerLeftPadding,
+                    child: buildFileSearchField(),
+                  ),
+                if (showSearch && scriptRef != null)
+                  Positioned(
+                    top: denseSpacing,
+                    right: searchFieldRightPadding,
+                    child: buildSearchInFileField(),
+                  ),
+              ],
+            );
+          },
         );
       },
     );
@@ -413,6 +394,14 @@ class _CodeViewState extends State<CodeView>
     );
   }
 
+  Widget buildFileSearchField() {
+    return wrapInElevatedCard(
+      FileSearchField(
+        controller: widget.controller,
+      ),
+    );
+  }
+
   Widget buildSearchInFileField() {
     return wrapInElevatedCard(
       buildSearchField(
@@ -422,6 +411,17 @@ class _CodeViewState extends State<CodeView>
         shouldRequestFocus: true,
         supportsNavigation: true,
         onClose: () => widget.controller.toggleSearchInFileVisibility(false),
+      ),
+    );
+  }
+
+  Widget buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Center(
+      child: Text(
+        'Open a file: $openFileKeySetDescription',
+        style: theme.textTheme.subtitle1,
       ),
     );
   }
@@ -1110,7 +1110,7 @@ final goToLineOption = ScriptPopupMenuOption(
 );
 
 void showFileOpener(BuildContext context, DebuggerController controller) {
-  controller.toggleFileOpener(true);
+  controller.toggleFileOpenerVisibility(true);
 }
 
 final openFileOption = ScriptPopupMenuOption(

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -1022,18 +1022,6 @@ class DebuggerController extends DisposableController
     _showFileOpener.value = visible;
   }
 
-  void hideSearchInFileIfVisible() {
-    if (showSearchInFileField.value) {
-      toggleSearchInFileVisibility(false);
-    }
-  }
-
-  void hideFileOpenerIfVisible() {
-    if (showFileOpener.value) {
-      toggleFileOpenerVisibility(false);
-    }
-  }
-
   @override
   List<SourceToken> matchesForSearch(String search) {
     if (search == null || search.isEmpty || parsedScript.value == null) {

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -148,17 +148,17 @@ class DebuggerController extends DisposableController
 
   ValueListenable<ParsedScript> get currentParsedScript => parsedScript;
 
-  final _showSearchInFileField = ValueNotifier<bool>(false);
-
   ValueListenable<bool> get showSearchInFileField => _showSearchInFileField;
 
-  final _scriptLocation = ValueNotifier<ScriptLocation>(null);
+  final _showSearchInFileField = ValueNotifier<bool>(false);
 
   ValueListenable<ScriptLocation> get scriptLocation => _scriptLocation;
 
-  final _showFileOpener = ValueNotifier<bool>(false);
+  final _scriptLocation = ValueNotifier<ScriptLocation>(null);
 
   ValueListenable<bool> get showFileOpener => _showFileOpener;
+
+  final _showFileOpener = ValueNotifier<bool>(false);
 
   /// Jump to the given ScriptRef and optional SourcePosition.
   void showScriptLocation(ScriptLocation scriptLocation) {
@@ -1018,8 +1018,20 @@ class DebuggerController extends DisposableController
     }
   }
 
-  void toggleFileOpener(bool visible) {
+  void toggleFileOpenerVisibility(bool visible) {
     _showFileOpener.value = visible;
+  }
+
+  void hideSearchInFileIfVisible() {
+    if (showSearchInFileField.value) {
+      toggleSearchInFileVisibility(false);
+    }
+  }
+
+  void hideFileOpenerIfVisible() {
+    if (showFileOpener.value) {
+      toggleFileOpenerVisibility(false);
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -156,6 +156,10 @@ class DebuggerController extends DisposableController
 
   ValueListenable<ScriptLocation> get scriptLocation => _scriptLocation;
 
+  final _showFileOpener = ValueNotifier<bool>(false);
+
+  ValueListenable<bool> get showFileOpener => _showFileOpener;
+
   /// Jump to the given ScriptRef and optional SourcePosition.
   void showScriptLocation(ScriptLocation scriptLocation) {
     _showScriptLocation(scriptLocation);
@@ -1012,6 +1016,10 @@ class DebuggerController extends DisposableController
     if (!visible) {
       resetSearch();
     }
+  }
+
+  void toggleFileOpener(bool visible) {
+    _showFileOpener.value = visible;
   }
 
   @override

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -303,7 +303,6 @@ class EscapeAction extends Action<EscapeIntent> {
       Navigator.of(intent._context).pop(dialogDefaultContext);
       intent._controller.toggleSearchInFileVisibility(false);
     }
-    print('show file opener ${intent._controller.showFileOpener.value}');
     if (intent._controller.showFileOpener.value) {
       intent._controller.toggleFileOpener(false);
     }
@@ -321,7 +320,6 @@ class OpenFileAction extends Action<OpenFileIntent> {
   @override
   void invoke(OpenFileIntent intent) {
     intent._controller.toggleFileOpener(true);
-    // showOpenFileDialog(intent._context, intent._controller);
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -167,7 +167,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         goToLineNumberKeySet: GoToLineNumberIntent(context, controller),
         searchInFileKeySet: SearchInFileIntent(controller),
         escapeKeySet: EscapeIntent(context, controller),
-        openFileKeySet: OpenFileIntent(context, controller),
+        openFileKeySet: OpenFileIntent(controller),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{
@@ -310,9 +310,8 @@ class EscapeAction extends Action<EscapeIntent> {
 }
 
 class OpenFileIntent extends Intent {
-  const OpenFileIntent(this._context, this._controller);
+  const OpenFileIntent(this._controller);
 
-  final BuildContext _context;
   final DebuggerController _controller;
 }
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -292,8 +292,14 @@ class EscapeIntent extends Intent {
 class EscapeAction extends Action<EscapeIntent> {
   @override
   void invoke(EscapeIntent intent) {
-    Navigator.of(intent._context).pop(dialogDefaultContext);
-    intent._controller.toggleSearchInFileVisibility(false);
+    if (intent._controller.showSearchInFileField.value) {
+      Navigator.of(intent._context).pop(dialogDefaultContext);
+      intent._controller.toggleSearchInFileVisibility(false);
+    }
+    print('show file opener ${intent._controller.showFileOpener.value}');
+    if (intent._controller.showFileOpener.value) {
+      intent._controller.toggleFileOpener(false);
+    }
   }
 }
 
@@ -307,7 +313,8 @@ class OpenFileIntent extends Intent {
 class OpenFileAction extends Action<OpenFileIntent> {
   @override
   void invoke(OpenFileIntent intent) {
-    showOpenFileDialog(intent._context, intent._controller);
+    intent._controller.toggleFileOpener(true);
+    // showOpenFileDialog(intent._context, intent._controller);
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -276,8 +276,8 @@ class GoToLineNumberAction extends Action<GoToLineNumberIntent> {
   @override
   void invoke(GoToLineNumberIntent intent) {
     showGoToLineDialog(intent._context, intent._controller);
-    intent._controller.hideFileOpenerIfVisible();
-    intent._controller.hideSearchInFileIfVisible();
+    intent._controller.toggleFileOpenerVisibility(false);
+    intent._controller.toggleSearchInFileVisibility(false);
   }
 }
 
@@ -291,7 +291,7 @@ class SearchInFileAction extends Action<SearchInFileIntent> {
   @override
   void invoke(SearchInFileIntent intent) {
     intent._controller.toggleSearchInFileVisibility(true);
-    intent._controller.hideFileOpenerIfVisible();
+    intent._controller.toggleFileOpenerVisibility(false);
   }
 }
 
@@ -304,8 +304,8 @@ class EscapeIntent extends Intent {
 class EscapeAction extends Action<EscapeIntent> {
   @override
   void invoke(EscapeIntent intent) {
-    intent._controller.hideSearchInFileIfVisible();
-    intent._controller.hideFileOpenerIfVisible();
+    intent._controller.toggleSearchInFileVisibility(false);
+    intent._controller.toggleFileOpenerVisibility(false);
   }
 }
 
@@ -319,7 +319,7 @@ class OpenFileAction extends Action<OpenFileIntent> {
   @override
   void invoke(OpenFileIntent intent) {
     intent._controller.toggleFileOpenerVisibility(true);
-    intent._controller.hideSearchInFileIfVisible();
+    intent._controller.toggleSearchInFileVisibility(false);
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -12,7 +12,6 @@ import '../analytics/analytics.dart' as ga;
 import '../analytics/constants.dart' as analytics_constants;
 import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
-import '../dialogs.dart';
 import '../flex_split_column.dart';
 import '../listenable.dart';
 import '../screen.dart';
@@ -166,7 +165,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
       shortcuts: <LogicalKeySet, Intent>{
         goToLineNumberKeySet: GoToLineNumberIntent(context, controller),
         searchInFileKeySet: SearchInFileIntent(controller),
-        escapeKeySet: EscapeIntent(context, controller),
+        escapeKeySet: EscapeIntent(controller),
         openFileKeySet: OpenFileIntent(controller),
       },
       child: Actions(
@@ -273,6 +272,8 @@ class GoToLineNumberAction extends Action<GoToLineNumberIntent> {
   @override
   void invoke(GoToLineNumberIntent intent) {
     showGoToLineDialog(intent._context, intent._controller);
+    intent._controller.hideFileOpenerIfVisible();
+    intent._controller.hideSearchInFileIfVisible();
   }
 }
 
@@ -286,26 +287,21 @@ class SearchInFileAction extends Action<SearchInFileIntent> {
   @override
   void invoke(SearchInFileIntent intent) {
     intent._controller.toggleSearchInFileVisibility(true);
+    intent._controller.hideFileOpenerIfVisible();
   }
 }
 
 class EscapeIntent extends Intent {
-  const EscapeIntent(this._context, this._controller);
+  const EscapeIntent(this._controller);
 
-  final BuildContext _context;
   final DebuggerController _controller;
 }
 
 class EscapeAction extends Action<EscapeIntent> {
   @override
   void invoke(EscapeIntent intent) {
-    if (intent._controller.showSearchInFileField.value) {
-      Navigator.of(intent._context).pop(dialogDefaultContext);
-      intent._controller.toggleSearchInFileVisibility(false);
-    }
-    if (intent._controller.showFileOpener.value) {
-      intent._controller.toggleFileOpener(false);
-    }
+    intent._controller.hideSearchInFileIfVisible();
+    intent._controller.hideFileOpenerIfVisible();
   }
 }
 
@@ -318,7 +314,8 @@ class OpenFileIntent extends Intent {
 class OpenFileAction extends Action<OpenFileIntent> {
   @override
   void invoke(OpenFileIntent intent) {
-    intent._controller.toggleFileOpener(true);
+    intent._controller.toggleFileOpenerVisibility(true);
+    intent._controller.hideSearchInFileIfVisible();
   }
 }
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/common_widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -13,7 +12,6 @@ import '../ui/search.dart';
 import '../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
-import '../common_widgets.dart';
 
 const int numOfMatchesToShow = 10;
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -14,6 +14,7 @@ import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
 const int numOfMatchesToShow = 10;
+const double autocompleteMatchTileHeight = 50.0;
 
 class FileSearchField extends StatefulWidget {
   const FileSearchField({
@@ -66,7 +67,7 @@ class _FileSearchFieldState extends State<FileSearchField>
       context: context,
       searchFieldKey: fileSearchFieldKey,
       onTap: _onSelection,
-      autocompleteMatchTileHeight: 50.0,
+      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
     );
   }
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -2,20 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/common_widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../auto_dispose_mixin.dart';
-import '../common_widgets.dart';
-import '../dialogs.dart';
-import '../theme.dart';
 import '../ui/search.dart';
 import '../utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
+import '../common_widgets.dart';
 
-const int numOfMatchesToShow = 6;
+const int numOfMatchesToShow = 10;
 
 class FileSearchField extends StatefulWidget {
   const FileSearchField({
@@ -77,31 +77,29 @@ class _FileSearchFieldState extends State<FileSearchField>
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-
-    return Container(
-      decoration: BoxDecoration(
-        border: Border(
-          top: defaultBorderSide(theme),
-        ),
-      ),
-      padding: const EdgeInsets.all(denseSpacing),
-      child: buildAutoCompleteSearchField(
-        controller: _autoCompleteController,
-        searchFieldKey: fileSearchFieldKey,
-        searchFieldEnabled: true,
-        shouldRequestFocus: true,
-        closeOverlayOnEscape: false,
-        onSelection: _onSelection,
-      ),
+    return buildAutoCompleteSearchField(
+      controller: _autoCompleteController,
+      searchFieldKey: fileSearchFieldKey,
+      searchFieldEnabled: true,
+      shouldRequestFocus: true,
+      keyEventsToPropogate: {LogicalKeyboardKey.escape},
+      onSelection: _onSelection,
+      onClose: _onClose,
     );
   }
 
   void _onSelection(String scriptUri) {
     final scriptRef = _scriptsCache[scriptUri];
     widget.controller.showScriptLocation(ScriptLocation(scriptRef));
+    _onClose();
+  }
+
+  void _onClose() {
+    setState(() {
+      _autoCompleteController.closeAutoCompleteOverlay();
+    });
+    widget.controller.toggleFileOpener(false);
     _scriptsCache.clear();
-    Navigator.of(context).pop(dialogDefaultContext);
   }
 
   @override

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -66,6 +66,7 @@ class _FileSearchFieldState extends State<FileSearchField>
       context: context,
       searchFieldKey: fileSearchFieldKey,
       onTap: _onSelection,
+      autocompleteMatchTileHeight: 50.0,
     );
   }
 
@@ -83,6 +84,7 @@ class _FileSearchFieldState extends State<FileSearchField>
       keyEventsToPropogate: {LogicalKeyboardKey.escape},
       onSelection: _onSelection,
       onClose: _onClose,
+      label: 'Open',
     );
   }
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -93,15 +93,14 @@ class _FileSearchFieldState extends State<FileSearchField>
   }
 
   void _onClose() {
-    setState(() {
-      _autoCompleteController.closeAutoCompleteOverlay();
-    });
-    widget.controller.toggleFileOpener(false);
+    _autoCompleteController.closeAutoCompleteOverlay();
+    widget.controller.toggleFileOpenerVisibility(false);
     _scriptsCache.clear();
   }
 
   @override
   void dispose() {
+    _onClose();
     _autoCompleteController.dispose();
     super.dispose();
   }

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -113,6 +113,7 @@ class AutoComplete extends StatefulWidget {
     this.controller, {
     @required this.searchFieldKey,
     @required this.onTap,
+    this.autocompleteMatchTileHeight,
     bool bottom = true, // If false placed above.
     bool maxWidth = true,
   })  : isBottom = bottom,
@@ -121,6 +122,7 @@ class AutoComplete extends StatefulWidget {
   final AutoCompleteSearchControllerMixin controller;
   final GlobalKey searchFieldKey;
   final SelectAutoComplete onTap;
+  final double autocompleteMatchTileHeight;
   final bool isBottom;
   final bool isMaxWidth;
 
@@ -139,6 +141,8 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
     final onTap = autoComplete.onTap;
     final bottom = autoComplete.isBottom;
     final isMaxWidth = autoComplete.isMaxWidth;
+    final autocompleteMatchTileHeight =
+        autoComplete.autocompleteMatchTileHeight;
 
     addAutoDisposeListener(controller.searchAutoCompleteNotifier, () {
       controller.handleAutoCompleteOverlay(
@@ -147,6 +151,7 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
         onTap: onTap,
         bottom: bottom,
         maxWidth: isMaxWidth,
+        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
       );
     });
   }
@@ -170,9 +175,8 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
 
     // Approximation but it's pretty accurate. Could consider using a layout builder
     // or maybe build in an overlay (that's isn't visible) to compute.
-    // TODO(https://github.com/flutter/devtools/issues/3075) This approximation
-    // doesn't work for the new file opener, should compute the actual height.
-    final tileEntryHeight = box.size.height;
+    final tileEntryHeight =
+        autoComplete.autocompleteMatchTileHeight ?? box.size.height;
 
     // Compute to global coordinates.
     final offset = box.localToGlobal(Offset.zero);
@@ -324,6 +328,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required SelectAutoComplete onTap,
     bool bottom = true,
     bool maxWidth = true,
+    double autocompleteMatchTileHeight,
   }) {
     return OverlayEntry(builder: (context) {
       return AutoComplete(
@@ -332,6 +337,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
         onTap: onTap,
         bottom: bottom,
         maxWidth: maxWidth,
+        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
       );
     });
   }
@@ -352,6 +358,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required SelectAutoComplete onTap,
     bool bottom = true,
     bool maxWidth = true,
+    double autocompleteMatchTileHeight,
   }) {
     if (autoCompleteOverlay != null) {
       closeAutoCompleteOverlay();
@@ -363,6 +370,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       onTap: onTap,
       bottom: bottom,
       maxWidth: maxWidth,
+      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
     );
 
     Overlay.of(context).insert(autoCompleteOverlay);
@@ -529,11 +537,13 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
     @required bool shouldRequestFocus,
     @required SelectAutoComplete onSelection,
     HighlightAutoComplete onHighlightDropdown,
+    String label,
     InputDecoration decoration,
     bool tracking = false,
     bool supportClearField = false,
     Set<LogicalKeyboardKey> keyEventsToPropogate = const {},
     VoidCallback onClose,
+    double autocompleteMatchTileHeight,
   }) {
     _onSelection = onSelection;
 
@@ -612,6 +622,7 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
         shouldRequestFocus: shouldRequestFocus,
         autoCompleteLayerLink: controller.autoCompleteLayerLink,
         decoration: decoration,
+        label: label,
         tracking: tracking,
         onClose: onClose,
       ),
@@ -681,6 +692,7 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
     @required bool searchFieldEnabled,
     @required bool shouldRequestFocus,
     @required LayerLink autoCompleteLayerLink,
+    String label,
     InputDecoration decoration,
     bool supportsNavigation = false,
     VoidCallback onClose,
@@ -740,7 +752,7 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
                 OutlineInputBorder(borderSide: searchFocusBorderColor),
             labelStyle: TextStyle(color: searchColor),
             border: const OutlineInputBorder(),
-            labelText: 'Search',
+            labelText: label ?? 'Search',
             suffix: (supportsNavigation || onClose != null)
                 ? _buildSearchFieldSuffix(
                     controller,

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -170,6 +170,8 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
 
     // Approximation but it's pretty accurate. Could consider using a layout builder
     // or maybe build in an overlay (that's isn't visible) to compute.
+    // TODO(https://github.com/flutter/devtools/issues/3075) This approximation
+    // doesn't work for the new file opener, should compute the actual height.
     final tileEntryHeight = box.size.height;
 
     // Compute to global coordinates.

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -632,7 +632,9 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
   }
 
   KeyEventResult _determineKeyEventResult(
-      int keyEventId, Set<LogicalKeyboardKey> keyEventsToPropogate) {
+    int keyEventId,
+    Set<LogicalKeyboardKey> keyEventsToPropogate,
+  ) {
     final shouldPropogateKeyEvent = keyEventsToPropogate
         .any((key) => key.keyId & LogicalKeyboardKey.valueMask == keyEventId);
     return shouldPropogateKeyEvent

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -326,18 +326,18 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required BuildContext context,
     @required GlobalKey searchFieldKey,
     @required SelectAutoComplete onTap,
+    double autocompleteMatchTileHeight,
     bool bottom = true,
     bool maxWidth = true,
-    double autocompleteMatchTileHeight,
   }) {
     return OverlayEntry(builder: (context) {
       return AutoComplete(
         this,
         searchFieldKey: searchFieldKey,
         onTap: onTap,
+        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
         bottom: bottom,
         maxWidth: maxWidth,
-        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
       );
     });
   }
@@ -356,9 +356,9 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required BuildContext context,
     @required GlobalKey searchFieldKey,
     @required SelectAutoComplete onTap,
+    double autocompleteMatchTileHeight,
     bool bottom = true,
     bool maxWidth = true,
-    double autocompleteMatchTileHeight,
   }) {
     if (autoCompleteOverlay != null) {
       closeAutoCompleteOverlay();
@@ -368,9 +368,9 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       context: context,
       searchFieldKey: searchFieldKey,
       onTap: onTap,
+      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
       bottom: bottom,
       maxWidth: maxWidth,
-      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
     );
 
     Overlay.of(context).insert(autoCompleteOverlay);
@@ -537,13 +537,12 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
     @required bool shouldRequestFocus,
     @required SelectAutoComplete onSelection,
     HighlightAutoComplete onHighlightDropdown,
-    String label,
     InputDecoration decoration,
+    String label,
     bool tracking = false,
     bool supportClearField = false,
     Set<LogicalKeyboardKey> keyEventsToPropogate = const {},
     VoidCallback onClose,
-    double autocompleteMatchTileHeight,
   }) {
     _onSelection = onSelection;
 
@@ -566,7 +565,10 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
             clearSearchField(controller, force: true);
           }
 
-          return _determineKeyEventResult(key, keyEventsToPropogate);
+          return _determineKeyEventResult(
+            key,
+            keyEventsToPropogate,
+          );
         } else if (controller.autoCompleteOverlay != null) {
           if (key == enter || key == enterMac || key == tab || key == tabMac) {
             // Enter / Tab pressed.
@@ -692,8 +694,8 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
     @required bool searchFieldEnabled,
     @required bool shouldRequestFocus,
     @required LayerLink autoCompleteLayerLink,
-    String label,
     InputDecoration decoration,
+    String label,
     bool supportsNavigation = false,
     VoidCallback onClose,
     bool tracking = false,

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -430,7 +430,6 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.variables)
           .thenReturn(ValueNotifier(testVariables));
-      // when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Variables'), findsOneWidget);
 
@@ -459,12 +458,11 @@ void main() {
       );
 
       // Expand list.
-      final collapsedText1 = find.selectableTextContaining('0: 3');
-      final collapsedText2 = find.selectableTextContaining('1: 4');
-      expect(collapsedText1, findsNWidgets(0), reason: 'Selectable text 0: 3');
-      expect(collapsedText2, findsNWidgets(0), reason: 'Selectable text 1: 4');
+      expect(find.selectableTextContaining('0: 3'), findsNothing);
+      expect(find.selectableTextContaining('1: 4'), findsNothing);
+
       await tester.tap(listFinder);
-      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
+      await tester.pump();
       expect(find.selectableTextContaining('0: 3'), findsOneWidget);
       expect(find.selectableTextContaining('1: 4'), findsOneWidget);
 
@@ -472,7 +470,7 @@ void main() {
       expect(mapElement1Finder, findsNothing);
       expect(mapElement2Finder, findsNothing);
       await tester.tap(mapFinder);
-      await tester.pumpAndSettle();
+      await tester.pump();
       expect(mapElement1Finder, findsOneWidget);
       expect(mapElement2Finder, findsOneWidget);
     });
@@ -657,6 +655,7 @@ final isolateRef = IsolateRef(
   isSystemIsolate: false,
 );
 
+// List<Variable> get testVariables => [
 final testVariables = [
   Variable.create(
     BoundVariable(

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -430,7 +430,6 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.variables)
           .thenReturn(ValueNotifier(testVariables));
-      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Variables'), findsOneWidget);
 
@@ -459,8 +458,8 @@ void main() {
       );
 
       // Expand list.
-      // expect(find.selectableTextContaining('0: 3'), findsNothing);
-      // expect(find.selectableTextContaining('1: 4'), findsNothing);
+      expect(find.selectableTextContaining('0: 3'), findsNothing);
+      expect(find.selectableTextContaining('1: 4'), findsNothing);
       await tester.tap(listFinder);
       await tester.pumpAndSettle();
       expect(find.selectableTextContaining('0: 3'), findsOneWidget);

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -430,6 +430,7 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.variables)
           .thenReturn(ValueNotifier(testVariables));
+      // when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Variables'), findsOneWidget);
 
@@ -458,10 +459,12 @@ void main() {
       );
 
       // Expand list.
-      expect(find.selectableTextContaining('0: 3'), findsNothing);
-      expect(find.selectableTextContaining('1: 4'), findsNothing);
+      final collapsedText1 = find.selectableTextContaining('0: 3');
+      final collapsedText2 = find.selectableTextContaining('1: 4');
+      expect(collapsedText1, findsNWidgets(0), reason: 'Selectable text 0: 3');
+      expect(collapsedText2, findsNWidgets(0), reason: 'Selectable text 1: 4');
       await tester.tap(listFinder);
-      await tester.pumpAndSettle();
+      await tester.pumpAndSettle(const Duration(milliseconds: 1000));
       expect(find.selectableTextContaining('0: 3'), findsOneWidget);
       expect(find.selectableTextContaining('1: 4'), findsOneWidget);
 

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -192,6 +192,8 @@ void main() {
             .thenReturn(ValueNotifier(mockParsedScript));
         when(debuggerController.showSearchInFileField)
             .thenReturn(ValueNotifier(false));
+        when(debuggerController.showFileOpener)
+            .thenReturn(ValueNotifier(false));
         when(debuggerController.scriptsHistory).thenReturn(scriptsHistory);
         when(debuggerController.searchMatches).thenReturn(ValueNotifier([]));
         when(debuggerController.activeSearchMatch)
@@ -229,6 +231,7 @@ void main() {
       ];
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
 
       // Libraries view is hidden
       when(debuggerController.librariesVisible)
@@ -244,6 +247,7 @@ void main() {
       ];
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
 
       // Libraries view is shown
       when(debuggerController.librariesVisible).thenReturn(ValueNotifier(true));
@@ -284,6 +288,7 @@ void main() {
 
       when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
 
       await pumpDebuggerScreen(tester, debuggerController);
 
@@ -374,6 +379,7 @@ void main() {
       when(debuggerController.stackFramesWithLocation)
           .thenReturn(ValueNotifier(stackFramesWithLocation));
       when(debuggerController.isPaused).thenReturn(ValueNotifier(true));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
 
       expect(find.text('Call Stack'), findsOneWidget);
@@ -424,6 +430,7 @@ void main() {
         (WidgetTester tester) async {
       when(debuggerController.variables)
           .thenReturn(ValueNotifier(testVariables));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Variables'), findsOneWidget);
 
@@ -479,6 +486,7 @@ void main() {
 
     testWidgetsWithWindowSize('debugger controls running', windowSize,
         (WidgetTester tester) async {
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,
@@ -500,6 +508,7 @@ void main() {
     testWidgetsWithWindowSize('debugger controls paused', windowSize,
         (WidgetTester tester) async {
       when(debuggerController.isPaused).thenReturn(ValueNotifier(true));
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       when(debuggerController.stackFramesWithLocation)
           .thenReturn(ValueNotifier([
         StackFrameAndSourcePosition(
@@ -542,6 +551,7 @@ void main() {
     testWidgetsWithWindowSize(
         'debugger controls break on exceptions', windowSize,
         (WidgetTester tester) async {
+      when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
       await tester.pumpWidget(wrapWithControllers(
         Builder(builder: screen.build),
         debugger: debuggerController,

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -459,8 +459,8 @@ void main() {
       );
 
       // Expand list.
-      expect(find.selectableTextContaining('0: 3'), findsNothing);
-      expect(find.selectableTextContaining('1: 4'), findsNothing);
+      // expect(find.selectableTextContaining('0: 3'), findsNothing);
+      // expect(find.selectableTextContaining('1: 4'), findsNothing);
       await tester.tap(listFinder);
       await tester.pumpAndSettle();
       expect(find.selectableTextContaining('0: 3'), findsOneWidget);

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -655,7 +655,6 @@ final isolateRef = IsolateRef(
   isSystemIsolate: false,
 );
 
-// List<Variable> get testVariables => [
 final testVariables = [
   Variable.create(
     BoundVariable(

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -168,6 +168,14 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   }
 
   @override
+  Future<void> sendDwdsEvent({
+    @required String screen,
+    @required String action,
+  }) {
+    return Future.value();
+  }
+
+  @override
   void manuallyDisconnect() {
     changeState(false, manual: true);
   }

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -170,10 +170,11 @@ extension SelectableTextChecking on CommonFinders {
   }
 
   Finder selectableTextContaining(String text) {
-    return find.byWidgetPredicate((widget) =>
+    final found = find.byWidgetPredicate((widget) =>
         widget is SelectableText &&
         ((widget.data?.contains(text) ?? false) ||
             (widget.textSpan?.toPlainText()?.contains(text) ?? false)));
+    return found;
   }
 }
 

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -170,11 +170,10 @@ extension SelectableTextChecking on CommonFinders {
   }
 
   Finder selectableTextContaining(String text) {
-    final found = find.byWidgetPredicate((widget) =>
+    return find.byWidgetPredicate((widget) =>
         widget is SelectableText &&
         ((widget.data?.contains(text) ?? false) ||
             (widget.textSpan?.toPlainText()?.contains(text) ?? false)));
-    return found;
   }
 }
 


### PR DESCRIPTION
Moves the file opener out of a dialog so that it shows up at the top of the codeview. It now works similarly to the "search in file" field. 

![new file opener](https://user-images.githubusercontent.com/21270878/132919380-a961bcdd-3124-48ef-9696-4551ee16f719.gif)


Material dialogs can't be positioned anywhere other than center, so this gives us more flexibility with the positioning.