### PR TITLE
Focus workaround so that keyboard shortcuts always work

### DIFF
--- a/packages/devtools_app/lib/src/shared/scaffold.dart
+++ b/packages/devtools_app/lib/src/shared/scaffold.dart
@@ -546,7 +546,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   }
 }
 
-class KeyboardShortcuts extends StatelessWidget {
+class KeyboardShortcuts extends StatefulWidget {
   const KeyboardShortcuts({
     @required this.keyboardShortcuts,
     @required this.child,
@@ -557,15 +557,35 @@ class KeyboardShortcuts extends StatelessWidget {
   final Widget child;
 
   @override
+  KeyboardShortcutsState createState() => KeyboardShortcutsState();
+}
+
+class KeyboardShortcutsState extends State<KeyboardShortcuts>
+    with AutoDisposeMixin {
+  FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusNode = FocusNode(debugLabel: 'keyboard-shortcuts');
+    autoDisposeFocusNode(_focusNode);
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (keyboardShortcuts.isEmpty) {
-      return child;
+    if (widget.keyboardShortcuts.isEmpty) {
+      return widget.child;
     }
-    return Shortcuts(
-      shortcuts: keyboardShortcuts.shortcuts,
-      child: Actions(
-        actions: keyboardShortcuts.actions,
-        child: child,
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () => FocusScope.of(context).requestFocus(_focusNode),
+      child: FocusableActionDetector(
+        child: widget.child,
+        shortcuts: widget.keyboardShortcuts.shortcuts,
+        actions: widget.keyboardShortcuts.actions,
+        autofocus: true,
+        focusNode: _focusNode,
       ),
     );
   }


### PR DESCRIPTION
Continued work on https://github.com/flutter/devtools/issues/3457

This change is a workaround to avoid the behavior described in https://github.com/flutter/flutter/issues/97389. It adds a `GestureDetector` that detects click events anywhere on the screen (that isn't already a focusable widget), and moves the focus to the keyboard shortcuts instead.

With this change, a user can do things like resize the console and still use keyboard shortcuts afterwards (this wasn't working before):
![Jan-27-2022 17-50-26](https://user-images.githubusercontent.com/21270878/151473250-391a3b12-4109-4eaf-a58e-fe2c76dc21ff.gif)


