### PR TITLE
Fix casting errors on memory screen.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -817,7 +817,7 @@ class MemoryController extends DisposableController
           customEventKind =
               MemoryTimeline.customEventName(event.extensionKind!);
         }
-        final jsonData = event.extensionData!.data as Map<String, Object>;
+        final jsonData = event.extensionData!.data.cast<String, Object>();
         // TODO(terry): Display events enabled in a settings page for now only these events.
         switch (extensionEventKind) {
           case 'Flutter.ImageSizesForFrame':

--- a/packages/devtools_app/lib/src/screens/memory/memory_protocol.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_protocol.dart
@@ -25,7 +25,7 @@ class MemoryTracker {
   final isolateHeaps = <String, MemoryUsage>{};
 
   /// Polled VM current RSS.
-  late int processRss;
+  int processRss = 0;
 
   /// Polled adb dumpsys meminfo values.
   late AdbMemoryInfo adbMemoryInfo;

--- a/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
@@ -1015,7 +1015,7 @@ class MemoryBodyState extends State<MemoryBody>
     if (event[eventName] == imageSizesForFrameEvent) {
       // TODO(terry): Need a more generic event displayer.
       // Flutter event emit the event name and value.
-      final data = event[eventData] as Map<String, Object>;
+      final data = (event[eventData] as Map).cast<String, Object>();
       final key = data.keys.first;
       output.writeln('${longValueToShort(key)}');
       final values = data[key] as Map<dynamic, dynamic>;


### PR DESCRIPTION
Errors:
```
flutter: [ERROR]: type '_InternalLinkedHashMap<String, dynamic>' is not a subtype of type 'Map<String, Object>' in type cast
flutter: [ERROR]: LateInitializationError: Field 'processRss' has not been initialized.
```