### PR TITLE
Update release scripts

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -54,7 +54,7 @@ function download_canvaskit() {
     exit -1
   fi
 
-  local canvaskit_url="https://unpkg.com/canvaskit-wasm@$(local_canvaskit_version)/bin/"
+  local canvaskit_url=https://unpkg.com/canvaskit-wasm@$local_canvaskit_version/bin/
 
   mkdir -p build/web/assets/canvaskit/profiling
 

--- a/tool/pub_publish.sh
+++ b/tool/pub_publish.sh
@@ -18,6 +18,13 @@ if ! flutter pub publish --force; then
 fi
 
 popd
+pushd packages/devtools_test
+if ! flutter pub publish --force; then
+    echo "flutter pub publish devtools_test failed."
+    exit -1
+fi
+
+popd
 pushd packages/devtools_app
 if ! flutter pub publish --force; then
     echo "flutter pub publish devtools_app failed."

--- a/tool/publish.sh
+++ b/tool/publish.sh
@@ -4,6 +4,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+FLUTTER_DIR="`pwd`/flutter-sdk"
+PATH="$FLUTTER_DIR/bin":$PATH
+
+flutter --version
+
 set -x #echo on
 echo "Editing .gitignore to comment out build directory"
 


### PR DESCRIPTION
We need to use the version of flutter from `/flutter-sdk` for the `publish.sh` script (we already do this for the `build_release.sh` script), and the canvaskit version is now stored differently on flutter (https://github.com/flutter/engine/commit/057c49c4271c94f3b039b4f6fe3ac51a8f39f03c#diff-0569728ab50c0b8a004cd2d3eba60fb7b6990a090457fd23e5a930a0547e359f), so that changes how we need to look it up.