### PR TITLE
Refactor script caching logic out of `DebuggerController` into `ScriptManager`

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -38,6 +38,7 @@ export 'src/screens/performance/timeline_streams.dart';
 export 'src/screens/profiler/cpu_profile_model.dart';
 export 'src/screens/profiler/profile_granularity.dart';
 export 'src/screens/profiler/profiler_screen_controller.dart';
+export 'src/scripts/script_manager.dart';
 export 'src/service/isolate_manager.dart';
 export 'src/service/isolate_state.dart';
 export 'src/service/service_extension_manager.dart';

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -11,6 +11,7 @@ import '../config_specific/import_export/import_export.dart';
 import '../config_specific/logger/logger.dart';
 import '../primitives/message_bus.dart';
 import '../primitives/utils.dart';
+import '../scripts/script_manager.dart';
 import '../service/service.dart';
 import '../service/service_manager.dart';
 import '../service/vm_service_wrapper.dart';
@@ -28,6 +29,7 @@ class FrameworkCore {
     setGlobal(FrameworkController, FrameworkController());
     setGlobal(SurveyService, SurveyService());
     setGlobal(OfflineModeController, OfflineModeController());
+    setGlobal(ScriptManager, ScriptManager());
   }
 
   static void init() {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -37,9 +37,7 @@ class DebuggerController extends DisposableController
   // `initialSwitchToIsolate` can be set to false for tests to skip the logic
   // in `switchToIsolate`.
   DebuggerController({this.initialSwitchToIsolate = true}) {
-    _programExplorerController = ProgramExplorerController(
-      debuggerController: this,
-    );
+    _programExplorerController = ProgramExplorerController();
     autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable.listen(_handleConnectionAvailable),
     );
@@ -95,11 +93,9 @@ class DebuggerController extends DisposableController
     _lastEvent = null;
     _currentScriptRef.value = null;
     _scriptLocation.value = null;
-    _uriToScriptMap.clear();
     _stackFramesWithLocation.value = [];
     _selectedStackFrame.value = null;
     _variables.value = [];
-    _sortedScripts.value = [];
     _breakpoints.value = [];
     _breakpointsWithLocation.value = [];
     _selectedBreakpoint.value = null;
@@ -160,8 +156,6 @@ class DebuggerController extends DisposableController
   ProgramExplorerController get programExplorerController =>
       _programExplorerController;
   ProgramExplorerController _programExplorerController;
-
-  final ScriptCache _scriptCache = ScriptCache();
 
   final ScriptsHistory scriptsHistory = ScriptsHistory();
   VoidCallback _scriptHistoryListener;
@@ -237,9 +231,9 @@ class DebuggerController extends DisposableController
   }
 
   Future<Script> getScriptForRef(ScriptRef ref) async {
-    final cachedScript = getScriptCached(ref);
+    final cachedScript = scriptManager.getScriptCached(ref);
     if (cachedScript == null && ref != null) {
-      return await getScript(ref);
+      return await scriptManager.getScript(ref);
     }
     return cachedScript;
   }
@@ -307,9 +301,6 @@ class DebuggerController extends DisposableController
     return null;
   }
 
-  // A cached map of uris to ScriptRefs.
-  final Map<String, ScriptRef> _uriToScriptMap = {};
-
   final _stackFramesWithLocation =
       ValueNotifier<List<StackFrameAndSourcePosition>>([]);
 
@@ -328,11 +319,6 @@ class DebuggerController extends DisposableController
   final _variables = ValueNotifier<List<DartObjectNode>>([]);
 
   ValueListenable<List<DartObjectNode>> get variables => _variables;
-
-  final _sortedScripts = ValueNotifier<List<ScriptRef>>([]);
-
-  /// Return the sorted list of ScriptRefs active in the current isolate.
-  ValueListenable<List<ScriptRef>> get sortedScripts => _sortedScripts;
 
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
 
@@ -668,19 +654,6 @@ class DebuggerController extends DisposableController
     }
   }
 
-  Future<List<ScriptRef>> _retrieveAndSortScripts(IsolateRef ref) async {
-    assert(isolateRef != null);
-    final scriptList = await _service.getScripts(isolateRef.id);
-    // We filter out non-unique ScriptRefs here (dart-lang/sdk/issues/41661).
-    final scriptRefs = Set.of(scriptList.scripts).toList();
-    scriptRefs.sort((a, b) {
-      // We sort uppercase so that items like dart:foo sort before items like
-      // dart:_foo.
-      return a.uri.toUpperCase().compareTo(b.uri.toUpperCase());
-    });
-    return scriptRefs;
-  }
-
   void _updateAfterIsolateReload(Event reloadEvent) async {
     // Generally this has the value 'success'; we update our data in any case.
     // ignore: unused_local_variable
@@ -688,17 +661,13 @@ class DebuggerController extends DisposableController
 
     _clearAutocompleteCaches();
     // Refresh the list of scripts.
-    final scriptRefs = await _retrieveAndSortScripts(isolateRef);
-    for (var scriptRef in scriptRefs) {
-      _uriToScriptMap[scriptRef.uri] = scriptRef;
-    }
-
+    final previousScriptRefs = scriptManager.sortedScripts.value;
+    final currentScriptRefs =
+        await scriptManager.retrieveAndSortScripts(isolateRef);
     final removedScripts =
-        Set.of(_sortedScripts.value).difference(Set.of(scriptRefs));
+        Set.of(previousScriptRefs).difference(Set.of(currentScriptRefs));
     final addedScripts =
-        Set.of(scriptRefs).difference(Set.of(_sortedScripts.value));
-
-    _sortedScripts.value = scriptRefs;
+        Set.of(currentScriptRefs).difference(Set.of(previousScriptRefs));
 
     // TODO(devoncarew): Show a message in the logging view.
 
@@ -728,7 +697,7 @@ class DebuggerController extends DisposableController
   /// This method ensures that the source for the script is populated in our
   /// cache, in order to reduce flashing in the editor view.
   void _populateScriptAndShowLocation(ScriptRef scriptRef) {
-    getScript(scriptRef).then((script) {
+    scriptManager.getScript(scriptRef).then((script) {
       showScriptLocation(ScriptLocation(scriptRef));
     });
   }
@@ -863,10 +832,8 @@ class DebuggerController extends DisposableController
   }
 
   void _clearCaches() {
-    _scriptCache.clear();
     _lastEvent = null;
     _breakPositionsMap.clear();
-    _uriToScriptMap.clear();
     _clearAutocompleteCaches();
   }
 
@@ -883,32 +850,9 @@ class DebuggerController extends DisposableController
     return _service.getObject(isolateRef.id, objRef.id);
   }
 
-  /// Return a cached [Script] for the given [ScriptRef], returning null
-  /// if there is no cached [Script].
-  Script getScriptCached(ScriptRef scriptRef) {
-    return _scriptCache.getScriptCached(scriptRef);
-  }
-
-  /// Retrieve the [Script] for the given [ScriptRef].
-  ///
-  /// This caches the script lookup for future invocations.
-  Future<Script> getScript(ScriptRef scriptRef) {
-    return _scriptCache.getScript(_service, isolateRef, scriptRef);
-  }
-
-  /// Return the [ScriptRef] at the given [uri].
-  ScriptRef scriptRefForUri(String uri) {
-    return _uriToScriptMap[uri];
-  }
-
   Future<void> _populateScripts(Isolate isolate) async {
     assert(isolate != null);
-    final scriptRefs = await _retrieveAndSortScripts(isolateRef);
-    _sortedScripts.value = scriptRefs;
-
-    for (var scriptRef in scriptRefs) {
-      _uriToScriptMap[scriptRef.uri] = scriptRef;
-    }
+    final scriptRefs = await scriptManager.retrieveAndSortScripts(isolateRef);
 
     // Update the selected script.
     final mainScriptRef = scriptRefs.firstWhere((ref) {
@@ -923,7 +867,7 @@ class DebuggerController extends DisposableController
       Breakpoint breakpoint) async {
     if (breakpoint.resolved) {
       final bp = BreakpointAndSourcePosition.create(breakpoint);
-      return getScript(bp.scriptRef).then((Script script) {
+      return scriptManager.getScript(bp.scriptRef).then((Script script) {
         final pos = SourcePosition.calculatePosition(script, bp.tokenPos);
         return BreakpointAndSourcePosition.create(breakpoint, pos);
       });
@@ -940,7 +884,7 @@ class DebuggerController extends DisposableController
       return StackFrameAndSourcePosition(frame);
     }
 
-    final script = await getScript(location.script);
+    final script = await scriptManager.getScript(location.script);
     final position =
         SourcePosition.calculatePosition(script, location.tokenPos);
     return StackFrameAndSourcePosition(frame, position: position);
@@ -1092,53 +1036,6 @@ class DebuggerController extends DisposableController
       }
     }
     return matches;
-  }
-}
-
-class ScriptCache {
-  ScriptCache();
-
-  Map<String, Script> _scripts = {};
-  final Map<String, Future<Script>> _inProgress = {};
-
-  /// Return a cached [Script] for the given [ScriptRef], returning null
-  /// if there is no cached [Script].
-  Script getScriptCached(ScriptRef scriptRef) {
-    return _scripts[scriptRef?.id];
-  }
-
-  /// Retrieve the [Script] for the given [ScriptRef].
-  ///
-  /// This caches the script lookup for future invocations.
-  Future<Script> getScript(
-      VmService vmService, IsolateRef isolateRef, ScriptRef scriptRef) {
-    if (_scripts.containsKey(scriptRef.id)) {
-      return Future.value(_scripts[scriptRef.id]);
-    }
-
-    if (_inProgress.containsKey(scriptRef.id)) {
-      return _inProgress[scriptRef.id];
-    }
-
-    // We make a copy here as the future could complete after a clear()
-    // operation is performed.
-    final scripts = _scripts;
-
-    final Future<Script> scriptFuture = vmService
-        .getObject(isolateRef.id, scriptRef.id)
-        .then((obj) => obj as Script);
-    _inProgress[scriptRef.id] = scriptFuture;
-
-    unawaited(scriptFuture.then((script) {
-      scripts[scriptRef.id] = script;
-    }));
-
-    return scriptFuture;
-  }
-
-  void clear() {
-    _scripts = {};
-    _inProgress.clear();
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -140,7 +140,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
             children: [
               child,
               ProgramExplorer(
-                debugController: controller,
+                controller: controller.programExplorerController,
                 onSelected: _onLocationSelected,
               ),
             ],
@@ -384,7 +384,7 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
     }
 
     final fileName = ' at ' + frame.location.script.uri.split('/').last;
-    final script = await widget.controller.getScript(frame.location.script);
+    final script = await scriptManager.getScript(frame.location.script);
     final pos =
         SourcePosition.calculatePosition(script, frame.location.tokenPos);
 

--- a/packages/devtools_app/lib/src/screens/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/file_search.dart
@@ -11,6 +11,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
+import '../../shared/globals.dart';
 import '../../ui/search.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
@@ -56,7 +57,7 @@ class FileSearchFieldState extends State<FileSearchField>
     _query = autoCompleteController.search;
 
     _searchResults = FileSearchResults.emptyQuery(
-      widget.debuggerController.sortedScripts.value,
+      scriptManager.sortedScripts.value,
     );
 
     // Open the autocomplete results immediately before a query is entered:
@@ -93,7 +94,7 @@ class FileSearchFieldState extends State<FileSearchField>
     // filter down the previous matches. Otherwise search through all scripts:
     final scripts = currentQuery.startsWith(previousQuery)
         ? _searchResults.scriptRefs
-        : widget.debuggerController.sortedScripts.value;
+        : scriptManager.sortedScripts.value;
 
     final searchResults = _createSearchResults(currentQuery, scripts);
     if (searchResults.scriptRefs.isEmpty) {

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -15,7 +15,6 @@ import '../../shared/globals.dart';
 import '../../shared/theme.dart';
 import '../../shared/tree.dart';
 import '../../shared/utils.dart';
-import 'debugger_controller.dart';
 import 'debugger_model.dart';
 import 'program_explorer_controller.dart';
 import 'program_explorer_model.dart';

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -403,16 +403,16 @@ class _ProgramOutlineView extends StatelessWidget {
 /// Picker that displays the program's structure, allowing for navigation and
 /// filtering.
 class ProgramExplorer extends StatelessWidget {
-  ProgramExplorer({
+  const ProgramExplorer({
     Key key,
-    @required this.debugController,
-    @required this.onSelected,
-  })  : controller = debugController.programExplorerController,
-        super(key: key);
+    @required this.controller,
+    this.onSelected,
+    this.title = 'File Explorer',
+  })  : super(key: key);
 
   final ProgramExplorerController controller;
-  final DebuggerController debugController;
   final void Function(ScriptLocation) onSelected;
+  final String title;
 
   @override
   Widget build(BuildContext context) {
@@ -423,8 +423,8 @@ class ProgramExplorer extends StatelessWidget {
         if (!initialized) {
           body = const CenteredCircularProgressIndicator();
         } else {
-          const fileExplorerHeader = AreaPaneHeader(
-            title: Text('File Explorer'),
+          final fileExplorerHeader = AreaPaneHeader(
+            title: Text(title),
             needsTopBorder: false,
           );
           final fileExplorer = _FileExplorer(
@@ -454,9 +454,9 @@ class ProgramExplorer extends StatelessWidget {
                       totalHeight: constraints.maxHeight,
                       initialFractions: const [0.7, 0.3],
                       minSizes: const [0.0, 0.0],
-                      headers: const <PreferredSizeWidget>[
+                      headers: <PreferredSizeWidget>[
                         fileExplorerHeader,
-                        AreaPaneHeader(title: Text('Outline')),
+                        const AreaPaneHeader(title: Text('Outline')),
                       ],
                       children: [
                         fileExplorer,
@@ -495,7 +495,7 @@ class ProgramExplorer extends StatelessWidget {
       node.expand();
     }
 
-    onSelected(node.location);
+    if (onSelected != null) onSelected(node.location);
   }
 
   void onItemExpanded(VMServiceObjectNode node) async {

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -408,7 +408,7 @@ class ProgramExplorer extends StatelessWidget {
     @required this.controller,
     this.onSelected,
     this.title = 'File Explorer',
-  })  : super(key: key);
+  }) : super(key: key);
 
   final ProgramExplorerController controller;
   final void Function(ScriptLocation) onSelected;

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -13,13 +13,10 @@ import '../../primitives/auto_dispose.dart';
 import '../../primitives/trees.dart';
 import '../../primitives/utils.dart';
 import '../../shared/globals.dart';
-import 'debugger_controller.dart';
 import 'program_explorer_model.dart';
 
 class ProgramExplorerController extends DisposableController
     with AutoDisposeControllerMixin {
-  ProgramExplorerController({@required this.debuggerController});
-
   /// The outline view nodes for the currently selected library.
   ValueListenable<List<VMServiceObjectNode>> get outlineNodes => _outlineNodes;
   final _outlineNodes = ListValueNotifier<VMServiceObjectNode>([]);
@@ -49,8 +46,6 @@ class ProgramExplorerController extends DisposableController
   ValueListenable<bool> get initialized => _initialized;
   final _initialized = ValueNotifier<bool>(false);
   bool _initializing = false;
-
-  DebuggerController debuggerController;
 
   /// Returns true if [function] is a getter or setter that was not explicitly
   /// defined (e.g., `int foo` creates `int get foo` and `set foo(int)`).
@@ -92,7 +87,7 @@ class ProgramExplorerController extends DisposableController
     // TODO(elliette): If file was opened from before the reload, we should try
     // to open that one instead of the entrypoint file.
     addAutoDisposeListener(
-      debuggerController.sortedScripts,
+      scriptManager.sortedScripts,
       refresh,
     );
   }

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -158,7 +158,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
     // The name of this node is not exposed to users.
     final root = VMServiceObjectNode(controller, '<root>', ObjRef(id: '0'));
 
-    final scripts = controller.debuggerController.sortedScripts.value;
+    final scripts = scriptManager.sortedScripts.value;
 
     for (final script in scripts) {
       _buildScriptNode(root, script);
@@ -314,7 +314,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
       script = location.script;
     }
 
-    script = await controller.debuggerController.getScript(script);
+    script = await scriptManager.getScript(script);
     final position = tokenPos == 0
         ? null
         : SourcePosition.calculatePosition(script, tokenPos);

--- a/packages/devtools_app/lib/src/scripts/script_manager.dart
+++ b/packages/devtools_app/lib/src/scripts/script_manager.dart
@@ -37,7 +37,7 @@ class ScriptManager extends DisposableController
   IsolateRef get _currentIsolate =>
       serviceManager.isolateManager.selectedIsolate.value!;
 
-  final _ScriptCache _scriptCache = _ScriptCache();
+  final _scriptCache = _ScriptCache();
 
   /// Refreshes the current set of scripts, updating [sortedScripts]. Returns
   /// the updated value of [sortedScripts].
@@ -71,8 +71,8 @@ class ScriptManager extends DisposableController
 class _ScriptCache {
   _ScriptCache();
 
-  Map<String, Script> _scripts = {};
-  final Map<String, Future<Script>> _inProgress = {};
+  final _scripts = <String, Script>{};
+  final _inProgress = <String, Future<Script>>{};
 
   /// Return a cached [Script] for the given [ScriptRef], returning null
   /// if there is no cached [Script].
@@ -84,7 +84,10 @@ class _ScriptCache {
   ///
   /// This caches the script lookup for future invocations.
   Future<Script> getScript(
-      VmService vmService, IsolateRef isolateRef, ScriptRef scriptRef) {
+    VmService vmService,
+    IsolateRef isolateRef,
+    ScriptRef scriptRef,
+  ) {
     final scriptId = scriptRef.id!;
     if (_scripts.containsKey(scriptId)) {
       return Future.value(_scripts[scriptId]);
@@ -111,7 +114,7 @@ class _ScriptCache {
   }
 
   void clear() {
-    _scripts = {};
+    _scripts.clear();
     _inProgress.clear();
   }
 }

--- a/packages/devtools_app/lib/src/scripts/script_manager.dart
+++ b/packages/devtools_app/lib/src/scripts/script_manager.dart
@@ -1,0 +1,117 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../primitives/auto_dispose.dart';
+import '../service/vm_service_wrapper.dart';
+import '../shared/globals.dart';
+
+class ScriptManager extends DisposableController
+    with AutoDisposeControllerMixin {
+  ScriptManager() {
+    autoDisposeStreamSubscription(
+      serviceManager.onConnectionAvailable.listen((service) {
+        if (service == _lastService) return;
+        _lastService = service;
+        _scriptCache.clear();
+      }),
+    );
+    addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
+      _scriptCache.clear();
+    });
+  }
+
+  /// Return the sorted list of ScriptRefs active in the current isolate.
+  ValueListenable<List<ScriptRef>> get sortedScripts => _sortedScripts;
+
+  final _sortedScripts = ValueNotifier<List<ScriptRef>>([]);
+
+  VmServiceWrapper get _service => serviceManager.service!;
+  VmServiceWrapper? _lastService;
+
+  IsolateRef get _currentIsolate =>
+      serviceManager.isolateManager.selectedIsolate.value!;
+
+  final _ScriptCache _scriptCache = _ScriptCache();
+
+  /// Refreshes the current set of scripts, updating [sortedScripts]. Returns
+  /// the updated value of [sortedScripts].
+  Future<List<ScriptRef>> retrieveAndSortScripts(IsolateRef isolateRef) async {
+    final scriptList = await _service.getScripts(isolateRef.id!);
+    // We filter out non-unique ScriptRefs here (dart-lang/sdk/issues/41661).
+    final scriptRefs = Set.of(scriptList.scripts!).toList();
+    scriptRefs.sort((a, b) {
+      // We sort uppercase so that items like dart:foo sort before items like
+      // dart:_foo.
+      return a.uri!.toUpperCase().compareTo(b.uri!.toUpperCase());
+    });
+    _sortedScripts.value = scriptRefs;
+    return scriptRefs;
+  }
+
+  /// Return a cached [Script] for the given [ScriptRef], returning null
+  /// if there is no cached [Script].
+  Script? getScriptCached(ScriptRef scriptRef) {
+    return _scriptCache.getScriptCached(scriptRef);
+  }
+
+  /// Retrieve the [Script] for the given [ScriptRef].
+  ///
+  /// This caches the script lookup for future invocations.
+  Future<Script> getScript(ScriptRef scriptRef) {
+    return _scriptCache.getScript(_service, _currentIsolate, scriptRef);
+  }
+}
+
+class _ScriptCache {
+  _ScriptCache();
+
+  Map<String, Script> _scripts = {};
+  final Map<String, Future<Script>> _inProgress = {};
+
+  /// Return a cached [Script] for the given [ScriptRef], returning null
+  /// if there is no cached [Script].
+  Script? getScriptCached(ScriptRef scriptRef) {
+    return _scripts[scriptRef.id];
+  }
+
+  /// Retrieve the [Script] for the given [ScriptRef].
+  ///
+  /// This caches the script lookup for future invocations.
+  Future<Script> getScript(
+      VmService vmService, IsolateRef isolateRef, ScriptRef scriptRef) {
+    final scriptId = scriptRef.id!;
+    if (_scripts.containsKey(scriptId)) {
+      return Future.value(_scripts[scriptId]);
+    }
+
+    if (_inProgress.containsKey(scriptId)) {
+      return _inProgress[scriptId]!;
+    }
+
+    // We make a copy here as the future could complete after a clear()
+    // operation is performed.
+    final scripts = _scripts;
+
+    final Future<Script> scriptFuture = vmService
+        .getObject(isolateRef.id!, scriptId)
+        .then((obj) => obj as Script);
+    _inProgress[scriptId] = scriptFuture;
+
+    unawaited(scriptFuture.then((script) {
+      scripts[scriptId] = script;
+    }));
+
+    return scriptFuture;
+  }
+
+  void clear() {
+    _scripts = {};
+    _inProgress.clear();
+  }
+}

--- a/packages/devtools_app/lib/src/shared/globals.dart
+++ b/packages/devtools_app/lib/src/shared/globals.dart
@@ -9,6 +9,7 @@ import '../config_specific/import_export/import_export.dart';
 import '../extension_points/extensions_base.dart';
 import '../primitives/message_bus.dart';
 import '../primitives/storage.dart';
+import '../scripts/script_manager.dart';
 import '../service/service_manager.dart';
 import 'framework_controller.dart';
 import 'preferences.dart';
@@ -18,6 +19,8 @@ final Map<Type, dynamic> globals = <Type, dynamic>{};
 
 ServiceConnectionManager get serviceManager =>
     globals[ServiceConnectionManager];
+
+ScriptManager get scriptManager => globals[ScriptManager];
 
 MessageBus get messageBus => globals[MessageBus];
 

--- a/packages/devtools_app/test/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger_screen_test.dart
@@ -26,16 +26,19 @@ void main() {
   DebuggerScreen screen;
   FakeServiceManager fakeServiceManager;
   MockDebuggerController debuggerController;
+  MockScriptManager scriptManager;
 
   const windowSize = Size(4000.0, 4000.0);
   const smallWindowSize = Size(1000.0, 1000.0);
 
   setUp(() {
     fakeServiceManager = FakeServiceManager();
+    scriptManager = MockScriptManager();
     when(fakeServiceManager.connectedApp.isProfileBuildNow).thenReturn(false);
     when(fakeServiceManager.connectedApp.isDartWebAppNow).thenReturn(false);
     setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(ScriptManager, scriptManager);
     fakeServiceManager.consoleService.ensureServiceInitialized();
   });
 
@@ -216,7 +219,7 @@ void main() {
 
       when(debuggerController.programExplorerController.selectedNodeIndex)
           .thenReturn(ValueNotifier(0));
-      when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(scriptManager.sortedScripts).thenReturn(ValueNotifier(scripts));
       when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
 
       // File Explorer view is hidden
@@ -234,7 +237,7 @@ void main() {
 
       when(debuggerController.programExplorerController.selectedNodeIndex)
           .thenReturn(ValueNotifier(0));
-      when(debuggerController.sortedScripts).thenReturn(ValueNotifier(scripts));
+      when(scriptManager.sortedScripts).thenReturn(ValueNotifier(scripts));
       when(debuggerController.programExplorerController.rootObjectNodes)
           .thenReturn(
         ValueNotifier(
@@ -287,7 +290,7 @@ void main() {
       when(debuggerController.breakpointsWithLocation)
           .thenReturn(ValueNotifier(breakpointsWithLocation));
 
-      when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
+      when(scriptManager.sortedScripts).thenReturn(ValueNotifier([]));
       when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
       when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
 

--- a/packages/devtools_app/test/file_search_test.dart
+++ b/packages/devtools_app/test/file_search_test.dart
@@ -6,6 +6,7 @@
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/file_search.dart';
+import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/ui/search.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -15,6 +16,7 @@ import 'package:mockito/mockito.dart';
 
 void main() {
   final debuggerController = MockDebuggerController.withDefaults();
+  final scriptManager = MockScriptManager();
 
   Widget buildFileSearch() {
     return MaterialApp(
@@ -30,9 +32,10 @@ void main() {
 
   group('File search', () {
     setUp(() {
-      when(debuggerController.sortedScripts)
+      when(scriptManager.sortedScripts)
           .thenReturn(ValueNotifier(mockScriptRefs));
       setGlobal(IdeTheme, IdeTheme());
+      setGlobal(ScriptManager, scriptManager);
     });
 
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -121,6 +121,7 @@ class FlutterTestEnvironment {
       setGlobal(PreferencesController, preferencesController);
       setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
       setGlobal(MessageBus, MessageBus());
+      setGlobal(ScriptManager, ScriptManager());
 
       // Clear out VM service calls from the test driver.
       // ignore: invalid_use_of_visible_for_testing_member

--- a/packages/devtools_test/lib/src/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks.dart
@@ -740,8 +740,7 @@ class MockDebuggerController extends Mock implements DebuggerController {
       MockProgramExplorerController.withDefaults();
 }
 
-class MockScriptManager extends Mock implements ScriptManager {
-}
+class MockScriptManager extends Mock implements ScriptManager {}
 
 class MockProgramExplorerController extends Mock
     implements ProgramExplorerController {

--- a/packages/devtools_test/lib/src/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks.dart
@@ -720,7 +720,6 @@ class MockDebuggerController extends Mock implements DebuggerController {
     when(debuggerController.fileExplorerVisible)
         .thenReturn(ValueNotifier(false));
     when(debuggerController.currentScriptRef).thenReturn(ValueNotifier(null));
-    when(debuggerController.sortedScripts).thenReturn(ValueNotifier([]));
     when(debuggerController.selectedBreakpoint).thenReturn(ValueNotifier(null));
     when(debuggerController.stackFramesWithLocation)
         .thenReturn(ValueNotifier([]));
@@ -741,6 +740,9 @@ class MockDebuggerController extends Mock implements DebuggerController {
       MockProgramExplorerController.withDefaults();
 }
 
+class MockScriptManager extends Mock implements ScriptManager {
+}
+
 class MockProgramExplorerController extends Mock
     implements ProgramExplorerController {
   MockProgramExplorerController();
@@ -750,6 +752,7 @@ class MockProgramExplorerController extends Mock
     when(controller.initialized).thenReturn(ValueNotifier(true));
     when(controller.rootObjectNodes).thenReturn(ValueNotifier([]));
     when(controller.outlineNodes).thenReturn(ValueNotifier([]));
+    when(controller.outlineSelection).thenReturn(ValueNotifier(null));
     when(controller.isLoadingOutline).thenReturn(ValueNotifier(false));
 
     return controller;


### PR DESCRIPTION
Allows for removal of `DebuggerController` dependency in `ProgramExplorerController` while maintaining a shared script caching mechanism.