### PR TITLE
Add multi-isolate support to the CPU profiler

### DIFF
--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -39,8 +39,7 @@ class ConnectedApp {
   bool _isFlutterApp;
 
   FlutterVersion get flutterVersionNow {
-    assert(isFlutterNativeAppNow);
-    return _flutterVersion;
+    return isFlutterNativeAppNow ? _flutterVersion : null;
   }
 
   FlutterVersion _flutterVersion;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -57,8 +57,15 @@ class CpuProfilerController
   /// The analytics screen id for which this controller is active.
   final String analyticsScreenId;
 
-  /// Store of cached CPU profiles.
-  final cpuProfileStore = CpuProfileStore();
+  /// The store of cached CPU profiles for the currently selected isolate.
+  CpuProfileStore get cpuProfileStore =>
+      _cpuProfileStoreByIsolateId.putIfAbsent(
+        serviceManager.isolateManager.selectedIsolate.value?.id,
+        () => CpuProfileStore(),
+      );
+
+  /// Store of cached CPU profiles for each isolate.
+  final _cpuProfileStoreByIsolateId = <String, CpuProfileStore>{};
 
   /// Notifies that new cpu profile data is available.
   ValueListenable<CpuProfileData> get dataNotifier => _dataNotifier;
@@ -416,9 +423,9 @@ class CpuProfilerController
     await serviceManager.service.clearSamples();
   }
 
-  void reset() {
+  void reset({CpuProfileData data}) {
     _selectedCpuStackFrameNotifier.value = null;
-    _dataNotifier.value = baseStateCpuProfileData;
+    _dataNotifier.value = data ?? baseStateCpuProfileData;
     _processingNotifier.value = false;
     transformer.reset();
     resetSearch();

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -18,6 +19,7 @@ import '../common_widgets.dart';
 import '../config_specific/import_export/import_export.dart';
 import '../config_specific/launch_url/launch_url.dart';
 import '../globals.dart';
+import '../listenable.dart';
 import '../notifications.dart';
 import '../screen.dart';
 import '../theme.dart';
@@ -53,6 +55,10 @@ class ProfilerScreen extends Screen {
 
   @override
   String get docPageId => id;
+
+  @override
+  ValueListenable<bool> get showIsolateSelector =>
+      const FixedValueListenable<bool>(true);
 
   @override
   Widget build(BuildContext context) => const ProfilerScreenBody();

--- a/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
@@ -3,8 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
 
 import '../analytics/constants.dart' as analytics_constants;
+import '../auto_dispose.dart';
 import '../config_specific/import_export/import_export.dart';
 import '../config_specific/logger/allowed_error.dart';
 import '../globals.dart';
@@ -15,12 +17,20 @@ import 'cpu_profile_service.dart';
 import 'profile_granularity.dart';
 import 'profiler_screen.dart';
 
-class ProfilerScreenController {
+class ProfilerScreenController extends DisposableController
+    with AutoDisposeControllerMixin {
   ProfilerScreenController() {
-    allowedError(
-      serviceManager.service.setProfilePeriod(mediumProfilePeriod),
-      logError: false,
-    );
+    if (!offlineMode) {
+      allowedError(
+        serviceManager.service.setProfilePeriod(mediumProfilePeriod),
+        logError: false,
+      );
+
+      _currentIsolate = serviceManager.isolateManager.selectedIsolate.value;
+      addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
+        switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
+      });
+    }
   }
 
   final cpuProfilerController =
@@ -30,12 +40,30 @@ class ProfilerScreenController {
 
   CpuProfileData get cpuProfileData => cpuProfilerController.dataNotifier.value;
 
+  final _previousProfileByIsolateId = <String, CpuProfileData>{};
+
   /// Notifies that a CPU profile is currently being recorded.
   ValueListenable<bool> get recordingNotifier => _recordingNotifier;
 
   final _recordingNotifier = ValueNotifier<bool>(false);
 
   final int _profileStartMicros = 0;
+
+  IsolateRef _currentIsolate;
+
+  void switchToIsolate(IsolateRef ref) {
+    // Store the data for the current isolate.
+    if (_currentIsolate?.id != null) {
+      _previousProfileByIsolateId[_currentIsolate?.id] =
+          cpuProfilerController.dataNotifier.value;
+    }
+    // Update the current isolate.
+    _currentIsolate = ref;
+    // Load any existing data for the new isolate.
+    final previousData = _previousProfileByIsolateId[ref?.id];
+    _recordingNotifier.value = false;
+    cpuProfilerController.reset(data: previousData);
+  }
 
   Future<void> startRecording() async {
     await clear();
@@ -66,8 +94,10 @@ class ProfilerScreenController {
     await cpuProfilerController.clear();
   }
 
+  @override
   void dispose() {
     _recordingNotifier.dispose();
     cpuProfilerController.dispose();
+    super.dispose();
   }
 }


### PR DESCRIPTION
![Screen Shot 2021-09-14 at 11 13 05 AM](https://user-images.githubusercontent.com/43759233/133315872-d72a2d5c-a26b-4299-9c2d-70f0e92b4adc.png)
![Screen Shot 2021-09-14 at 11 13 10 AM](https://user-images.githubusercontent.com/43759233/133315882-4e15710a-f980-4b9a-8a58-098b3f73bbf4.png)

Add the isolate selector to the CPU profiler page. Each isolate is given an instance of `CpuProfileStore` to track cached profiles for the isolate.

Fixes https://github.com/flutter/devtools/issues/3226