### PR TITLE
Fix failed assert when reconnecting to an application.

### DIFF
--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -47,7 +47,8 @@ class DebuggerController extends DisposableController
       initialize();
     }
     _scriptHistoryListener = () {
-      _showScriptLocation(ScriptLocation(scriptsHistory.current.value));
+      if (scriptsHistory.current.value != null)
+        _showScriptLocation(ScriptLocation(scriptsHistory.current.value));
     };
     scriptsHistory.current.addListener(_scriptHistoryListener);
   }


### PR DESCRIPTION
```
══╡ EXCEPTION CAUGHT BY FOUNDATION LIBRARY ╞════════════════════════════════════════════════════════
The following assertion was thrown while dispatching notifications for ValueNotifier<ScriptRef?>:
'package:devtools_app/src/debugger/debugger_model.dart': Failed assertion: line 81 pos 15:
'scriptRef != null': is not true.

When the exception was thrown, this was the stack:
#2      new ScriptLocation (package:devtools_app/src/debugger/debugger_model.dart:81:15)
#3      new DebuggerController.<anonymous closure> (package:devtools_app/src/debugger/debugger_controller.dart:50:27)
#4      ChangeNotifier.notifyListeners (package:flutter/src/foundation/change_notifier.dart:305:24)
#5      ValueNotifier.value= (package:flutter/src/foundation/change_notifier.dart:410:5)
#6      HistoryManager.clear (package:devtools_app/src/primitives/history_manager.dart:20:14)
#7      DebuggerController.onServiceShutdown (package:devtools_app/src/debugger/debugger_controller.dart:91:20)
#8      DebuggerController._handleConnectionAvailable (package:devtools_app/src/debugger/debugger_controller.dart:115:5)
(elided 19 frames from class _AssertionError and dart:async)
```