### PR TITLE
Fix `Method not found` errors for URL launcher

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/launch_url/launch_url.dart
+++ b/packages/devtools_app/lib/src/config_specific/launch_url/launch_url.dart
@@ -10,8 +10,8 @@ import '_launch_url_stub.dart'
     if (dart.library.io) '_launch_url_desktop.dart';
 
 Future<void> launchUrl(String url, BuildContext context) async {
-  if (await url_launcher.canLaunchUrl(Uri.parse(url))) {
-    await url_launcher.launchUrl(Uri.parse(url));
+  if (await url_launcher.canLaunch(url)) {
+    await url_launcher.launch(url);
   } else {
     Notifications.of(context)!.push('Unable to open $url.');
   }


### PR DESCRIPTION
Fixes Dart DevTools being broken when you try to run at head due to the following errors:

```
lib/src/config_specific/launch_url/launch_url.dart:13:26: Error: Method not found: 'canLaunchUrl'.
  if (await url_launcher.canLaunchUrl(Uri.parse(url))) {
                         ^^^^^^^^^^^^
lib/src/config_specific/launch_url/launch_url.dart:14:24: Error: Method not found: 'launchUrl'.
    await url_launcher.launchUrl(Uri.parse(url));
```