### PR TITLE
Always show the vertical scrollbar in the DevTools debugger

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -278,6 +278,7 @@ class _CodeViewState extends State<CodeView>
               child: Scrollbar(
                 key: CodeView.debuggerCodeViewVerticalScrollbarKey,
                 controller: textController,
+                isAlwaysShown: true,
                 // Only listen for vertical scroll notifications (ignore those
                 // from the nested horizontal SingleChildScrollView):
                 notificationPredicate: (ScrollNotification notification) =>


### PR DESCRIPTION
Follow up PR from https://github.com/flutter/devtools/pull/3393#discussion_r717051093

Always show the vertical scrollbar in the DevTools debugger page (previously it would only show up when the page was scrolled). 