### PR TITLE
Use AutomaticKeepAlive on the FlameChart widget

### DIFF
--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -101,11 +101,7 @@ abstract class FlameChart<T, V> extends StatefulWidget {
 // like implementation).
 abstract class FlameChartState<T extends FlameChart,
         V extends FlameChartDataMixin<V>> extends State<T>
-    with
-        AutoDisposeMixin,
-        AutomaticKeepAliveClientMixin,
-        FlameChartColorMixin,
-        TickerProviderStateMixin {
+    with AutoDisposeMixin, FlameChartColorMixin, TickerProviderStateMixin {
   int get rowOffsetForTopPadding => 2;
 
   // The "top" positional value for each flame chart node will be 0.0 because
@@ -280,12 +276,7 @@ abstract class FlameChartState<T extends FlameChart,
   }
 
   @override
-  bool wantKeepAlive = true;
-
-  @override
   Widget build(BuildContext context) {
-    super.build(context);
-
     // TODO(kenz): handle tooltips hover here instead of wrapping each row in a
     // MouseRegion widget.
     return MouseRegion(

--- a/packages/devtools_app/lib/src/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/charts/flame_chart.dart
@@ -101,7 +101,11 @@ abstract class FlameChart<T, V> extends StatefulWidget {
 // like implementation).
 abstract class FlameChartState<T extends FlameChart,
         V extends FlameChartDataMixin<V>> extends State<T>
-    with AutoDisposeMixin, FlameChartColorMixin, TickerProviderStateMixin {
+    with
+        AutoDisposeMixin,
+        AutomaticKeepAliveClientMixin,
+        FlameChartColorMixin,
+        TickerProviderStateMixin {
   int get rowOffsetForTopPadding => 2;
 
   // The "top" positional value for each flame chart node will be 0.0 because
@@ -276,7 +280,12 @@ abstract class FlameChartState<T extends FlameChart,
   }
 
   @override
+  bool wantKeepAlive = true;
+
+  @override
   Widget build(BuildContext context) {
+    super.build(context);
+
     // TODO(kenz): handle tooltips hover here instead of wrapping each row in a
     // MouseRegion widget.
     return MouseRegion(

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -79,13 +79,21 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     );
 
     final tabViews = [
-      TimelineEventsView(
-        controller: controller,
-        processing: widget.processing,
-        processingProgress: widget.processingProgress,
+      KeepAliveWrapper(
+        child: TimelineEventsView(
+          controller: controller,
+          processing: widget.processing,
+          processingProgress: widget.processingProgress,
+        ),
       ),
-      if (frameAnalysisSupported) frameAnalysisView,
-      if (rasterMetricsSupported) rasterMetrics,
+      if (frameAnalysisSupported)
+        KeepAliveWrapper(
+          child: frameAnalysisView,
+        ),
+      if (rasterMetricsSupported)
+        KeepAliveWrapper(
+          child: rasterMetrics,
+        ),
     ];
 
     return AnalyticsTabbedView(

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -292,21 +292,27 @@ class _CpuProfilerState extends State<CpuProfiler>
   }
 
   List<Widget> _buildProfilerViews() {
-    final bottomUp = CpuBottomUpTable(widget.bottomUpRoots);
-    final callTree = CpuCallTreeTable(widget.callTreeRoots);
-    final cpuFlameChart = LayoutBuilder(
-      builder: (context, constraints) {
-        return CpuProfileFlameChart(
-          data: data,
-          controller: widget.controller,
-          width: constraints.maxWidth,
-          height: constraints.maxHeight,
-          selectionNotifier: widget.controller.selectedCpuStackFrameNotifier,
-          searchMatchesNotifier: widget.controller.searchMatches,
-          activeSearchMatchNotifier: widget.controller.activeSearchMatch,
-          onDataSelected: (sf) => widget.controller.selectCpuStackFrame(sf),
-        );
-      },
+    final bottomUp = KeepAliveWrapper(
+      child: CpuBottomUpTable(widget.bottomUpRoots),
+    );
+    final callTree = KeepAliveWrapper(
+      child: CpuCallTreeTable(widget.callTreeRoots),
+    );
+    final cpuFlameChart = KeepAliveWrapper(
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          return CpuProfileFlameChart(
+            data: data,
+            controller: widget.controller,
+            width: constraints.maxWidth,
+            height: constraints.maxHeight,
+            selectionNotifier: widget.controller.selectedCpuStackFrameNotifier,
+            searchMatchesNotifier: widget.controller.searchMatches,
+            activeSearchMatchNotifier: widget.controller.activeSearchMatch,
+            onDataSelected: (sf) => widget.controller.selectCpuStackFrame(sf),
+          );
+        },
+      ),
     );
     final summaryView = widget.summaryView;
     // TODO(kenz): make this order configurable.

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1932,6 +1932,14 @@ class ElevatedCard extends StatelessWidget {
   }
 }
 
+/// A convenience wrapper for a [StatefulWidget] that uses the
+/// [AutomaticKeepAliveClientMixin] on its [State].
+///
+/// Wrap a widget in this class if you want [child] to stay alive, and avoid
+/// rebuilding. This is useful for children of [TabView]s. When wrapped in this
+/// wrapper, [child] will not be destroyed and rebuilt when switching tabs.
+///
+/// See [AutomaticKeepAliveClientMixin] for more information.
 class KeepAliveWrapper extends StatefulWidget {
   const KeepAliveWrapper({Key? key, required this.child}) : super(key: key);
 

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1931,3 +1931,24 @@ class ElevatedCard extends StatelessWidget {
     );
   }
 }
+
+class KeepAliveWrapper extends StatefulWidget {
+  const KeepAliveWrapper({Key? key, required this.child}) : super(key: key);
+
+  final Widget child;
+
+  @override
+  State<KeepAliveWrapper> createState() => _KeepAliveWrapperState();
+}
+
+class _KeepAliveWrapperState extends State<KeepAliveWrapper>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool wantKeepAlive = true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}


### PR DESCRIPTION
This wrapper can be used to prevent rebuilds between tab switches:
![keep-alives](https://user-images.githubusercontent.com/43759233/167959342-8a98b288-29d3-45ca-beb1-b9a4a70c0731.gif)

By wrapping a widget in `KeepAliveWrapper`, we can ensure its state is maintained when switching from one widget to another. This PR significantly improves the performance of switching tabs on the Performance page and on the Cpu Profiler page. We should consider using this elsewhere in DevTools when we have a tab view switching between views that are expensive to build / render.

