### PR TITLE
add a repository field to the pubspecs

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -5,7 +5,7 @@ description: Web-based performance tooling for Dart and Flutter.
 # that updates all versions of devtools packages (devtools_app, devtools_test).
 version: 2.13.0-dev.1
 
-homepage: https://github.com/flutter/devtools
+repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
 environment:
   sdk: '>=2.16.0 <3.0.0'

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -3,7 +3,7 @@ description: Package of shared structures between devtools_app, dds, and other t
 
 version: 2.13.0-dev.1
 
-homepage: https://github.com/flutter/devtools
+repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -8,7 +8,7 @@ description: A package containing shared test helpers for Dart DevTools tests.
 # this package.
 version: 2.13.0-dev.1
 
-homepage: https://github.com/flutter/devtools
+repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
- add a `repository` field to the pubspec files

Separately - if we're no longer going to publish package:devtools_app - you may want to add a `publish_to: none` line to the pubspec file for it.
