### PR TITLE
Remove dependency on package:pedantic

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -4,9 +4,10 @@
 
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:provider/provider.dart';
 
 import '../devtools.dart' as devtools;

--- a/packages/devtools_app/lib/src/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_controller.dart
@@ -10,7 +10,6 @@ import 'dart:async';
 
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart';

--- a/packages/devtools_app/lib/src/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/debugger/debugger_model.dart
@@ -4,13 +4,14 @@
 
 // @dart=2.9
 
+import 'dart:async';
+
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_controller.dart
@@ -21,7 +21,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart';

--- a/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/inspector/inspector_tree_controller.dart
@@ -13,7 +13,6 @@ import 'dart:math';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:pedantic/pedantic.dart';
 
 import '../config_specific/logger/logger.dart';
 import '../debugger/debugger_controller.dart';

--- a/packages/devtools_app/lib/src/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/performance/performance_controller.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../analytics/analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/provider/instance_viewer/instance_providers.dart
+++ b/packages/devtools_app/lib/src/provider/instance_viewer/instance_providers.dart
@@ -9,7 +9,6 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart' hide SentinelException;
 
 import '../../primitives/utils.dart';

--- a/packages/devtools_app/lib/src/shared/device_dialog.dart
+++ b/packages/devtools_app/lib/src/shared/device_dialog.dart
@@ -4,8 +4,9 @@
 
 // ignore_for_file: import_of_legacy_library_into_null_safe
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../info/info_controller.dart';

--- a/packages/devtools_app/lib/src/shared/service.dart
+++ b/packages/devtools_app/lib/src/shared/service.dart
@@ -6,7 +6,6 @@
 
 import 'dart:async';
 
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/utils.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
 

--- a/packages/devtools_app/lib/src/shared/service_manager.dart
+++ b/packages/devtools_app/lib/src/shared/service_manager.dart
@@ -9,7 +9,6 @@ import 'dart:core';
 import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
 import '../analytics/analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -4,8 +4,9 @@
 
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../devtools.dart' as devtools;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   js: ^0.6.1+1
   mime: ^1.0.0
   path: ^1.8.0
-  pedantic: ^1.11.0
   provider: ^5.0.0
   sse: ^4.0.0
   stack_trace: ^1.10.0

--- a/packages/devtools_app/test/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger_evalution_test.dart
@@ -4,6 +4,8 @@
 
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:devtools_app/src/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/debugger/evaluate.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
@@ -12,7 +14,6 @@ import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pedantic/pedantic.dart';
 
 import 'test_infra/flutter_test_driver.dart';
 import 'test_infra/flutter_test_environment.dart';

--- a/packages/devtools_app/test/integration_tests/integration.dart
+++ b/packages/devtools_app/test/integration_tests/integration.dart
@@ -11,7 +11,6 @@ import 'dart:io';
 
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:webkit_inspection_protocol/webkit_inspection_protocol.dart'
     show ConsoleAPIEvent, RemoteObject;
 

--- a/packages/devtools_app/test/linked_scroll_controller_test.dart
+++ b/packages/devtools_app/test/linked_scroll_controller_test.dart
@@ -4,10 +4,11 @@
 
 // @dart=2.9
 
+import 'dart:async';
+
 import 'package:devtools_app/src/primitives/flutter_widgets/linked_scroll_controller.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:pedantic/pedantic.dart';
 
 // This file was originally forked from package:flutter_widgets. Note that the
 // source may diverge over time.

--- a/packages/devtools_app/test/test_infra/flutter_test_driver.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_driver.dart
@@ -12,7 +12,6 @@ import 'dart:io';
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:flutter/foundation.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:vm_service/utils.dart';
 import 'package:vm_service/vm_service.dart';
 import 'package:vm_service/vm_service_io.dart';


### PR DESCRIPTION
package:pedantic is [deprecated](https://pub.dev/documentation/pedantic/latest/). We were only using this package for the `unawaited` method, which we can get from `dart:async` instead. 