### PR TITLE
Remove unused imports and package:meta dependency

### DIFF
--- a/case_study/platform_channel/lib/channel_demo.dart
+++ b/case_study/platform_channel/lib/channel_demo.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
 class ChannelDemo extends StatefulWidget {
   @override

--- a/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
+++ b/packages/devtools_app/assets/scripts/inspector_polyfill_script.dart
@@ -68,7 +68,6 @@ import 'package:flutter/painting.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/src/widgets/app.dart';
-import 'package:flutter/src/widgets/basic.dart';
 import 'package:flutter/src/widgets/binding.dart';
 import 'package:flutter/src/widgets/debug.dart';
 import 'package:flutter/src/widgets/framework.dart';

--- a/packages/devtools_app/lib/src/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/app_size/app_size_controller.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_snapshot_analysis/precompiler_trace.dart';
 import 'package:vm_snapshot_analysis/program_info.dart';

--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 /// Provides functionality to simplify listening to streams and ValueNotifiers.
 ///

--- a/packages/devtools_app/lib/src/charts/chart.dart
+++ b/packages/devtools_app/lib/src/charts/chart.dart
@@ -5,7 +5,6 @@
 import 'dart:math';
 import 'dart:ui';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import '../auto_dispose_mixin.dart';

--- a/packages/devtools_app/lib/src/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/charts/chart_controller.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../auto_dispose.dart';

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 import '../common_widgets.dart';
 import '../theme.dart';

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -5,9 +5,7 @@
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
 
 import 'scaffold.dart';
 import 'theme.dart';

--- a/packages/devtools_app/lib/src/config_specific/drag_and_drop/drag_and_drop.dart
+++ b/packages/devtools_app/lib/src/config_specific/drag_and_drop/drag_and_drop.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'auto_dispose.dart';

--- a/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/custom_pointer_scroll_view.dart
@@ -8,7 +8,6 @@ import 'dart:ui';
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart' hide Stack;
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -7,7 +7,6 @@ import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/debugger/hover.dart
+++ b/packages/devtools_app/lib/src/debugger/hover.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 

--- a/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/debugger/syntax_highlighter.dart
@@ -7,7 +7,6 @@ import 'dart:convert';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
-import 'package:flutter/widgets.dart';
 
 import '../theme.dart';
 import 'span_parser.dart';

--- a/packages/devtools_app/lib/src/device_dialog.dart
+++ b/packages/devtools_app/lib/src/device_dialog.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/eval_on_dart_library.dart
@@ -8,8 +8,6 @@ import 'dart:async';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'auto_dispose.dart';

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../devtools.dart' as devtools show version;
 import '../config_specific/logger/logger.dart';

--- a/packages/devtools_app/lib/src/framework_controller.dart
+++ b/packages/devtools_app/lib/src/framework_controller.dart
@@ -4,7 +4,7 @@
 
 import 'dart:async';
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 import 'globals.dart';
 

--- a/packages/devtools_app/lib/src/geometry.dart
+++ b/packages/devtools_app/lib/src/geometry.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 // TODO(kenz): consolidate the logic between [VerticalLineSegment] and
 // [HorizontalLineSegment] by using [LineSegment] and switching on the main axis

--- a/packages/devtools_app/lib/src/history_manager.dart
+++ b/packages/devtools_app/lib/src/history_manager.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 
 class HistoryManager<T> {
   /// The currently selected historical item.

--- a/packages/devtools_app/lib/src/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../debugger/debugger_controller.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -18,7 +18,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -4,7 +4,6 @@
 
 import 'dart:collection';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/packages/devtools_app/lib/src/inspector/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen_details_tab.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import '../auto_dispose_mixin.dart';
 import '../theme.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -10,10 +10,8 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/rendering.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../auto_dispose.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -13,7 +13,6 @@ library inspector_tree;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 import '../theme.dart';
 import '../utils.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -10,7 +10,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
 
 import '../auto_dispose_mixin.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/box/box.dart
@@ -4,10 +4,8 @@
 
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../../math_utils.dart';
 import '../../../theme.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/flex/flex.dart
@@ -6,8 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../../math_utils.dart';
 import '../../../theme.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/flex/utils.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/flex/utils.dart
@@ -6,7 +6,6 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../inspector_data_models.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/ui/arrow.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/ui/arrow.dart
@@ -5,8 +5,6 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../../theme.dart';
 

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/ui/free_space.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/ui/free_space.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../../common_widgets.dart';
 import '../../../utils.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/ui/layout_explorer_widget.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/ui/layout_explorer_widget.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 
 import '../../../globals.dart';

--- a/packages/devtools_app/lib/src/inspector/layout_explorer/ui/widget_constraints.dart
+++ b/packages/devtools_app/lib/src/inspector/layout_explorer/ui/widget_constraints.dart
@@ -1,7 +1,4 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import 'package:flutter/widgets.dart';
 
 import '../../../math_utils.dart';
 import '../../../theme.dart';

--- a/packages/devtools_app/lib/src/landing_screen.dart
+++ b/packages/devtools_app/lib/src/landing_screen.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -9,7 +9,6 @@ import 'dart:math' as math;
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
 import 'package:intl/intl.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../analytics/analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/allowed_error.dart';

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
 import '../analytics/analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_model.dart
@@ -9,7 +9,7 @@
 import 'dart:collection';
 import 'dart:math' as math;
 
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 import '../../charts/flame_chart.dart';
 import '../../profiler/cpu_profile_model.dart';

--- a/packages/devtools_app/lib/src/performance/legacy/timeline_event_processor.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_event_processor.dart
@@ -9,7 +9,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 import '../../config_specific/logger/logger.dart';
 import '../../trace_event.dart';

--- a/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/timeline_flame_chart.dart
@@ -7,7 +7,6 @@
 // hits flutter stable.
 
 import 'dart:math' as math;
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/devtools_app/lib/src/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/performance/performance_model.dart
@@ -5,7 +5,6 @@ import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 import '../charts/flame_chart.dart';
 import '../profiler/cpu_profile_model.dart';

--- a/packages/devtools_app/lib/src/performance/timeline_event_processor.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_event_processor.dart
@@ -5,7 +5,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 import '../config_specific/logger/logger.dart';
 import '../trace_event.dart';

--- a/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_flame_chart.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 import 'dart:math' as math;
-import 'dart:ui';
 
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../analytics/analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_model.dart
@@ -4,8 +4,7 @@
 import 'dart:collection';
 import 'dart:convert';
 
-import 'package:flutter/cupertino.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 
 import '../charts/flame_chart.dart';
 import '../trace_event.dart';

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_service.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 import '../globals.dart';
 import '../vm_flags.dart' as vm_flags;

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_transformer.dart
@@ -4,7 +4,6 @@
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 
 import '../utils.dart';
 import 'cpu_profile_model.dart';

--- a/packages/devtools_app/lib/src/provider/instance_viewer/instance_details.dart
+++ b/packages/devtools_app/lib/src/provider/instance_viewer/instance_details.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../eval_on_dart_library.dart';

--- a/packages/devtools_app/lib/src/provider/instance_viewer/result.dart
+++ b/packages/devtools_app/lib/src/provider/instance_viewer/result.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide SentinelException;
 
 import '../../eval_on_dart_library.dart';

--- a/packages/devtools_app/lib/src/provider/provider_nodes.dart
+++ b/packages/devtools_app/lib/src/provider/provider_nodes.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../eval_on_dart_library.dart';

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -5,9 +5,7 @@
 import 'dart:async';
 import 'dart:math' as math;
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
 
 import 'analytics/prompt.dart';

--- a/packages/devtools_app/lib/src/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service_extensions.dart
@@ -5,7 +5,6 @@
 library service_extensions;
 
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 import 'analytics/constants.dart' as analytics_constants;
 import 'ui/icons.dart';

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -7,7 +7,6 @@ import 'dart:core';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:meta/meta.dart';
 import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 

--- a/packages/devtools_app/lib/src/split.dart
+++ b/packages/devtools_app/lib/src/split.dart
@@ -6,7 +6,6 @@ import 'dart:math' as math;
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
 
 import 'utils.dart';
 

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -7,7 +7,6 @@ import 'package:flutter/services.dart';
 import 'auto_dispose_mixin.dart';
 import 'collapsible_mixin.dart';
 import 'common_widgets.dart';
-import 'common_widgets.dart' show ScrollControllerAutoScroll;
 import 'flutter_widgets/linked_scroll_controller.dart';
 import 'table_data.dart';
 import 'theme.dart';

--- a/packages/devtools_app/lib/src/table_data.dart
+++ b/packages/devtools_app/lib/src/table_data.dart
@@ -4,9 +4,7 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 import 'trees.dart';
 import 'utils.dart';

--- a/packages/devtools_app/lib/src/ui/filter.dart
+++ b/packages/devtools_app/lib/src/ui/filter.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../auto_dispose_mixin.dart';

--- a/packages/devtools_app/lib/src/ui/icons.dart
+++ b/packages/devtools_app/lib/src/ui/icons.dart
@@ -14,7 +14,6 @@
 library icons;
 
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 import '../inspector/layout_explorer/ui/widgets_theme.dart';
 import '../theme.dart';

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -6,10 +6,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/painting.dart';
-import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 
 import '../auto_dispose.dart';
 import '../auto_dispose_mixin.dart';

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -4,7 +4,6 @@
  * found in the LICENSE file.
  */
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 

--- a/packages/devtools_app/lib/src/version.dart
+++ b/packages/devtools_app/lib/src/version.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:meta/meta.dart';
 
 import 'utils.dart';
 

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -5,7 +5,7 @@
 import 'dart:async';
 
 import 'package:dds/vm_service_extensions.dart';
-import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'globals.dart';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -43,7 +43,6 @@ dependencies:
   image: ^3.0.2
   intl: '>=0.16.1 <0.18.0'
   js: ^0.6.1+1
-  meta: ^1.3.0
   mime: ^1.0.0
   path: ^1.8.0
   pedantic: ^1.11.0

--- a/packages/devtools_app/test/association_variable_test.dart
+++ b/packages/devtools_app/test/association_variable_test.dart
@@ -5,8 +5,8 @@
 import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/test/banner_messages_test.dart
+++ b/packages/devtools_app/test/banner_messages_test.dart
@@ -9,7 +9,6 @@ import 'package:devtools_app/src/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/scaffold.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 

--- a/packages/devtools_app/test/chart_test.dart
+++ b/packages/devtools_app/test/chart_test.dart
@@ -7,7 +7,6 @@ import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'support/memory_test_data.dart';

--- a/packages/devtools_app/test/core/message_bus_test.dart
+++ b/packages/devtools_app/test/core/message_bus_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:devtools_app/src/core/message_bus.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/devtools_app/test/extent_delegate_list_view_test.dart
+++ b/packages/devtools_app/test/extent_delegate_list_view_test.dart
@@ -5,7 +5,6 @@
 @TestOn('vm')
 import 'package:devtools_app/src/extent_delegate_list.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -5,7 +5,6 @@
 import 'package:devtools_app/src/debugger/file_search.dart';
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:devtools_app/src/utils.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';

--- a/packages/devtools_app/test/fixtures/flutter_app/lib/overflow_errors.dart
+++ b/packages/devtools_app/test/fixtures/flutter_app/lib/overflow_errors.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 void main() => runApp(const OverflowingApp());

--- a/packages/devtools_app/test/flame_chart_test.dart
+++ b/packages/devtools_app/test/flame_chart_test.dart
@@ -13,7 +13,6 @@ import 'package:devtools_app/src/ui/utils.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'support/cpu_profile_test_data.dart';

--- a/packages/devtools_app/test/integration/dart_cli_profile_test.dart
+++ b/packages/devtools_app/test/integration/dart_cli_profile_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/devtools_app/test/integration_tests/server_test.dart
+++ b/packages/devtools_app/test/integration_tests/server_test.dart
@@ -8,8 +8,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:devtools_shared/devtools_shared.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../support/chrome.dart';

--- a/packages/devtools_app/test/landing_screen_test.dart
+++ b/packages/devtools_app/test/landing_screen_test.dart
@@ -5,7 +5,7 @@
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/landing_screen.dart';
 import 'package:devtools_app/src/service_manager.dart';
-import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'support/mocks.dart';

--- a/packages/devtools_app/test/layout_explorer/layout_explorer_test_utils.dart
+++ b/packages/devtools_app/test/layout_explorer/layout_explorer_test_utils.dart
@@ -5,7 +5,6 @@
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'layout_explorer_serialization_delegate.dart';

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -3,9 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:async';
-import 'dart:ui';
-
 import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';

--- a/packages/devtools_app/test/matchers/matchers.dart
+++ b/packages/devtools_app/test/matchers/matchers.dart
@@ -10,7 +10,6 @@ import 'dart:io' as io;
 
 import 'package:devtools_app/src/inspector/diagnostics_node.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:matcher/matcher.dart';
 
 RemoteDiagnosticsNode findNodeMatching(
     RemoteDiagnosticsNode node, String text) {

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -3,8 +3,6 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
-import 'dart:ui';
-
 import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
@@ -15,7 +13,6 @@ import 'package:devtools_app/src/memory/memory_vm_chart.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:devtools_shared/devtools_shared.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/provider/provider_screen_test.dart
+++ b/packages/devtools_app/test/provider/provider_screen_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:devtools_app/src/banner_messages.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/provider/instance_viewer/instance_details.dart';

--- a/packages/devtools_app/test/service_extension_widgets_test.dart
+++ b/packages/devtools_app/test/service_extension_widgets_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:devtools_app/src/core/message_bus.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_extensions.dart';

--- a/packages/devtools_app/test/span_parser_test.dart
+++ b/packages/devtools_app/test/span_parser_test.dart
@@ -7,8 +7,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:devtools_app/src/debugger/span_parser.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 
 const helloWorld = '''
 void main() {

--- a/packages/devtools_app/test/support/file_utils.dart
+++ b/packages/devtools_app/test/support/file_utils.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'dart:io' as io;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/support/utils.dart
+++ b/packages/devtools_app/test/support/utils.dart
@@ -13,7 +13,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:path/path.dart' as path;
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_snapshot_analysis/treemap.dart';

--- a/packages/devtools_app/test/support/wrappers.dart
+++ b/packages/devtools_app/test/support/wrappers.dart
@@ -18,7 +18,6 @@ import 'package:devtools_app/src/theme.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:provider/provider.dart';
 
 import '../support/mocks.dart';
@@ -113,7 +112,6 @@ Widget wrapWithInspectorControllers(Widget widget) {
 
 /// Call [testWidgets], allowing the test to set specific values for app globals
 /// ([MessageBus], ...).
-@isTest
 void testWidgetsWithContext(
   String description,
   WidgetTesterCallback callback, {
@@ -139,7 +137,6 @@ void testWidgetsWithContext(
 }
 
 /// Runs a test with the size of the app window under test to [windowSize].
-@isTest
 void testWidgetsWithWindowSize(
   String name,
   Size windowSize,

--- a/packages/devtools_app/test/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/syntax_highlighter_test.dart
@@ -12,9 +12,7 @@ import 'package:devtools_app/src/debugger/syntax_highlighter.dart';
 import 'package:devtools_app/src/routing.dart';
 import 'package:devtools_app/src/theme.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 
 import 'support/wrappers.dart';
 

--- a/packages/devtools_app/test/theme_test.dart
+++ b/packages/devtools_app/test/theme_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:ui';
-
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/theme.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_app/test/typed_data_variable_test.dart
+++ b/packages/devtools_app/test/typed_data_variable_test.dart
@@ -10,7 +10,6 @@ import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:meta/meta.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:devtools_app/src/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/devtools_server/lib/src/devtools_command.dart
+++ b/packages/devtools_server/lib/src/devtools_command.dart
@@ -4,7 +4,6 @@
 
 import 'package:args/command_runner.dart';
 
-import '../devtools_server.dart';
 import 'server.dart';
 
 const commandDescription =

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
 import 'dart:convert';
 import 'dart:core';
 import 'dart:io';


### PR DESCRIPTION
The latest flutter triggered a new lint about unused imports - most cases where we were importing two files for the same thing. For example, looks like package:flutter/foundation.dart now has an @required annotation, so we can remove package:meta.