### PR TITLE
Add placeholder for a custom mutation observer script

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -27,6 +27,9 @@
     <script type="text/javascript" src="devtools_analytics.js"></script>	
     <!-- End of DevTools Google Analytics -->
 
+    <!-- DO NOT REMOVE: -->
+    <!-- OBSERVER SCRIPT PLACEHOLDER -->
+
     <script type="text/javascript">
         function supportsES6Classes() {
             "use strict";


### PR DESCRIPTION
Add a placeholder for a mutation observer script in `index.html`. 

This script is needed for google3, and will be added as part of the DevTools roll into google3.