### PR TITLE
Expose more common `devtools_app` package source files via `devtools_app.dart`

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -4,8 +4,11 @@
 
 export 'src/analytics/analytics_controller.dart';
 export 'src/app_size/app_size_controller.dart';
+export 'src/auto_dispose.dart';
+export 'src/auto_dispose_mixin.dart';
 export 'src/banner_messages.dart';
 export 'src/charts/treemap.dart';
+export 'src/common_widgets.dart';
 export 'src/connected_app.dart';
 export 'src/console_service.dart';
 export 'src/debugger/debugger_controller.dart';
@@ -32,6 +35,7 @@ export 'src/profiler/cpu_profile_model.dart';
 export 'src/profiler/profile_granularity.dart';
 export 'src/profiler/profiler_screen_controller.dart';
 export 'src/routing.dart';
+export 'src/screen.dart';
 export 'src/service_extensions.dart';
 export 'src/service_manager.dart';
 export 'src/theme.dart';


### PR DESCRIPTION
Following up on PR/3406 and exposing more common `devtools_app` package source files via `lib/devtools_app.dart`.