### PR TITLE
Add shell script to serve release bundle locally

### DIFF
--- a/tool/serve_release_bundle.sh
+++ b/tool/serve_release_bundle.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Copyright 2022 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+
+# Builds a release bundle for DevTools and serve it locally. Automates 
+# the steps described at: 
+# https://docs.flutter.dev/deployment/web#building-the-app-for-release
+
+# Note: This script must be executed from the top-level directory:
+# ./tool/serve_release_bundle.sh
+
+SCRIPT_PATH=$(dirname "$0")
+
+# Build the release bundle:
+$SCRIPT_PATH/build_release.sh
+
+# Navigate to the web directory:
+pushd packages/devtools_app/build/web
+
+# Start a server to serve the web directory:
+echo "-------------------------------------------"
+echo "SERVING DEVTOOLS AT: http://localhost:8000/"
+echo "-------------------------------------------"
+if python3 --version 2>&1 | grep -q '^Python 3\.'; then
+    # This is how to start a simple server with Python 3:
+    python3 -m http.server 8000
+elif python --version 2>&1 | grep -q '^Python 3\.'; then
+    # This is how to start a simple server with Python 3 if
+    # the command is aliased to "python":
+    python -m http.server 8000
+elif python --version 2>&1 | grep -q '^Python 2\.'; then
+    # This is how to start a simple server with Python 2:
+    python -m SimpleHTTPServer 8000
+else 
+    echo "[ERROR] Server not started. Is Python installed?"
+    exit 1
+fi


### PR DESCRIPTION
Adds a shell script to serve the release bundle of DevTools on a local server. 

This can be used to debug service worker issues, since the service worker is disabled in development mode. Should also make it easier to debug other release bundle-specific issues. 