### PR TITLE
Fix a parsing bug with the SemanticVersion class

### DIFF
--- a/packages/devtools_app/lib/src/version.dart
+++ b/packages/devtools_app/lib/src/version.dart
@@ -114,6 +114,13 @@ class SemanticVersion with CompareMixin {
   });
 
   factory SemanticVersion.parse(String versionString) {
+    // Remove any build metadata, denoted by a '+' character and whatever
+    // follows.
+    final buildMetadataIndex = versionString.indexOf('+');
+    if (buildMetadataIndex != -1) {
+      versionString = versionString.substring(0, buildMetadataIndex);
+    }
+
     // [versionString] is expected to be of the form for VM.version, Dart, and
     // Flutter, respectively:
     // 2.15.0-233.0.dev (dev) (Mon Oct 18 14:06:26 2021 -0700) on "ios_x64"

--- a/packages/devtools_app/test/version_test.dart
+++ b/packages/devtools_app/test/version_test.dart
@@ -99,6 +99,16 @@ void main() {
         SemanticVersion.parse('2.6.0-12.0.pre.443').toString(),
         equals('2.6.0-12.0'),
       );
+
+      expect(
+        SemanticVersion.parse('2.6.0-1.2.dev+build.metadata').toString(),
+        equals('2.6.0-1.2'),
+      );
+
+      expect(
+        SemanticVersion.parse('2.6.0+build.metadata').toString(),
+        equals('2.6.0'),
+      );
     });
 
     test('isVersionSupported', () {


### PR DESCRIPTION
We do not need the build meta data (anything after a '+' sign) because it is irrelevant when comparing two versions. See https://semver.org/#spec-item-10 for more info.