### PR TITLE
Only send the dwds event when the service is registered

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -427,14 +427,13 @@ class InspectorController extends DisposableController
     }
 
     if (flutterAppFrameReady) {
-      if (serviceManager.connectedApp!.isDartWebAppNow!) {
-        unawaited(
-          serviceManager.sendDwdsEvent(
-            screen: InspectorScreen.id,
-            action: analytics_constants.pageReady,
-          ),
-        );
-      }
+      unawaited(
+        serviceManager.sendDwdsEvent(
+          screen: InspectorScreen.id,
+          action: analytics_constants.pageReady,
+        ),
+      );
+
       if (_disposed) return;
       // We need to start by querying the inspector service to find out the
       // current state of the UI.

--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -368,6 +368,9 @@ class ServiceConnectionManager {
     required String screen,
     required String action,
   }) async {
+    final serviceRegistered = serviceManager.registeredMethodsForService
+        .containsKey(registrations.dwdsSendEvent);
+    if (!serviceRegistered) return;
     await _callServiceExtensionOnMainIsolate(
       registrations.dwdsSendEvent,
       args: {


### PR DESCRIPTION
This will prevent us from attempting to send this dwds event when the dwds service is not registered (non web apps and some special cases internally).

FYI @annagrin 