### PR TITLE
Refactors `AutoDisposeMixin` to have separate cancel methods for listeners, stream subscriptions, and focus nodes

### DIFF
--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -95,7 +95,9 @@ mixin AutoDisposeControllerMixin on DisposableController implements Disposer {
 
   @override
   void dispose() {
-    cancel();
+    cancelStreamSubscriptions();
+    cancelListeners();
+    cancelFocusNodes();
     super.dispose();
   }
 
@@ -127,9 +129,5 @@ mixin AutoDisposeControllerMixin on DisposableController implements Disposer {
   @override
   void cancelFocusNodes() {
     _delegate.cancelFocusNodes();
-  }
-
-  void cancel() {
-    print('CANCEL');
   }
 }

--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -115,7 +115,21 @@ mixin AutoDisposeControllerMixin on DisposableController implements Disposer {
   }
 
   @override
+  void cancelStreamSubscriptions() {
+    _delegate.cancelStreamSubscriptions();
+  }
+
+  @override
+  void cancelListeners() {
+    _delegate.cancelListeners();
+  }
+
+  @override
+  void cancelFocusNodes() {
+    _delegate.cancelFocusNodes();
+  }
+
   void cancel() {
-    _delegate.cancel();
+    print('CANCEL');
   }
 }

--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -42,26 +42,36 @@ class Disposer {
     listenable.addListener(listener);
   }
 
-  /// Cancel all listeners added & stream subscriptions.
+  /// Cancel all stream subscriptions added.
   ///
-  /// It is fine to call this method and then add additional listeners.
-  void cancel() {
-    for (FocusNode focusNode in _focusNodes) {
-      focusNode.dispose();
-    }
-    _focusNodes.clear();
-
+  /// It is fine to call this method and then add additional subscriptions.
+  void cancelStreamSubscriptions() {
     for (StreamSubscription subscription in _subscriptions) {
       subscription.cancel();
     }
     _subscriptions.clear();
+  }
 
+  /// Cancel all listeners added.
+  ///
+  /// It is fine to call this method and then add additional listeners.
+  void cancelListeners() {
     assert(_listenables.length == _listeners.length);
     for (int i = 0; i < _listenables.length; ++i) {
       _listenables[i].removeListener(_listeners[i]);
     }
     _listenables.clear();
     _listeners.clear();
+  }
+
+  /// Cancel all focus nodes added.
+  ///
+  /// It is fine to call this method and then add additional focus nodes.
+  void cancelFocusNodes() {
+    for (FocusNode focusNode in _focusNodes) {
+      focusNode.dispose();
+    }
+    _focusNodes.clear();
   }
 }
 

--- a/packages/devtools_app/lib/src/auto_dispose.dart
+++ b/packages/devtools_app/lib/src/auto_dispose.dart
@@ -22,7 +22,7 @@ class Disposer {
   final List<VoidCallback> _listeners = [];
 
   /// Track a stream subscription to be automatically cancelled on dispose.
-  void autoDispose(StreamSubscription subscription) {
+  void autoDisposeStreamSubscription(StreamSubscription subscription) {
     if (subscription == null) return;
     _subscriptions.add(subscription);
   }
@@ -105,8 +105,8 @@ mixin AutoDisposeControllerMixin on DisposableController implements Disposer {
   }
 
   @override
-  void autoDispose(StreamSubscription subscription) {
-    _delegate.autoDispose(subscription);
+  void autoDisposeStreamSubscription(StreamSubscription subscription) {
+    _delegate.autoDisposeStreamSubscription(subscription);
   }
 
   @override

--- a/packages/devtools_app/lib/src/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/auto_dispose_mixin.dart
@@ -23,7 +23,9 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
 
   @override
   void dispose() {
-    cancel();
+    cancelStreamSubscriptions();
+    cancelListeners();
+    cancelFocusNodes();
     super.dispose();
   }
 
@@ -45,7 +47,21 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
   }
 
   @override
+  void cancelStreamSubscriptions() {
+    _delegate.cancelStreamSubscriptions();
+  }
+
+  @override
+  void cancelListeners() {
+    _delegate.cancelListeners();
+  }
+
+  @override
+  void cancelFocusNodes() {
+    _delegate.cancelFocusNodes();
+  }
+
   void cancel() {
-    _delegate.cancel();
+    print('CANCEL');
   }
 }

--- a/packages/devtools_app/lib/src/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/auto_dispose_mixin.dart
@@ -60,8 +60,4 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
   void cancelFocusNodes() {
     _delegate.cancelFocusNodes();
   }
-
-  void cancel() {
-    print('CANCEL');
-  }
 }

--- a/packages/devtools_app/lib/src/auto_dispose_mixin.dart
+++ b/packages/devtools_app/lib/src/auto_dispose_mixin.dart
@@ -37,8 +37,8 @@ mixin AutoDisposeMixin<T extends StatefulWidget> on State<T>
   }
 
   @override
-  void autoDispose(StreamSubscription subscription) {
-    _delegate.autoDispose(subscription);
+  void autoDisposeStreamSubscription(StreamSubscription subscription) {
+    _delegate.autoDisposeStreamSubscription(subscription);
   }
 
   @override

--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -160,7 +160,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
   @override
   void didUpdateWidget(_ConsoleOutput oldWidget) {
     if (oldWidget.lines != widget.lines) {
-      cancel();
+      cancelListeners();
       _initHelper();
     }
     super.didUpdateWidget(oldWidget);

--- a/packages/devtools_app/lib/src/console.dart
+++ b/packages/devtools_app/lib/src/console.dart
@@ -160,13 +160,13 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
   @override
   void didUpdateWidget(_ConsoleOutput oldWidget) {
     if (oldWidget.lines != widget.lines) {
-      cancelListeners();
       _initHelper();
     }
     super.didUpdateWidget(oldWidget);
   }
 
   void _initHelper() {
+    cancelListeners();
     addAutoDisposeListener(widget.lines, _onConsoleLinesChanged);
     addAutoDisposeListener(_scroll, _onScrollChanged);
     _onConsoleLinesChanged();

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -181,6 +181,7 @@ class ConsoleService extends Disposer {
 
   void vmServiceOpened(VmServiceWrapper service) {
     cancelStreamSubscriptions();
+    cancelListeners();
     // The debug stream listener must be added as soon as the service is opened
     // because this stream does not send event history upon the first
     // subscription like the streams in [ensureServiceInitialized].

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -180,7 +180,7 @@ class ConsoleService extends Disposer {
   }
 
   void vmServiceOpened(VmServiceWrapper service) {
-    cancel();
+    cancelStreamSubscriptions();
     // The debug stream listener must be added as soon as the service is opened
     // because this stream does not send event history upon the first
     // subscription like the streams in [ensureServiceInitialized].
@@ -242,7 +242,7 @@ class ConsoleService extends Disposer {
   }
 
   void handleVmServiceClosed() {
-    cancel();
+    cancelStreamSubscriptions();
     _serviceInitialized = false;
   }
 

--- a/packages/devtools_app/lib/src/console_service.dart
+++ b/packages/devtools_app/lib/src/console_service.dart
@@ -184,7 +184,8 @@ class ConsoleService extends Disposer {
     // The debug stream listener must be added as soon as the service is opened
     // because this stream does not send event history upon the first
     // subscription like the streams in [ensureServiceInitialized].
-    autoDispose(service.onDebugEvent.listen(_handleDebugEvent));
+    autoDisposeStreamSubscription(
+        service.onDebugEvent.listen(_handleDebugEvent));
     addAutoDisposeListener(serviceManager.isolateManager.mainIsolate, () {
       clearStdio();
     });
@@ -207,11 +208,14 @@ class ConsoleService extends Disposer {
   void ensureServiceInitialized() {
     assert(serviceManager.isServiceAvailable);
     if (!_serviceInitialized && serviceManager.isServiceAvailable) {
-      autoDispose(serviceManager.service.onStdoutEventWithHistory
+      autoDisposeStreamSubscription(serviceManager
+          .service.onStdoutEventWithHistory
           .listen(_handleStdoutEvent));
-      autoDispose(serviceManager.service.onStderrEventWithHistory
+      autoDisposeStreamSubscription(serviceManager
+          .service.onStderrEventWithHistory
           .listen(_handleStderrEvent));
-      autoDispose(serviceManager.service.onExtensionEventWithHistory
+      autoDisposeStreamSubscription(serviceManager
+          .service.onExtensionEventWithHistory
           .listen(_handleExtensionEvent));
       _serviceInitialized = true;
     }

--- a/packages/devtools_app/lib/src/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/debugger/codeview.dart
@@ -117,7 +117,7 @@ class _CodeViewState extends State<CodeView>
     super.didUpdateWidget(oldWidget);
 
     if (widget.controller != oldWidget.controller) {
-      cancel();
+      cancelListeners();
 
       addAutoDisposeListener(
           widget.controller.scriptLocation, _handleScriptLocationChanged);
@@ -656,7 +656,7 @@ class _LinesState extends State<Lines> with AutoDisposeMixin {
   void initState() {
     super.initState();
 
-    cancel();
+    cancelListeners();
     searchMatches = widget.searchMatchesNotifier.value;
     addAutoDisposeListener(widget.searchMatchesNotifier, () {
       setState(() {

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -37,7 +37,7 @@ class DebuggerController extends DisposableController
     _programExplorerController = ProgramExplorerController(
       debuggerController: this,
     );
-    autoDispose(serviceManager.onConnectionAvailable
+    autoDisposeStreamSubscription(serviceManager.onConnectionAvailable
         .listen(_handleConnectionAvailable));
     if (_service != null) {
       initialize();
@@ -123,8 +123,10 @@ class DebuggerController extends DisposableController
     addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
       switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
     });
-    autoDispose(_service.onDebugEvent.listen(_handleDebugEvent));
-    autoDispose(_service.onIsolateEvent.listen(_handleIsolateEvent));
+    autoDisposeStreamSubscription(
+        _service.onDebugEvent.listen(_handleDebugEvent));
+    autoDisposeStreamSubscription(
+        _service.onIsolateEvent.listen(_handleIsolateEvent));
   }
 
   final bool initialSwitchToIsolate;

--- a/packages/devtools_app/lib/src/debugger/evaluate.dart
+++ b/packages/devtools_app/lib/src/debugger/evaluate.dart
@@ -29,7 +29,7 @@ class ExpressionEvalField extends StatefulWidget {
 }
 
 class _ExpressionEvalFieldState extends State<ExpressionEvalField>
-    with SearchFieldMixin, AutoDisposeMixin {
+    with AutoDisposeMixin, SearchFieldMixin {
   AutoCompleteController _autoCompleteController;
   int historyPosition = -1;
 

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -27,7 +27,7 @@ class FileSearchField extends StatefulWidget {
 }
 
 class FileSearchFieldState extends State<FileSearchField>
-    with SearchFieldMixin, AutoDisposeMixin {
+    with AutoDisposeMixin, SearchFieldMixin {
   AutoCompleteController autoCompleteController;
 
   final _scriptsCache = <String, ScriptRef>{};

--- a/packages/devtools_app/lib/src/error_badge_manager.dart
+++ b/packages/devtools_app/lib/src/error_badge_manager.dart
@@ -41,11 +41,12 @@ class ErrorBadgeManager extends DisposableController
     );
 
     // Log Flutter extension events.
-    autoDispose(
+    autoDisposeStreamSubscription(
         service.onExtensionEventWithHistory.listen(_handleExtensionEvent));
 
     // Log stderr events.
-    autoDispose(service.onStderrEventWithHistory.listen(_handleStdErr));
+    autoDisposeStreamSubscription(
+        service.onStderrEventWithHistory.listen(_handleStdErr));
   }
 
   void _handleExtensionEvent(Event e) async {

--- a/packages/devtools_app/lib/src/initializer.dart
+++ b/packages/devtools_app/lib/src/initializer.dart
@@ -82,7 +82,7 @@ class _InitializerState extends State<Initializer>
     // Trigger a rebuild when the connection becomes available. This is done
     // by onConnectionAvailable and not onStateChange because we also need
     // to have queried what type of app this is before we load the UI.
-    autoDispose(
+    autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable.listen((_) => setState(() {})),
     );
 

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -134,13 +134,13 @@ class InspectorController extends DisposableController
       });
     }
 
-    autoDispose(
+    autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable.listen(_handleConnectionStart),
     );
     if (serviceManager.connectedAppInitialized) {
       _handleConnectionStart(serviceManager.service);
     }
-    autoDispose(
+    autoDisposeStreamSubscription(
       serviceManager.onConnectionClosed.listen(_handleConnectionStop),
     );
 

--- a/packages/devtools_app/lib/src/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_service.dart
@@ -207,9 +207,9 @@ class InspectorService extends InspectorServiceBase {
         ) {
     // Note: We do not need to listen to event history here because the
     // inspector uses a separate API to get the current inspector selection.
-    autoDispose(serviceManager.service.onExtensionEvent
+    autoDisposeStreamSubscription(serviceManager.service.onExtensionEvent
         .listen(onExtensionVmServiceReceived));
-    autoDispose(
+    autoDisposeStreamSubscription(
         serviceManager.service.onDebugEvent.listen(onDebugVmServiceReceived));
   }
 

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -625,7 +625,8 @@ class _InspectorTreeState extends State<InspectorTree>
     _scrollControllerX.dispose();
     _scrollControllerY.dispose();
     constraintDisplayController?.dispose();
-    // TODO(elliette): audtodispose.
+    // TODO(https://github.com/flutter/devtools/issues/3538): Switch to using
+    // autoDisposeFocusNode.
     _focusNode.dispose();
   }
 

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -600,6 +600,7 @@ class _InspectorTreeState extends State<InspectorTree>
       constraintDisplayController = longAnimationController(this);
     }
     _focusNode = FocusNode(debugLabel: 'inspector-tree');
+    autoDisposeFocusNode(_focusNode);
     _bindToController();
   }
 
@@ -625,9 +626,6 @@ class _InspectorTreeState extends State<InspectorTree>
     _scrollControllerX.dispose();
     _scrollControllerY.dispose();
     constraintDisplayController?.dispose();
-    // TODO(https://github.com/flutter/devtools/issues/3538): Switch to using
-    // autoDisposeFocusNode.
-    _focusNode.dispose();
   }
 
   @override

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -608,7 +608,10 @@ class _InspectorTreeState extends State<InspectorTree>
     if (oldWidget.controller != widget.controller) {
       final InspectorTreeController oldController = oldWidget.controller;
       oldController?.removeClient(this);
-      cancel();
+
+      // TODO(elliette): Figure out if we can remove this. See explanation:
+      // https://github.com/flutter/devtools/pull/1290/files#r342399899.
+      cancelListeners();
 
       _bindToController();
     }
@@ -622,6 +625,7 @@ class _InspectorTreeState extends State<InspectorTree>
     _scrollControllerX.dispose();
     _scrollControllerY.dispose();
     constraintDisplayController?.dispose();
+    // TODO(elliette): audtodispose.
     _focusNode.dispose();
   }
 

--- a/packages/devtools_app/lib/src/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/logging/logging_controller.dart
@@ -163,12 +163,12 @@ class LoggingController extends DisposableController
         FilterControllerMixin<LogData>,
         AutoDisposeControllerMixin {
   LoggingController() {
-    autoDispose(
+    autoDisposeStreamSubscription(
         serviceManager.onConnectionAvailable.listen(_handleConnectionStart));
     if (serviceManager.connectedAppInitialized) {
       _handleConnectionStart(serviceManager.service);
     }
-    autoDispose(
+    autoDisposeStreamSubscription(
         serviceManager.onConnectionClosed.listen(_handleConnectionStop));
     _handleBusEvents();
   }
@@ -250,22 +250,24 @@ class LoggingController extends DisposableController
     // Log stdout events.
     final _StdoutEventHandler stdoutHandler =
         _StdoutEventHandler(this, 'stdout');
-    autoDispose(service.onStdoutEventWithHistory.listen(stdoutHandler.handle));
+    autoDisposeStreamSubscription(
+        service.onStdoutEventWithHistory.listen(stdoutHandler.handle));
 
     // Log stderr events.
     final _StdoutEventHandler stderrHandler =
         _StdoutEventHandler(this, 'stderr', isError: true);
-    autoDispose(service.onStderrEventWithHistory.listen(stderrHandler.handle));
+    autoDisposeStreamSubscription(
+        service.onStderrEventWithHistory.listen(stderrHandler.handle));
 
     // Log GC events.
-    autoDispose(service.onGCEvent.listen(_handleGCEvent));
+    autoDisposeStreamSubscription(service.onGCEvent.listen(_handleGCEvent));
 
     // Log `dart:developer` `log` events.
-    autoDispose(
+    autoDisposeStreamSubscription(
         service.onLoggingEventWithHistory.listen(_handleDeveloperLogEvent));
 
     // Log Flutter extension events.
-    autoDispose(
+    autoDisposeStreamSubscription(
         service.onExtensionEventWithHistory.listen(_handleExtensionEvent));
   }
 
@@ -522,7 +524,7 @@ class LoggingController extends DisposableController
   void _handleBusEvents() {
     // TODO(jacobr): expose the messageBus for use by vm tests.
     if (messageBus != null) {
-      autoDispose(
+      autoDisposeStreamSubscription(
           messageBus.onEvent(type: 'reload.end').listen((BusEvent event) {
         log(
           LogData(
@@ -533,7 +535,7 @@ class LoggingController extends DisposableController
         );
       }));
 
-      autoDispose(
+      autoDisposeStreamSubscription(
           messageBus.onEvent(type: 'restart.end').listen((BusEvent event) {
         log(
           LogData(
@@ -545,14 +547,14 @@ class LoggingController extends DisposableController
       }));
 
       // Listen for debugger events.
-      autoDispose(messageBus
+      autoDisposeStreamSubscription(messageBus
           .onEvent()
           .where((event) =>
               event.type == 'debugger' || event.type.startsWith('debugger.'))
           .listen(_handleDebuggerEvent));
 
       // Listen for DevTools internal events.
-      autoDispose(messageBus
+      autoDisposeStreamSubscription(messageBus
           .onEvent()
           .where((event) => event.type.startsWith('devtools.'))
           .listen(_handleDevToolsEvent));

--- a/packages/devtools_app/lib/src/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/logging/logging_screen.dart
@@ -101,7 +101,7 @@ class _LoggingScreenState extends State<LoggingScreenBody>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     filteredLogs = controller.filteredData.value;
     addAutoDisposeListener(controller.filteredData, () {

--- a/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_allocation_table_view.dart
@@ -83,7 +83,7 @@ class AllocationTableViewState extends State<AllocationTableView>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     // TODO(terry): setState should be called to set our state not change the
     //              controller. Have other ValueListenables on controller to

--- a/packages/devtools_app/lib/src/memory/memory_analyzer.dart
+++ b/packages/devtools_app/lib/src/memory/memory_analyzer.dart
@@ -538,7 +538,7 @@ class AnalysisInstanceViewState extends State<AnalysisInstanceViewTable>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     // Update the chart when the memorySource changes.
     addAutoDisposeListener(controller.selectedSnapshotNotifier, () {

--- a/packages/devtools_app/lib/src/memory/memory_android_chart.dart
+++ b/packages/devtools_app/lib/src/memory/memory_android_chart.dart
@@ -145,7 +145,7 @@ class MemoryAndroidChartState extends State<MemoryAndroidChart>
 
     colorScheme = Theme.of(context).colorScheme;
 
-    cancel();
+    cancelListeners();
 
     setupTraces();
     _chartController.setupData();

--- a/packages/devtools_app/lib/src/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/memory/memory_controller.dart
@@ -830,7 +830,8 @@ class MemoryController extends DisposableController
     // Log Flutter extension events.
     // Note: We do not need to listen to event history here because we do not
     // have matching historical data about total memory usage.
-    autoDispose(serviceManager.service.onExtensionEvent.listen((Event event) {
+    autoDisposeStreamSubscription(
+        serviceManager.service.onExtensionEvent.listen((Event event) {
       var extensionEventKind = event.extensionKind;
       String customEventKind;
       if (MemoryTimeline.isCustomEvent(event.extensionKind)) {
@@ -855,12 +856,12 @@ class MemoryController extends DisposableController
       }
     }));
 
-    autoDispose(
+    autoDisposeStreamSubscription(
       _memoryTracker.onChange.listen((_) {
         _memoryTrackerController.add(_memoryTracker);
       }),
     );
-    autoDispose(
+    autoDisposeStreamSubscription(
       _memoryTracker.onChange.listen((_) {
         _memoryTrackerController.add(_memoryTracker);
       }),
@@ -891,14 +892,14 @@ class MemoryController extends DisposableController
       _handleIsolateChanged,
     );
 
-    autoDispose(
+    autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable
           .listen((_) => _handleConnectionStart(serviceManager)),
     );
     if (serviceManager.connectedAppInitialized) {
       _handleConnectionStart(serviceManager);
     }
-    autoDispose(
+    autoDisposeStreamSubscription(
       serviceManager.onConnectionClosed.listen(_handleConnectionStop),
     );
   }

--- a/packages/devtools_app/lib/src/memory/memory_events_pane.dart
+++ b/packages/devtools_app/lib/src/memory/memory_events_pane.dart
@@ -207,7 +207,7 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
     final themeData = Theme.of(context);
     colorScheme = themeData.colorScheme;
 
-    cancel();
+    cancelListeners();
 
     setupTraces(isDarkMode: themeData.isDarkTheme);
     _chartController.setupData();

--- a/packages/devtools_app/lib/src/memory/memory_events_pane.dart
+++ b/packages/devtools_app/lib/src/memory/memory_events_pane.dart
@@ -217,13 +217,12 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
       setState(() {
         _processHeapSample(_memoryTimeline.sampleAddedNotifier.value);
       });
-
-      // Monitor event fired.
-      addAutoDisposeListener(_memoryTimeline.eventNotifier, () {
-        setState(() {
-          // TODO(terry): New event received.
-          //_processHeapSample(_memoryTimeline.eventNotifier.value);
-        });
+    });
+    // Monitor event fired.
+    addAutoDisposeListener(_memoryTimeline.eventNotifier, () {
+      setState(() {
+        // TODO(terry): New event received.
+        //_processHeapSample(_memoryTimeline.eventNotifier.value);
       });
     });
   }

--- a/packages/devtools_app/lib/src/memory/memory_filter.dart
+++ b/packages/devtools_app/lib/src/memory/memory_filter.dart
@@ -158,8 +158,6 @@ class SnapshotFilterState extends State<SnapshotFilterDialog>
     for (var key in oldFiltered.keys) {
       oldFilteredLibraries[key] = oldFiltered[key].first.hide;
     }
-
-    cancel();
   }
 
   void addLibrary(String libraryName, {bool hideState = false}) {

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -197,7 +197,7 @@ class HeapTreeViewState extends State<HeapTree>
 
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
@@ -1176,7 +1176,7 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     // Update the tree when the tree state changes e.g., expand, collapse, etc.
     addAutoDisposeListener(controller.treeChangedNotifier, () {

--- a/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_treemap.dart
@@ -48,7 +48,7 @@ class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
       root = sizes.root;
     }
 
-    cancel();
+    cancelListeners();
 
     addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {

--- a/packages/devtools_app/lib/src/memory/memory_instance_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_instance_tree_view.dart
@@ -45,7 +45,7 @@ class InstanceTreeViewState extends State<InstanceTreeView>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     // TODO(terry): setState should be called to set our state not change the
     //              controller. Have other ValueListenables on controller to

--- a/packages/devtools_app/lib/src/memory/memory_vm_chart.dart
+++ b/packages/devtools_app/lib/src/memory/memory_vm_chart.dart
@@ -130,7 +130,7 @@ class MemoryVMChartState extends State<MemoryVMChart> with AutoDisposeMixin {
 
     colorScheme = Theme.of(context).colorScheme;
 
-    cancel();
+    cancelListeners();
 
     setupTraces();
     _chartController.setupData();

--- a/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/flutter_frames_chart.dart
@@ -90,7 +90,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
     if (newController == _controller) return;
     _controller = newController;
 
-    cancel();
+    cancelListeners();
     _selectedFrame = _controller.selectedFrame.value;
     addAutoDisposeListener(_controller.selectedFrame, () {
       setState(() {

--- a/packages/devtools_app/lib/src/performance/legacy/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/flutter_frames_chart.dart
@@ -81,7 +81,7 @@ class _LegacyFlutterFramesChartState extends State<LegacyFlutterFramesChart>
     if (newController == _controller) return;
     _controller = newController;
 
-    cancel();
+    cancelListeners();
     _selectedFrame = _controller.selectedFrame.value;
     addAutoDisposeListener(_controller.selectedFrame, () {
       setState(() {

--- a/packages/devtools_app/lib/src/performance/legacy/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/legacy/performance_screen.dart
@@ -115,7 +115,7 @@ class LegacyPerformanceScreenBodyState
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     processing = controller.processing.value;
     addAutoDisposeListener(controller.processing, () {

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -231,7 +231,7 @@ class PerformanceController extends DisposableController
 
       // Listen for Flutter.Frame events with frame timing data.
       // Listen for Flutter.RebuiltWidgets events.
-      autoDispose(
+      autoDisposeStreamSubscription(
           serviceManager.service.onExtensionEventWithHistory.listen((event) {
         if (event.extensionKind == 'Flutter.Frame') {
           final frame = FlutterFrame.parse(event.extensionData.data);
@@ -241,7 +241,8 @@ class PerformanceController extends DisposableController
         }
       }));
 
-      autoDispose(serviceManager.onConnectionClosed.listen((_) {
+      autoDisposeStreamSubscription(
+          serviceManager.onConnectionClosed.listen((_) {
         _pollingTimer?.cancel();
         _timelinePollingRateLimiter?.dispose();
       }));

--- a/packages/devtools_app/lib/src/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/performance/performance_screen.dart
@@ -101,7 +101,7 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     processing = controller.processing.value;
     addAutoDisposeListener(controller.processing, () {

--- a/packages/devtools_app/lib/src/performance/timeline_streams.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_streams.dart
@@ -132,7 +132,8 @@ class TimelineStreamManager extends Disposer {
 
     // Listen for timeline events immediately, but wait until [connectedApp]
     // has been initialized to initialize timeline stream values.
-    autoDispose(service.onTimelineEvent.listen(handleTimelineEvent));
+    autoDisposeStreamSubscription(
+        service.onTimelineEvent.listen(handleTimelineEvent));
     unawaited(connectedApp.initialized.future.then((_) async {
       // The timeline is not supported for web applications.
       if (!connectedApp.isDartWebAppNow) {

--- a/packages/devtools_app/lib/src/performance/timeline_streams.dart
+++ b/packages/devtools_app/lib/src/performance/timeline_streams.dart
@@ -127,7 +127,7 @@ class TimelineStreamManager extends Disposer {
     VmServiceWrapper service,
     ConnectedApp connectedApp,
   ) async {
-    cancel();
+    cancelStreamSubscriptions();
     _service = service;
 
     // Listen for timeline events immediately, but wait until [connectedApp]

--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -97,7 +97,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
     if (newController == controller) return;
     controller = newController;
 
-    cancel();
+    cancelListeners();
 
     addAutoDisposeListener(controller.recordingNotifier, () {
       setState(() {

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -743,8 +743,10 @@ class IsolateManager extends Disposer {
 
     cancelStreamSubscriptions();
     _service = service;
-    autoDispose(service.onIsolateEvent.listen(_handleIsolateEvent));
-    autoDispose(service.onDebugEvent.listen(_handleDebugEvent));
+    autoDisposeStreamSubscription(
+        service.onIsolateEvent.listen(_handleIsolateEvent));
+    autoDisposeStreamSubscription(
+        service.onDebugEvent.listen(_handleDebugEvent));
 
     // We don't yet known the main isolate.
     _mainIsolate.value = null;
@@ -1293,14 +1295,17 @@ class ServiceExtensionManager extends Disposer {
     _connectedApp = connectedApp;
     _service = service;
     // TODO(kenz): do we want to listen with event history here?
-    autoDispose(service.onExtensionEvent.listen(_handleExtensionEvent));
+    autoDisposeStreamSubscription(
+        service.onExtensionEvent.listen(_handleExtensionEvent));
     addAutoDisposeListener(
       hasServiceExtension(extensions.didSendFirstFrameEvent),
       _maybeCheckForFirstFlutterFrame,
     );
     addAutoDisposeListener(_isolateManager.mainIsolate, _onMainIsolateChanged);
-    autoDispose(service.onDebugEvent.listen(_handleDebugEvent));
-    autoDispose(service.onIsolateEvent.listen(_handleIsolateEvent));
+    autoDisposeStreamSubscription(
+        service.onDebugEvent.listen(_handleDebugEvent));
+    autoDisposeStreamSubscription(
+        service.onIsolateEvent.listen(_handleIsolateEvent));
     final mainIsolateRef = _isolateManager.mainIsolate.value;
     if (mainIsolateRef != null) {
       _checkForFirstFrameStarted = false;

--- a/packages/devtools_app/lib/src/service_manager.dart
+++ b/packages/devtools_app/lib/src/service_manager.dart
@@ -720,7 +720,7 @@ class IsolateManager extends Disposer {
   }
 
   void _handleVmServiceClosed() {
-    cancel();
+    cancelStreamSubscriptions();
     _selectedIsolate.value = null;
     _service = null;
     _lastIsolateIndex = 0;
@@ -741,7 +741,7 @@ class IsolateManager extends Disposer {
   void vmServiceOpened(VmServiceWrapper service) {
     _selectedIsolate.value = null;
 
-    cancel();
+    cancelStreamSubscriptions();
     _service = service;
     autoDispose(service.onIsolateEvent.listen(_handleIsolateEvent));
     autoDispose(service.onDebugEvent.listen(_handleDebugEvent));
@@ -1182,7 +1182,7 @@ class ServiceExtensionManager extends Disposer {
   }
 
   void vmServiceClosed() {
-    cancel();
+    cancelStreamSubscriptions();
     _mainIsolateClosed();
   }
 
@@ -1288,7 +1288,8 @@ class ServiceExtensionManager extends Disposer {
   void vmServiceOpened(
       VmServiceWrapper service, ConnectedApp connectedApp) async {
     _checkForFirstFrameStarted = false;
-    cancel();
+    cancelStreamSubscriptions();
+    cancelListeners();
     _connectedApp = connectedApp;
     _service = service;
     // TODO(kenz): do we want to listen with event history here?

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -394,6 +394,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
         List.generate(dataRoots.length, (index) => dataRoots[index].isExpanded);
     _updateItems();
     _focusNode = FocusNode(debugLabel: 'table');
+    autoDisposeFocusNode(_focusNode);
   }
 
   void expandParents(T parent) {
@@ -431,15 +432,6 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     rootsExpanded =
         List.generate(dataRoots.length, (index) => dataRoots[index].isExpanded);
     _updateItems();
-  }
-
-  @override
-  void dispose() {
-    // TODO(https://github.com/flutter/devtools/issues/3538): Switch to using
-    // autoDisposeFocusNode once we are only canceling  the listeners in
-    // didUpdateWidget.
-    _focusNode.dispose();
-    super.dispose();
   }
 
   void _initData() {

--- a/packages/devtools_app/lib/src/table.dart
+++ b/packages/devtools_app/lib/src/table.dart
@@ -414,7 +414,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
 
     if (widget == oldWidget) return;
 
-    cancel();
+    cancelListeners();
 
     addAutoDisposeListener(selectionNotifier, () {
       setState(() {
@@ -838,7 +838,7 @@ class _TableState<T> extends State<_Table<T>> with AutoDisposeMixin {
   void didUpdateWidget(_Table oldWidget) {
     super.didUpdateWidget(oldWidget);
 
-    cancel();
+    cancelListeners();
 
     // TODO(kenz): pull this code into a helper and also call from initState.
     // Detect selection changes but only care about scrollIntoView.
@@ -1206,7 +1206,7 @@ class _TableRowState<T> extends State<TableRow<T>>
       scrollController = widget.linkedScrollControllerGroup.addAndGet();
     }
 
-    cancel();
+    cancelListeners();
     _initSearchListeners();
   }
 

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -587,7 +587,8 @@ typedef OverlayXPositionBuilder = double Function(
 
 // TODO(elliette) Consider refactoring this mixin to be a widget. See discussion
 // at https://github.com/flutter/devtools/pull/3532#discussion_r767015567.
-mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
+mixin SearchFieldMixin<T extends StatefulWidget>
+    on AutoDisposeMixin<T>, State<T> {
   TextEditingController searchTextFieldController;
   FocusNode _searchFieldFocusNode;
   FocusNode _rawKeyboardFocusNode;
@@ -599,6 +600,8 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
     super.initState();
     _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
     _rawKeyboardFocusNode = FocusNode(debugLabel: 'search-raw-keyboard');
+    autoDisposeFocusNode(_searchFieldFocusNode);
+    autoDisposeFocusNode(_rawKeyboardFocusNode);
 
     searchTextFieldController = TextEditingController();
   }
@@ -611,10 +614,6 @@ mixin SearchFieldMixin<T extends StatefulWidget> on State<T> {
   void dispose() {
     super.dispose();
     searchTextFieldController?.dispose();
-    // TODO(https://github.com/flutter/devtools/issues/3538): Switch to
-    // autoDisposeFocusNode.
-    _searchFieldFocusNode?.dispose();
-    _rawKeyboardFocusNode?.dispose();
   }
 
   /// Platform independent (Mac or Linux).

--- a/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/ui/service_extension_widgets.dart
@@ -100,7 +100,7 @@ class _ServiceExtensionButtonGroupState
   @override
   void didUpdateWidget(ServiceExtensionButtonGroup oldWidget) {
     if (!listEquals(oldWidget.extensions, widget.extensions)) {
-      cancel();
+      cancelListeners();
       _initExtensionState();
       setState(() {});
     }

--- a/packages/devtools_app/lib/src/vm_flags.dart
+++ b/packages/devtools_app/lib/src/vm_flags.dart
@@ -58,7 +58,7 @@ class VmFlagManager extends Disposer {
   }
 
   Future<void> vmServiceOpened(VmServiceWrapper service) async {
-    cancel();
+    cancelStreamSubscriptions();
     _service = service;
     // Upon setting the vm service, get initial values for vm flags.
     await _initFlags();

--- a/packages/devtools_app/lib/src/vm_flags.dart
+++ b/packages/devtools_app/lib/src/vm_flags.dart
@@ -63,7 +63,7 @@ class VmFlagManager extends Disposer {
     // Upon setting the vm service, get initial values for vm flags.
     await _initFlags();
 
-    autoDispose(service.onVMEvent.listen(handleVmEvent));
+    autoDisposeStreamSubscription(service.onVMEvent.listen(handleVmEvent));
   }
 
   void vmServiceClosed() {

--- a/packages/devtools_app/test/auto_dispose_mixin_test.dart
+++ b/packages/devtools_app/test/auto_dispose_mixin_test.dart
@@ -27,7 +27,7 @@ class _AutoDisposedWidgetState extends State<AutoDisposedWidget>
   @override
   void initState() {
     super.initState();
-    autoDispose(widget.stream.listen(_onData));
+    autoDisposeStreamSubscription(widget.stream.listen(_onData));
   }
 
   void _onData(dynamic data) {
@@ -48,10 +48,10 @@ void main() {
       final controller2 = StreamController(sync: true);
       var c1Events = 0;
       var c2Events = 0;
-      disposer.autoDispose(controller1.stream.listen((data) {
+      disposer.autoDisposeStreamSubscription(controller1.stream.listen((data) {
         c1Events++;
       }));
-      disposer.autoDispose(controller2.stream.listen((data) {
+      disposer.autoDisposeStreamSubscription(controller2.stream.listen((data) {
         c2Events++;
       }));
       expect(c1Events, 0);

--- a/packages/devtools_app/test/auto_dispose_mixin_test.dart
+++ b/packages/devtools_app/test/auto_dispose_mixin_test.dart
@@ -63,7 +63,7 @@ void main() {
       controller2.add(null);
       expect(c1Events, 2);
       expect(c2Events, 1);
-      disposer.cancel();
+      disposer.cancelStreamSubscriptions();
 
       // Make sure stream subscriptions are cancelled.
       controller1.add(null);
@@ -89,7 +89,7 @@ void main() {
       expect(values.last, equals(15));
       // ignore: invalid_use_of_protected_member
       expect(notifier.hasListeners, isTrue);
-      disposer.cancel();
+      disposer.cancelListeners();
       // ignore: invalid_use_of_protected_member
       expect(notifier.hasListeners, isFalse);
       notifier.value = 17;
@@ -106,7 +106,7 @@ void main() {
       notifier.value = 19;
       expect(values.length, equals(3));
       expect(values.last, equals(19));
-      disposer.cancel();
+      disposer.cancelListeners();
 
       // ignore: invalid_use_of_protected_member
       expect(notifier.hasListeners, isFalse);
@@ -129,7 +129,7 @@ void main() {
       // After disposal, all notifier methods will throw. Disposer needs
       // to ignore this when cancelling.
       notifier.dispose();
-      expect(() => disposer.cancel(), throwsA(anything));
+      expect(() => disposer.cancelListeners(), throwsA(anything));
       expect(values, [72]);
     });
   });
@@ -176,7 +176,7 @@ void main() {
     expect(values.last, equals(15));
     // ignore: invalid_use_of_protected_member
     expect(notifier.hasListeners, isTrue);
-    controller.cancel();
+    controller.cancelListeners();
     // ignore: invalid_use_of_protected_member
     expect(notifier.hasListeners, isFalse);
     notifier.value = 17;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3538

Follow up to https://github.com/flutter/devtools/pull/3532, this way we can use `autoDisposeFocusNode` in widgets we weren't able to use it in before. 

Also renames the `autoDispose` method to `autoDisposeStreamSubscription` for clarity.