### PR TITLE
[provider] Fix the mutation of private properties

### DIFF
--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_providers.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_providers.dart
@@ -407,20 +407,8 @@ Future<List<ObjectField>> _parseFields(
     final owner =
         await eval.safeGetClass(fieldDeclaration.owner! as ClassRef, isAlive);
 
-    String ownerUri;
-    String ownerName;
-    final ownerMixin = owner.mixin;
-    if (ownerMixin == null) {
-      ownerUri = owner.library!.uri!;
-      ownerName = owner.name!;
-    } else {
-      final mixinClass =
-          await eval.safeGetClass(ownerMixin.typeClass!, isAlive);
-
-      ownerUri = mixinClass.library!.uri!;
-      ownerName = mixinClass.name!;
-    }
-
+    final ownerUri = fieldDeclaration.location!.script!.uri!;
+    final ownerName = owner.mixin?.name ?? owner.name!;
     final ownerPackageName = tryParsePackageName(ownerUri);
 
     return ObjectField(

--- a/packages/devtools_app/test/provider/provider_controller_test.dart
+++ b/packages/devtools_app/test/provider/provider_controller_test.dart
@@ -108,46 +108,41 @@ Future<void> runProviderControllerTests(FlutterTestEnvironment env) async {
   );
 
   group('Provider controllers', () {
-    test(
-      'can mutate private properties from mixins',
-      () async {
-        final container = ProviderContainer();
-        addTearDown(container.dispose);
+    test('can mutate private properties from mixins', () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
 
-        final sub = container.listen(
-          instanceProvider(
-            const InstancePath.fromProviderId('0').pathForChild(
-              const PathToProperty.objectProperty(
-                name: '_privateMixinProperty',
-                ownerUri: 'package:provider_app/mixin.dart',
-                ownerName: 'Mixin',
-              ),
+      final sub = container.listen(
+        instanceProvider(
+          const InstancePath.fromProviderId('0').pathForChild(
+            const PathToProperty.objectProperty(
+              name: '_privateMixinProperty',
+              ownerUri: 'package:provider_app/mixin.dart',
+              ownerName: 'Mixin',
             ),
-          ).future,
-          (prev, next) {},
-        );
+          ),
+        ).future,
+        (prev, next) {},
+      );
 
-        var instance = await sub.read();
+      var instance = await sub.read();
 
-        expect(
-          instance,
-          isA<NumInstance>()
-              .having((e) => e.displayString, 'displayString', '0'),
-        );
+      expect(
+        instance,
+        isA<NumInstance>().having((e) => e.displayString, 'displayString', '0'),
+      );
 
-        await instance.setter!('42');
+      await instance.setter!('42');
 
-        // read the instance again since it should have changed
-        instance = await sub.read();
+      // read the instance again since it should have changed
+      instance = await sub.read();
 
-        expect(
-          instance,
-          isA<NumInstance>()
-              .having((e) => e.displayString, 'displayString', '42'),
-        );
-      },
-      skip: 'wait https://github.com/dart-lang/sdk/issues/45093 to be fixed',
-    );
+      expect(
+        instance,
+        isA<NumInstance>()
+            .having((e) => e.displayString, 'displayString', '42'),
+      );
+    });
 
     test(
       'sortedProviderNodesProvider',


### PR DESCRIPTION
This unskips a test that was skipped during the migration to null-safety of the provider tab

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
