### PR TITLE
Set same-site=none for Google Analytics cookies

### DIFF
--- a/packages/devtools_app/web/devtools_analytics.js
+++ b/packages/devtools_app/web/devtools_analytics.js
@@ -34,7 +34,8 @@ function initializeGA() {
       'metric3': 'shader_compilation_duration_micros',
       'metric4': 'cpu_sample_count',
       'metric5': 'cpu_stack_depth',
-    }
+    },
+    cookie_flags: 'SameSite=None;Secure',
   });
 }
 


### PR DESCRIPTION
Fixes an issue where Google Analytics events were not being sent when DevTools was embedded. 

Adds the [`cookie_flags` property](https://developers.google.com/analytics/devguides/collection/gtagjs/cookies-user-id) to specify that the Google Analytics cookies should be `SameSite=None` (as opposed to the default, `SameSite=Lax`).

Confirmed that we are now sending GA events in embedded contexts.

Note: SameSite cookies explanation: https://developers.google.com/search/blog/2020/01/get-ready-for-new-samesitenone-secure


