### PR TITLE
Fixes VM service breakage due to deprecated method

### DIFF
--- a/packages/devtools_app/lib/src/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/debugger/controls.dart
@@ -154,7 +154,7 @@ class BreakOnExceptionsControl extends StatelessWidget {
           onChanged: controller.isSystemIsolate
               ? null
               : (ExceptionMode mode) {
-                  controller.setExceptionPauseMode(mode.id);
+                  controller.setIsolatePauseMode(mode.id);
                 },
           isDense: true,
           items: [

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -538,7 +538,7 @@ class DebuggerController extends DisposableController
   }
 
   Future<void> setExceptionPauseMode(String mode) async {
-    await _service.setExceptionPauseMode(isolateRef.id, mode);
+    await _service.setIsolatePauseMode(isolateRef.id, mode);
     _exceptionPauseMode.value = mode;
   }
 
@@ -774,6 +774,9 @@ class DebuggerController extends DisposableController
     // Collecting frames for Dart web applications can be slow. At the potential
     // cost of a flicker in the stack view, display only the top frame
     // initially.
+    // TODO(elliette): Find a better solution for this. Currently, this means
+    // we fetch all variable objects twice (once in _getFullStack and once in
+    // in_createStackFrameWithLocation).
     if (await serviceManager.connectedApp.isDartWebApp) {
       _populateFrameInfo(
         [

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -774,9 +774,6 @@ class DebuggerController extends DisposableController
     // Collecting frames for Dart web applications can be slow. At the potential
     // cost of a flicker in the stack view, display only the top frame
     // initially.
-    // TODO(elliette): Find a better solution for this. Currently, this means
-    // we fetch all variable objects twice (once in _getFullStack and once in
-    // in_createStackFrameWithLocation).
     if (await serviceManager.connectedApp.isDartWebApp) {
       _populateFrameInfo(
         [

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -537,8 +537,8 @@ class DebuggerController extends DisposableController
     }
   }
 
-  Future<void> setExceptionPauseMode(String mode) async {
-    await _service.setIsolatePauseMode(isolateRef.id, mode);
+  Future<void> setIsolatePauseMode(String mode) async {
+    await _service.setIsolatePauseMode(isolateRef.id, exceptionPauseMode: mode);
     _exceptionPauseMode.value = mode;
   }
 

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -841,9 +841,9 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Success> setExceptionPauseMode(String isolateId, String mode) {
-    return trackFuture('setExceptionPauseMode',
-        _vmService.setExceptionPauseMode(isolateId, mode));
+  Future<Success> setIsolatePauseMode(String isolateId, String mode) {
+    return trackFuture(
+        'setIsolatePauseMode', _vmService.setIsolatePauseMode(isolateId, mode));
   }
 
   @override

--- a/packages/devtools_app/lib/src/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/vm_service_wrapper.dart
@@ -841,9 +841,19 @@ class VmServiceWrapper implements VmService {
   }
 
   @override
-  Future<Success> setIsolatePauseMode(String isolateId, String mode) {
+  Future<Success> setIsolatePauseMode(
+    String isolateId, {
+    /*ExceptionPauseMode*/ String exceptionPauseMode,
+    bool shouldPauseOnExit,
+  }) {
     return trackFuture(
-        'setIsolatePauseMode', _vmService.setIsolatePauseMode(isolateId, mode));
+      'setIsolatePauseMode',
+      _vmService.setIsolatePauseMode(
+        isolateId,
+        exceptionPauseMode: exceptionPauseMode,
+        shouldPauseOnExit: shouldPauseOnExit,
+      ),
+    );
   }
 
   @override

--- a/packages/devtools_app/test/integration_tests/debugger.dart
+++ b/packages/devtools_app/test/integration_tests/debugger.dart
@@ -212,7 +212,7 @@ void debuggingTests() {
     expect(await debuggingManager.getState(), 'running');
 
     // set break on exceptions mode
-    await debuggingManager.setExceptionPauseMode('All');
+    await debuggingManager.setIsolatePauseMode('All');
 
     // wait for paused state
     await waitFor(() async => await debuggingManager.getState() == 'paused');
@@ -232,7 +232,7 @@ void debuggingTests() {
     ]);
 
     // resume
-    await debuggingManager.setExceptionPauseMode('Unhandled');
+    await debuggingManager.setIsolatePauseMode('Unhandled');
     await debuggingManager.resume();
 
     await delay();
@@ -367,8 +367,8 @@ class DebuggingManager {
     await tools.tabInstance.send('debugger.addBreakpoint', [path, line]);
   }
 
-  Future<void> setExceptionPauseMode(String mode) async {
-    await tools.tabInstance.send('debugger.setExceptionPauseMode', mode);
+  Future<void> setIsolatePauseMode(String mode) async {
+    await tools.tabInstance.send('debugger.setIsolatePauseMode', mode);
   }
 
   Future<List<String>> getBreakpoints() async {

--- a/packages/devtools_test/lib/flutter_test_driver.dart
+++ b/packages/devtools_test/lib/flutter_test_driver.dart
@@ -362,8 +362,10 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       // to hit breakpoints, etc.
       await waitForPause();
       if (runConfig.pauseOnExceptions) {
-        await vmService.setExceptionPauseMode(
-            await getFlutterIsolateId(), ExceptionPauseMode.kUnhandled);
+        await vmService.setIsolatePauseMode(
+          await getFlutterIsolateId(),
+          exceptionPauseMode: ExceptionPauseMode.kUnhandled,
+        );
       }
       await resume(wait: false);
     }


### PR DESCRIPTION
Fixes error:

```
lib/src/vm_service_wrapper.dart:853:20 - 'setExceptionPauseMode' is deprecated and shouldn't be used. Use setIsolatePauseMode instead. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
```