### PR TITLE
Update release_notes.dart

### DIFF
--- a/packages/devtools_app/lib/src/release_notes.dart
+++ b/packages/devtools_app/lib/src/release_notes.dart
@@ -6,10 +6,14 @@ import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:http/http.dart' as http;
 
 import '../devtools.dart' as devtools;
-import '../devtools_app.dart';
+import 'auto_dispose_mixin.dart';
+import 'common_widgets.dart';
 import 'config_specific/launch_url/launch_url.dart';
 import 'config_specific/logger/logger.dart' as logger;
 import 'config_specific/server/server.dart' as server;
+import 'theme.dart';
+import 'utils.dart';
+import 'version.dart';
 
 class ReleaseNotesViewer extends StatefulWidget {
   const ReleaseNotesViewer({


### PR DESCRIPTION
Fix circular dependency between src and devtools_app.dart. The library release_notes.dart in src should not reference devtools_app.dart.

![chart](https://user-images.githubusercontent.com/12115586/151236544-81a5ab70-ef37-4d20-b824-b5c52a228136.png)

## Pre-launch Checklist

- [ v ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ v ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ v ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ v ] I signed the [CLA].
- [ v ] I listed at least one issue that this PR fixes in the description above.
- [ v ] I updated/added relevant documentation (doc comments with `///`).
- [ v ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ v ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
