### PR TITLE
[Cleanup]  Make`InspectorTreeConfig`'s `onNodeAdded` and `onClientActiveChange` args optional

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree.dart
@@ -294,8 +294,8 @@ class InspectorTreeConfig {
   InspectorTreeConfig({
     @required this.summaryTree,
     @required this.treeType,
-    @required this.onNodeAdded,
-    @required this.onClientActiveChange,
+    this.onNodeAdded,
+    this.onClientActiveChange,
     this.onSelectionChange,
     this.onExpand,
     this.onHover,

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -106,14 +106,14 @@ class InspectorTreeController extends Object {
     final firstClient = _clients.isEmpty;
     _clients.add(value);
     if (firstClient) {
-      config.onClientActiveChange(true);
+      config.onClientActiveChange?.call(true);
     }
   }
 
   void removeClient(InspectorControllerClient value) {
     _clients.remove(value);
     if (_clients.isEmpty) {
-      config.onClientActiveChange(false);
+      config.onClientActiveChange?.call(false);
     }
   }
 


### PR DESCRIPTION
`InspectorTreeConfig`'s `onNodeAdded` and `onClientActiveChange` constructor args are currently marked as `@required`, when users should still be able to create an instance of `InspectorTreeConfig` without setting them.