### PR TITLE
Quick fix to survey url parsing bug

### DIFF
--- a/packages/devtools_app/lib/src/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_web.dart
@@ -689,11 +689,19 @@ Map<String, dynamic> generateSurveyQueryParameters() {
   final url = window.location.toString();
   const fromValuePrefix = '#/';
   final startIndex = url.indexOf(fromValuePrefix);
-  final endIndex = url.indexOf('?');
-  final fromPage = url.substring(
-    startIndex + fromValuePrefix.length,
-    endIndex,
-  );
+  // Use the last index because the url can be of the form
+  // 'http://127.0.0.1:9103/?#/?' and we want to be referencing the last '?'
+  // character.
+  final endIndex = url.lastIndexOf('?');
+  var fromPage = '';
+  try {
+    fromPage = url.substring(
+      startIndex + fromValuePrefix.length,
+      endIndex,
+    );
+  } catch (_) {
+    // Fail gracefully if finding the [fromPage] value throws an exception.
+  }
 
   final clientId = flutterClientId;
   final internalValue = (!isExternalBuild).toString();


### PR DESCRIPTION
This is a quick fix that we will try to cherry pick into flutter. The more robust fix is to solve https://github.com/flutter/devtools/issues/2475 and figure out if we can make our url able to be parsed by `Uri.parse`, but this fix will ensure that we do not prevent the DevTools survey from being able to go out (if we can cherry-pick in to flutter that is).