### PR TITLE
Ensure there's no querystring before the fragment when launching the browser from the server

### DIFF
--- a/packages/devtools_server/lib/src/server.dart
+++ b/packages/devtools_server/lib/src/server.dart
@@ -270,19 +270,25 @@ Future<HttpServer?> serveDevTools({
         .replace(queryParameters: queryParameters)
         .toString();
 
+    String page = '';
+
     // If app size parameters are present, open to the standalone `appsize`
     // page, regardless if there is a vm service uri specified. We only check
     // for the presence of [appSizeBase] here because [appSizeTest] may or may
     // not be specified (it should only be present for diffs). If [appSizeTest]
     // is present without [appSizeBase], we will ignore the parameter.
     if (appSizeBase != null) {
-      final startQueryParamIndex = url.indexOf('?');
-      if (startQueryParamIndex != -1) {
-        url = '${url.substring(0, startQueryParamIndex)}'
-            '/#/appsize'
-            '${url.substring(startQueryParamIndex)}';
-      }
+      page = 'appsize';
     }
+
+    // Move any querystring to after the fragment where it's expected.
+    var startQueryParamIndex = url.indexOf('?');
+    if (startQueryParamIndex == -1) {
+      startQueryParamIndex = url.length;
+    }
+    url = '${url.substring(0, startQueryParamIndex)}'
+        '/#/$page'
+        '${url.substring(startQueryParamIndex)}';
 
     try {
       await Chrome.start([url]);


### PR DESCRIPTION
@kenzieschmoll this may fix #2475, though I'm not certain if it's the right fix yet. It seems that when we build a URL here with a querystring, it ends up being left on the URL when the fragment is added. The reason we end up with a `?` is this code:

```
String url = Uri.parse(devToolsUrl)
        .replace(queryParameters: queryParameters)
        .toString();
```

This adds a `?` (before any fragment) even if `queryParameters` is empty.

I tweaked the code to ensure we always have a fragment and the QS is moved after that (which was already happening for appsize, but not other cases) and it seems to work correctly for me now.

Although, a question I haven't figured out yet is who is doing the redirecting... is it Flutter, or DevTools. If it's in DevTools, it may be possible to handle this there (would would also avoid the issue if you manually navigate to `localhost:1234/?`). If it's Flutter it might be less clear.