### PR TITLE
Add scrolling support to all hover cards

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -793,15 +793,10 @@ class _LineItemState extends State<LineItem> {
           if (_hasMouseExited) return;
           _hoverCard?.remove();
           _hoverCard = HoverCard.fromHoverEvent(
-            contents: SingleChildScrollView(
-              child: Container(
-                constraints: BoxConstraints(maxHeight: maxHoverCardHeight),
-                child: Material(
-                  child: ExpandableVariable(
-                    debuggerController: _debuggerController,
-                    variable: variable,
-                  ),
-                ),
+            contents: Material(
+              child: ExpandableVariable(
+                debuggerController: _debuggerController,
+                variable: variable,
               ),
             ),
             event: event,

--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -114,7 +114,9 @@ class HoverCard {
     required double width,
     required Offset position,
     String? title,
+    double? maxCardHeight,
   }) {
+    maxCardHeight ??= maxHoverCardHeight;
     final overlayState = Overlay.of(context)!;
     final colorScheme = Theme.of(context).colorScheme;
     final focusColor = Theme.of(context).focusColor;
@@ -157,7 +159,12 @@ class HoverCard {
                   ),
                   Divider(color: colorScheme.hoverTextStyle.color),
                 ],
-                contents,
+                SingleChildScrollView(
+                  child: Container(
+                    constraints: BoxConstraints(maxHeight: maxCardHeight!),
+                    child: contents,
+                  ),
+                ),
               ],
             ),
           ),


### PR DESCRIPTION
Moved the scrolling support for Debugger hover cards up one level so that all hover cards can use this same functionality. Fixes https://github.com/flutter/devtools/issues/3922