### PR TITLE
[Debugger] - 'Step Over' button before 'Step in'

### DIFF
--- a/packages/devtools_app/lib/src/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/controls.dart
@@ -93,15 +93,15 @@ class _DebuggingControlsState extends State<DebuggingControls>
       child: Row(
         children: [
           DebuggerButton(
-            title: 'Step In',
-            icon: Codicons.debugStepInto,
-            onPressed: canStep ? controller.stepIn : null,
+            title: 'Step Over',
+            icon: Codicons.debugStepOver,
+            onPressed: canStep ? controller.stepOver : null,
           ),
           LeftBorder(
             child: DebuggerButton(
-              title: 'Step Over',
-              icon: Codicons.debugStepOver,
-              onPressed: canStep ? controller.stepOver : null,
+              title: 'Step In',
+              icon: Codicons.debugStepInto,
+              onPressed: canStep ? controller.stepIn : null,
             ),
           ),
           LeftBorder(


### PR DESCRIPTION
A small PR related to [this issue](url).

Before this PR :
![DevToolsBefore](https://user-images.githubusercontent.com/840911/134229698-f4476951-0098-4097-a3aa-eb6090dadfb1.png)

After this PR : 
![DevToolsAfter](https://user-images.githubusercontent.com/840911/134229815-9548c71f-6af5-4aa8-8cc1-753f580b2b2d.png)

