### PR TITLE
Migrate linked_scroll_controller to null safety.

### DIFF
--- a/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
@@ -216,8 +216,7 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     required ScrollContext context,
     double? initialPixels,
     ScrollPosition? oldPosition,
-  })  : assert(owner != null),
-        super(
+  }) : super(
           physics: physics,
           context: context,
           initialPixels: initialPixels,
@@ -347,7 +346,7 @@ class _LinkedScrollActivity extends ScrollActivity {
   void unlink(_LinkedScrollPosition driver) {
     drivers.remove(driver);
     if (drivers.isEmpty) {
-      delegate?.goIdle();
+      delegate.goIdle();
     }
   }
 

--- a/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
@@ -29,8 +29,8 @@ class LinkedScrollControllerGroup {
 
   final _allControllers = <_LinkedScrollController>[];
 
-  ChangeNotifier get offsetNotifier => _offsetNotifier;
-  _LinkedScrollControllerGroupOffsetNotifier _offsetNotifier;
+  ChangeNotifier/*!*/ get offsetNotifier => _offsetNotifier;
+  _LinkedScrollControllerGroupOffsetNotifier/*!*/ _offsetNotifier;
 
   bool get hasAttachedControllers => _attachedControllers.isNotEmpty;
 
@@ -166,7 +166,7 @@ class _LinkedScrollController extends ScrollController {
 
   @override
   _LinkedScrollPosition createScrollPosition(ScrollPhysics physics,
-      ScrollContext context, ScrollPosition oldPosition) {
+      ScrollContext context, ScrollPosition/*!*/ oldPosition) {
     return _LinkedScrollPosition(
       this,
       physics: physics,

--- a/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 
@@ -29,8 +27,8 @@ class LinkedScrollControllerGroup {
 
   final _allControllers = <_LinkedScrollController>[];
 
-  ChangeNotifier/*!*/ get offsetNotifier => _offsetNotifier;
-  _LinkedScrollControllerGroupOffsetNotifier/*!*/ _offsetNotifier;
+  ChangeNotifier get offsetNotifier => _offsetNotifier;
+  late final _LinkedScrollControllerGroupOffsetNotifier _offsetNotifier;
 
   bool get hasAttachedControllers => _attachedControllers.isNotEmpty;
 
@@ -82,8 +80,8 @@ class LinkedScrollControllerGroup {
   /// Animates the scroll position of all linked controllers to [offset].
   Future<void> animateTo(
     double offset, {
-    @required Curve curve,
-    @required Duration duration,
+    required Curve curve,
+    required Duration duration,
   }) async {
     // All scroll controllers are already linked with their peers, so we only
     // need to interact with one controller to mirror the interaction with all
@@ -126,7 +124,7 @@ class _LinkedScrollControllerGroupOffsetNotifier extends ChangeNotifier {
   /// The cached offset for the group.
   ///
   /// This value will be used in determining whether to notify listeners.
-  double _cachedOffset;
+  double? _cachedOffset;
 
   @override
   void notifyListeners() {
@@ -141,7 +139,8 @@ class _LinkedScrollControllerGroupOffsetNotifier extends ChangeNotifier {
 /// A scroll controller that mirrors its movements to a peer, which must also
 /// be a [_LinkedScrollController].
 class _LinkedScrollController extends ScrollController {
-  _LinkedScrollController(this._controllers, {double initialScrollOffset})
+  _LinkedScrollController(this._controllers,
+      {required double initialScrollOffset})
       : super(initialScrollOffset: initialScrollOffset);
 
   final LinkedScrollControllerGroup _controllers;
@@ -158,7 +157,8 @@ class _LinkedScrollController extends ScrollController {
         position is _LinkedScrollPosition,
         '_LinkedScrollControllers can only be used with'
         ' _LinkedScrollPositions.');
-    final _LinkedScrollPosition linkedPosition = position;
+    final _LinkedScrollPosition linkedPosition =
+        position as _LinkedScrollPosition;
     assert(linkedPosition.owner == this,
         '_LinkedScrollPosition cannot change controllers once created.');
     super.attach(position);
@@ -166,7 +166,7 @@ class _LinkedScrollController extends ScrollController {
 
   @override
   _LinkedScrollPosition createScrollPosition(ScrollPhysics physics,
-      ScrollContext context, ScrollPosition/*!*/ oldPosition) {
+      ScrollContext context, ScrollPosition? oldPosition) {
     return _LinkedScrollPosition(
       this,
       physics: physics,
@@ -177,7 +177,7 @@ class _LinkedScrollController extends ScrollController {
   }
 
   @override
-  _LinkedScrollPosition get position => super.position;
+  _LinkedScrollPosition get position => super.position as _LinkedScrollPosition;
 
   Iterable<_LinkedScrollController> get _allPeersWithClients =>
       _controllers._attachedControllers.where((peer) => peer != this);
@@ -194,7 +194,8 @@ class _LinkedScrollController extends ScrollController {
   Iterable<_LinkedScrollActivity> link(_LinkedScrollPosition driver) {
     assert(hasClients);
     final activities = <_LinkedScrollActivity>[];
-    for (_LinkedScrollPosition position in positions) {
+    for (_LinkedScrollPosition position
+        in positions as Iterable<_LinkedScrollPosition>) {
       activities.add(position.link(driver));
     }
     return activities;
@@ -211,10 +212,10 @@ class _LinkedScrollController extends ScrollController {
 class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
   _LinkedScrollPosition(
     this.owner, {
-    ScrollPhysics physics,
-    ScrollContext context,
-    double initialPixels,
-    ScrollPosition oldPosition,
+    required ScrollPhysics physics,
+    required ScrollContext context,
+    double? initialPixels,
+    ScrollPosition? oldPosition,
   })  : assert(owner != null),
         super(
           physics: physics,
@@ -240,11 +241,11 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
   void _holdInternal() {
     // TODO: passing null to hold seems fishy, but it doesn't
     // appear to hurt anything. Revisit this if bad things happen.
-    super.hold(null);
+    super.hold(() {});
   }
 
   @override
-  void beginActivity(ScrollActivity newActivity) {
+  void beginActivity(ScrollActivity? newActivity) {
     if (newActivity == null) {
       return;
     }
@@ -307,7 +308,8 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     if (this.activity is! _LinkedScrollActivity) {
       beginActivity(_LinkedScrollActivity(this));
     }
-    final _LinkedScrollActivity activity = this.activity;
+    final _LinkedScrollActivity activity =
+        this.activity as _LinkedScrollActivity;
     activity.link(driver);
     return activity;
   }
@@ -334,7 +336,7 @@ class _LinkedScrollActivity extends ScrollActivity {
   _LinkedScrollActivity(_LinkedScrollPosition delegate) : super(delegate);
 
   @override
-  _LinkedScrollPosition get delegate => super.delegate;
+  _LinkedScrollPosition get delegate => super.delegate as _LinkedScrollPosition;
 
   final Set<_LinkedScrollPosition> drivers = <_LinkedScrollPosition>{};
 
@@ -372,9 +374,8 @@ class _LinkedScrollActivity extends ScrollActivity {
 
   void _updateUserScrollDirection() {
     assert(drivers.isNotEmpty);
-    ScrollDirection/*!*/ commonDirection;
+    ScrollDirection commonDirection = drivers.first.userScrollDirection;
     for (var driver in drivers) {
-      commonDirection ??= driver.userScrollDirection;
       if (driver.userScrollDirection != commonDirection) {
         commonDirection = ScrollDirection.idle;
       }

--- a/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/primitives/flutter_widgets/linked_scroll_controller.dart
@@ -372,7 +372,7 @@ class _LinkedScrollActivity extends ScrollActivity {
 
   void _updateUserScrollDirection() {
     assert(drivers.isNotEmpty);
-    ScrollDirection commonDirection;
+    ScrollDirection/*!*/ commonDirection;
     for (var driver in drivers) {
       commonDirection ??= driver.userScrollDirection;
       if (driver.userScrollDirection != commonDirection) {


### PR DESCRIPTION
Merged linked_scroll_controller in consistency with the forked source: https://github.com/google/flutter.widgets/blob/master/packages/linked_scroll_controller/lib/linked_scroll_controller.dart