### PR TITLE
Add an assert and error logging to debug why opening a file sometimes doesn't work

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -213,6 +213,9 @@ class DebuggerController extends DisposableController
   /// history).
   void _showScriptLocation(ScriptLocation scriptLocation) {
     _currentScriptRef.value = scriptLocation?.scriptRef;
+    if (_currentScriptRef.value == null) {
+      log('Trying to show a location with a null script ref', LogLevel.error);
+    }
 
     _parseCurrentScript();
 

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -73,7 +73,10 @@ class GenericInstanceRef {
 
 /// A tuple of a script and an optional location.
 class ScriptLocation {
-  ScriptLocation(this.scriptRef, {this.location});
+  ScriptLocation(
+    this.scriptRef, {
+    this.location,
+  }) : assert(scriptRef != null);
 
   final ScriptRef scriptRef;
 


### PR DESCRIPTION
Continued work towards https://github.com/flutter/devtools/issues/3457

When we try to open a file and it fails, we handle it by showing the empty state debugger page, but we don't log any errors indicating what went wrong. However, the empty state page is only shown if the `scriptRef` is null, so we should be able to check for that. I've added some `asserts` / `logs` to make debugging easier when we run into this again (I wasn't able to reproduce it myself).  