### PR TITLE
Reduce chart heights and size of flutter frame bars

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
@@ -289,7 +289,7 @@ class FlutterFramesChartItem extends StatelessWidget {
     required this.displayRefreshRate,
   });
 
-  static const defaultFrameWidth = 32.0;
+  static const defaultFrameWidth = 24.0;
 
   static const selectedIndicatorHeight = 8.0;
 

--- a/packages/devtools_app/lib/src/shared/theme.dart
+++ b/packages/devtools_app/lib/src/shared/theme.dart
@@ -173,7 +173,7 @@ double get defaultListItemHeight => scaleByFontFactor(28.0);
 // TODO(jacobr) define a more sophisticated formula for chart height.
 // The chart height does need to increase somewhat to leave room for the legend
 // and tick marks but does not need to scale linearly with the font factor.
-double get defaultChartHeight => scaleByFontFactor(150.0);
+double get defaultChartHeight => scaleByFontFactor(120.0);
 
 /// Width of all settings dialogs.
 double get dialogSettingsWidth => scaleByFontFactor(700.0);


### PR DESCRIPTION
We are already limited in screen real estate, and this chart is taking up ore space than it needs:

Before:
<img width="1205" alt="Screen Shot 2022-05-11 at 1 05 22 PM" src="https://user-images.githubusercontent.com/43759233/167938244-3a774b0c-9e9f-43f7-923f-82912556e21b.png">

After: 
<img width="1205" alt="Screen Shot 2022-05-11 at 1 03 45 PM" src="https://user-images.githubusercontent.com/43759233/167938288-faf6276b-c2b6-4011-b9ff-fb115dce719e.png">

