### PR TITLE
Move dwds pageReady event in the inspector.

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -427,13 +427,6 @@ class InspectorController extends DisposableController
     }
 
     if (flutterAppFrameReady) {
-      unawaited(
-        serviceManager.sendDwdsEvent(
-          screen: InspectorScreen.id,
-          action: analytics_constants.pageReady,
-        ),
-      );
-
       if (_disposed) return;
       // We need to start by querying the inspector service to find out the
       // current state of the UI.

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -21,7 +21,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../analytics/constants.dart' as analytics_constants;
 import '../../config_specific/logger/logger.dart';
 import '../../config_specific/url/url.dart';
 import '../../primitives/auto_dispose.dart';

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -987,6 +987,10 @@ class _InspectorTreeState extends State<InspectorTree>
 
     if (!firstInspectorTreeLoadCompleted && widget.isSummaryTree) {
       ga.timeEnd(InspectorScreen.id, analytics_constants.pageReady);
+      serviceManager.sendDwdsEvent(
+        screen: InspectorScreen.id,
+        action: analytics_constants.pageReady,
+      );
       firstInspectorTreeLoadCompleted = true;
     }
     return LayoutBuilder(


### PR DESCRIPTION
@annagrin

This event will be sent when the summary tree loads for the first time. It will not be sent for subsequent loads of the inspector tree.