### PR TITLE
Create `PerformanceControllerMixin` and use in performance components

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
@@ -45,7 +45,7 @@ class FlutterFramesChart extends StatefulWidget {
 }
 
 class _FlutterFramesChartState extends State<FlutterFramesChart>
-    with AutoDisposeMixin {
+    with AutoDisposeMixin, PerformanceControllerMixin {
   static const _defaultFrameWidthWithPadding =
       FlutterFramesChartItem.defaultFrameWidth + densePadding * 2;
 
@@ -57,10 +57,6 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
 
   double get _frameChartScrollbarOffset =>
       defaultScrollBarOffset + _frameNumberSectionHeight;
-
-  late PerformanceController _controller;
-
-  bool _controllerInitialized = false;
 
   late final LinkedScrollControllerGroup _linkedScrollControllerGroup;
 
@@ -89,16 +85,13 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final newController = Provider.of<PerformanceController>(context);
-    if (_controllerInitialized && newController == _controller) return;
-    _controller = newController;
-    _controllerInitialized = true;
+    if (!initPerformanceController()) return;
 
     cancelListeners();
-    _selectedFrame = _controller.selectedFrame.value;
-    addAutoDisposeListener(_controller.selectedFrame, () {
+    _selectedFrame = performanceController.selectedFrame.value;
+    addAutoDisposeListener(performanceController.selectedFrame, () {
       setState(() {
-        _selectedFrame = _controller.selectedFrame.value;
+        _selectedFrame = performanceController.selectedFrame.value;
       });
     });
 
@@ -206,7 +199,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
                 itemCount: widget.frames.length,
                 itemExtent: _defaultFrameWidthWithPadding,
                 itemBuilder: (context, index) => FlutterFramesChartItem(
-                  controller: _controller,
+                  controller: performanceController,
                   frame: widget.frames[index],
                   selected: widget.frames[index] == _selectedFrame,
                   msPerPx: _msPerPx,

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -7,7 +7,9 @@ import 'dart:math' as math;
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:pedantic/pedantic.dart';
+import 'package:provider/provider.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
@@ -860,5 +862,18 @@ class PerformanceController extends DisposableController
     _timelinePollingRateLimiter?.dispose();
     cpuProfilerController.dispose();
     super.dispose();
+  }
+}
+
+mixin PerformanceControllerMixin<T extends StatefulWidget> on State<T> {
+  PerformanceController get performanceController => _performanceController!;
+
+  PerformanceController? _performanceController;
+
+  bool initPerformanceController() {
+    final newController = Provider.of<PerformanceController>(context);
+    if (newController == _performanceController) return false;
+    _performanceController = newController;
+    return true;
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/analytics_common.dart';
@@ -64,11 +63,8 @@ class PerformanceScreenBody extends StatefulWidget {
 class PerformanceScreenBodyState extends State<PerformanceScreenBody>
     with
         AutoDisposeMixin,
-        OfflineScreenMixin<PerformanceScreenBody, OfflinePerformanceData> {
-  PerformanceController get controller => _controller!;
-
-  PerformanceController? _controller;
-
+        OfflineScreenMixin<PerformanceScreenBody, OfflinePerformanceData>,
+        PerformanceControllerMixin {
   bool processing = false;
 
   double processingProgress = 0.0;
@@ -98,27 +94,27 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
     );
     maybePushDebugModePerformanceMessage(context, PerformanceScreen.id);
 
-    final newController = Provider.of<PerformanceController>(context);
-    if (newController == _controller) return;
-    _controller = newController;
+    if (!initPerformanceController()) return;
 
     cancelListeners();
 
-    processing = controller.processing.value;
-    addAutoDisposeListener(controller.processing, () {
+    processing = performanceController.processing.value;
+    addAutoDisposeListener(performanceController.processing, () {
       setState(() {
-        processing = controller.processing.value;
+        processing = performanceController.processing.value;
       });
     });
 
-    processingProgress = controller.processor.progressNotifier.value;
-    addAutoDisposeListener(controller.processor.progressNotifier, () {
+    processingProgress = performanceController.processor.progressNotifier.value;
+    addAutoDisposeListener(performanceController.processor.progressNotifier,
+        () {
       setState(() {
-        processingProgress = controller.processor.progressNotifier.value;
+        processingProgress =
+            performanceController.processor.progressNotifier.value;
       });
     });
 
-    addAutoDisposeListener(controller.selectedFrame);
+    addAutoDisposeListener(performanceController.selectedFrame);
 
     // Load offline timeline data if available.
     if (shouldLoadOfflineData()) {
@@ -142,8 +138,8 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
   @override
   Widget build(BuildContext context) {
     final isOfflineFlutterApp = offlineController.offlineMode.value &&
-        controller.offlinePerformanceData != null &&
-        controller.offlinePerformanceData!.frames.isNotEmpty;
+        performanceController.offlinePerformanceData != null &&
+        performanceController.offlinePerformanceData!.frames.isNotEmpty;
 
     final performanceScreen = Column(
       children: [
@@ -153,8 +149,8 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
             (!offlineController.offlineMode.value &&
                 serviceManager.connectedApp!.isFlutterAppNow!))
           DualValueListenableBuilder<List<FlutterFrame>, double>(
-            firstListenable: controller.flutterFrames,
-            secondListenable: controller.displayRefreshRate,
+            firstListenable: performanceController.flutterFrames,
+            secondListenable: performanceController.displayRefreshRate,
             builder: (context, frames, displayRefreshRate, child) {
               return FlutterFramesChart(
                 frames,
@@ -168,12 +164,12 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
             initialFractions: const [0.7, 0.3],
             children: [
               TabbedPerformanceView(
-                controller: controller,
+                controller: performanceController,
                 processing: processing,
                 processingProgress: processingProgress,
               ),
               ValueListenableBuilder<TimelineEvent?>(
-                valueListenable: controller.selectedTimelineEvent,
+                valueListenable: performanceController.selectedTimelineEvent,
                 builder: (context, selectedEvent, _) {
                   return EventDetails(selectedEvent);
                 },
@@ -205,19 +201,19 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         _PrimaryControls(
-          controller: controller,
+          controller: performanceController,
           processing: processing,
           onClear: () => setState(() {}),
         ),
         const SizedBox(width: defaultSpacing),
-        SecondaryPerformanceControls(controller: controller),
+        SecondaryPerformanceControls(controller: performanceController),
       ],
     );
   }
 
   @override
   FutureOr<void> processOfflineData(OfflinePerformanceData offlineData) async {
-    await controller.processOfflineData(offlineData);
+    await performanceController.processOfflineData(offlineData);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/timeline_flame_chart.dart
@@ -7,7 +7,6 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../charts/flame_chart.dart';
 import '../../primitives/auto_dispose_mixin.dart';
@@ -142,7 +141,8 @@ class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
 }
 
 class TimelineFlameChartState
-    extends FlameChartState<TimelineFlameChart, TimelineEvent> {
+    extends FlameChartState<TimelineFlameChart, TimelineEvent>
+    with PerformanceControllerMixin {
   /// Stores the [FlameChartNode] for each [TimelineEvent] in the chart.
   ///
   /// We need to be able to look up a [FlameChartNode] based on its
@@ -158,10 +158,6 @@ class TimelineFlameChartState
   final eventGroupStartYValues = Expando<double>();
 
   int widestRow = -1;
-
-  late PerformanceController _performanceController;
-
-  bool _controllerInitialized = false;
 
   FlutterFrame? _selectedFrame;
 
@@ -187,22 +183,17 @@ class TimelineFlameChartState
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newController = Provider.of<PerformanceController>(context);
-    if (_controllerInitialized && newController == _performanceController) {
-      return;
-    }
-    _performanceController = newController;
-    _controllerInitialized = true;
+    if (!initPerformanceController()) return;
 
     // If there is already a selected frame, handle setting that data and
     // positioning/zooming the flame chart accordingly.
-    _selectedFrame = _performanceController.selectedFrame.value;
+    _selectedFrame = performanceController.selectedFrame.value;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await _centerSelectedFrame();
     });
 
     addAutoDisposeListener(
-      _performanceController.selectedFrame,
+      performanceController.selectedFrame,
       _handleSelectedFrame,
     );
   }
@@ -228,7 +219,7 @@ class TimelineFlameChartState
   double topYForData(TimelineEvent data) {
     final eventGroupKey = PerformanceUtils.computeEventGroupKey(
       data,
-      _performanceController.threadNamesById,
+      performanceController.threadNamesById,
     );
     final eventGroup = widget.data.eventGroups[eventGroupKey]!;
     final rowOffsetInGroup = eventGroup.rowIndexForEvent[data]!;
@@ -342,7 +333,7 @@ class TimelineFlameChartState
   }
 
   void _handleSelectedFrame() async {
-    final selectedFrame = _performanceController.selectedFrame.value;
+    final selectedFrame = performanceController.selectedFrame.value;
     if (selectedFrame == _selectedFrame) return;
 
     setState(() {
@@ -360,9 +351,9 @@ class TimelineFlameChartState
       final time = _selected.timeToCenterFrame();
       final event = _selected.eventToCenterFrame();
       if (time == null || event == null) {
-        if (_performanceController.firstWellFormedFrameMicros != null &&
+        if (performanceController.firstWellFormedFrameMicros != null &&
             _selected.timeFromFrameTiming.start!.inMicroseconds <
-                _performanceController.firstWellFormedFrameMicros!) {
+                performanceController.firstWellFormedFrameMicros!) {
           Notifications.of(context)!.push(
             'No timeline events available for the selected frame. Timeline '
             'events occurred too long ago before DevTools could access them. '
@@ -541,7 +532,7 @@ class TimelineFlameChartState
 
   Widget _buildSectionLabels({required BoxConstraints constraints}) {
     final colorScheme = Theme.of(context).colorScheme;
-    final eventGroups = _performanceController.data!.eventGroups;
+    final eventGroups = performanceController.data!.eventGroups;
 
     final children = <Widget>[];
     for (int i = 0; i < eventGroups.length; i++) {
@@ -606,7 +597,7 @@ class TimelineFlameChartState
     required BoxConstraints constraints,
   }) {
     final threadButtonContainerWidth = buttonMinWidth + defaultSpacing;
-    final eventGroups = _performanceController.data!.eventGroups;
+    final eventGroups = performanceController.data!.eventGroups;
 
     Widget buildNavigatorButton(int index, {required bool isNext}) {
       // Add spacing to account for timestamps at top of chart.


### PR DESCRIPTION
This eliminates boilerplate code that was used in each stateful widget using the inherited PerformanceController from package:provider.

Inspired by @polina-c's original use of this in https://github.com/flutter/devtools/pull/4136.