### PR TITLE
Show warning for internal Flutter Web apps

### DIFF
--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -9,7 +9,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:url_launcher/url_launcher.dart';
 
 import '../analytics/analytics.dart' as ga;
 import '../config_specific/launch_url/launch_url.dart';

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1787,20 +1787,21 @@ class InternalFlutterWebWarningText extends StatelessWidget {
         children: [
           TextSpan(
               text:
-                  'Warning: Flutter DevTools is not currently supported for Flutter Web apps.\n\n',
+                  'Warning: Flutter DevTools is currently not supported for Flutter Web apps.\n\n',
               style: theme.subtleTextStyle
                   .copyWith(color: theme.colorScheme.errorTextColor)),
           TextSpan(
               text: 'Some debugging features might not work as expected.\n',
               style: theme.subtleTextStyle),
           TextSpan(text: 'See ', style: theme.subtleTextStyle),
-          TextSpan(
-              text: 'b/204213138',
-              style: theme.linkTextStyle,
-              recognizer: TapGestureRecognizer()
-                ..onTap = () async {
-                  await launch('https://b.corp.google.com/issues/204213138');
-                }),
+          LinkTextSpan(
+            link: const Link(
+              display: 'b/204213138',
+              url: 'https://b.corp.google.com/issues/204213138',
+            ),
+            context: context,
+            style: theme.linkTextStyle,
+          ),
           TextSpan(text: ' for details.', style: theme.subtleTextStyle),
         ],
       ),

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -9,6 +9,7 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../analytics/analytics.dart' as ga;
 import '../config_specific/launch_url/launch_url.dart';
@@ -1769,6 +1770,38 @@ class PubWarningText extends StatelessWidget {
             text: '\ncommand.',
             style: theme.subtleTextStyle,
           ),
+        ],
+      ),
+    );
+  }
+}
+
+class InternalFlutterWebWarningText extends StatelessWidget {
+  const InternalFlutterWebWarningText({Key key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return RichText(
+      text: TextSpan(
+        children: [
+          TextSpan(
+              text:
+                  'Warning: Flutter DevTools is not currently supported for Flutter Web apps.\n\n',
+              style: theme.subtleTextStyle
+                  .copyWith(color: theme.colorScheme.errorTextColor)),
+          TextSpan(
+              text: 'Some debugging features might not work as expected.\n',
+              style: theme.subtleTextStyle),
+          TextSpan(text: 'See ', style: theme.subtleTextStyle),
+          TextSpan(
+              text: 'b/204213138',
+              style: theme.linkTextStyle,
+              recognizer: TapGestureRecognizer()
+                ..onTap = () async {
+                  await launch('https://b.corp.google.com/issues/204213138');
+                }),
+          TextSpan(text: ' for details.', style: theme.subtleTextStyle),
         ],
       ),
     );

--- a/packages/devtools_app/lib/src/shared/scaffold.dart
+++ b/packages/devtools_app/lib/src/shared/scaffold.dart
@@ -138,48 +138,67 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
 
     _initTitle();
     _maybeShowPubWarning();
+    _maybeShowInternalFlutterWebWarning();
   }
 
   bool _pubWarningShown = false;
+
+  bool _internalFlutterWebWarningShown = false;
+
+  void _maybeShowInternalFlutterWebWarning() {
+    if (isExternalBuild) return;
+    if (_internalFlutterWebWarningShown) return;
+
+    serviceManager.onConnectionAvailable?.listen((_) {
+      if (serviceManager.connectedApp.isFlutterWebAppNow) {
+        _showWarning(const InternalFlutterWebWarningText());
+        _internalFlutterWebWarningShown = true;
+      }
+    });
+  }
 
   // TODO(kenz): remove the pub warning code after devtools version 2.8.0 ships
   void _maybeShowPubWarning() {
     if (!_pubWarningShown) {
       serviceManager.onConnectionAvailable?.listen((event) {
         if (shouldShowPubWarning()) {
-          final colorScheme = Theme.of(context).colorScheme;
-          OverlayEntry _entry;
-          Overlay.of(context).insert(
-            _entry = OverlayEntry(
-              maintainState: true,
-              builder: (context) {
-                return Material(
-                  color: colorScheme.overlayShadowColor,
-                  child: Center(
-                    child: Container(
-                      padding: const EdgeInsets.all(defaultSpacing),
-                      color: colorScheme.overlayBackgroundColor,
-                      child: Column(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const PubWarningText(),
-                          const SizedBox(height: defaultSpacing),
-                          ElevatedButton(
-                            child: const Text('Got it'),
-                            onPressed: () => _entry.remove(),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                );
-              },
-            ),
-          );
+          _showWarning(const PubWarningText());
           _pubWarningShown = true;
         }
       });
     }
+  }
+
+  void _showWarning(Widget warningText) {
+    final colorScheme = Theme.of(context).colorScheme;
+    OverlayEntry _entry;
+    Overlay.of(context).insert(
+      _entry = OverlayEntry(
+        maintainState: true,
+        builder: (context) {
+          return Material(
+            color: colorScheme.overlayShadowColor,
+            child: Center(
+              child: Container(
+                padding: const EdgeInsets.all(defaultSpacing),
+                color: colorScheme.overlayBackgroundColor,
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    warningText,
+                    const SizedBox(height: defaultSpacing),
+                    ElevatedButton(
+                      child: const Text('Got it'),
+                      onPressed: () => _entry.remove(),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
   }
 
   @override


### PR DESCRIPTION
Shows a warning that Flutter DevTools is not supported for internal Flutter Web apps, and includes a link to the bug. 

The warning is shown when a user first opens Flutter DevTools:


![Screen Shot 2022-01-27 at 11 47 21 AM](https://user-images.githubusercontent.com/21270878/151434499-76e1cfff-0cc9-4629-a536-304ab301cc0f.png)


Resolves https://github.com/flutter/devtools/issues/3593
