### PR TITLE
Fix bug causing the codeview to scroll to the bottom of a file when a breakpoint is hit

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -155,8 +155,8 @@ class _CodeViewState extends State<CodeView>
       log('LinkedScrollControllerGroup has no attached controllers');
       return;
     }
-    final location = widget.controller.scriptLocation.value?.location;
-    if (location?.line == null) {
+    final line = widget.controller.scriptLocation.value?.location?.line;
+    if (line == null) {
       // Don't scroll to top if we're just rebuilding the code view for the
       // same script.
       if (_lastScriptRef?.uri != scriptRef?.uri) {
@@ -182,7 +182,7 @@ class _CodeViewState extends State<CodeView>
     // middle third of the screen.
     final lineCount = parsedScript?.lineCount;
     if (lineCount != null && lineCount * CodeView.rowHeight > extent) {
-      final lineIndex = lineCount - 1;
+      final lineIndex = line - 1;
       final scrollPosition =
           lineIndex * CodeView.rowHeight - ((extent - CodeView.rowHeight) / 2);
       if (animate) {


### PR DESCRIPTION
Fixes a bug introduced in null-safety migration of the debugger screen 🤦‍♀️ 

When we hit a breakpoint, we were trying to scroll to the last line in the file, instead of the line with the breakpoint. 

This was before the null-safety migration:
```
    if (parsedScript.lineCount * CodeView.rowHeight > extent) {
      final lineIndex = location.line - 1;
      final scrollPosition =
          lineIndex * CodeView.rowHeight - ((extent - CodeView.rowHeight) / 2);
```

And this is after:

```
    final lineCount = parsedScript?.lineCount;
    if (lineCount != null && lineCount * CodeView.rowHeight > extent) {
      final lineIndex = lineCount - 1; <-- THIS IS THE WRONG LINE INDEX! SHOULD BE location.line - 1
```

I've changed it back to using the correct line index.

I've also opened a follow up to add a test: https://github.com/flutter/devtools/issues/4073
