### PR TITLE
Add additional variants of inspector goldens to prevent test flakes

### DIFF
--- a/packages/devtools_app/test/goldens/inspector_service_text_details_tree_v3.txt
+++ b/packages/devtools_app/test/goldens/inspector_service_text_details_tree_v3.txt
@@ -1,0 +1,20 @@
+Text
+ │ data: "Hello, World!"
+ │ textAlign: null
+ │ textDirection: null
+ │ locale: null
+ │ softWrap: null
+ │ overflow: null
+ │ textScaleFactor: null
+ │ maxLines: null
+ │ textWidthBasis: null
+ │ textHeightBehavior: null
+ │ dependencies: [MediaQuery, DefaultTextStyle]
+ │
+ └─RichText
+     softWrap: wrapping at box width
+     maxLines: unlimited
+     text: "Hello, World!"
+     dependencies: [Directionality,
+       _LocalizationsScope-[GlobalKey#00000]]
+     renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools_app/test/goldens/inspector_service_text_details_tree_v4.txt
+++ b/packages/devtools_app/test/goldens/inspector_service_text_details_tree_v4.txt
@@ -1,0 +1,20 @@
+Text
+ │ data: "Hello, World!"
+ │ textAlign: null
+ │ textDirection: null
+ │ locale: null
+ │ softWrap: null
+ │ overflow: null
+ │ textScaleFactor: null
+ │ maxLines: null
+ │ textWidthBasis: null
+ │ textHeightBehavior: null
+ │ dependencies: [DefaultTextStyle, MediaQuery]
+ │
+ └─RichText
+     softWrap: wrapping at box width
+     maxLines: unlimited
+     text: "Hello, World!"
+     dependencies: [Directionality,
+       _LocalizationsScope-[GlobalKey#00000]]
+     renderObject: RenderParagraph#00000 relayoutBoundary=up2

--- a/packages/devtools_app/test/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector_service_test.dart
@@ -370,6 +370,10 @@ void main() async {
                 'inspector_service_text_details_tree.txt'),
             equalsGoldenIgnoringHashCodes(
                 'inspector_service_text_details_tree_v2.txt'),
+            equalsGoldenIgnoringHashCodes(
+                'inspector_service_text_details_tree_v3.txt'),
+            equalsGoldenIgnoringHashCodes(
+                'inspector_service_text_details_tree_v4.txt'),
           ),
         );
         expect(nodeInDetailsTree.valueRef, equals(nodeInSummaryTree.valueRef));


### PR DESCRIPTION
Some inspector goldens have properties with a list of items. List order is not always consistent, so this PR adds different variations of the goldens in an effort to eliminate test flakes.

e.g.
`│ dependencies: [MediaQuery, DefaultTextStyle]`
vs
`│ dependencies: [DefaultTextStyle, MediaQuery]`