### PR TITLE
Remove internal Flutter Web warning

### DIFF
--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1778,39 +1778,6 @@ class PubWarningText extends StatelessWidget {
   }
 }
 
-class InternalFlutterWebWarningText extends StatelessWidget {
-  const InternalFlutterWebWarningText({Key? key}) : super(key: key);
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return RichText(
-      text: TextSpan(
-        children: [
-          TextSpan(
-              text:
-                  'Warning: Flutter DevTools is currently not supported for Flutter Web apps.\n\n',
-              style: theme.subtleTextStyle
-                  .copyWith(color: theme.colorScheme.errorTextColor)),
-          TextSpan(
-              text: 'Some debugging features might not work as expected.\n',
-              style: theme.subtleTextStyle),
-          TextSpan(text: 'See ', style: theme.subtleTextStyle),
-          LinkTextSpan(
-            link: const Link(
-              display: 'b/204213138',
-              url: 'https://b.corp.google.com/issues/204213138',
-            ),
-            context: context,
-            style: theme.linkTextStyle,
-          ),
-          TextSpan(text: ' for details.', style: theme.subtleTextStyle),
-        ],
-      ),
-    );
-  }
-}
-
 class BlinkingIcon extends StatefulWidget {
   const BlinkingIcon({
     Key? key,

--- a/packages/devtools_app/lib/src/shared/scaffold.dart
+++ b/packages/devtools_app/lib/src/shared/scaffold.dart
@@ -133,53 +133,6 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     );
 
     _initTitle();
-    _maybeShowInternalFlutterWebWarning();
-  }
-
-  bool _internalFlutterWebWarningShown = false;
-
-  void _maybeShowInternalFlutterWebWarning() {
-    if (isExternalBuild) return;
-    if (_internalFlutterWebWarningShown) return;
-
-    serviceManager.onConnectionAvailable.listen((_) {
-      if (serviceManager.connectedApp!.isFlutterWebAppNow) {
-        _showWarning(const InternalFlutterWebWarningText());
-        _internalFlutterWebWarningShown = true;
-      }
-    });
-  }
-
-  void _showWarning(Widget warningText) {
-    final colorScheme = Theme.of(context).colorScheme;
-    late OverlayEntry _entry;
-    Overlay.of(context)!.insert(
-      _entry = OverlayEntry(
-        maintainState: true,
-        builder: (context) {
-          return Material(
-            color: colorScheme.overlayShadowColor,
-            child: Center(
-              child: Container(
-                padding: const EdgeInsets.all(defaultSpacing),
-                color: colorScheme.overlayBackgroundColor,
-                child: Column(
-                  mainAxisSize: MainAxisSize.min,
-                  children: [
-                    warningText,
-                    const SizedBox(height: defaultSpacing),
-                    ElevatedButton(
-                      child: const Text('Got it'),
-                      onPressed: () => _entry.remove(),
-                    ),
-                  ],
-                ),
-              ),
-            ),
-          );
-        },
-      ),
-    );
   }
 
   @override


### PR DESCRIPTION
Flutter Web is now supported for internal users, therefore we shouldn't show the warning modal when users open DevTools. 