### PR TITLE
Fix bugs with performance page search and improve performance

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -46,6 +46,7 @@ export 'src/service_manager.dart';
 export 'src/split.dart';
 export 'src/theme.dart';
 export 'src/trace_event.dart';
+export 'src/trees.dart';
 export 'src/ui/icons.dart';
 export 'src/ui/search.dart';
 export 'src/utils.dart';

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -1049,8 +1049,12 @@ class DebuggerController extends DisposableController
     _showFileOpener.value = visible;
   }
 
+  // TODO(kenz): search through previous matches when possible.
   @override
-  List<SourceToken> matchesForSearch(String search) {
+  List<SourceToken> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search == null || search.isEmpty || parsedScript.value == null) {
       return [];
     }

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -597,8 +597,12 @@ class LoggingController extends DisposableController
     );
   }
 
+  // TODO(kenz): search through previous matches when possible.
   @override
-  List<LogData> matchesForSearch(String search) {
+  List<LogData> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search == null || search.isEmpty) return [];
     final matches = <LogData>[];
     final caseInsensitiveSearch = search.toLowerCase();
@@ -610,11 +614,8 @@ class LoggingController extends DisposableController
           (log.details != null &&
               log.details.toLowerCase().contains(caseInsensitiveSearch))) {
         matches.add(log);
-        // TODO(kenz): use the value of this property in the logs table to
+        // TODO(kenz): use the value of log.isSearchMatch in the logs table to
         // improve performance. This will require some refactoring of FlatTable.
-        log.isSearchMatch = true;
-      } else {
-        log.isSearchMatch = false;
       }
     }
     return matches;

--- a/packages/devtools_app/lib/src/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/network/network_controller.dart
@@ -354,8 +354,12 @@ class NetworkController
     }
   }
 
+  // TODO(kenz): search through previous matches when possible.
   @override
-  List<NetworkRequest> matchesForSearch(String search) {
+  List<NetworkRequest> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search == null || search.isEmpty) return [];
     final matches = <NetworkRequest>[];
     final caseInsensitiveSearch = search.toLowerCase();
@@ -364,12 +368,9 @@ class NetworkController
     for (final request in currentRequests) {
       if (request.uri.toLowerCase().contains(caseInsensitiveSearch)) {
         matches.add(request);
-        // TODO(kenz): use the value of this property in the network requests
-        // table to improve performance. This will require some refactoring of
-        // FlatTable.
-        request.isSearchMatch = true;
-      } else {
-        request.isSearchMatch = false;
+        // TODO(kenz): use the value request.isSearchMatch in the network
+        // requests table to improve performance. This will require some
+        // refactoring of FlatTable.
       }
     }
     return matches;

--- a/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_controller.dart
@@ -468,7 +468,10 @@ class LegacyPerformanceController
   }
 
   @override
-  List<LegacyTimelineEvent> matchesForSearch(String search) {
+  List<LegacyTimelineEvent> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search?.isEmpty ?? true) return [];
     final matches = <LegacyTimelineEvent>[];
     for (final event in data.timelineEvents) {

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -808,19 +808,31 @@ class PerformanceController extends DisposableController
   }
 
   @override
-  List<TimelineEvent> matchesForSearch(String search) {
+  List<TimelineEvent> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search?.isEmpty ?? true) return [];
     final matches = <TimelineEvent>[];
-    final events = List<TimelineEvent>.from(data.timelineEvents);
-    for (final event in events) {
-      breadthFirstTraversal<TimelineEvent>(event, action: (TimelineEvent e) {
-        if (e.name.caseInsensitiveContains(search)) {
-          matches.add(e);
-          e.isSearchMatch = true;
-        } else {
-          e.isSearchMatch = false;
+    if (searchPreviousMatches) {
+      final previousMatches = searchMatches.value;
+      for (final previousMatch in previousMatches) {
+        if (previousMatch.name.caseInsensitiveContains(search)) {
+          matches.add(previousMatch);
         }
-      });
+      }
+    } else {
+      final events = List<TimelineEvent>.from(data.timelineEvents);
+      for (final event in events) {
+        breadthFirstTraversal<TimelineEvent>(
+          event,
+          action: (TimelineEvent e) {
+            if (e.name.caseInsensitiveContains(search)) {
+              matches.add(e);
+            }
+          },
+        );
+      }
     }
     return matches;
   }

--- a/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profile_controller.dart
@@ -240,8 +240,12 @@ class CpuProfilerController
     }
   }
 
+  // TODO(kenz): search through previous matches when possible.
   @override
-  List<CpuStackFrame> matchesForSearch(String search) {
+  List<CpuStackFrame> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
     if (search?.isEmpty ?? true) return [];
     final regexSearch = RegExp(search, caseSensitive: false);
     final matches = <CpuStackFrame>[];
@@ -250,9 +254,6 @@ class CpuProfilerController
       if (frame.name.caseInsensitiveContains(regexSearch) ||
           frame.processedUrl.caseInsensitiveContains(regexSearch)) {
         matches.add(frame);
-        frame.isSearchMatch = true;
-      } else {
-        frame.isSearchMatch = false;
       }
     }
     return matches;

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -164,14 +164,16 @@ void main() {
       expect(
           controller.dataNotifier.value.stackFrames.values.length, equals(17));
 
-      var matches = controller.matchesForSearch('render');
-      verifyIsSearchMatch(
+      controller.search = 'render';
+      var matches = controller.searchMatches.value;
+      verifyIsSearchMatchForTreeData(
         controller.dataNotifier.value.stackFrames.values.toList(),
         matches,
       );
 
-      matches = controller.matchesForSearch('THREAD');
-      verifyIsSearchMatch(
+      controller.search = 'THREAD';
+      matches = controller.searchMatches.value;
+      verifyIsSearchMatchForTreeData(
         controller.dataNotifier.value.stackFrames.values.toList(),
         matches,
       );

--- a/packages/devtools_app/test/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging_controller_test.dart
@@ -102,11 +102,13 @@ void main() {
       addGcData('gc2');
 
       expect(controller.filteredData.value, hasLength(5));
-      var matches = controller.matchesForSearch('abc');
+      controller.search = 'abc';
+      var matches = controller.searchMatches.value;
       expect(matches.length, equals(2));
       verifyIsSearchMatch(controller.filteredData.value, matches);
 
-      matches = controller.matchesForSearch('gc');
+      controller.search = 'gc';
+      matches = controller.searchMatches.value;
       expect(matches.length, equals(2));
       verifyIsSearchMatch(controller.filteredData.value, matches);
     });

--- a/packages/devtools_app/test/network_controller_test.dart
+++ b/packages/devtools_app/test/network_controller_test.dart
@@ -164,11 +164,13 @@ void main() {
       final profile = requestsNotifier.value;
       expect(profile.requests.length, numRequests);
 
-      var matches = controller.matchesForSearch('year=2019');
+      controller.search = 'year=2019';
+      var matches = controller.searchMatches.value;
       expect(matches.length, equals(5));
       verifyIsSearchMatch(profile.requests, matches);
 
-      matches = controller.matchesForSearch('IPv6');
+      controller.search = 'IPv6';
+      matches = controller.searchMatches.value;
       expect(matches.length, equals(2));
       verifyIsSearchMatch(profile.requests, matches);
     });

--- a/packages/devtools_app/test/search_test.dart
+++ b/packages/devtools_app/test/search_test.dart
@@ -1,0 +1,87 @@
+import 'package:devtools_app/src/ui/search.dart';
+import 'package:devtools_app/src/utils.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+// TODO(https://github.com/flutter/devtools/issues/3514): increase test coverage
+
+void main() {
+  TestSearchController searchController;
+
+  final testData = <TestSearchData>[
+    TestSearchData('Foo'),
+    TestSearchData('Bar'),
+    TestSearchData('FooBar'),
+    TestSearchData('Baz'),
+    TestSearchData('FooBaz'),
+  ];
+
+  group('SearchControllerMixin', () {
+    setUp(() {
+      searchController = TestSearchController()..data.addAll(testData);
+    });
+
+    test('updates values for query', () {
+      expect(searchController.search, isEmpty);
+      expect(searchController.searchMatches.value, isEmpty);
+
+      searchController.search = 'foo';
+
+      expect(searchController.search, equals('foo'));
+      expect(searchController.searchMatches.value.length, equals(3));
+      expect(searchController.activeSearchMatch.value.name, equals('Foo'));
+      expect(searchController.matchIndex.value, equals(1));
+      for (final data in testData) {
+        if (data.name.caseInsensitiveContains('foo')) {
+          expect(data.isSearchMatch, isTrue);
+        } else {
+          expect(data.isSearchMatch, isFalse);
+        }
+      }
+    });
+
+    test('updates values for empty query', () {
+      searchController.search = 'foo';
+      expect(searchController.search, equals('foo'));
+      expect(searchController.searchMatches.value.length, equals(3));
+      expect(searchController.activeSearchMatch.value.name, equals('Foo'));
+      expect(searchController.matchIndex.value, equals(1));
+      for (final data in testData) {
+        if (data.name.caseInsensitiveContains('foo')) {
+          expect(data.isSearchMatch, isTrue);
+        } else {
+          expect(data.isSearchMatch, isFalse);
+        }
+      }
+
+      // Set the search query to the empty string
+      searchController.search = '';
+      expect(searchController.search, equals(''));
+      expect(searchController.searchMatches.value, isEmpty);
+      expect(searchController.activeSearchMatch.value, isNull);
+      expect(searchController.matchIndex.value, equals(0));
+      for (final data in testData) {
+        expect(data.isSearchMatch, isFalse);
+      }
+    });
+  });
+}
+
+class TestSearchController with SearchControllerMixin<TestSearchData> {
+  final data = <TestSearchData>[];
+
+  @override
+  List<TestSearchData> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
+    return data
+        .where((element) => element.name.caseInsensitiveContains(search))
+        .toList();
+  }
+}
+
+class TestSearchData with DataSearchStateMixin {
+  TestSearchData(this.name);
+
+  final String name;
+}

--- a/packages/devtools_test/lib/utils.dart
+++ b/packages/devtools_test/lib/utils.dart
@@ -295,6 +295,24 @@ void verifyIsSearchMatch(
   }
 }
 
+void verifyIsSearchMatchForTreeData<T extends TreeDataSearchStateMixin<T>>(
+  List<T> data,
+  List<T> matches,
+) {
+  for (final node in data) {
+    breadthFirstTraversal<T>(
+      node,
+      action: (T e) {
+        if (matches.contains(e)) {
+          expect(e.isSearchMatch, isTrue);
+        } else {
+          expect(e.isSearchMatch, isFalse);
+        }
+      },
+    );
+  }
+}
+
 Future<void> waitFor(
   Future<bool> condition(), {
   // TODO(kenz): shorten this as long as it doesn't cause flakes.


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3507

In addition to a bug fix for empty search queries, this PR
- improves the search controller performance by adding a signal to search through previous matches when the new search query contains the previous search query. Classes that mixin `SearchControllerMixin` will be responsible for implementing the two different types of searches (search through previous matches & search all data) in the `matchesForSearch` method they override. This PR does this for the PerformanceController, and adds TODOs for the other controllers.
- pushes logic for setting the `isSearchMatch` attribute into the `SearchControllerMixin`. This will ensure that classes mixing in `SearchControllerMixin` will get this functionality for free.
- fixes a bug with how we were verifying search matches in tests. We were not verifying tree structures properly. 