### PR TITLE
Add new 'invokeServiceMethodWithArgReturningNode' helper to 'ObjectGroupBase'

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -637,7 +637,9 @@ abstract class ObjectGroupBase implements Disposable {
   }
 
   Future<RemoteDiagnosticsNode> invokeServiceMethodWithArgReturningNode(
-      String methodName, String arg) async {
+    String methodName,
+    String arg,
+  ) async {
     if (disposed) return null;
     if (useDaemonApi) {
       return parseDiagnosticsNodeDaemon(

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -636,6 +636,18 @@ abstract class ObjectGroupBase implements Disposable {
     }
   }
 
+  Future<RemoteDiagnosticsNode> invokeServiceMethodWithArgReturningNode(
+      String methodName, String arg) async {
+    if (disposed) return null;
+    if (useDaemonApi) {
+      return parseDiagnosticsNodeDaemon(
+          invokeServiceMethodDaemonArg(methodName, arg, groupName));
+    } else {
+      return parseDiagnosticsNodeObservatory(
+          invokeServiceMethodObservatoryWithGroupName1(methodName, arg));
+    }
+  }
+
   Future<void> invokeVoidServiceMethodInspectorRef(
       String methodName, InspectorInstanceRef ref) async {
     if (disposed) return;


### PR DESCRIPTION
This change adds a new `invokeServiceMethodWithArgReturningNode` function to `ObjectGroupBase` to allow the invocation of inspector service methods that return a single `RemoteDiagnosticsNode` with a single string argument.