### PR TITLE
VM service wrapper implements `noSuchMethod`

### DIFF
--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -1189,6 +1189,13 @@ class VmServiceWrapper implements VmService {
     );
     return future;
   }
+
+  /// Prevent DevTools from blocking Dart SDK rolls if changes in
+  /// package:vm_service are unimplemented in DevTools.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    return super.noSuchMethod(invocation);
+  }
 }
 
 class TrackedFuture<T> {


### PR DESCRIPTION
Have the VM service wrapper implement `noSuchMethod`, so that VmService changes do not break DevTools at compile time. Without this, DevTools could block Dart SDK rolls into google3.
