### PR TITLE
Bump url_launcher dependency version to v6.1.0

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -48,7 +48,7 @@ dependencies:
   sse: ^4.0.0
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0
-  url_launcher: ^6.0.18
+  url_launcher: ^6.1.0
   url_launcher_web: ^2.0.6
   vm_service: ^8.2.2
   vm_snapshot_analysis: ^0.7.1

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -7,7 +7,7 @@ import 'package:mockito/annotations.dart';
 import 'package:vm_service/vm_service.dart';
 
 // See https://github.com/dart-lang/mockito/blob/master/NULL_SAFETY_README.md
-// Run `sh tools/generate_code.sh` to regenerate mocks.
+// Run `sh tool/generate_code.sh` to regenerate mocks.
 @GenerateMocks([
   ConnectedApp,
   ErrorBadgeManager,


### PR DESCRIPTION
There's code here that calls `canLaunchUrl`:

https://github.com/flutter/devtools/blob/059a14966f0e1aec993bd651a72bc37b7737d5c7/packages/devtools_app/lib/src/config_specific/launch_url/launch_url.dart#L15

This API was only added in `url_launcher` v6.1.0 (see https://pub.dev/packages/url_launcher/changelog). Without this, I see anlaysis errors about the method not existing (unless I ran `pub update`).

I suspect the bots aren't hitting it because they're getting slightly different versions of dependencies that might be forcing this to 6.1.0 (which I'm not, because I haven't deleted my lockfile).