### PR TITLE
Do not focus a line in the code view when no `outlineNode` is selected

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -708,7 +708,7 @@ class _LinesState extends State<Lines> with AutoDisposeMixin {
               widget.debugController.programExplorerController.outlineSelection,
           builder: (context, outlineNode, _) {
             final isFocusedLine =
-                outlineNode.location?.location?.line == lineNum;
+                (outlineNode?.location?.location?.line ?? -1) == lineNum;
             return LineItem(
               lineContents: widget.lines[index],
               pausedFrame: isPausedLine ? widget.pausedFrame : null,


### PR DESCRIPTION
If we don't have a location and line on the `outlineNode`, use `-1` as the index.

This fixes an error when launching DevTools from g3, where the debugger page would try to load without a location. 

