### PR TITLE
Refactors file search to use `FileSearchResults` and `FileQuery` classes 

### DIFF
--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -218,6 +218,7 @@ class FileSearchResults {
     @required this.query,
     @required this.allScripts,
   }) {
+    // ignore: prefer_asserts_in_initializer_lists
     assert(!query.isEmpty);
 
     for (final scriptRef in allScripts) {


### PR DESCRIPTION
Continued work towards https://github.com/flutter/devtools/issues/3554

This change should be a no-op, it simply refactors the FileSearch widget to make it easier to add support for multi-token and regexp search.

This refactor moves logic from the FileSearch widget into two utility classes:
1. `FileQuery`: has methods to determine whether a file path matches the query, and to build an `AutoCompleteMatch` for the file
2. `FileSearchResults`: finds all the matches for a query and provides a `getter` for the top X matches.
