### PR TITLE
Use proper frame id to number frames in the performance page

### DIFF
--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -229,9 +229,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
               }
               return Center(
                 child: Text(
-                  // TODO(https://github.com/flutter/flutter/issues/94896): stop
-                  // dividing by 2 to get the proper id.
-                  '${widget.frames[index].id ~/ 2}',
+                  '${widget.frames[index].id}',
                   style: themeData.subtleChartTextStyle,
                 ),
               );

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -103,12 +103,7 @@ class PerformanceController extends DisposableController
     if (existingTabForFrame != null) {
       _selectedAnalysisTab.value = existingTabForFrame;
     } else {
-      // TODO(https://github.com/flutter/flutter/issues/94896): stop dividing by
-      // 2 to get the proper id.
-      final newTab = FlutterFrameAnalysisTabData(
-        'Frame ${frame.id ~/ 2}',
-        frame,
-      );
+      final newTab = FlutterFrameAnalysisTabData('Frame ${frame.id}', frame);
       _analysisTabs.add(newTab);
       _selectedAnalysisTab.value = newTab;
     }


### PR DESCRIPTION
Per discussion on https://github.com/flutter/flutter/issues/94896, the non-contiguous frame numbering is WAI, so we should just use the number that the engine assigned to the frame.