### PR TITLE
Hide the Raster Metrics and Frame Analysis tabs for non flutter apps

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -40,6 +40,7 @@ export 'src/screens/network/network_screen.dart';
 export 'src/screens/performance/performance_controller.dart';
 export 'src/screens/performance/performance_model.dart';
 export 'src/screens/performance/performance_screen.dart';
+export 'src/screens/performance/raster_metrics_controller.dart';
 export 'src/screens/performance/timeline_streams.dart';
 export 'src/screens/profiler/cpu_profile_model.dart';
 export 'src/screens/profiler/profile_granularity.dart';

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -9,6 +9,7 @@ import '../../analytics/constants.dart' as analytics_constants;
 import '../../charts/flame_chart.dart';
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
 import '../../shared/theme.dart';
 import '../../ui/search.dart';
 import '../../ui/tab.dart';
@@ -78,6 +79,7 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
       ),
     );
 
+    final isFlutterApp = serviceManager.connectedApp!.isFlutterAppNow!;
     final tabViews = [
       KeepAliveWrapper(
         child: TimelineEventsView(
@@ -86,24 +88,24 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
           processingProgress: widget.processingProgress,
         ),
       ),
-      if (frameAnalysisSupported)
+      if (frameAnalysisSupported && isFlutterApp)
         KeepAliveWrapper(
           child: frameAnalysisView,
         ),
-      if (rasterMetricsSupported)
+      if (rasterMetricsSupported && isFlutterApp)
         KeepAliveWrapper(
           child: rasterMetrics,
         ),
     ];
 
     return AnalyticsTabbedView(
-      tabs: _generateTabs(),
+      tabs: _generateTabs(isFlutterApp: isFlutterApp),
       tabViews: tabViews,
       gaScreen: analytics_constants.performance,
     );
   }
 
-  List<DevToolsTab> _generateTabs() {
+  List<DevToolsTab> _generateTabs({required bool isFlutterApp}) {
     final data = controller.data;
     final hasData = data != null && !data.isEmpty;
     final searchFieldEnabled = hasData && !widget.processing;
@@ -122,11 +124,11 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
           ],
         ),
       ),
-      if (frameAnalysisSupported)
+      if (frameAnalysisSupported && isFlutterApp)
         _buildTab(
           tabName: 'Frame Analysis',
         ),
-      if (rasterMetricsSupported)
+      if (rasterMetricsSupported && isFlutterApp)
         _buildTab(
           tabName: 'Raster Metrics',
           trailing: Row(

--- a/packages/devtools_app/test/performance/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/performance/flutter_frames_chart_test.dart
@@ -14,7 +14,6 @@ import 'package:devtools_app/src/ui/colors.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
 
 import '../test_data/performance.dart';
 
@@ -36,7 +35,12 @@ void main() {
   group('FlutterFramesChart', () {
     setUp(() async {
       final fakeServiceManager = FakeServiceManager();
-      when(fakeServiceManager.connectedApp!.isFlutterAppNow).thenReturn(true);
+      mockConnectedApp(
+        fakeServiceManager.connectedApp!,
+        isFlutterApp: true,
+        isProfileBuild: true,
+        isWebApp: false,
+      );
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(OfflineModeController, OfflineModeController());
       setGlobal(IdeTheme, IdeTheme());
@@ -140,7 +144,7 @@ void main() {
                 OverlayEntry(
                   builder: (context) {
                     return FlutterFramesChartItem(
-                      controller: MockPerformanceController(),
+                      controller: createMockPerformanceControllerWithDefaults(),
                       frame: testFrame0,
                       selected: true,
                       msPerPx: 1,

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -10,7 +10,6 @@ import 'package:devtools_app/src/screens/performance/frame_analysis.dart';
 import 'package:devtools_app/src/screens/performance/performance_controller.dart';
 import 'package:devtools_app/src/screens/performance/performance_model.dart';
 import 'package:devtools_app/src/screens/performance/raster_metrics.dart';
-import 'package:devtools_app/src/screens/performance/raster_metrics_controller.dart';
 import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
 import 'package:devtools_app/src/screens/performance/timeline_flame_chart.dart';
 import 'package:devtools_app/src/service/service_manager.dart';

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -2,15 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:devtools_app/src/charts/flame_chart.dart';
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/primitives/listenable.dart';
 import 'package:devtools_app/src/screens/performance/frame_analysis.dart';
 import 'package:devtools_app/src/screens/performance/performance_controller.dart';
 import 'package:devtools_app/src/screens/performance/performance_model.dart';
 import 'package:devtools_app/src/screens/performance/raster_metrics.dart';
+import 'package:devtools_app/src/screens/performance/raster_metrics_controller.dart';
 import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
 import 'package:devtools_app/src/screens/performance/timeline_flame_chart.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
@@ -28,8 +28,8 @@ import 'package:vm_service/vm_service.dart' as vm_service;
 import '../test_data/performance.dart';
 
 void main() {
-  FakeServiceManager fakeServiceManager;
-  late PerformanceController controller;
+  late FakeServiceManager fakeServiceManager;
+  late MockPerformanceController controller;
 
   Future<void> _setUpServiceManagerWithTimeline(
     Map<String, dynamic> timelineJson,
@@ -40,15 +40,16 @@ void main() {
       ),
     );
     final app = fakeServiceManager.connectedApp!;
-    when(app.initialized).thenReturn(Completer()..complete(true));
-    when(app.isDartWebAppNow).thenReturn(false);
-    when(app.isFlutterAppNow).thenReturn(true);
+    mockConnectedApp(
+      app,
+      isFlutterApp: true,
+      isProfileBuild: true,
+      isWebApp: false,
+    );
     when(app.flutterVersionNow).thenReturn(
       FlutterVersion.parse((await fakeServiceManager.flutterVersion).json!),
     );
-    when(app.isProfileBuild).thenAnswer((_) => Future.value(true));
-    when(app.isDartCliAppNow).thenReturn(false);
-    when(app.isDebugFlutterAppNow).thenReturn(false);
+
     setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(OfflineModeController, OfflineModeController());
     when(serviceManager.connectedApp!.isDartWebApp)
@@ -60,14 +61,14 @@ void main() {
       await _setUpServiceManagerWithTimeline(testTimelineJson);
       setGlobal(IdeTheme, IdeTheme());
       setGlobal(PreferencesController, PreferencesController());
-      controller = PerformanceController()..data = PerformanceData();
+      controller = createMockPerformanceControllerWithDefaults();
       frameAnalysisSupported = true;
       rasterMetricsSupported = true;
     });
 
     Future<void> pumpView(
       WidgetTester tester, {
-      PerformanceController? performanceController,
+      MockPerformanceController? performanceController,
       bool runAsync = false,
     }) async {
       if (performanceController != null) {
@@ -136,8 +137,9 @@ void main() {
           ..setEventFlow(animatorBeginFrameEvent)
           ..setEventFlow(goldenRasterTimelineEvent);
 
-        controller = PerformanceController()..data = PerformanceData();
-        await controller.toggleSelectedFrame(frame0);
+        controller = createMockPerformanceControllerWithDefaults();
+        when(controller.selectedFrame)
+            .thenReturn(FixedValueListenable<FlutterFrame?>(frame0));
 
         await pumpView(tester, performanceController: controller);
 
@@ -187,6 +189,30 @@ void main() {
         expect(find.byType(RenderingLayerVisualizer), findsOneWidget);
         expect(find.text('Take Snapshot'), findsOneWidget);
         expect(find.byType(ClearButton), findsOneWidget);
+      });
+    });
+
+    testWidgetsWithWindowSize(
+        'only shows Timeline Events tab for non-flutter app', windowSize,
+        (WidgetTester tester) async {
+      await tester.runAsync(() async {
+        await _setUpServiceManagerWithTimeline({});
+        final app = fakeServiceManager.connectedApp!;
+        mockConnectedApp(
+          app,
+          isFlutterApp: false,
+          isProfileBuild: false,
+          isWebApp: false,
+        );
+        when(app.flutterVersionNow).thenReturn(null);
+
+        await pumpView(tester);
+        await tester.pumpAndSettle();
+        expect(find.byType(AnalyticsTabbedView), findsOneWidget);
+        expect(find.byType(DevToolsTab), findsOneWidget);
+        expect(find.text('Timeline Events'), findsOneWidget);
+        expect(find.text('Frame Analysis'), findsNothing);
+        expect(find.text('Raster Metrics'), findsNothing);
       });
     });
   });

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -15,6 +15,7 @@ import 'package:vm_service/vm_service.dart';
   DebuggerController,
   ErrorBadgeManager,
   HeapSnapshotGraph,
+  PerformanceController,
   ProgramExplorerController,
   ScriptManager,
   ServiceConnectionManager,

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -5,9 +5,24 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mockito/mockito.dart';
-import 'package:vm_service/vm_service.dart';
+import 'package:vm_service/vm_service.dart' hide TimelineEvent;
 
 import 'generated.mocks.dart';
+
+MockPerformanceController createMockPerformanceControllerWithDefaults() {
+  final controller = MockPerformanceController();
+  when(controller.data).thenReturn(PerformanceData());
+  when(controller.searchMatches)
+      .thenReturn(const FixedValueListenable<List<TimelineEvent>>([]));
+  when(controller.searchInProgressNotifier)
+      .thenReturn(const FixedValueListenable<bool>(false));
+  when(controller.matchIndex).thenReturn(ValueNotifier<int>(0));
+  when(controller.rasterMetricsController)
+      .thenReturn(RasterMetricsController());
+  when(controller.selectedFrame)
+      .thenReturn(const FixedValueListenable<FlutterFrame?>(null));
+  return controller;
+}
 
 MockProgramExplorerController
     createMockProgramExplorerControllerWithDefaults() {

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -146,8 +146,6 @@ class MockMemoryController extends Mock implements MemoryController {}
 
 class MockFlutterMemoryController extends Mock implements MemoryController {}
 
-class MockPerformanceController extends Mock implements PerformanceController {}
-
 class MockProfilerScreenController extends Mock
     implements ProfilerScreenController {}
 
@@ -279,6 +277,11 @@ void mockConnectedApp(
   when(connectedApp.isDartWebApp).thenAnswer((_) => Future.value(isWebApp));
   when(connectedApp.isDartWebAppNow).thenReturn(isWebApp);
 
+  // CLI app.
+  final isCliApp = !isFlutterApp && !isWebApp;
+  when(connectedApp.isDartCliApp).thenAnswer((_) => Future.value(isCliApp));
+  when(connectedApp.isDartCliAppNow).thenReturn(isCliApp);
+
   // Run mode.
   when(connectedApp.isProfileBuild)
       .thenAnswer((_) => Future.value(isProfileBuild));
@@ -288,6 +291,7 @@ void mockConnectedApp(
 
   // Initialized.
   when(connectedApp.connectedAppInitialized).thenReturn(true);
+  when(connectedApp.initialized).thenReturn(Completer()..complete(true));
 }
 
 void mockFlutterVersion(


### PR DESCRIPTION
We should only show the "Timeline Events" tab on the Performance page when connected to a non-flutter app.