### PR TITLE
Migrate Screens Debugger files to null safety

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
 
 // ignore_for_file: avoid_redundant_argument_values
 
 import 'dart:async';
 
+import 'package:collection/collection.dart';
 import 'package:async/async.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
@@ -46,9 +46,9 @@ class DebuggerController extends DisposableController
     }
     _scriptHistoryListener = () {
       if (scriptsHistory.current.value != null)
-        _showScriptLocation(ScriptLocation(scriptsHistory.current.value));
+        _showScriptLocation(ScriptLocation(scriptsHistory.current.value!));
     };
-    scriptsHistory.current.addListener(_scriptHistoryListener);
+    scriptsHistory.current.addListener(_scriptHistoryListener!);
   }
 
   bool _firstDebuggerScreenLoaded = false;
@@ -68,13 +68,13 @@ class DebuggerController extends DisposableController
   }
 
   Future<void> _maybeSetUpProgramExplorer() async {
-    if (!programExplorerController.initialized.value) {
+    if (!programExplorerController!.initialized.value) {
       programExplorerController
-        ..initListeners()
+        ?..initListeners()
         ..initialize();
     }
     if (currentScriptRef.value != null) {
-      await programExplorerController.selectScriptNode(currentScriptRef.value);
+      await programExplorerController!.selectScriptNode(currentScriptRef.value);
     }
   }
 
@@ -91,20 +91,20 @@ class DebuggerController extends DisposableController
     _isPaused.value = false;
     _resuming.value = false;
     _lastEvent = null;
-    _currentScriptRef.value = null;
-    _scriptLocation.value = null;
+    _currentScriptRef!.value = null as ScriptRef;
+    _scriptLocation!.value = null as ScriptLocation;
     _stackFramesWithLocation.value = [];
-    _selectedStackFrame.value = null;
+    _selectedStackFrame.value = null as StackFrameAndSourcePosition;
     _variables.value = [];
     _breakpoints.value = [];
     _breakpointsWithLocation.value = [];
-    _selectedBreakpoint.value = null;
+    _selectedBreakpoint.value = null as BreakpointAndSourcePosition;
     _librariesVisible.value = false;
     isolateRef = null;
     _firstDebuggerScreenLoaded = false;
   }
 
-  VmServiceWrapper _lastService;
+  VmServiceWrapper? _lastService;
 
   void _handleConnectionAvailable(VmServiceWrapper service) {
     if (service == _lastService) return;
@@ -118,11 +118,11 @@ class DebuggerController extends DisposableController
   void initialize() {
     if (initialSwitchToIsolate) {
       assert(serviceManager.isolateManager.selectedIsolate.value != null);
-      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
+      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value!);
     }
 
     addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
-      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
+      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value!);
     });
     autoDisposeStreamSubscription(
         _service.onDebugEvent.listen(_handleDebugEvent));
@@ -133,9 +133,9 @@ class DebuggerController extends DisposableController
   final bool initialSwitchToIsolate;
 
   IsolateState get isolateDebuggerState =>
-      serviceManager.isolateManager.isolateDebuggerState(isolateRef);
+      serviceManager.isolateManager.isolateDebuggerState(isolateRef)!;
 
-  VmServiceWrapper get _service => serviceManager.service;
+  VmServiceWrapper get _service => serviceManager.service!;
 
   /// Cache of autocomplete matches to show for a library when that library is
   /// imported.
@@ -153,12 +153,12 @@ class DebuggerController extends DisposableController
   Map<LibraryRef, Future<Set<String>>>
       libraryMemberAndImportsAutocompleteCache = {};
 
-  ProgramExplorerController get programExplorerController =>
+  ProgramExplorerController? get programExplorerController =>
       _programExplorerController;
-  ProgramExplorerController _programExplorerController;
+  ProgramExplorerController? _programExplorerController;
 
   final ScriptsHistory scriptsHistory = ScriptsHistory();
-  VoidCallback _scriptHistoryListener;
+  VoidCallback? _scriptHistoryListener;
 
   final _isPaused = ValueNotifier<bool>(false);
 
@@ -170,26 +170,26 @@ class DebuggerController extends DisposableController
   /// VM, but haven't yet received the 'resumed' isolate event.
   ValueListenable<bool> get resuming => _resuming;
 
-  Event _lastEvent;
+  Event? _lastEvent;
 
-  Event get lastEvent => _lastEvent;
+  Event? get lastEvent => _lastEvent;
 
-  final _currentScriptRef = ValueNotifier<ScriptRef>(null);
+  final ValueNotifier<ScriptRef>? _currentScriptRef = ValueNotifier<ScriptRef>(null as ScriptRef);
 
-  ValueListenable<ScriptRef> get currentScriptRef => _currentScriptRef;
+  ValueListenable<ScriptRef> get currentScriptRef => _currentScriptRef!;
 
   @visibleForTesting
-  final parsedScript = ValueNotifier<ParsedScript>(null);
+  final ValueNotifier<ParsedScript>? parsedScript = ValueNotifier<ParsedScript>(null as ParsedScript);
 
-  ValueListenable<ParsedScript> get currentParsedScript => parsedScript;
+  ValueListenable<ParsedScript>? get currentParsedScript => parsedScript;
 
   ValueListenable<bool> get showSearchInFileField => _showSearchInFileField;
 
   final _showSearchInFileField = ValueNotifier<bool>(false);
 
-  ValueListenable<ScriptLocation> get scriptLocation => _scriptLocation;
+  ValueListenable<ScriptLocation>? get scriptLocation => _scriptLocation;
 
-  final _scriptLocation = ValueNotifier<ScriptLocation>(null);
+  final ValueNotifier<ScriptLocation>? _scriptLocation = ValueNotifier<ScriptLocation>(null as ScriptLocation);
 
   ValueListenable<bool> get showFileOpener => _showFileOpener;
 
@@ -209,16 +209,16 @@ class DebuggerController extends DisposableController
 
     // Update the scripts history (and make sure we don't react to the
     // subsequent event).
-    scriptsHistory.current.removeListener(_scriptHistoryListener);
-    scriptsHistory.pushEntry(scriptLocation.scriptRef);
-    scriptsHistory.current.addListener(_scriptHistoryListener);
+    scriptsHistory.current.removeListener(_scriptHistoryListener!);
+    scriptsHistory.pushEntry(scriptLocation.scriptRef!);
+    scriptsHistory.current.addListener(_scriptHistoryListener!);
   }
 
   /// Show the given script location (without updating the script navigation
   /// history).
   void _showScriptLocation(ScriptLocation scriptLocation) {
-    _currentScriptRef.value = scriptLocation?.scriptRef;
-    if (_currentScriptRef.value == null) {
+    _currentScriptRef!.value = scriptLocation.scriptRef!;
+    if (_currentScriptRef!.value == null) {
       log('Trying to show a location with a null script ref', LogLevel.error);
     }
 
@@ -226,8 +226,8 @@ class DebuggerController extends DisposableController
 
     // We want to notify regardless of the previous scriptLocation, temporarily
     // set to null to ensure that happens.
-    _scriptLocation.value = null;
-    _scriptLocation.value = scriptLocation;
+    _scriptLocation!.value = null as ScriptLocation;
+    _scriptLocation!.value = scriptLocation;
   }
 
   Future<Script> getScriptForRef(ScriptRef ref) async {
@@ -235,21 +235,21 @@ class DebuggerController extends DisposableController
     if (cachedScript == null && ref != null) {
       return await scriptManager.getScript(ref);
     }
-    return cachedScript;
+    return cachedScript!;
   }
 
   /// Parses the current script into executable lines and prepares the script
   /// for syntax highlighting.
   Future<void> _parseCurrentScript() async {
     // Return early if the current script has not changed.
-    if (parsedScript.value?.script?.id == _currentScriptRef?.value?.id) return;
+    if (parsedScript!.value.script.id == _currentScriptRef?.value.id) return;
 
-    final scriptRef = _currentScriptRef.value;
+    final scriptRef = _currentScriptRef!.value;
     final script = await getScriptForRef(scriptRef);
 
     // Create a new SyntaxHighlighter with the script's source in preparation
     // for building the code view.
-    final highlighter = SyntaxHighlighter(source: script?.source ?? '');
+    final highlighter = SyntaxHighlighter(source: script.source ?? '');
 
     // Gather the data to display breakable lines.
     var executableLines = <int>{};
@@ -262,7 +262,7 @@ class DebuggerController extends DisposableController
         // Ignore - not supported for all vm service implementations.
         log('$e');
       }
-      parsedScript.value = ParsedScript(
+      parsedScript!.value = ParsedScript(
         script: script,
         highlighter: highlighter,
         executableLines: executableLines,
@@ -273,17 +273,17 @@ class DebuggerController extends DisposableController
   /// Find the owner library for a ClassRef, FuncRef, or LibraryRef.
   ///
   /// If Dart had union types, ref would be type ClassRef | FuncRef | LibraryRef
-  Future<LibraryRef> findOwnerLibrary(Object ref) async {
+  Future<LibraryRef?> findOwnerLibrary(Object ref) async {
     if (ref is LibraryRef) {
       return ref;
     }
     if (ref is ClassRef) {
       if (ref.library != null) {
-        return ref.library;
+        return ref.library!;
       }
       // Fallback for older VMService versions.
       final clazz = await classFor(ref);
-      return clazz?.library;
+      return clazz!.library;
     }
     if (ref is FuncRef) {
       return findOwnerLibrary(ref.owner);
@@ -294,9 +294,13 @@ class DebuggerController extends DisposableController
   /// Returns the class for the provided [ClassRef].
   ///
   /// May return null.
-  Future<Class> classFor(ClassRef classRef) async {
+  Future<Class?> classFor(ClassRef classRef) async {
     try {
-      return _clazzCache[classRef] ??= await getObject(classRef);
+      if(_clazzCache[classRef] != null) {
+        return _clazzCache[classRef];
+      }
+
+      await getObject(classRef);
     } catch (_) {}
     return null;
   }
@@ -307,14 +311,19 @@ class DebuggerController extends DisposableController
   ValueListenable<List<StackFrameAndSourcePosition>>
       get stackFramesWithLocation => _stackFramesWithLocation;
 
-  final _selectedStackFrame = ValueNotifier<StackFrameAndSourcePosition>(null);
+  final _selectedStackFrame = ValueNotifier<StackFrameAndSourcePosition>(null as StackFrameAndSourcePosition);
 
   ValueListenable<StackFrameAndSourcePosition> get selectedStackFrame =>
       _selectedStackFrame;
 
-  Frame get frameForEval =>
-      _selectedStackFrame.value?.frame ??
-      _stackFramesWithLocation.value?.safeFirst?.frame;
+  Frame get frameForEval {
+
+    if(_selectedStackFrame.value.frame != null) {  //dep
+      return _selectedStackFrame.value.frame!;
+    }
+
+    return _stackFramesWithLocation.value.safeFirst!.frame!;
+  }
 
   final _variables = ValueNotifier<List<DartObjectNode>>([]);
 
@@ -330,7 +339,7 @@ class DebuggerController extends DisposableController
   ValueListenable<List<BreakpointAndSourcePosition>>
       get breakpointsWithLocation => _breakpointsWithLocation;
 
-  final _selectedBreakpoint = ValueNotifier<BreakpointAndSourcePosition>(null);
+  final _selectedBreakpoint = ValueNotifier<BreakpointAndSourcePosition>(null as BreakpointAndSourcePosition);
 
   ValueListenable<BreakpointAndSourcePosition> get selectedBreakpoint =>
       _selectedBreakpoint;
@@ -351,7 +360,7 @@ class DebuggerController extends DisposableController
     _librariesVisible.value = !_librariesVisible.value;
   }
 
-  IsolateRef isolateRef;
+  IsolateRef? isolateRef;
   bool get isSystemIsolate => isolateRef?.isSystemIsolate ?? false;
 
   final EvalHistory evalHistory = EvalHistory();
@@ -371,15 +380,15 @@ class DebuggerController extends DisposableController
       return;
     }
 
-    final isolate = await _service.getIsolate(isolateRef.id);
+    final isolate = await _service.getIsolate(isolateRef!.id!);
     if (isolate.id != isolateRef?.id) {
       // Current request is obsolete.
       return;
     }
 
     if (isolate.pauseEvent != null &&
-        isolate.pauseEvent.kind != EventKind.kResume) {
-      _lastEvent = isolate.pauseEvent;
+        isolate.pauseEvent!.kind != EventKind.kResume) {
+      _lastEvent = isolate.pauseEvent!;
       await _pause(true, pauseEvent: isolate.pauseEvent);
     }
     if (isolate.id != isolateRef?.id) {
@@ -387,7 +396,7 @@ class DebuggerController extends DisposableController
       return;
     }
 
-    _breakpoints.value = isolate.breakpoints;
+    _breakpoints.value = isolate.breakpoints!;
 
     // Build _breakpointsWithLocation from _breakpoints.
     if (_breakpoints.value != null) {
@@ -402,21 +411,21 @@ class DebuggerController extends DisposableController
       });
     }
 
-    _exceptionPauseMode.value = isolate.exceptionPauseMode;
+    _exceptionPauseMode.value = isolate.exceptionPauseMode!;
 
-    if (isolate.id != isolateRef?.id) {
+    if (isolate.id != isolateRef!.id) {
       // Current request is obsolete.
       return;
     }
     await _populateScripts(isolate);
   }
 
-  Future<Success> pause() => _service.pause(isolateRef.id);
+  Future<Success> pause() => _service.pause(isolateRef!.id!);
 
   Future<Success> resume() {
     _log.log('resume()');
     _resuming.value = true;
-    return _service.resume(isolateRef.id);
+    return _service.resume(isolateRef!.id!);
   }
 
   Future<Success> stepOver() {
@@ -424,10 +433,10 @@ class DebuggerController extends DisposableController
     _resuming.value = true;
 
     // Handle async suspensions; issue StepOption.kOverAsyncSuspension.
-    final useAsyncStepping = _lastEvent?.atAsyncSuspension ?? false;
+    final useAsyncStepping = _lastEvent!.atAsyncSuspension ?? false;
     return _service
         .resume(
-          isolateRef.id,
+          isolateRef!.id!,
           step: useAsyncStepping
               ? StepOption.kOverAsyncSuspension
               : StepOption.kOver,
@@ -438,13 +447,13 @@ class DebuggerController extends DisposableController
   Future<Success> stepIn() {
     _resuming.value = true;
 
-    return _service.resume(isolateRef.id, step: StepOption.kInto);
+    return _service.resume(isolateRef!.id!, step: StepOption.kInto);
   }
 
   Future<Success> stepOut() {
     _resuming.value = true;
 
-    return _service.resume(isolateRef.id, step: StepOption.kOut);
+    return _service.resume(isolateRef!.id!, step: StepOption.kOut);
   }
 
   /// Evaluate the given expression in the context of the currently selected
@@ -466,12 +475,12 @@ class DebuggerController extends DisposableController
       );
     }
 
-    final frame = selectedStackFrame.value?.frame ??
+    final frame = selectedStackFrame.value.frame ??
         stackFramesWithLocation.value.first.frame;
 
     return _service.evaluateInFrame(
-      isolateRef.id,
-      frame.index,
+      isolateRef!.id!,
+      frame!.index!,
       expression,
       disableBreakpoints: true,
     );
@@ -480,8 +489,8 @@ class DebuggerController extends DisposableController
   /// Call `toString()` on the given instance and return the result.
   Future<Response> invokeToString(InstanceRef instance) {
     return _service.invoke(
-      isolateRef.id,
-      instance.id,
+      isolateRef!.id!,
+      instance.id!,
       'toString',
       <String>[],
       disableBreakpoints: true,
@@ -489,14 +498,15 @@ class DebuggerController extends DisposableController
   }
 
   /// Retrieves the full string value of a [stringRef].
-  Future<String> retrieveFullStringValue(
+  Future<String?> retrieveFullStringValue(
     InstanceRef stringRef, {
-    String onUnavailable(String truncatedValue),
+    String onUnavailable(String truncatedValue)?,
   }) async {
-    return serviceManager.service.retrieveFullStringValue(
-      isolateRef.id,
+    final String Function(String?)? onUnavailableLocal = onUnavailable as String Function(String? p1)?;
+    return serviceManager.service!.retrieveFullStringValue(
+      isolateRef!.id!,
       stringRef,
-      onUnavailable: onUnavailable,
+      onUnavailable: onUnavailableLocal,
     );
   }
 
@@ -508,10 +518,10 @@ class DebuggerController extends DisposableController
   }
 
   Future<Breakpoint> addBreakpoint(String scriptId, int line) =>
-      _service.addBreakpoint(isolateRef.id, scriptId, line);
+      _service.addBreakpoint(isolateRef!.id!, scriptId, line);
 
   Future<void> removeBreakpoint(Breakpoint breakpoint) =>
-      _service.removeBreakpoint(isolateRef.id, breakpoint.id);
+      _service.removeBreakpoint(isolateRef!.id!, breakpoint.id!);
 
   Future<void> toggleBreakpoint(ScriptRef script, int line) async {
     if (serviceManager.isolateManager.selectedIsolate.value == null) {
@@ -521,19 +531,19 @@ class DebuggerController extends DisposableController
     // The VM doesn't support debugging for system isolates and will crash on
     // a failed assert in debug mode. Disable the toggle breakpoint
     // functionality for system isolates.
-    if (serviceManager.isolateManager.selectedIsolate.value.isSystemIsolate) {
+    if (serviceManager.isolateManager.selectedIsolate.value!.isSystemIsolate!) {
       return;
     }
 
-    final bp = breakpointsWithLocation.value.firstWhere((bp) {
+    final bp = breakpointsWithLocation.value.firstWhereOrNull((bp) {
       return bp.scriptRef == script && bp.line == line;
-    }, orElse: () => null);
+    });
 
     if (bp != null) {
-      await removeBreakpoint(bp.breakpoint);
+      await removeBreakpoint(bp.breakpoint!);
     } else {
       try {
-        await addBreakpoint(script.id, line);
+        await addBreakpoint(script.id!, line);
       } catch (_) {
         // ignore errors setting breakpoints
       }
@@ -541,7 +551,7 @@ class DebuggerController extends DisposableController
   }
 
   Future<void> setIsolatePauseMode(String mode) async {
-    await _service.setIsolatePauseMode(isolateRef.id, exceptionPauseMode: mode);
+    await _service.setIsolatePauseMode(isolateRef!.id!, exceptionPauseMode: mode);
     _exceptionPauseMode.value = mode;
   }
 
@@ -552,9 +562,9 @@ class DebuggerController extends DisposableController
     assert(event.kind == EventKind.kPauseStart);
     assert(_resuming.value);
 
-    final id = event.isolate.id;
+    final id = event.isolate!.id;
     _log.log('resume() $id');
-    return _service.resume(id);
+    return _service.resume(id!);
   }
 
   void _handleDebugEvent(Event event) {
@@ -563,12 +573,12 @@ class DebuggerController extends DisposableController
     // We're resuming and another isolate has started in a paused state,
     // resume any pauseState isolates.
     if (_resuming.value &&
-        event.isolate.id != isolateRef?.id &&
+        event.isolate!.id != isolateRef!.id &&
         event.kind == EventKind.kPauseStart) {
       _resumeIsolatePauseStart(event);
     }
 
-    if (event.isolate.id != isolateRef?.id) return;
+    if (event.isolate!.id != isolateRef!.id) return;
 
     _lastEvent = event;
 
@@ -590,10 +600,10 @@ class DebuggerController extends DisposableController
       // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'
       // that knows how to notify when performing a list edit operation.
       case EventKind.kBreakpointAdded:
-        _breakpoints.value = [..._breakpoints.value, event.breakpoint];
+        _breakpoints.value = [..._breakpoints.value, event.breakpoint!];
 
         // ignore: unawaited_futures
-        _createBreakpointWithLocation(event.breakpoint).then((bp) {
+        _createBreakpointWithLocation(event.breakpoint!).then((bp) {
           final list = [
             ..._breakpointsWithLocation.value,
             bp,
@@ -607,14 +617,14 @@ class DebuggerController extends DisposableController
         _breakpoints.value = [
           for (var b in _breakpoints.value)
             if (b != event.breakpoint) b,
-          event.breakpoint
+          event.breakpoint!
         ];
 
         // ignore: unawaited_futures
-        _createBreakpointWithLocation(event.breakpoint).then((bp) {
+        _createBreakpointWithLocation(event.breakpoint!).then((bp) {
           final list = _breakpointsWithLocation.value.toList();
           // Remote the bp with the older, unresolved information from the list.
-          list.removeWhere((breakpoint) => bp.breakpoint.id == bp.id);
+          list.removeWhere((breakpoint) => bp.breakpoint!.id == bp.id);
           // Add the bp with the newer, resolved information.
           list.add(bp);
           list.sort();
@@ -627,8 +637,8 @@ class DebuggerController extends DisposableController
         final breakpoint = event.breakpoint;
 
         // Update _selectedBreakpoint if necessary.
-        if (_selectedBreakpoint.value?.breakpoint == breakpoint) {
-          _selectedBreakpoint.value = null;
+        if (_selectedBreakpoint.value.breakpoint == breakpoint) {
+          _selectedBreakpoint.value = null as BreakpointAndSourcePosition;
         }
 
         _breakpoints.value = [
@@ -646,7 +656,7 @@ class DebuggerController extends DisposableController
   }
 
   void _handleIsolateEvent(Event event) {
-    if (event.isolate.id != isolateRef?.id) return;
+    if (event.isolate!.id != isolateRef!.id) return;
     switch (event.kind) {
       case EventKind.kIsolateReload:
         _updateAfterIsolateReload(event);
@@ -663,7 +673,7 @@ class DebuggerController extends DisposableController
     // Refresh the list of scripts.
     final previousScriptRefs = scriptManager.sortedScripts.value;
     final currentScriptRefs =
-        await scriptManager.retrieveAndSortScripts(isolateRef);
+        await scriptManager.retrieveAndSortScripts(isolateRef!);
     final removedScripts =
         Set.of(previousScriptRefs).difference(Set.of(currentScriptRefs));
     final addedScripts =
@@ -683,7 +693,7 @@ class DebuggerController extends DisposableController
     if (removedScripts.contains(currentScriptRef.value)) {
       final uri = currentScriptRef.value.uri;
       final newScriptRef = addedScripts
-          .firstWhere((script) => script.uri == uri, orElse: () => null);
+          .firstWhereOrNull((script) => script.uri == uri);
 
       if (newScriptRef != null) {
         // Display the script location.
@@ -723,14 +733,14 @@ class DebuggerController extends DisposableController
 
     // Remove the breakpoints.
     for (final bp in breakpointsToRemove) {
-      removeBreakpoint(bp.breakpoint);
+      removeBreakpoint(bp.breakpoint!);
     }
 
     // Add them back to the newer versions of those scripts.
     for (final scriptRef in addedScripts) {
       for (final bp in breakpointsToRemove) {
         if (scriptRef.uri == bp.scriptUri) {
-          addBreakpoint(scriptRef.id, bp.line);
+          addBreakpoint(scriptRef.id!, bp.line);
         }
       }
     }
@@ -740,9 +750,9 @@ class DebuggerController extends DisposableController
 
   ValueListenable<bool> get hasTruncatedFrames => _hasTruncatedFrames;
 
-  CancelableOperation<_StackInfo> _getStackOperation;
+  CancelableOperation<_StackInfo>? _getStackOperation;
 
-  Future<void> _pause(bool paused, {Event pauseEvent}) async {
+  Future<void> _pause(bool paused, {Event? pauseEvent}) async {
     // TODO(jacobr): unify pause support with
     // serviceManager.isolateManager.selectedIsolateState.isPaused.value;
     // listening for changes there instead of having separate logic.
@@ -763,10 +773,10 @@ class DebuggerController extends DisposableController
     // TODO(elliette): Find a better solution for this. Currently, this means
     // we fetch all variable objects twice (once in _getFullStack and once in
     // in_createStackFrameWithLocation).
-    if (await serviceManager.connectedApp.isDartWebApp) {
+    if (await serviceManager.connectedApp!.isDartWebApp) {
       _populateFrameInfo(
         [
-          await _createStackFrameWithLocation(pauseEvent.topFrame),
+          await _createStackFrameWithLocation(pauseEvent!.topFrame!),
         ],
         truncated: true,
       );
@@ -781,7 +791,7 @@ class DebuggerController extends DisposableController
     _getStackOperation = CancelableOperation.fromFuture(_getStackInfo(
       limit: initialFrameRequestCount,
     ));
-    final stackInfo = await _getStackOperation.value;
+    final stackInfo = await _getStackOperation!.value;
     _populateFrameInfo(
       stackInfo.frames,
       truncated: stackInfo.truncated ?? false,
@@ -793,26 +803,26 @@ class DebuggerController extends DisposableController
     }
   }
 
-  Future<_StackInfo> _getStackInfo({int limit}) async {
+  Future<_StackInfo> _getStackInfo({int? limit}) async {
     _log.log('getStack() with limit: $limit');
-    final stack = await _service.getStack(isolateRef.id, limit: limit);
-    _log.log('getStack() completed (frames: ${stack.frames.length})');
+    final stack = await _service.getStack(isolateRef!.id!, limit: limit);
+    _log.log('getStack() completed (frames: ${stack.frames!.length})');
 
     final frames = _framesForCallStack(
-      stack.frames,
+      stack.frames!,
       asyncCausalFrames: stack.asyncCausalFrames,
       reportedException: _lastEvent?.exception,
     );
 
     return _StackInfo(
       await Future.wait(frames.map(_createStackFrameWithLocation)),
-      stack.truncated,
+      stack.truncated!,
     );
   }
 
   void _populateFrameInfo(
     List<StackFrameAndSourcePosition> frames, {
-    @required final bool truncated,
+    required final bool truncated,
   }) {
     _log.log('populated frame info');
     _stackFramesWithLocation.value = frames;
@@ -827,7 +837,7 @@ class DebuggerController extends DisposableController
   Future<void> _getFullStack() async {
     await _getStackOperation?.cancel();
     _getStackOperation = CancelableOperation.fromFuture(_getStackInfo());
-    final stackInfo = await _getStackOperation.value;
+    final stackInfo = await _getStackOperation!.value;
     _populateFrameInfo(stackInfo.frames, truncated: stackInfo.truncated);
   }
 
@@ -847,25 +857,25 @@ class DebuggerController extends DisposableController
   ///
   /// The return value can be one of [Obj] or [Sentinel].
   Future<Obj> getObject(ObjRef objRef) {
-    return _service.getObject(isolateRef.id, objRef.id);
+    return _service.getObject(isolateRef!.id!, objRef.id!);
   }
 
   Future<void> _populateScripts(Isolate isolate) async {
     assert(isolate != null);
-    final scriptRefs = await scriptManager.retrieveAndSortScripts(isolateRef);
+    final scriptRefs = await scriptManager.retrieveAndSortScripts(isolateRef!);
 
     // Update the selected script.
-    final mainScriptRef = scriptRefs.firstWhere((ref) {
-      return ref.uri == isolate.rootLib.uri;
-    }, orElse: () => null);
+    final mainScriptRef = scriptRefs.firstWhereOrNull((ref) {
+      return ref.uri == isolate.rootLib!.uri;
+    });
 
     // Display the script location.
-    _populateScriptAndShowLocation(mainScriptRef);
+    _populateScriptAndShowLocation(mainScriptRef!);
   }
 
   Future<BreakpointAndSourcePosition> _createBreakpointWithLocation(
       Breakpoint breakpoint) async {
-    if (breakpoint.resolved) {
+    if (breakpoint.resolved!) {
       final bp = BreakpointAndSourcePosition.create(breakpoint);
       return scriptManager.getScript(bp.scriptRef).then((Script script) {
         final pos = SourcePosition.calculatePosition(script, bp.tokenPos);
@@ -884,9 +894,9 @@ class DebuggerController extends DisposableController
       return StackFrameAndSourcePosition(frame);
     }
 
-    final script = await scriptManager.getScript(location.script);
+    final script = await scriptManager.getScript(location.script!);
     final position =
-        SourcePosition.calculatePosition(script, location.tokenPos);
+        SourcePosition.calculatePosition(script, location.tokenPos!);
     return StackFrameAndSourcePosition(frame, position: position);
   }
 
@@ -901,18 +911,18 @@ class DebuggerController extends DisposableController
     }
   }
 
-  void selectStackFrame(StackFrameAndSourcePosition frame) {
-    _selectedStackFrame.value = frame;
+  void selectStackFrame(StackFrameAndSourcePosition? frame) {
+    _selectedStackFrame.value = frame!;
 
     if (frame != null) {
-      _variables.value = _createVariablesForFrame(frame.frame);
+      _variables.value = _createVariablesForFrame(frame.frame!);
     } else {
       _variables.value = [];
     }
 
-    if (frame?.scriptRef != null) {
+    if (frame.scriptRef != null) {
       showScriptLocation(
-          ScriptLocation(frame.scriptRef, location: frame.position));
+          ScriptLocation(frame.scriptRef!, location: frame.position));
     }
   }
 
@@ -923,7 +933,7 @@ class DebuggerController extends DisposableController
     }
 
     final variables =
-        frame.vars.map((v) => DartObjectNode.create(v, isolateRef)).toList();
+        frame.vars!.map((v) => DartObjectNode.create(v, isolateRef!)).toList();
     variables
       ..forEach(buildVariablesTree)
       ..sort((a, b) => sortFieldsByName(a.name, b.name));
@@ -932,8 +942,8 @@ class DebuggerController extends DisposableController
 
   List<Frame> _framesForCallStack(
     List<Frame> stackFrames, {
-    List<Frame> asyncCausalFrames,
-    InstanceRef reportedException,
+    List<Frame>? asyncCausalFrames,
+    InstanceRef? reportedException,
   }) {
     // Prefer asyncCausalFrames if they exist.
     List<Frame> frames = asyncCausalFrames ?? stackFrames;
@@ -972,15 +982,15 @@ class DebuggerController extends DisposableController
   /// Return the list of valid positions for breakpoints for a given script.
   Future<List<SourcePosition>> getBreakablePositions(Script script) async {
     if (!_breakPositionsMap.containsKey(script.id)) {
-      _breakPositionsMap[script.id] = await _getBreakablePositions(script);
+      _breakPositionsMap[script.id!] = await _getBreakablePositions(script);
     }
 
-    return _breakPositionsMap[script.id];
+    return _breakPositionsMap[script.id!]!;
   }
 
   Future<List<SourcePosition>> _getBreakablePositions(Script script) async {
     final report = await _service.getSourceReport(
-      isolateRef.id,
+      isolateRef!.id!,
       [SourceReportKind.kPossibleBreakpoints],
       scriptId: script.id,
       forceCompile: true,
@@ -988,10 +998,10 @@ class DebuggerController extends DisposableController
 
     final positions = <SourcePosition>[];
 
-    for (SourceReportRange range in report.ranges) {
+    for (SourceReportRange range in report.ranges!) {
       if (range.possibleBreakpoints != null) {
-        for (int tokenPos in range.possibleBreakpoints) {
-          positions.add(SourcePosition.calculatePosition(script, tokenPos));
+        for (int tokenPos in range.possibleBreakpoints!) {
+          positions.add(SourcePosition.calculatePosition(script, tokenPos)!);
         }
       }
     }
@@ -1016,13 +1026,13 @@ class DebuggerController extends DisposableController
     String search, {
     bool searchPreviousMatches = false,
   }) {
-    if (search == null || search.isEmpty || parsedScript.value == null) {
+    if (search == null || search.isEmpty || parsedScript!.value == null) {
       return [];
     }
     final matches = <SourceToken>[];
     final caseInsensitiveSearch = search.toLowerCase();
 
-    final currentScript = parsedScript.value;
+    final currentScript = parsedScript!.value;
     for (int i = 0; i < currentScript.lines.length; i++) {
       final line = currentScript.lines[i].toLowerCase();
       final matchesForLine = caseInsensitiveSearch.allMatches(line);
@@ -1110,7 +1120,7 @@ class EvalHistory {
     }
   }
 
-  String get currentText {
+  String? get currentText {
     return _historyPosition == -1 ? null : _evalHistory[_historyPosition];
   }
 }
@@ -1124,9 +1134,9 @@ class _StackInfo {
 
 class ParsedScript {
   ParsedScript({
-    @required this.script,
-    @required this.highlighter,
-    @required this.executableLines,
+    required this.script,
+    required this.highlighter,
+    required this.executableLines,
   })  : assert(script != null),
         lines = (script.source?.split('\n') ?? const []).toList();
 

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
@@ -134,11 +134,11 @@ class DiagnosticsNodeDescription extends StatelessWidget {
       enabled: () => diagnosticLocal.inspectorService != null,
       onHover: (event) async {
         final group = inspectorService.createObjectGroup('hover');
-        final value =
-            await group.toObservatoryInstanceRef(diagnosticLocal.valueRef);
+        final Object value =
+            (await group.toObservatoryInstanceRef(diagnosticLocal.valueRef)) as Object;
         final variable = DartObjectNode.fromValue(
           value: value,
-          isolateRef: inspectorService.isolateRef,
+          isolateRef: inspectorService.isolateRef!,
           diagnostic: diagnosticLocal,
         );
         await buildVariablesTree(variable);

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -1057,7 +1057,7 @@ abstract class ObjectGroupBase implements Disposable {
     return await inspectorLibrary.eval(
       expression,
       isAlive: this,
-      scope: <String, String>{'object': instanceRef.id!},
+      scope: <String, String>{'object': instanceRef!.id!},
     );
   }
 

--- a/packages/devtools_app/lib/src/shared/console_service.dart
+++ b/packages/devtools_app/lib/src/shared/console_service.dart
@@ -81,10 +81,10 @@ class ConsoleService extends Disposer {
   }) async {
     _stdioTrailingNewline = false;
     final variable = DartObjectNode.fromValue(
-      name: name,
-      value: value,
+      name: name!,
+      value: value!,
       diagnostic: diagnostic,
-      isolateRef: isolateRef,
+      isolateRef: isolateRef!,
     );
     // TODO(jacobr): fix out of order issues by tracking raw order.
     await buildVariablesTree(variable, expandAll: expandAll);
@@ -265,7 +265,7 @@ class ConsoleService extends Disposer {
         try {
           if (await inspector.isInspectable(
             GenericInstanceRef(
-              isolateRef: event.isolate,
+              isolateRef: event.isolate!,
               value: event.inspectee,
             ),
           )) {

--- a/packages/devtools_app/test/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger_controller_test.dart
@@ -4,9 +4,7 @@
 
 // ignore_for_file: import_of_legacy_library_into_null_safe
 
-import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -272,9 +270,9 @@ void main() {
       debuggerController = TestDebuggerController(
         initialSwitchToIsolate: false,
       );
-      debuggerController.parsedScript.value = ParsedScript(
+      debuggerController.parsedScript!.value = ParsedScript(
         script: testScript,
-        highlighter: null,
+        highlighter: null as SyntaxHighlighter,
         executableLines: {},
       );
     });
@@ -301,7 +299,7 @@ void main() {
         equals('[]'),
       );
       expect(
-        debuggerController.matchesForSearch(null).toString(),
+        debuggerController.matchesForSearch(null as String).toString(),
         equals('[]'),
       );
     });


### PR DESCRIPTION

#3025 is the generic issue, don't know if there is a specific one for this

This is a first cut at migrating these files to null safety. It was an unsophisticated stab at getting rid of the syntax errors and having the existing tests pass.

On the con/undone side, a few files were modified outside of the two main debugger files. Nulls are used extensively as marker values in these files. There wasn't any attempt yet to look at removing their usage. No attempt was made to remove the assert code or fix the warnings where a null condition won't be excuted.

- [ y] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ y] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ y] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [y ] I signed the [CLA].
- [y ] I listed at least one issue that this PR fixes in the description above.
- [ n] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [y ] All existing and new tests are passing.


