### PR TITLE
Add inspector tab switch analytics and fix regression with network screen tabs

### DIFF
--- a/packages/devtools_app/lib/src/analytics/_analytics_stub.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_stub.dart
@@ -70,6 +70,7 @@ void select(
   String screenName,
   String selectedItem, {
   int value = 0,
+  bool nonInteraction,
   ScreenAnalyticsMetrics Function() screenMetricsProvider,
 }) {}
 

--- a/packages/devtools_app/lib/src/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_web.dart
@@ -427,6 +427,7 @@ void select(
   String screenName,
   String selectedItem, {
   int value = 0,
+  bool nonInteraction,
   ScreenAnalyticsMetrics Function() screenMetricsProvider,
 }) {
   GTag.event(
@@ -435,6 +436,7 @@ void select(
       event_category: analytics_constants.selectEvent,
       event_label: selectedItem,
       value: value,
+      non_interaction: nonInteraction,
       send_to: gaDevToolsPropertyId(),
       user_app: userAppType,
       user_build: userBuildType,

--- a/packages/devtools_app/lib/src/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/app_size/app_size_screen.dart
@@ -83,10 +83,17 @@ class AppSizeBody extends StatefulWidget {
 
 class _AppSizeBodyState extends State<AppSizeBody>
     with AutoDisposeMixin, SingleTickerProviderStateMixin {
-  static final diffTab =
-      DevToolsTab(text: 'Diff', key: AppSizeScreen.diffTabKey);
-  static final analysisTab =
-      DevToolsTab(text: 'Analysis', key: AppSizeScreen.analysisTabKey);
+  static const _gaPrefix = 'appSizeTab';
+  static final diffTab = DevToolsTab.create(
+    tabName: 'Diff',
+    gaPrefix: _gaPrefix,
+    key: AppSizeScreen.diffTabKey,
+  );
+  static final analysisTab = DevToolsTab.create(
+    tabName: 'Analysis',
+    gaPrefix: _gaPrefix,
+    key: AppSizeScreen.analysisTabKey,
+  );
   static final tabs = [analysisTab, diffTab];
 
   AppSizeController controller;

--- a/packages/devtools_app/lib/src/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_screen.dart
@@ -78,8 +78,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
 
   DebuggerController _debuggerController;
 
-  bool get enableButtons => actionInProgress == false;
-
   bool searchVisible = false;
 
   /// Indicates whether search can be closed. The value is set to true when
@@ -144,14 +142,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     });
   }
 
-  void _onExpandClick() {
-    blockWhileInProgress(inspectorController.expandAllNodesInDetailsTree);
-  }
-
-  void _onResetClick() {
-    blockWhileInProgress(inspectorController.collapseDetailsToSelected);
-  }
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -175,10 +165,9 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       initialFractions: const [0.33, 0.67],
       children: [
         summaryTree,
-        InspectorDetailsTabController(
+        InspectorDetails(
           detailsTree: detailsTree,
           controller: inspectorController,
-          actionButtons: _expandCollapseButtons(),
         ),
       ],
     );
@@ -307,44 +296,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       // TODO(jacobr): implement TogglePlatformSelector.
       //  TogglePlatformSelector().selector
     ];
-  }
-
-  Widget _expandCollapseButtons() {
-    return Container(
-      alignment: Alignment.centerRight,
-      decoration: BoxDecoration(
-        border: Border(
-          left: defaultBorderSide(Theme.of(context)),
-        ),
-      ),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.end,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          SizedBox(
-            child: IconLabelButton(
-              icon: Icons.unfold_more,
-              onPressed: enableButtons ? _onExpandClick : null,
-              label: 'Expand all',
-              minScreenWidthForTextBeforeScaling:
-                  minScreenWidthForTextBeforeScaling,
-              outlined: false,
-            ),
-          ),
-          const SizedBox(width: denseSpacing),
-          SizedBox(
-            child: IconLabelButton(
-              icon: Icons.unfold_less,
-              onPressed: enableButtons ? _onResetClick : null,
-              label: 'Collapse to selected',
-              minScreenWidthForTextBeforeScaling:
-                  minScreenWidthForTextBeforeScaling,
-              outlined: false,
-            ),
-          )
-        ],
-      ),
-    );
   }
 
   void _refreshInspector() {

--- a/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/memory/memory_heap_tree_view.dart
@@ -149,9 +149,19 @@ class HeapTreeViewState extends State<HeapTree>
   static const int analysisTabIndex = 0;
   static const int allocationsTabIndex = 1;
 
+  static const _gaPrefix = 'memoryTab';
+
   static final List<Tab> dartHeapTabs = [
-    DevToolsTab(key: dartHeapAnalysisTabKey, text: 'Analysis'),
-    DevToolsTab(key: dartHeapAllocationsTabKey, text: 'Allocations'),
+    DevToolsTab.create(
+      key: dartHeapAnalysisTabKey,
+      gaPrefix: _gaPrefix,
+      tabName: 'Analysis',
+    ),
+    DevToolsTab.create(
+      key: dartHeapAllocationsTabKey,
+      gaPrefix: _gaPrefix,
+      tabName: 'Allocations',
+    ),
   ];
 
   MemoryController controller;

--- a/packages/devtools_app/lib/src/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/memory/memory_screen.dart
@@ -23,7 +23,6 @@ import '../shared/screen.dart';
 import '../shared/theme.dart';
 import '../shared/utils.dart';
 import '../ui/icons.dart';
-import '../ui/tab.dart';
 import 'memory_android_chart.dart' as android;
 import 'memory_charts.dart';
 import 'memory_controller.dart';
@@ -75,11 +74,6 @@ class MemoryScreen extends Screen {
 
 class MemoryBody extends StatefulWidget {
   const MemoryBody();
-
-  static final List<Tab> memoryTabs = [
-    DevToolsTab(text: 'Analysis'),
-    DevToolsTab(text: 'Allocations'),
-  ];
 
   @override
   MemoryBodyState createState() => MemoryBodyState();

--- a/packages/devtools_app/lib/src/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/network/network_request_inspector.dart
@@ -10,12 +10,12 @@ import '../analytics/constants.dart' as analytics_constants;
 import '../http/http_request_data.dart';
 import '../shared/common_widgets.dart';
 import '../ui/tab.dart';
-import 'network_model.dart';
+import 'network_controller.dart';
 import 'network_request_inspector_views.dart';
 
 /// A [Widget] which displays information about a network request.
 class NetworkRequestInspector extends StatelessWidget {
-  const NetworkRequestInspector(this.data);
+  const NetworkRequestInspector(this.controller);
 
   static const _overviewTabTitle = 'Overview';
   static const _headersTabTitle = 'Headers';
@@ -36,63 +36,61 @@ class NetworkRequestInspector extends StatelessWidget {
   @visibleForTesting
   static const noRequestSelectedKey = Key('No Request Selected');
 
-  final NetworkRequest data;
+  final NetworkController controller;
 
   Widget _buildTab(String tabName) {
-    return DevToolsTab(
-      key: ValueKey<String>(tabName),
-      gaId: 'requestInspectorTab_$tabName',
-      child: Text(
-        tabName,
-        overflow: TextOverflow.ellipsis,
-      ),
+    return DevToolsTab.create(
+      tabName: tabName,
+      gaPrefix: 'requestInspectorTab',
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final tabs = <DevToolsTab>[
-      _buildTab(NetworkRequestInspector._overviewTabTitle),
-      if (data is HttpRequestData) ...[
-        _buildTab(NetworkRequestInspector._headersTabTitle),
-        if ((data as HttpRequestData).requestBody != null)
-          _buildTab(NetworkRequestInspector._requestTabTitle),
-        if ((data as HttpRequestData).responseBody != null)
-          _buildTab(NetworkRequestInspector._responseTabTitle),
-        if ((data as HttpRequestData).hasCookies)
-          _buildTab(NetworkRequestInspector._cookiesTabTitle),
-      ],
-    ];
-    final tabViews = [
-      NetworkRequestOverviewView(data),
-      if (data is HttpRequestData) ...[
-        HttpRequestHeadersView(data),
-        if ((data as HttpRequestData).requestBody != null)
-          HttpRequestView(data),
-        if ((data as HttpRequestData).responseBody != null)
-          HttpResponseView(data),
-        if ((data as HttpRequestData).hasCookies) HttpRequestCookiesView(data),
-      ],
-    ];
-
-    return Card(
-      margin: EdgeInsets.zero,
-      color: Theme.of(context).canvasColor,
-      child: RoundedOutlinedBorder(
-        child: (data == null)
-            ? Center(
-                child: Text(
-                  'No request selected',
-                  key: NetworkRequestInspector.noRequestSelectedKey,
-                  style: Theme.of(context).textTheme.headline6,
-                ),
-              )
-            : AnalyticsTabbedView(
-                tabs: tabs,
-                tabViews: tabViews,
-                gaScreen: analytics_constants.network,
-              ),
-      ),
+    return ValueListenableBuilder(
+      valueListenable: controller.selectedRequest,
+      builder: (context, data, _) {
+        final tabs = <DevToolsTab>[
+          _buildTab(NetworkRequestInspector._overviewTabTitle),
+          if (data is HttpRequestData) ...[
+            _buildTab(NetworkRequestInspector._headersTabTitle),
+            if (data.requestBody != null)
+              _buildTab(NetworkRequestInspector._requestTabTitle),
+            if (data.responseBody != null)
+              _buildTab(NetworkRequestInspector._responseTabTitle),
+            if (data.hasCookies)
+              _buildTab(NetworkRequestInspector._cookiesTabTitle),
+          ],
+        ];
+        final tabViews = [
+          NetworkRequestOverviewView(data),
+          if (data is HttpRequestData) ...[
+            HttpRequestHeadersView(data),
+            if (data.requestBody != null) HttpRequestView(data),
+            if (data.responseBody != null) HttpResponseView(data),
+            if (data.hasCookies) HttpRequestCookiesView(data),
+          ],
+        ];
+        return Card(
+          margin: EdgeInsets.zero,
+          color: Theme.of(context).canvasColor,
+          child: RoundedOutlinedBorder(
+            child: (data == null)
+                ? Center(
+                    child: Text(
+                      'No request selected',
+                      key: NetworkRequestInspector.noRequestSelectedKey,
+                      style: Theme.of(context).textTheme.headline6,
+                    ),
+                  )
+                : AnalyticsTabbedView(
+                    tabs: tabs,
+                    tabViews: tabViews,
+                    gaScreen: analytics_constants.network,
+                  ),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/network/network_screen.dart
@@ -290,28 +290,27 @@ class _NetworkProfilerBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<NetworkRequest, List<NetworkRequest>>(
-      firstListenable: controller.selectedRequest,
-      secondListenable: controller.filteredData,
-      builder: (context, selectedRequest, filteredRequests, _) {
-        return GestureDetector(
-          onTap: () => FocusScope.of(context)?.unfocus(),
-          child: Split(
-            initialFractions: const [0.5, 0.5],
-            minSizes: const [200, 200],
-            axis: Axis.horizontal,
-            children: [
-              NetworkRequestsTable(
+    return GestureDetector(
+      onTap: () => FocusScope.of(context)?.unfocus(),
+      child: Split(
+        initialFractions: const [0.5, 0.5],
+        minSizes: const [200, 200],
+        axis: Axis.horizontal,
+        children: [
+          ValueListenableBuilder(
+            valueListenable: controller.filteredData,
+            builder: (context, filteredRequests, _) {
+              return NetworkRequestsTable(
                 networkController: controller,
                 requests: filteredRequests,
                 searchMatchesNotifier: controller.searchMatches,
                 activeSearchMatchNotifier: controller.activeSearchMatch,
-              ),
-              NetworkRequestInspector(selectedRequest),
-            ],
+              );
+            },
           ),
-        );
-      },
+          NetworkRequestInspector(controller),
+        ],
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/profiler/cpu_profiler.dart
@@ -39,13 +39,21 @@ class CpuProfiler extends StatefulWidget {
         bottomUpRoots = data?.bottomUpRoots ?? [],
         tabs = [
           if (summaryView != null)
-            DevToolsTab(key: summaryTab, text: 'Summary'),
+            _buildTab(key: summaryTab, tabName: 'Summary'),
           if (data != null && !data.isEmpty) ...[
-            DevToolsTab(key: bottomUpTab, text: 'Bottom Up'),
-            DevToolsTab(key: callTreeTab, text: 'Call Tree'),
-            DevToolsTab(key: flameChartTab, text: 'CPU Flame Chart'),
+            _buildTab(key: bottomUpTab, tabName: 'Bottom Up'),
+            _buildTab(key: callTreeTab, tabName: 'Call Tree'),
+            _buildTab(key: flameChartTab, tabName: 'CPU Flame Chart'),
           ],
         ];
+
+  static DevToolsTab _buildTab({Key key, @required String tabName}) {
+    return DevToolsTab.create(
+      key: key,
+      tabName: tabName,
+      gaPrefix: 'cpuProfilerTab',
+    );
+  }
 
   final CpuProfileData data;
 

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -11,7 +11,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../primitives/listenable.dart';
-import '../ui/tab.dart';
 import 'globals.dart';
 import 'scaffold.dart';
 import 'theme.dart';
@@ -148,7 +147,7 @@ abstract class Screen {
       valueListenable:
           serviceManager.errorBadgeManager.errorCountNotifier(screenId),
       builder: (context, count, _) {
-        final tab = DevToolsTab(
+        final tab = Tab(
           key: tabKey,
           child: Row(
             children: <Widget>[


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/3270. We were tracking tab selections on the network page too many times because we were unnecessarily rebuilding the tab controller. 