### PR TITLE
Add connected app information to offline snapshots

### DIFF
--- a/packages/devtools_app/lib/src/banner_messages.dart
+++ b/packages/devtools_app/lib/src/banner_messages.dart
@@ -437,7 +437,7 @@ void maybePushDebugModePerformanceMessage(
   BuildContext context,
   String screenId,
 ) {
-  if (offlineMode) return;
+  if (offlineController.offlineMode) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
     Provider.of<BannerMessagesController>(context)
         .addMessage(DebugModePerformanceMessage(screenId).build(context));
@@ -448,7 +448,7 @@ void maybePushDebugModeMemoryMessage(
   BuildContext context,
   String screenId,
 ) {
-  if (offlineMode) return;
+  if (offlineController.offlineMode) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
     Provider.of<BannerMessagesController>(context)
         .addMessage(DebugModeMemoryMessage(screenId).build(context));

--- a/packages/devtools_app/lib/src/banner_messages.dart
+++ b/packages/devtools_app/lib/src/banner_messages.dart
@@ -437,7 +437,7 @@ void maybePushDebugModePerformanceMessage(
   BuildContext context,
   String screenId,
 ) {
-  if (offlineController.offlineMode) return;
+  if (offlineController.offlineMode.value) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
     Provider.of<BannerMessagesController>(context)
         .addMessage(DebugModePerformanceMessage(screenId).build(context));
@@ -448,7 +448,7 @@ void maybePushDebugModeMemoryMessage(
   BuildContext context,
   String screenId,
 ) {
-  if (offlineController.offlineMode) return;
+  if (offlineController.offlineMode.value) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
     Provider.of<BannerMessagesController>(context)
         .addMessage(DebugModeMemoryMessage(screenId).build(context));

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -508,7 +508,7 @@ class ProcessingInfo extends StatelessWidget {
 /// onPressed:
 ///
 /// setState(() {
-///   offlineMode = false;
+///   offlineController.exitOfflineMode();
 /// }
 class ExitOfflineButton extends IconLabelButton {
   const ExitOfflineButton({@required VoidCallback onPressed})

--- a/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/config_specific/import_export/import_export.dart
@@ -4,6 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:flutter/foundation.dart';
+
 import '../../../devtools.dart';
 import '../../connected_app.dart';
 import '../../globals.dart';
@@ -135,9 +137,9 @@ abstract class ExportController {
 }
 
 class OfflineModeController {
-  bool get offlineMode => _offlineMode;
+  ValueListenable<bool> get offlineMode => _offlineMode;
 
-  bool _offlineMode = false;
+  final _offlineMode = ValueNotifier(false);
 
   Map<String, dynamic> offlineDataJson = {};
 
@@ -145,13 +147,19 @@ class OfflineModeController {
   /// offline and online modes.
   ConnectedApp _previousConnectedApp;
 
+  bool shouldLoadOfflineData(String screenId) {
+    return _offlineMode.value &&
+        offlineDataJson.isNotEmpty &&
+        offlineDataJson[screenId] != null;
+  }
+
   void enterOfflineMode() {
     _previousConnectedApp = serviceManager.connectedApp;
-    _offlineMode = true;
+    _offlineMode.value = true;
   }
 
   void exitOfflineMode() {
     serviceManager.connectedApp = _previousConnectedApp;
-    _offlineMode = false;
+    _offlineMode.value = false;
   }
 }

--- a/packages/devtools_app/lib/src/connected_app.dart
+++ b/packages/devtools_app/lib/src/connected_app.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 
+import 'config_specific/import_export/import_export.dart';
 import 'config_specific/logger/logger.dart' as logger;
 import 'eval_on_dart_library.dart';
 import 'globals.dart';
@@ -152,4 +153,35 @@ class ConnectedApp {
     }
     generateDevToolsTitle();
   }
+}
+
+class OfflineConnectedApp extends ConnectedApp {
+  OfflineConnectedApp({
+    this.isFlutterAppNow,
+    this.isProfileBuildNow,
+    this.isDartWebAppNow,
+    this.isRunningOnDartVM,
+  });
+
+  factory OfflineConnectedApp.parse(Map<String, Object> json) {
+    if (json == null) return null;
+    return OfflineConnectedApp(
+      isFlutterAppNow: json[isFlutterAppKey],
+      isProfileBuildNow: json[isProfileBuildKey],
+      isDartWebAppNow: json[isDartWebAppKey],
+      isRunningOnDartVM: json[isRunningOnDartVMKey],
+    );
+  }
+
+  @override
+  final bool isFlutterAppNow;
+
+  @override
+  final bool isProfileBuildNow;
+
+  @override
+  final bool isDartWebAppNow;
+
+  @override
+  final bool isRunningOnDartVM;
 }

--- a/packages/devtools_app/lib/src/device_dialog.dart
+++ b/packages/devtools_app/lib/src/device_dialog.dart
@@ -98,7 +98,10 @@ class DeviceDialog extends StatelessWidget {
   Widget _connectToNewAppButton(BuildContext context) {
     return ElevatedButton(
       onPressed: () {
-        DevToolsRouterDelegate.of(context).navigate(homePageId, {'uri': null});
+        DevToolsRouterDelegate.of(context).navigateHome(
+          clearUriParam: true,
+          clearScreenParam: true,
+        );
         Navigator.of(context, rootNavigator: true).pop('dialog');
       },
       child: Text(connectToNewAppText.toUpperCase()),

--- a/packages/devtools_app/lib/src/example/conditional_screen.dart
+++ b/packages/devtools_app/lib/src/example/conditional_screen.dart
@@ -54,7 +54,8 @@ class _ExampleConditionalScreenBodyState
     controller = newController;
 
     if (shouldLoadOfflineData()) {
-      final json = offlineController.offlineDataJson[ExampleConditionalScreen.id];
+      final json =
+          offlineController.offlineDataJson[ExampleConditionalScreen.id];
       if (json.isNotEmpty) {
         loadOfflineData(json['title']);
       }
@@ -93,9 +94,7 @@ class _ExampleConditionalScreenBodyState
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineController.offlineMode &&
-        offlineController.offlineDataJson.isNotEmpty &&
-        offlineController.offlineDataJson[ExampleConditionalScreen.id] != null;
+    return offlineController.shouldLoadOfflineData(ExampleConditionalScreen.id);
   }
 }
 

--- a/packages/devtools_app/lib/src/example/conditional_screen.dart
+++ b/packages/devtools_app/lib/src/example/conditional_screen.dart
@@ -54,7 +54,7 @@ class _ExampleConditionalScreenBodyState
     controller = newController;
 
     if (shouldLoadOfflineData()) {
-      final json = offlineDataJson[ExampleConditionalScreen.id];
+      final json = offlineController.offlineDataJson[ExampleConditionalScreen.id];
       if (json.isNotEmpty) {
         loadOfflineData(json['title']);
       }
@@ -93,9 +93,9 @@ class _ExampleConditionalScreenBodyState
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineMode &&
-        offlineDataJson.isNotEmpty &&
-        offlineDataJson[ExampleConditionalScreen.id] != null;
+    return offlineController.offlineMode &&
+        offlineController.offlineDataJson.isNotEmpty &&
+        offlineController.offlineDataJson[ExampleConditionalScreen.id] != null;
   }
 }
 

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -7,9 +7,9 @@ import 'dart:async';
 import 'package:meta/meta.dart';
 
 import '../../devtools.dart' as devtools show version;
+import '../config_specific/import_export/import_export.dart';
 import '../config_specific/logger/logger.dart';
 import '../core/message_bus.dart';
-import '../debugger/program_explorer_controller.dart';
 import '../framework_controller.dart';
 import '../globals.dart';
 import '../service.dart';
@@ -27,7 +27,7 @@ class FrameworkCore {
     setGlobal(MessageBus, MessageBus());
     setGlobal(FrameworkController, FrameworkController());
     setGlobal(SurveyService, SurveyService());
-    setGlobal(ProgramExplorerController, ProgramExplorerController());
+    setGlobal(OfflineModeController, OfflineModeController());
   }
 
   static void init({String url}) {

--- a/packages/devtools_app/lib/src/globals.dart
+++ b/packages/devtools_app/lib/src/globals.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'config_specific/ide_theme/ide_theme.dart';
+import 'config_specific/import_export/import_export.dart';
 import 'core/message_bus.dart';
 import 'extension_points/extensions_base.dart';
 import 'framework_controller.dart';
@@ -10,13 +11,6 @@ import 'preferences.dart';
 import 'service_manager.dart';
 import 'storage.dart';
 import 'survey.dart';
-
-/// Snapshot mode is an offline mode where DevTools can operate on an imported
-/// data file.
-bool offlineMode = false;
-
-// TODO(kenz): store this data in an inherited widget.
-Map<String, dynamic> offlineDataJson = {};
 
 final Map<Type, dynamic> globals = <Type, dynamic>{};
 
@@ -35,6 +29,8 @@ PreferencesController get preferences => globals[PreferencesController];
 
 DevToolsExtensionPoints get devToolsExtensionPoints =>
     globals[DevToolsExtensionPoints];
+
+OfflineModeController get offlineController => globals[OfflineModeController];
 
 IdeTheme get ideTheme => globals[IdeTheme];
 

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -162,8 +162,10 @@ class _InitializerState extends State<Initializer>
                 ElevatedButton(
                     onPressed: () {
                       hideDisconnectedOverlay();
-                      DevToolsRouterDelegate.of(context)
-                          .navigate(homePageId, {'uri': null});
+                      DevToolsRouterDelegate.of(context).navigateHome(
+                        clearUriParam: true,
+                        clearScreenParam: true,
+                      );
                     },
                     child: const Text(connectToNewAppText))
               else

--- a/packages/devtools_app/lib/src/performance/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/event_details.dart
@@ -62,9 +62,9 @@ class EventDetails extends StatelessWidget {
 
   Widget _buildDetails(PerformanceController controller) {
     if (selectedEvent.isUiEvent) {
-      // In [offlineMode], we do not need to worry about whether the profiler is
-      // enabled.
-      if (offlineMode) {
+      // In [offlineController.offlineMode], we do not need to worry about
+      // whether the profiler is enabled.
+      if (offlineController.offlineMode) {
         return _buildCpuProfiler(controller.cpuProfilerController);
       }
       return ValueListenableBuilder<Flag>(

--- a/packages/devtools_app/lib/src/performance/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/event_details.dart
@@ -44,7 +44,13 @@ class EventDetails extends StatelessWidget {
           ),
           Expanded(
             child: selectedEvent != null
-                ? _buildDetails(controller)
+                ? ValueListenableBuilder(
+                    valueListenable: offlineController.offlineMode,
+                    builder: (context, offline, _) => _buildDetails(
+                      controller,
+                      offline,
+                    ),
+                  )
                 : _buildInstructions(theme),
           ),
         ],
@@ -60,11 +66,11 @@ class EventDetails extends StatelessWidget {
         '${selectedEvent.name} (${msText(selectedEvent.time.duration)})';
   }
 
-  Widget _buildDetails(PerformanceController controller) {
+  Widget _buildDetails(PerformanceController controller, bool offlineMode) {
     if (selectedEvent.isUiEvent) {
       // In [offlineController.offlineMode], we do not need to worry about
       // whether the profiler is enabled.
-      if (offlineController.offlineMode) {
+      if (offlineMode) {
         return _buildCpuProfiler(controller.cpuProfilerController);
       }
       return ValueListenableBuilder<Flag>(

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -118,7 +118,9 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
       );
       Provider.of<BannerMessagesController>(context).addMessage(
         ShaderJankMessage(
-          offlineController.offlineMode ? SimpleScreen.id : PerformanceScreen.id,
+          offlineController.offlineMode.value
+              ? SimpleScreen.id
+              : PerformanceScreen.id,
           jankyFramesCount: shaderJankFrames.length,
           jankDuration: shaderJankDuration,
         ).build(context),

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -118,7 +118,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
       );
       Provider.of<BannerMessagesController>(context).addMessage(
         ShaderJankMessage(
-          offlineMode ? SimpleScreen.id : PerformanceScreen.id,
+          offlineController.offlineMode ? SimpleScreen.id : PerformanceScreen.id,
           jankyFramesCount: shaderJankFrames.length,
           jankDuration: shaderJankDuration,
         ).build(context),

--- a/packages/devtools_app/lib/src/performance/legacy/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/event_details.dart
@@ -66,9 +66,9 @@ class EventDetails extends StatelessWidget {
 
   Widget _buildDetails(LegacyPerformanceController controller) {
     if (selectedEvent.isUiEvent) {
-      // In [offlineMode], we do not need to worry about whether the profiler is
-      // enabled.
-      if (offlineMode) {
+      // In [offlineController.offlineMode], we do not need to worry about
+      // whether the profiler is enabled.
+      if (offlineController.offlineMode) {
         return _buildCpuProfiler(controller.cpuProfilerController);
       }
       return ValueListenableBuilder<Flag>(

--- a/packages/devtools_app/lib/src/performance/legacy/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/event_details.dart
@@ -48,7 +48,13 @@ class EventDetails extends StatelessWidget {
           ),
           Expanded(
             child: selectedEvent != null
-                ? _buildDetails(controller)
+                ? ValueListenableBuilder(
+                    valueListenable: offlineController.offlineMode,
+                    builder: (context, offline, _) => _buildDetails(
+                      controller,
+                      offline,
+                    ),
+                  )
                 : _buildInstructions(theme),
           ),
         ],
@@ -64,11 +70,12 @@ class EventDetails extends StatelessWidget {
         '${selectedEvent.name} (${msText(selectedEvent.time.duration)})';
   }
 
-  Widget _buildDetails(LegacyPerformanceController controller) {
+  Widget _buildDetails(
+      LegacyPerformanceController controller, bool offlineMode) {
     if (selectedEvent.isUiEvent) {
       // In [offlineController.offlineMode], we do not need to worry about
       // whether the profiler is enabled.
-      if (offlineController.offlineMode) {
+      if (offlineMode) {
         return _buildCpuProfiler(controller.cpuProfilerController);
       }
       return ValueListenableBuilder<Flag>(

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -147,7 +147,7 @@ class LegacyPerformanceController
   }
 
   Future<void> _initHelper() async {
-    if (!offlineController.offlineMode) {
+    if (!offlineController.offlineMode.value) {
       await serviceManager.onServiceAvailable;
 
       // Default to true for profile builds only.
@@ -193,7 +193,8 @@ class LegacyPerformanceController
           shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
-      } else if ((!offlineController.offlineMode || offlinePerformanceData == null) &&
+      } else if ((!offlineController.offlineMode.value ||
+              offlinePerformanceData == null) &&
           cpuProfilerController.profilerEnabled) {
         // Fetch a profile if not in offline mode and if the profiler is enabled
         cpuProfilerController.reset();
@@ -236,7 +237,7 @@ class LegacyPerformanceController
         cpuProfilerController.cpuProfileStore.lookupProfile(time: frame.time);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
-      if (!offlineController.offlineMode) {
+      if (!offlineController.offlineMode.value) {
         await cpuProfilerController.pullAndProcessProfile(
           startMicros: frame.time.start.inMicroseconds,
           extentMicros: frame.time.duration.inMicroseconds,

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -123,7 +123,7 @@ class LegacyPerformanceController
 
   /// Timeline data loaded via import.
   ///
-  /// This is expected to be null when we are not in [offlineMode].
+  /// This is expected to be null when we are not in [offlineController.offlineMode].
   ///
   /// This will contain the original data from the imported file, regardless of
   /// any selection modifications that occur while the data is displayed. [data]
@@ -147,7 +147,7 @@ class LegacyPerformanceController
   }
 
   Future<void> _initHelper() async {
-    if (!offlineMode) {
+    if (!offlineController.offlineMode) {
       await serviceManager.onServiceAvailable;
 
       // Default to true for profile builds only.
@@ -193,7 +193,7 @@ class LegacyPerformanceController
           shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
-      } else if ((!offlineMode || offlinePerformanceData == null) &&
+      } else if ((!offlineController.offlineMode || offlinePerformanceData == null) &&
           cpuProfilerController.profilerEnabled) {
         // Fetch a profile if not in offline mode and if the profiler is enabled
         cpuProfilerController.reset();
@@ -236,7 +236,7 @@ class LegacyPerformanceController
         cpuProfilerController.cpuProfileStore.lookupProfile(time: frame.time);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
-      if (!offlineMode) {
+      if (!offlineController.offlineMode) {
         await cpuProfilerController.pullAndProcessProfile(
           startMicros: frame.time.start.inMicroseconds,
           extentMicros: frame.time.duration.inMicroseconds,

--- a/packages/devtools_app/lib/src/performance/legacy/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_screen.dart
@@ -135,7 +135,7 @@ class LegacyPerformanceScreenBodyState
 
     // Refresh data on page load if data is null. On subsequent tab changes,
     // this should not be called.
-    if (controller.data == null && !offlineMode) {
+    if (controller.data == null && !offlineController.offlineMode) {
       controller.refreshData();
     }
 
@@ -146,10 +146,10 @@ class LegacyPerformanceScreenBodyState
       // require a top level field named "traceEvents". See how timeline data is
       // encoded in [ExportController.encode].
       final timelineJson =
-          Map<String, dynamic>.from(offlineDataJson[LegacyPerformanceScreen.id])
+          Map<String, dynamic>.from(offlineController.offlineDataJson[LegacyPerformanceScreen.id])
             ..addAll({
               LegacyPerformanceData.traceEventsKey:
-                  offlineDataJson[LegacyPerformanceData.traceEventsKey]
+                  offlineController.offlineDataJson[LegacyPerformanceData.traceEventsKey]
             });
       final offlinePerformanceData =
           LegacyOfflinePerformanceData.parse(timelineJson);
@@ -161,16 +161,16 @@ class LegacyPerformanceScreenBodyState
 
   @override
   Widget build(BuildContext context) {
-    final isOfflineFlutterApp = offlineMode &&
+    final isOfflineFlutterApp = offlineController.offlineMode &&
         controller.offlinePerformanceData != null &&
         controller.offlinePerformanceData.frames.isNotEmpty;
 
     final performanceScreen = Column(
       children: [
-        if (!offlineMode) _buildPerformanceControls(),
+        if (!offlineController.offlineMode) _buildPerformanceControls(),
         const SizedBox(height: denseRowSpacing),
         if (isOfflineFlutterApp ||
-            (!offlineMode && serviceManager.connectedApp.isFlutterAppNow))
+            (!offlineController.offlineMode && serviceManager.connectedApp.isFlutterAppNow))
           ValueListenableBuilder(
             valueListenable: controller.flutterFrames,
             builder: (context, frames, _) => ValueListenableBuilder(
@@ -321,10 +321,10 @@ class LegacyPerformanceScreenBodyState
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineMode &&
-        offlineDataJson.isNotEmpty &&
-        offlineDataJson[LegacyPerformanceScreen.id] != null &&
-        offlineDataJson[LegacyPerformanceData.traceEventsKey] != null;
+    return offlineController.offlineMode &&
+        offlineController.offlineDataJson.isNotEmpty &&
+        offlineController.offlineDataJson[LegacyPerformanceScreen.id] != null &&
+        offlineController.offlineDataJson[LegacyPerformanceData.traceEventsKey] != null;
   }
 }
 

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -111,7 +111,7 @@ class PerformanceController extends DisposableController
 
   /// Timeline data loaded via import.
   ///
-  /// This is expected to be null when we are not in [offlineMode].
+  /// This is expected to be null when we are not in [offlineController.offlineMode].
   ///
   /// This will contain the original data from the imported file, regardless of
   /// any selection modifications that occur while the data is displayed. [data]
@@ -178,7 +178,7 @@ class PerformanceController extends DisposableController
   }
 
   Future<void> _initHelper() async {
-    if (!offlineMode) {
+    if (!offlineController.offlineMode) {
       await serviceManager.onServiceAvailable;
       await _initData();
 
@@ -305,7 +305,7 @@ class PerformanceController extends DisposableController
           shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
-      } else if ((!offlineMode || offlinePerformanceData == null) &&
+      } else if ((!offlineController.offlineMode || offlinePerformanceData == null) &&
           cpuProfilerController.profilerEnabled) {
         // Fetch a profile if not in offline mode and if the profiler is enabled
         cpuProfilerController.reset();
@@ -341,7 +341,7 @@ class PerformanceController extends DisposableController
       return;
     }
 
-    if (!offlineMode) {
+    if (!offlineController.offlineMode) {
       final bool frameBeforeFirstWellFormedFrame =
           firstWellFormedFrameMicros != null &&
               frame.timeFromFrameTiming.start.inMicroseconds <
@@ -390,7 +390,7 @@ class PerformanceController extends DisposableController
         .lookupProfile(time: frame.timeFromEventFlows);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
-      if (!offlineMode && frame.timeFromEventFlows.isWellFormed) {
+      if (!offlineController.offlineMode && frame.timeFromEventFlows.isWellFormed) {
         await cpuProfilerController.pullAndProcessProfile(
           startMicros: frame.timeFromEventFlows.start.inMicroseconds,
           extentMicros: frame.timeFromEventFlows.duration.inMicroseconds,
@@ -593,7 +593,7 @@ class PerformanceController extends DisposableController
   void addTimelineEvent(TimelineEvent event) {
     data.addTimelineEvent(event);
     if (event is SyncTimelineEvent) {
-      if (!offlineMode &&
+      if (!offlineController.offlineMode &&
           serviceManager.hasConnection &&
           !serviceManager.connectedApp.isFlutterAppNow) {
         return;

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -178,7 +178,7 @@ class PerformanceController extends DisposableController
   }
 
   Future<void> _initHelper() async {
-    if (!offlineController.offlineMode) {
+    if (!offlineController.offlineMode.value) {
       await serviceManager.onServiceAvailable;
       await _initData();
 
@@ -305,7 +305,8 @@ class PerformanceController extends DisposableController
           shouldRefreshSearchMatches: true,
         );
         data.cpuProfileData = cpuProfilerController.dataNotifier.value;
-      } else if ((!offlineController.offlineMode || offlinePerformanceData == null) &&
+      } else if ((!offlineController.offlineMode.value ||
+              offlinePerformanceData == null) &&
           cpuProfilerController.profilerEnabled) {
         // Fetch a profile if not in offline mode and if the profiler is enabled
         cpuProfilerController.reset();
@@ -341,7 +342,7 @@ class PerformanceController extends DisposableController
       return;
     }
 
-    if (!offlineController.offlineMode) {
+    if (!offlineController.offlineMode.value) {
       final bool frameBeforeFirstWellFormedFrame =
           firstWellFormedFrameMicros != null &&
               frame.timeFromFrameTiming.start.inMicroseconds <
@@ -390,7 +391,8 @@ class PerformanceController extends DisposableController
         .lookupProfile(time: frame.timeFromEventFlows);
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
-      if (!offlineController.offlineMode && frame.timeFromEventFlows.isWellFormed) {
+      if (!offlineController.offlineMode.value &&
+          frame.timeFromEventFlows.isWellFormed) {
         await cpuProfilerController.pullAndProcessProfile(
           startMicros: frame.timeFromEventFlows.start.inMicroseconds,
           extentMicros: frame.timeFromEventFlows.duration.inMicroseconds,
@@ -593,7 +595,7 @@ class PerformanceController extends DisposableController
   void addTimelineEvent(TimelineEvent event) {
     data.addTimelineEvent(event);
     if (event is SyncTimelineEvent) {
-      if (!offlineController.offlineMode &&
+      if (!offlineController.offlineMode.value &&
           serviceManager.hasConnection &&
           !serviceManager.connectedApp.isFlutterAppNow) {
         return;

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -127,10 +127,10 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
       // require a top level field named "traceEvents". See how timeline data is
       // encoded in [ExportController.encode].
       final timelineJson =
-          Map<String, dynamic>.from(offlineDataJson[PerformanceScreen.id])
+          Map<String, dynamic>.from(offlineController.offlineDataJson[PerformanceScreen.id])
             ..addAll({
               PerformanceData.traceEventsKey:
-                  offlineDataJson[PerformanceData.traceEventsKey]
+                  offlineController.offlineDataJson[PerformanceData.traceEventsKey]
             });
       final offlinePerformanceData = OfflinePerformanceData.parse(timelineJson);
       if (!offlinePerformanceData.isEmpty) {
@@ -141,16 +141,16 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    final isOfflineFlutterApp = offlineMode &&
+    final isOfflineFlutterApp = offlineController.offlineMode &&
         controller.offlinePerformanceData != null &&
         controller.offlinePerformanceData.frames.isNotEmpty;
 
     final performanceScreen = Column(
       children: [
-        if (!offlineMode) _buildPerformanceControls(),
+        if (!offlineController.offlineMode) _buildPerformanceControls(),
         const SizedBox(height: denseRowSpacing),
         if (isOfflineFlutterApp ||
-            (!offlineMode && serviceManager.connectedApp.isFlutterAppNow))
+            (!offlineController.offlineMode && serviceManager.connectedApp.isFlutterAppNow))
           ValueListenableBuilder(
             valueListenable: controller.flutterFrames,
             builder: (context, frames, _) => ValueListenableBuilder(
@@ -222,10 +222,10 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineMode &&
-        offlineDataJson.isNotEmpty &&
-        offlineDataJson[PerformanceScreen.id] != null &&
-        offlineDataJson[PerformanceData.traceEventsKey] != null;
+    return offlineController.offlineMode &&
+        offlineController.offlineDataJson.isNotEmpty &&
+        offlineController.offlineDataJson[PerformanceScreen.id] != null &&
+        offlineController.offlineDataJson[PerformanceData.traceEventsKey] != null;
   }
 }
 

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -135,7 +135,7 @@ class CpuProfilerController
   /// use this getter. Otherwise, clients subscribing to change notifications,
   /// should listen to [profilerFlagNotifier].
   bool get profilerEnabled =>
-      offlineMode ? true : profilerFlagNotifier.value.valueAsString == 'true';
+      offlineController.offlineMode ? true : profilerFlagNotifier.value.valueAsString == 'true';
 
   Future<dynamic> enableCpuProfiler() {
     return serviceManager.service.enableCpuProfiler();

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -134,8 +134,9 @@ class CpuProfilerController
   /// Clients interested in the current value of [profilerFlagNotifier] should
   /// use this getter. Otherwise, clients subscribing to change notifications,
   /// should listen to [profilerFlagNotifier].
-  bool get profilerEnabled =>
-      offlineController.offlineMode ? true : profilerFlagNotifier.value.valueAsString == 'true';
+  bool get profilerEnabled => offlineController.offlineMode.value
+      ? true
+      : profilerFlagNotifier.value.valueAsString == 'true';
 
   Future<dynamic> enableCpuProfiler() {
     return serviceManager.service.enableCpuProfiler();

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -124,7 +124,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
     // Load offline profiler data if available.
     if (shouldLoadOfflineData()) {
       final profilerJson =
-          Map<String, dynamic>.from(offlineDataJson[ProfilerScreen.id]);
+          Map<String, dynamic>.from(offlineController.offlineDataJson[ProfilerScreen.id]);
       final offlineProfilerData = CpuProfileData.parse(profilerJson);
       if (!offlineProfilerData.isEmpty) {
         loadOfflineData(offlineProfilerData);
@@ -134,7 +134,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    if (offlineMode) return _buildProfilerScreenBody(controller);
+    if (offlineController.offlineMode) return _buildProfilerScreenBody(controller);
     return ValueListenableBuilder<Flag>(
       valueListenable: controller.cpuProfilerController.profilerFlagNotifier,
       builder: (context, profilerFlag, _) {
@@ -148,7 +148,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   Widget _buildProfilerScreenBody(ProfilerScreenController controller) {
     final profilerScreen = Column(
       children: [
-        if (!offlineMode)
+        if (!offlineController.offlineMode)
           ProfilerScreenControls(
             controller: controller,
             recording: recording,
@@ -263,9 +263,9 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineMode &&
-        offlineDataJson.isNotEmpty &&
-        offlineDataJson[ProfilerScreen.id] != null;
+    return offlineController.offlineMode &&
+        offlineController.offlineDataJson.isNotEmpty &&
+        offlineController.offlineDataJson[ProfilerScreen.id] != null;
   }
 }
 

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -87,6 +87,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   void initState() {
     super.initState();
     ga.screen(ProfilerScreen.id);
+    addAutoDisposeListener(offlineController.offlineMode);
   }
 
   @override
@@ -123,8 +124,8 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
 
     // Load offline profiler data if available.
     if (shouldLoadOfflineData()) {
-      final profilerJson =
-          Map<String, dynamic>.from(offlineController.offlineDataJson[ProfilerScreen.id]);
+      final profilerJson = Map<String, dynamic>.from(
+          offlineController.offlineDataJson[ProfilerScreen.id]);
       final offlineProfilerData = CpuProfileData.parse(profilerJson);
       if (!offlineProfilerData.isEmpty) {
         loadOfflineData(offlineProfilerData);
@@ -134,7 +135,8 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    if (offlineController.offlineMode) return _buildProfilerScreenBody(controller);
+    if (offlineController.offlineMode.value)
+      return _buildProfilerScreenBody(controller);
     return ValueListenableBuilder<Flag>(
       valueListenable: controller.cpuProfilerController.profilerFlagNotifier,
       builder: (context, profilerFlag, _) {
@@ -148,7 +150,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   Widget _buildProfilerScreenBody(ProfilerScreenController controller) {
     final profilerScreen = Column(
       children: [
-        if (!offlineController.offlineMode)
+        if (!offlineController.offlineMode.value)
           ProfilerScreenControls(
             controller: controller,
             recording: recording,
@@ -263,9 +265,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
 
   @override
   bool shouldLoadOfflineData() {
-    return offlineController.offlineMode &&
-        offlineController.offlineDataJson.isNotEmpty &&
-        offlineController.offlineDataJson[ProfilerScreen.id] != null;
+    return offlineController.shouldLoadOfflineData(ProfilerScreen.id);
   }
 }
 

--- a/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
@@ -20,7 +20,7 @@ import 'profiler_screen.dart';
 class ProfilerScreenController extends DisposableController
     with AutoDisposeControllerMixin {
   ProfilerScreenController() {
-    if (!offlineMode) {
+    if (!offlineController.offlineMode) {
       allowedError(
         serviceManager.service.setProfilePeriod(mediumProfilePeriod),
         logError: false,

--- a/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen_controller.dart
@@ -20,7 +20,7 @@ import 'profiler_screen.dart';
 class ProfilerScreenController extends DisposableController
     with AutoDisposeControllerMixin {
   ProfilerScreenController() {
-    if (!offlineController.offlineMode) {
+    if (!offlineController.offlineMode.value) {
       allowedError(
         serviceManager.service.setProfilePeriod(mediumProfilePeriod),
         logError: false,

--- a/packages/devtools_app/lib/src/routing.dart
+++ b/packages/devtools_app/lib/src/routing.dart
@@ -137,8 +137,9 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     final newArgs = {...currentConfiguration.args, ...?argUpdates};
 
     // Ensure we disconnect from any previously connected applications if we do
-    // not have a vm service uri as a query parameter.
-    if (newArgs['uri'] == null) {
+    // not have a vm service uri as a query parameter, unless we are loading an
+    // offline file.
+    if (page != snapshotPageId && newArgs['uri'] == null) {
       serviceManager.manuallyDisconnect();
     }
 

--- a/packages/devtools_app/lib/src/routing.dart
+++ b/packages/devtools_app/lib/src/routing.dart
@@ -147,6 +147,16 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     notifyListeners();
   }
 
+  void navigateHome({bool clearUriParam = false, bool clearScreenParam}) {
+    navigate(
+      homePageId,
+      {
+        if (clearUriParam) 'uri': null,
+        if (clearScreenParam) 'screen': null,
+      },
+    );
+  }
+
   /// Replaces the navigation stack with a new route.
   void _replaceStack(DevToolsRouteConfiguration configuration) {
     routes

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -129,6 +129,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   void initState() {
     super.initState();
 
+    addAutoDisposeListener(offlineController.offlineMode);
+
     _setupTabController();
 
     _connectVmSubscription =
@@ -275,7 +277,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     // screen based on the flutter version of the imported file.
     final args = {'screen': screenId};
     final routerDelegate = DevToolsRouterDelegate.of(context);
-    if (!offlineController.offlineMode) {
+    if (!offlineController.offlineMode.value) {
       routerDelegate.navigate(snapshotPageId, args);
     } else {
       // If we are already in offline mode, we need to replace the existing page
@@ -317,7 +319,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           children: tabBodies,
         ),
         if (serviceManager.connectedAppInitialized &&
-            !offlineController.offlineMode &&
+            !offlineController.offlineMode.value &&
             _currentScreen.showFloatingDebuggerControls)
           Container(
             alignment: Alignment.topCenter,
@@ -343,7 +345,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
               child: Scaffold(
                 appBar: widget.embed ? null : _buildAppBar(scaffoldTitle),
                 body: (serviceManager.connectedAppInitialized &&
-                        !offlineController.offlineMode &&
+                        !offlineController.offlineMode.value &&
                         _currentScreen.showConsole(widget.embed))
                     ? Split(
                         axis: Axis.vertical,

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -275,12 +275,11 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     // screen based on the flutter version of the imported file.
     final args = {'screen': screenId};
     final routerDelegate = DevToolsRouterDelegate.of(context);
-    // If we are already in offline mode, we need to replace the existing page
-    // so clicking Back does not go through all of the old snapshots.
-    if (!offlineMode) {
-      enterOfflineMode();
+    if (!offlineController.offlineMode) {
       routerDelegate.navigate(snapshotPageId, args);
     } else {
+      // If we are already in offline mode, we need to replace the existing page
+      // so clicking Back does not go through all of the old snapshots.
       // Router.neglect will cause the router to ignore this change, so
       // dragging a new export into the browser will not result in a new
       // history entry.
@@ -318,7 +317,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           children: tabBodies,
         ),
         if (serviceManager.connectedAppInitialized &&
-            !offlineMode &&
+            !offlineController.offlineMode &&
             _currentScreen.showFloatingDebuggerControls)
           Container(
             alignment: Alignment.topCenter,
@@ -344,7 +343,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
               child: Scaffold(
                 appBar: widget.embed ? null : _buildAppBar(scaffoldTitle),
                 body: (serviceManager.connectedAppInitialized &&
-                        !offlineMode &&
+                        !offlineController.offlineMode &&
                         _currentScreen.showConsole(widget.embed))
                     ? Split(
                         axis: Axis.vertical,
@@ -469,12 +468,6 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         ],
       ),
     );
-  }
-
-  void enterOfflineMode() {
-    setState(() {
-      offlineMode = true;
-    });
   }
 
   /// Returns the width of the scaffold title, tabs and default icons.

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -219,7 +219,7 @@ mixin OfflineScreenMixin<T extends StatefulWidget, U> on State<T> {
 
 /// Check whether a screen should be shown in the UI.
 bool shouldShowScreen(Screen screen) {
-  if (offlineMode) {
+  if (offlineController.offlineMode) {
     return screen.worksOffline;
   }
   // No sense in ever showing screens in non-offline mode unless the service

--- a/packages/devtools_app/lib/src/screen.dart
+++ b/packages/devtools_app/lib/src/screen.dart
@@ -219,7 +219,7 @@ mixin OfflineScreenMixin<T extends StatefulWidget, U> on State<T> {
 
 /// Check whether a screen should be shown in the UI.
 bool shouldShowScreen(Screen screen) {
-  if (offlineController.offlineMode) {
+  if (offlineController.offlineMode.value) {
     return screen.worksOffline;
   }
   // No sense in ever showing screens in non-offline mode unless the service

--- a/packages/devtools_app/lib/src/snapshot_screen.dart
+++ b/packages/devtools_app/lib/src/snapshot_screen.dart
@@ -78,10 +78,7 @@ class _SnapshotScreenBodyState extends State<SnapshotScreenBody> {
               // the homepage so that clicking Back will not return here.
               Router.neglect(
                 context,
-                () => routerDelegate.navigate(
-                  homePageId,
-                  {'screen': null},
-                ),
+                () => routerDelegate.navigateHome(clearScreenParam: true),
               );
             }),
           ],

--- a/packages/devtools_app/lib/src/snapshot_screen.dart
+++ b/packages/devtools_app/lib/src/snapshot_screen.dart
@@ -72,7 +72,7 @@ class _SnapshotScreenBodyState extends State<SnapshotScreenBody> {
         Row(
           children: [
             ExitOfflineButton(onPressed: () {
-              offlineMode = false;
+              offlineController.exitOfflineMode();
               reset();
               // Use Router.neglect to replace the current history entry with
               // the homepage so that clicking Back will not return here.
@@ -102,7 +102,7 @@ class _SnapshotScreenBodyState extends State<SnapshotScreenBody> {
 
   void reset() {
     setState(() {
-      offlineDataJson.clear();
+      offlineController.offlineDataJson.clear();
       _screen = null;
     });
   }

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_controller.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_model.dart';
@@ -20,6 +21,7 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
       controller = CpuProfilerController();
     });
 

--- a/packages/devtools_app/test/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:devtools_app/src/charts/flame_chart.dart';
 import 'package:devtools_app/src/common_widgets.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_bottom_up.dart';
 import 'package:devtools_app/src/profiler/cpu_profile_call_tree.dart';
@@ -39,6 +40,7 @@ void main() {
     when(fakeServiceManager.connectedApp.isFlutterNativeAppNow)
         .thenReturn(false);
     setGlobal(ServiceConnectionManager, fakeServiceManager);
+    setGlobal(OfflineModeController, OfflineModeController());
   });
 
   group('CpuProfiler', () {

--- a/packages/devtools_app/test/event_details_test.dart
+++ b/packages/devtools_app/test/event_details_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/event_details.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
@@ -38,6 +39,7 @@ void main() {
     setUp(() {
       final fakeServiceManager = FakeServiceManager();
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
       when(serviceManager.connectedApp.isDartWebAppNow).thenReturn(false);
     });
 

--- a/packages/devtools_app/test/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/flutter_frames_chart_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/flutter_frames_chart.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
@@ -35,6 +36,7 @@ void main() {
       final fakeServiceManager = FakeServiceManager();
       when(fakeServiceManager.connectedApp.isFlutterAppNow).thenReturn(true);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
     });
 
     testWidgets('builds with no frames', (WidgetTester tester) async {

--- a/packages/devtools_app/test/import_export_test.dart
+++ b/packages/devtools_app/test/import_export_test.dart
@@ -3,9 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/utils.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'support/mocks.dart';
 import 'support/wrappers.dart';
 
 void main() async {
@@ -15,6 +18,8 @@ void main() async {
     setUp(() {
       notifications = TestNotifications();
       importController = ImportController(notifications, (_) {});
+      setGlobal(OfflineModeController, OfflineModeController());
+      setGlobal(ServiceConnectionManager, FakeServiceManager());
     });
 
     test('importData pushes proper notifications', () async {

--- a/packages/devtools_app/test/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory_screen_test.dart
@@ -6,6 +6,7 @@
 import 'dart:ui';
 
 import 'package:devtools_app/src/common_widgets.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/memory/memory_controller.dart';
 import 'package:devtools_app/src/memory/memory_events_pane.dart';
@@ -111,6 +112,7 @@ void main() {
 
     setUp(() async {
       await ensureInspectorDependencies();
+      setGlobal(OfflineModeController, OfflineModeController());
       fakeServiceManager = FakeServiceManager();
       when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)

--- a/packages/devtools_app/test/performance_controller_test.dart
+++ b/packages/devtools_app/test/performance_controller_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_model.dart';
@@ -25,6 +26,7 @@ void main() async {
 
   PerformanceController performanceController;
   env.afterNewSetup = () async {
+    setGlobal(OfflineModeController, OfflineModeController());
     performanceController = PerformanceController()..data = PerformanceData();
     await performanceController.initialized;
   };

--- a/packages/devtools_app/test/performance_controller_test.dart
+++ b/packages/devtools_app/test/performance_controller_test.dart
@@ -36,7 +36,7 @@ void main() async {
 
     test('processOfflineData', () async {
       await env.setupEnvironment();
-      offlineMode = true;
+      offlineController.enterOfflineMode();
       final offlineTimelineData =
           OfflinePerformanceData.parse(offlinePerformanceDataJson);
       await performanceController.processOfflineData(offlineTimelineData);

--- a/packages/devtools_app/test/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance_screen_test.dart
@@ -4,6 +4,7 @@
 
 @TestOn('vm')
 import 'package:devtools_app/src/common_widgets.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/event_details.dart';
 import 'package:devtools_app/src/performance/flutter_frames_chart.dart';
@@ -71,6 +72,7 @@ void main() {
     setUp(() async {
       await ensureInspectorDependencies();
       _setUpServiceManagerWithTimeline(testTimelineJson);
+      setGlobal(OfflineModeController, OfflineModeController());
       screen = const PerformanceScreen();
     });
 

--- a/packages/devtools_app/test/profiler_screen_controller_test.dart
+++ b/packages/devtools_app/test/profiler_screen_controller_test.dart
@@ -1,6 +1,7 @@
 // Copyright 2019 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/service_manager.dart';
@@ -16,6 +17,7 @@ void main() {
     setUp(() {
       fakeServiceManager = FakeServiceManager();
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
       controller = ProfilerScreenController();
     });
 

--- a/packages/devtools_app/test/profiler_screen_test.dart
+++ b/packages/devtools_app/test/profiler_screen_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/common_widgets.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/profiler/cpu_profiler.dart';
 import 'package:devtools_app/src/profiler/profiler_screen.dart';
@@ -35,6 +36,7 @@ void main() {
       when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
           .thenReturn(ValueNotifier<int>(0));
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
       screen = const ProfilerScreen();
     });
 

--- a/packages/devtools_app/test/scaffold_test.dart
+++ b/packages/devtools_app/test/scaffold_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/analytics/analytics_controller.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/framework_controller.dart';
 import 'package:devtools_app/src/globals.dart';
@@ -37,6 +38,7 @@ void main() {
       setGlobal(ServiceConnectionManager, mockServiceManager);
       setGlobal(FrameworkController, FrameworkController());
       setGlobal(SurveyService, SurveyService());
+      setGlobal(OfflineModeController, OfflineModeController());
     });
 
     Widget wrapScaffold(Widget child) {

--- a/packages/devtools_app/test/support/mocks.dart
+++ b/packages/devtools_app/test/support/mocks.dart
@@ -91,7 +91,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   bool get isServiceAvailable => hasConnection;
 
   @override
-  final ConnectedApp connectedApp = MockConnectedApp();
+  ConnectedApp connectedApp = MockConnectedApp();
 
   @override
   final ConsoleService consoleService = ConsoleService();

--- a/packages/devtools_app/test/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/timeline_flame_chart_test.dart
@@ -5,6 +5,7 @@
 import 'dart:io';
 
 import 'package:devtools_app/src/charts/flame_chart.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_screen.dart';
@@ -41,6 +42,7 @@ void main() {
       when(fakeServiceManager.connectedApp.isDebugFlutterAppNow)
           .thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(OfflineModeController, OfflineModeController());
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
     }

--- a/packages/devtools_app/test/visible_screens_test.dart
+++ b/packages/devtools_app/test/visible_screens_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:devtools_app/src/app.dart';
 import 'package:devtools_app/src/app_size/app_size_screen.dart';
+import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/framework_controller.dart';
 import 'package:devtools_app/src/globals.dart';
@@ -33,6 +34,7 @@ void main() {
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(FrameworkController, FrameworkController());
       setGlobal(PreferencesController, PreferencesController());
+      setGlobal(OfflineModeController, OfflineModeController());
 
       await whenValueNonNull(serviceManager.isolateManager.selectedIsolate);
     });
@@ -186,7 +188,7 @@ void main() {
     });
 
     testWidgets('are correct when offline', (WidgetTester tester) async {
-      offlineMode = true;
+      offlineController.enterOfflineMode();
       setupMockValues(web: true); // Web apps would normally hide
 
       expect(
@@ -203,7 +205,7 @@ void main() {
             // AppSizeScreen,
             // VMDeveloperToolsScreen,
           ]));
-      offlineMode = false;
+      offlineController.exitOfflineMode();
     });
 
     testWidgets('are correct for Dart CLI app with VM developer mode enabled',


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3361.

This will allow for things like hiding flutter-specific features when the exported data was for a non-flutter app.