### PR TITLE
Add support for selecting objects in the program explorer outline view

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -177,7 +177,8 @@ class _CodeViewState extends State<CodeView>
     // middle third of the screen.
     if (parsedScript.lineCount * CodeView.rowHeight > extent) {
       final lineIndex = location.line - 1;
-      final scrollPosition = lineIndex * CodeView.rowHeight;
+      final scrollPosition =
+          lineIndex * CodeView.rowHeight - ((extent - CodeView.rowHeight) / 2);
       if (animate) {
         verticalController.animateTo(
           scrollPosition,
@@ -701,14 +702,15 @@ class _LinesState extends State<Lines> with AutoDisposeMixin {
       itemBuilder: (context, index) {
         final lineNum = index + 1;
         final isPausedLine = pausedLine == lineNum;
-        return ValueListenableBuilder(
+        return ValueListenableBuilder<int>(
           valueListenable:
               widget.debugController.programExplorerController.focusedLine,
           builder: (context, focusedLine, _) {
+            final isFocusedLine = focusedLine == lineNum;
             return LineItem(
               lineContents: widget.lines[index],
               pausedFrame: isPausedLine ? widget.pausedFrame : null,
-              focused: isPausedLine || focusedLine == lineNum,
+              focused: isPausedLine || isFocusedLine,
               searchMatches: searchMatchesForLine(index),
               activeSearchMatch:
                   activeSearch?.position?.line == index ? activeSearch : null,

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -31,6 +31,7 @@ import 'debugger_model.dart';
 import 'file_search.dart';
 import 'hover.dart';
 import 'key_sets.dart';
+import 'program_explorer_model.dart';
 import 'variables.dart';
 
 final debuggerCodeViewSearchKey =
@@ -702,11 +703,12 @@ class _LinesState extends State<Lines> with AutoDisposeMixin {
       itemBuilder: (context, index) {
         final lineNum = index + 1;
         final isPausedLine = pausedLine == lineNum;
-        return ValueListenableBuilder<int>(
+        return ValueListenableBuilder<VMServiceObjectNode>(
           valueListenable:
-              widget.debugController.programExplorerController.focusedLine,
-          builder: (context, focusedLine, _) {
-            final isFocusedLine = focusedLine == lineNum;
+              widget.debugController.programExplorerController.outlineSelection,
+          builder: (context, outlineNode, _) {
+            final isFocusedLine =
+                outlineNode.location?.location?.line == lineNum;
             return LineItem(
               lineContents: widget.lines[index],
               pausedFrame: isPausedLine ? widget.pausedFrame : null,

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -178,11 +178,8 @@ class DebuggerController extends DisposableController
   final _clazzCache = <ClassRef, Class>{};
 
   /// Jump to the given ScriptRef and optional SourcePosition.
-  void showScriptLocation(
-    ScriptLocation scriptLocation, {
-    bool centerLocation = true,
-  }) {
-    _showScriptLocation(scriptLocation, centerLocation: centerLocation);
+  void showScriptLocation(ScriptLocation scriptLocation) {
+    _showScriptLocation(scriptLocation);
 
     // Update the scripts history (and make sure we don't react to the
     // subsequent event).
@@ -193,11 +190,7 @@ class DebuggerController extends DisposableController
 
   /// Show the given script location (without updating the script navigation
   /// history).
-  void _showScriptLocation(
-    ScriptLocation scriptLocation, {
-    bool centerLocation = true,
-  }) {
-    _shouldCenterScrollLocation = centerLocation;
+  void _showScriptLocation(ScriptLocation scriptLocation) {
     _currentScriptRef.value = scriptLocation?.scriptRef;
 
     _parseCurrentScript();
@@ -305,9 +298,6 @@ class DebuggerController extends DisposableController
 
   /// Return the sorted list of ScriptRefs active in the current isolate.
   ValueListenable<List<ScriptRef>> get sortedScripts => _sortedScripts;
-
-  bool get shouldCenterScrollLocation => _shouldCenterScrollLocation;
-  bool _shouldCenterScrollLocation = true;
 
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -120,9 +120,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
   void _onLocationSelected(ScriptLocation location) {
     if (location != null) {
-      controller.showScriptLocation(
-        location,
-      );
+      controller.showScriptLocation(location);
     }
   }
 

--- a/packages/devtools_app/lib/src/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_screen.dart
@@ -122,7 +122,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
     if (location != null) {
       controller.showScriptLocation(
         location,
-        centerLocation: location.location == null,
       );
     }
   }

--- a/packages/devtools_app/lib/src/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/debugger/program_explorer.dart
@@ -92,7 +92,7 @@ class _ProgramExplorerRow extends StatelessWidget {
     } else if (node.object is Field) {
       final field = node.object as Field;
       final subtext = _buildFieldTypeText(field);
-      toolTip = '$subtext ${field.name}';
+      toolTip = '$subtext${field.name}';
     } else if (node.script != null) {
       toolTip = node.script.uri;
     }
@@ -116,7 +116,9 @@ class _ProgramExplorerRow extends StatelessWidget {
     if (field.isFinal && !field.isConst) {
       buffer.write('final ');
     }
-    buffer.write(field.declaredType.name);
+    if (field.declaredType.name != null) {
+      buffer.write('${field.declaredType.name} ');
+    }
     return buffer.toString();
   }
 
@@ -320,7 +322,6 @@ class _ProgramOutlineView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print(controller.isLoadingOutline);
     return ValueListenableBuilder<bool>(
       valueListenable: controller.isLoadingOutline,
       builder: (context, isLoadingOutline, _) {
@@ -344,7 +345,11 @@ class _ProgramOutlineView extends StatelessWidget {
                 return _ProgramExplorerRow(
                   controller: controller,
                   node: node,
-                  onTap: onTap,
+                  onTap: () async {
+                    await node.populateLocation();
+                    controller.selectOutlineNode(node);
+                    onTap();
+                  },
                 );
               },
             );
@@ -438,6 +443,8 @@ class ProgramExplorer extends StatelessWidget {
       return;
     }
 
+    await node.populateLocation();
+
     if (node.object != null && node.object is! Obj) {
       await controller.populateNode(node);
     }
@@ -448,24 +455,7 @@ class ProgramExplorer extends StatelessWidget {
       node.expand();
     }
 
-    ScriptRef script = node.script;
-    int tokenPos = 0;
-    if (node.object != null &&
-        (node.object is FieldRef ||
-            node.object is FuncRef ||
-            node.object is ClassRef)) {
-      final location = (node.object as dynamic).location;
-      tokenPos = location.tokenPos;
-      script = location.script;
-    }
-
-    script = await debugController.getScript(script);
-    final location = tokenPos == 0
-        ? null
-        : SourcePosition.calculatePosition(script, tokenPos);
-    onSelected(
-      ScriptLocation(script, location: location),
-    );
+    onSelected(node.location);
   }
 
   void onItemExpanded(VMServiceObjectNode node) async {

--- a/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
@@ -38,7 +38,9 @@ class ProgramExplorerController extends DisposableController
   VMServiceObjectNode _scriptSelection;
 
   /// The currently selected node in the Program Explorer outline.
-  VMServiceObjectNode _outlineSelection;
+  ValueListenable<VMServiceObjectNode> get outlineSelection =>
+      _outlineSelection;
+  final _outlineSelection = ValueNotifier<VMServiceObjectNode>(null);
 
   /// The processed roots of the tree.
   ValueListenable<List<VMServiceObjectNode>> get rootObjectNodes =>
@@ -51,12 +53,6 @@ class ProgramExplorerController extends DisposableController
   ValueListenable<bool> get initialized => _initialized;
   final _initialized = ValueNotifier<bool>(false);
   bool _initializing = false;
-
-  /// The line corresponding with the currently selected outline node. Results
-  /// in the declaration of the selected outline node being highlighted in the
-  /// [CodeView].
-  ValueListenable<int> get focusedLine => _focusedLine;
-  final _focusedLine = ValueNotifier<int>(null);
 
   DebuggerController debuggerController;
 
@@ -121,8 +117,7 @@ class ProgramExplorerController extends DisposableController
   /// Clears controller state and re-initializes.
   void refresh() {
     _scriptSelection = null;
-    _outlineSelection = null;
-    _focusedLine.value = null;
+    _outlineSelection.value = null;
     _isLoadingOutline.value = true;
     _outlineNodes.clear();
     _initialized.value = false;
@@ -142,8 +137,7 @@ class ProgramExplorerController extends DisposableController
       _scriptSelection?.unselect();
       _scriptSelection = node;
       _isLoadingOutline.value = true;
-      _outlineSelection = null;
-      _focusedLine.value = null;
+      _outlineSelection.value = null;
       _outlineNodes
         ..clear()
         ..addAll(await _scriptSelection.outline);
@@ -155,11 +149,10 @@ class ProgramExplorerController extends DisposableController
     if (!node.isSelectable) {
       return;
     }
-    if (_outlineSelection != node) {
+    if (_outlineSelection.value != node) {
       node.select();
-      _focusedLine.value = node.location?.location?.line;
-      _outlineSelection?.unselect();
-      _outlineSelection = node;
+      _outlineSelection.value?.unselect();
+      _outlineSelection.value = node;
     }
   }
 

--- a/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/program_explorer_controller.dart
@@ -11,7 +11,6 @@ import '../auto_dispose.dart';
 import '../globals.dart';
 import '../utils.dart';
 import 'debugger_controller.dart';
-import 'debugger_model.dart';
 import 'program_explorer_model.dart';
 
 class ProgramExplorerController extends DisposableController
@@ -35,9 +34,10 @@ class ProgramExplorerController extends DisposableController
   ValueListenable<bool> get isLoadingOutline => _isLoadingOutline;
   final _isLoadingOutline = ValueNotifier<bool>(false);
 
-  /// The currently selected node.
-  VMServiceObjectNode _selected;
+  /// The currently selected node in the Program Explorer file picker.
+  VMServiceObjectNode _scriptSelection;
 
+  /// The currently selected node in the Program Explorer outline.
   VMServiceObjectNode _outlineSelection;
 
   /// The processed roots of the tree.
@@ -52,6 +52,9 @@ class ProgramExplorerController extends DisposableController
   final _initialized = ValueNotifier<bool>(false);
   bool _initializing = false;
 
+  /// The line corresponding with the currently selected outline node. Results
+  /// in the declaration of the selected outline node being highlighted in the
+  /// [CodeView].
   ValueListenable<int> get focusedLine => _focusedLine;
   final _focusedLine = ValueNotifier<int>(null);
 
@@ -117,7 +120,7 @@ class ProgramExplorerController extends DisposableController
 
   /// Clears controller state and re-initializes.
   void refresh() {
-    _selected = null;
+    _scriptSelection = null;
     _outlineSelection = null;
     _focusedLine.value = null;
     _isLoadingOutline.value = true;
@@ -133,17 +136,17 @@ class ProgramExplorerController extends DisposableController
     if (!node.isSelectable) {
       return;
     }
-    if (_selected != node) {
+    if (_scriptSelection != node) {
       await populateNode(node);
       node.select();
-      _selected?.unselect();
-      _selected = node;
+      _scriptSelection?.unselect();
+      _scriptSelection = node;
       _isLoadingOutline.value = true;
       _outlineSelection = null;
       _focusedLine.value = null;
       _outlineNodes
         ..clear()
-        ..addAll(await _selected.outline);
+        ..addAll(await _scriptSelection.outline);
       _isLoadingOutline.value = false;
     }
   }


### PR DESCRIPTION
Selecting an object from the outline view currently only highlights the corresponding definition in the codeview and tries to scroll to the definition. Will eventually be used to display additional information about the selected program object.

Fixes https://github.com/flutter/devtools/issues/3389

**Demo:**
![ezgif-3-3f50744802db](https://user-images.githubusercontent.com/24210656/139732508-f0023d95-35c3-4bb2-b5d4-fd4c1162d648.gif)

