### PR TITLE
Preferences keep split fractions base on screen and children

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -127,6 +127,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     final widgetTrees = Split(
       axis: splitAxis,
       initialFractions: const [0.33, 0.67],
+      fractionsKey: 'inspector_detail_tree',
       children: [
         summaryTree,
         InspectorDetailsTabController(

--- a/packages/devtools_app/lib/src/preferences.dart
+++ b/packages/devtools_app/lib/src/preferences.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 
 import 'config_specific/logger/logger.dart';
@@ -13,10 +15,12 @@ class PreferencesController {
   final ValueNotifier<bool> _darkModeTheme = ValueNotifier(true);
   final ValueNotifier<bool> _vmDeveloperMode = ValueNotifier(false);
   final ValueNotifier<bool> _denseMode = ValueNotifier(false);
+  final ValueNotifier<String> _splitFractions = ValueNotifier('{}');
 
   ValueListenable<bool> get darkModeTheme => _darkModeTheme;
   ValueListenable<bool> get vmDeveloperModeEnabled => _vmDeveloperMode;
   ValueListenable<bool> get denseModeEnabled => _denseMode;
+  ValueListenable<String> get splitFractions => _splitFractions;
 
   Future<void> init() async {
     if (storage != null) {
@@ -37,6 +41,13 @@ class PreferencesController {
       toggleDenseMode(value == 'true');
       _denseMode.addListener(() {
         storage.setValue('ui.denseMode', '${_denseMode.value}');
+      });
+
+      final String _splitFractionsValue =
+          await storage.getValue('ui.splitFractions');
+      setSplitFractions(_splitFractionsValue);
+      _splitFractions.addListener(() {
+        storage.setValue('ui.splitFractions', '${_splitFractions.value}');
       });
     } else {
       // This can happen when running tests.
@@ -59,5 +70,19 @@ class PreferencesController {
   /// Change the value for the dense mode setting.
   void toggleDenseMode(bool enableDenseMode) {
     _denseMode.value = enableDenseMode;
+  }
+
+  /// Change the value for the split fractions setting.
+  void setSplitFractions(String splitFractions) {
+    dynamic decoded;
+    try {
+      decoded = jsonDecode(splitFractions);
+    } catch (e) {
+      decoded = false;
+    }
+    _splitFractions.value = ((splitFractions?.isNotEmpty ?? false) &&
+            decoded is Map<String, dynamic>)
+        ? splitFractions
+        : '{}';
   }
 }

--- a/packages/devtools_app/lib/src/scaffold.dart
+++ b/packages/devtools_app/lib/src/scaffold.dart
@@ -408,6 +408,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
                             DebuggerConsole.buildHeader(),
                           ],
                           initialFractions: const [0.8, 0.2],
+                          fractionsKey: 'inspector_console',
                         )
                       : content,
                   bottomNavigationBar: widget.embed ? null : _buildStatusLine(),

--- a/packages/devtools_app/test/app_size_screen_test.dart
+++ b/packages/devtools_app/test/app_size_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/file_import.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/notifications.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/utils.dart';
@@ -28,6 +29,7 @@ import 'package:mockito/mockito.dart';
 void main() {
   setUp(() {
     setGlobal(ServiceConnectionManager, FakeServiceManager());
+    setGlobal(PreferencesController, PreferencesController());
   });
 
   final lastModifiedTime = DateTime.parse('2020-07-28 13:29:00');

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:devtools_app/src/debugger/debugger_model.dart';
 import 'package:devtools_app/src/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/debugger/program_explorer_model.dart';
 import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_test/mocks.dart';
 import 'package:devtools_test/utils.dart';
@@ -35,6 +36,7 @@ void main() {
     when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
     when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
     setGlobal(ServiceConnectionManager, fakeServiceManager);
+    setGlobal(PreferencesController, PreferencesController());
     fakeServiceManager.consoleService.ensureServiceInitialized();
   });
 

--- a/packages/devtools_app/test/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/inspector/inspector_tree.dart';
 import 'package:devtools_app/src/inspector/layout_explorer/flex/flex.dart';
 import 'package:devtools_app/src/inspector/layout_explorer/layout_explorer.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_test/mocks.dart';
@@ -43,6 +44,7 @@ void main() {
           .thenReturn(ValueNotifier<int>(0));
 
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(PreferencesController, PreferencesController());
       fakeServiceManager.consoleService.ensureServiceInitialized();
     });
 

--- a/packages/devtools_app/test/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging_screen_test.dart
@@ -9,6 +9,7 @@ import 'package:devtools_app/src/common_widgets.dart';
 import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/logging/logging_controller.dart';
 import 'package:devtools_app/src/logging/logging_screen.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_extensions.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/ui/service_extension_widgets.dart';
@@ -53,6 +54,7 @@ void main() {
       when(fakeServiceManager.errorBadgeManager.errorCountNotifier(any))
           .thenReturn(ValueNotifier<int>(0));
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(PreferencesController, PreferencesController());
 
       screen = const LoggingScreen();
     });

--- a/packages/devtools_app/test/network_profiler_test.dart
+++ b/packages/devtools_app/test/network_profiler_test.dart
@@ -12,6 +12,7 @@ import 'package:devtools_app/src/network/network_model.dart';
 import 'package:devtools_app/src/network/network_request_inspector.dart';
 import 'package:devtools_app/src/network/network_request_inspector_views.dart';
 import 'package:devtools_app/src/network/network_screen.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/utils.dart';
@@ -65,6 +66,7 @@ void main() {
         ..httpEnableTimelineLoggingResult = false
         ..dartIoVersion = SemanticVersion(major: 1, minor: 6);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(PreferencesController, PreferencesController());
     });
 
     testWidgetsWithWindowSize('starts and stops', windowSize, (

--- a/packages/devtools_app/test/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance_screen_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/performance/flutter_frames_chart.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_screen.dart';
 import 'package:devtools_app/src/performance/timeline_flame_chart.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_test/mocks.dart';
@@ -71,6 +72,7 @@ void main() {
       await ensureInspectorDependencies();
       _setUpServiceManagerWithTimeline(testTimelineJson);
       setGlobal(OfflineModeController, OfflineModeController());
+      setGlobal(PreferencesController, PreferencesController());
       screen = const PerformanceScreen();
     });
 

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -16,7 +16,7 @@ void main() {
     test('has value', () {
       expect(controller.darkModeTheme.value, isNotNull);
       expect(controller.denseModeEnabled.value, isNotNull);
-      expect(controller.splitFractions.value, isNotNull);
+      expect(controller.splitFractions, isNotNull);
     });
 
     test('toggleDarkModeTheme', () {
@@ -59,23 +59,32 @@ void main() {
       expect(controller.denseModeEnabled.value, isNot(originalValue));
     });
 
-    test('setSplitFractions valid data', () {
+    test('updateSplitFractions', () {
       bool valueChanged = false;
-      final originalValue = controller.splitFractions.value;
+      const String fractionsKey = 'test';
+      const List<double> testValue = [0.33342342423, 0.98989899343];
+      const List<double> testValue2 = [0.33342342424, 0.98989899344];
+      final originalValue = controller.lookupSplitFractions(fractionsKey).value;
 
-      controller.splitFractions.addListener(() {
+      controller.lookupSplitFractions(fractionsKey).addListener(() {
         valueChanged = true;
       });
 
-      controller.setSplitFractions(
-          '{"_hash01231234":[0.33342342423, 0.98989899343]}');
+      controller.updateSplitFractions(fractionsKey, testValue);
       expect(valueChanged, isTrue);
-      expect(controller.splitFractions.value, isNot(originalValue));
+      expect(controller.lookupSplitFractions(fractionsKey).value,
+          isNot(originalValue));
 
       valueChanged = false;
-      controller.setSplitFractions('data should be object "{}" json string');
+      controller.updateSplitFractions(fractionsKey, testValue);
+      expect(valueChanged, isFalse);
+
+      controller.updateSplitFractions(fractionsKey, testValue2);
       expect(valueChanged, isTrue);
-      expect(controller.splitFractions.value, equals(originalValue));
+      expect(
+          controller.isListEqual(
+              controller.lookupSplitFractions(fractionsKey).value, testValue2),
+          isTrue);
     });
   });
 }

--- a/packages/devtools_app/test/preferences_controller_test.dart
+++ b/packages/devtools_app/test/preferences_controller_test.dart
@@ -16,6 +16,7 @@ void main() {
     test('has value', () {
       expect(controller.darkModeTheme.value, isNotNull);
       expect(controller.denseModeEnabled.value, isNotNull);
+      expect(controller.splitFractions.value, isNotNull);
     });
 
     test('toggleDarkModeTheme', () {
@@ -56,6 +57,25 @@ void main() {
       controller.toggleDenseMode(!controller.denseModeEnabled.value);
       expect(valueChanged, isTrue);
       expect(controller.denseModeEnabled.value, isNot(originalValue));
+    });
+
+    test('setSplitFractions valid data', () {
+      bool valueChanged = false;
+      final originalValue = controller.splitFractions.value;
+
+      controller.splitFractions.addListener(() {
+        valueChanged = true;
+      });
+
+      controller.setSplitFractions(
+          '{"_hash01231234":[0.33342342423, 0.98989899343]}');
+      expect(valueChanged, isTrue);
+      expect(controller.splitFractions.value, isNot(originalValue));
+
+      valueChanged = false;
+      controller.setSplitFractions('data should be object "{}" json string');
+      expect(valueChanged, isTrue);
+      expect(controller.splitFractions.value, equals(originalValue));
     });
   });
 }

--- a/packages/devtools_app/test/provider/provider_screen_test.dart
+++ b/packages/devtools_app/test/provider/provider_screen_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:devtools_app/src/banner_messages.dart';
 import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/provider/instance_viewer/instance_details.dart';
 import 'package:devtools_app/src/provider/instance_viewer/instance_providers.dart';
 import 'package:devtools_app/src/provider/provider_list.dart';
@@ -30,6 +31,7 @@ void main() {
 
   setUp(() {
     setGlobal(ServiceConnectionManager, FakeServiceManager());
+    setGlobal(PreferencesController, PreferencesController());
   });
 
   setUp(() {

--- a/packages/devtools_app/test/split_test.dart
+++ b/packages/devtools_app/test/split_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/globals.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_app/src/split.dart';
 import 'package:devtools_app/src/utils.dart';
@@ -14,6 +15,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   setUp(() {
     setGlobal(ServiceConnectionManager, FakeServiceManager());
+    setGlobal(PreferencesController, PreferencesController());
   });
 
   // Note: tester by default has a window size of 800x600.

--- a/packages/devtools_app/test/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/timeline_flame_chart_test.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/globals.dart';
 import 'package:devtools_app/src/performance/performance_controller.dart';
 import 'package:devtools_app/src/performance/performance_screen.dart';
 import 'package:devtools_app/src/performance/timeline_flame_chart.dart';
+import 'package:devtools_app/src/preferences.dart';
 import 'package:devtools_app/src/service_manager.dart';
 import 'package:devtools_test/mocks.dart';
 import 'package:devtools_test/performance_test_data.dart';
@@ -42,6 +43,7 @@ void main() {
           .thenReturn(false);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(OfflineModeController, OfflineModeController());
+      setGlobal(PreferencesController, PreferencesController());
       when(serviceManager.connectedApp.isDartWebApp)
           .thenAnswer((_) => Future.value(false));
     }


### PR DESCRIPTION
Save split panel size after changed to preferences, so users can resize panel and do not need do it again each time run new Devtools instance.

Storage key is string base on current page path and hashCode of list children widget. Make it a bit unique and do not conflict with other Split / Page.

By this way I just need start and it will auto show my favorites layout, perfect! (Second monitor vertical, android emulator always on top)

![2021-10-31_020702](https://user-images.githubusercontent.com/35319492/139555601-0f5255d4-3061-452d-b909-d9cab67d8f6a.png)

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat