### PR TITLE
Fix null exception in program explorer code

### DIFF
--- a/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
@@ -69,15 +69,17 @@ class ProgramExplorerController extends DisposableController
     }
     _initializing = true;
     _isolate = serviceManager.isolateManager.selectedIsolate.value;
-    final libraries = await Future.wait(
-      serviceManager.isolateManager
-          .isolateDebuggerState(_isolate)
-          .isolateNow
-          .libraries
-          .map(
-            (lib) => VMServiceLibraryContents.getLibraryContents(lib),
-          ),
-    );
+    final libraries = _isolate != null
+        ? await Future.wait(
+            serviceManager.isolateManager
+                .isolateDebuggerState(_isolate)
+                .isolateNow
+                .libraries
+                .map(
+                  (lib) => VMServiceLibraryContents.getLibraryContents(lib),
+                ),
+          )
+        : <VMServiceLibraryContents>[];
 
     void mapIdsToLibrary(LibraryRef lib, Iterable<ObjRef> objs) {
       for (final e in objs) {


### PR DESCRIPTION
Fixes this exception:
```
[ERROR:flutter/lib/ui/ui_dart_state.cc(209)] Unhandled Exception: NoSuchMethodError: The getter 'isolateNow' was called on null.
Receiver: null
Tried calling: isolateNow
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:68:5)
#1      ProgramExplorerController.initialize (package:devtools_app/src/debugger/program_explorer_controller.dart:75:18)
#2      ProgramExplorerController.refresh (package:devtools_app/src/debugger/program_explorer_controller.dart:155:18)
#3      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:308:24)
#4      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:412:5)
#5      IsolateManager._handleVmServiceClosed (package:devtools_app/src/service_manager.dart:719:22)
#6      ServiceConnectionManager.vmServiceClosed (package:devtools_app/src/service_manager.dart:341:20)
```