### PR TITLE
Update dependencies to null-safe, except ansicolor.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -18,13 +18,13 @@ environment:
   flutter: '>=1.10.0'
 
 dependencies:
-  ansi_up: ^0.0.2
+  ansi_up: ^1.0.0
   #     path: ../../third_party/packages/ansi_up
   # Pin ansicolor to version before pre-NNBD version 1.1.0, should be ^1.0.5
   # See https://github.com/flutter/devtools/issues/2530
   ansicolor: 1.0.5
   async: ^2.0.0
-  codicon: ^0.0.3
+  codicon: ^1.0.0
   collection: ^1.15.0
   dds: ^2.2.0
   dds_service_extensions: ^1.3.0
@@ -53,10 +53,10 @@ dependencies:
   sse: ^4.0.0
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0
-  url_launcher: ^5.0.0
-  url_launcher_web: ^0.1.1+6
+  url_launcher: ^6.0.18
+  url_launcher_web: ^2.0.6
   vm_service: ^8.1.0
-  vm_snapshot_analysis: ^0.6.0
+  vm_snapshot_analysis: ^0.7.1
   web_socket_channel: ^2.1.0
   # widget_icons: ^0.0.1
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   pedantic: ^1.11.0
   provider: ^5.0.0
   vm_service: ^8.1.0
-  vm_snapshot_analysis: ^0.6.0
+  vm_snapshot_analysis: ^0.7.1
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 
 dependency_overrides:


### PR DESCRIPTION
ansicolor has breaking change, so it will be updated in a separate PR