### PR TITLE
Isolate selector in footer bar is a `PopupMenu` instead of a `DropdownMenu`

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -73,7 +73,7 @@ class DebuggerScreen extends Screen {
   Widget build(BuildContext context) => const DebuggerScreenBody();
 
   @override
-  Widget buildStatus(BuildContext context, TextTheme textTheme) {
+  Widget buildStatus(BuildContext context) {
     final controller = Provider.of<DebuggerController>(context);
     return DebuggerStatus(controller: controller);
   }

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
@@ -39,7 +39,7 @@ class LoggingScreen extends Screen {
   Widget build(BuildContext context) => const LoggingScreenBody();
 
   @override
-  Widget buildStatus(BuildContext context, TextTheme textTheme) {
+  Widget buildStatus(BuildContext context) {
     final LoggingController controller =
         Provider.of<LoggingController>(context);
 

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -43,7 +43,7 @@ class NetworkScreen extends Screen {
   Widget build(BuildContext context) => const NetworkScreenBody();
 
   @override
-  Widget buildStatus(BuildContext context, TextTheme textTheme) {
+  Widget buildStatus(BuildContext context) {
     final networkController = Provider.of<NetworkController>(context);
     final color = Theme.of(context).textTheme.bodyText2!.color!;
 

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -198,7 +198,7 @@ abstract class Screen {
   /// Build a widget to display in the status line.
   ///
   /// If this method returns `null`, then no page specific status is displayed.
-  Widget? buildStatus(BuildContext context, TextTheme textTheme) {
+  Widget? buildStatus(BuildContext context) {
     return null;
   }
 }

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -220,7 +220,6 @@ class IsolateSelector extends StatelessWidget {
             },
           ).toList(),
         );
-        // );
       },
     );
   }

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -56,7 +56,12 @@ class StatusLine extends StatelessWidget {
     final isNarrow = isExtraNarrow || ScreenSize(context).width == MediaSize.xs;
     final Widget? pageStatus = currentScreen.buildStatus(context);
     return [
-      buildHelpUrlStatus(context, currentScreen, isNarrow),
+      Expanded(
+        child: Align(
+          alignment: Alignment.centerLeft,
+          child: buildHelpUrlStatus(context, currentScreen, isNarrow),
+        ),
+      ),
       const BulletSpacer(),
       if (!isExtraNarrow && showIsolateSelector) ...[
         const IsolateSelector(),
@@ -66,7 +71,12 @@ class StatusLine extends StatelessWidget {
         pageStatus,
         const BulletSpacer(),
       ],
-      buildConnectionStatus(context, isExtraNarrow)
+      Expanded(
+        child: Align(
+          alignment: Alignment.centerRight,
+          child: buildConnectionStatus(context, isExtraNarrow),
+        ),
+      ),
     ];
   }
 

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -52,16 +52,16 @@ class StatusLine extends StatelessWidget {
   }
 
   List<Widget> _getStatusItems(BuildContext context, bool showIsolateSelector) {
-    final isSmall = ScreenSize(context).width == MediaSize.extraSmall;
+    final isNarrow = ScreenSize(context).width == MediaSize.extraSmall;
     final Widget? pageStatus = currentScreen.buildStatus(context);
     return [
       buildHelpUrlStatus(context, currentScreen),
       const BulletSpacer(),
-      if (!isSmall && showIsolateSelector) ...[
+      if (!isNarrow && showIsolateSelector) ...[
         const IsolateSelector(),
         const BulletSpacer(),
       ],
-      if (!isSmall && pageStatus != null) ...[
+      if (!isNarrow && pageStatus != null) ...[
         pageStatus,
         const BulletSpacer(),
       ],

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -66,7 +66,7 @@ class StatusLine extends StatelessWidget {
         pageStatus,
         const BulletSpacer(),
       ],
-      buildConnectionStatus(context, isNarrow)
+      buildConnectionStatus(context, isExtraNarrow)
     ];
   }
 
@@ -94,11 +94,11 @@ class StatusLine extends StatelessWidget {
       );
     } else {
       // Use a placeholder for pages with no explicit documentation.
-      return const Text('DevTools ${devtools.version}');
+      return Text('${isNarrow ? '' : 'DevTools '}${devtools.version}');
     }
   }
 
-  Widget buildConnectionStatus(BuildContext context, bool isNarrow) {
+  Widget buildConnectionStatus(BuildContext context, bool isExtraNarrow) {
     final textTheme = Theme.of(context).textTheme;
     return ValueListenableBuilder<ConnectedState>(
       valueListenable: serviceManager.connectedState,
@@ -158,7 +158,7 @@ class StatusLine extends StatelessWidget {
                         Icons.info_outline,
                         size: actionsIconSize,
                       ),
-                      if (!isNarrow) ...[
+                      if (!isExtraNarrow) ...[
                         const SizedBox(width: denseSpacing),
                         Text(
                           description,
@@ -176,10 +176,18 @@ class StatusLine extends StatelessWidget {
           return child!;
         }
       },
-      child: Text(
-        'No client connection',
-        style: textTheme.bodyText2,
-      ),
+      child: isExtraNarrow
+          ? DevToolsTooltip(
+              message: 'No client connection',
+              child: Icon(
+                Icons.warning_amber_rounded,
+                size: actionsIconSize,
+              ),
+            )
+          : Text(
+              'No client connection',
+              style: textTheme.bodyText2,
+            ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -110,6 +110,7 @@ class StatusLine extends StatelessWidget {
 
   Widget buildConnectionStatus(BuildContext context, bool isExtraNarrow) {
     final textTheme = Theme.of(context).textTheme;
+    const noConnectionMsg = 'No client connection';
     return ValueListenableBuilder<ConnectedState>(
       valueListenable: serviceManager.connectedState,
       builder: (context, connectedState, child) {
@@ -188,14 +189,14 @@ class StatusLine extends StatelessWidget {
       },
       child: isExtraNarrow
           ? DevToolsTooltip(
-              message: 'No client connection',
+              message: noConnectionMsg,
               child: Icon(
                 Icons.warning_amber_rounded,
                 size: actionsIconSize,
               ),
             )
           : Text(
-              'No client connection',
+              noConnectionMsg,
               style: textTheme.bodyText2,
             ),
     );

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -158,13 +158,14 @@ class StatusLine extends StatelessWidget {
                         Icons.info_outline,
                         size: actionsIconSize,
                       ),
-                      if (!isNarrow) const SizedBox(width: denseSpacing),
-                      if (!isNarrow)
+                      if (!isNarrow) ...[
+                        const SizedBox(width: denseSpacing),
                         Text(
                           description,
                           style: textTheme.bodyText2,
                           overflow: TextOverflow.clip,
                         ),
+                      ]
                     ],
                   ),
                 ),

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -52,7 +52,7 @@ class StatusLine extends StatelessWidget {
   }
 
   List<Widget> _getStatusItems(BuildContext context, bool showIsolateSelector) {
-    final isNarrow = ScreenSize(context).width == MediaSize.extraSmall;
+    final isNarrow = ScreenSize(context).width == MediaSize.xs;
     final Widget? pageStatus = currentScreen.buildStatus(context);
     return [
       buildHelpUrlStatus(context, currentScreen),

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -47,7 +47,7 @@ class StatusLine extends StatelessWidget {
           buildHelpUrlStatus(context, currentScreen, textTheme),
           const BulletSpacer()
         ]);
-    // Display an isolate selector.
+        // Display an isolate selector.
         if (showIsolateSelector) {
           children.addAll([const IsolateSelector(), const BulletSpacer()]);
         }

--- a/packages/devtools_app/lib/src/shared/status_line.dart
+++ b/packages/devtools_app/lib/src/shared/status_line.dart
@@ -52,12 +52,13 @@ class StatusLine extends StatelessWidget {
   }
 
   List<Widget> _getStatusItems(BuildContext context, bool showIsolateSelector) {
-    final isNarrow = ScreenSize(context).width == MediaSize.xs;
+    final isExtraNarrow = ScreenSize(context).width == MediaSize.xxs;
+    final isNarrow = isExtraNarrow || ScreenSize(context).width == MediaSize.xs;
     final Widget? pageStatus = currentScreen.buildStatus(context);
     return [
-      buildHelpUrlStatus(context, currentScreen),
+      buildHelpUrlStatus(context, currentScreen, isNarrow),
       const BulletSpacer(),
-      if (!isNarrow && showIsolateSelector) ...[
+      if (!isExtraNarrow && showIsolateSelector) ...[
         const IsolateSelector(),
         const BulletSpacer(),
       ],
@@ -65,20 +66,21 @@ class StatusLine extends StatelessWidget {
         pageStatus,
         const BulletSpacer(),
       ],
-      buildConnectionStatus(context)
+      buildConnectionStatus(context, isNarrow)
     ];
   }
 
   Widget buildHelpUrlStatus(
     BuildContext context,
     Screen currentScreen,
+    bool isNarrow,
   ) {
     final String? docPageId = currentScreen.docPageId;
     if (docPageId != null) {
       return RichText(
         text: LinkTextSpan(
           link: Link(
-            display: 'flutter.dev/devtools/$docPageId',
+            display: isNarrow ? docPageId : 'flutter.dev/devtools/$docPageId',
             url: 'https://flutter.dev/devtools/$docPageId',
           ),
           onTap: () {
@@ -96,7 +98,7 @@ class StatusLine extends StatelessWidget {
     }
   }
 
-  Widget buildConnectionStatus(BuildContext context) {
+  Widget buildConnectionStatus(BuildContext context, bool isNarrow) {
     final textTheme = Theme.of(context).textTheme;
     return ValueListenableBuilder<ConnectedState>(
       valueListenable: serviceManager.connectedState,
@@ -156,12 +158,13 @@ class StatusLine extends StatelessWidget {
                         Icons.info_outline,
                         size: actionsIconSize,
                       ),
-                      const SizedBox(width: denseSpacing),
-                      Text(
-                        description,
-                        style: textTheme.bodyText2,
-                        overflow: TextOverflow.clip,
-                      ),
+                      if (!isNarrow) const SizedBox(width: denseSpacing),
+                      if (!isNarrow)
+                        Text(
+                          description,
+                          style: textTheme.bodyText2,
+                          overflow: TextOverflow.clip,
+                        ),
                     ],
                   ),
                 ),

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -221,3 +221,47 @@ class ThemedColor {
     return colorScheme.isLight ? light : dark;
   }
 }
+
+// TODO(elliette): Add mixin for comparing enums. Eg, size > MediaSize.small
+// Requires enhanced enums feature in Dart SDK >= 2.17.
+enum MediaSize {
+  extraSmall,
+  small,
+  medium,
+  large,
+  extraLarge,
+}
+
+class ScreenSize {
+  ScreenSize(BuildContext context) {
+    _height = _calculateHeight(context);
+    _width = _calculateWidth(context);
+  }
+
+  MediaSize get height => _height;
+  MediaSize get width => _width;
+  late MediaSize _height;
+  late MediaSize _width;
+
+  MediaSize _calculateWidth(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width < 600) return MediaSize.extraSmall;
+    if (width >= 600 && width < 900) return MediaSize.small;
+    if (width >= 900 && width < 1200) return MediaSize.medium;
+    if (width >= 1200 && width < 1500)
+      return MediaSize.large;
+    else
+      return MediaSize.extraLarge;
+  }
+
+  MediaSize _calculateHeight(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width < 300) return MediaSize.extraSmall;
+    if (width >= 300 && width < 500) return MediaSize.small;
+    if (width >= 500 && width < 700) return MediaSize.medium;
+    if (width >= 700 && width < 900)
+      return MediaSize.large;
+    else
+      return MediaSize.extraLarge;
+  }
+}

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -222,7 +222,7 @@ class ThemedColor {
   }
 }
 
-// TODO(elliette): Add mixin for comparing enums. Eg, size > MediaSize.small
+// TODO(elliette): Add mixin for comparing enums. Eg, size > MediaSize.s
 // Requires enhanced enums feature in Dart SDK >= 2.17.
 enum MediaSize {
   xs,
@@ -245,23 +245,23 @@ class ScreenSize {
 
   MediaSize _calculateWidth(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width < 600) return MediaSize.extraSmall;
-    if (width >= 600 && width < 900) return MediaSize.small;
-    if (width >= 900 && width < 1200) return MediaSize.medium;
+    if (width < 600) return MediaSize.xs;
+    if (width >= 600 && width < 900) return MediaSize.s;
+    if (width >= 900 && width < 1200) return MediaSize.m;
     if (width >= 1200 && width < 1500)
-      return MediaSize.large;
+      return MediaSize.l;
     else
-      return MediaSize.extraLarge;
+      return MediaSize.xl;
   }
 
   MediaSize _calculateHeight(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width < 300) return MediaSize.extraSmall;
-    if (width >= 300 && width < 500) return MediaSize.small;
-    if (width >= 500 && width < 700) return MediaSize.medium;
+    if (width < 300) return MediaSize.xs;
+    if (width >= 300 && width < 500) return MediaSize.s;
+    if (width >= 500 && width < 700) return MediaSize.m;
     if (width >= 700 && width < 900)
-      return MediaSize.large;
+      return MediaSize.l;
     else
-      return MediaSize.extraLarge;
+      return MediaSize.xl;
   }
 }

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -247,22 +247,22 @@ class ScreenSize {
   MediaSize _calculateWidth(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
     if (width < 300) return MediaSize.xxs;
-    if (width >= 300 && width < 600) return MediaSize.xs;
-    if (width >= 600 && width < 900) return MediaSize.s;
-    if (width >= 900 && width < 1200) return MediaSize.m;
-    if (width >= 1200 && width < 1500)
+    if (width < 600) return MediaSize.xs;
+    if (width < 900) return MediaSize.s;
+    if (width < 1200) return MediaSize.m;
+    if (width < 1500)
       return MediaSize.l;
     else
       return MediaSize.xl;
   }
 
   MediaSize _calculateHeight(BuildContext context) {
-    final width = MediaQuery.of(context).size.width;
-    if (width < 300) return MediaSize.xxs;
-    if (width >= 300 && width < 450) return MediaSize.xs;
-    if (width >= 450 && width < 600) return MediaSize.s;
-    if (width >= 600 && width < 750) return MediaSize.m;
-    if (width >= 750 && width < 900)
+    final height = MediaQuery.of(context).size.height;
+    if (height < 300) return MediaSize.xxs;
+    if (height < 450) return MediaSize.xs;
+    if (height < 600) return MediaSize.s;
+    if (height < 750) return MediaSize.m;
+    if (height < 900)
       return MediaSize.l;
     else
       return MediaSize.xl;

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -225,11 +225,11 @@ class ThemedColor {
 // TODO(elliette): Add mixin for comparing enums. Eg, size > MediaSize.small
 // Requires enhanced enums feature in Dart SDK >= 2.17.
 enum MediaSize {
-  extraSmall,
-  small,
-  medium,
-  large,
-  extraLarge,
+  xs,
+  s,
+  m,
+  l,
+  xl,
 }
 
 class ScreenSize {

--- a/packages/devtools_app/lib/src/ui/utils.dart
+++ b/packages/devtools_app/lib/src/ui/utils.dart
@@ -225,6 +225,7 @@ class ThemedColor {
 // TODO(elliette): Add mixin for comparing enums. Eg, size > MediaSize.s
 // Requires enhanced enums feature in Dart SDK >= 2.17.
 enum MediaSize {
+  xxs,
   xs,
   s,
   m,
@@ -245,7 +246,8 @@ class ScreenSize {
 
   MediaSize _calculateWidth(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width < 600) return MediaSize.xs;
+    if (width < 300) return MediaSize.xxs;
+    if (width >= 300 && width < 600) return MediaSize.xs;
     if (width >= 600 && width < 900) return MediaSize.s;
     if (width >= 900 && width < 1200) return MediaSize.m;
     if (width >= 1200 && width < 1500)
@@ -256,10 +258,11 @@ class ScreenSize {
 
   MediaSize _calculateHeight(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width < 300) return MediaSize.xs;
-    if (width >= 300 && width < 500) return MediaSize.s;
-    if (width >= 500 && width < 700) return MediaSize.m;
-    if (width >= 700 && width < 900)
+    if (width < 300) return MediaSize.xxs;
+    if (width >= 300 && width < 450) return MediaSize.xs;
+    if (width >= 450 && width < 600) return MediaSize.s;
+    if (width >= 600 && width < 750) return MediaSize.m;
+    if (width >= 750 && width < 900)
       return MediaSize.l;
     else
       return MediaSize.xl;

--- a/packages/devtools_app/test/ui_utils_test.dart
+++ b/packages/devtools_app/test/ui_utils_test.dart
@@ -286,17 +286,4 @@ void expectScreenSize(
   final BuildContext context = tester.element(find.byType(Container));
   expect(ScreenSize(context).width, equals(width));
   expect(ScreenSize(context).height, equals(height));
-
-  // await tester.pumpWidget(
-  //   wrap(
-  //     Builder(
-  //       builder: (context) {
-  //         expectLater(ScreenSize(context).width, equals(width));
-  //         expectLater(ScreenSize(context).height, equals(height));
-  //         return Container();
-  //       },
-  //     ),
-  //   ),
-  // );
-  // await tester.pumpAndSettle();
 }

--- a/packages/devtools_app/test/ui_utils_test.dart
+++ b/packages/devtools_app/test/ui_utils_test.dart
@@ -165,6 +165,68 @@ void main() {
     });
   });
 
+  group('ScreenSize', () {
+    testWidgetsWithWindowSize(
+        'handles screens with xxs width and xl height', const Size(250, 1000),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.xxs,
+        height: MediaSize.xl,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'handles screens with xs width and l height', const Size(500, 800),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.xs,
+        height: MediaSize.l,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'handles screens with s width and m height', const Size(800, 700),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.s,
+        height: MediaSize.m,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'handles screens with m width and s height', const Size(1100, 550),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.m,
+        height: MediaSize.s,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'handles screens with l width and xs height', const Size(1400, 400),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.l,
+        height: MediaSize.xs,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'handles screens with xl width and xxs height', const Size(1600, 250),
+        (WidgetTester tester) async {
+      return expectScreenSize(
+        tester,
+        width: MediaSize.xl,
+        height: MediaSize.xxs,
+      );
+    });
+  });
+
   testWidgetsWithWindowSize('OffsetScrollbar goldens', const Size(300, 300),
       (WidgetTester tester) async {
     const root = Key('root');
@@ -213,4 +275,28 @@ void main() {
       matchesGoldenFile('goldens/offset_scrollbar_scrolled.png'),
     );
   });
+}
+
+void expectScreenSize(
+  WidgetTester tester, {
+  required MediaSize width,
+  required MediaSize height,
+}) async {
+  await tester.pumpWidget(wrap(Container()));
+  final BuildContext context = tester.element(find.byType(Container));
+  expect(ScreenSize(context).width, equals(width));
+  expect(ScreenSize(context).height, equals(height));
+
+  // await tester.pumpWidget(
+  //   wrap(
+  //     Builder(
+  //       builder: (context) {
+  //         expectLater(ScreenSize(context).width, equals(width));
+  //         expectLater(ScreenSize(context).height, equals(height));
+  //         return Container();
+  //       },
+  //     ),
+  //   ),
+  // );
+  // await tester.pumpAndSettle();
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3985

Also cleans up some unnecessary formatting in the footer (removes individual alignment of items, which was unnecessary because they end up being aligned correctly in their row with `spaceBetween`). 
