### PR TITLE
IDE theme can be `null`

### DIFF
--- a/packages/devtools_app/lib/src/shared/globals.dart
+++ b/packages/devtools_app/lib/src/shared/globals.dart
@@ -34,7 +34,7 @@ DevToolsExtensionPoints get devToolsExtensionPoints =>
 
 OfflineModeController get offlineController => globals[OfflineModeController];
 
-IdeTheme get ideTheme => globals[IdeTheme];
+IdeTheme? get ideTheme => globals[IdeTheme];
 
 void setGlobal(Type clazz, dynamic instance) {
   globals[clazz] = instance;

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -40,14 +40,14 @@ void debugLogger(String message) {
 }
 
 double scaleByFontFactor(double original) {
-  return (original * ideTheme.fontSizeFactor).roundToDouble();
+  return (original * (ideTheme?.fontSizeFactor ?? 1.0)).roundToDouble();
 }
 
 bool isDense() {
   return preferences.denseModeEnabled.value || isEmbedded();
 }
 
-bool isEmbedded() => ideTheme.embed;
+bool isEmbedded() => ideTheme?.embed ?? false;
 
 mixin CompareMixin implements Comparable {
   bool operator <(other) {


### PR DESCRIPTION
If the IDE theme global hasn't been set, then `ideTheme` is `null`. 

This was causing errors runtime errors when rolling DevTools into g3. I think it might make sense for the other global values to be nullable as well. 
