### PR TITLE
Calculate tile size for the autocomplete widget

### DIFF
--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -47,7 +47,6 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
         onTap: _onSelection,
         bottom: false,
         maxWidth: false,
-        autoCompleteMatchTileHeight: 50.0,
       );
     });
     addAutoDisposeListener(

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -47,6 +47,7 @@ class _ExpressionEvalFieldState extends State<ExpressionEvalField>
         onTap: _onSelection,
         bottom: false,
         maxWidth: false,
+        autoCompleteMatchTileHeight: 50.0,
       );
     });
     addAutoDisposeListener(

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -14,7 +14,6 @@ import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
 const int numOfMatchesToShow = 10;
-const double autoCompleteMatchTileHeight = 50.0;
 
 class FileSearchField extends StatefulWidget {
   const FileSearchField({
@@ -67,7 +66,6 @@ class _FileSearchFieldState extends State<FileSearchField>
       context: context,
       searchFieldKey: fileSearchFieldKey,
       onTap: _onSelection,
-      autoCompleteMatchTileHeight: autoCompleteMatchTileHeight,
     );
   }
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -14,7 +14,7 @@ import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
 const int numOfMatchesToShow = 10;
-const double autocompleteMatchTileHeight = 50.0;
+const double autoCompleteMatchTileHeight = 50.0;
 
 class FileSearchField extends StatefulWidget {
   const FileSearchField({
@@ -67,7 +67,7 @@ class _FileSearchFieldState extends State<FileSearchField>
       context: context,
       searchFieldKey: fileSearchFieldKey,
       onTap: _onSelection,
-      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
+      autoCompleteMatchTileHeight: autoCompleteMatchTileHeight,
     );
   }
 

--- a/packages/devtools_app/lib/src/theme.dart
+++ b/packages/devtools_app/lib/src/theme.dart
@@ -314,6 +314,8 @@ extension DevToolsColorScheme on ColorScheme {
   Color get autoCompleteHighlightColor =>
       isLight ? Colors.grey[300] : Colors.grey[700];
 
+  Color get autoCompleteTextColor => isLight ? Colors.black : Colors.white;
+
   // Title of the hover card.
   TextStyle get hoverTitleTextStyle => TextStyle(
         color: defaultForeground,

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -177,10 +177,9 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
                 ))
             .toList();
 
-    const padding = 8.0;
     final tileEntryHeight = tileContents.isEmpty
         ? 0.0
-        : calculateTextSpanHeight(tileContents.first) + padding;
+        : calculateTextSpanHeight(tileContents.first) + denseSpacing;
 
     // Find the searchField and place overlay below bottom of TextField and
     // make overlay width of TextField. This is also we decide the height of
@@ -220,7 +219,7 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
                 ? colorScheme.autoCompleteHighlightColor
                 : colorScheme.defaultBackgroundColor,
             child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: padding),
+              padding: const EdgeInsets.symmetric(horizontal: denseSpacing),
               child: Align(
                 alignment: Alignment.centerLeft,
                 child: Text.rich(

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -113,7 +113,7 @@ class AutoComplete extends StatefulWidget {
     this.controller, {
     @required this.searchFieldKey,
     @required this.onTap,
-    this.autocompleteMatchTileHeight,
+    this.autoCompleteMatchTileHeight,
     bool bottom = true, // If false placed above.
     bool maxWidth = true,
   })  : isBottom = bottom,
@@ -122,7 +122,7 @@ class AutoComplete extends StatefulWidget {
   final AutoCompleteSearchControllerMixin controller;
   final GlobalKey searchFieldKey;
   final SelectAutoComplete onTap;
-  final double autocompleteMatchTileHeight;
+  final double autoCompleteMatchTileHeight;
   final bool isBottom;
   final bool isMaxWidth;
 
@@ -141,8 +141,8 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
     final onTap = autoComplete.onTap;
     final bottom = autoComplete.isBottom;
     final isMaxWidth = autoComplete.isMaxWidth;
-    final autocompleteMatchTileHeight =
-        autoComplete.autocompleteMatchTileHeight;
+    final autoCompleteMatchTileHeight =
+        autoComplete.autoCompleteMatchTileHeight;
 
     addAutoDisposeListener(controller.searchAutoCompleteNotifier, () {
       controller.handleAutoCompleteOverlay(
@@ -151,7 +151,7 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
         onTap: onTap,
         bottom: bottom,
         maxWidth: isMaxWidth,
-        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
+        autoCompleteMatchTileHeight: autoCompleteMatchTileHeight,
       );
     });
   }
@@ -176,7 +176,7 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
     // Approximation but it's pretty accurate. Could consider using a layout builder
     // or maybe build in an overlay (that's isn't visible) to compute.
     final tileEntryHeight =
-        autoComplete.autocompleteMatchTileHeight ?? box.size.height;
+        autoComplete.autoCompleteMatchTileHeight ?? box.size.height;
 
     // Compute to global coordinates.
     final offset = box.localToGlobal(Offset.zero);
@@ -326,7 +326,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required BuildContext context,
     @required GlobalKey searchFieldKey,
     @required SelectAutoComplete onTap,
-    double autocompleteMatchTileHeight,
+    double autoCompleteMatchTileHeight,
     bool bottom = true,
     bool maxWidth = true,
   }) {
@@ -335,7 +335,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
         this,
         searchFieldKey: searchFieldKey,
         onTap: onTap,
-        autocompleteMatchTileHeight: autocompleteMatchTileHeight,
+        autoCompleteMatchTileHeight: autoCompleteMatchTileHeight,
         bottom: bottom,
         maxWidth: maxWidth,
       );
@@ -356,7 +356,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     @required BuildContext context,
     @required GlobalKey searchFieldKey,
     @required SelectAutoComplete onTap,
-    double autocompleteMatchTileHeight,
+    double autoCompleteMatchTileHeight,
     bool bottom = true,
     bool maxWidth = true,
   }) {
@@ -368,7 +368,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       context: context,
       searchFieldKey: searchFieldKey,
       onTap: onTap,
-      autocompleteMatchTileHeight: autocompleteMatchTileHeight,
+      autoCompleteMatchTileHeight: autoCompleteMatchTileHeight,
       bottom: bottom,
       maxWidth: maxWidth,
     );

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -177,10 +177,10 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
                 ))
             .toList();
 
-    const minTileHeight = 48.0;
+    const padding = 8.0;
     final tileEntryHeight = tileContents.isEmpty
-        ? minTileHeight
-        : max(minTileHeight, calculateTextSpanHeight(tileContents.first));
+        ? 0.0
+        : calculateTextSpanHeight(tileContents.first) + padding;
 
     // Find the searchField and place overlay below bottom of TextField and
     // make overlay width of TextField. This is also we decide the height of
@@ -204,29 +204,32 @@ class AutoCompleteState extends State<AutoComplete> with AutoDisposeMixin {
         ? searchAutoComplete.value.length
         : (maxAreaForPopup / tileEntryHeight).truncateToDouble();
 
-    final autoCompleteTiles = <ListTile>[];
+    final autoCompleteTiles = <GestureDetector>[];
     final count = min(searchAutoComplete.value.length, totalTiles);
     for (var index = 0; index < count; index++) {
       final textSpan = tileContents[index];
       autoCompleteTiles.add(
-        ListTile(
-          minVerticalPadding: 0,
-          dense: true,
-          title: Align(
-            alignment: Alignment.centerLeft,
-            child: Text.rich(
-              textSpan,
-              maxLines: 1,
-            ),
-          ),
-          tileColor: controller.currentDefaultIndex == index
-              ? colorScheme.autoCompleteHighlightColor
-              : colorScheme.defaultBackgroundColor,
+        GestureDetector(
           onTap: () {
             controller.selectTheSearch = true;
             controller.search = textSpan.text;
             autoComplete.onTap(textSpan.text);
           },
+          child: Container(
+            color: controller.currentDefaultIndex == index
+                ? colorScheme.autoCompleteHighlightColor
+                : colorScheme.defaultBackgroundColor,
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: padding),
+              child: Align(
+                alignment: Alignment.centerLeft,
+                child: Text.rich(
+                  textSpan,
+                  maxLines: 1,
+                ),
+              ),
+            ),
+          ),
         ),
       );
     }

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -123,6 +123,17 @@ double calculateTextSpanWidth(TextSpan span) {
   return textPainter.width;
 }
 
+/// Returns the height in pixels of the [span].
+double calculateTextSpanHeight(TextSpan span) {
+  final textPainter = TextPainter(
+    text: span,
+    textAlign: TextAlign.left,
+    textDirection: TextDirection.ltr,
+  )..layout();
+
+  return textPainter.height;
+}
+
 /// Scrollbar that is offset by the amount specified by an [offsetController].
 ///
 /// This makes it possible to create a [ListView] with both vertical and


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3375

Calculates the size of the autocomplete tiles to be dependent on the text size. Instead of using the `ListTile` widget (which has a minimum height of 48px: https://github.com/flutter/flutter/blob/master/packages/flutter/lib/src/material/list_tile.dart#L1379-L1380), we now use our own implementation so that they can be narrower.
