### PR TITLE
Export `Storage` class and create new `MockStorage` class for testing

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -13,6 +13,7 @@ export 'src/http/http_request_data.dart';
 export 'src/primitives/auto_dispose.dart';
 export 'src/primitives/auto_dispose_mixin.dart';
 export 'src/primitives/listenable.dart';
+export 'src/primitives/storage.dart';
 export 'src/primitives/trace_event.dart';
 export 'src/primitives/trees.dart';
 export 'src/primitives/utils.dart';

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -12,7 +12,6 @@ import 'dart:io';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/config_specific/framework_initialize/_framework_initialize_desktop.dart';
 import 'package:devtools_app/src/primitives/message_bus.dart';
-import 'package:devtools_app/src/primitives/storage.dart';
 
 import 'flutter_test_driver.dart';
 

--- a/packages/devtools_test/lib/src/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks.dart
@@ -708,6 +708,8 @@ class MockPerformanceController extends Mock implements PerformanceController {}
 class MockProfilerScreenController extends Mock
     implements ProfilerScreenController {}
 
+class MockStorage extends Mock implements Storage {}
+
 class TestDebuggerController extends DebuggerController {
   TestDebuggerController({bool initialSwitchToIsolate = true})
       : super(initialSwitchToIsolate: initialSwitchToIsolate);


### PR DESCRIPTION
This change exports the `Storage` class in `devtools_app.dart` and also creates a new `MockStorage` class for an internal test use case.