### PR TITLE
Keep mapping of thread ids to thread names up to date

### DIFF
--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -576,6 +576,11 @@ class PerformanceController extends DisposableController
     List<TraceEventWrapper> traceEvents, {
     bool isInitialUpdate = false,
   }) {
+    final isFlutterApp = offlineController.offlineMode.value
+        ? offlinePerformanceData != null &&
+            offlinePerformanceData.frames.isNotEmpty
+        : serviceManager.connectedApp.isFlutterAppNow;
+
     final threadNameEvents = traceEvents
         .map((TraceEventWrapper wrapper) => wrapper.event)
         .where((TraceEvent event) {
@@ -589,7 +594,7 @@ class PerformanceController extends DisposableController
     for (TraceEvent event in threadNameEvents) {
       final name = event.args['name'];
 
-      if (isInitialUpdate) {
+      if (isFlutterApp && isInitialUpdate) {
         // Android: "1.ui (12652)"
         // iOS: "io.flutter.1.ui (12652)"
         // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
@@ -621,7 +626,7 @@ class PerformanceController extends DisposableController
       threadNamesById[event.threadId] = name;
     }
 
-    if (isInitialUpdate) {
+    if (isFlutterApp && isInitialUpdate) {
       if (uiThreadId == null || rasterThreadId == null) {
         log('Could not find UI thread and / or Raster thread from names: '
             '${threadNamesById.values}');
@@ -862,6 +867,7 @@ class PerformanceController extends DisposableController
     allTraceEvents.clear();
     offlinePerformanceData = null;
     cpuProfilerController.reset();
+    threadNamesById.clear();
     data?.clear();
     processor?.reset();
     _flutterFrames.clear();

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -8,7 +8,7 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:vm_service/vm_service.dart' as vm_service;
+import 'package:pedantic/pedantic.dart';
 
 import '../analytics/analytics.dart' as ga;
 import '../analytics/constants.dart' as analytics_constants;
@@ -250,7 +250,7 @@ class PerformanceController extends DisposableController
       }));
 
       // Load available timeline events.
-      await _pullTraceEventsFromVmTimeline(shouldPrimeThreadIds: true);
+      await _pullTraceEventsFromVmTimeline(isInitialPull: true);
 
       _processing.value = true;
       await processTraceEvents(allTraceEvents);
@@ -280,7 +280,7 @@ class PerformanceController extends DisposableController
   }
 
   Future<void> _pullTraceEventsFromVmTimeline({
-    bool shouldPrimeThreadIds = false,
+    bool isInitialPull = false,
   }) async {
     final currentVmTime = await serviceManager.service.getVMTimelineMicros();
     debugTraceEventCallback(
@@ -295,16 +295,18 @@ class PerformanceController extends DisposableController
     );
     _nextPollStartMicros = currentVmTime.timestamp + 1;
 
-    // TODO(kenz): move this priming logic into the loop below.
-    if (shouldPrimeThreadIds) primeThreadIds(timeline);
+    final traceEvents = <TraceEventWrapper>[];
     for (final event in timeline.traceEvents) {
       final eventWrapper = TraceEventWrapper(
         TraceEvent(event.json),
         DateTime.now().millisecondsSinceEpoch,
       );
+      traceEvents.add(eventWrapper);
       allTraceEvents.add(eventWrapper);
       debugTraceEventCallback(() => log(eventWrapper.event.json));
     }
+
+    updateThreadIds(traceEvents, isInitialUpdate: isInitialPull);
   }
 
   FutureOr<void> processAvailableEvents() async {
@@ -570,10 +572,12 @@ class PerformanceController extends DisposableController
     }
   }
 
-  void primeThreadIds(vm_service.Timeline timeline) {
-    threadNamesById.clear();
-    final threadNameEvents = timeline.traceEvents
-        .map((event) => TraceEvent(event.json))
+  void updateThreadIds(
+    List<TraceEventWrapper> traceEvents, {
+    bool isInitialUpdate = false,
+  }) {
+    final threadNameEvents = traceEvents
+        .map((TraceEventWrapper wrapper) => wrapper.event)
         .where((TraceEvent event) {
       return event.phase == 'M' && event.name == 'thread_name';
     }).toList();
@@ -585,45 +589,49 @@ class PerformanceController extends DisposableController
     for (TraceEvent event in threadNameEvents) {
       final name = event.args['name'];
 
-      // Android: "1.ui (12652)"
-      // iOS: "io.flutter.1.ui (12652)"
-      // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
-      if (name.contains('.ui')) {
-        uiThreadId = event.threadId;
-      }
+      if (isInitialUpdate) {
+        // Android: "1.ui (12652)"
+        // iOS: "io.flutter.1.ui (12652)"
+        // MacOS, Linux, Windows, Dream (g3): "io.flutter.ui (225695)"
+        if (name.contains('.ui')) {
+          uiThreadId = event.threadId;
+        }
 
-      // Android: "1.raster (12651)"
-      // iOS: "io.flutter.1.raster (12651)"
-      // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
-      // MacOS: Does not exist
-      // Also look for .gpu here for older versions of Flutter.
-      // TODO(kenz): remove check for .gpu name in April 2021.
-      if (name.contains('.raster') || name.contains('.gpu')) {
-        rasterThreadId = event.threadId;
-      }
+        // Android: "1.raster (12651)"
+        // iOS: "io.flutter.1.raster (12651)"
+        // Linux, Windows, Dream (g3): "io.flutter.raster (12651)"
+        // MacOS: Does not exist
+        // Also look for .gpu here for older versions of Flutter.
+        // TODO(kenz): remove check for .gpu name in April 2021.
+        if (name.contains('.raster') || name.contains('.gpu')) {
+          rasterThreadId = event.threadId;
+        }
 
-      // Android: "1.platform (22585)"
-      // iOS: "io.flutter.1.platform (22585)"
-      // MacOS, Linux, Windows, Dream (g3): "io.flutter.platform (22596)"
-      if (name.contains('.platform')) {
-        // MacOS and Flutter apps with platform views do not have a .gpu thread.
-        // In these cases, the "Raster" events will come on the .platform thread
-        // instead.
-        rasterThreadId ??= event.threadId;
+        // Android: "1.platform (22585)"
+        // iOS: "io.flutter.1.platform (22585)"
+        // MacOS, Linux, Windows, Dream (g3): "io.flutter.platform (22596)"
+        if (name.contains('.platform')) {
+          // MacOS and Flutter apps with platform views do not have a .gpu
+          // thread. In these cases, the "Raster" events will come on the
+          // .platform thread instead.
+          rasterThreadId ??= event.threadId;
+        }
       }
 
       threadNamesById[event.threadId] = name;
     }
 
-    if (uiThreadId == null || rasterThreadId == null) {
-      log('Could not find UI thread and / or Raster thread from names: '
-          '${threadNamesById.values}');
-    }
+    if (isInitialUpdate) {
+      if (uiThreadId == null || rasterThreadId == null) {
+        log('Could not find UI thread and / or Raster thread from names: '
+            '${threadNamesById.values}');
+      }
 
-    processor.primeThreadIds(
-      uiThreadId: uiThreadId,
-      rasterThreadId: rasterThreadId,
-    );
+      processor.primeThreadIds(
+        uiThreadId: uiThreadId,
+        rasterThreadId: rasterThreadId,
+      );
+    }
   }
 
   void addTimelineEvent(TimelineEvent event) {


### PR DESCRIPTION
This change updates the map of known threads each time new
timeline data is loaded.

The timeline lanes of threads that did not exist when the first batch of
timeline data was loaded were previously labeled `Unknown`. Now
they have the same labeling as other threads.

Fixes #1881