### PR TITLE
Send pageReady event to dwds from Inspector page

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -23,6 +23,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../analytics/constants.dart' as analytics_constants;
 import '../../config_specific/logger/logger.dart';
 import '../../config_specific/url/url.dart';
 import '../../primitives/auto_dispose.dart';
@@ -412,6 +413,12 @@ class InspectorController extends DisposableController
     }
 
     if (flutterAppFrameReady) {
+      // TODO: measure and send DevTools pageReady analytics:
+      // https://github.com/flutter/devtools/issues/3879
+      await serviceManager.sendDwdsEvent(
+        screen: InspectorScreen.id,
+        action: analytics_constants.pageReady,
+      );
       _rootDirectories = await inspectorService.inferPubRootDirectoryIfNeeded();
       if (_disposed) return;
       // We need to start by querying the inspector service to find out the

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -181,6 +181,10 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
                   .hasServiceExtension(
                       extensions.toggleSelectWidgetMode.extension),
               builder: (_, selectModeSupported, __) {
+                serviceManager.sendDwdsEvent(
+                  screen: InspectorScreen.id,
+                  action: analytics_constants.pageReady,
+                );
                 return ServiceExtensionButtonGroup(
                   extensions: [
                     selectModeSupported

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -181,10 +181,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
                   .hasServiceExtension(
                       extensions.toggleSelectWidgetMode.extension),
               builder: (_, selectModeSupported, __) {
-                serviceManager.sendDwdsEvent(
-                  screen: InspectorScreen.id,
-                  action: analytics_constants.pageReady,
-                );
                 return ServiceExtensionButtonGroup(
                   extensions: [
                     selectModeSupported


### PR DESCRIPTION
Send `pageReady` event from the Inspector page, similar to what is already
done from the Debugger page.

Closes: https://github.com/flutter/devtools/issues/3711