### PR TITLE
Adds multi-token file search, and prioritizes file name matches over full path matches 

### DIFF
--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -161,7 +161,7 @@ class FileQuery {
     if (isEmpty) return false;
 
     final fileName = _fileName(script.uri);
-    // print('checking if $fileName contains $query');
+
     if (isMultiToken) {
       return tokens.every((token) => fileName.caseInsensitiveContains(token));
     }

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -173,10 +173,10 @@ class FileQuery {
     if (isEmpty) return AutoCompleteMatch(script.uri);
 
     final fileName = _fileName(script.uri);
-    final fileNameIdx = script.uri.lastIndexOf(fileName);
+    final fileNameIndex = script.uri.lastIndexOf(fileName);
     final matchedSegments = _findExactSegments(fileName)
         .map((range) =>
-            Range(range.begin + fileNameIdx, range.end + fileNameIdx))
+            Range(range.begin + fileNameIndex, range.end + fileNameIndex))
         .toList();
     return AutoCompleteMatch(script.uri, matchedSegments: matchedSegments);
   }
@@ -217,10 +217,10 @@ class FileQuery {
           _findFuzzySegments(script.uri, query.replaceAll(' ', ''));
     } else {
       final fileName = _fileName(script.uri);
-      final fileNameIdx = script.uri.lastIndexOf(fileName);
+      final fileNameIndex = script.uri.lastIndexOf(fileName);
       matchedSegments = _findFuzzySegments(fileName, query)
           .map((range) =>
-              Range(range.begin + fileNameIdx, range.end + fileNameIdx))
+              Range(range.begin + fileNameIndex, range.end + fileNameIndex))
           .toList();
     }
 
@@ -230,11 +230,9 @@ class FileQuery {
   List<Range> _findExactSegments(String file) {
     final matchedSegments = <Range>[];
     for (final token in isMultiToken ? tokens : [query]) {
-      final autoCompleteResultSegments = <Range>[];
       final start = file.indexOf(token);
       final end = start + token.length;
-      autoCompleteResultSegments.add(Range(start, end));
-      matchedSegments.addAll(autoCompleteResultSegments);
+      matchedSegments.add(Range(start, end));
     }
     matchedSegments
         .sort((rangeA, rangeB) => rangeA.begin.compareTo(rangeB.begin));

--- a/packages/devtools_app/lib/src/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/debugger/file_search.dart
@@ -83,7 +83,7 @@ class FileSearchFieldState extends State<FileSearchField>
 
   void _handleSearch() {
     final previousQuery = _query;
-    final currentQuery = autoCompleteController.search;
+    final currentQuery = autoCompleteController.search.trim();
 
     // If the current query is a continuation of the previous query, then
     // filter down the previous matches. Otherwise search through all scripts:
@@ -153,8 +153,41 @@ class FileQuery {
 
   bool get isEmpty => query.isEmpty;
 
+  bool get isMultiToken => query.contains(' ');
+
+  List<String> get tokens => query.split(' ');
+
+  bool isExactFileNameMatch(ScriptRef script) {
+    if (isEmpty) return false;
+
+    final fileName = _fileName(script.uri);
+    // print('checking if $fileName contains $query');
+    if (isMultiToken) {
+      return tokens.every((token) => fileName.caseInsensitiveContains(token));
+    }
+
+    return fileName.caseInsensitiveContains(query);
+  }
+
+  AutoCompleteMatch createExactFileNameAutoCompleteMatch(ScriptRef script) {
+    if (isEmpty) return AutoCompleteMatch(script.uri);
+
+    final fileName = _fileName(script.uri);
+    final fileNameIdx = script.uri.lastIndexOf(fileName);
+    final matchedSegments = _findExactSegments(fileName)
+        .map((range) =>
+            Range(range.begin + fileNameIdx, range.end + fileNameIdx))
+        .toList();
+    return AutoCompleteMatch(script.uri, matchedSegments: matchedSegments);
+  }
+
   bool isExactFullPathMatch(ScriptRef script) {
     if (isEmpty) return false;
+
+    if (isMultiToken) {
+      return tokens.every((token) => script.uri.caseInsensitiveContains(token));
+    }
+
     return script.uri.caseInsensitiveContains(query);
   }
 
@@ -168,32 +201,48 @@ class FileQuery {
   bool isFuzzyMatch(ScriptRef script) {
     if (isEmpty) return false;
 
-    final fileName = _fileName(script.uri);
-    return fileName.caseInsensitiveFuzzyMatch(query);
+    if (isMultiToken) {
+      return script.uri.caseInsensitiveFuzzyMatch(query.replaceAll(' ', ''));
+    }
+
+    return _fileName(script.uri).caseInsensitiveFuzzyMatch(query);
   }
 
   AutoCompleteMatch createFuzzyMatchAutoCompleteMatch(ScriptRef script) {
     if (isEmpty) return AutoCompleteMatch(script.uri);
 
-    final fileName = _fileName(script.uri);
-    final fileNameIdx = script.uri.lastIndexOf(fileName);
-    final matchedSegments = _findFuzzySegments(fileName)
-        .map((range) =>
-            Range(range.begin + fileNameIdx, range.end + fileNameIdx))
-        .toList();
+    List<Range> matchedSegments;
+    if (isMultiToken) {
+      matchedSegments =
+          _findFuzzySegments(script.uri, query.replaceAll(' ', ''));
+    } else {
+      final fileName = _fileName(script.uri);
+      final fileNameIdx = script.uri.lastIndexOf(fileName);
+      matchedSegments = _findFuzzySegments(fileName, query)
+          .map((range) =>
+              Range(range.begin + fileNameIdx, range.end + fileNameIdx))
+          .toList();
+    }
 
     return AutoCompleteMatch(script.uri, matchedSegments: matchedSegments);
   }
 
   List<Range> _findExactSegments(String file) {
-    final autoCompleteResultSegments = <Range>[];
-    final start = file.indexOf(query);
-    final end = start + query.length;
-    autoCompleteResultSegments.add(Range(start, end));
-    return autoCompleteResultSegments;
+    final matchedSegments = <Range>[];
+    for (final token in isMultiToken ? tokens : [query]) {
+      final autoCompleteResultSegments = <Range>[];
+      final start = file.indexOf(token);
+      final end = start + token.length;
+      autoCompleteResultSegments.add(Range(start, end));
+      matchedSegments.addAll(autoCompleteResultSegments);
+    }
+    matchedSegments
+        .sort((rangeA, rangeB) => rangeA.begin.compareTo(rangeB.begin));
+
+    return matchedSegments;
   }
 
-  List<Range> _findFuzzySegments(String file) {
+  List<Range> _findFuzzySegments(String file, String query) {
     final autoCompleteResultSegments = <Range>[];
     var queryIndex = 0;
     for (int matchIndex = 0; matchIndex < file.length; matchIndex++) {
@@ -218,6 +267,7 @@ class FileSearchResults {
     return FileSearchResults._(
       query: FileQuery.empty(),
       allScripts: allScripts,
+      exactFileNameMatches: [],
       exactFullPathMatches: [],
       fuzzyMatches: [],
     );
@@ -228,11 +278,14 @@ class FileSearchResults {
     @required List<ScriptRef> allScripts,
   }) {
     assert(!query.isEmpty);
+    final List<ScriptRef> exactFileNameMatches = [];
     final List<ScriptRef> exactFullPathMatches = [];
     final List<ScriptRef> fuzzyMatches = [];
 
     for (final scriptRef in allScripts) {
-      if (query.isExactFullPathMatch(scriptRef)) {
+      if (query.isExactFileNameMatch(scriptRef)) {
+        exactFileNameMatches.add(scriptRef);
+      } else if (query.isExactFullPathMatch(scriptRef)) {
         exactFullPathMatches.add(scriptRef);
       } else if (query.isFuzzyMatch(scriptRef)) {
         fuzzyMatches.add(scriptRef);
@@ -242,6 +295,7 @@ class FileSearchResults {
     return FileSearchResults._(
       query: query,
       allScripts: allScripts,
+      exactFileNameMatches: exactFileNameMatches,
       exactFullPathMatches: exactFullPathMatches,
       fuzzyMatches: fuzzyMatches,
     );
@@ -250,24 +304,35 @@ class FileSearchResults {
   FileSearchResults._({
     @required this.query,
     @required this.allScripts,
+    @required List<ScriptRef> exactFileNameMatches,
     @required List<ScriptRef> exactFullPathMatches,
     @required List<ScriptRef> fuzzyMatches,
-  })  : _exactFullPathMatches = exactFullPathMatches,
+  })  : _exactFileNameMatches = exactFileNameMatches,
+        _exactFullPathMatches = exactFullPathMatches,
         _fuzzyMatches = fuzzyMatches;
 
   final List<ScriptRef> allScripts;
   final FileQuery query;
+  final List<ScriptRef> _exactFileNameMatches;
   final List<ScriptRef> _exactFullPathMatches;
   final List<ScriptRef> _fuzzyMatches;
 
   FileSearchResults get topMatches => _buildTopMatches();
 
-  List<ScriptRef> get scriptRefs =>
-      query.isEmpty ? allScripts : [..._exactFullPathMatches, ..._fuzzyMatches];
+  List<ScriptRef> get scriptRefs => query.isEmpty
+      ? allScripts
+      : [
+          ..._exactFileNameMatches,
+          ..._exactFullPathMatches,
+          ..._fuzzyMatches,
+        ];
 
   List<AutoCompleteMatch> get autoCompleteMatches => query.isEmpty
       ? allScripts.map((script) => AutoCompleteMatch(script.uri)).toList()
       : [
+          ..._exactFileNameMatches
+              .map(query.createExactFileNameAutoCompleteMatch)
+              .toList(),
           ..._exactFullPathMatches
               .map(query.createExactFullPathAutoCompleteMatch)
               .toList(),
@@ -279,12 +344,14 @@ class FileSearchResults {
   FileSearchResults copyWith({
     List<ScriptRef> allScripts,
     FileQuery query,
+    List<ScriptRef> exactFileNameMatches,
     List<ScriptRef> exactFullPathMatches,
     List<ScriptRef> fuzzyMatches,
   }) {
     return FileSearchResults._(
       query: query ?? this.query,
       allScripts: allScripts ?? this.allScripts,
+      exactFileNameMatches: exactFileNameMatches ?? _exactFileNameMatches,
       exactFullPathMatches: exactFullPathMatches ?? _exactFullPathMatches,
       fuzzyMatches: fuzzyMatches ?? _fuzzyMatches,
     );
@@ -303,15 +370,20 @@ class FileSearchResults {
 
     final topMatches = [];
     int matchesLeft = numOfMatchesToShow;
-    for (final matches in [_exactFullPathMatches, _fuzzyMatches]) {
+    for (final matches in [
+      _exactFileNameMatches,
+      _exactFullPathMatches,
+      _fuzzyMatches
+    ]) {
       final selected = _takeMatches(matches, matchesLeft);
       topMatches.add(selected);
       matchesLeft -= selected.length;
     }
 
     return copyWith(
-      exactFullPathMatches: topMatches[0],
-      fuzzyMatches: topMatches[1],
+      exactFileNameMatches: topMatches[0],
+      exactFullPathMatches: topMatches[1],
+      fuzzyMatches: topMatches[2],
     );
   }
 

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -68,15 +68,16 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
+            'zoo:animals/insects/Caterpillar.dart',
+            'zoo:animals/insects/Cicada.dart',
+            'kitchen:food/milk/Carton.dart',
+            'travel:adventure/Cave_tours_europe.dart',
+            // Exact full path matches:
             'zoo:animals/Cats/meow.dart',
             'zoo:animals/Cats/purr.dart',
-            'zoo:animals/inseCts/caterpillar.dart',
-            'zoo:animals/inseCts/cicada.dart',
             'kitChen:food/catering/party.dart',
             'kitChen:food/carton/milk.dart',
-            'kitChen:food/milk/carton.dart',
-            'travel:adventure/Cave_tours_europe.dart',
             'travel:Canada/banff.dart'
           ],
         ),
@@ -89,15 +90,16 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
-            'zoo:animals/CAts/meow.dart',
-            'zoo:animals/CAts/purr.dart',
+            // Exact file name matches:
             'zoo:animals/insects/CAterpillar.dart',
             'zoo:animals/insects/ciCAda.dart',
-            'kitchen:food/CAtering/party.dart',
-            'kitchen:food/CArton/milk.dart',
             'kitchen:food/milk/CArton.dart',
             'travel:adventure/CAve_tours_europe.dart',
+            // Exact full path matches:
+            'zoo:animals/CAts/meow.dart',
+            'zoo:animals/CAts/purr.dart',
+            'kitchen:food/CAtering/party.dart',
+            'kitchen:food/CArton/milk.dart',
             'travel:CAnada/banff.dart'
           ],
         ),
@@ -110,10 +112,11 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
+            'zoo:animals/insects/CATerpillar.dart',
+            // Exact full path matches:
             'zoo:animals/CATs/meow.dart',
             'zoo:animals/CATs/purr.dart',
-            'zoo:animals/insects/CATerpillar.dart',
             'kitchen:food/CATering/party.dart',
             // Fuzzy matches:
             'zoo:animals/insects/CicAda.darT',
@@ -130,8 +133,9 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
             'zoo:animals/insects/CATErpillar.dart',
+            // Exact full path matches:
             'kitchen:food/CATEring/party.dart',
             // Fuzzy matches:
             'travel:adventure/CAve_Tours_Europe.dart'
@@ -146,8 +150,9 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
             'zoo:animals/insects/CATERpillar.dart',
+            // Exact full path matches:
             'kitchen:food/CATERing/party.dart',
             // Fuzzy matches:
             'travel:adventure/CAve_Tours_EuRope.dart'
@@ -162,7 +167,7 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
             'zoo:animals/insects/CATERPillar.dart',
             // Fuzzy matches:
             'travel:adventure/CAve_Tours_EuRoPe.dart'
@@ -177,7 +182,7 @@ void main() {
         ),
         equals(
           [
-            // Exact matches:
+            // Exact file name matches:
             'zoo:animals/insects/CATERPIllar.dart',
           ],
         ),
@@ -185,6 +190,190 @@ void main() {
 
       autoCompleteController.search = 'caterpie';
       expect(autoCompleteController.searchAutoComplete.value, equals([]));
+    });
+
+    testWidgetsWithWindowSize(
+        'Multi token search returns expected files', const Size(1000.0, 4000.0),
+        (WidgetTester tester) async {
+      await tester.pumpWidget(buildFileSearch());
+      final FileSearchFieldState state =
+          tester.state(find.byType(FileSearchField));
+      final autoCompleteController = state.autoCompleteController;
+
+      autoCompleteController.search = '';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Show all results (truncated to 10):
+            'zoo:animals/cats/meow.dart',
+            'zoo:animals/cats/purr.dart',
+            'zoo:animals/dogs/bark.dart',
+            'zoo:animals/dogs/growl.dart',
+            'zoo:animals/insects/caterpillar.dart',
+            'zoo:animals/insects/cicada.dart',
+            'kitchen:food/catering/party.dart',
+            'kitchen:food/carton/milk.dart',
+            'kitchen:food/milk/carton.dart',
+            'travel:adventure/cave_tours_europe.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'f';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact file name matches:
+            'travel:canada/banFf.dart',
+            // Exact full path matches:
+            'kitchen:Food/catering/party.dart',
+            'kitchen:Food/carton/milk.dart',
+            'kitchen:Food/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'fo';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOod/catering/party.dart',
+            'kitchen:FOod/carton/milk.dart',
+            'kitchen:FOod/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'foo';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOd/catering/party.dart',
+            'kitchen:FOOd/carton/milk.dart',
+            'kitchen:FOOd/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/catering/party.dart',
+            'kitchen:FOOD/carton/milk.dart',
+            'kitchen:FOOD/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food ';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/catering/party.dart',
+            'kitchen:FOOD/carton/milk.dart',
+            'kitchen:FOOD/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food c';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitChen:FOOD/catering/party.dart',
+            'kitChen:FOOD/carton/milk.dart',
+            'kitChen:FOOD/milk/carton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food ca';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/CAtering/party.dart',
+            'kitchen:FOOD/CArton/milk.dart',
+            'kitchen:FOOD/milk/CArton.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food car';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/CARton/milk.dart',
+            'kitchen:FOOD/milk/CARton.dart',
+            // Fuzzy matches:
+            'kitchen:FOOD/CAteRing/party.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food cart';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/CARTon/milk.dart',
+            'kitchen:FOOD/milk/CARTon.dart',
+            // Fuzzy matches:
+            'kitchen:FOOD/CAteRing/parTy.dart',
+          ],
+        ),
+      );
+
+      autoCompleteController.search = 'food carto';
+      expect(
+        getAutoCompleteMatch(
+          autoCompleteController.searchAutoComplete.value,
+        ),
+        equals(
+          [
+            // Exact full path matches:
+            'kitchen:FOOD/CARTOn/milk.dart',
+            'kitchen:FOOD/milk/CARTOn.dart',
+          ],
+        ),
+      );
     });
   });
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/3554

This PR makes two changes to the existing file search:
1. Adds the ability for a user to do a multi-token search, eg. `"devtools_app file search"`
2. Prioritizes matches on the file name over the full path, e.g. for query `"debugger"`, `devtools/debugger.dart` is shown before `debugger/file_search.dart`
