### PR TITLE
Send event to dwds when debug screen is ready

### DIFF
--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -108,3 +108,4 @@ const String documentationLink = 'documentationLink';
 // This should track the time from `initState` for a screen to the time when
 // the page data has loaded and is ready to interact with.
 const String pageReady = 'pageReady';
+const String screenReady = 'screenReady';

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -108,4 +108,3 @@ const String documentationLink = 'documentationLink';
 // This should track the time from `initState` for a screen to the time when
 // the page data has loaded and is ready to interact with.
 const String pageReady = 'pageReady';
-const String screenReady = 'screenReady';

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:codicon/codicon.dart';
+import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:provider/provider.dart';
@@ -118,7 +119,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                 parsedScript != null &&
                 !_shownFirstScript) {
               ga.timeEnd(DebuggerScreen.id, analytics_constants.pageReady);
-              // TODO(annagrin): mark end of IPL timing for debugger page here.
+              serviceManager.sendDwdsEvent(
+                  screen: DebuggerScreen.id,
+                  action: analytics_constants.screenReady);
               _shownFirstScript = true;
             }
             return CodeView(

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -120,8 +120,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                 !_shownFirstScript) {
               ga.timeEnd(DebuggerScreen.id, analytics_constants.pageReady);
               serviceManager.sendDwdsEvent(
-                  screen: DebuggerScreen.id,
-                  action: analytics_constants.screenReady);
+                screen: DebuggerScreen.id,
+                action: analytics_constants.pageReady,
+              );
               _shownFirstScript = true;
             }
             return CodeView(

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:codicon/codicon.dart';
-import 'package:devtools_app/src/globals.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:provider/provider.dart';
@@ -15,6 +14,7 @@ import '../auto_dispose_mixin.dart';
 import '../common_widgets.dart';
 import '../dialogs.dart';
 import '../flex_split_column.dart';
+import '../globals.dart';
 import '../listenable.dart';
 import '../screen.dart';
 import '../split.dart';

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -366,8 +366,10 @@ class ServiceConnectionManager {
     );
   }
 
-  Future<void> sendDwdsEvent(
-      {@required String screen, @required String action}) async {
+  Future<void> sendDwdsEvent({
+    @required String screen,
+    @required String action,
+  }) async {
     if (!kIsWeb) return;
     return await _callServiceExtensionOnMainIsolate(registrations.dwdsSendEvent,
         args: {
@@ -375,7 +377,7 @@ class ServiceConnectionManager {
           'payload': {
             'screen': screen,
             'action': action,
-          }
+          },
         });
   }
 

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -366,8 +366,9 @@ class ServiceConnectionManager {
     );
   }
 
-  Future<Response> sendDwdsEvent(
+  Future<void> sendDwdsEvent(
       {@required String screen, @required String action}) async {
+    if (!kIsWeb) return;
     return await _callServiceExtensionOnMainIsolate(registrations.dwdsSendEvent,
         args: {
           'type': 'DevtoolsEvent',

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -366,6 +366,18 @@ class ServiceConnectionManager {
     );
   }
 
+  Future<Response> sendDwdsEvent(
+      {@required String screen, @required String action}) async {
+    return await _callServiceExtensionOnMainIsolate(registrations.dwdsSendEvent,
+        args: {
+          'type': 'DevtoolsEvent',
+          'payload': {
+            'screen': screen,
+            'action': action,
+          }
+        });
+  }
+
   Future<Response> _callServiceOnMainIsolate(String name) async {
     final isolate = await whenValueNonNull(isolateManager.mainIsolate);
     return await callService(name, isolateId: isolate.id);

--- a/packages/devtools_app/lib/src/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service_registrations.dart
@@ -78,3 +78,6 @@ const displayRefreshRate = '_flutter.getDisplayRefreshRate';
 /// Flutter engine returns estimate how much memory is used by layer/picture raster
 /// cache entries in bytes.
 const flutterEngineEstimateRasterCache = '_flutter.estimateRasterCacheMemory';
+
+/// Dwds listens to events for recording end-to-end analytics.
+const dwdsSendEvent = 'ext.dwds.sendEvent';


### PR DESCRIPTION
- Add `sendDwdsEvent` to `ServiceConnectionManager` to send devtools events to via `ext.dwds.sendEvent` extension.
- Send event to indicate that debugger screen is ready.

Helps: https://github.com/dart-lang/webdev/issues/1406