### PR TITLE
Fix bug with search

### DIFF
--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -101,6 +101,7 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
     // [matchIndex] is 1-based. Subtract 1 for the 0-based list [searchMatches].
     final activeMatchIndex = matchIndex.value - 1;
     if (activeMatchIndex < 0) {
+      _activeSearchMatch.value?.isActiveSearchMatch = false;
       _activeSearchMatch.value = null;
       return;
     }


### PR DESCRIPTION
We were not unsetting the active search match when a new search query yielding no matches was entered.