### PR TITLE
Add ability to profile app start up and improve CPU profile caching

### DIFF
--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -58,6 +58,7 @@ const traceEventProcessingTime = 'traceEventProcessingTime';
 // CPU profiler UX actions:
 const profileGranularityPrefix = 'profileGranularity';
 const loadAllCpuSamples = 'loadAllCpuSamples';
+const profileAppStartUp = 'profileAppStartUp';
 const cpuProfileFlameChartHelp = 'cpuProfileFlameChartHelp';
 const cpuProfileProcessingTime = 'cpuProfileProcessingTime';
 

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -94,6 +94,7 @@ class IconLabelButton extends StatelessWidget {
     this.minScreenWidthForTextBeforeScaling,
     this.elevatedButton = false,
     this.tooltip,
+    this.tooltipPadding,
   })  : assert((icon == null) != (imageIcon == null)),
         super(key: key);
 
@@ -114,6 +115,8 @@ class IconLabelButton extends StatelessWidget {
 
   final String tooltip;
 
+  final EdgeInsetsGeometry tooltipPadding;
+
   @override
   Widget build(BuildContext context) {
     final iconLabel = MaterialIconLabel(
@@ -125,8 +128,9 @@ class IconLabelButton extends StatelessWidget {
     );
     if (elevatedButton) {
       return maybeWrapWithTooltip(
-        tooltip,
-        ElevatedButton(
+        tooltip: tooltip,
+        tooltipPadding: tooltipPadding,
+        child: ElevatedButton(
           onPressed: onPressed,
           child: iconLabel,
         ),
@@ -135,8 +139,9 @@ class IconLabelButton extends StatelessWidget {
     // TODO(kenz): this SizedBox wrapper should be unnecessary once
     // https://github.com/flutter/flutter/issues/79894 is fixed.
     return maybeWrapWithTooltip(
-      tooltip,
-      SizedBox(
+      tooltip: tooltip,
+      tooltipPadding: tooltipPadding,
+      child: SizedBox(
         height: defaultButtonHeight,
         width: !includeText(context, minScreenWidthForTextBeforeScaling)
             ? buttonMinWidth
@@ -1294,10 +1299,15 @@ class Link {
   final String url;
 }
 
-Widget maybeWrapWithTooltip(String tooltip, Widget child) {
+Widget maybeWrapWithTooltip({
+  @required String tooltip,
+  EdgeInsetsGeometry tooltipPadding,
+  @required Widget child,
+}) {
   if (tooltip != null) {
     return DevToolsTooltip(
       tooltip: tooltip,
+      padding: tooltipPadding,
       child: child,
     );
   }

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -183,13 +183,14 @@ class LegacyPerformanceController
 
     if (event.isUiEvent && updateProfiler) {
       final storedProfile =
-          cpuProfilerController.cpuProfileStore.lookupProfile(event.time);
+          cpuProfilerController.cpuProfileStore.lookupProfile(time: event.time);
       if (storedProfile != null) {
         await cpuProfilerController.processAndSetData(
           storedProfile,
           processId: 'Stored profile for ${event.time}',
           storeAsUserTagNone: true,
           shouldApplyFilters: true,
+          shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       } else if ((!offlineMode || offlinePerformanceData == null) &&
@@ -232,7 +233,7 @@ class LegacyPerformanceController
     await selectTimelineEvent(frame.uiEventFlow, updateProfiler: false);
 
     final storedProfileForFrame =
-        cpuProfilerController.cpuProfileStore.lookupProfile(frame.time);
+        cpuProfilerController.cpuProfileStore.lookupProfile(time: frame.time);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       if (!offlineMode) {
@@ -251,7 +252,10 @@ class LegacyPerformanceController
         );
       }
       data.cpuProfileData = storedProfileForFrame;
-      cpuProfilerController.loadProcessedData(storedProfileForFrame);
+      cpuProfilerController.loadProcessedData(
+        storedProfileForFrame,
+        storeAsUserTagNone: true,
+      );
     }
 
     if (debugTimeline) {
@@ -468,6 +472,7 @@ class LegacyPerformanceController
     if (offlinePerformanceData.cpuProfileData != null) {
       cpuProfilerController.loadProcessedData(
         offlinePerformanceData.cpuProfileData,
+        storeAsUserTagNone: true,
       );
     }
   }

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -295,13 +295,14 @@ class PerformanceController extends DisposableController
 
     if (event.isUiEvent && updateProfiler) {
       final storedProfile =
-          cpuProfilerController.cpuProfileStore.lookupProfile(event.time);
+          cpuProfilerController.cpuProfileStore.lookupProfile(time: event.time);
       if (storedProfile != null) {
         await cpuProfilerController.processAndSetData(
           storedProfile,
           processId: 'Stored profile for ${event.time}',
           storeAsUserTagNone: true,
           shouldApplyFilters: true,
+          shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
       } else if ((!offlineMode || offlinePerformanceData == null) &&
@@ -386,7 +387,7 @@ class PerformanceController extends DisposableController
     if (_currentFrameBeingSelected != frame) return;
 
     final storedProfileForFrame = cpuProfilerController.cpuProfileStore
-        .lookupProfile(frame.timeFromEventFlows);
+        .lookupProfile(time: frame.timeFromEventFlows);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       if (!offlineMode && frame.timeFromEventFlows.isWellFormed) {
@@ -407,7 +408,10 @@ class PerformanceController extends DisposableController
       }
       if (_currentFrameBeingSelected != frame) return;
       data.cpuProfileData = storedProfileForFrame;
-      cpuProfilerController.loadProcessedData(storedProfileForFrame);
+      cpuProfilerController.loadProcessedData(
+        storedProfileForFrame,
+        storeAsUserTagNone: true,
+      );
     }
 
     if (debugTimeline) {
@@ -756,6 +760,7 @@ class PerformanceController extends DisposableController
     if (offlinePerformanceData.cpuProfileData != null) {
       cpuProfilerController.loadProcessedData(
         offlinePerformanceData.cpuProfileData,
+        storeAsUserTagNone: true,
       );
     }
   }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -165,13 +165,6 @@ class CpuProfilerController
         shouldApplyFilters: true,
         shouldRefreshSearchMatches: true,
       );
-      cpuProfileStore.storeProfile(_dataNotifier.value, label: userTagNone);
-      cpuProfileStore.storeProfile(
-        _dataNotifier.value,
-        time: TimeRange()
-          ..start = Duration(microseconds: startMicros)
-          ..end = Duration(microseconds: startMicros + extentMicros),
-      );
     }
 
     if (analyticsScreenId != null) {
@@ -213,6 +206,10 @@ class CpuProfilerController
       await transformer.processData(cpuProfileData, processId: processId);
       if (storeAsUserTagNone) {
         cpuProfileStore.storeProfile(cpuProfileData, label: userTagNone);
+        cpuProfileStore.storeProfile(
+          cpuProfileData,
+          time: cpuProfileData.profileMetaData.time,
+        );
       }
       if (shouldApplyFilters) {
         cpuProfileData = applyToggleFilters(cpuProfileData);

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -32,11 +32,27 @@ class CpuProfilerController
   /// the message that no filters are applied.
   static const userTagNone = 'none';
 
+  /// User tag that marks app start up for Flutter apps.
+  ///
+  /// This needs to match the tag set and unset at these locations,
+  /// respectively:
+  ///
+  /// Flutter Engine - https://github.com/flutter/engine/blob/master/runtime/dart_isolate.cc#L369
+  /// Flutter Framework - https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/binding.dart#L866
+  static const appStartUpUserTag = 'AppStartUp';
+
   /// Data for the initial value and reset value of [_dataNotifier].
   ///
   /// When this data is the value of [_dataNotifier], the CPU profiler is in a
   /// base state where recording instructions should be shown.
   static CpuProfileData baseStateCpuProfileData = CpuProfileData.empty();
+
+  /// Data used to represent and empty profile when attempting to load the
+  /// 'AppStartUp' profile.
+  ///
+  /// When this data is the value of [_dataNotifier], the CPU profiler will show
+  /// an empty message specific to the app start up use case.
+  static CpuProfileData emptyAppStartUpProfile = CpuProfileData.empty();
 
   /// The analytics screen id for which this controller is active.
   final String analyticsScreenId;
@@ -61,10 +77,13 @@ class CpuProfilerController
   ValueListenable<String> get userTagFilter => _userTagFilter;
   final _userTagFilter = ValueNotifier<String>(userTagNone);
 
-  @visibleForTesting
-  final dataByTag = <String, CpuProfileData>{};
+  Iterable<String> get userTags =>
+      cpuProfileStore.lookupProfile(label: userTagNone)?.userTags ?? [];
 
-  Iterable<String> get userTags => dataByTag[userTagNone]?.userTags ?? [];
+  bool get isToggleFilterActive =>
+      toggleFilters.firstWhere((filter) => filter.enabled.value,
+          orElse: () => null) !=
+      null;
 
   /// The toggle filters available for the CPU profiler.
   ///
@@ -144,12 +163,14 @@ class CpuProfilerController
         processId: processId,
         storeAsUserTagNone: true,
         shouldApplyFilters: true,
+        shouldRefreshSearchMatches: true,
       );
-      cpuProfileStore.addProfile(
-        TimeRange()
+      cpuProfileStore.storeProfile(_dataNotifier.value, label: userTagNone);
+      cpuProfileStore.storeProfile(
+        _dataNotifier.value,
+        time: TimeRange()
           ..start = Duration(microseconds: startMicros)
           ..end = Duration(microseconds: startMicros + extentMicros),
-        _dataNotifier.value,
       );
     }
 
@@ -184,23 +205,29 @@ class CpuProfilerController
     @required String processId,
     @required bool storeAsUserTagNone,
     @required bool shouldApplyFilters,
+    @required bool shouldRefreshSearchMatches,
   }) async {
     _processingNotifier.value = true;
     _dataNotifier.value = null;
     try {
       await transformer.processData(cpuProfileData, processId: processId);
       if (storeAsUserTagNone) {
-        dataByTag[userTagNone] = cpuProfileData;
+        cpuProfileStore.storeProfile(cpuProfileData, label: userTagNone);
       }
       if (shouldApplyFilters) {
-        cpuProfileData = _filterData(
-          cpuProfileData,
-          Filter(toggleFilters: toggleFilters),
-        );
+        cpuProfileData = applyToggleFilters(cpuProfileData);
         await transformer.processData(cpuProfileData, processId: processId);
+        if (storeAsUserTagNone) {
+          cpuProfileStore.storeProfile(
+            cpuProfileData,
+            label: _wrapWithFilterSuffix(userTagNone),
+          );
+        }
       }
       _dataNotifier.value = cpuProfileData;
-      refreshSearchMatches();
+      if (shouldRefreshSearchMatches) {
+        refreshSearchMatches();
+      }
       _processingNotifier.value = false;
     } on AssertionError catch (_) {
       _dataNotifier.value = cpuProfileData;
@@ -229,10 +256,109 @@ class CpuProfilerController
     return matches;
   }
 
-  void loadProcessedData(CpuProfileData data) {
+  Future<void> loadAllSamples() async {
+    reset();
+    await pullAndProcessProfile(
+      startMicros: 0,
+      // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
+      // give us all cpu samples we have available
+      extentMicros: maxJsInt,
+      processId: 'Load all samples',
+    );
+  }
+
+  @visibleForTesting
+  String generateToggleFilterSuffix() {
+    final suffixList = <String>[];
+    for (final toggleFilter in toggleFilters) {
+      if (toggleFilter.enabled.value) {
+        suffixList.add(toggleFilter.name);
+      }
+    }
+    return suffixList.join(',');
+  }
+
+  String _wrapWithFilterSuffix(String label) {
+    final filterSuffix = generateToggleFilterSuffix();
+    return '$label${filterSuffix.isNotEmpty ? '-$filterSuffix' : ''}';
+  }
+
+  Future<void> loadAppStartUpProfile() async {
+    reset();
+    _processingNotifier.value = true;
+    _dataNotifier.value = null;
+
+    final storedProfileWithFilters = cpuProfileStore.lookupProfile(
+      label: _wrapWithFilterSuffix(appStartUpUserTag),
+    );
+    if (storedProfileWithFilters != null) {
+      _dataNotifier.value = storedProfileWithFilters;
+      refreshSearchMatches();
+      _processingNotifier.value = false;
+      return;
+    }
+
+    var appStartUpProfile = cpuProfileStore.lookupProfile(
+      label: appStartUpUserTag,
+    );
+    if (appStartUpProfile == null) {
+      final cpuProfile = await serviceManager.service.getCpuProfile(
+        startMicros: 0,
+        // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
+        // give us all cpu samples we have available
+        extentMicros: maxJsInt,
+      );
+      appStartUpProfile = CpuProfileData.fromUserTag(
+        cpuProfile,
+        appStartUpUserTag,
+      );
+      cpuProfileStore.storeProfile(appStartUpProfile, label: userTagNone);
+      cpuProfileStore.storeProfile(appStartUpProfile, label: appStartUpUserTag);
+    }
+
+    if (appStartUpProfile.isEmpty) {
+      _processingNotifier.value = false;
+      _dataNotifier.value = emptyAppStartUpProfile;
+      return;
+    }
+
+    _userTagFilter.value = appStartUpUserTag;
+
+    if (isToggleFilterActive) {
+      final filteredAppStartUpProfile = applyToggleFilters(appStartUpProfile);
+      await processAndSetData(
+        filteredAppStartUpProfile,
+        processId: 'filter app start up profile',
+        storeAsUserTagNone: false,
+        shouldApplyFilters: false,
+        shouldRefreshSearchMatches: true,
+      );
+      cpuProfileStore.storeProfile(
+        filteredAppStartUpProfile,
+        label: _wrapWithFilterSuffix(appStartUpUserTag),
+      );
+      return;
+    }
+
+    if (!appStartUpProfile.processed) {
+      await transformer.processData(appStartUpProfile);
+    }
+
+    _processingNotifier.value = false;
+    _dataNotifier.value = appStartUpProfile;
+  }
+
+  // TODO(kenz): filter the data before calling this method, or pass in
+  // unprocessed data to avoid processing the data twice.
+  void loadProcessedData(
+    CpuProfileData data, {
+    @required bool storeAsUserTagNone,
+  }) {
     assert(data.processed);
     _dataNotifier.value = data;
-    dataByTag[userTagNone] = data;
+    if (storeAsUserTagNone) {
+      cpuProfileStore.storeProfile(data, label: userTagNone);
+    }
   }
 
   Future<void> loadDataWithTag(String tag) async {
@@ -245,7 +371,11 @@ class CpuProfilerController
       _dataNotifier.value = await processDataForTag(tag);
     } catch (e) {
       // In the event of an error, reset the data to the original CPU profile.
-      _dataNotifier.value = dataByTag[userTagNone];
+      final filteredOriginalData = cpuProfileStore.lookupProfile(
+        label: _wrapWithFilterSuffix(userTagNone),
+      );
+      assert(filteredOriginalData != null);
+      _dataNotifier.value = filteredOriginalData;
       throw Exception('Error loading data with tag "$tag": ${e.toString()}');
     } finally {
       _processingNotifier.value = false;
@@ -253,14 +383,29 @@ class CpuProfilerController
   }
 
   Future<CpuProfileData> processDataForTag(String tag) async {
-    final fullData = dataByTag[userTagNone];
-    final data = dataByTag.putIfAbsent(
-      tag,
-      () => CpuProfileData.fromUserTag(fullData, tag),
+    final filteredDataForTag = cpuProfileStore.lookupProfile(
+      label: _wrapWithFilterSuffix(tag),
     );
+    if (filteredDataForTag != null) {
+      if (!filteredDataForTag.processed) {
+        await transformer.processData(filteredDataForTag);
+      }
+      return filteredDataForTag;
+    }
+
+    var data = cpuProfileStore.lookupProfile(label: tag);
+    if (data == null) {
+      final fullData = cpuProfileStore.lookupProfile(label: userTagNone);
+      data = CpuProfileData.fromUserTag(fullData, tag);
+      cpuProfileStore.storeProfile(data, label: tag);
+    }
+
+    data = applyToggleFilters(data);
     if (!data.processed) {
       await transformer.processData(data);
     }
+    cpuProfileStore.storeProfile(data, label: _wrapWithFilterSuffix(tag));
+
     return data;
   }
 
@@ -279,7 +424,6 @@ class CpuProfilerController
   void reset() {
     _selectedCpuStackFrameNotifier.value = null;
     _dataNotifier.value = baseStateCpuProfileData;
-    dataByTag.clear();
     _processingNotifier.value = false;
     transformer.reset();
     resetSearch();
@@ -300,13 +444,20 @@ class CpuProfilerController
 
   @override
   void filterData(Filter<CpuStackFrame> filter) {
-    final originalData = dataByTag[userTagNone];
-    final filteredData = _filterData(originalData, filter);
+    final dataLabel = _wrapWithFilterSuffix(_userTagFilter.value);
+    var filteredData = cpuProfileStore.lookupProfile(label: dataLabel);
+    if (filteredData == null) {
+      final originalData =
+          cpuProfileStore.lookupProfile(label: _userTagFilter.value);
+      filteredData = _filterData(originalData, filter);
+      cpuProfileStore.storeProfile(filteredData, label: dataLabel);
+    }
     processAndSetData(
       filteredData,
       processId: 'filter $_filterIdentifier',
       storeAsUserTagNone: false,
       shouldApplyFilters: false,
+      shouldRefreshSearchMatches: true,
     );
     _filterIdentifier++;
   }
@@ -327,5 +478,9 @@ class CpuProfilerController
       return shouldInclude;
     };
     return CpuProfileData.filterFrom(originalData, filterCallback);
+  }
+
+  CpuProfileData applyToggleFilters(CpuProfileData data) {
+    return _filterData(data, Filter(toggleFilters: toggleFilters));
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -37,8 +37,8 @@ class CpuProfilerController
   /// This needs to match the tag set and unset at these locations,
   /// respectively:
   ///
-  /// Flutter Engine - https://github.com/flutter/engine/blob/master/runtime/dart_isolate.cc#L369
-  /// Flutter Framework - https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/widgets/binding.dart#L866
+  /// Flutter Engine - https://github.com/flutter/engine/blob/f52653ba4568b4a40e8624d47773d156740ea9f7/runtime/dart_isolate.cc#L369
+  /// Flutter Framework - https://github.com/flutter/flutter/blob/33f4107cd1029c3847f119e23719f6147dbc39db/packages/flutter/lib/src/widgets/binding.dart#L866
   static const appStartUpUserTag = 'AppStartUp';
 
   /// Data for the initial value and reset value of [_dataNotifier].
@@ -78,12 +78,10 @@ class CpuProfilerController
   final _userTagFilter = ValueNotifier<String>(userTagNone);
 
   Iterable<String> get userTags =>
-      cpuProfileStore.lookupProfile(label: userTagNone)?.userTags ?? [];
+      cpuProfileStore.lookupProfile(label: userTagNone)?.userTags ?? const [];
 
   bool get isToggleFilterActive =>
-      toggleFilters.firstWhere((filter) => filter.enabled.value,
-          orElse: () => null) !=
-      null;
+      toggleFilters.any((filter) => filter.enabled.value);
 
   /// The toggle filters available for the CPU profiler.
   ///
@@ -258,7 +256,7 @@ class CpuProfilerController
     await pullAndProcessProfile(
       startMicros: 0,
       // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
-      // give us all cpu samples we have available
+      // give us all cpu samples we have available.
       extentMicros: maxJsInt,
       processId: 'Load all samples',
     );
@@ -302,7 +300,7 @@ class CpuProfilerController
       final cpuProfile = await serviceManager.service.getCpuProfile(
         startMicros: 0,
         // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
-        // give us all cpu samples we have available
+        // give us all cpu samples we have available.
         extentMicros: maxJsInt,
       );
       appStartUpProfile = CpuProfileData.fromUserTag(

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -4,6 +4,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
+import 'package:flutter/cupertino.dart';
 import 'package:meta/meta.dart';
 
 import '../charts/flame_chart.dart';
@@ -124,6 +125,10 @@ class CpuProfileData {
     );
   }
 
+  /// Generate a cpu profile from [originalData] where each sample contains the
+  /// userTag [tag].
+  ///
+  /// [originalData] does not need to be [processed] to run this operation.
   factory CpuProfileData.fromUserTag(CpuProfileData originalData, String tag) {
     if (!originalData.userTags.contains(tag)) {
       return CpuProfileData.empty();
@@ -179,6 +184,10 @@ class CpuProfileData {
     );
   }
 
+  /// Generate a cpu profile from [originalData] where each stack frame meets
+  /// the condition specified by [includeFilter].
+  ///
+  /// [originalData] does not need to be [processed] to run this operation.
   factory CpuProfileData.filterFrom(
     CpuProfileData originalData,
     bool Function(CpuStackFrame) includeFilter,
@@ -311,7 +320,18 @@ class CpuProfileData {
 
   CpuStackFrame get cpuProfileRoot => _cpuProfileRoot;
 
-  Iterable<String> get userTags => _cpuProfileRoot.userTags;
+  Iterable<String> get userTags {
+    if (_userTags != null) {
+      return _userTags;
+    }
+    final tags = <String>{};
+    for (final cpuSample in cpuSamples) {
+      tags.add(cpuSample.userTag);
+    }
+    return _userTags = tags;
+  }
+
+  Iterable<String> _userTags;
 
   CpuStackFrame _cpuProfileRoot;
 
@@ -702,43 +722,69 @@ int stackFrameIdCompare(String a, String b) {
 }
 
 class CpuProfileStore {
-  final _profiles = <TimeRange, CpuProfileData>{};
-
-  /// Lookup a profile from the cache [_profiles] for the given range [time].
+  /// Store of CPU profiles keyed by a label.
   ///
-  /// If [_profiles] contains a CPU profile for a time range that encompasses
-  /// [time], a sub profile will be generated, cached in [_profiles] and then
-  /// returned. This method will return null if no profiles are cached for
-  /// [time] or if a sub profile cannot be generated for [time].
-  CpuProfileData lookupProfile(TimeRange time) {
+  /// This label will contain information regarding any toggle filters or user
+  /// tag filters applied to the profile.
+  final _profilesByLabel = <String, CpuProfileData>{};
+
+  /// Store of CPU profiles keyed by a time range.
+  ///
+  /// These time ranges are allowed to overlap.
+  final _profilesByTime = <TimeRange, CpuProfileData>{};
+
+  /// Lookup a profile from either cache: [_profilesByLabel] or
+  /// [_profilesByTime].
+  ///
+  /// Only one of [label] and [time] may be non-null.
+  ///
+  /// If this lookup is based on [label], a cached profile will be returned from
+  /// [_profilesByLabel], or null if one is not available.
+  ///
+  /// If this lookup is based on [time] and [_profilesByTime] contains a CPU
+  /// profile for a time range that encompasses [time], a sub profile will be
+  /// generated, cached in [_profilesByTime] and then returned. This method will
+  /// return null if no profiles are cached for [time] or if a sub profile
+  /// cannot be generated for [time].
+  CpuProfileData lookupProfile({String label, TimeRange time}) {
+    assert((label == null) != (time == null));
+
+    if (label != null) {
+      return _profilesByLabel[label];
+    }
+
     if (!time.isWellFormed) return null;
 
     // If we have a profile for a time range encompassing [time], then we can
     // generate and cache the profile for [time] without needing to pull data
     // from the vm service.
     _maybeGenerateSubProfile(time);
-    return _profiles[time];
+    return _profilesByTime[time];
   }
 
-  void addProfile(TimeRange time, CpuProfileData profile) {
-    _profiles[time] = profile;
+  void storeProfile(CpuProfileData profile, {String label, TimeRange time}) {
+    assert((label == null) != (time == null));
+    if (label != null) {
+      _profilesByLabel[label] = profile;
+    }
+    _profilesByTime[time] = profile;
   }
 
   void _maybeGenerateSubProfile(TimeRange time) {
-    if (_profiles.containsKey(time)) return;
+    if (_profilesByTime.containsKey(time)) return;
     final encompassingTimeRange = _encompassingTimeRange(time);
     if (encompassingTimeRange != null) {
-      final encompassingProfile = _profiles[encompassingTimeRange];
+      final encompassingProfile = _profilesByTime[encompassingTimeRange];
 
       final subProfile = CpuProfileData.subProfile(encompassingProfile, time);
-      _profiles[time] = subProfile;
+      _profilesByTime[time] = subProfile;
     }
   }
 
   TimeRange _encompassingTimeRange(TimeRange time) {
     int shortestDurationMicros = maxJsInt;
     TimeRange encompassingTimeRange;
-    for (final t in _profiles.keys) {
+    for (final t in _profilesByTime.keys) {
       // We want to find the shortest encompassing time range for [time].
       if (t.containsRange(time) &&
           t.duration.inMicroseconds < shortestDurationMicros) {
@@ -750,6 +796,7 @@ class CpuProfileStore {
   }
 
   void clear() {
-    _profiles.clear();
+    _profilesByTime.clear();
+    _profilesByLabel.clear();
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -721,6 +721,10 @@ int stackFrameIdCompare(String a, String b) {
   }
 }
 
+// TODO(kenz): this store could be improved by allowing profiles stored by
+// time range to also have a concept of which filters were applied. This isn't
+// critical as the CPU profiles that are stored by time will be small, so the
+// time that would be saved by only filtering these profiles once is minimal.
 class CpuProfileStore {
   /// Store of CPU profiles keyed by a label.
   ///
@@ -766,6 +770,7 @@ class CpuProfileStore {
     assert((label == null) != (time == null));
     if (label != null) {
       _profilesByLabel[label] = profile;
+      return;
     }
     _profilesByTime[time] = profile;
   }

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -155,11 +155,7 @@ class _CpuProfilerState extends State<CpuProfiler>
                 if (currentTab.key != CpuProfiler.summaryTab) ...[
                   FilterButton(
                     onPressed: _showFilterDialog,
-                    isFilterActive: widget.controller.toggleFilters.firstWhere(
-                          (filter) => filter.enabled.value,
-                          orElse: () => null,
-                        ) !=
-                        null,
+                    isFilterActive: widget.controller.isToggleFilterActive,
                   ),
                   const SizedBox(width: denseSpacing),
                   UserTagDropdown(widget.controller),

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -146,6 +146,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
           ProfilerScreenControls(
             controller: controller,
             recording: recording,
+            processing: processing,
           ),
         const SizedBox(height: denseRowSpacing),
         Expanded(
@@ -156,6 +157,26 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
                       CpuProfilerController.baseStateCpuProfileData ||
                   cpuProfileData == null) {
                 return _buildRecordingInfo();
+              }
+              if (cpuProfileData ==
+                  CpuProfilerController.emptyAppStartUpProfile) {
+                return Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: const [
+                      Text(
+                        'There are no app start up samples available.',
+                        textAlign: TextAlign.center,
+                      ),
+                      SizedBox(height: denseSpacing),
+                      Text(
+                        'To avoid this, try to open the DevTools CPU profiler '
+                        'sooner after starting your app.',
+                        textAlign: TextAlign.center,
+                      ),
+                    ],
+                  ),
+                );
               }
               if (cpuProfileData.isEmpty) {
                 // TODO(kenz): remove the note about profiling on iOS after
@@ -228,7 +249,10 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   @override
   FutureOr<void> processOfflineData(CpuProfileData offlineData) async {
     await controller.cpuProfilerController.transformer.processData(offlineData);
-    controller.cpuProfilerController.loadProcessedData(offlineData);
+    controller.cpuProfilerController.loadProcessedData(
+      offlineData,
+      storeAsUserTagNone: true,
+    );
   }
 
   @override
@@ -243,11 +267,14 @@ class ProfilerScreenControls extends StatelessWidget {
   const ProfilerScreenControls({
     @required this.controller,
     @required this.recording,
+    @required this.processing,
   });
 
   final ProfilerScreenController controller;
 
   final bool recording;
+
+  final bool processing;
 
   @override
   Widget build(BuildContext context) {
@@ -261,7 +288,7 @@ class ProfilerScreenControls extends StatelessWidget {
         const SizedBox(width: defaultSpacing),
         _SecondaryControls(
           controller: controller,
-          recording: recording,
+          profilerBusy: recording || processing,
         ),
       ],
     );
@@ -274,7 +301,7 @@ class _PrimaryControls extends StatelessWidget {
     @required this.recording,
   });
 
-  static const _primaryControlsMinIncludeTextWidth = 880.0;
+  static const _primaryControlsMinIncludeTextWidth = 1050.0;
 
   final ProfilerScreenController controller;
 
@@ -331,34 +358,54 @@ class _PrimaryControls extends StatelessWidget {
 class _SecondaryControls extends StatelessWidget {
   const _SecondaryControls({
     @required this.controller,
-    @required this.recording,
+    @required this.profilerBusy,
   });
 
-  static const _secondaryControlsMinIncludeTextWidth = 880.0;
+  static const _secondaryControlsMinScreenWidthForText = 1050.0;
 
-  static const _loadAllCpuSamplesMinIncludeTextWidth = 660.0;
+  static const _profilingControlsMinScreenWidthForText = 815.0;
 
   final ProfilerScreenController controller;
 
-  final bool recording;
+  final bool profilerBusy;
 
   @override
   Widget build(BuildContext context) {
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
+        if (serviceManager.connectedApp.isFlutterNativeAppNow)
+          IconLabelButton(
+            icon: Icons.timer,
+            label: 'Profile app start up',
+            tooltip: 'Load all Dart CPU samples that occurred before \n'
+                'the first Flutter frame was drawn (if available)',
+            tooltipPadding: const EdgeInsets.all(denseSpacing),
+            minScreenWidthForTextBeforeScaling:
+                _profilingControlsMinScreenWidthForText,
+            onPressed: !profilerBusy
+                ? () {
+                    ga.select(
+                      analytics_constants.cpuProfiler,
+                      analytics_constants.profileAppStartUp,
+                    );
+                    controller.cpuProfilerController.loadAppStartUpProfile();
+                  }
+                : null,
+          ),
+        const SizedBox(width: denseSpacing),
         RefreshButton(
           label: 'Load all CPU samples',
           tooltip: 'Load all available CPU samples from the profiler',
           minScreenWidthForTextBeforeScaling:
-              _loadAllCpuSamplesMinIncludeTextWidth,
-          onPressed: !recording
+              _profilingControlsMinScreenWidthForText,
+          onPressed: !profilerBusy
               ? () {
                   ga.select(
                     analytics_constants.cpuProfiler,
                     analytics_constants.loadAllCpuSamples,
                   );
-                  controller.loadAllSamples();
+                  controller.cpuProfilerController.loadAllSamples();
                 }
               : null,
         ),
@@ -370,7 +417,7 @@ class _SecondaryControls extends StatelessWidget {
         ),
         const SizedBox(width: denseSpacing),
         ExportButton(
-          onPressed: !recording &&
+          onPressed: !profilerBusy &&
                   controller.cpuProfileData != null &&
                   !controller.cpuProfileData.isEmpty
               ? () {
@@ -382,7 +429,7 @@ class _SecondaryControls extends StatelessWidget {
                 }
               : null,
           minScreenWidthForTextBeforeScaling:
-              _secondaryControlsMinIncludeTextWidth,
+              _secondaryControlsMinScreenWidthForText,
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
@@ -6,12 +6,23 @@ import 'package:flutter/foundation.dart';
 
 import '../analytics/constants.dart' as analytics_constants;
 import '../config_specific/import_export/import_export.dart';
+import '../config_specific/logger/allowed_error.dart';
+import '../globals.dart';
 import '../utils.dart';
 import 'cpu_profile_controller.dart';
 import 'cpu_profile_model.dart';
+import 'cpu_profile_service.dart';
+import 'profile_granularity.dart';
 import 'profiler_screen.dart';
 
 class ProfilerScreenController {
+  ProfilerScreenController() {
+    allowedError(
+      serviceManager.service.setProfilePeriod(mediumProfilePeriod),
+      logError: false,
+    );
+  }
+
   final cpuProfilerController =
       CpuProfilerController(analyticsScreenId: analytics_constants.cpuProfiler);
 
@@ -39,17 +50,6 @@ class ProfilerScreenController {
       // give us all cpu samples we have available
       extentMicros: maxJsInt,
       processId: 'Profile $_profileStartMicros',
-    );
-  }
-
-  Future<void> loadAllSamples() async {
-    cpuProfilerController.reset();
-    await cpuProfilerController.pullAndProcessProfile(
-      startMicros: 0,
-      // Using [maxJsInt] as [extentMicros] for the getCpuProfile requests will
-      // give us all cpu samples we have available
-      extentMicros: maxJsInt,
-      processId: 'Load all samples',
     );
   }
 

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -177,6 +177,11 @@ void main() {
     });
 
     test('processDataForTag', () async {
+      // Disable toggle filters for the purpose of this test.
+      for (final toggleFilter in controller.toggleFilters) {
+        toggleFilter.enabled.value = false;
+      }
+
       final cpuProfileDataWithTags =
           CpuProfileData.parse(cpuProfileDataWithUserTagsJson);
       await controller.transformer.processData(cpuProfileDataWithTags);
@@ -240,6 +245,71 @@ void main() {
     Frame1 - children: 1 - excl: 0 - incl: 2
       Frame5 - children: 1 - excl: 1 - incl: 2
         Frame6 - children: 0 - excl: 1 - incl: 1
+''',
+        ),
+      );
+    });
+
+    test('processDataForTag applies toggle filters by default', () async {
+      expect(controller.toggleFilters[0].enabled.value, isTrue);
+      final cpuProfileDataWithTags =
+          CpuProfileData.parse(cpuProfileDataWithUserTagsJson);
+      await controller.transformer.processData(cpuProfileDataWithTags);
+      controller.loadProcessedData(
+        cpuProfileDataWithTags,
+        storeAsUserTagNone: true,
+      );
+
+      expect(
+          controller.dataNotifier.value.cpuProfileRoot.profileMetaData.time
+              .duration.inMicroseconds,
+          equals(250));
+      expect(
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
+  all - children: 1 - excl: 0 - incl: 5
+    Frame1 - children: 2 - excl: 0 - incl: 5
+      Frame2 - children: 2 - excl: 0 - incl: 2
+        Frame3 - children: 0 - excl: 1 - incl: 1
+        Frame4 - children: 0 - excl: 1 - incl: 1
+      Frame5 - children: 1 - excl: 2 - incl: 3
+        Frame6 - children: 0 - excl: 1 - incl: 1
+''',
+        ),
+      );
+
+      await controller.loadDataWithTag('userTagA');
+      expect(
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
+  all - children: 2 - excl: 0 - incl: 2
+    Frame2 - children: 0 - excl: 1 - incl: 1
+    Frame5 - children: 0 - excl: 1 - incl: 1
+''',
+        ),
+      );
+
+      await controller.loadDataWithTag('userTagB');
+      expect(
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
+  all - children: 1 - excl: 0 - incl: 1
+    Frame2 - children: 0 - excl: 1 - incl: 1
+''',
+        ),
+      );
+
+      await controller.loadDataWithTag('userTagC');
+      expect(
+        controller.dataNotifier.value.cpuProfileRoot.toStringDeep(),
+        equals(
+          '''
+  all - children: 1 - excl: 0 - incl: 2
+    Frame5 - children: 1 - excl: 1 - incl: 2
+      Frame6 - children: 0 - excl: 1 - incl: 1
 ''',
         ),
       );

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -17,6 +17,7 @@ import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 
 import 'support/cpu_profile_test_data.dart';
 import 'support/mocks.dart';
@@ -26,6 +27,7 @@ void main() {
   CpuProfiler cpuProfiler;
   CpuProfileData cpuProfileData;
   CpuProfilerController controller;
+  ServiceConnectionManager fakeServiceManager;
 
   setUp(() async {
     final transformer = CpuProfileTransformer();
@@ -33,7 +35,10 @@ void main() {
     cpuProfileData = CpuProfileData.parse(goldenCpuProfileDataJson);
     await transformer.processData(cpuProfileData);
 
-    setGlobal(ServiceConnectionManager, FakeServiceManager());
+    fakeServiceManager = FakeServiceManager();
+    when(fakeServiceManager.connectedApp.isFlutterNativeAppNow)
+        .thenReturn(false);
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
   });
 
   group('CpuProfiler', () {
@@ -293,9 +298,11 @@ void main() {
         expect(find.text('Filter by tag: userTagB'), findsWidgets);
         expect(find.text('Filter by tag: userTagC'), findsWidgets);
 
-        await tester.tap(find.text('CPU Flame Chart'));
+        await tester.tap(find.text('Call Tree'));
         await tester.pumpAndSettle();
-        expect(find.byType(CpuProfileFlameChart), findsOneWidget);
+        expect(find.byType(CpuCallTreeTable), findsOneWidget);
+        await tester.tap(find.text('Expand All'));
+        await tester.pumpAndSettle();
 
         expect(
           controller
@@ -313,14 +320,16 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Filter by tag: userTagA').last);
         await tester.pumpAndSettle();
+        await tester.tap(find.text('Expand All'));
+        await tester.pumpAndSettle();
         expect(
           controller
               .cpuProfileData.profileMetaData.time.duration.inMicroseconds,
           equals(100),
         );
-        expect(find.text('Frame1'), findsOneWidget);
+        expect(find.text('Frame1'), findsNothing);
         expect(find.text('Frame2'), findsOneWidget);
-        expect(find.text('Frame3'), findsOneWidget);
+        expect(find.text('Frame3'), findsNothing);
         expect(find.text('Frame4'), findsNothing);
         expect(find.text('Frame5'), findsOneWidget);
         expect(find.text('Frame6'), findsNothing);
@@ -329,15 +338,17 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Filter by tag: userTagB').last);
         await tester.pumpAndSettle();
+        await tester.tap(find.text('Expand All'));
+        await tester.pumpAndSettle();
         expect(
           controller
               .cpuProfileData.profileMetaData.time.duration.inMicroseconds,
           equals(50),
         );
-        expect(find.text('Frame1'), findsOneWidget);
+        expect(find.text('Frame1'), findsNothing);
         expect(find.text('Frame2'), findsOneWidget);
         expect(find.text('Frame3'), findsNothing);
-        expect(find.text('Frame4'), findsOneWidget);
+        expect(find.text('Frame4'), findsNothing);
         expect(find.text('Frame5'), findsNothing);
         expect(find.text('Frame6'), findsNothing);
 
@@ -345,12 +356,14 @@ void main() {
         await tester.pumpAndSettle();
         await tester.tap(find.text('Filter by tag: userTagC').last);
         await tester.pumpAndSettle();
+        await tester.tap(find.text('Expand All'));
+        await tester.pumpAndSettle();
         expect(
           controller
               .cpuProfileData.profileMetaData.time.duration.inMicroseconds,
           equals(100),
         );
-        expect(find.text('Frame1'), findsOneWidget);
+        expect(find.text('Frame1'), findsNothing);
         expect(find.text('Frame2'), findsNothing);
         expect(find.text('Frame3'), findsNothing);
         expect(find.text('Frame4'), findsNothing);

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -270,7 +270,10 @@ void main() {
         await controller.cpuProfilerController.transformer
             .processData(cpuProfileData);
         // Call this to force the value of `_dataByTag[userTagNone]` to be set.
-        controller.cpuProfilerController.loadProcessedData(cpuProfileData);
+        controller.cpuProfilerController.loadProcessedData(
+          cpuProfileData,
+          storeAsUserTagNone: true,
+        );
       });
 
       testWidgetsWithWindowSize('can filter data by user tag', windowSize,

--- a/packages/devtools_app/test/support/cpu_profile_test_data.dart
+++ b/packages/devtools_app/test/support/cpu_profile_test_data.dart
@@ -47,7 +47,8 @@ final Map<String, dynamic> cpuProfileDataWithUserTagsJson = {
       'category': 'Dart',
       'name': 'Frame2',
       'parent': '140357727781376-1',
-      'resolvedUrl': '',
+      'resolvedUrl':
+          'org-dartlang-sdk:///third_party/dart/sdk/lib/vm/compact_hash.dart',
     },
     '140357727781376-3': {
       'category': 'Dart',
@@ -65,13 +66,15 @@ final Map<String, dynamic> cpuProfileDataWithUserTagsJson = {
       'category': 'Dart',
       'name': 'Frame5',
       'parent': '140357727781376-1',
-      'resolvedUrl': '',
+      'resolvedUrl':
+          'org-dartlang-sdk:///third_party/dart/sdk/lib/vm/compact_hash.dart',
     },
     '140357727781376-6': {
       'category': 'Dart',
       'name': 'Frame6',
       'parent': '140357727781376-5',
-      'resolvedUrl': '',
+      'resolvedUrl':
+          'path/to/flutter/packages/flutter/lib/src/rendering/custom_layout.dart',
     },
   },
   'traceEvents': [


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/2982. We will still use the DDS apis once they are available.
![Screen Shot 2021-09-09 at 3 44 17 PM](https://user-images.githubusercontent.com/43759233/132925187-51716bd7-3814-4741-b464-a380d006d0f4.png)
When an app start up profile is available, clicking this button will load the profile and automatically select the AppStartUp usertag:
![Screen Shot 2021-09-10 at 3 45 31 PM](https://user-images.githubusercontent.com/43759233/132925229-7a72abba-3988-43b6-889d-bfe5e04e38f1.png)
When an app start up profile is not available, a warning message will be displayed. The default profiling rate may cause this case to occur more often than we like. See https://github.com/flutter/flutter/issues/84884#issuecomment-917050444 for some more details.
![Screen Shot 2021-09-09 at 3 39 27 PM](https://user-images.githubusercontent.com/43759233/132925256-d1b8458d-54ca-4f37-8f98-5e32f5299b50.png)

The PR also fixes https://github.com/flutter/devtools/issues/3317 and improves the caching for the CPU profiler in general. This will prevent duplicate processing actions when a user is changing filters back and forth. This also fixes bugs where the filters were not applied correctly to profiles cached by user tag.