### PR TITLE
Improves searching in the file picker 

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -398,7 +398,6 @@ class _CodeViewState extends State<CodeView>
     return wrapInElevatedCard(
       FileSearchField(
         debuggerController: widget.controller,
-        autoCompleteController: AutoCompleteController(),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -397,7 +397,8 @@ class _CodeViewState extends State<CodeView>
   Widget buildFileSearchField() {
     return wrapInElevatedCard(
       FileSearchField(
-        controller: widget.controller,
+        debuggerController: widget.controller,
+        autoCompleteController: AutoCompleteController(),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -61,8 +61,8 @@ class _FileSearchFieldState extends State<FileSearchField>
     final previousQuery = _query;
     final currentQuery = widget.autoCompleteController.search;
 
-    // If the current query is a continuation of the previous query, then wittle
-    // down the matches. Otherwise search through all scripts:
+    // If the current query is a continuation of the previous query, then
+    // whittle down the matches. Otherwise search through all scripts:
     final scripts = currentQuery.startsWith(previousQuery)
         ? _matches
         : widget.debuggerController.sortedScripts.value;

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -530,6 +530,8 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
   /// pop-up is visible close the pop-up on first ESCAPE.
   /// [keyEventsToPropogate] a set of key events that should be propogated to
   /// other handlers
+  /// TODO(elliette): Have this return a private _AutoCompleteSearchField widget
+  ///  instead.
   Widget buildAutoCompleteSearchField({
     @required AutoCompleteSearchControllerMixin controller,
     @required GlobalKey searchFieldKey,

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/debugger/file_search.dart';
-import 'package:devtools_app/src/ui/search.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -14,15 +13,14 @@ import 'support/wrappers.dart';
 
 void main() {
   final debuggerController = MockDebuggerController.withDefaults();
-  final autoCompleteController = AutoCompleteController();
 
   Widget buildFileSearch() {
     return MaterialApp(
       home: Scaffold(
         body: Card(
           child: FileSearchField(
-              debuggerController: debuggerController,
-              autoCompleteController: autoCompleteController),
+            debuggerController: debuggerController,
+          ),
         ),
       ),
     );
@@ -38,22 +36,25 @@ void main() {
         'Search returns expected files', const Size(1000.0, 4000.0),
         (WidgetTester tester) async {
       await tester.pumpWidget(buildFileSearch());
+      final FileSearchFieldState state =
+          tester.state(find.byType(FileSearchField));
+      final autoCompleteController = state.autoCompleteController;
 
       autoCompleteController.search = '';
       expect(
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Show all results (truncated to 10):
-            'animals/cats/meow.dart',
-            'animals/cats/purr.dart',
-            'animals/dogs/bark.dart',
-            'animals/dogs/growl.dart',
-            'animals/insects/caterpillar.dart',
-            'animals/insects/cicada.dart',
-            'food/catering/party.dart',
-            'food/carton/milk.dart',
-            'food/milk/carton.dart',
-            'travel/adventure/cave_tours_europe.dart',
+            'zoo:animals/cats/meow.dart',
+            'zoo:animals/cats/purr.dart',
+            'zoo:animals/dogs/bark.dart',
+            'zoo:animals/dogs/growl.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'zoo:animals/insects/cicada.dart',
+            'kitchen:food/catering/party.dart',
+            'kitchen:food/carton/milk.dart',
+            'kitchen:food/milk/carton.dart',
+            'travel:adventure/cave_tours_europe.dart',
           ]),
           reason: 'Correct search results for empty query.');
 
@@ -62,15 +63,15 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/cats/meow.dart',
-            'animals/cats/purr.dart',
-            'animals/insects/caterpillar.dart',
-            'animals/insects/cicada.dart',
-            'food/catering/party.dart',
-            'food/carton/milk.dart',
-            'food/milk/carton.dart',
-            'travel/adventure/cave_tours_europe.dart',
-            'travel/canada/banff.dart',
+            'zoo:animals/cats/meow.dart',
+            'zoo:animals/cats/purr.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'zoo:animals/insects/cicada.dart',
+            'kitchen:food/catering/party.dart',
+            'kitchen:food/carton/milk.dart',
+            'kitchen:food/milk/carton.dart',
+            'travel:adventure/cave_tours_europe.dart',
+            'travel:canada/banff.dart',
           ]),
           reason: 'Correct search results for "c" query.');
 
@@ -79,15 +80,15 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/cats/meow.dart',
-            'animals/cats/purr.dart',
-            'animals/insects/caterpillar.dart',
-            'animals/insects/cicada.dart',
-            'food/catering/party.dart',
-            'food/carton/milk.dart',
-            'food/milk/carton.dart',
-            'travel/adventure/cave_tours_europe.dart',
-            'travel/canada/banff.dart',
+            'zoo:animals/cats/meow.dart',
+            'zoo:animals/cats/purr.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'zoo:animals/insects/cicada.dart',
+            'kitchen:food/catering/party.dart',
+            'kitchen:food/carton/milk.dart',
+            'kitchen:food/milk/carton.dart',
+            'travel:adventure/cave_tours_europe.dart',
+            'travel:canada/banff.dart',
           ]),
           reason: 'Correct search results for "ca" query.');
 
@@ -96,14 +97,14 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/cats/meow.dart',
-            'animals/cats/purr.dart',
-            'animals/insects/caterpillar.dart',
-            'food/catering/party.dart',
+            'zoo:animals/cats/meow.dart',
+            'zoo:animals/cats/purr.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'kitchen:food/catering/party.dart',
             // Fuzzy matches:
-            'animals/insects/cicada.dart',
-            'food/milk/carton.dart',
-            'travel/adventure/cave_tours_europe.dart',
+            'zoo:animals/insects/cicada.dart',
+            'kitchen:food/milk/carton.dart',
+            'travel:adventure/cave_tours_europe.dart',
           ]),
           reason: 'Correct search results for "cat" query.');
 
@@ -112,10 +113,10 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/insects/caterpillar.dart',
-            'food/catering/party.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'kitchen:food/catering/party.dart',
             // Fuzzy matches:
-            'travel/adventure/cave_tours_europe.dart',
+            'travel:adventure/cave_tours_europe.dart',
           ]),
           reason: 'Correct search results for "cate" query.');
 
@@ -124,10 +125,10 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/insects/caterpillar.dart',
-            'food/catering/party.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'kitchen:food/catering/party.dart',
             // Fuzzy matches:
-            'travel/adventure/cave_tours_europe.dart',
+            'travel:adventure/cave_tours_europe.dart',
           ]),
           reason: 'Correct search results for "cater" query.');
 
@@ -136,9 +137,9 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/insects/caterpillar.dart',
+            'zoo:animals/insects/caterpillar.dart',
             // Fuzzy matches:
-            'travel/adventure/cave_tours_europe.dart',
+            'travel:adventure/cave_tours_europe.dart',
           ]),
           reason: 'Correct search results for "caterp" query.');
 
@@ -147,7 +148,7 @@ void main() {
           autoCompleteController.searchAutoComplete.value,
           equals([
             // Exact matches:
-            'animals/insects/caterpillar.dart',
+            'zoo:animals/insects/caterpillar.dart',
           ]),
           reason: 'Correct search results for "caterpi" query.');
 

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -150,6 +150,15 @@ void main() {
             'animals/insects/caterpillar.dart',
           ]),
           reason: 'Correct search results for "caterpi" query.');
+
+      autoCompleteController.search = 'caterpie';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // No matches message:
+            'No files found.',
+          ]),
+          reason: 'Correct search results for "caterpie" query.');
     });
   });
 }

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -1,0 +1,155 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/debugger/file_search.dart';
+import 'package:devtools_app/src/ui/search.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+import 'support/mocks.dart';
+import 'support/wrappers.dart';
+
+void main() {
+  final debuggerController = MockDebuggerController.withDefaults();
+  final autoCompleteController = AutoCompleteController();
+
+  Widget buildFileSearch() {
+    return MaterialApp(
+      home: Scaffold(
+        body: Card(
+          child: FileSearchField(
+              debuggerController: debuggerController,
+              autoCompleteController: autoCompleteController),
+        ),
+      ),
+    );
+  }
+
+  group('File search', () {
+    setUp(() {
+      when(debuggerController.sortedScripts)
+          .thenReturn(ValueNotifier(mockScriptRefs));
+    });
+
+    testWidgetsWithWindowSize(
+        'Search returns expected files', const Size(1000.0, 4000.0),
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildFileSearch());
+
+      autoCompleteController.search = '';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Show all results (truncated to 10):
+            'animals/cats/meow.dart',
+            'animals/cats/purr.dart',
+            'animals/dogs/bark.dart',
+            'animals/dogs/growl.dart',
+            'animals/insects/caterpillar.dart',
+            'animals/insects/cicada.dart',
+            'food/catering/party.dart',
+            'food/carton/milk.dart',
+            'food/milk/carton.dart',
+            'travel/adventure/cave_tours_europe.dart',
+          ]),
+          reason: 'Correct search results for empty query.');
+
+      autoCompleteController.search = 'c';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/cats/meow.dart',
+            'animals/cats/purr.dart',
+            'animals/insects/caterpillar.dart',
+            'animals/insects/cicada.dart',
+            'food/catering/party.dart',
+            'food/carton/milk.dart',
+            'food/milk/carton.dart',
+            'travel/adventure/cave_tours_europe.dart',
+            'travel/canada/banff.dart',
+          ]),
+          reason: 'Correct search results for "c" query.');
+
+      autoCompleteController.search = 'ca';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/cats/meow.dart',
+            'animals/cats/purr.dart',
+            'animals/insects/caterpillar.dart',
+            'animals/insects/cicada.dart',
+            'food/catering/party.dart',
+            'food/carton/milk.dart',
+            'food/milk/carton.dart',
+            'travel/adventure/cave_tours_europe.dart',
+            'travel/canada/banff.dart',
+          ]),
+          reason: 'Correct search results for "ca" query.');
+
+      autoCompleteController.search = 'cat';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/cats/meow.dart',
+            'animals/cats/purr.dart',
+            'animals/insects/caterpillar.dart',
+            'food/catering/party.dart',
+            // Fuzzy matches:
+            'animals/insects/cicada.dart',
+            'food/milk/carton.dart',
+            'travel/adventure/cave_tours_europe.dart',
+          ]),
+          reason: 'Correct search results for "cat" query.');
+
+      autoCompleteController.search = 'cate';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/insects/caterpillar.dart',
+            'food/catering/party.dart',
+            // Fuzzy matches:
+            'travel/adventure/cave_tours_europe.dart',
+          ]),
+          reason: 'Correct search results for "cate" query.');
+
+      autoCompleteController.search = 'cater';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/insects/caterpillar.dart',
+            'food/catering/party.dart',
+            // Fuzzy matches:
+            'travel/adventure/cave_tours_europe.dart',
+          ]),
+          reason: 'Correct search results for "cater" query.');
+
+      autoCompleteController.search = 'caterp';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/insects/caterpillar.dart',
+            // Fuzzy matches:
+            'travel/adventure/cave_tours_europe.dart',
+          ]),
+          reason: 'Correct search results for "caterp" query.');
+
+      autoCompleteController.search = 'caterpi';
+      expect(
+          autoCompleteController.searchAutoComplete.value,
+          equals([
+            // Exact matches:
+            'animals/insects/caterpillar.dart',
+          ]),
+          reason: 'Correct search results for "caterpi" query.');
+    });
+  });
+}

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -42,55 +42,55 @@ void main() {
 
       autoCompleteController.search = '';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Show all results (truncated to 10):
-            'zoo:animals/cats/meow.dart',
-            'zoo:animals/cats/purr.dart',
-            'zoo:animals/dogs/bark.dart',
-            'zoo:animals/dogs/growl.dart',
-            'zoo:animals/insects/caterpillar.dart',
-            'zoo:animals/insects/cicada.dart',
-            'kitchen:food/catering/party.dart',
-            'kitchen:food/carton/milk.dart',
-            'kitchen:food/milk/carton.dart',
-            'travel:adventure/cave_tours_europe.dart',
-          ]),
-          reason: 'Correct search results for empty query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Show all results (truncated to 10):
+          'zoo:animals/cats/meow.dart',
+          'zoo:animals/cats/purr.dart',
+          'zoo:animals/dogs/bark.dart',
+          'zoo:animals/dogs/growl.dart',
+          'zoo:animals/insects/caterpillar.dart',
+          'zoo:animals/insects/cicada.dart',
+          'kitchen:food/catering/party.dart',
+          'kitchen:food/carton/milk.dart',
+          'kitchen:food/milk/carton.dart',
+          'travel:adventure/cave_tours_europe.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'c';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Exact matches:
-            'zoo:animals/cats/meow.dart',
-            'zoo:animals/cats/purr.dart',
-            'zoo:animals/insects/caterpillar.dart',
-            'zoo:animals/insects/cicada.dart',
-            'kitchen:food/catering/party.dart',
-            'kitchen:food/carton/milk.dart',
-            'kitchen:food/milk/carton.dart',
-            'travel:adventure/cave_tours_europe.dart',
-            'travel:canada/banff.dart',
-          ]),
-          reason: 'Correct search results for "c" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Exact matches:
+          'zoo:animals/cats/meow.dart',
+          'zoo:animals/cats/purr.dart',
+          'zoo:animals/insects/caterpillar.dart',
+          'zoo:animals/insects/cicada.dart',
+          'kitchen:food/catering/party.dart',
+          'kitchen:food/carton/milk.dart',
+          'kitchen:food/milk/carton.dart',
+          'travel:adventure/cave_tours_europe.dart',
+          'travel:canada/banff.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'ca';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Exact matches:
-            'zoo:animals/cats/meow.dart',
-            'zoo:animals/cats/purr.dart',
-            'zoo:animals/insects/caterpillar.dart',
-            'zoo:animals/insects/cicada.dart',
-            'kitchen:food/catering/party.dart',
-            'kitchen:food/carton/milk.dart',
-            'kitchen:food/milk/carton.dart',
-            'travel:adventure/cave_tours_europe.dart',
-            'travel:canada/banff.dart',
-          ]),
-          reason: 'Correct search results for "ca" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Exact matches:
+          'zoo:animals/cats/meow.dart',
+          'zoo:animals/cats/purr.dart',
+          'zoo:animals/insects/caterpillar.dart',
+          'zoo:animals/insects/cicada.dart',
+          'kitchen:food/catering/party.dart',
+          'kitchen:food/carton/milk.dart',
+          'kitchen:food/milk/carton.dart',
+          'travel:adventure/cave_tours_europe.dart',
+          'travel:canada/banff.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'cat';
       expect(
@@ -110,27 +110,27 @@ void main() {
 
       autoCompleteController.search = 'cate';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Exact matches:
-            'zoo:animals/insects/caterpillar.dart',
-            'kitchen:food/catering/party.dart',
-            // Fuzzy matches:
-            'travel:adventure/cave_tours_europe.dart',
-          ]),
-          reason: 'Correct search results for "cate" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Exact matches:
+          'zoo:animals/insects/caterpillar.dart',
+          'kitchen:food/catering/party.dart',
+          // Fuzzy matches:
+          'travel:adventure/cave_tours_europe.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'cater';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Exact matches:
-            'zoo:animals/insects/caterpillar.dart',
-            'kitchen:food/catering/party.dart',
-            // Fuzzy matches:
-            'travel:adventure/cave_tours_europe.dart',
-          ]),
-          reason: 'Correct search results for "cater" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Exact matches:
+          'zoo:animals/insects/caterpillar.dart',
+          'kitchen:food/catering/party.dart',
+          // Fuzzy matches:
+          'travel:adventure/cave_tours_europe.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'caterp';
       expect(
@@ -145,21 +145,21 @@ void main() {
 
       autoCompleteController.search = 'caterpi';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // Exact matches:
-            'zoo:animals/insects/caterpillar.dart',
-          ]),
-          reason: 'Correct search results for "caterpi" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // Exact matches:
+          'zoo:animals/insects/caterpillar.dart',
+        ]),
+      );
 
       autoCompleteController.search = 'caterpie';
       expect(
-          autoCompleteController.searchAutoComplete.value,
-          equals([
-            // No matches message:
-            'No files found.',
-          ]),
-          reason: 'Correct search results for "caterpie" query.');
+        autoCompleteController.searchAutoComplete.value,
+        equals([
+          // No matches message:
+          'No files found.',
+        ]),
+      );
     });
   });
 }

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -1357,3 +1357,17 @@ final mockParsedScript = ParsedScript(
     highlighter: SyntaxHighlighter.withGrammar(
         grammar: mockGrammar, source: mockScript.source),
     executableLines: <int>{});
+
+final mockScriptRefs = [
+  ScriptRef(uri: 'animals/cats/meow.dart', id: 'fake/id/1'),
+  ScriptRef(uri: 'animals/cats/purr.dart', id: 'fake/id/2'),
+  ScriptRef(uri: 'animals/dogs/bark.dart', id: 'fake/id/3'),
+  ScriptRef(uri: 'animals/dogs/growl.dart', id: 'fake/id/4'),
+  ScriptRef(uri: 'animals/insects/caterpillar.dart', id: 'fake/id/5'),
+  ScriptRef(uri: 'animals/insects/cicada.dart', id: 'fake/id/6'),
+  ScriptRef(uri: 'food/catering/party.dart', id: 'fake/id/7'),
+  ScriptRef(uri: 'food/carton/milk.dart', id: 'fake/id/8'),
+  ScriptRef(uri: 'food/milk/carton.dart', id: 'fake/id/9'),
+  ScriptRef(uri: 'travel/adventure/cave_tours_europe.dart', id: 'fake/id/10'),
+  ScriptRef(uri: 'travel/canada/banff.dart', id: 'fake/id/11'),
+];

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -1359,15 +1359,15 @@ final mockParsedScript = ParsedScript(
     executableLines: <int>{});
 
 final mockScriptRefs = [
-  ScriptRef(uri: 'animals/cats/meow.dart', id: 'fake/id/1'),
-  ScriptRef(uri: 'animals/cats/purr.dart', id: 'fake/id/2'),
-  ScriptRef(uri: 'animals/dogs/bark.dart', id: 'fake/id/3'),
-  ScriptRef(uri: 'animals/dogs/growl.dart', id: 'fake/id/4'),
-  ScriptRef(uri: 'animals/insects/caterpillar.dart', id: 'fake/id/5'),
-  ScriptRef(uri: 'animals/insects/cicada.dart', id: 'fake/id/6'),
-  ScriptRef(uri: 'food/catering/party.dart', id: 'fake/id/7'),
-  ScriptRef(uri: 'food/carton/milk.dart', id: 'fake/id/8'),
-  ScriptRef(uri: 'food/milk/carton.dart', id: 'fake/id/9'),
-  ScriptRef(uri: 'travel/adventure/cave_tours_europe.dart', id: 'fake/id/10'),
-  ScriptRef(uri: 'travel/canada/banff.dart', id: 'fake/id/11'),
+  ScriptRef(uri: 'zoo:animals/cats/meow.dart', id: 'fake/id/1'),
+  ScriptRef(uri: 'zoo:animals/cats/purr.dart', id: 'fake/id/2'),
+  ScriptRef(uri: 'zoo:animals/dogs/bark.dart', id: 'fake/id/3'),
+  ScriptRef(uri: 'zoo:animals/dogs/growl.dart', id: 'fake/id/4'),
+  ScriptRef(uri: 'zoo:animals/insects/caterpillar.dart', id: 'fake/id/5'),
+  ScriptRef(uri: 'zoo:animals/insects/cicada.dart', id: 'fake/id/6'),
+  ScriptRef(uri: 'kitchen:food/catering/party.dart', id: 'fake/id/7'),
+  ScriptRef(uri: 'kitchen:food/carton/milk.dart', id: 'fake/id/8'),
+  ScriptRef(uri: 'kitchen:food/milk/carton.dart', id: 'fake/id/9'),
+  ScriptRef(uri: 'travel:adventure/cave_tours_europe.dart', id: 'fake/id/10'),
+  ScriptRef(uri: 'travel:canada/banff.dart', id: 'fake/id/11'),
 ];


### PR DESCRIPTION
Makes a few changes to the file search to speed it up:

* while the current query is a continuation of the previous query (eg, "cat" is a continuation of "ca"), search through the previous matches only (before this, we were searching through all the files each time the query changed)
* only fuzzy-match on the file name, not the entire file path
* combine the exact match and fuzzy match for files into one loop, instead of doing two separate loops (this also fixes an edge case where you could have a file listed multiple times in the results because it would be included in the exact matches and the fuzzy matches)

Also adds a test to the file search to validate that it returns the expected results.