### PR TITLE
Don't register service worker when running DevTools locally

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -72,8 +72,7 @@
     }
 
     if ('serviceWorker' in navigator) {
-      if (window.location.hostname === 'localhost' ||
-          window.location.href.includes('index.ddc.html')) {
+      if (window.location.href.includes('index.ddc.html')) {
         // If we are running DevTools locally, immediately load `main.dart.js` and
         // unregister any service workers:
         loadMainDartJs();

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -72,47 +72,65 @@
     }
 
     if ('serviceWorker' in navigator) {
-      // Service workers are supported. Use them.
-      window.addEventListener('load', function () {
-        // Wait for registration to finish before dropping the <script> tag.
-        // Otherwise, the browser will load the script multiple times,
-        // potentially different versions.
-        var serviceWorkerUrl = 'service_worker.js?v=' + version;
-        navigator.serviceWorker.register(serviceWorkerUrl)
-          .then((reg) => {
-            function waitForActivation(serviceWorker) {
-              serviceWorker.addEventListener('statechange', () => {
-                if (serviceWorker.state == 'activated') {
+      if (window.location.hostname === 'localhost' ||
+          window.location.href.includes('index.ddc.html')) {
+        // If we are running DevTools locally, immediately load `main.dart.js` and
+        // unregister any service workers:
+        loadMainDartJs();
+        navigator.serviceWorker.getRegistrations().then(function(registrations) {
+          for (let registration of registrations) {
+            registration.unregister();
+          }
+        });
+      } else {
+        // Service workers are supported. Use them.
+        window.addEventListener('load', function() {
+          // Wait for registration to finish before dropping the <script> tag.
+          // Otherwise, the browser will load the script multiple times,
+          // potentially different versions.
+          var serviceWorkerUrl = 'service_worker.js?v=' + version;
+          navigator.serviceWorker.register(serviceWorkerUrl)
+              .then((reg) => {
+                function waitForActivation(serviceWorker) {
+                  serviceWorker.addEventListener('statechange', () => {
+                    if (serviceWorker.state == 'activated') {
+                      loadMainDartJs();
+                    }
+                  });
+                }
+                if (!reg.active && (reg.installing || reg.waiting)) {
+                  // No active web worker and we have installed or are installing
+                  // one for the first time. Simply wait for it to activate.
+                  waitForActivation(reg.installing || reg.waiting);
+                } else if (!reg.active.scriptURL.endsWith(version)) {
+                  // When the app updates the version changes, so we
+                  // need to ask the service worker to update.
+                  reg.update();
+                  waitForActivation(reg.installing);
+                } else {
+                  // Existing service worker is still good.
                   loadMainDartJs();
                 }
+              })
+              .catch((err) => {
+                console.warn(
+                    ` Falling back to plain <script> tag. Error loading service worker: ${
+                        err}`);
+                loadMainDartJs();
               });
-            }
-            if (!reg.active && (reg.installing || reg.waiting)) {
-              // No active web worker and we have installed or are installing
-              // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing || reg.waiting);
-            } else if (!reg.active.scriptURL.endsWith(version)) {
-              // When the app updates the version changes, so we
-              // need to ask the service worker to update.
-              reg.update();
-              waitForActivation(reg.installing);
-            } else {
-              // Existing service worker is still good.
+
+          // If service worker doesn't succeed in a reasonable amount of time,
+          // fallback to plain <script> tag.
+          setTimeout(() => {
+            if (!scriptLoaded) {
+              console.warn(
+                  'Failed to load app from service worker. Falling back to plain <script> tag.',
+              );
               loadMainDartJs();
             }
-          });
-
-        // If service worker doesn't succeed in a reasonable amount of time,
-        // fallback to plain <script> tag.
-        setTimeout(() => {
-          if (!scriptLoaded) {
-            console.warn(
-              'Failed to load app from service worker. Falling back to plain <script> tag.',
-            );
-            loadMainDartJs();
-          }
-        }, 4000);
-      });
+          }, 4000);
+        });
+      }
     } else {
       // Service workers not supported. Just drop the <script> tag.
       loadMainDartJs();


### PR DESCRIPTION
Adds a check to see if DevTools is running locally in `index.html`, which is determined by:
* the host name is `localhost` OR
* the `index.html` file is called `index.ddc.html` 

If so, we skip the service worker registration step (before, this would fail after 4 seconds). 

I've also caught any error coming from registering the service worker, and logging it to the console as a warning.



