### PR TITLE
Create ProfilableDataMixin and generalize bottom up transformer code

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -154,66 +154,79 @@ class CpuProfileTransformer {
   }
 }
 
-// ignore: avoid_classes_with_only_static_members
-/// Process for converting a [CpuStackFrame] into a bottom-up representation of
-/// the CPU profile.
-class BottomUpProfileTransformer {
-  static List<CpuStackFrame> processData(CpuStackFrame stackFrame) {
-    final List<CpuStackFrame> bottomUpRoots = getRoots(stackFrame, null, []);
+// TODO(kenz): move this into a shared file for use with the TimelineEvent
+// class.
+/// Process for converting a [ProfilableDataMixin] into a bottom-up
+/// representation of the profile.
+class BottomUpTransformer<T extends ProfilableDataMixin<T>> {
+  List<T> bottomUpRootsFor({
+    required T topDownRoot,
+    required void Function(List<T>) mergeSamples,
+  }) {
+    final bottomUpRoots = generateBottomUpRoots(
+      node: topDownRoot,
+      currentBottomUpRoot: null,
+      bottomUpRoots: <T>[],
+    );
 
     // Set the bottom up sample counts for each sample.
     bottomUpRoots.forEach(cascadeSampleCounts);
 
     // Merge samples when possible starting at the root (the leaf node of the
-    // original CPU sample).
-    mergeProfileRoots(bottomUpRoots);
+    // original sample).
+    mergeSamples(bottomUpRoots);
 
     return bottomUpRoots;
   }
 
-  /// Returns the roots for a bottom up representation of a CpuStackFrame node.
+  /// Returns the roots for a bottom up representation of a
+  /// [ProfilableDataMixin] node.
   ///
-  /// Each root is a leaf from the original CpuStackFrame tree, and its children
-  /// will be the reverse call stack of the original sample. The stack frames
-  /// returned will not be merged to combine common roots, and the sample counts
-  /// will not reflect the bottom up sample counts. These steps will occur later
-  /// in the bottom-up conversion process.
+  /// Each root is a leaf from the original [ProfilableDataMixin] tree, and its
+  /// children will be the reverse stack of the original profile sample. The
+  /// stack returned will not be merged to combine common roots, and the sample
+  /// counts will not reflect the bottom up sample counts. These steps will
+  /// occur later in the bottom-up conversion process.
   @visibleForTesting
-  static List<CpuStackFrame> getRoots(
-    CpuStackFrame node,
-    CpuStackFrame? currentBottomUpRoot,
-    List<CpuStackFrame> bottomUpRoots,
-  ) {
-    final copy = node.shallowCopy();
+  List<T> generateBottomUpRoots({
+    required T node,
+    required T? currentBottomUpRoot,
+    required List<T> bottomUpRoots,
+  }) {
+    final copy = node.shallowCopy() as T;
 
     if (currentBottomUpRoot != null) {
       copy.addChild(currentBottomUpRoot.deepCopy());
     }
 
-    // [copy] is the new root of the bottom up call stack.
+    // [copy] is the new root of the bottom up stack.
     currentBottomUpRoot = copy;
 
     if (node.exclusiveSampleCount > 0) {
       // This node is a leaf node, meaning it is a bottom up root.
       bottomUpRoots.add(currentBottomUpRoot);
     }
-    for (CpuStackFrame child in node.children) {
-      getRoots(child, currentBottomUpRoot, bottomUpRoots);
+    for (final child in node.children.cast<T>()) {
+      generateBottomUpRoots(
+        node: child,
+        currentBottomUpRoot: currentBottomUpRoot,
+        bottomUpRoots: bottomUpRoots,
+      );
     }
     return bottomUpRoots;
   }
 
-  /// Sets sample counts of [stackFrame] and all children to
-  /// [exclusiveSampleCount].
+  /// Sets sample counts of [node] and all children to [exclusiveSampleCount].
   ///
-  /// This is necessary for the transformation of a [CpuStackFrame] to its
+  /// This is necessary for the transformation of a [ProfilableDataMixin] to its
   /// bottom-up representation. This is an intermediate step between
-  /// [getRoots] and [mergeProfileRoots].
+  /// [generateBottomUpRoots] and the [mergeSamples] callback passed to
+  /// [bottomUpRootsFor].
   @visibleForTesting
-  static void cascadeSampleCounts(CpuStackFrame stackFrame) {
-    stackFrame.inclusiveSampleCount = stackFrame.exclusiveSampleCount;
-    for (CpuStackFrame child in stackFrame.children) {
-      child.exclusiveSampleCount = stackFrame.exclusiveSampleCount;
+  void cascadeSampleCounts(T node) {
+    node.inclusiveSampleCount = node.exclusiveSampleCount;
+    for (final child in node.children.cast<T>()) {
+      child.exclusiveSampleCount = node.exclusiveSampleCount;
       cascadeSampleCounts(child);
     }
   }
@@ -229,7 +242,7 @@ class BottomUpProfileTransformer {
 ///
 /// At the time this method is called, we assume we have a list of roots with
 /// accurate inclusive/exclusive sample counts.
-void mergeProfileRoots(List<CpuStackFrame> roots) {
+void mergeCpuProfileRoots(List<CpuStackFrame> roots) {
   // Loop through a copy of [roots] so that we can remove nodes from [roots]
   // once we have merged them.
   final List<CpuStackFrame> rootsCopy = List.from(roots);
@@ -251,7 +264,7 @@ void mergeProfileRoots(List<CpuStackFrame> roots) {
       root.exclusiveSampleCount += match.exclusiveSampleCount;
       root.inclusiveSampleCount += match.inclusiveSampleCount;
       roots.remove(match);
-      mergeProfileRoots(root.children);
+      mergeCpuProfileRoots(root.children);
     }
   }
 

--- a/packages/devtools_app/test/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler_controller_test.dart
@@ -246,7 +246,7 @@ void main() {
         equals(250),
       );
       expect(
-        dataNotifierValue.cpuProfileRoot.toStringDeep(),
+        dataNotifierValue.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 5
@@ -262,7 +262,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagA');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 2
@@ -276,7 +276,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagB');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 1
@@ -289,7 +289,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagC');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 2
@@ -320,7 +320,7 @@ void main() {
         equals(250),
       );
       expect(
-        cpuProfileRoot.toStringDeep(),
+        cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 5
@@ -336,7 +336,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagA');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 2 - excl: 0 - incl: 2
@@ -348,7 +348,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagB');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 1
@@ -359,7 +359,7 @@ void main() {
 
       await controller.loadDataWithTag('userTagC');
       expect(
-        controller.dataNotifier.value!.cpuProfileRoot.toStringDeep(),
+        controller.dataNotifier.value!.cpuProfileRoot.profileAsString(),
         equals(
           '''
   all - children: 1 - excl: 0 - incl: 2


### PR DESCRIPTION
This PR abstracts some CPU profiling logic in preparation for use with other TreeNode types (e.g. TimelineEvent). 