### PR TITLE
Fix null safety errors across DevTools

### DIFF
--- a/packages/devtools_app/lib/src/primitives/enum_utils.dart
+++ b/packages/devtools_app/lib/src/primitives/enum_utils.dart
@@ -27,7 +27,8 @@ class EnumUtils<T> {
   final Map<String, T> _lookupTable = {};
   final Map<T, String> _reverseLookupTable = {};
 
-  T? enumEntry(String enumName) => _lookupTable[enumName];
+  T? enumEntry(String? enumName) =>
+      enumName != null ? _lookupTable[enumName] : null;
 
   String? name(T enumEntry) => _reverseLookupTable[enumEntry];
 }

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -207,11 +207,12 @@ Future<void> delayForBatchProcessing({int micros = 0}) async {
 /// duration specified by `timeoutMillis` has passed.
 ///
 /// Completes with null on timeout.
-Future<T?> timeout<T>(Future<T> operation, int timeoutMillis) => Future.any<T>([
+Future<T?> timeout<T>(Future<T> operation, int timeoutMillis) =>
+    Future.any<T?>([
       operation,
-      Future<T>.delayed(
+      Future<T?>.delayed(
         Duration(milliseconds: timeoutMillis),
-        () => Future.value(),
+        () => Future<T?>.value(),
       )
     ]);
 

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -211,7 +211,6 @@ Future<T?> timeout<T>(Future<T> operation, int timeoutMillis) => Future.any<T>([
       operation,
       Future<T>.delayed(
         Duration(milliseconds: timeoutMillis),
-        // ignore: unnecessary_parenthesis
         () => Future.value(),
       )
     ]);

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -207,12 +207,12 @@ Future<void> delayForBatchProcessing({int micros = 0}) async {
 /// duration specified by `timeoutMillis` has passed.
 ///
 /// Completes with null on timeout.
-Future<T> timeout<T>(Future<T> operation, int timeoutMillis) => Future.any<T>([
+Future<T?> timeout<T>(Future<T> operation, int timeoutMillis) => Future.any<T>([
       operation,
       Future<T>.delayed(
         Duration(milliseconds: timeoutMillis),
         // ignore: unnecessary_parenthesis
-        (() => null) as FutureOr<T> Function()?,
+        () => Future.value(),
       )
     ]);
 

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
@@ -841,7 +841,7 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
         ((diagnostic.inlineProperties.isNotEmpty) || diagnostic.hasChildren))
       return true;
     // TODO(jacobr): do something smarter to avoid expandable variable flicker.
-    final instanceRef = ref!.instanceRef;
+    final instanceRef = ref?.instanceRef;
     return instanceRef != null ? instanceRef.valueAsString == null : false;
   }
 

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -305,7 +305,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
   }
 
   Future<void> populateLocation() async {
-    ScriptRef scriptRef = script!;
+    ScriptRef? scriptRef = script;
     int? tokenPos = 0;
     if (object != null &&
         (object is FieldRef || object is FuncRef || object is ClassRef)) {
@@ -314,15 +314,17 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
       scriptRef = location.script;
     }
 
-    final fetchedScript = await scriptManager.getScript(scriptRef);
-    final position = tokenPos == 0
-        ? null
-        : SourcePosition.calculatePosition(fetchedScript, tokenPos!);
+    if (scriptRef != null) {
+      final fetchedScript = await scriptManager.getScript(scriptRef);
+      final position = tokenPos == 0
+          ? null
+          : SourcePosition.calculatePosition(fetchedScript, tokenPos!);
 
-    location = ScriptLocation(
-      scriptRef,
-      location: position,
-    );
+      location = ScriptLocation(
+        scriptRef,
+        location: position,
+      );
+    }
   }
 
   /// Clear the _childrenAsMap map recursively to save memory.

--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -4,7 +4,6 @@
 
 // ignore_for_file: avoid_redundant_argument_values
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Stack;
 import 'package:flutter/rendering.dart';
 import 'package:provider/provider.dart';
@@ -58,13 +57,13 @@ class ExpandableVariable extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (variable == null) return const SizedBox();
+    final _variable = variable;
+    if (_variable == null) return const SizedBox();
     // TODO(kenz): preserve expanded state of tree on switching frames and
     // on stepping.
     return TreeView<DartObjectNode>(
       dataRootsListenable:
-          FixedValueListenable<List<DartObjectNode?>>([variable])
-              as ValueListenable<List<DartObjectNode>>,
+          FixedValueListenable<List<DartObjectNode>>([_variable]),
       shrinkWrap: true,
       dataDisplayProvider: (variable, onPressed) =>
           displayProvider(context, variable, onPressed, debuggerController),

--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -52,18 +52,23 @@ class ExpandableVariable extends StatelessWidget {
     required this.debuggerController,
   }) : super(key: key);
 
+  @visibleForTesting
+  static const emptyExpandableVariableKey = Key('empty expandable variable');
+
   final DartObjectNode? variable;
+
   final DebuggerController debuggerController;
 
   @override
   Widget build(BuildContext context) {
-    final _variable = variable;
-    if (_variable == null) return const SizedBox();
+    final variable = this.variable;
+    if (variable == null)
+      return const SizedBox(key: emptyExpandableVariableKey);
     // TODO(kenz): preserve expanded state of tree on switching frames and
     // on stepping.
     return TreeView<DartObjectNode>(
       dataRootsListenable:
-          FixedValueListenable<List<DartObjectNode>>([_variable]),
+          FixedValueListenable<List<DartObjectNode>>([variable]),
       shrinkWrap: true,
       dataDisplayProvider: (variable, onPressed) =>
           displayProvider(context, variable, onPressed, debuggerController),

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
@@ -51,7 +51,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
 
   static final CustomIconMaker iconMaker = CustomIconMaker();
 
-  static BoxConstraints deserializeConstraints(Map<String, Object> json) {
+  static BoxConstraints deserializeConstraints(Map<String, Object?> json) {
     return BoxConstraints(
       minWidth: double.parse(json['minWidth'] as String? ?? '0.0'),
       maxWidth: double.parse(json['maxWidth'] as String? ?? 'Infinity'),
@@ -60,7 +60,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     );
   }
 
-  static BoxParentData deserializeParentData(Map<String, Object> json) {
+  static BoxParentData deserializeParentData(Map<String, Object?> json) {
     return BoxParentData()
       ..offset = Offset(
         double.parse(json['offsetX'] as String? ?? '0.0'),
@@ -137,12 +137,12 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   RemoteDiagnosticsNode? _parentRenderElement;
 
   BoxConstraints get constraints =>
-      deserializeConstraints(json['constraints'] as Map<String, Object>? ?? {});
+      deserializeConstraints(json['constraints'] as Map<String, Object?>? ?? {});
 
   BoxParentData get parentData =>
-      deserializeParentData(json['parentData'] as Map<String, Object>? ?? {});
+      deserializeParentData(json['parentData'] as Map<String, Object?>? ?? {});
 
-  Size get size => deserializeSize(json['size'] as Map<String, Object>? ?? {});
+  Size get size => deserializeSize((json['size'] as Map?)?.cast<String, Object>() ?? {});
 
   bool get isLocalClass {
     final objectGroup = inspectorService;
@@ -375,7 +375,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
       return null;
     }
     _creationLocation = InspectorSourceLocation(
-      json['creationLocation'] as Map<String, Object>? ?? {},
+      json['creationLocation'] as Map<String, Object?>? ?? {},
       null,
     );
     return _creationLocation;
@@ -498,8 +498,8 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     return _valueProperties;
   }
 
-  Map<String, Object>? get valuePropertiesJson =>
-      json['valueProperties'] as Map<String, Object>?;
+  Map<String, Object?>? get valuePropertiesJson =>
+      json['valueProperties'] as Map<String, Object?>?;
 
   bool get hasChildren {
     // In the summary tree, json['hasChildren']==true when the node has details
@@ -601,8 +601,8 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     if (cachedProperties == null) {
       cachedProperties = [];
       if (json.containsKey('properties')) {
-        final List<Object> jsonArray = json['properties'] as List<Object>;
-        for (var element in jsonArray.cast<Map<String, Object>>()) {
+        final jsonArray = json['properties'] as List<Object?>;
+        for (var element in jsonArray.cast<Map<String, Object?>>()) {
           cachedProperties!.add(
             RemoteDiagnosticsNode(element, inspectorService, true, parent),
           );
@@ -695,7 +695,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
 class InspectorSourceLocation {
   InspectorSourceLocation(this.json, this.parent);
 
-  final Map<String, Object> json;
+  final Map<String, Object?> json;
   final InspectorSourceLocation? parent;
 
   String? get path => JsonUtils.getStringMember(json, 'file');

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
@@ -575,10 +575,10 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
       return;
     }
 
-    final jsonArray = json['children'] as List<Object>?;
+    final jsonArray = json['children'] as List<Object?>?;
     if (jsonArray?.isNotEmpty == true) {
       final nodes = <RemoteDiagnosticsNode>[];
-      for (var element in jsonArray!.cast<Map<String, Object>>()) {
+      for (var element in jsonArray!.cast<Map<String, Object?>>()) {
         final child =
             RemoteDiagnosticsNode(element, inspectorService, false, parent);
         child.parent = this;

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
@@ -136,13 +136,14 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
 
   RemoteDiagnosticsNode? _parentRenderElement;
 
-  BoxConstraints get constraints =>
-      deserializeConstraints(json['constraints'] as Map<String, Object?>? ?? {});
+  BoxConstraints get constraints => deserializeConstraints(
+      json['constraints'] as Map<String, Object?>? ?? {});
 
   BoxParentData get parentData =>
       deserializeParentData(json['parentData'] as Map<String, Object?>? ?? {});
 
-  Size get size => deserializeSize((json['size'] as Map?)?.cast<String, Object>() ?? {});
+  Size get size =>
+      deserializeSize((json['size'] as Map?)?.cast<String, Object>() ?? {});
 
   bool get isLocalClass {
     final objectGroup = inspectorService;

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
@@ -137,13 +137,18 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   RemoteDiagnosticsNode? _parentRenderElement;
 
   BoxConstraints get constraints => deserializeConstraints(
-      json['constraints'] as Map<String, Object?>? ?? {});
+        json['constraints'] as Map<String, Object?>? ?? {},
+      );
 
   BoxParentData get parentData =>
       deserializeParentData(json['parentData'] as Map<String, Object?>? ?? {});
 
-  Size get size =>
-      deserializeSize((json['size'] as Map?)?.cast<String, Object>() ?? {});
+  // [deserializeSize] expects a parameter of type Map<String, Object> (note the
+  // non-nullable Object), so we need to first type check as a Map and then we
+  // can cast to the expected type.
+  Size get size => deserializeSize(
+        (json['size'] as Map?)?.cast<String, Object>() ?? <String, Object>{},
+      );
 
   bool get isLocalClass {
     final objectGroup = inspectorService;

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
@@ -392,22 +392,22 @@ class FlexLayoutProperties extends LayoutProperties {
     );
     return FlexLayoutProperties._fromNode(
       node,
-      direction: _directionUtils.enumEntry(data['direction'] as String) ??
+      direction: _directionUtils.enumEntry(data['direction'] as String?) ??
           Axis.vertical,
       mainAxisAlignment: _mainAxisAlignmentUtils
-          .enumEntry(data['mainAxisAlignment'] as String),
+          .enumEntry(data['mainAxisAlignment'] as String?),
       mainAxisSize:
-          _mainAxisSizeUtils.enumEntry(data['mainAxisSize'] as String),
+          _mainAxisSizeUtils.enumEntry(data['mainAxisSize'] as String?),
       crossAxisAlignment: _crossAxisAlignmentUtils
-          .enumEntry(data['crossAxisAlignment'] as String),
+          .enumEntry(data['crossAxisAlignment'] as String?),
       textDirection:
-          _textDirectionUtils.enumEntry(data['textDirection'] as String) ??
+          _textDirectionUtils.enumEntry(data['textDirection'] as String?) ??
               TextDirection.ltr,
       verticalDirection: _verticalDirectionUtils
-              .enumEntry(data['verticalDirection'] as String) ??
+              .enumEntry(data['verticalDirection'] as String?) ??
           VerticalDirection.down,
       textBaseline:
-          _textBaselineUtils.enumEntry(data['textBaseline'] as String),
+          _textBaselineUtils.enumEntry(data['textBaseline'] as String?),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -822,7 +822,7 @@ abstract class ObjectGroupBase implements Disposable {
     FutureOr<InstanceRef?> instanceRefFuture,
   ) async {
     return parseDiagnosticsNodeHelper(
-      await instanceRefToJson(await instanceRefFuture) as Map<String, Object>?,
+      await instanceRefToJson(await instanceRefFuture) as Map<String, Object?>?,
     );
   }
 
@@ -850,13 +850,13 @@ abstract class ObjectGroupBase implements Disposable {
   }
 
   List<RemoteDiagnosticsNode> parseDiagnosticsNodesHelper(
-    List<Object>? jsonObject,
+    List<Object?>? jsonObject,
     RemoteDiagnosticsNode? parent,
     bool isProperty,
   ) {
     if (disposed || jsonObject == null) return const [];
     final nodes = <RemoteDiagnosticsNode>[];
-    for (var element in jsonObject.cast<Map<String, Object>>()) {
+    for (var element in jsonObject.cast<Map<String, Object?>>()) {
       nodes.add(RemoteDiagnosticsNode(element, this, isProperty, parent));
     }
     return nodes;
@@ -870,7 +870,7 @@ abstract class ObjectGroupBase implements Disposable {
     if (disposed || jsonFuture == null) return const [];
 
     return parseDiagnosticsNodesHelper(
-      await jsonFuture as List<Object>?,
+      await jsonFuture as List<Object?>?,
       parent,
       isProperty,
     );
@@ -1355,7 +1355,7 @@ class ObjectGroup extends ObjectGroupBase {
       'getDetailsSubtree',
       args,
     );
-    return parseDiagnosticsNodeHelper(json as Map<String, Object>?);
+    return parseDiagnosticsNodeHelper(json as Map<String, Object?>?);
   }
 
   Future<void> invokeSetFlexProperties(

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -815,7 +815,7 @@ abstract class ObjectGroupBase implements Disposable {
     Future<Object?> json,
   ) async {
     if (disposed) return null;
-    return parseDiagnosticsNodeHelper(await json as Map<String, Object>?);
+    return parseDiagnosticsNodeHelper(await json as Map<String, Object?>?);
   }
 
   Future<RemoteDiagnosticsNode?> parseDiagnosticsNodeObservatory(
@@ -827,7 +827,7 @@ abstract class ObjectGroupBase implements Disposable {
   }
 
   RemoteDiagnosticsNode? parseDiagnosticsNodeHelper(
-    Map<String, Object>? jsonElement,
+    Map<String, Object?>? jsonElement,
   ) {
     if (disposed) return null;
     if (jsonElement == null) return null;

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service_polyfill.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service_polyfill.dart
@@ -66,7 +66,7 @@ $script''',
   final encodedResult =
       await group.inspectorLibrary.retrieveFullValueAsString(result!);
   if (encodedResult != null) {
-    final Map<String, Object> errors = json.decode(encodedResult);
+    final Map<String, Object?> errors = json.decode(encodedResult);
     for (String name in errors.keys) {
       log(
         "Unable to add service extension '$name' due to error:\n${errors[name]}",

--- a/packages/devtools_app/lib/src/screens/inspector/layout_explorer/ui/layout_explorer_widget.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/layout_explorer/ui/layout_explorer_widget.dart
@@ -78,7 +78,9 @@ abstract class LayoutExplorerWidgetState<W extends LayoutExplorerWidget,
     if (shouldFetch) {
       _dirty = false;
       final newSelection = await fetchLayoutProperties();
-      _setProperties(newSelection);
+      if (newSelection != null) {
+        _setProperties(newSelection);
+      }
     } else {
       updateHighlighted(_properties);
     }
@@ -100,13 +102,15 @@ abstract class LayoutExplorerWidgetState<W extends LayoutExplorerWidget,
   /// of the current widget.
   RemoteDiagnosticsNode? getRoot(RemoteDiagnosticsNode? node);
 
-  Future<L> fetchLayoutProperties() async {
+  Future<L?> fetchLayoutProperties() async {
     objectGroupManager?.cancelNext();
     final manager = objectGroupManager!;
     final nextObjectGroup = manager.next;
-    final node = (await nextObjectGroup.getLayoutExplorerNode(
+    final node = await nextObjectGroup.getLayoutExplorerNode(
       getRoot(selectedNode),
-    ))!;
+    );
+    if (node == null) return null;
+
     if (!nextObjectGroup.disposed) {
       assert(manager.next == nextObjectGroup);
       manager.promoteNext();
@@ -203,7 +207,9 @@ abstract class LayoutExplorerWidgetState<W extends LayoutExplorerWidget,
     if (!_dirty) return;
     _dirty = false;
     final updatedProperties = await fetchLayoutProperties();
-    _changeProperties(updatedProperties);
+    if (updatedProperties != null) {
+      _changeProperties(updatedProperties);
+    }
   }
 
   void _changeProperties(L nextProperties) {
@@ -277,7 +283,10 @@ abstract class LayoutExplorerWidgetState<W extends LayoutExplorerWidget,
   // TODO(albertusangga): Investigate why onForceRefresh is not getting called.
   @override
   Future<void> onForceRefresh() async {
-    _setProperties(await fetchLayoutProperties());
+    final properties = await fetchLayoutProperties();
+    if (properties != null) {
+      _setProperties(properties);
+    }
   }
 
   /// Currently this is not working so we should listen to controller selection event instead.

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -924,9 +924,9 @@ class ImageSizesForFrame {
   }
 
   final String? source;
-  final Map<String, Object>? displaySize;
-  final Map<String, Object>? imageSize;
-  final Map<String, Object>? rawJson;
+  final Map<String, Object?>? displaySize;
+  final Map<String, Object?>? imageSize;
+  final Map<String, Object?>? rawJson;
 
   String get summary {
     final file = path.basename(source!);

--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -1097,6 +1097,8 @@ class MemoryController extends DisposableController
         ExternalReferences(this, snapshotGraph.externalSize);
     for (final liveExternal
         in heapGraph?.externals ?? <HeapGraphExternalLive>[]) {
+      if (liveExternal == null) continue;
+
       final HeapGraphClassLive? classLive =
           liveExternal.live.theClass as HeapGraphClassLive?;
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_graph_model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_graph_model.dart
@@ -206,9 +206,9 @@ HeapGraph convertHeapGraph(
   return HeapGraph(
     controller,
     builtInClasses,
-    classes as List<HeapGraphClassLive>,
-    elements as List<HeapGraphElementLive>,
-    externals as List<HeapGraphExternalLive>,
+    classes,
+    elements,
+    externals,
   );
 }
 
@@ -234,16 +234,16 @@ class HeapGraph {
   static HeapGraphClassSentinel classSentinel = HeapGraphClassSentinel();
 
   /// Indexed by classId.
-  final List<HeapGraphClassLive> classes;
+  final List<HeapGraphClassLive?> classes;
 
   /// Sentinel Object, all object sentinels point to this object.
   static HeapGraphElementSentinel elementSentinel = HeapGraphElementSentinel();
 
   /// Index by objectId.
-  final List<HeapGraphElementLive> elements;
+  final List<HeapGraphElementLive?> elements;
 
   /// Index by objectId of all external properties
-  List<HeapGraphExternalLive> externals;
+  List<HeapGraphExternalLive?> externals;
 
   /// Group all classes by libraries (key is library, value are classes).
   /// This is the entire set of objects (no filter applied).
@@ -298,6 +298,8 @@ class HeapGraph {
     if (rawGroupByLibrary.isNotEmpty || rawGroupByClass.isNotEmpty) return;
 
     for (final c in classes) {
+      if (c == null) continue;
+
       final sb = StringBuffer();
 
       final libraryKey = normalizeLibraryName(c.origin);
@@ -376,7 +378,7 @@ class HeapGraph {
   void computeInstancesForClasses() {
     if (!instancesComputed) {
       for (final instance in elements) {
-        instance.theClass!.addInstance(instance);
+        instance?.theClass!.addInstance(instance);
       }
 
       _instancesComputed = true;
@@ -504,8 +506,8 @@ abstract class HeapGraphClass {
     if (_instances == null) {
       final len = graph?.elements.length ?? 0;
       for (var i = 0; i < len; i++) {
-        final HeapGraphElementLive converted = graph!.elements[i];
-        if (converted.theClass == this) {
+        final HeapGraphElementLive? converted = graph!.elements[i];
+        if (converted != null && converted.theClass == this) {
           _instances.add(converted);
         }
       }

--- a/packages/devtools_app/lib/src/screens/memory/memory_snapshot_models.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_snapshot_models.dart
@@ -845,8 +845,10 @@ FieldReference createScalar(
       final classId = originClassId;
       dataValue = data.toString();
       final dataTypeClass = controller!.heapGraph!.classes[classId];
-      final predefined = predefinedClasses[dataTypeClass.fullQualifiedName]!;
-      dataType = predefined.prettyName;
+      if (dataTypeClass != null) {
+        final predefined = predefinedClasses[dataTypeClass.fullQualifiedName]!;
+        dataType = predefined.prettyName;
+      }
   }
 
   return FieldReference.createScaler(

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -235,7 +235,7 @@ class NetworkController
         // The above call won't complete immediately if the isolate is paused,
         // so give up waiting after 500ms.
         final state = await timeout(httpFuture, 500);
-        if (state.enabled != true) {
+        if (state?.enabled != true) {
           enabled = false;
         }
       },

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
@@ -84,8 +84,7 @@ class CpuProfilerController
   final _userTagFilter = ValueNotifier<String>(userTagNone);
 
   Iterable<String> get userTags =>
-      cpuProfileStore.lookupProfile(label: userTagNone)?.userTags
-          as Iterable<String>? ??
+      cpuProfileStore.lookupProfile(label: userTagNone)?.userTags ??
       const <String>[];
 
   bool get isToggleFilterActive =>

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -410,19 +410,22 @@ class CpuProfileData {
 
   CpuStackFrame get cpuProfileRoot => _cpuProfileRoot;
 
-  Iterable<String?> get userTags {
+  Iterable<String> get userTags {
     if (_userTags != null) {
       return _userTags!;
     }
-    final tags = <String?>{};
+    final tags = <String>{};
     for (final cpuSample in cpuSamples) {
-      tags.add(cpuSample.userTag);
+      final tag = cpuSample.userTag;
+      if (tag != null) {
+        tags.add(tag);
+      }
     }
     _userTags = tags;
     return _userTags!;
   }
 
-  Iterable<String?>? _userTags;
+  Iterable<String>? _userTags;
 
   late final CpuStackFrame _cpuProfileRoot;
 

--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -7,6 +7,7 @@
 import 'dart:async';
 import 'dart:core';
 
+import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
@@ -419,9 +420,8 @@ class ServiceConnectionManager {
         flutterViewListResponse.json!['views'].cast<Map<String, dynamic>>();
 
     // Each isolate should only have one FlutterView.
-    final flutterView = views.firstWhere(
+    final flutterView = views.firstWhereOrNull(
       (view) => view['type'] == 'FlutterView',
-      orElse: () => null,
     );
 
     if (flutterView == null) {

--- a/packages/devtools_app/lib/src/shared/eval_on_dart_library.dart
+++ b/packages/devtools_app/lib/src/shared/eval_on_dart_library.dart
@@ -559,7 +559,7 @@ class EvalOnDartLibrary extends DisposableController
       return request();
     }
     // Future that completes when the request has finished.
-    final Completer<T> response = Completer();
+    final Completer<T?> response = Completer();
     // This is an optimization to avoid sending stale requests across the wire.
     void wrappedRequest() async {
       if (isAlive != null && isAlive.disposed || _disposed) {

--- a/packages/devtools_app/test/enum_utils_test.dart
+++ b/packages/devtools_app/test/enum_utils_test.dart
@@ -10,14 +10,15 @@ enum Color { red, green, blue }
 void main() {
   final colorUtils = EnumUtils<Color>(Color.values);
 
-  test('getEnum', () {
+  test('enumEntry', () {
     expect(colorUtils.enumEntry('red'), Color.red);
     expect(colorUtils.enumEntry('green'), Color.green);
     expect(colorUtils.enumEntry('blue'), Color.blue);
     expect(colorUtils.enumEntry('yellow'), null);
+    expect(colorUtils.enumEntry(null), null);
   });
 
-  test('getName', () {
+  test('name', () {
     expect(colorUtils.name(Color.red), 'red');
     expect(colorUtils.name(Color.green), 'green');
     expect(colorUtils.name(Color.blue), 'blue');

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -173,6 +173,7 @@ void main() {
         await Future.delayed(const Duration(milliseconds: 200));
         return ++value;
       }
+
       expect(value, equals(0));
 
       var result = await timeout<int>(operation(), 100);

--- a/packages/devtools_app/test/utils_test.dart
+++ b/packages/devtools_app/test/utils_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/primitives/utils.dart';
+import 'package:devtools_shared/devtools_test_utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -164,6 +165,25 @@ void main() {
       // 400ms is arbitrary. It is less than 500, which is what matters. This
       // can be increased if this test starts to flake.
       expect(end! - start, lessThan(400));
+    });
+
+    test('timeout', () async {
+      int value = 0;
+      Future<int> operation() async {
+        await Future.delayed(const Duration(milliseconds: 200));
+        return ++value;
+      }
+      expect(value, equals(0));
+
+      var result = await timeout<int>(operation(), 100);
+      await delay();
+      expect(value, equals(1));
+      expect(result, isNull);
+
+      result = await timeout<int>(operation(), 500);
+      await delay();
+      expect(value, equals(2));
+      expect(result, equals(2));
     });
 
     group('TimeRange', () {

--- a/packages/devtools_app/test/variables_test.dart
+++ b/packages/devtools_app/test/variables_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: import_of_legacy_library_into_null_safe
+
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
+import 'package:devtools_app/src/screens/debugger/variables.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/tree.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('debugger variables', () {
+    late DartObjectNode objectNode;
+
+    setUp(() {
+      setGlobal(IdeTheme, IdeTheme());
+      objectNode = DartObjectNode.text('test node');
+    });
+
+    Future<void> pumpExpandableVariable(
+      WidgetTester tester,
+      DartObjectNode? variable,
+    ) async {
+      await tester.pumpWidget(
+        wrap(
+          ExpandableVariable(
+            variable: variable,
+            debuggerController: MockDebuggerController(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+      expect(find.byType(ExpandableVariable), findsOneWidget);
+    }
+
+    testWidgets('ExpandableVariable builds without error',
+        (WidgetTester tester) async {
+      await pumpExpandableVariable(tester, objectNode);
+      expect(find.byType(TreeView<DartObjectNode>), findsOneWidget);
+      expect(
+        find.byKey(ExpandableVariable.emptyExpandableVariableKey),
+        findsNothing,
+      );
+    });
+
+    testWidgets('ExpandableVariable builds for null variable',
+        (WidgetTester tester) async {
+      await pumpExpandableVariable(tester, null);
+      expect(find.byType(TreeView<DartObjectNode>), findsNothing);
+      expect(
+        find.byKey(ExpandableVariable.emptyExpandableVariableKey),
+        findsOneWidget,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Several DevTools workflows were broken due to errors with type casting and null safety.