### PR TITLE
Check for CHROME_PATH env variable in devtools_shared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.11.3
+Check for CHROME_PATH env variable in devtools_shared [#3805](https://github.com/flutter/devtools/pull/3805)
+
 ## 2.11.2
 * Fix selection issue if file is already visible in program explorer [#3794](https://github.com/flutter/devtools/pull/3794) 
 * Automatic scrolling in the Program Explorer [#3786](https://github.com/flutter/devtools/pull/3786)

--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.dart matches the following line so
 // if you change it you must also modify tools/update_version.dart.
-const String version = '2.11.2';
+const String version = '2.11.3';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -3,7 +3,7 @@ description: Web-based performance tooling for Dart and Flutter.
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.11.2
+version: 2.11.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -25,7 +25,7 @@ dependencies:
   collection: ^1.15.0
   dds: ^2.2.0
   dds_service_extensions: ^1.3.0
-  devtools_shared: 2.11.2
+  devtools_shared: 2.11.3
   file: ^6.0.0
   file_selector: ^0.8.0
   file_selector_linux: ^0.0.2
@@ -57,7 +57,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.0.4
-  devtools_test: 2.11.2
+  devtools_test: 2.11.3
   flutter_test:
     sdk: flutter
   mockito: ^5.0.9

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -61,7 +61,7 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var version = '2.11.2';
+    var version = '2.11.3';
     var scriptLoaded = false;
     function loadMainDartJs() {
       if (scriptLoaded) {

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.11.3
+Check for CHROME_PATH env variable in devtools_shared [#3805](https://github.com/flutter/devtools/pull/3805)
+
 ## 2.11.1
 - Update CLI test driver with the correct Dart VM Service prefix
 ## 2.11.0

--- a/packages/devtools_shared/lib/src/test/chrome.dart
+++ b/packages/devtools_shared/lib/src/test/chrome.dart
@@ -54,6 +54,11 @@ class Chrome {
       }
     }
 
+    final pathFromEnv = Platform.environment['CHROME_PATH'];
+    if (pathFromEnv != null && FileSystemEntity.isFileSync(pathFromEnv)) {
+      return Chrome.from(pathFromEnv);
+    }
+
     // TODO(devoncarew): check default install locations for linux
     // TODO(devoncarew): try `which` on mac, linux
 

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app, dds, and other tools.
 
-version: 2.11.2
+version: 2.11.3
 
 homepage: https://github.com/flutter/devtools
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -6,7 +6,7 @@ description: A package containing shared test helpers for Dart DevTools tests.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 2.11.2
+version: 2.11.3
 
 homepage: https://github.com/flutter/devtools
 
@@ -20,8 +20,8 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: 2.11.2
-  devtools_app: 2.11.2
+  devtools_shared: 2.11.3
+  devtools_app: 2.11.3
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
This fixes some issues with the SDK bots testing the DevTools server tests. This PR also bumps the devtools version from 2.11.2 to 2.11.3 in preparation for releasing devtools_shared, which dds will then depend on.