### PR TITLE
upgrade package:provider version to eliminate null safety warnings

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -44,7 +44,7 @@ dependencies:
   js: ^0.6.1+1
   mime: ^1.0.0
   path: ^1.8.0
-  provider: ^5.0.0
+  provider: ^6.0.2
   sse: ^4.0.0
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   mockito: ^5.0.9
   path: ^1.8.0
   pedantic: ^1.11.0
-  provider: ^5.0.0
+  provider: ^6.0.2
   vm_service: ^8.1.0
   vm_snapshot_analysis: ^0.7.1
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'


### PR DESCRIPTION
Removes spurious warnings when running DevTools. There will still be one warning related to package:flutter_riverpod until https://github.com/rrousselGit/riverpod/issues/1156 is resolved and a new version of flutter_riverpod is published.