### PR TITLE
Fix duplicate scrollbars shown on web

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -311,6 +311,10 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
       ),
       routerDelegate: DevToolsRouterDelegate(_getPage),
       routeInformationParser: DevToolsRouteInformationParser(),
+      // Disable default scrollbar behavior on web to fix duplicate scrollbars
+      // bug, see https://github.com/flutter/flutter/issues/90697:
+      scrollBehavior:
+          const MaterialScrollBehavior().copyWith(scrollbars: !kIsWeb),
     );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3372

With https://flutter.dev/docs/release/breaking-changes/default-desktop-scrollbars, ScrollBehaviors now automatically apply Scrollbars to scrolling widgets on desktop platforms. For some reason, an extra scrollbar is automatically being added in the debugger on web, but not on desktop. I've opened up https://github.com/flutter/flutter/issues/90697 in Flutter since this doesn't seem to be intended. 

However, for now disabling the default scrollbars for web fixes the issue we are seeing.