### PR TITLE
Implement `noSuchMethod` in VmServiceWrapper

### DIFF
--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -1156,6 +1156,13 @@ class VmServiceWrapper implements VmService {
           ? 'Service'
           : '_Service';
 
+  // This is an escape hatch to ensure DevTools doesn't break on
+  // package:vm_service changes.
+  @override
+  dynamic noSuchMethod(Invocation invocation) {
+    super.noSuchMethod(invocation);
+  }
+
   @visibleForTesting
   int vmServiceCallCount = 0;
 


### PR DESCRIPTION
Implementing `noSuchMethod` will ensure that DevTools is not broken by updates to the VmService class that we implement. When new methods are added to VmService, we can implement them as we need.