### PR TITLE
Remove pub warning

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -49,7 +49,6 @@ import 'shared/scaffold.dart';
 import 'shared/screen.dart';
 import 'shared/snapshot_screen.dart';
 import 'shared/theme.dart';
-import 'shared/utils.dart';
 import 'ui/service_extension_widgets.dart';
 import 'vm_developer/vm_developer_tools_controller.dart';
 import 'vm_developer/vm_developer_tools_screen.dart';
@@ -63,13 +62,6 @@ const showVmDeveloperMode = false;
 
 /// Whether this DevTools build is external.
 bool isExternalBuild = true;
-
-// TODO(kenz): remove the pub warning code after devtools version 2.8.0 ships
-/// Whether DevTools should warn users to stop launching DevTools from Pub.
-///
-/// This flag will be turned on for the final release of DevTools on pub, but
-/// should remain off at HEAD.
-const showPubWarning = false;
 
 /// Top-level configuration for the app.
 @immutable
@@ -514,10 +506,6 @@ class DevToolsAboutDialog extends StatelessWidget {
         children: [
           _aboutDevTools(context),
           const SizedBox(height: defaultSpacing),
-          if (shouldShowPubWarning()) ...[
-            const PubWarningText(),
-            const SizedBox(height: defaultSpacing),
-          ],
           ...dialogSubHeader(theme, 'Feedback'),
           Wrap(
             children: [

--- a/packages/devtools_app/lib/src/shared/scaffold.dart
+++ b/packages/devtools_app/lib/src/shared/scaffold.dart
@@ -139,11 +139,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         frameworkController.onShowPageId.listen(_showPageById);
 
     _initTitle();
-    _maybeShowPubWarning();
     _maybeShowInternalFlutterWebWarning();
   }
-
-  bool _pubWarningShown = false;
 
   bool _internalFlutterWebWarningShown = false;
 
@@ -157,18 +154,6 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         _internalFlutterWebWarningShown = true;
       }
     });
-  }
-
-  // TODO(kenz): remove the pub warning code after devtools version 2.8.0 ships
-  void _maybeShowPubWarning() {
-    if (!_pubWarningShown) {
-      serviceManager.onConnectionAvailable?.listen((event) {
-        if (shouldShowPubWarning()) {
-          _showWarning(const PubWarningText());
-          _pubWarningShown = true;
-        }
-      });
-    }
   }
 
   void _showWarning(Widget warningText) {

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -14,11 +14,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 
-import '../app.dart';
 import '../config_specific/logger/logger.dart' as logger;
 import 'globals.dart';
 import 'notifications.dart';
-import 'version.dart';
 
 /// Attempts to copy a String of `data` to the clipboard.
 ///
@@ -75,12 +73,3 @@ mixin CompareMixin implements Comparable {
     return compareTo(other) >= 0;
   }
 }
-
-bool shouldShowPubWarning() =>
-    showPubWarning &&
-    (serviceManager.connectedApp?.isFlutterAppNow != null &&
-            serviceManager.connectedApp.flutterVersionNow >=
-                SemanticVersion(major: 2, minor: 8) ||
-        (serviceManager.vm != null &&
-            SemanticVersion.parse(serviceManager.vm.version) >=
-                SemanticVersion(major: 2, minor: 15)));


### PR DESCRIPTION
This warning was enabled for the last release of DevTools on pub. Users who are still trying to activate DevTools from pub will continue to see this warning, but the code is no longer necessary at head. 