### PR TITLE
Create `DualValueListenableBuilder` widget and clean up ValueListenableBuilders to user `child` property

### DIFF
--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -40,57 +40,56 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
     final textTheme = theme.textTheme;
     return ValueListenableBuilder(
       valueListenable: _controller.shouldPrompt,
-      builder: (context, showPrompt, _) {
+      builder: (context, showPrompt, child) {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            if (showPrompt)
-              Card(
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(defaultBorderRadius),
-                  side: BorderSide(
-                    color: theme.focusColor,
-                  ),
-                ),
-                color: theme.canvasColor,
-                margin: const EdgeInsets.only(bottom: denseSpacing),
-                child: Padding(
-                  padding: const EdgeInsets.all(defaultSpacing),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Text(
-                            'Send usage statistics for DevTools?',
-                            style: textTheme.headline5,
-                          ),
-                          CircularIconButton(
-                            icon: Icons.close,
-                            onPressed: _controller.hidePrompt,
-                            backgroundColor: theme.canvasColor,
-                            foregroundColor:
-                                theme.colorScheme.contrastForeground,
-                          ),
-                        ],
-                      ),
-                      const Padding(
-                        padding: EdgeInsets.only(top: defaultSpacing),
-                      ),
-                      _analyticsDescription(textTheme),
-                      const SizedBox(height: denseRowSpacing),
-                      _actionButtons(),
-                    ],
-                  ),
-                ),
-              ),
+            if (showPrompt) child,
             Expanded(child: widget.child),
           ],
         );
       },
+      child: Card(
+        shape: RoundedRectangleBorder(
+          borderRadius: BorderRadius.circular(defaultBorderRadius),
+          side: BorderSide(
+            color: theme.focusColor,
+          ),
+        ),
+        color: theme.canvasColor,
+        margin: const EdgeInsets.only(bottom: denseSpacing),
+        child: Padding(
+          padding: const EdgeInsets.all(defaultSpacing),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Send usage statistics for DevTools?',
+                    style: textTheme.headline5,
+                  ),
+                  CircularIconButton(
+                    icon: Icons.close,
+                    onPressed: _controller.hidePrompt,
+                    backgroundColor: theme.canvasColor,
+                    foregroundColor: theme.colorScheme.contrastForeground,
+                  ),
+                ],
+              ),
+              const Padding(
+                padding: EdgeInsets.only(top: defaultSpacing),
+              ),
+              _analyticsDescription(textTheme),
+              const SizedBox(height: denseRowSpacing),
+              _actionButtons(),
+            ],
+          ),
+        ),
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -210,21 +210,12 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
         // enabled.
         return ValueListenableBuilder<bool>(
           valueListenable: preferences.vmDeveloperModeEnabled,
-          builder: (_, __, ___) {
+          builder: (_, __, child) {
             final tabs = _visibleScreens()
                 .where((p) => embed && page != null ? p.screenId == page : true)
                 .where((p) => !hide.contains(p.screenId))
                 .toList();
-            if (tabs.isEmpty) {
-              return DevToolsScaffold.withChild(
-                child: CenteredMessage(
-                  page != null
-                      ? 'The "$page" screen is not available for this application.'
-                      : 'No tabs available for this application.',
-                ),
-                ideTheme: ideTheme,
-              );
-            }
+            if (tabs.isEmpty) return child;
             return _providedControllers(
               child: DevToolsScaffold(
                 embed: embed,
@@ -244,6 +235,14 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
               ),
             );
           },
+          child: DevToolsScaffold.withChild(
+            child: CenteredMessage(
+              page != null
+                  ? 'The "$page" screen is not available for this application.'
+                  : 'No tabs available for this application.',
+            ),
+            ideTheme: ideTheme,
+          ),
         );
       },
     );

--- a/packages/devtools_app/lib/src/common_widgets.dart
+++ b/packages/devtools_app/lib/src/common_widgets.dart
@@ -11,6 +11,7 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'analytics/analytics.dart' as ga;
+import 'auto_dispose_mixin.dart';
 import 'config_specific/launch_url/launch_url.dart';
 import 'flutter_widgets/linked_scroll_controller.dart';
 import 'globals.dart';
@@ -1813,6 +1814,58 @@ class _BlinkingIconState extends State<BlinkingIcon> {
       widget.icon,
       size: widget.size,
       color: color,
+    );
+  }
+}
+
+/// A widget that listens for changes to two different [ValueListenable]s and
+/// rebuilds for change notifications to either.
+///
+/// This widget is preferred over nesting two [ValueListenableBuilder]s in a
+/// single build method.
+class DualValueListenableBuilder<T, U> extends StatefulWidget {
+  const DualValueListenableBuilder({
+    Key key,
+    @required this.firstListenable,
+    @required this.secondListenable,
+    @required this.builder,
+    this.child,
+  }) : super(key: key);
+
+  final ValueListenable<T> firstListenable;
+
+  final ValueListenable<U> secondListenable;
+
+  final Widget Function(
+    BuildContext context,
+    T firstValue,
+    U secondValue,
+    Widget child,
+  ) builder;
+
+  final Widget child;
+
+  @override
+  _DualValueListenableBuilderState createState() =>
+      _DualValueListenableBuilderState<T, U>();
+}
+
+class _DualValueListenableBuilderState<T, U>
+    extends State<DualValueListenableBuilder<T, U>> with AutoDisposeMixin {
+  @override
+  void initState() {
+    super.initState();
+    addAutoDisposeListener(widget.firstListenable);
+    addAutoDisposeListener(widget.secondListenable);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.builder(
+      context,
+      widget.firstListenable.value,
+      widget.secondListenable.value,
+      widget.child,
     );
   }
 }

--- a/packages/devtools_app/lib/src/debugger/breakpoints.dart
+++ b/packages/devtools_app/lib/src/debugger/breakpoints.dart
@@ -36,21 +36,18 @@ class _BreakpointsState extends State<Breakpoints> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<List<BreakpointAndSourcePosition>>(
-      valueListenable: controller.breakpointsWithLocation,
-      builder: (context, breakpoints, _) {
-        return ValueListenableBuilder<BreakpointAndSourcePosition>(
-          valueListenable: controller.selectedBreakpoint,
-          builder: (context, selectedBreakpoint, _) {
-            return ListView.builder(
-              itemCount: breakpoints.length,
-              itemExtent: defaultListItemHeight,
-              itemBuilder: (_, index) {
-                return buildBreakpoint(
-                  breakpoints[index],
-                  selectedBreakpoint,
-                );
-              },
+    return DualValueListenableBuilder<List<BreakpointAndSourcePosition>,
+        BreakpointAndSourcePosition>(
+      firstListenable: controller.breakpointsWithLocation,
+      secondListenable: controller.selectedBreakpoint,
+      builder: (context, breakpoints, selectedBreakpoint, _) {
+        return ListView.builder(
+          itemCount: breakpoints.length,
+          itemExtent: defaultListItemHeight,
+          itemBuilder: (_, index) {
+            return buildBreakpoint(
+              breakpoints[index],
+              selectedBreakpoint,
             );
           },
         );

--- a/packages/devtools_app/lib/src/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/debugger/call_stack.dart
@@ -33,20 +33,17 @@ class _CallStackState extends State<CallStack> {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
-      valueListenable: controller.stackFramesWithLocation,
-      builder: (context, stackFrames, _) {
-        return ValueListenableBuilder<StackFrameAndSourcePosition>(
-          valueListenable: controller.selectedStackFrame,
-          builder: (context, selectedFrame, _) {
-            return ListView.builder(
-              itemCount: stackFrames.length,
-              itemExtent: defaultListItemHeight,
-              itemBuilder: (_, index) {
-                final frame = stackFrames[index];
-                return _buildStackFrame(frame, frame == selectedFrame);
-              },
-            );
+    return DualValueListenableBuilder<List<StackFrameAndSourcePosition>,
+        StackFrameAndSourcePosition>(
+      firstListenable: controller.stackFramesWithLocation,
+      secondListenable: controller.selectedStackFrame,
+      builder: (context, stackFrames, selectedFrame, _) {
+        return ListView.builder(
+          itemCount: stackFrames.length,
+          itemExtent: defaultListItemHeight,
+          itemBuilder: (_, index) {
+            final frame = stackFrames[index];
+            return _buildStackFrame(frame, frame == selectedFrame);
           },
         );
       },

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -203,31 +203,27 @@ class _CodeViewState extends State<CodeView>
       return const CenteredCircularProgressIndicator();
     }
 
-    return ValueListenableBuilder(
-      valueListenable: widget.controller.showFileOpener,
-      builder: (context, showFileOpener, _) {
-        return ValueListenableBuilder(
-          valueListenable: widget.controller.showSearchInFileField,
-          builder: (context, showSearch, _) {
-            return Stack(
-              children: [
-                scriptRef == null
-                    ? buildEmptyState(context)
-                    : buildCodeArea(context),
-                if (showFileOpener)
-                  Positioned(
-                    left: fileOpenerLeftPadding,
-                    child: buildFileSearchField(),
-                  ),
-                if (showSearch && scriptRef != null)
-                  Positioned(
-                    top: denseSpacing,
-                    right: searchFieldRightPadding,
-                    child: buildSearchInFileField(),
-                  ),
-              ],
-            );
-          },
+    return DualValueListenableBuilder<bool, bool>(
+      firstListenable: widget.controller.showFileOpener,
+      secondListenable: widget.controller.showSearchInFileField,
+      builder: (context, showFileOpener, showSearch, _) {
+        return Stack(
+          children: [
+            scriptRef == null
+                ? buildEmptyState(context)
+                : buildCodeArea(context),
+            if (showFileOpener)
+              Positioned(
+                left: fileOpenerLeftPadding,
+                child: buildFileSearchField(),
+              ),
+            if (showSearch && scriptRef != null)
+              Positioned(
+                top: denseSpacing,
+                right: searchFieldRightPadding,
+                child: buildSearchInFileField(),
+              ),
+          ],
         );
       },
     );

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -46,44 +46,40 @@ class NetworkScreen extends Screen {
     final networkController = Provider.of<NetworkController>(context);
     final color = Theme.of(context).textTheme.bodyText2.color;
 
-    return ValueListenableBuilder<bool>(
-      valueListenable: networkController.recordingNotifier,
-      builder: (context, recording, _) {
-        return ValueListenableBuilder<NetworkRequests>(
-          valueListenable: networkController.requests,
-          builder: (context, networkRequests, _) {
-            return ValueListenableBuilder<List<NetworkRequest>>(
-              valueListenable: networkController.filteredData,
-              builder: (context, filteredRequests, _) {
-                final filteredCount = filteredRequests.length;
-                final totalCount = networkRequests.requests.length;
-
-                return Row(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    Text(
-                      'Showing ${nf.format(filteredCount)} of '
-                      '${nf.format(totalCount)} '
-                      '${pluralize('request', totalCount)}',
-                    ),
-                    const SizedBox(width: denseSpacing),
-                    SizedBox(
-                      width: smallProgressSize,
-                      height: smallProgressSize,
-                      child: recording
-                          ? CircularProgressIndicator(
-                              strokeWidth: 2,
-                              valueColor: AlwaysStoppedAnimation<Color>(color),
-                            )
-                          : const SizedBox(),
-                    ),
-                  ],
-                );
-              },
-            );
-          },
+    return DualValueListenableBuilder<NetworkRequests, List<NetworkRequest>>(
+      firstListenable: networkController.requests,
+      secondListenable: networkController.filteredData,
+      builder: (context, networkRequests, filteredRequests, child) {
+        final filteredCount = filteredRequests.length;
+        final totalCount = networkRequests.requests.length;
+        return Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'Showing ${nf.format(filteredCount)} of '
+              '${nf.format(totalCount)} '
+              '${pluralize('request', totalCount)}',
+            ),
+            const SizedBox(width: denseSpacing),
+            child,
+          ],
         );
       },
+      child: ValueListenableBuilder<bool>(
+        valueListenable: networkController.recordingNotifier,
+        builder: (context, recording, _) {
+          return SizedBox(
+            width: smallProgressSize,
+            height: smallProgressSize,
+            child: recording
+                ? CircularProgressIndicator(
+                    strokeWidth: 2,
+                    valueColor: AlwaysStoppedAnimation<Color>(color),
+                  )
+                : const SizedBox(),
+          );
+        },
+      ),
     );
   }
 }
@@ -147,7 +143,9 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
       children: [
         _NetworkProfilerControls(controller: _networkController),
         const SizedBox(height: denseRowSpacing),
-        _NetworkProfilerBody(controller: _networkController),
+        Expanded(
+          child: _NetworkProfilerBody(controller: _networkController),
+        ),
       ],
     );
   }
@@ -290,31 +288,25 @@ class _NetworkProfilerBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<NetworkRequest>(
-      valueListenable: controller.selectedRequest,
-      builder: (context, selectedRequest, _) {
-        return Expanded(
-          // TODO(@lesliearkorful): remove GestureDetector once #80455 is fixed
-          child: GestureDetector(
-            onTap: () => FocusScope.of(context)?.unfocus(),
-            child: Split(
-              initialFractions: const [0.5, 0.5],
-              minSizes: const [200, 200],
-              axis: Axis.horizontal,
-              children: [
-                ValueListenableBuilder<List<NetworkRequest>>(
-                    valueListenable: controller.filteredData,
-                    builder: (context, filteredRequests, _) {
-                      return NetworkRequestsTable(
-                        networkController: controller,
-                        requests: filteredRequests,
-                        searchMatchesNotifier: controller.searchMatches,
-                        activeSearchMatchNotifier: controller.activeSearchMatch,
-                      );
-                    }),
-                NetworkRequestInspector(selectedRequest),
-              ],
-            ),
+    return DualValueListenableBuilder<NetworkRequest, List<NetworkRequest>>(
+      firstListenable: controller.selectedRequest,
+      secondListenable: controller.filteredData,
+      builder: (context, selectedRequest, filteredRequests, _) {
+        return GestureDetector(
+          onTap: () => FocusScope.of(context)?.unfocus(),
+          child: Split(
+            initialFractions: const [0.5, 0.5],
+            minSizes: const [200, 200],
+            axis: Axis.horizontal,
+            children: [
+              NetworkRequestsTable(
+                networkController: controller,
+                requests: filteredRequests,
+                searchMatchesNotifier: controller.searchMatches,
+                activeSearchMatchNotifier: controller.activeSearchMatch,
+              ),
+              NetworkRequestInspector(selectedRequest),
+            ],
           ),
         );
       },

--- a/packages/devtools_app/lib/src/performance/event_details.dart
+++ b/packages/devtools_app/lib/src/performance/event_details.dart
@@ -88,9 +88,9 @@ class EventDetails extends StatelessWidget {
   Widget _buildCpuProfiler(CpuProfilerController cpuProfilerController) {
     return ValueListenableBuilder<CpuProfileData>(
       valueListenable: cpuProfilerController.dataNotifier,
-      builder: (context, cpuProfileData, _) {
+      builder: (context, cpuProfileData, child) {
         if (cpuProfileData == null) {
-          return _buildProcessingInfo(cpuProfilerController);
+          return child;
         }
         return CpuProfiler(
           data: cpuProfileData,
@@ -98,6 +98,7 @@ class EventDetails extends StatelessWidget {
           summaryView: EventSummary(selectedEvent),
         );
       },
+      child: _buildProcessingInfo(cpuProfilerController),
     );
   }
 

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -151,17 +151,15 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
         if (isOfflineFlutterApp ||
             (!offlineController.offlineMode.value &&
                 serviceManager.connectedApp.isFlutterAppNow))
-          ValueListenableBuilder(
-            valueListenable: controller.flutterFrames,
-            builder: (context, frames, _) => ValueListenableBuilder(
-              valueListenable: controller.displayRefreshRate,
-              builder: (context, displayRefreshRate, _) {
-                return FlutterFramesChart(
-                  frames,
-                  displayRefreshRate,
-                );
-              },
-            ),
+          DualValueListenableBuilder<List<FlutterFrame>, double>(
+            firstListenable: controller.flutterFrames,
+            secondListenable: controller.displayRefreshRate,
+            builder: (context, frames, displayRefreshRate, child) {
+              return FlutterFramesChart(
+                frames,
+                displayRefreshRate,
+              );
+            },
           ),
         Expanded(
           child: Split(
@@ -246,7 +244,7 @@ class _PrimaryControls extends StatelessWidget {
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: controller.recordingFrames,
-      builder: (context, recording, _) {
+      builder: (context, recording, child) {
         return Row(
           children: [
             OutlinedIconButton(
@@ -261,14 +259,15 @@ class _PrimaryControls extends StatelessWidget {
               onPressed: recording ? null : _resumeFrameRecording,
             ),
             const SizedBox(width: denseSpacing),
-            OutlinedIconButton(
-              icon: Icons.block,
-              tooltip: 'Clear',
-              onPressed: processing ? null : _clearPerformanceData,
-            ),
+            child,
           ],
         );
       },
+      child: OutlinedIconButton(
+        icon: Icons.block,
+        tooltip: 'Clear',
+        onPressed: processing ? null : _clearPerformanceData,
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -146,6 +146,49 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   }
 
   Widget _buildProfilerScreenBody(ProfilerScreenController controller) {
+    final emptyAppStartUpProfileView = Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: const [
+          Text(
+            'There are no app start up samples available.',
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: denseSpacing),
+          Text(
+            'To avoid this, try to open the DevTools CPU profiler '
+            'sooner after starting your app.',
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+    // TODO(kenz): remove the note about profiling on iOS after
+    // https://github.com/flutter/flutter/issues/88466 is fixed.
+    final emptyProfileView = Center(
+      child: RichText(
+        textAlign: TextAlign.center,
+        text: TextSpan(
+          text: 'No CPU samples recorded.',
+          children: serviceManager.vm.operatingSystem == 'ios'
+              ? [
+                  const TextSpan(
+                    text: '''
+\n\nIf you are attempting to profile on a real iOS device, you may be hitting a known issue. Try using this ''',
+                  ),
+                  LinkTextSpan(
+                    link: const Link(
+                      display: 'workaround',
+                      url: iosProfilerWorkaround,
+                    ),
+                    context: context,
+                  ),
+                  const TextSpan(text: '.'),
+                ]
+              : [],
+        ),
+      ),
+    );
     final profilerScreen = Column(
       children: [
         if (!offlineController.offlineMode.value)
@@ -166,51 +209,10 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
               }
               if (cpuProfileData ==
                   CpuProfilerController.emptyAppStartUpProfile) {
-                return Center(
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.center,
-                    children: const [
-                      Text(
-                        'There are no app start up samples available.',
-                        textAlign: TextAlign.center,
-                      ),
-                      SizedBox(height: denseSpacing),
-                      Text(
-                        'To avoid this, try to open the DevTools CPU profiler '
-                        'sooner after starting your app.',
-                        textAlign: TextAlign.center,
-                      ),
-                    ],
-                  ),
-                );
+                return emptyAppStartUpProfileView;
               }
               if (cpuProfileData.isEmpty) {
-                // TODO(kenz): remove the note about profiling on iOS after
-                // https://github.com/flutter/flutter/issues/88466 is fixed.
-                return Center(
-                  child: RichText(
-                    textAlign: TextAlign.center,
-                    text: TextSpan(
-                      text: 'No CPU samples recorded.',
-                      children: serviceManager.vm.operatingSystem == 'ios'
-                          ? [
-                              const TextSpan(
-                                text: '''
-\n\nIf you are attempting to profile on a real iOS device, you may be hitting a known issue. Try using this ''',
-                              ),
-                              LinkTextSpan(
-                                link: const Link(
-                                  display: 'workaround',
-                                  url: iosProfilerWorkaround,
-                                ),
-                                context: context,
-                              ),
-                              const TextSpan(text: '.'),
-                            ]
-                          : [],
-                    ),
-                  ),
-                );
+                return emptyProfileView;
               }
               return CpuProfiler(
                 data: cpuProfileData,

--- a/packages/devtools_app/lib/src/vm_developer/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/vm_developer/vm_statistics_view.dart
@@ -34,14 +34,12 @@ class VMStatisticsViewBody extends StatelessWidget {
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: controller.refreshing,
-      builder: (context, refreshing, _) {
+      builder: (context, refreshing, child) {
         return Column(
           children: [
             Row(
               children: [
-                RefreshButton(
-                  onPressed: controller.refresh,
-                ),
+                child,
               ],
             ),
             Expanded(
@@ -52,6 +50,9 @@ class VMStatisticsViewBody extends StatelessWidget {
           ],
         );
       },
+      child: RefreshButton(
+        onPressed: controller.refresh,
+      ),
     );
   }
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/2989.

Using the [ValueListenableBuilder.child](https://api.flutter.dev/flutter/widgets/ValueListenableBuilder/child.html) property wherever possible improves performance by reducing the widgets being rebuilt upon change notifications to the value listenable.