### PR TITLE
Refactor `Variable` class and rename it to `DartObjectNode`

### DIFF
--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -74,7 +74,7 @@ class ConsoleService extends Disposer {
     bool expandAll = false,
   }) async {
     _stdioTrailingNewline = false;
-    final variable = Variable.fromValue(
+    final variable = DartObjectNode.fromValue(
       name: name,
       value: value,
       diagnostic: diagnostic,

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -23,7 +23,7 @@ class ConsoleLine {
         forceScrollIntoView: forceScrollIntoView,
       );
 
-  factory ConsoleLine.variable(
+  factory ConsoleLine.dartObjectNode(
     DartObjectNode variable, {
     bool forceScrollIntoView = false,
   }) =>
@@ -85,7 +85,7 @@ class ConsoleService extends Disposer {
     if (expandAll) {
       variable.expandCascading();
     }
-    _stdio.add(ConsoleLine.variable(
+    _stdio.add(ConsoleLine.dartObjectNode(
       variable,
       forceScrollIntoView: forceScrollIntoView,
     ));

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -24,7 +24,7 @@ class ConsoleLine {
       );
 
   factory ConsoleLine.variable(
-    Variable variable, {
+    DartObjectNode variable, {
     bool forceScrollIntoView = false,
   }) =>
       VariableConsoleLine(
@@ -54,7 +54,7 @@ class VariableConsoleLine extends ConsoleLine {
       : super._(
           forceScrollIntoView,
         );
-  final Variable variable;
+  final DartObjectNode variable;
 
   @override
   String toString() {

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -800,7 +800,7 @@ class _LineItemState extends State<LineItem> {
           final response = await _debuggerController.evalAtCurrentFrame(word);
           final isolateRef = _debuggerController.isolateRef;
           if (response is! InstanceRef) return;
-          final variable = Variable.fromValue(
+          final variable = DartObjectNode.fromValue(
             value: response,
             isolateRef: isolateRef,
           );

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -309,9 +309,9 @@ class DebuggerController extends DisposableController
       _selectedStackFrame.value?.frame ??
       _stackFramesWithLocation.value?.safeFirst?.frame;
 
-  final _variables = ValueNotifier<List<Variable>>([]);
+  final _variables = ValueNotifier<List<DartObjectNode>>([]);
 
-  ValueListenable<List<Variable>> get variables => _variables;
+  ValueListenable<List<DartObjectNode>> get variables => _variables;
 
   final _sortedScripts = ValueNotifier<List<ScriptRef>>([]);
 

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -955,14 +955,14 @@ class DebuggerController extends DisposableController
     }
   }
 
-  List<Variable> _createVariablesForFrame(Frame frame) {
+  List<DartObjectNode> _createVariablesForFrame(Frame frame) {
     // vars can be null for async frames.
     if (frame.vars == null) {
       return [];
     }
 
     final variables =
-        frame.vars.map((v) => Variable.create(v, isolateRef)).toList();
+        frame.vars.map((v) => DartObjectNode.create(v, isolateRef)).toList();
     variables
       ..forEach(buildVariablesTree)
       ..sort((a, b) => sortFieldsByName(a.name, b.name));

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -696,10 +696,6 @@ List<DartObjectNode> _createVariablesForFields(
 
 // TODO(jacobr): gracefully handle cases where the isolate has closed and
 // InstanceRef objects have become sentinels.
-// TODO(jacobr): consider a new class name. This class is more just the data
-// model for a tree of Dart objects with properties rather than a "Variable".
-// TODO(elliette): Refactor to make name, ref, text named (and potentially
-// required?) parameters. Give ref a type.
 class DartObjectNode extends TreeNode<DartObjectNode> {
   DartObjectNode._({
     this.name,

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -311,8 +311,8 @@ class StackFrameAndSourcePosition {
 }
 
 Future<void> addExpandableChildren(
-  Variable variable,
-  List<Variable> children, {
+  DartObjectNode variable,
+  List<DartObjectNode> children, {
   bool expandAll = false,
 }) async {
   final tasks = <Future>[];
@@ -328,12 +328,13 @@ Future<void> addExpandableChildren(
 }
 
 /// Builds the tree representation for a [Variable] object by querying data,
-/// creating child Variable objects, and assigning parent-child relationships.
+/// creating child DartObjectNode objects, and assigning parent-child
+/// relationships.
 ///
 /// We call this method as we expand variables in the variable tree, because
 /// building the tree for all variable data at once is very expensive.
 Future<void> buildVariablesTree(
-  Variable variable, {
+  DartObjectNode variable, {
   bool expandAll = false,
 }) async {
   final ref = variable.ref;
@@ -382,20 +383,20 @@ Future<void> buildVariablesTree(
     }
   }
 
-  if (variable.childCount > Variable.MAX_CHILDREN_IN_GROUPING) {
+  if (variable.childCount > DartObjectNode.MAX_CHILDREN_IN_GROUPING) {
     final numChildrenInGrouping =
-        variable.childCount >= pow(Variable.MAX_CHILDREN_IN_GROUPING, 2)
+        variable.childCount >= pow(DartObjectNode.MAX_CHILDREN_IN_GROUPING, 2)
             ? (roundToNearestPow10(variable.childCount) /
-                    Variable.MAX_CHILDREN_IN_GROUPING)
+                    DartObjectNode.MAX_CHILDREN_IN_GROUPING)
                 .floor()
-            : Variable.MAX_CHILDREN_IN_GROUPING;
+            : DartObjectNode.MAX_CHILDREN_IN_GROUPING;
 
     var start = variable.offset ?? 0;
     final end = start + variable.childCount;
     while (start < end) {
       final count = min(end - start, numChildrenInGrouping);
       variable.addChild(
-        Variable.grouping(variable.ref, offset: start, count: count),
+        DartObjectNode.grouping(variable.ref, offset: start, count: count),
       );
       start += count;
     }
@@ -428,7 +429,7 @@ Future<void> buildVariablesTree(
     final ObjectGroupBase service = diagnostic.inspectorService;
     final diagnosticChildren = await diagnostic.children;
     if (diagnosticChildren?.isNotEmpty ?? false) {
-      final childrenNode = Variable.text(
+      final childrenNode = DartObjectNode.text(
         pluralize('child', diagnosticChildren.length, plural: 'children'),
       );
       variable.addChild(childrenNode);
@@ -499,7 +500,7 @@ Future<void> buildVariablesTree(
 // `getObject` is called with offset/count for an object that has no length.
 Future<Obj> _getObjectWithRetry(
   String objectId,
-  Variable variable,
+  DartObjectNode variable,
 ) async {
   try {
     final dynamic result = await serviceManager.service.getObject(
@@ -513,14 +514,14 @@ Future<Obj> _getObjectWithRetry(
   }
 }
 
-Future<Variable> _buildVariable(
+Future<DartObjectNode> _buildVariable(
   RemoteDiagnosticsNode diagnostic,
   ObjectGroupBase inspectorService,
   IsolateRef isolateRef,
 ) async {
   final instanceRef =
       await inspectorService.toObservatoryInstanceRef(diagnostic.valueRef);
-  return Variable.fromValue(
+  return DartObjectNode.fromValue(
     name: diagnostic.name,
     value: instanceRef,
     diagnostic: diagnostic,
@@ -528,12 +529,12 @@ Future<Variable> _buildVariable(
   );
 }
 
-Future<List<Variable>> _createVariablesForDiagnostics(
+Future<List<DartObjectNode>> _createVariablesForDiagnostics(
   ObjectGroupBase inspectorService,
   List<RemoteDiagnosticsNode> diagnostics,
   IsolateRef isolateRef,
 ) async {
-  final variables = <Future<Variable>>[];
+  final variables = <Future<DartObjectNode>>[];
   for (var diagnostic in diagnostics) {
     // Omit hidden properties.
     if (diagnostic.level == DiagnosticLevel.hidden) continue;
@@ -546,29 +547,29 @@ Future<List<Variable>> _createVariablesForDiagnostics(
   }
 }
 
-List<Variable> _createVariablesForAssociations(
+List<DartObjectNode> _createVariablesForAssociations(
   Instance instance,
   IsolateRef isolateRef,
 ) {
-  final variables = <Variable>[];
+  final variables = <DartObjectNode>[];
   for (var i = 0; i < instance.associations.length; i++) {
     final association = instance.associations[i];
     if (association.key is! InstanceRef) {
       continue;
     }
-    final key = Variable.fromValue(
+    final key = DartObjectNode.fromValue(
       name: '[key]',
       value: association.key,
       isolateRef: isolateRef,
     );
-    final value = Variable.fromValue(
+    final value = DartObjectNode.fromValue(
       name: '[value]',
       value: association.value,
       isolateRef: isolateRef,
     );
     final entryNum = instance.offset == null ? i : i + instance.offset;
     variables.add(
-      Variable.text('[Entry $entryNum]')
+      DartObjectNode.text('[Entry $entryNum]')
         ..addChild(key)
         ..addChild(value),
     );
@@ -582,12 +583,12 @@ List<Variable> _createVariablesForAssociations(
 ///
 /// This method does not currently support [Uint64List] or
 /// [Int64List].
-List<Variable> _createVariablesForBytes(
+List<DartObjectNode> _createVariablesForBytes(
   Instance instance,
   IsolateRef isolateRef,
 ) {
   final bytes = base64.decode(instance.bytes);
-  final variables = <Variable>[];
+  final variables = <DartObjectNode>[];
   List<dynamic> result;
   switch (instance.kind) {
     case InstanceKind.kUint8ClampedList:
@@ -603,7 +604,7 @@ List<Variable> _createVariablesForBytes(
     case InstanceKind.kUint64List:
       // TODO: https://github.com/flutter/devtools/issues/2159
       if (kIsWeb) {
-        return <Variable>[];
+        return <DartObjectNode>[];
       }
       result = Uint64List.view(bytes.buffer);
       break;
@@ -619,7 +620,7 @@ List<Variable> _createVariablesForBytes(
     case InstanceKind.kInt64List:
       // TODO: https://github.com/flutter/devtools/issues/2159
       if (kIsWeb) {
-        return <Variable>[];
+        return <DartObjectNode>[];
       }
       result = Int64List.view(bytes.buffer);
       break;
@@ -645,7 +646,7 @@ List<Variable> _createVariablesForBytes(
   for (int i = 0; i < result.length; i++) {
     final name = instance.offset == null ? i : i + instance.offset;
     variables.add(
-      Variable.fromValue(
+      DartObjectNode.fromValue(
         name: '[$name]',
         value: result[i],
         isolateRef: isolateRef,
@@ -655,15 +656,15 @@ List<Variable> _createVariablesForBytes(
   return variables;
 }
 
-List<Variable> _createVariablesForElements(
+List<DartObjectNode> _createVariablesForElements(
   Instance instance,
   IsolateRef isolateRef,
 ) {
-  final variables = <Variable>[];
+  final variables = <DartObjectNode>[];
   for (int i = 0; i < instance.elements.length; i++) {
     final name = instance.offset == null ? i : i + instance.offset;
     variables.add(
-      Variable.fromValue(
+      DartObjectNode.fromValue(
         name: '[$name]',
         value: instance.elements[i],
         isolateRef: isolateRef,
@@ -673,17 +674,17 @@ List<Variable> _createVariablesForElements(
   return variables;
 }
 
-List<Variable> _createVariablesForFields(
+List<DartObjectNode> _createVariablesForFields(
   Instance instance,
   IsolateRef isolateRef, {
   Set<String> existingNames,
 }) {
-  final variables = <Variable>[];
+  final variables = <DartObjectNode>[];
   for (var field in instance.fields) {
     final name = field.decl.name;
     if (existingNames != null && existingNames.contains(name)) continue;
     variables.add(
-      Variable.fromValue(
+      DartObjectNode.fromValue(
         name: name,
         value: field.value,
         isolateRef: isolateRef,
@@ -699,9 +700,15 @@ List<Variable> _createVariablesForFields(
 // model for a tree of Dart objects with properties rather than a "Variable".
 // TODO(elliette): Refactor to make name, ref, text named (and potentially
 // required?) parameters. Give ref a type.
-class Variable extends TreeNode<Variable> {
-  Variable._(this.name, ref, this.text, {int offset, int childCount})
-      : _ref = ref,
+class DartObjectNode extends TreeNode<DartObjectNode> {
+  DartObjectNode._({
+    this.name,
+    this.text,
+    GenericInstanceRef ref,
+    int offset,
+    int childCount,
+  })  : assert(name != null || text != null),
+        _ref = ref,
         _offset = offset,
         _childCount = childCount {
     indentChildren = ref?.diagnostic?.style != DiagnosticsTreeStyle.flat;
@@ -712,51 +719,48 @@ class Variable extends TreeNode<Variable> {
   ///
   /// [value] should typically be an [InstanceRef] but can also be a [Sentinel]
   /// [ObjRef] or primitive type such as num or String.
-  factory Variable.fromValue({
+  factory DartObjectNode.fromValue({
     String name = '',
     @required Object value,
     RemoteDiagnosticsNode diagnostic,
     @required IsolateRef isolateRef,
   }) {
-    return Variable._(
-      name,
-      GenericInstanceRef(
+    return DartObjectNode._(
+      name: name,
+      ref: GenericInstanceRef(
         isolateRef: isolateRef,
         diagnostic: diagnostic,
         value: value,
       ),
-      null,
     );
   }
 
-  factory Variable.create(
+  factory DartObjectNode.create(
     BoundVariable variable,
     IsolateRef isolateRef,
   ) {
     final value = variable.value;
-    return Variable._(
-      variable.name,
-      GenericInstanceRef(
+    return DartObjectNode._(
+      name: variable.name,
+      ref: GenericInstanceRef(
         isolateRef: isolateRef,
         value: value,
       ),
-      null,
     );
   }
 
-  factory Variable.text(String text) {
-    return Variable._(null, null, text);
+  factory DartObjectNode.text(String text) {
+    return DartObjectNode._(text: text);
   }
 
-  factory Variable.grouping(
+  factory DartObjectNode.grouping(
     GenericInstanceRef ref, {
     @required int offset,
     @required int count,
   }) {
-    return Variable._(
-      null,
-      ref,
-      '[$offset - ${offset + count - 1}]',
+    return DartObjectNode._(
+      ref: ref,
+      text: '[$offset - ${offset + count - 1}]',
       offset: offset,
       childCount: count,
     );
@@ -925,7 +929,7 @@ class Variable extends TreeNode<Variable> {
   bool _isInspectable;
 
   @override
-  Variable shallowCopy() {
+  DartObjectNode shallowCopy() {
     throw UnimplementedError('This method is not implemented. Implement if you '
         'need to call `shallowCopy` on an instance of this class.');
   }

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -449,7 +449,7 @@ Future<void> buildVariablesTree(
   if (inspectorService != null) {
     final tasks = <Future>[];
     ObjectGroupBase group;
-    Future<void> _maybeUpdateRef(Variable child) async {
+    Future<void> _maybeUpdateRef(DartObjectNode child) async {
       if (child.ref == null) return;
       if (child.ref.diagnostic == null) {
         // TODO(jacobr): also check whether the InstanceRef is an instance of

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -327,8 +327,8 @@ Future<void> addExpandableChildren(
   }
 }
 
-/// Builds the tree representation for a [Variable] object by querying data,
-/// creating child DartObjectNode objects, and assigning parent-child
+/// Builds the tree representation for a [DartObjectNode] object by querying
+/// data, creating child [DartObjectNode] objects, and assigning parent-child
 /// relationships.
 ///
 /// We call this method as we expand variables in the variable tree, because

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -703,8 +703,7 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
     GenericInstanceRef ref,
     int offset,
     int childCount,
-  })  : assert(name != null || text != null),
-        _ref = ref,
+  })  : _ref = ref,
         _offset = offset,
         _childCount = childCount {
     indentChildren = ref?.diagnostic?.style != DiagnosticsTreeStyle.flat;

--- a/packages/devtools_app/lib/src/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/debugger/variables.dart
@@ -26,13 +26,13 @@ class Variables extends StatelessWidget {
   Widget build(BuildContext context) {
     final controller = Provider.of<DebuggerController>(context);
 
-    return ValueListenableBuilder<List<Variable>>(
+    return ValueListenableBuilder<List<DartObjectNode>>(
       valueListenable: controller.variables,
       builder: (context, variables, _) {
         if (variables.isEmpty) return const SizedBox();
         // TODO(kenz): preserve expanded state of tree on switching frames and
         // on stepping.
-        return TreeView<Variable>(
+        return TreeView<DartObjectNode>(
           dataRoots: variables,
           dataDisplayProvider: (variable, onPressed) =>
               displayProvider(context, variable, onPressed, controller),
@@ -42,7 +42,7 @@ class Variables extends StatelessWidget {
     );
   }
 
-  void onItemPressed(Variable v, DebuggerController controller) {
+  void onItemPressed(DartObjectNode v, DebuggerController controller) {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
       v.children.forEach(buildVariablesTree);
@@ -53,7 +53,7 @@ class Variables extends StatelessWidget {
 class VariablesList extends StatelessWidget {
   const VariablesList({Key key, this.lines}) : super(key: key);
 
-  final List<Variable> lines;
+  final List<DartObjectNode> lines;
 
   @override
   Widget build(BuildContext context) {
@@ -61,7 +61,7 @@ class VariablesList extends StatelessWidget {
     if (lines.isEmpty) return const SizedBox();
     // TODO(kenz): preserve expanded state of tree on switching frames and
     // on stepping.
-    return TreeView<Variable>(
+    return TreeView<DartObjectNode>(
       dataRoots: lines,
       dataDisplayProvider: (variable, onPressed) =>
           displayProvider(context, variable, onPressed, controller),
@@ -69,7 +69,7 @@ class VariablesList extends StatelessWidget {
     );
   }
 
-  void onItemPressed(Variable v, DebuggerController controller) {
+  void onItemPressed(DartObjectNode v, DebuggerController controller) {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
       v.children.forEach(buildVariablesTree);
@@ -85,18 +85,18 @@ class ExpandableVariable extends StatelessWidget {
   })  : assert(debuggerController != null),
         super(key: key);
 
-  final ValueListenable<Variable> variable;
+  final ValueListenable<DartObjectNode> variable;
   final DebuggerController debuggerController;
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<Variable>(
+    return ValueListenableBuilder<DartObjectNode>(
       valueListenable: variable,
       builder: (context, variable, _) {
         if (variable == null) return const SizedBox();
         // TODO(kenz): preserve expanded state of tree on switching frames and
         // on stepping.
-        return TreeView<Variable>(
+        return TreeView<DartObjectNode>(
           dataRoots: [variable],
           shrinkWrap: true,
           dataDisplayProvider: (variable, onPressed) =>
@@ -108,7 +108,7 @@ class ExpandableVariable extends StatelessWidget {
     );
   }
 
-  void onItemPressed(Variable v, DebuggerController controller) {
+  void onItemPressed(DartObjectNode v, DebuggerController controller) {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
       v.children.forEach(buildVariablesTree);
@@ -119,7 +119,7 @@ class ExpandableVariable extends StatelessWidget {
 // TODO(jacobr): this looks like a widget.
 Widget displayProvider(
   BuildContext context,
-  Variable variable,
+  DartObjectNode variable,
   VoidCallback onTap,
   DebuggerController controller,
 ) {

--- a/packages/devtools_app/lib/src/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/inspector/diagnostics.dart
@@ -120,7 +120,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
         final group =
             serviceManager.inspectorService.createObjectGroup('hover');
         final value = await group.toObservatoryInstanceRef(diagnostic.valueRef);
-        final variable = Variable.fromValue(
+        final variable = DartObjectNode.fromValue(
           value: value,
           isolateRef: serviceManager.inspectorService.isolateRef,
           diagnostic: diagnostic,

--- a/packages/devtools_app/test/association_variable_test.dart
+++ b/packages/devtools_app/test/association_variable_test.dart
@@ -74,7 +74,7 @@ void main() {
       name: 'my-isolate',
       isSystemIsolate: false,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -134,7 +134,7 @@ void main() {
       ],
       identityHashCode: null,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -192,7 +192,7 @@ void main() {
       ],
       identityHashCode: null,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -223,7 +223,7 @@ Matcher matchesVariable({
   @required String name,
   @required Object value,
 }) {
-  return const TypeMatcher<Variable>()
+  return const TypeMatcher<DartObjectNode>()
       .having(
         (v) => v.displayValue,
         'displayValue',

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -835,8 +835,8 @@ void resetRoot() {
   rootNumber = 0;
 }
 
-Variable buildParentListVariable({int length = 2}) {
-  return Variable.create(
+DartObjectNode buildParentListVariable({int length = 2}) {
+  return DartObjectNode.create(
     BoundVariable(
       name: incrementRoot(),
       value: InstanceRef(
@@ -858,12 +858,12 @@ Variable buildParentListVariable({int length = 2}) {
   );
 }
 
-Variable buildListVariable({int length = 2}) {
+DartObjectNode buildListVariable({int length = 2}) {
   final listVariable = buildParentListVariable(length: length);
 
   for (int i = 0; i < length; i++) {
     listVariable.addChild(
-      Variable.create(
+      DartObjectNode.create(
         BoundVariable(
           name: '$i',
           value: InstanceRef(
@@ -887,8 +887,8 @@ Variable buildListVariable({int length = 2}) {
   return listVariable;
 }
 
-Variable buildParentMapVariable({int length = 2}) {
-  return Variable.create(
+DartObjectNode buildParentMapVariable({int length = 2}) {
+  return DartObjectNode.create(
     BoundVariable(
       name: incrementRoot(),
       value: InstanceRef(
@@ -909,12 +909,12 @@ Variable buildParentMapVariable({int length = 2}) {
   );
 }
 
-Variable buildMapVariable({int length = 2}) {
+DartObjectNode buildMapVariable({int length = 2}) {
   final mapVariable = buildParentMapVariable(length: length);
 
   for (int i = 0; i < length; i++) {
     mapVariable.addChild(
-      Variable.create(
+      DartObjectNode.create(
         BoundVariable(
           name: "['key${i + 1}']",
           value: InstanceRef(
@@ -938,8 +938,8 @@ Variable buildMapVariable({int length = 2}) {
   return mapVariable;
 }
 
-Variable buildStringVariable(String value) {
-  return Variable.create(
+DartObjectNode buildStringVariable(String value) {
+  return DartObjectNode.create(
     BoundVariable(
       name: incrementRoot(),
       value: InstanceRef(
@@ -962,8 +962,8 @@ Variable buildStringVariable(String value) {
   );
 }
 
-Variable buildBooleanVariable(bool value) {
-  return Variable.create(
+DartObjectNode buildBooleanVariable(bool value) {
+  return DartObjectNode.create(
     BoundVariable(
       name: incrementRoot(),
       value: InstanceRef(

--- a/packages/devtools_app/test/typed_data_variable_test.dart
+++ b/packages/devtools_app/test/typed_data_variable_test.dart
@@ -55,7 +55,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -90,7 +90,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -125,7 +125,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -160,7 +160,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -195,7 +195,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -230,7 +230,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -265,7 +265,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -300,7 +300,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -335,7 +335,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -371,7 +371,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -406,7 +406,7 @@ void main() {
       length: 4,
     );
 
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -442,7 +442,7 @@ void main() {
       length: 4,
     );
 
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -478,7 +478,7 @@ void main() {
       length: 4,
     );
 
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -514,7 +514,7 @@ void main() {
       length: 4,
     );
 
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -548,7 +548,7 @@ void main() {
       identityHashCode: null,
       length: 4,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -603,7 +603,7 @@ void main() {
       identityHashCode: null,
       length: 332,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -633,7 +633,7 @@ void main() {
       identityHashCode: null,
       length: 300,
     );
-    final variable = Variable.create(
+    final variable = DartObjectNode.create(
       BoundVariable(
         name: 'test',
         value: instance,
@@ -658,10 +658,10 @@ Matcher matchesVariable({
   @required String name,
   @required Object value,
 }) {
-  return const TypeMatcher<Variable>().having(
+  return const TypeMatcher<DartObjectNode>().having(
       (v) => v,
       'boundVar',
-      const TypeMatcher<Variable>()
+      const TypeMatcher<DartObjectNode>()
           .having((v) => v.name, 'name', equals(name))
           .having((v) => v.ref.value, 'value', equals(value)));
 }
@@ -670,9 +670,9 @@ Matcher matchesVariableGroup({
   @required int start,
   @required int end,
 }) {
-  return const TypeMatcher<Variable>().having(
+  return const TypeMatcher<DartObjectNode>().having(
       (v) => v,
       'boundVar',
-      const TypeMatcher<Variable>()
+      const TypeMatcher<DartObjectNode>()
           .having((v) => v.text, 'text', equals('[$start - $end]')));
 }


### PR DESCRIPTION
Addresses two TODOs on the `Variable` class:

1. Consider a new class name. This class is more just the data model for a tree of Dart objects with properties rather than a "Variable".
2. Refactor to make `name`, `ref,` `text` named (and potentially required?) parameters. Give `ref` a type.