### PR TITLE
Add is_embedded dimension to DevTools analytics

### DIFF
--- a/packages/devtools_app/lib/src/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_web.dart
@@ -84,6 +84,7 @@ class GtagEventDevTools extends GtagEvent {
     String ide_launched, // dimension7 Devtools launched (CLI, VSCode, Android)
     String flutter_client_id, // dimension8 Flutter tool client_id (~/.flutter).
     bool is_external_build, // dimension9 External build or google3
+    bool is_embedded, // dimension10 Whether devtools is embedded
 
     // Performance screen metrics. See [PerformanceScreenMetrics].
     int ui_duration_micros,
@@ -181,6 +182,7 @@ GtagEventDevTools gtagEventWithScreenMetrics({
     ide_launched: ideLaunched,
     flutter_client_id: flutterClientId,
     is_external_build: isExternalBuild,
+    is_embedded: ideTheme.embed,
     ui_duration_micros: screenMetrics is PerformanceScreenMetrics
         ? screenMetrics.uiDuration?.inMicroseconds
         : null,
@@ -273,6 +275,7 @@ void screen(
       ide_launched: ideLaunched,
       flutter_client_id: flutterClientId,
       is_external_build: isExternalBuild,
+      is_embedded: ideTheme.embed,
     ),
   );
 }

--- a/packages/devtools_app/web/devtools_analytics.js
+++ b/packages/devtools_app/web/devtools_analytics.js
@@ -27,6 +27,7 @@ function initializeGA() {
       'dimension7': 'ide_launched',
       'dimension8': 'flutter_client_id',
       'dimension9': 'is_external_build',
+      'dimension10': 'is_embedded',
        // Custom metrics:
       'metric1': 'ui_duration_micros',
       'metric2': 'raster_duration_micros',


### PR DESCRIPTION
This will allow us to see whether a user is using the embedded version of DevTools in an IDE. We already have information as to which IDE a user is using from the `?ide=` query parameter