### PR TITLE
Add a ga hit when an inspector tree node is selected

### DIFF
--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -52,6 +52,7 @@ const String togglePlatform = 'togglePlatform';
 const String selectWidgetMode = 'selectWidgetMode';
 const String enableOnDeviceInspector = 'enableOnDeviceInspector';
 const String showOnDeviceInspector = 'showInspector';
+const String treeNodeSelection = 'treeNodeSelection';
 
 // Performance UX actions:
 const refreshTimelineEvents = 'refreshTimelineEvents';

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -14,6 +14,8 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
+import '../../analytics/analytics.dart' as ga;
+import '../../analytics/constants.dart' as analytics_constants;
 import '../../config_specific/logger/logger.dart';
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
@@ -410,6 +412,10 @@ class InspectorTreeController extends Object
 
   void onSelectNode(InspectorTreeNode node) {
     selection = node;
+    ga.select(
+      analytics_constants.inspector,
+      analytics_constants.treeNodeSelection,
+    );
     expandPath(node);
   }
 


### PR DESCRIPTION
fixes https://github.com/flutter/devtools/issues/3823.

This will not be triggered for programatic selections, only when a user taps an inspector row or selects a node from the breadcrumb navigator in the details tree.