### PR TITLE
Fix formatting in debugger exception menu

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -231,7 +231,7 @@ class DebuggerButton extends StatelessWidget {
         child: MaterialIconLabel(
           label: title,
           iconData: icon,
-          minScreenWidthForTextBeforeScaling: 1300.0,
+          minScreenWidthForTextBeforeScaling: 1350.0,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -16,7 +16,7 @@ import 'debugger_controller.dart';
 class DebuggingControls extends StatefulWidget {
   const DebuggingControls({Key? key}) : super(key: key);
 
-  static const minWidthBeforeScaline = 1300.0;
+  static const minWidthBeforeScaling = 1300.0;
 
   @override
   _DebuggingControlsState createState() => _DebuggingControlsState();
@@ -148,7 +148,7 @@ class BreakOnExceptionsControl extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final isInSmallMode = MediaQuery.of(context).size.width <
-        DebuggingControls.minWidthBeforeScaline;
+        DebuggingControls.minWidthBeforeScaling;
     return ValueListenableBuilder<String?>(
       valueListenable: controller.exceptionPauseMode,
       builder: (BuildContext context, modeId, _) {
@@ -238,7 +238,7 @@ class DebuggerButton extends StatelessWidget {
           label: title,
           iconData: icon,
           minScreenWidthForTextBeforeScaling:
-              DebuggingControls.minWidthBeforeScaline,
+              DebuggingControls.minWidthBeforeScaling,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -13,6 +13,8 @@ import '../../shared/theme.dart';
 import '../../ui/label.dart';
 import 'debugger_controller.dart';
 
+const minWidthBeforeScaline = 1300.0;
+
 class DebuggingControls extends StatefulWidget {
   const DebuggingControls({Key? key}) : super(key: key);
 
@@ -145,7 +147,8 @@ class BreakOnExceptionsControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isInSmallMode = MediaQuery.of(context).size.width < mediumDeviceWidth;
+    final isInSmallMode =
+        MediaQuery.of(context).size.width < minWidthBeforeScaline;
     return ValueListenableBuilder<String?>(
       valueListenable: controller.exceptionPauseMode,
       builder: (BuildContext context, modeId, _) {
@@ -234,7 +237,7 @@ class DebuggerButton extends StatelessWidget {
         child: MaterialIconLabel(
           label: title,
           iconData: icon,
-          minScreenWidthForTextBeforeScaling: mediumDeviceWidth,
+          minScreenWidthForTextBeforeScaling: minWidthBeforeScaline,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -13,10 +13,10 @@ import '../../shared/theme.dart';
 import '../../ui/label.dart';
 import 'debugger_controller.dart';
 
-const minWidthBeforeScaline = 1300.0;
-
 class DebuggingControls extends StatefulWidget {
   const DebuggingControls({Key? key}) : super(key: key);
+
+  static const minWidthBeforeScaline = 1300.0;
 
   @override
   _DebuggingControlsState createState() => _DebuggingControlsState();
@@ -147,8 +147,8 @@ class BreakOnExceptionsControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isInSmallMode =
-        MediaQuery.of(context).size.width < minWidthBeforeScaline;
+    final isInSmallMode = MediaQuery.of(context).size.width <
+        DebuggingControls.minWidthBeforeScaline;
     return ValueListenableBuilder<String?>(
       valueListenable: controller.exceptionPauseMode,
       builder: (BuildContext context, modeId, _) {
@@ -237,7 +237,8 @@ class DebuggerButton extends StatelessWidget {
         child: MaterialIconLabel(
           label: title,
           iconData: icon,
-          minScreenWidthForTextBeforeScaling: minWidthBeforeScaline,
+          minScreenWidthForTextBeforeScaling:
+              DebuggingControls.minWidthBeforeScaline,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -145,6 +145,7 @@ class BreakOnExceptionsControl extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isInSmallMode = MediaQuery.of(context).size.width < mediumDeviceWidth;
     return ValueListenableBuilder<String?>(
       valueListenable: controller.exceptionPauseMode,
       builder: (BuildContext context, modeId, _) {
@@ -161,20 +162,11 @@ class BreakOnExceptionsControl extends StatelessWidget {
             for (var mode in ExceptionMode.modes)
               DropdownMenuItem<ExceptionMode>(
                 value: mode,
-                child: Text(mode.description),
+                child: Text(
+                  isInSmallMode ? mode.name : mode.description,
+                ),
               )
           ],
-          selectedItemBuilder: (BuildContext context) {
-            return [
-              for (var mode in ExceptionMode.modes)
-                DropdownMenuItem<ExceptionMode>(
-                  value: mode,
-                  child: Text(
-                    includeText(context, 1300.0) ? mode.description : mode.name,
-                  ),
-                )
-            ];
-          },
         );
       },
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -164,6 +164,17 @@ class BreakOnExceptionsControl extends StatelessWidget {
                 child: Text(mode.description),
               )
           ],
+          selectedItemBuilder: (BuildContext context) {
+            return [
+              for (var mode in ExceptionMode.modes)
+                DropdownMenuItem<ExceptionMode>(
+                  value: mode,
+                  child: Text(
+                    includeText(context, 1300.0) ? mode.description : mode.name,
+                  ),
+                )
+            ];
+          },
         );
       },
     );
@@ -176,17 +187,17 @@ class ExceptionMode {
   static final modes = [
     ExceptionMode(
       ExceptionPauseMode.kNone,
-      'Ignore',
+      'Ignore exceptions',
       "Don't stop on exceptions",
     ),
     ExceptionMode(
       ExceptionPauseMode.kUnhandled,
-      'Uncaught',
+      'Uncaught exceptions',
       'Stop on uncaught exceptions',
     ),
     ExceptionMode(
       ExceptionPauseMode.kAll,
-      'All',
+      'All exceptions',
       'Stop on all exceptions',
     ),
   ];
@@ -231,7 +242,7 @@ class DebuggerButton extends StatelessWidget {
         child: MaterialIconLabel(
           label: title,
           iconData: icon,
-          minScreenWidthForTextBeforeScaling: 1350.0,
+          minScreenWidthForTextBeforeScaling: mediumDeviceWidth,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -231,7 +231,7 @@ class DebuggerButton extends StatelessWidget {
         child: MaterialIconLabel(
           label: title,
           iconData: icon,
-          minScreenWidthForTextBeforeScaling: mediumDeviceWidth,
+          minScreenWidthForTextBeforeScaling: 1300.0,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -164,15 +164,6 @@ class BreakOnExceptionsControl extends StatelessWidget {
                 child: Text(mode.description),
               )
           ],
-          selectedItemBuilder: (BuildContext context) {
-            return [
-              for (var mode in ExceptionMode.modes)
-                DropdownMenuItem<ExceptionMode>(
-                  value: mode,
-                  child: Text(mode.name),
-                )
-            ];
-          },
         );
       },
     );

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -28,7 +28,7 @@ const tooltipWaitLong = Duration(milliseconds: 1000);
 /// The width of the package:flutter_test debugger device.
 const debuggerDeviceWidth = 800.0;
 
-const mediumDeviceWidth = 1000.0;
+const mediumDeviceWidth = 1300.0;
 
 const defaultDialogRadius = 20.0;
 double get areaPaneHeaderHeight => scaleByFontFactor(36.0);

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -28,8 +28,6 @@ const tooltipWaitLong = Duration(milliseconds: 1000);
 /// The width of the package:flutter_test debugger device.
 const debuggerDeviceWidth = 800.0;
 
-const mediumDeviceWidth = 1300.0;
-
 const defaultDialogRadius = 20.0;
 double get areaPaneHeaderHeight => scaleByFontFactor(36.0);
 

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -28,8 +28,6 @@ const tooltipWaitLong = Duration(milliseconds: 1000);
 /// The width of the package:flutter_test debugger device.
 const debuggerDeviceWidth = 800.0;
 
-const mediumDeviceWidth = 1000.0;
-
 const defaultDialogRadius = 20.0;
 double get areaPaneHeaderHeight => scaleByFontFactor(36.0);
 

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -28,6 +28,8 @@ const tooltipWaitLong = Duration(milliseconds: 1000);
 /// The width of the package:flutter_test debugger device.
 const debuggerDeviceWidth = 800.0;
 
+const mediumDeviceWidth = 1000.0;
+
 const defaultDialogRadius = 20.0;
 double get areaPaneHeaderHeight => scaleByFontFactor(36.0);
 

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:html';
+
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/console.dart';
 import 'package:devtools_app/src/screens/debugger/controls.dart';
@@ -9,6 +11,7 @@ import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -112,7 +115,11 @@ void main() {
         debugger: debuggerController,
       ),
     );
-    expect(find.text("Don't stop on exceptions"), findsOneWidget);
+    if (windowSize.width < mediumDeviceWidth) {
+      expect(find.text('Ignore exceptions'), findsOneWidget);
+    } else {
+      expect(find.text("Don't stop on exceptions"), findsOneWidget);
+    }
   });
 }
 

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -9,7 +9,6 @@ import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -113,7 +112,7 @@ void main() {
         debugger: debuggerController,
       ),
     );
-    if (windowSize.width < mediumDeviceWidth) {
+    if (windowSize.width < DebuggingControls.minWidthBeforeScaline) {
       expect(find.text('Ignore exceptions'), findsOneWidget);
     } else {
       expect(find.text("Don't stop on exceptions"), findsOneWidget);

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:html';
-
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/console.dart';
 import 'package:devtools_app/src/screens/debugger/controls.dart';

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -113,10 +113,12 @@ void main() {
       ),
     );
     if (windowSize.width < DebuggingControls.minWidthBeforeScaling) {
-      expect(find.text('Ignore exceptions'), findsOneWidget);
+      // expect(find.text('Ignore exceptions'), findsOneWidget);
     } else {
-      expect(find.text("Don't stop on exceptions"), findsOneWidget);
+      // expect(find.text("Don't stop on exceptions"), findsOneWidget);
     }
+
+    expect(find.text('Ignore exceptions'), findsOneWidget);
   });
 }
 

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -19,6 +19,7 @@ void main() {
   const screen = DebuggerScreen();
 
   const windowSize = Size(4000.0, 4000.0);
+  const smallWindowSize = Size(1100.0, 1100.0);
 
   final fakeServiceManager = FakeServiceManager();
   final scriptManager = MockScriptManager();
@@ -112,13 +113,19 @@ void main() {
         debugger: debuggerController,
       ),
     );
-    if (windowSize.width < DebuggingControls.minWidthBeforeScaling) {
-      // expect(find.text('Ignore exceptions'), findsOneWidget);
-    } else {
-      // expect(find.text("Don't stop on exceptions"), findsOneWidget);
-    }
-
     expect(find.text("Don't stop on exceptions"), findsOneWidget);
+  });
+
+  testWidgetsWithWindowSize(
+      'debugger controls break on exceptions abbreviated on small window',
+      smallWindowSize, (WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrapWithControllers(
+        Builder(builder: screen.build),
+        debugger: debuggerController,
+      ),
+    );
+    expect(find.text('Ignore exceptions'), findsOneWidget);
   });
 }
 

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -112,7 +112,7 @@ void main() {
         debugger: debuggerController,
       ),
     );
-    expect(find.text('Ignore'), findsOneWidget);
+    expect(find.text("Don't stop on exceptions"), findsOneWidget);
   });
 }
 

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -112,7 +112,7 @@ void main() {
         debugger: debuggerController,
       ),
     );
-    if (windowSize.width < DebuggingControls.minWidthBeforeScaline) {
+    if (windowSize.width < DebuggingControls.minWidthBeforeScaling) {
       expect(find.text('Ignore exceptions'), findsOneWidget);
     } else {
       expect(find.text("Don't stop on exceptions"), findsOneWidget);

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -118,7 +118,7 @@ void main() {
       // expect(find.text("Don't stop on exceptions"), findsOneWidget);
     }
 
-    expect(find.text('Ignore exceptions'), findsOneWidget);
+    expect(find.text("Don't stop on exceptions"), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
![](https://media.giphy.com/media/11p1apCPqM7WEw/giphy.gif)

Fixes https://github.com/flutter/devtools/issues/3875

This PR fixes the formatting for the debugger exception menu.

The dropdown menu button, and the menu that is opened after clicking it, has a width that is determined by the size of the  largest `selectedItemBuilder` widget.
Currently those `selectedItemBuilder` widgets are abbreviated versions of the menu item texts. This results in the menu items being compressed.

The alleviate this formatting issue, the selection text and menu items are being set to be the same values.

To help the UX in smaller screens, a compressed version of the item/selection text will be used when the screen width is less than 1300.0 pixels.

 
 
## Screenshots
### Expanded version
![image](https://user-images.githubusercontent.com/1386322/167439542-a29318c9-1e0e-4781-9373-acf0b6a39a30.png)

### Compressed Version
![image](https://user-images.githubusercontent.com/1386322/167439524-412b2113-c892-4556-b4c5-e1c07f15de68.png)





## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
