### PR TITLE
Run serveRequests in an error zone and log errors

### DIFF
--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## 0.2.6-dev.2
 - Updated package:vm_service to >= 4.1.0
-- Made `serveDevtools` Serve requests from in an error zone and log errors.
 
 ## 0.2.3
 - Updated package:vm_service to >= 3.0.0

--- a/packages/devtools_server/CHANGELOG.md
+++ b/packages/devtools_server/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.2.6-dev.2
 - Updated package:vm_service to >= 4.1.0
+- Made `serveDevtools` Serve requests from in an error zone and log errors.
 
 ## 0.2.3
 - Updated package:vm_service to >= 3.0.0

--- a/packages/devtools_server/lib/src/devtools_command.dart
+++ b/packages/devtools_server/lib/src/devtools_command.dart
@@ -4,7 +4,6 @@
 
 import 'package:args/command_runner.dart';
 
-import '../devtools_server.dart';
 import 'server.dart';
 
 const commandDescription =

--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -233,7 +233,11 @@ Future<HttpServer?> serveDevTools({
   // Ensure browsers don't cache older versions of the app.
   _server.defaultResponseHeaders
       .add(HttpHeaders.cacheControlHeader, 'max-age=900');
-  shelf.serveRequests(_server, handler);
+  // Serve requests in an error zone to prevent failures
+  // when running from another error zone.
+  runZonedGuarded(() => shelf.serveRequests(_server, handler!), (e, _) {
+    print('Error serving requests: $e');
+  });
 
   final devToolsUrl = 'http://${_server.address.host}:${_server.port}';
 


### PR DESCRIPTION
We have a large number of DDR server crashes due to `serveRequests` calls not running in a proper error zone.

See dart-lang/shelf#202 for discussion.

**Related issues**

Similar issue https://github.com/dart-lang/build/pull/3203
Similar issue dart-lang/webdev#1418

Closes: flutter/devtools#3415