### PR TITLE
Add a button for opening a file when no file is selected 

### DIFF
--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -447,9 +447,13 @@ class _CodeViewState extends State<CodeView>
     final theme = Theme.of(context);
 
     return Center(
-      child: Text(
-        'Open a file: $openFileKeySetDescription',
-        style: theme.textTheme.subtitle1,
+      child: ElevatedButton(
+        autofocus: true,
+        onPressed: () => widget.controller.toggleFileOpenerVisibility(true),
+        child: Text(
+          'Open a file ($openFileKeySetDescription)',
+          style: theme.textTheme.subtitle1,
+        ),
       ),
     );
   }


### PR DESCRIPTION
Continuing work towards https://github.com/flutter/devtools/issues/3457

This change just adds a button to open a file, I still need to figure out what causes DevTools to lose focus. 

<img width="1169" alt="Screen Shot 2021-11-12 at 3 51 22 PM" src="https://user-images.githubusercontent.com/21270878/141596643-ff854fdb-f93b-45f2-b8ba-1fdbe5381b6a.png">


