### PR TITLE
Fix a null ref in CPU Profile when using offline snapshots with no connection

### DIFF
--- a/packages/devtools_app/lib/src/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/profiler/profiler_screen.dart
@@ -170,7 +170,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
         textAlign: TextAlign.center,
         text: TextSpan(
           text: 'No CPU samples recorded.',
-          children: serviceManager.vm.operatingSystem == 'ios'
+          children: serviceManager.vm?.operatingSystem == 'ios'
               ? [
                   const TextSpan(
                     text: '''


### PR DESCRIPTION
When using an offline snapshot, `serviceManager.vm` seems to be null here, so this throws (although it's only shown if there are no CPU samples, the widget is always constructed so this code always executes).

Fixes #3595.
