### PR TITLE
Example of improving performance by reducing # of widgets

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -977,17 +977,22 @@ class _RenderFlameRow extends RenderBox {
         chartZoom: zoom,
         chartStartInset: startInset,
       );
-      node.draw(
-        canvas: context.canvas,
-        topLeft: offset + Offset(left + accumulated - _controller!.offset, 0),
-        selected: node == selected,
-        hovered: node == hovered,
-        searchMatch: node.data.isSearchMatch,
-        activeSearchMatch: node.data.isActiveSearchMatch,
-        zoom: zoom,
-        colorScheme: colorScheme,
-      );
-      accumulated += extentDelegate!.itemExtent(index);
+      final position =
+          offset + Offset(left + accumulated - _controller!.offset, 0);
+      final double extent = extentDelegate!.itemExtent(index);
+      if (position.dx + extent >= 0 && position.dx <= size.width) {
+        node.draw(
+          canvas: context.canvas,
+          topLeft: position,
+          selected: node == selected,
+          hovered: node == hovered,
+          searchMatch: node.data.isSearchMatch,
+          activeSearchMatch: node.data.isActiveSearchMatch,
+          zoom: zoom,
+          colorScheme: colorScheme,
+        );
+      }
+      accumulated += extent;
       index += 1;
     }
   }


### PR DESCRIPTION
A draft example of our discussion from a few weeks back on improving performance. This change replaces the node widgets with a single widget representing a row, placing it in a single child scroll view. This doesn't completely work, as the item extents and sizing are not correctly calculated, but it does demonstrate the principles here:

@kenzieschmoll @goderbauer @dnfield 

What the unfinished chart currently looks like:

![image](https://user-images.githubusercontent.com/8975114/157313409-d04763ac-a7c6-4e11-b687-cc2cfe89000b.png)
