### PR TITLE
Remove outdated Flutter Version checks in the Inspector

### DIFF
--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -68,9 +68,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         BlockingActionMixin,
         AutoDisposeMixin,
         SearchFieldMixin<InspectorScreenBody> {
-  bool _expandCollapseSupported = false;
-  bool _layoutExplorerSupported = false;
-
   InspectorController inspectorController;
 
   InspectorTreeController get summaryTreeController =>
@@ -123,8 +120,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       inspectorTree: inspectorTreeController,
       detailsTree: detailsTree,
       treeType: FlutterTreeType.widget,
-      onExpandCollapseSupported: _onExpandCollapseSupported,
-      onLayoutExplorerSupported: _onLayoutExplorerSupported,
     );
 
     summaryTreeController.setSearchTarget(searchTarget);
@@ -184,7 +179,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
           detailsTree: detailsTree,
           controller: inspectorController,
           actionButtons: _expandCollapseButtons(),
-          layoutExplorerSupported: _layoutExplorerSupported,
         ),
       ],
     );
@@ -316,8 +310,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   }
 
   Widget _expandCollapseButtons() {
-    if (!_expandCollapseSupported) return null;
-
     return Container(
       alignment: Alignment.centerRight,
       decoration: BoxDecoration(
@@ -353,18 +345,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         ],
       ),
     );
-  }
-
-  void _onExpandCollapseSupported() {
-    setState(() {
-      _expandCollapseSupported = true;
-    });
-  }
-
-  void _onLayoutExplorerSupported() {
-    setState(() {
-      _layoutExplorerSupported = true;
-    });
   }
 
   void _refreshInspector() {

--- a/packages/devtools_app/lib/src/inspector/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen_details_tab.dart
@@ -18,14 +18,12 @@ class InspectorDetailsTabController extends StatefulWidget {
     this.detailsTree,
     this.actionButtons,
     this.controller,
-    this.layoutExplorerSupported,
     Key key,
   }) : super(key: key);
 
   final Widget detailsTree;
   final Widget actionButtons;
   final InspectorController controller;
-  final bool layoutExplorerSupported;
 
   @override
   _InspectorDetailsTabControllerState createState() =>
@@ -37,39 +35,30 @@ class _InspectorDetailsTabControllerState
     with TickerProviderStateMixin, AutoDisposeMixin {
   static const _detailsTreeTabIndex = 1;
   static const _tabsLengthWithLayoutExplorer = 2;
-  static const _tabsLengthWithoutLayoutExplorer = 1;
 
-  TabController _tabControllerWithLayoutExplorer;
-  TabController _tabControllerWithoutLayoutExplorer;
+  TabController _tabController;
 
   @override
   void initState() {
     super.initState();
     addAutoDisposeListener(
-      _tabControllerWithLayoutExplorer =
-          TabController(length: _tabsLengthWithLayoutExplorer, vsync: this),
-    );
-    addAutoDisposeListener(
-      _tabControllerWithoutLayoutExplorer =
-          TabController(length: _tabsLengthWithoutLayoutExplorer, vsync: this),
+      _tabController = TabController(
+        length: _tabsLengthWithLayoutExplorer,
+        vsync: this,
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
     final tabs = <Tab>[
-      if (widget.layoutExplorerSupported) _buildTab('Layout Explorer'),
+      _buildTab('Layout Explorer'),
       _buildTab('Widget Details Tree'),
     ];
     final tabViews = <Widget>[
-      if (widget.layoutExplorerSupported)
-        LayoutExplorerTab(controller: widget.controller),
+      LayoutExplorerTab(controller: widget.controller),
       widget.detailsTree,
     ];
-    final _tabController = widget.layoutExplorerSupported
-        ? _tabControllerWithLayoutExplorer
-        : _tabControllerWithoutLayoutExplorer;
-
     final theme = Theme.of(context);
     final focusColor = theme.focusColor;
     final borderSide = BorderSide(color: focusColor);

--- a/packages/devtools_app/test/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector_screen_test.dart
@@ -74,7 +74,8 @@ void main() {
       fakeExtensionManager.fakeFrame();
     }
 
-    testWidgets('builds its tab', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('builds its tab', windowSize,
+        (WidgetTester tester) async {
       await tester.pumpWidget(buildInspectorScreen());
       await tester.pumpAndSettle();
       expect(find.byType(InspectorScreenBody), findsOneWidget);


### PR DESCRIPTION
These versions of flutter we are gating on are over 2 years old, so it is safe to remove.

Fixes https://github.com/flutter/devtools/issues/3644