### PR TITLE
Fix enum parsing.

### DIFF
--- a/packages/devtools_app/lib/src/provider/instance_viewer/instance_providers.dart
+++ b/packages/devtools_app/lib/src/provider/instance_viewer/instance_providers.dart
@@ -213,7 +213,7 @@ Future<EnumInstance> _tryParseEnum(
 
   final nameSplit = name.valueAsString.split('.');
 
-  if (nameSplit.length > 2) return null;
+  if (nameSplit.length != 2) return null;
 
   return EnumInstance(
     type: nameSplit.first,


### PR DESCRIPTION
Sometimes there is just one word.

Error: 
```
flutter: [ERROR]: Provider AutoDisposeFutureProvider<InstanceDetails>#0003c(from: Instance of 'AutoDisposeFutureProviderFamily<InstanceDetails, InstancePath>', argument: InstancePath.fromProviderId(providerId: 0, pathToProperty: [PathToProperty.objectProperty(name: _selectedMailboxPage, ownerUri: package:gallery/studies/reply/model/email_store.dart, ownerName: EmailStore)])) failed with "RangeError (index): Invalid value: Only valid value is 0: 1"
flutter: #0      List.[] (dart:core-patch/growable_array.dart:281:36)
#1      _tryParseEnum (package:devtools_app/src/provider/instance_viewer/instance_providers.dart:222:21)
<asynchronous suspension>
#2      rawInstanceProvider.<anonymous closure> (package:devtools_app/src/provider/instance_viewer/instance_providers.dart:356:27)
<asynchronous suspension>
#3      _FutureProviderStateMixin.valueChanged.<anonymous closure> (package:riverpod/src/future_provider.dart:125:7)
<asynchronous suspension>
```