### PR TITLE
Fix selection issue if file is already visible in program explorer

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -60,22 +60,22 @@ class DebuggerController extends DisposableController
   /// for performance reasons. None of the code here needs to be called when
   /// DevTools first connects to an app, and doing so inhibits DevTools from
   /// connecting to low-end devices.
-  void onFirstDebuggerScreenLoad() {
+  Future<void> onFirstDebuggerScreenLoad() async {
     if (!_firstDebuggerScreenLoaded) {
-      _maybeSetUpProgramExplorer();
+      await _maybeSetUpProgramExplorer();
       addAutoDisposeListener(currentScriptRef, _maybeSetUpProgramExplorer);
       _firstDebuggerScreenLoaded = true;
     }
   }
 
-  void _maybeSetUpProgramExplorer() {
+  Future<void> _maybeSetUpProgramExplorer() async {
     if (!programExplorerController.initialized.value) {
       programExplorerController
         ..initListeners()
         ..initialize();
     }
     if (currentScriptRef.value != null) {
-      programExplorerController.selectScriptNode(currentScriptRef.value);
+      await programExplorerController.selectScriptNode(currentScriptRef.value);
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -315,8 +315,6 @@ class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance
-        .addPostFrameCallback((_) => _maybeScrollToSelectedNode());
     return Scrollbar(
       isAlwaysShown: true,
       controller: _scrollController,

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -344,17 +344,19 @@ class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
     // If the node offset is invalid, don't scroll.
     if (selectedNodeOffset < 0) return;
 
-    final extentVisible = Range(
-      _scrollController.offset,
-      _scrollController.offset + _scrollController.position.extentInside,
-    );
-    if (!extentVisible.contains(selectedNodeOffset)) {
-      _scrollController.animateTo(
-        selectedNodeOffset - _selectedNodeTopSpacing,
-        duration: longDuration,
-        curve: defaultCurve,
+    setState(() {
+      final extentVisible = Range(
+        _scrollController.offset,
+        _scrollController.offset + _scrollController.position.extentInside,
       );
-    }
+      if (!extentVisible.contains(selectedNodeOffset)) {
+        _scrollController.animateTo(
+          selectedNodeOffset - _selectedNodeTopSpacing,
+          duration: longDuration,
+          curve: defaultCurve,
+        );
+      }
+    });
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -342,19 +342,17 @@ class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
     // If the node offset is invalid, don't scroll.
     if (selectedNodeOffset < 0) return;
 
-    setState(() {
-      final extentVisible = Range(
-        _scrollController.offset,
-        _scrollController.offset + _scrollController.position.extentInside,
+    final extentVisible = Range(
+      _scrollController.offset,
+      _scrollController.offset + _scrollController.position.extentInside,
+    );
+    if (!extentVisible.contains(selectedNodeOffset)) {
+      _scrollController.animateTo(
+        selectedNodeOffset - _selectedNodeTopSpacing,
+        duration: longDuration,
+        curve: defaultCurve,
       );
-      if (!extentVisible.contains(selectedNodeOffset)) {
-        _scrollController.animateTo(
-          selectedNodeOffset - _selectedNodeTopSpacing,
-          duration: longDuration,
-          curve: defaultCurve,
-        );
-      }
-    });
+    }
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -97,23 +97,23 @@ class ProgramExplorerController extends DisposableController
     );
   }
 
-  void selectScriptNode(ScriptRef script) {
+  Future<void> selectScriptNode(ScriptRef script) async {
     if (!initialized.value) {
       return;
     }
-    _selectScriptNode(script, _rootObjectNodes.value);
+    await _selectScriptNode(script, _rootObjectNodes.value);
     _rootObjectNodes.notifyListeners();
   }
 
-  void _selectScriptNode(
+  Future<void> _selectScriptNode(
     ScriptRef script,
     List<VMServiceObjectNode> nodes,
-  ) {
+  ) async {
     final searchCondition = (node) => node.script?.uri == script.uri;
     for (final node in nodes) {
       final result = node.firstChildWithCondition(searchCondition);
       if (result != null) {
-        selectNode(result);
+        await selectNode(result);
         result.expandAscending();
         _selectedNodeIndex.value = _calculateNodeIndex(
           matchingNodeCondition: searchCondition,
@@ -158,7 +158,7 @@ class ProgramExplorerController extends DisposableController
 
   /// Marks [node] as the currently selected node, clearing the selection state
   /// of any currently selected node.
-  void selectNode(VMServiceObjectNode node) async {
+  Future<void> selectNode(VMServiceObjectNode node) async {
     if (!node.isSelectable) {
       return;
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3793

Changes to fix the issue:
* `awaits` asynchronous node selection. Before this, a rebuild could be triggered before the new node was selected and the previous node was unselected. 
* Removes the `postFrameCallback` - this was being used as a band-aid to fix the above issue. Now that we are `await`-ing node selection, there is no need to trigger a rebuild with `postFrameCallback`. 

![scrolling_fix](https://user-images.githubusercontent.com/21270878/157108187-853b8d64-4ac4-4c19-85b1-5c7fe06e344b.gif)

