### PR TITLE
Create `ProvidedControllerMixin` and use throughout DevTools

### DIFF
--- a/packages/devtools_app/lib/src/analytics/prompt.dart
+++ b/packages/devtools_app/lib/src/analytics/prompt.dart
@@ -4,11 +4,11 @@
 
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../config_specific/launch_url/launch_url.dart';
 import '../shared/common_widgets.dart';
 import '../shared/theme.dart';
+import '../shared/utils.dart';
 import 'analytics_controller.dart';
 
 /// Conditionally displays a prompt to request permission for collection of
@@ -22,16 +22,12 @@ class AnalyticsPrompt extends StatefulWidget {
   State<AnalyticsPrompt> createState() => _AnalyticsPromptState();
 }
 
-class _AnalyticsPromptState extends State<AnalyticsPrompt> {
-  AnalyticsController? _controller;
-
+class _AnalyticsPromptState extends State<AnalyticsPrompt>
+    with ProvidedControllerMixin<AnalyticsController, AnalyticsPrompt> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newAnalyticsController = Provider.of<AnalyticsController>(context);
-    if (newAnalyticsController == _controller) return;
-    _controller = newAnalyticsController;
+    initController();
   }
 
   @override
@@ -39,7 +35,7 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     return ValueListenableBuilder<bool>(
-      valueListenable: _controller!.shouldPrompt,
+      valueListenable: controller.shouldPrompt,
       builder: (context, showPrompt, child) {
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -74,7 +70,7 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
                   ),
                   CircularIconButton(
                     icon: Icons.close,
-                    onPressed: _controller!.hidePrompt,
+                    onPressed: controller.hidePrompt,
                     backgroundColor: theme.canvasColor,
                     foregroundColor: theme.colorScheme.contrastForeground,
                   ),
@@ -131,7 +127,7 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
         ElevatedButton(
           onPressed: () {
             // This will also hide the prompt.
-            _controller!.toggleAnalyticsEnabled(false);
+            controller.toggleAnalyticsEnabled(false);
           },
           style: ElevatedButton.styleFrom(primary: Colors.grey),
           child: const Text('No thanks.'),
@@ -141,7 +137,7 @@ class _AnalyticsPromptState extends State<AnalyticsPrompt> {
         ),
         ElevatedButton(
           onPressed: () {
-            _controller!
+            controller
               ..toggleAnalyticsEnabled(true)
               ..hidePrompt();
           },

--- a/packages/devtools_app/lib/src/example/conditional_screen.dart
+++ b/packages/devtools_app/lib/src/example/conditional_screen.dart
@@ -5,11 +5,11 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
 import '../shared/screen.dart';
+import '../shared/utils.dart';
 
 /// This is an example implementation of a conditional screen that supports
 /// offline mode and uses a provided controller [ExampleController].
@@ -43,16 +43,14 @@ class _ExampleConditionalScreenBody extends StatefulWidget {
 
 class _ExampleConditionalScreenBodyState
     extends State<_ExampleConditionalScreenBody>
-    with OfflineScreenMixin<_ExampleConditionalScreenBody, String> {
-  ExampleController? controller;
-
+    with
+        OfflineScreenMixin<_ExampleConditionalScreenBody, String>,
+        ProvidedControllerMixin<ExampleController,
+            _ExampleConditionalScreenBody> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final newController = Provider.of<ExampleController>(context);
-    if (newController == controller) return;
-    controller = newController;
-
+    if (!initController()) return;
     if (shouldLoadOfflineData()) {
       final json =
           offlineController.offlineDataJson[ExampleConditionalScreen.id];
@@ -65,7 +63,7 @@ class _ExampleConditionalScreenBodyState
   @override
   Widget build(BuildContext context) {
     final exampleScreen = ValueListenableBuilder<String>(
-      valueListenable: controller!.title,
+      valueListenable: controller.title,
       builder: (context, String value, _) {
         return Center(child: Text(value));
       },
@@ -89,7 +87,7 @@ class _ExampleConditionalScreenBodyState
 
   @override
   FutureOr<void> processOfflineData(String offlineData) async {
-    await controller!.processOfflineData(offlineData);
+    await controller.processOfflineData(offlineData);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
@@ -23,17 +22,12 @@ class Breakpoints extends StatefulWidget {
   _BreakpointsState createState() => _BreakpointsState();
 }
 
-class _BreakpointsState extends State<Breakpoints> {
-  DebuggerController get controller => _controller!;
-  DebuggerController? _controller;
-
+class _BreakpointsState extends State<Breakpoints>
+    with ProvidedControllerMixin<DebuggerController, Breakpoints> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<DebuggerController>(context);
-    if (newController == _controller) return;
-    _controller = newController;
+    initController();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -3,11 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart' hide Stack;
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/common_widgets.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
 
@@ -18,18 +18,12 @@ class CallStack extends StatefulWidget {
   _CallStackState createState() => _CallStackState();
 }
 
-class _CallStackState extends State<CallStack> {
-  DebuggerController get controller => _controller!;
-  DebuggerController? _controller;
-
+class _CallStackState extends State<CallStack>
+    with ProvidedControllerMixin<DebuggerController, CallStack> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<DebuggerController>(context);
-    if (newController == _controller) return;
-
-    _controller = newController;
+    initController();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -9,7 +9,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart' hide Stack;
 
 import '../../config_specific/logger/logger.dart';
@@ -757,7 +756,8 @@ class LineItem extends StatefulWidget {
   _LineItemState createState() => _LineItemState();
 }
 
-class _LineItemState extends State<LineItem> {
+class _LineItemState extends State<LineItem>
+    with ProvidedControllerMixin<DebuggerController, LineItem> {
   /// A timer that shows a [HoverCard] with an evaluation result when completed.
   Timer? _showTimer;
 
@@ -766,8 +766,6 @@ class _LineItemState extends State<LineItem> {
 
   /// Displays the evaluation result of a source code item.
   HoverCard? _hoverCard;
-
-  late DebuggerController _debuggerController;
 
   String _previousHoverWord = '';
   bool _hasMouseExited = false;
@@ -785,7 +783,7 @@ class _LineItemState extends State<LineItem> {
     _showTimer?.cancel();
     _removeTimer?.cancel();
     _hasMouseExited = false;
-    if (!_debuggerController.isPaused.value) return;
+    if (!controller.isPaused.value) return;
     _showTimer = Timer(LineItem._hoverDelay, () async {
       final word = wordForHover(
         event.localPosition.dx,
@@ -796,8 +794,8 @@ class _LineItemState extends State<LineItem> {
       _hoverCard?.remove();
       if (word != '') {
         try {
-          final response = await _debuggerController.evalAtCurrentFrame(word);
-          final isolateRef = _debuggerController.isolateRef;
+          final response = await controller.evalAtCurrentFrame(word);
+          final isolateRef = controller.isolateRef;
           if (response is! InstanceRef) return;
           final variable = DartObjectNode.fromValue(
             value: response,
@@ -809,7 +807,7 @@ class _LineItemState extends State<LineItem> {
           _hoverCard = HoverCard.fromHoverEvent(
             contents: Material(
               child: ExpandableVariable(
-                debuggerController: _debuggerController,
+                debuggerController: controller,
                 variable: variable,
               ),
             ),
@@ -826,6 +824,12 @@ class _LineItemState extends State<LineItem> {
   }
 
   @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    initController();
+  }
+
+  @override
   void dispose() {
     _showTimer?.cancel();
     _removeTimer?.cancel();
@@ -837,7 +841,6 @@ class _LineItemState extends State<LineItem> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final darkTheme = theme.brightness == Brightness.dark;
-    _debuggerController = Provider.of<DebuggerController>(context);
 
     Widget child;
     final column = widget.pausedFrame?.column;

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -4,12 +4,12 @@
 
 import 'package:codicon/codicon.dart';
 import 'package:flutter/material.dart' hide Stack;
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import '../../ui/label.dart';
 import 'debugger_controller.dart';
 
@@ -23,14 +23,13 @@ class DebuggingControls extends StatefulWidget {
 }
 
 class _DebuggingControlsState extends State<DebuggingControls>
-    with AutoDisposeMixin {
-  DebuggerController get controller => _controller!;
-  DebuggerController? _controller;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<DebuggerController, DebuggingControls> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _controller = Provider.of<DebuggerController>(context);
+    if (!initController()) return;
     addAutoDisposeListener(controller.isPaused);
     addAutoDisposeListener(controller.resuming);
     addAutoDisposeListener(controller.stackFramesWithLocation);

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -18,6 +18,7 @@ import '../../shared/globals.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import '../../ui/icons.dart';
 import 'breakpoints.dart';
 import 'call_stack.dart';
@@ -94,13 +95,12 @@ class DebuggerScreenBody extends StatefulWidget {
 }
 
 class DebuggerScreenBodyState extends State<DebuggerScreenBody>
-    with AutoDisposeMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<DebuggerController, DebuggerScreenBody> {
   static const callStackTitle = 'Call Stack';
   static const variablesTitle = 'Variables';
   static const breakpointsTitle = 'Breakpoints';
-
-  DebuggerController get controller => _controller!;
-  DebuggerController? _controller;
 
   late bool _shownFirstScript;
 
@@ -115,10 +115,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<DebuggerController>(context);
-    if (newController == _controller) return;
-    _controller = newController;
+    if (!initController()) return;
     controller.onFirstDebuggerScreenLoad();
   }
 
@@ -406,9 +403,9 @@ class FloatingDebuggerControls extends StatefulWidget {
 }
 
 class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
-    with AutoDisposeMixin {
-  late DebuggerController controller;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<DebuggerController, FloatingDebuggerControls> {
   late bool paused;
 
   late double controlHeight;
@@ -416,7 +413,7 @@ class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    controller = Provider.of<DebuggerController>(context);
+    if (!initController()) return;
     paused = controller.isPaused.value;
     controlHeight = paused ? defaultButtonHeight : 0.0;
     addAutoDisposeListener(controller.isPaused, () {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -5,7 +5,6 @@
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
@@ -66,6 +65,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     with
         BlockingActionMixin,
         AutoDisposeMixin,
+        ProvidedControllerMixin<DebuggerController, InspectorScreenBody>,
         SearchFieldMixin<InspectorScreenBody> {
   late InspectorController inspectorController;
 
@@ -75,8 +75,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   InspectorTreeController get _detailsTreeController =>
       inspectorController.details!.inspectorTree;
 
-  late DebuggerController _debuggerController;
-  bool _isDebuggerControllerInitialized = false;
+  DebuggerController get _debuggerController => controller;
 
   bool searchVisible = false;
 
@@ -149,12 +148,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newDebuggerController = Provider.of<DebuggerController>(context);
-    if (_isDebuggerControllerInitialized &&
-        _debuggerController == newDebuggerController) return;
-    _isDebuggerControllerInitialized = true;
-    _debuggerController = newDebuggerController;
+    initController();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
@@ -6,7 +6,6 @@ import 'dart:math';
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
@@ -14,6 +13,7 @@ import '../../primitives/utils.dart';
 import '../../shared/split.dart';
 import '../../shared/table.dart';
 import '../../shared/table_data.dart';
+import '../../shared/utils.dart';
 import '../../ui/icons.dart';
 import '../../ui/search.dart';
 import 'memory_allocation_table_data.dart';
@@ -49,11 +49,10 @@ class AllocationTableView extends StatefulWidget {
 
 /// Table of the fields of an instance (type, name and value).
 class AllocationTableViewState extends State<AllocationTableView>
-    with AutoDisposeMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, AllocationTableView> {
   AllocationTableViewState() : super();
-
-  late MemoryController controller;
-  bool _initialized = false;
 
   final List<ColumnData<ClassHeapDetailStats>> columns = [];
 
@@ -79,11 +78,7 @@ class AllocationTableViewState extends State<AllocationTableView>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-    if (_initialized && newController == controller) return;
-    controller = newController;
-    _initialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_analyzer.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_analyzer.dart
@@ -5,7 +5,6 @@
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
@@ -532,11 +531,11 @@ class AnalysisInstanceViewTable extends StatefulWidget {
 
 /// Table of the fields of an instance (type, name and value).
 class AnalysisInstanceViewState extends State<AnalysisInstanceViewTable>
-    with AutoDisposeMixin {
-  bool _initialized = false;
-  late MemoryController _controller;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, AnalysisInstanceViewTable> {
   final TreeColumnData<AnalysisField> _treeColumn = _AnalysisFieldNameColumn();
+
   final _columns = <ColumnData<AnalysisField>>[];
 
   @override
@@ -554,25 +553,21 @@ class AnalysisInstanceViewState extends State<AnalysisInstanceViewTable>
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    final newController = Provider.of<MemoryController>(context);
-    if (_initialized && newController == _controller) return;
-    _initialized = true;
-    _controller = newController;
-
+    if (!initController()) return;
     cancelListeners();
 
     // Update the chart when the memorySource changes.
-    addAutoDisposeListener(_controller.selectedSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    _controller.analysisFieldsTreeTable = TreeTable<AnalysisField>(
-      dataRoots: _controller.analysisInstanceRoot!,
+    controller.analysisFieldsTreeTable = TreeTable<AnalysisField>(
+      dataRoots: controller.analysisInstanceRoot!,
       columns: _columns,
       treeColumn: _treeColumn,
       keyFactory: (typeRef) => PageStorageKey<String>(typeRef.name ?? ''),
@@ -580,7 +575,7 @@ class AnalysisInstanceViewState extends State<AnalysisInstanceViewTable>
       sortDirection: SortDirection.ascending,
     );
 
-    return _controller.analysisFieldsTreeTable;
+    return controller.analysisFieldsTreeTable;
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_android_chart.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_android_chart.dart
@@ -4,13 +4,13 @@
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../charts/chart.dart';
 import '../../charts/chart_controller.dart';
 import '../../charts/chart_trace.dart' as trace;
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'memory_controller.dart';
 import 'primitives/memory_timeline.dart';
 
@@ -122,16 +122,13 @@ enum TraceName {
 }
 
 class MemoryAndroidChartState extends State<MemoryAndroidChart>
-    with AutoDisposeMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryAndroidChart> {
   /// Controller attached to the chart.
   AndroidChartController get _chartController => widget.chartController;
 
-  bool _initialized = false;
-
-  /// Controller for managing memory collection.
-  late MemoryController _memoryController;
-
-  MemoryTimeline get _memoryTimeline => _memoryController.memoryTimeline;
+  MemoryTimeline get _memoryTimeline => controller.memoryTimeline;
 
   @override
   void initState() {
@@ -141,11 +138,7 @@ class MemoryAndroidChartState extends State<MemoryAndroidChart>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newMemoryController = Provider.of<MemoryController>(context);
-    if (_initialized && _memoryController == newMemoryController) return;
-    _memoryController = newMemoryController;
-    _initialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 
@@ -379,7 +372,7 @@ class MemoryAndroidChartState extends State<MemoryAndroidChart>
   /// Loads all heap samples (live data or offline).
   void _processHeapSample(HeapSample sample) {
     // If paused don't update the chart (data is still collected).
-    if (_memoryController.paused.value) return;
+    if (controller.paused.value) return;
     _chartController.addSample(sample);
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -7,9 +7,7 @@ import 'dart:async';
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
-import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../analytics/analytics.dart' as ga;
@@ -227,19 +225,6 @@ class AllocationSamples {
         );
       }
     }
-  }
-}
-
-mixin MemoryControllerMixin<T extends StatefulWidget> on State<T> {
-  MemoryController get memoryController => _memoryController!;
-  MemoryController? _memoryController;
-
-  /// Initializes the controller if needed and returns `true` if it was needed.
-  bool initMemoryController() {
-    final newController = Provider.of<MemoryController>(context);
-    if (newController == _memoryController) return false;
-    _memoryController = newController;
-    return true;
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_events_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_events_pane.dart
@@ -4,13 +4,13 @@
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../charts/chart.dart';
 import '../../charts/chart_controller.dart';
 import '../../charts/chart_trace.dart' as trace;
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'memory_controller.dart';
 import 'primitives/memory_timeline.dart';
 
@@ -150,14 +150,11 @@ enum TraceName {
 }
 
 class MemoryEventsPaneState extends State<MemoryEventsPane>
-    with AutoDisposeMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryEventsPane> {
   /// Controller attached to this chart.
   EventChartController get _chartController => widget.chartController;
-
-  bool _initialized = false;
-
-  /// Controller for managing memory collection.
-  late MemoryController _memoryController;
 
   /// Note: The event pane is a fixed size chart (y-axis does not scale). The
   ///       Y-axis fixed range is (visibleVmEvent to extensionEvent) e.g.,
@@ -186,7 +183,7 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
   /// VM's GCs are displayed in a smaller glyph and closer to the heap graph.
   static const visibleVmEvent = 0.4;
 
-  MemoryTimeline get _memoryTimeline => _memoryController.memoryTimeline;
+  MemoryTimeline get _memoryTimeline => controller.memoryTimeline;
 
   @override
   void initState() {
@@ -199,11 +196,7 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newMemoryController = Provider.of<MemoryController>(context);
-    if (_initialized && newMemoryController == _memoryController) return;
-    _initialized = true;
-    _memoryController = newMemoryController;
+    if (!initController()) return;
 
     final themeData = Theme.of(context);
 
@@ -422,7 +415,7 @@ class MemoryEventsPaneState extends State<MemoryEventsPane>
   /// Loads all heap samples (live data or offline).
   void _processHeapSample(HeapSample sample) {
     // If paused don't update the chart (data is still collected).
-    if (_memoryController.isPaused) return;
+    if (controller.isPaused) return;
     _chartController.addSample(sample);
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -9,7 +9,6 @@ import 'package:collection/collection.dart' show IterableExtension;
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:provider/provider.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
@@ -133,6 +132,7 @@ final String knownClassesRegExs = buildRegExs(knowClassesToAnalyzeForImages);
 class HeapTreeViewState extends State<HeapTree>
     with
         AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, HeapTree>,
         SearchFieldMixin<HeapTree>,
         TickerProviderStateMixin {
   @visibleForTesting
@@ -162,10 +162,6 @@ class HeapTreeViewState extends State<HeapTree>
       tabName: 'Allocations',
     ),
   ];
-
-  bool _controllerInitialized = false;
-
-  late MemoryController _controller;
 
   late TabController _tabController;
 
@@ -205,79 +201,75 @@ class HeapTreeViewState extends State<HeapTree>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-    if (_controllerInitialized && newController == _controller) return;
-    _controllerInitialized = true;
-    _controller = newController;
+    if (!initController()) return;
 
     cancelListeners();
 
-    addAutoDisposeListener(_controller.selectedSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.selectionSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectionSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.filterNotifier, () {
+    addAutoDisposeListener(controller.filterNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.leafSelectedNotifier, () {
+    addAutoDisposeListener(controller.leafSelectedNotifier, () {
       setState(() {
-        _controller.computeRoot();
+        controller.computeRoot();
       });
     });
 
-    addAutoDisposeListener(_controller.leafAnalysisSelectedNotifier, () {
+    addAutoDisposeListener(controller.leafAnalysisSelectedNotifier, () {
       setState(() {
-        _controller.computeAnalysisInstanceRoot();
+        controller.computeAnalysisInstanceRoot();
       });
     });
 
-    addAutoDisposeListener(_controller.searchNotifier, () {
-      _controller.closeAutoCompleteOverlay();
-      _controller..setCurrentHoveredIndexValue(0);
+    addAutoDisposeListener(controller.searchNotifier, () {
+      controller.closeAutoCompleteOverlay();
+      controller..setCurrentHoveredIndexValue(0);
     });
 
-    addAutoDisposeListener(_controller.searchAutoCompleteNotifier, () {
+    addAutoDisposeListener(controller.searchAutoCompleteNotifier, () {
       ga.select(
         analytics_constants.memory,
         analytics_constants.snapshotFilterDialog,
       );
-      _controller.handleAutoCompleteOverlay(
+      controller.handleAutoCompleteOverlay(
         context: context,
         searchFieldKey: memorySearchFieldKey,
         onTap: selectTheMatch,
       );
     });
 
-    addAutoDisposeListener(_controller.monitorAllocationsNotifier, () {
+    addAutoDisposeListener(controller.monitorAllocationsNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.memoryTimeline.sampleAddedNotifier, () {
+    addAutoDisposeListener(controller.memoryTimeline.sampleAddedNotifier, () {
       autoSnapshot();
     });
 
-    treeMapVisible = _controller.treeMapVisible.value;
-    addAutoDisposeListener(_controller.treeMapVisible, () {
+    treeMapVisible = controller.treeMapVisible.value;
+    addAutoDisposeListener(controller.treeMapVisible, () {
       setState(() {
-        treeMapVisible = _controller.treeMapVisible.value;
+        treeMapVisible = controller.treeMapVisible.value;
       });
     });
 
-    addAutoDisposeListener(_controller.lastMonitorTimestamp);
+    addAutoDisposeListener(controller.lastMonitorTimestamp);
   }
 
   @override
@@ -293,7 +285,7 @@ class HeapTreeViewState extends State<HeapTree>
 
   /// Detect spike in memory usage if so do an automatic snapshot.
   void autoSnapshot() {
-    final heapSample = _controller.memoryTimeline.sampleAddedNotifier.value!;
+    final heapSample = controller.memoryTimeline.sampleAddedNotifier.value!;
     final heapSum = heapSample.external + heapSample.used;
     heapMovingAverage.add(heapSum);
 
@@ -407,9 +399,9 @@ class HeapTreeViewState extends State<HeapTree>
           ),
         ],
       );
-    } else if (_controller.snapshotByLibraryData != null) {
+    } else if (controller.snapshotByLibraryData != null) {
       snapshotDisplay =
-          treeMapVisible ? MemoryHeapTreemap(_controller) : MemoryHeapTable();
+          treeMapVisible ? const MemoryHeapTreemap() : MemoryHeapTable();
     } else {
       snapshotDisplay = null;
     }
@@ -481,9 +473,9 @@ class HeapTreeViewState extends State<HeapTree>
       );
     }
 
-    final rightSideTable = _controller.isLeafSelected
+    final rightSideTable = controller.isLeafSelected
         ? InstanceTreeView()
-        : _controller.isAnalysisLeafSelected
+        : controller.isAnalysisLeafSelected
             ? Expanded(child: AnalysisInstanceViewTable())
             : helpScreen();
 
@@ -563,7 +555,7 @@ class HeapTreeViewState extends State<HeapTree>
       child: DropdownButton<String>(
         key: groupByMenuButtonKey,
         style: textTheme.bodyText2,
-        value: _controller.groupingBy.value,
+        value: controller.groupingBy.value,
         onChanged: (String? newValue) {
           setState(
             () {
@@ -571,9 +563,9 @@ class HeapTreeViewState extends State<HeapTree>
                 analytics_constants.memory,
                 '${analytics_constants.groupByPrefix}$newValue',
               );
-              _controller.selectedLeaf = null;
-              _controller.groupingBy.value = newValue!;
-              if (_controller.snapshots.isNotEmpty) {
+              controller.selectedLeaf = null;
+              controller.groupingBy.value = newValue!;
+              if (controller.snapshots.isNotEmpty) {
                 doGroupBy();
               }
             },
@@ -602,14 +594,14 @@ class HeapTreeViewState extends State<HeapTree>
               const Text('Treemap'),
               Switch(
                 value: treeMapVisible,
-                onChanged: _controller.snapshotByLibraryData != null
+                onChanged: controller.snapshotByLibraryData != null
                     ? (value) {
                         ga.select(
                           analytics_constants.memory,
                           '${analytics_constants.treemapToggle}-'
                           '${value ? 'show' : 'hide'}',
                         );
-                        _controller.toggleTreeMapVisible(value);
+                        controller.toggleTreeMapVisible(value);
                       }
                     : null,
               ),
@@ -628,13 +620,13 @@ class HeapTreeViewState extends State<HeapTree>
                   analytics_constants.expandAll,
                 );
                 if (snapshotDisplay is MemoryHeapTable) {
-                  _controller.groupByTreeTable.dataRoots.every((element) {
+                  controller.groupByTreeTable.dataRoots.every((element) {
                     element.expandCascading();
                     return true;
                   });
                 }
                 // All nodes expanded - signal tree state  changed.
-                _controller.treeChanged();
+                controller.treeChanged();
               },
             ),
             const SizedBox(width: denseSpacing),
@@ -645,16 +637,16 @@ class HeapTreeViewState extends State<HeapTree>
                   analytics_constants.collapseAll,
                 );
                 if (snapshotDisplay is MemoryHeapTable) {
-                  _controller.groupByTreeTable.dataRoots.every((element) {
+                  controller.groupByTreeTable.dataRoots.every((element) {
                     element.collapseCascading();
                     return true;
                   });
-                  if (_controller.instanceFieldsTreeTable != null) {
+                  if (controller.instanceFieldsTreeTable != null) {
                     // We're collapsing close the fields table.
-                    _controller.selectedLeaf = null;
+                    controller.selectedLeaf = null;
                   }
                   // All nodes collapsed - signal tree state changed.
-                  _controller.treeChanged();
+                  controller.treeChanged();
                 }
               },
             ),
@@ -705,18 +697,17 @@ class HeapTreeViewState extends State<HeapTree>
           removeUpdateBubble?.cancel();
 
           removeUpdateBubble = Timer(const Duration(seconds: 5), () {
-            _controller.lastMonitorTimestamp.value =
-                _controller.monitorTimestamp;
+            controller.lastMonitorTimestamp.value = controller.monitorTimestamp;
             removeUpdateBubble = null;
           });
         }
         final circleWidget = textWidgetWithUpdateCircle(
-          _controller.monitorTimestamp == null
+          controller.monitorTimestamp == null
               ? 'No allocations tracked'
-              : 'Allocations Tracked at ${MemoryController.formattedTimestamp(_controller.monitorTimestamp)}',
+              : 'Allocations Tracked at ${MemoryController.formattedTimestamp(controller.monitorTimestamp)}',
           style: Theme.of(context).colorScheme.italicTextStyle,
-          size: _controller.lastMonitorTimestamp.value ==
-                  _controller.monitorTimestamp
+          size: controller.lastMonitorTimestamp.value ==
+                  controller.monitorTimestamp
               ? 0
               : circleSize,
         );
@@ -840,19 +831,18 @@ class HeapTreeViewState extends State<HeapTree>
   Future<void> _allocationStart() async {
     // TODO(terry): Look at grouping by library or classes also filtering e.g.,
     // await controller.computeLibraries();
-    _controller.memoryTimeline.addMonitorStartEvent();
+    controller.memoryTimeline.addMonitorStartEvent();
 
     final allocationtimestamp = DateTime.now();
-    final currentAllocations = await _controller.getAllocationProfile();
+    final currentAllocations = await controller.getAllocationProfile();
 
-    if (_controller.monitorAllocations.isNotEmpty) {
-      final previousSize = _controller.monitorAllocations.length;
+    if (controller.monitorAllocations.isNotEmpty) {
+      final previousSize = controller.monitorAllocations.length;
       int previousIndex = 0;
       final currentSize = currentAllocations.length;
       int currentIndex = 0;
       while (currentIndex < currentSize && previousIndex < previousSize) {
-        final previousAllocation =
-            _controller.monitorAllocations[previousIndex];
+        final previousAllocation = controller.monitorAllocations[previousIndex];
         final currentAllocation = currentAllocations[currentIndex];
 
         if (previousAllocation.classRef.id == currentAllocation.classRef.id) {
@@ -886,7 +876,7 @@ class HeapTreeViewState extends State<HeapTree>
           // active in previousAllocations.
           final currentClassId = currentAllocation.classRef.id;
           final ClassHeapDetailStats? first =
-              _controller.monitorAllocations.firstWhereOrNull(
+              controller.monitorAllocations.firstWhereOrNull(
             (element) => element.classRef.id == currentClassId,
           );
           if (first != null) {
@@ -905,15 +895,15 @@ class HeapTreeViewState extends State<HeapTree>
       assert(currentSize == currentIndex, '$currentSize == $currentIndex');
     }
 
-    _controller.monitorTimestamp = allocationtimestamp;
-    _controller.monitorAllocations = currentAllocations;
+    controller.monitorTimestamp = allocationtimestamp;
+    controller.monitorAllocations = currentAllocations;
 
-    _controller.treeChanged();
+    controller.treeChanged();
   }
 
   Future<void> _allocationReset() async {
-    _controller.memoryTimeline.addMonitorResetEvent();
-    final currentAllocations = await _controller.resetAllocationProfile();
+    controller.memoryTimeline.addMonitorResetEvent();
+    final currentAllocations = await controller.resetAllocationProfile();
 
     // Reset all accumulators to zero.
     for (final classAllocation in currentAllocations) {
@@ -921,7 +911,7 @@ class HeapTreeViewState extends State<HeapTree>
       classAllocation.instancesDelta = 0;
     }
 
-    _controller.monitorAllocations = currentAllocations;
+    controller.monitorAllocations = currentAllocations;
   }
 
   /// Match, found,  select it and process via ValueNotifiers.
@@ -933,32 +923,32 @@ class HeapTreeViewState extends State<HeapTree>
 
     setState(() {
       if (_tabController.index == allocationsTabIndex) {
-        _controller.selectItemInAllocationTable(foundName);
+        controller.selectItemInAllocationTable(foundName);
       } else if (_tabController.index == analysisTabIndex &&
           snapshotDisplay is MemoryHeapTable) {
-        _controller.groupByTreeTable.dataRoots.every((element) {
+        controller.groupByTreeTable.dataRoots.every((element) {
           element.collapseCascading();
           return true;
         });
       }
     });
 
-    selectFromSearchField(_controller, foundName);
-    clearSearchField(_controller);
+    selectFromSearchField(controller, foundName);
+    clearSearchField(controller);
   }
 
   bool get _isSearchable {
     // Analysis tab and Snapshot exist or 'Allocations' tab allocations are monitored.
     return (_tabController.index == analysisTabIndex && !treeMapVisible) ||
         (_tabController.index == allocationsTabIndex &&
-            _controller.monitorAllocations.isNotEmpty);
+            controller.monitorAllocations.isNotEmpty);
   }
 
   Widget _buildSearchWidget(GlobalKey<State<StatefulWidget>> key) => Container(
         width: wideSearchTextWidth,
         height: defaultTextFieldHeight,
         child: buildAutoCompleteSearchField(
-          controller: _controller,
+          controller: controller,
           searchFieldKey: key,
           searchFieldEnabled: _isSearchable,
           shouldRequestFocus: _isSearchable,
@@ -1001,7 +991,7 @@ class HeapTreeViewState extends State<HeapTree>
       return;
     }
 
-    _controller.memoryTimeline.addSnapshotEvent(auto: !userGenerated);
+    controller.memoryTimeline.addSnapshotEvent(auto: !userGenerated);
 
     setState(() {
       snapshotState = SnapshotStatus.streaming;
@@ -1009,14 +999,14 @@ class HeapTreeViewState extends State<HeapTree>
 
     final snapshotTimestamp = DateTime.now();
 
-    final graph = await _controller.snapshotMemory();
+    final graph = await controller.snapshotMemory();
 
     // No snapshot collected, disconnected/crash application.
     if (graph == null) {
       setState(() {
         snapshotState = SnapshotStatus.done;
       });
-      _controller.selectedSnapshotTimestamp = DateTime.now();
+      controller.selectedSnapshotTimestamp = DateTime.now();
       return;
     }
 
@@ -1028,8 +1018,8 @@ class HeapTreeViewState extends State<HeapTree>
 
     // To debug particular classes add their names to the last
     // parameter classNamesToMonitor e.g., ['AppStateModel', 'Terry', 'TerryEntry']
-    _controller.heapGraph = convertHeapGraph(
-      _controller.filterConfig,
+    controller.heapGraph = convertHeapGraph(
+      controller.filterConfig,
       graph,
       [],
     );
@@ -1041,9 +1031,9 @@ class HeapTreeViewState extends State<HeapTree>
 
     await doGroupBy();
 
-    final root = _controller.computeAllLibraries(graph: graph)!;
+    final root = controller.computeAllLibraries(graph: graph)!;
 
-    final snapshot = _controller.storeSnapshot(
+    final snapshot = controller.storeSnapshot(
       snapshotTimestamp,
       graph,
       root,
@@ -1052,7 +1042,7 @@ class HeapTreeViewState extends State<HeapTree>
 
     final snapshotDoneTime = DateTime.now();
 
-    _controller.selectedSnapshotTimestamp = snapshotTimestamp;
+    controller.selectedSnapshotTimestamp = snapshotTimestamp;
 
     debugLogger(
       'Total Snapshot completed in'
@@ -1075,12 +1065,12 @@ class HeapTreeViewState extends State<HeapTree>
       snapshotState = SnapshotStatus.done;
     });
 
-    _controller.buildTreeFromAllData();
+    controller.buildTreeFromAllData();
     _analyze(snapshot: snapshot);
   }
 
   Future<void> doGroupBy() async {
-    _controller.heapGraph!
+    controller.heapGraph!
       ..computeInstancesForClasses()
       ..computeRawGroups()
       ..computeFilteredGroups();
@@ -1097,7 +1087,7 @@ class HeapTreeViewState extends State<HeapTree>
     // Pressing either the Apply or Cancel button will dismiss.
     showDialog(
       context: context,
-      builder: (BuildContext context) => SnapshotFilterDialog(_controller),
+      builder: (BuildContext context) => SnapshotFilterDialog(controller),
       barrierDismissible: false,
     );
   }
@@ -1107,7 +1097,7 @@ class HeapTreeViewState extends State<HeapTree>
     assert(
       () {
         // Analysis already completed we're done.
-        final foundMatch = _controller.completedAnalyses.firstWhereOrNull(
+        final foundMatch = controller.completedAnalyses.firstWhereOrNull(
           (element) => element.dateTime.compareTo(currentSnapDateTime) == 0,
         );
         if (foundMatch != null) {
@@ -1124,9 +1114,9 @@ class HeapTreeViewState extends State<HeapTree>
   }
 
   void _analyze({Snapshot? snapshot}) {
-    final AnalysesReference analysesNode = _controller.findAnalysesNode()!;
+    final AnalysesReference analysesNode = controller.findAnalysesNode()!;
 
-    snapshot ??= _controller.computeSnapshotToAnalyze!;
+    snapshot ??= controller.computeSnapshotToAnalyze!;
     final DateTime currentSnapDateTime = snapshot.collectedTimestamp;
 
     _debugCheckAnalyses(currentSnapDateTime);
@@ -1143,15 +1133,15 @@ class HeapTreeViewState extends State<HeapTree>
     analysesNode.addChild(analyzeSnapshot);
 
     // Analyze this snapshot.
-    final collectedData = collect(_controller, snapshot);
+    final collectedData = collect(controller, snapshot);
 
     // Analyze the collected data.
 
     // 1. Analysis of memory image usage.
-    imageAnalysis(_controller, analyzeSnapshot, collectedData);
+    imageAnalysis(controller, analyzeSnapshot, collectedData);
 
     // Add to our list of completed analyses.
-    _controller.completedAnalyses.add(analyzeSnapshot);
+    controller.completedAnalyses.add(analyzeSnapshot);
 
     // Expand the 'Analysis' node.
     if (!analysesNode.isExpanded) {
@@ -1159,7 +1149,7 @@ class HeapTreeViewState extends State<HeapTree>
     }
 
     // Select the snapshot just analyzed.
-    _controller.selectionSnapshotNotifier.value = Selection(
+    controller.selectionSnapshotNotifier.value = Selection(
       node: analyzeSnapshot,
       nodeIndex: analyzeSnapshot.index,
       scrollIntoView: true,
@@ -1180,11 +1170,11 @@ class MemoryHeapTable extends StatefulWidget {
 
 /// A table of the Memory graph class top-down call tree.
 class MemoryHeapTableState extends State<MemoryHeapTable>
-    with AutoDisposeMixin {
-  late MemoryController _controller;
-  bool _controllerInitialized = false;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryHeapTable> {
   final TreeColumnData<Reference> _treeColumn = _LibraryRefColumn();
+
   final List<ColumnData<Reference>> _columns = [];
 
   @override
@@ -1205,61 +1195,57 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-    if (_controllerInitialized && newController == _controller) return;
-    _controller = newController;
-    _controllerInitialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 
     // Update the tree when the tree state changes e.g., expand, collapse, etc.
-    addAutoDisposeListener(_controller.treeChangedNotifier, () {
-      if (_controller.isTreeChanged) {
+    addAutoDisposeListener(controller.treeChangedNotifier, () {
+      if (controller.isTreeChanged) {
         setState(() {});
       }
     });
 
     // Update the tree when the memorySource changes.
-    addAutoDisposeListener(_controller.selectedSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.filterNotifier, () {
+    addAutoDisposeListener(controller.filterNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
 
-    addAutoDisposeListener(_controller.searchAutoCompleteNotifier);
+    addAutoDisposeListener(controller.searchAutoCompleteNotifier);
 
-    addAutoDisposeListener(_controller.selectTheSearchNotifier, _handleSearch);
+    addAutoDisposeListener(controller.selectTheSearchNotifier, _handleSearch);
 
-    addAutoDisposeListener(_controller.searchNotifier, _handleSearch);
+    addAutoDisposeListener(controller.searchNotifier, _handleSearch);
   }
 
   void _handleSearch() {
-    final searchingValue = _controller.search;
+    final searchingValue = controller.search;
     if (searchingValue.isNotEmpty) {
-      if (_controller.selectTheSearch) {
+      if (controller.selectTheSearch) {
         // Found an exact match.
         selectItemInTree(searchingValue);
-        _controller.selectTheSearch = false;
-        _controller.resetSearch();
+        controller.selectTheSearch = false;
+        controller.resetSearch();
         return;
       }
 
       // No exact match, return the list of possible matches.
-      _controller.clearSearchAutoComplete();
+      controller.clearSearchAutoComplete();
 
       final matches = _snapshotMatches(searchingValue);
 
       // Remove duplicates and sort the matches.
       final normalizedMatches = matches.toSet().toList()..sort();
       // Use the top 10 matches:
-      _controller.searchAutoComplete.value = normalizedMatches
+      controller.searchAutoComplete.value = normalizedMatches
           .sublist(
             0,
             min(
@@ -1278,9 +1264,9 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
     final externalMatches = <String>[];
     final filteredMatches = <String>[];
 
-    switch (_controller.groupingBy.value) {
+    switch (controller.groupingBy.value) {
       case MemoryController.groupByLibrary:
-        final searchRoot = _controller.activeSnapshot;
+        final searchRoot = controller.activeSnapshot;
         for (final reference in searchRoot.children) {
           if (reference.isLibrary) {
             matches.addAll(
@@ -1311,7 +1297,7 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
       case MemoryController.groupByClass:
         matches.addAll(
           matchClasses(
-            _controller.groupByTreeTable.dataRoots,
+            controller.groupByTreeTable.dataRoots,
             searchingValue,
           ),
         );
@@ -1379,12 +1365,12 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
   /// Returns `true` if [searchingValue] is found in the tree.
   bool selectItemInTree(String searchingValue) {
     // Search the snapshots.
-    switch (_controller.groupingBy.value) {
+    switch (controller.groupingBy.value) {
       case MemoryController.groupByLibrary:
-        final searchRoot = _controller.activeSnapshot;
-        if (_controller.selectionSnapshotNotifier.value.node == null) {
+        final searchRoot = controller.activeSnapshot;
+        if (controller.selectionSnapshotNotifier.value.node == null) {
           // No selected node, then select the snapshot we're searching.
-          _controller.selectionSnapshotNotifier.value = Selection(
+          controller.selectionSnapshotNotifier.value = Selection(
             node: searchRoot,
             nodeIndex: searchRoot.index,
             scrollIntoView: true,
@@ -1417,7 +1403,7 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
         }
         break;
       case MemoryController.groupByClass:
-        for (final reference in _controller.groupByTreeTable.dataRoots) {
+        for (final reference in controller.groupByTreeTable.dataRoots) {
           if (reference.isClass) {
             return _selecteClassInTree(reference, searchingValue);
           }
@@ -1433,12 +1419,12 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
 
   bool _selectInTree(Reference reference, search) {
     if (reference.name == search) {
-      _controller.selectionSnapshotNotifier.value = Selection(
+      controller.selectionSnapshotNotifier.value = Selection(
         node: reference,
         nodeIndex: reference.index,
         scrollIntoView: true,
       );
-      _controller.clearSearchAutoComplete();
+      controller.clearSearchAutoComplete();
       return true;
     }
     return false;
@@ -1464,21 +1450,21 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
 
   @override
   Widget build(BuildContext context) {
-    final root = _controller.buildTreeFromAllData();
+    final root = controller.buildTreeFromAllData();
 
     if (root != null && root.children.isNotEmpty) {
       // Snapshots and analyses exists display the trees.
-      _controller.groupByTreeTable = TreeTable<Reference>(
+      controller.groupByTreeTable = TreeTable<Reference>(
         dataRoots: root.children,
         columns: _columns,
         treeColumn: _treeColumn,
         keyFactory: (libRef) => PageStorageKey<String?>(libRef.name),
         sortColumn: _columns[0],
         sortDirection: SortDirection.ascending,
-        selectionNotifier: _controller.selectionSnapshotNotifier,
+        selectionNotifier: controller.selectionSnapshotNotifier,
       );
 
-      return _controller.groupByTreeTable;
+      return controller.groupByTreeTable;
     } else {
       // Nothing collected yet (snapshots/analyses) - return an empty area.
       return const SizedBox();

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_treemap.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_treemap.dart
@@ -4,32 +4,27 @@
 
 import 'package:flutter/material.dart' hide TextStyle;
 import 'package:flutter/widgets.dart' hide TextStyle;
-import 'package:provider/provider.dart';
 
 import '../../charts/treemap.dart';
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'memory_controller.dart';
 import 'primitives/predefined_classes.dart';
 
 class MemoryHeapTreemap extends StatefulWidget {
-  const MemoryHeapTreemap(this.controller);
-
-  final MemoryController controller;
+  const MemoryHeapTreemap();
 
   @override
-  MemoryHeapTreemapState createState() => MemoryHeapTreemapState(controller);
+  MemoryHeapTreemapState createState() => MemoryHeapTreemapState();
 }
 
 class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
-    with AutoDisposeMixin {
-  MemoryHeapTreemapState(this._controller);
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryHeapTreemap> {
   InstructionsSize? _sizes;
-
-  bool _initialized = false;
-  late MemoryController _controller;
 
   TreemapNode? root;
 
@@ -38,23 +33,20 @@ class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
     super.didChangeDependencies();
 
     // TODO(terry): Unable to short-circuit need to investigate why?
-    final newController = Provider.of<MemoryController>(context);
-    if (_initialized && _controller == newController) return;
-    _controller = newController;
-    _initialized = true;
+    if (!initController()) return;
 
-    if (_controller.heapGraph != null) {
-      _sizes = InstructionsSize.fromSnapshot(_controller);
+    if (controller.heapGraph != null) {
+      _sizes = InstructionsSize.fromSnapshot(controller);
       root = _sizes!.root;
     }
 
     cancelListeners();
 
-    addAutoDisposeListener(_controller.selectedSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
 
-        _sizes = InstructionsSize.fromSnapshot(_controller);
+        _sizes = InstructionsSize.fromSnapshot(controller);
       });
     });
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_instance_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_instance_tree_view.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
@@ -20,11 +19,11 @@ class InstanceTreeView extends StatefulWidget {
 
 /// Table of the fields of an instance (type, name and value).
 class InstanceTreeViewState extends State<InstanceTreeView>
-    with AutoDisposeMixin {
-  late MemoryController _controller;
-  bool _controllerInitialized = false;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, InstanceTreeView> {
   final TreeColumnData<FieldReference> treeColumn = _FieldTypeColumn();
+
   final List<ColumnData<FieldReference>> columns = [];
 
   @override
@@ -42,11 +41,7 @@ class InstanceTreeViewState extends State<InstanceTreeView>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-    if (_controllerInitialized && newController == _controller) return;
-    _controller = newController;
-    _controllerInitialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 
@@ -54,17 +49,17 @@ class InstanceTreeViewState extends State<InstanceTreeView>
     //              controller. Have other ValueListenables on controller to
     //              listen to, so we don't need the setState calls.
     // Update the chart when the memorySource changes.
-    addAutoDisposeListener(_controller.selectedSnapshotNotifier, () {
+    addAutoDisposeListener(controller.selectedSnapshotNotifier, () {
       setState(() {
-        _controller.computeAllLibraries(rebuild: true);
+        controller.computeAllLibraries(rebuild: true);
       });
     });
   }
 
   @override
   Widget build(BuildContext context) {
-    _controller.instanceFieldsTreeTable = TreeTable<FieldReference>(
-      dataRoots: _controller.instanceRoot!,
+    controller.instanceFieldsTreeTable = TreeTable<FieldReference>(
+      dataRoots: controller.instanceRoot!,
       columns: columns,
       treeColumn: treeColumn,
       keyFactory: (typeRef) => PageStorageKey<String>(typeRef.name),
@@ -72,7 +67,7 @@ class InstanceTreeViewState extends State<InstanceTreeView>
       sortDirection: SortDirection.ascending,
     );
 
-    return _controller.instanceFieldsTreeTable!;
+    return controller.instanceFieldsTreeTable!;
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
@@ -63,10 +63,12 @@ class MemoryBodyState extends State<MemoryBody>
     with
         AutoDisposeMixin,
         SingleTickerProviderStateMixin,
-        MemoryControllerMixin {
+        ProvidedControllerMixin<MemoryController, MemoryBody> {
   late ChartControllers _chartControllers;
 
   late bool _isAndroidChartVisible;
+
+  MemoryController get memoryController => controller;
 
   OverlayEntry? _hoverOverlayEntry;
 
@@ -83,8 +85,7 @@ class MemoryBodyState extends State<MemoryBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     maybePushDebugModeMemoryMessage(context, MemoryScreen.id);
-
-    if (!initMemoryController()) return;
+    if (!initController()) return;
 
     _isAndroidChartVisible = memoryController.isAndroidChartVisible;
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_vm_chart.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_vm_chart.dart
@@ -4,13 +4,13 @@
 
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../charts/chart.dart';
 import '../../charts/chart_controller.dart';
 import '../../charts/chart_trace.dart' as trace;
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'memory_controller.dart';
 import 'primitives/memory_timeline.dart';
 
@@ -103,16 +103,14 @@ enum TraceName {
   rasterPicture,
 }
 
-class MemoryVMChartState extends State<MemoryVMChart> with AutoDisposeMixin {
-  bool _initialized = false;
-
+class MemoryVMChartState extends State<MemoryVMChart>
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryVMChart> {
   /// Controller attached to the chart.
   VMChartController get _chartController => widget.chartController;
 
-  /// Controller for managing memory collection.
-  late MemoryController _memoryController;
-
-  MemoryTimeline get _memoryTimeline => _memoryController.memoryTimeline;
+  MemoryTimeline get _memoryTimeline => controller.memoryTimeline;
 
   @override
   void initState() {
@@ -124,12 +122,7 @@ class MemoryVMChartState extends State<MemoryVMChart> with AutoDisposeMixin {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-
-    if (_initialized && _memoryController == newController) return;
-    _memoryController = newController;
-    _initialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 
@@ -309,7 +302,7 @@ class MemoryVMChartState extends State<MemoryVMChart> with AutoDisposeMixin {
   /// Loads all heap samples (live data or offline).
   void _processHeapSample(HeapSample sample) {
     // If paused don't update the chart (data is still collected).
-    if (_memoryController.paused.value) return;
+    if (controller.paused.value) return;
     _chartController.addSample(sample);
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/adb_button.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/adb_button.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../shared/common_widgets.dart';
+import '../../../../shared/utils.dart';
 import '../../memory_controller.dart';
 
 class ToggleAdbMemoryButton extends StatefulWidget {
@@ -19,23 +20,20 @@ class ToggleAdbMemoryButton extends StatefulWidget {
 }
 
 class _ToggleAdbMemoryButtonState extends State<ToggleAdbMemoryButton>
-    with MemoryControllerMixin {
+    with ProvidedControllerMixin<MemoryController, ToggleAdbMemoryButton> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    initMemoryController();
+    initController();
   }
 
   @override
   Widget build(BuildContext context) {
     return IconLabelButton(
-      icon: memoryController.isAndroidChartVisible
-          ? Icons.close
-          : Icons.show_chart,
+      icon: controller.isAndroidChartVisible ? Icons.close : Icons.show_chart,
       label: 'Android Memory',
       onPressed: widget.isAndroidCollection
-          ? memoryController.toggleAndroidChartVisibility
+          ? controller.toggleAndroidChartVisibility
           : null,
       minScreenWidthForTextBeforeScaling: 900,
     );

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/control_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/control_pane.dart
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../../../primitives/auto_dispose_mixin.dart';
+import '../../../../shared/utils.dart';
 import '../../memory_controller.dart';
 import 'primary_controls.dart';
 import 'secondary_controls.dart';
@@ -23,12 +23,11 @@ class MemoryControlPane extends StatefulWidget {
 }
 
 class _MemoryControlPaneState extends State<MemoryControlPane>
-    with AutoDisposeMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<MemoryController, MemoryControlPane> {
   /// Updated when the MemoryController's _androidCollectionEnabled ValueNotifier changes.
   bool _isAndroidCollection = MemoryController.androidADBDefault;
-
-  bool controllersInitialized = false;
-  late MemoryController _controller;
 
   @override
   Widget build(BuildContext context) {
@@ -48,22 +47,17 @@ class _MemoryControlPaneState extends State<MemoryControlPane>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<MemoryController>(context);
-    if (!controllersInitialized || newController != _controller) {
-      controllersInitialized = true;
-      _controller = newController;
-    }
+    if (!initController()) return;
 
     // TODO(polinach): do we need this listener?
     // https://github.com/flutter/devtools/pull/4136#discussion_r881773861
-    addAutoDisposeListener(_controller.androidCollectionEnabled, () {
-      _isAndroidCollection = _controller.androidCollectionEnabled.value;
+    addAutoDisposeListener(controller.androidCollectionEnabled, () {
+      _isAndroidCollection = controller.androidCollectionEnabled.value;
       setState(() {
-        if (!_isAndroidCollection && _controller.isAndroidChartVisible) {
+        if (!_isAndroidCollection && controller.isAndroidChartVisible) {
           // If we're no longer collecting android stats then hide the
           // chart and disable the Android Memory button.
-          _controller.toggleAndroidChartVisibility();
+          controller.toggleAndroidChartVisibility();
         }
       });
     });

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/interval_dropdown.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/interval_dropdown.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../../analytics/analytics.dart' as ga;
 import '../../../../analytics/constants.dart' as analytics_constants;
 import '../../../../shared/common_widgets.dart';
+import '../../../../shared/utils.dart';
 import '../../memory_controller.dart';
 import 'constants.dart';
 
@@ -21,12 +22,11 @@ class IntervalDropdown extends StatefulWidget {
 }
 
 class _IntervalDropdownState extends State<IntervalDropdown>
-    with MemoryControllerMixin<IntervalDropdown> {
+    with ProvidedControllerMixin<MemoryController, IntervalDropdown> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    initMemoryController();
+    initController();
   }
 
   @override
@@ -58,15 +58,15 @@ class _IntervalDropdownState extends State<IntervalDropdown>
     return RoundedDropDownButton<String>(
       isDense: true,
       style: textTheme.bodyText2,
-      value: displayDuration(memoryController.displayInterval),
+      value: displayDuration(controller.displayInterval),
       onChanged: (String? newValue) {
         setState(() {
           ga.select(
             analytics_constants.memory,
             '${analytics_constants.memoryDisplayInterval}-$newValue',
           );
-          memoryController.displayInterval = chartInterval(newValue!);
-          final duration = chartDuration(memoryController.displayInterval);
+          controller.displayInterval = chartInterval(newValue!);
+          final duration = chartDuration(controller.displayInterval);
 
           widget.chartControllers.event.zoomDuration = duration;
           widget.chartControllers.vm.zoomDuration = duration;

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/primary_controls.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/primary_controls.dart
@@ -8,6 +8,7 @@ import '../../../../analytics/analytics.dart' as ga;
 import '../../../../analytics/constants.dart' as analytics_constants;
 import '../../../../shared/common_widgets.dart';
 import '../../../../shared/theme.dart';
+import '../../../../shared/utils.dart';
 import '../../memory_controller.dart';
 import 'constants.dart';
 import 'interval_dropdown.dart';
@@ -25,42 +26,41 @@ class PrimaryControls extends StatefulWidget {
 }
 
 class _PrimaryControlsState extends State<PrimaryControls>
-    with MemoryControllerMixin {
+    with ProvidedControllerMixin<MemoryController, PrimaryControls> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    initMemoryController();
+    initController();
   }
 
   void _onPause() {
     ga.select(analytics_constants.memory, analytics_constants.pause);
-    memoryController.pauseLiveFeed();
+    controller.pauseLiveFeed();
   }
 
   void _onResume() {
     ga.select(analytics_constants.memory, analytics_constants.resume);
-    memoryController.resumeLiveFeed();
+    controller.resumeLiveFeed();
   }
 
   void _clearTimeline() {
     ga.select(analytics_constants.memory, analytics_constants.clear);
 
-    memoryController.memoryTimeline.reset();
+    controller.memoryTimeline.reset();
 
     // Clear any current Allocation Profile collected.
-    memoryController.monitorAllocations = [];
-    memoryController.monitorTimestamp = null;
-    memoryController.lastMonitorTimestamp.value = null;
-    memoryController.trackAllocations.clear();
-    memoryController.allocationSamples.clear();
+    controller.monitorAllocations = [];
+    controller.monitorTimestamp = null;
+    controller.lastMonitorTimestamp.value = null;
+    controller.trackAllocations.clear();
+    controller.allocationSamples.clear();
 
     // Clear all analysis and snapshots collected too.
-    memoryController.clearAllSnapshots();
-    memoryController.classRoot = null;
-    memoryController.topNode = null;
-    memoryController.selectedSnapshotTimestamp = null;
-    memoryController.selectedLeaf = null;
+    controller.clearAllSnapshots();
+    controller.classRoot = null;
+    controller.topNode = null;
+    controller.selectedSnapshotTimestamp = null;
+    controller.selectedLeaf = null;
 
     // Remove history of all plotted data in all charts.
     widget.chartControllers.resetAll();
@@ -69,7 +69,7 @@ class _PrimaryControlsState extends State<PrimaryControls>
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<bool>(
-      valueListenable: memoryController.paused,
+      valueListenable: controller.paused,
       builder: (context, paused, _) {
         return Row(
           mainAxisSize: MainAxisSize.min,
@@ -88,10 +88,9 @@ class _PrimaryControlsState extends State<PrimaryControls>
             const SizedBox(width: defaultSpacing),
             ClearButton(
               // TODO(terry): Button needs to be Delete for offline data.
-              onPressed:
-                  memoryController.memorySource == MemoryController.liveFeed
-                      ? _clearTimeline
-                      : null,
+              onPressed: controller.memorySource == MemoryController.liveFeed
+                  ? _clearTimeline
+                  : null,
               minScreenWidthForTextBeforeScaling:
                   primaryControlsMinVerboseWidth,
             ),

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/source_dropdown.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/source_dropdown.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../../analytics/analytics.dart' as ga;
 import '../../../../analytics/constants.dart' as analytics_constants;
 import '../../../../shared/common_widgets.dart';
+import '../../../../shared/utils.dart';
 import '../../memory_controller.dart';
 import 'constants.dart';
 
@@ -23,22 +24,21 @@ class MemorySourceDropdown extends StatefulWidget {
 }
 
 class _MemorySourceDropdownState extends State<MemorySourceDropdown>
-    with MemoryControllerMixin {
+    with ProvidedControllerMixin<MemoryController, MemorySourceDropdown> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    initMemoryController();
+    initController();
   }
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    final files = memoryController.memoryLog.offlineFiles();
+    final files = controller.memoryLog.offlineFiles();
 
     // Can we display dropdowns in verbose mode?
     final isVerbose =
-        memoryController.memorySourcePrefix == memorySourceMenuItemPrefix;
+        controller.memorySourcePrefix == memorySourceMenuItemPrefix;
 
     // First item is 'Live Feed', then followed by memory log filenames.
     files.insert(0, MemoryController.liveFeed);
@@ -54,7 +54,7 @@ class _MemorySourceDropdownState extends State<MemorySourceDropdown>
       return SourceDropdownMenuItem<String>(
         value: value,
         child: Text(
-          '${memoryController.memorySourcePrefix}$displayValue',
+          '${controller.memorySourcePrefix}$displayValue',
           key: sourcesKey,
         ),
       );
@@ -64,14 +64,14 @@ class _MemorySourceDropdownState extends State<MemorySourceDropdown>
       key: sourcesDropdownKey,
       isDense: true,
       style: textTheme.bodyText2,
-      value: memoryController.memorySource,
+      value: controller.memorySource,
       onChanged: (String? newValue) {
         setState(() {
           ga.select(
             analytics_constants.memory,
             analytics_constants.sourcesDropDown,
           );
-          memoryController.memorySource = newValue!;
+          controller.memorySource = newValue!;
         });
       },
       items: allMemorySources,

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -111,10 +111,9 @@ Example queries:
 }
 
 class _NetworkScreenBodyState extends State<NetworkScreenBody>
-    with AutoDisposeMixin {
-  bool _initialized = false;
-  late NetworkController _networkController;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<NetworkController, NetworkScreenBody> {
   @override
   void initState() {
     super.initState();
@@ -124,20 +123,15 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-
-    final newController = Provider.of<NetworkController>(context);
-    if (_initialized && newController == _networkController) return;
-
-    _networkController = newController;
-    _initialized = true;
-    _networkController.startRecording();
+    if (!initController()) return;
+    controller.startRecording();
   }
 
   @override
   void dispose() {
     // TODO(kenz): this won't work well if we eventually have multiple clients
     // that want to listen to network data.
-    _networkController.stopRecording();
+    controller.stopRecording();
     super.dispose();
   }
 
@@ -145,10 +139,10 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
   Widget build(BuildContext context) {
     return Column(
       children: [
-        _NetworkProfilerControls(controller: _networkController),
+        _NetworkProfilerControls(controller: controller),
         const SizedBox(height: denseRowSpacing),
         Expanded(
-          child: _NetworkProfilerBody(controller: _networkController),
+          child: _NetworkProfilerBody(controller: controller),
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
@@ -45,7 +45,9 @@ class FlutterFramesChart extends StatefulWidget {
 }
 
 class _FlutterFramesChartState extends State<FlutterFramesChart>
-    with AutoDisposeMixin, PerformanceControllerMixin {
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<PerformanceController, FlutterFramesChart> {
   static const _defaultFrameWidthWithPadding =
       FlutterFramesChartItem.defaultFrameWidth + densePadding * 2;
 
@@ -85,13 +87,13 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (!initPerformanceController()) return;
+    if (!initController()) return;
 
     cancelListeners();
-    _selectedFrame = performanceController.selectedFrame.value;
-    addAutoDisposeListener(performanceController.selectedFrame, () {
+    _selectedFrame = controller.selectedFrame.value;
+    addAutoDisposeListener(controller.selectedFrame, () {
       setState(() {
-        _selectedFrame = performanceController.selectedFrame.value;
+        _selectedFrame = controller.selectedFrame.value;
       });
     });
 
@@ -199,7 +201,7 @@ class _FlutterFramesChartState extends State<FlutterFramesChart>
                 itemCount: widget.frames.length,
                 itemExtent: _defaultFrameWidthWithPadding,
                 itemBuilder: (context, index) => FlutterFramesChartItem(
-                  controller: performanceController,
+                  controller: controller,
                   frame: widget.frames[index],
                   selected: widget.frames[index] == _selectedFrame,
                   msPerPx: _msPerPx,

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -7,9 +7,7 @@ import 'dart:math' as math;
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
-import 'package:flutter/material.dart';
 import 'package:pedantic/pedantic.dart';
-import 'package:provider/provider.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
@@ -880,18 +878,5 @@ class PerformanceController extends DisposableController
     _timelinePollingRateLimiter?.dispose();
     cpuProfilerController.dispose();
     super.dispose();
-  }
-}
-
-mixin PerformanceControllerMixin<T extends StatefulWidget> on State<T> {
-  PerformanceController get performanceController => _performanceController!;
-
-  PerformanceController? _performanceController;
-
-  bool initPerformanceController() {
-    final newController = Provider.of<PerformanceController>(context);
-    if (newController == _performanceController) return false;
-    _performanceController = newController;
-    return true;
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -21,6 +21,7 @@ import '../../shared/notifications.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import '../../shared/version.dart';
 import '../../ui/icons.dart';
 import '../../ui/vm_flag_widgets.dart';
@@ -64,7 +65,7 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
     with
         AutoDisposeMixin,
         OfflineScreenMixin<PerformanceScreenBody, OfflinePerformanceData>,
-        PerformanceControllerMixin {
+        ProvidedControllerMixin<PerformanceController, PerformanceScreenBody> {
   bool processing = false;
 
   double processingProgress = 0.0;
@@ -94,27 +95,25 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
     );
     maybePushDebugModePerformanceMessage(context, PerformanceScreen.id);
 
-    if (!initPerformanceController()) return;
+    if (!initController()) return;
 
     cancelListeners();
 
-    processing = performanceController.processing.value;
-    addAutoDisposeListener(performanceController.processing, () {
+    processing = controller.processing.value;
+    addAutoDisposeListener(controller.processing, () {
       setState(() {
-        processing = performanceController.processing.value;
+        processing = controller.processing.value;
       });
     });
 
-    processingProgress = performanceController.processor.progressNotifier.value;
-    addAutoDisposeListener(performanceController.processor.progressNotifier,
-        () {
+    processingProgress = controller.processor.progressNotifier.value;
+    addAutoDisposeListener(controller.processor.progressNotifier, () {
       setState(() {
-        processingProgress =
-            performanceController.processor.progressNotifier.value;
+        processingProgress = controller.processor.progressNotifier.value;
       });
     });
 
-    addAutoDisposeListener(performanceController.selectedFrame);
+    addAutoDisposeListener(controller.selectedFrame);
 
     // Load offline timeline data if available.
     if (shouldLoadOfflineData()) {
@@ -138,8 +137,8 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
   @override
   Widget build(BuildContext context) {
     final isOfflineFlutterApp = offlineController.offlineMode.value &&
-        performanceController.offlinePerformanceData != null &&
-        performanceController.offlinePerformanceData!.frames.isNotEmpty;
+        controller.offlinePerformanceData != null &&
+        controller.offlinePerformanceData!.frames.isNotEmpty;
 
     final performanceScreen = Column(
       children: [
@@ -149,8 +148,8 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
             (!offlineController.offlineMode.value &&
                 serviceManager.connectedApp!.isFlutterAppNow!))
           DualValueListenableBuilder<List<FlutterFrame>, double>(
-            firstListenable: performanceController.flutterFrames,
-            secondListenable: performanceController.displayRefreshRate,
+            firstListenable: controller.flutterFrames,
+            secondListenable: controller.displayRefreshRate,
             builder: (context, frames, displayRefreshRate, child) {
               return FlutterFramesChart(
                 frames,
@@ -164,12 +163,12 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
             initialFractions: const [0.7, 0.3],
             children: [
               TabbedPerformanceView(
-                controller: performanceController,
+                controller: controller,
                 processing: processing,
                 processingProgress: processingProgress,
               ),
               ValueListenableBuilder<TimelineEvent?>(
-                valueListenable: performanceController.selectedTimelineEvent,
+                valueListenable: controller.selectedTimelineEvent,
                 builder: (context, selectedEvent, _) {
                   return EventDetails(selectedEvent);
                 },
@@ -201,19 +200,19 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
       mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         _PrimaryControls(
-          controller: performanceController,
+          controller: controller,
           processing: processing,
           onClear: () => setState(() {}),
         ),
         const SizedBox(width: defaultSpacing),
-        SecondaryPerformanceControls(controller: performanceController),
+        SecondaryPerformanceControls(controller: controller),
       ],
     );
   }
 
   @override
   FutureOr<void> processOfflineData(OfflinePerformanceData offlineData) async {
-    await performanceController.processOfflineData(offlineData);
+    await controller.processOfflineData(offlineData);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/performance/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/timeline_flame_chart.dart
@@ -17,6 +17,7 @@ import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/notifications.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import '../../ui/colors.dart';
 import '../../ui/utils.dart';
 import 'performance_controller.dart';
@@ -142,7 +143,7 @@ class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
 
 class TimelineFlameChartState
     extends FlameChartState<TimelineFlameChart, TimelineEvent>
-    with PerformanceControllerMixin {
+    with ProvidedControllerMixin<PerformanceController, TimelineFlameChart> {
   /// Stores the [FlameChartNode] for each [TimelineEvent] in the chart.
   ///
   /// We need to be able to look up a [FlameChartNode] based on its
@@ -183,17 +184,17 @@ class TimelineFlameChartState
   void didChangeDependencies() {
     super.didChangeDependencies();
 
-    if (!initPerformanceController()) return;
+    if (!initController()) return;
 
     // If there is already a selected frame, handle setting that data and
     // positioning/zooming the flame chart accordingly.
-    _selectedFrame = performanceController.selectedFrame.value;
+    _selectedFrame = controller.selectedFrame.value;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       await _centerSelectedFrame();
     });
 
     addAutoDisposeListener(
-      performanceController.selectedFrame,
+      controller.selectedFrame,
       _handleSelectedFrame,
     );
   }
@@ -219,7 +220,7 @@ class TimelineFlameChartState
   double topYForData(TimelineEvent data) {
     final eventGroupKey = PerformanceUtils.computeEventGroupKey(
       data,
-      performanceController.threadNamesById,
+      controller.threadNamesById,
     );
     final eventGroup = widget.data.eventGroups[eventGroupKey]!;
     final rowOffsetInGroup = eventGroup.rowIndexForEvent[data]!;
@@ -333,7 +334,7 @@ class TimelineFlameChartState
   }
 
   void _handleSelectedFrame() async {
-    final selectedFrame = performanceController.selectedFrame.value;
+    final selectedFrame = controller.selectedFrame.value;
     if (selectedFrame == _selectedFrame) return;
 
     setState(() {
@@ -351,9 +352,9 @@ class TimelineFlameChartState
       final time = _selected.timeToCenterFrame();
       final event = _selected.eventToCenterFrame();
       if (time == null || event == null) {
-        if (performanceController.firstWellFormedFrameMicros != null &&
+        if (controller.firstWellFormedFrameMicros != null &&
             _selected.timeFromFrameTiming.start!.inMicroseconds <
-                performanceController.firstWellFormedFrameMicros!) {
+                controller.firstWellFormedFrameMicros!) {
           Notifications.of(context)!.push(
             'No timeline events available for the selected frame. Timeline '
             'events occurred too long ago before DevTools could access them. '
@@ -532,7 +533,7 @@ class TimelineFlameChartState
 
   Widget _buildSectionLabels({required BoxConstraints constraints}) {
     final colorScheme = Theme.of(context).colorScheme;
-    final eventGroups = performanceController.data!.eventGroups;
+    final eventGroups = controller.data!.eventGroups;
 
     final children = <Widget>[];
     for (int i = 0; i < eventGroups.length; i++) {
@@ -597,7 +598,7 @@ class TimelineFlameChartState
     required BoxConstraints constraints,
   }) {
     final threadButtonContainerWidth = buttonMinWidth + defaultSpacing;
-    final eventGroups = performanceController.data!.eventGroups;
+    final eventGroups = controller.data!.eventGroups;
 
     Widget buildNavigatorButton(int index, {required bool isNext}) {
       // Add spacing to account for timestamps at top of chart.

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart' hide Stack;
 
 import '../../analytics/analytics.dart' as ga;
@@ -21,6 +20,7 @@ import '../../shared/globals.dart';
 import '../../shared/notifications.dart';
 import '../../shared/screen.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import '../../ui/icons.dart';
 import '../../ui/vm_flag_widgets.dart';
 import 'cpu_profile_controller.dart';
@@ -72,10 +72,8 @@ class ProfilerScreenBody extends StatefulWidget {
 class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
     with
         AutoDisposeMixin,
-        OfflineScreenMixin<ProfilerScreenBody, CpuProfileData> {
-  late ProfilerScreenController controller;
-  bool _controllerInitialized = false;
-
+        OfflineScreenMixin<ProfilerScreenBody, CpuProfileData>,
+        ProvidedControllerMixin<ProfilerScreenController, ProfilerScreenBody> {
   bool recording = false;
 
   bool processing = false;
@@ -93,11 +91,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     maybePushDebugModePerformanceMessage(context, ProfilerScreen.id);
-
-    final newController = Provider.of<ProfilerScreenController>(context);
-    if (_controllerInitialized && newController == controller) return;
-    controller = newController;
-    _controllerInitialized = true;
+    if (!initController()) return;
 
     cancelListeners();
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -4,11 +4,11 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/screen.dart';
 import '../../shared/theme.dart';
+import '../../shared/utils.dart';
 import 'isolate_statistics_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
@@ -72,18 +72,14 @@ class VMDeveloperToolsScreenBody extends StatefulWidget {
 }
 
 class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
-    with AutoDisposeMixin {
-  bool initialized = false;
-  late VMDeveloperToolsController controller;
-
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<VMDeveloperToolsController,
+            VMDeveloperToolsScreenBody> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    final newController = Provider.of<VMDeveloperToolsController>(context);
-    // Don't access `controller` if we haven't already initialized it.
-    if (initialized && newController == controller) return;
-    controller = newController;
-    initialized = true;
+    initController();
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/console.dart
+++ b/packages/devtools_app/lib/src/shared/console.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../primitives/auto_dispose_mixin.dart';
 import '../primitives/utils.dart';
@@ -13,6 +12,7 @@ import '../screens/debugger/variables.dart';
 import 'common_widgets.dart';
 import 'console_service.dart';
 import 'theme.dart';
+import 'utils.dart';
 
 // TODO(devoncarew): Allow scrolling horizontally as well.
 
@@ -122,7 +122,9 @@ class _ConsoleOutput extends StatefulWidget {
 }
 
 class _ConsoleOutputState extends State<_ConsoleOutput>
-    with AutoDisposeMixin<_ConsoleOutput> {
+    with
+        AutoDisposeMixin<_ConsoleOutput>,
+        ProvidedControllerMixin<DebuggerController, _ConsoleOutput> {
   // The scroll controller must survive ConsoleOutput re-renders
   // to work as intended, so it must be part of the "state".
   final ScrollController _scroll = ScrollController();
@@ -133,8 +135,6 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
   bool _scrollToBottom = true;
   bool _considerScrollAtBottom = true;
   double _lastScrollOffset = 0.0;
-
-  late DebuggerController _debuggerController;
 
   @override
   void initState() {
@@ -196,7 +196,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    _debuggerController = Provider.of<DebuggerController>(context);
+    initController();
   }
 
   @override
@@ -250,7 +250,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
           } else if (line is VariableConsoleLine) {
             return ExpandableVariable(
               variable: line.variable,
-              debuggerController: _debuggerController,
+              debuggerController: controller,
             );
           } else {
             assert(

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
+import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../config_specific/logger/logger.dart' as logger;
@@ -90,5 +91,35 @@ extension VmExtension on VM {
         '($architectureBits bit)',
       operatingSystem,
     ].join(' ');
+  }
+}
+
+/// Mixin that provides a [controller] from package:provider for a State class.
+///
+/// [initController] must be called from [State.didChangeDependencies]. If
+/// [initController] returns false, return early from [didChangeDependencies] to
+/// avoid calling any initialization code that should only be called once for a
+/// controller. See [initController] documenation below for more details.
+mixin ProvidedControllerMixin<T, V extends StatefulWidget> on State<V> {
+  T get controller => _controller!;
+
+  T? _controller;
+
+  /// Initializes [_controller] from package:provider.
+  ///
+  /// This method should be called in [didChangeDependencies]. Returns whether
+  /// or not a new controller was provided upon subsequent calls to
+  /// [initController].
+  ///
+  /// This method will commonly be used to return early from
+  /// [didChangeDependencies] when initialization code should not be run again
+  /// if the provided controller has not changed.
+  ///
+  /// E.g. `if (!initController()) return;`
+  bool initController() {
+    final newController = Provider.of<T>(context);
+    if (newController == _controller) return false;
+    _controller = newController;
+    return true;
   }
 }

--- a/packages/devtools_app/test/shared/utils_test.dart
+++ b/packages/devtools_app/test/shared/utils_test.dart
@@ -2,11 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/utils.dart';
 import 'package:devtools_shared/devtools_test_utils.dart';
+import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
 
 void main() {
   group('utils', () {
@@ -1371,7 +1376,82 @@ void main() {
         expect(false.boolCompare(true), equals(1));
       });
     });
+
+    group('ProvidedControllerMixin', () {
+      setUp(() {
+        setGlobal(IdeTheme, IdeTheme());
+      });
+
+      testWidgets('updates controller when provided controller changes',
+          (WidgetTester tester) async {
+        final controller1 = TestProvidedController('id_1');
+        final controller2 = TestProvidedController('id_2');
+        final controllerNotifier =
+            ValueNotifier<TestProvidedController>(controller1);
+
+        final provider = ValueListenableBuilder<TestProvidedController>(
+          valueListenable: controllerNotifier,
+          builder: (context, controller, _) {
+            return Provider<TestProvidedController>.value(
+              value: controller,
+              child: Builder(
+                builder: (context) {
+                  return wrap(
+                    const TestStatefulWidget(),
+                  );
+                },
+              ),
+            );
+          },
+        );
+
+        await tester.pumpWidget(provider);
+        expect(find.text('Value 1'), findsOneWidget);
+        expect(find.text('Controller id_1'), findsOneWidget);
+
+        controllerNotifier.value = controller2;
+        await tester.pumpAndSettle();
+
+        expect(find.text('Value 2'), findsOneWidget);
+        expect(find.text('Controller id_2'), findsOneWidget);
+      });
+    });
   });
+}
+
+class TestProvidedController {
+  TestProvidedController(this.id);
+
+  final String id;
+}
+
+class TestStatefulWidget extends StatefulWidget {
+  const TestStatefulWidget({Key? key}) : super(key: key);
+
+  @override
+  State<TestStatefulWidget> createState() => _TestStatefulWidgetState();
+}
+
+class _TestStatefulWidgetState extends State<TestStatefulWidget>
+    with ProvidedControllerMixin<TestProvidedController, TestStatefulWidget> {
+  int _value = 0;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!initController()) return;
+    _value++;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Text('Value $_value'),
+        Text('Controller ${controller.id}'),
+      ],
+    );
+  }
 }
 
 // This was generated from a canvas with font size 14.0.


### PR DESCRIPTION
Deleted `PerformanceControllerMixin` and `MemoryControllerMixin` (fyi @polina-c) in favor of general `ProvidedControllerMixin` that can be used anywhere in DevTools. 

This reduces the boiler plate for using an inherited controller from 5 lines down to 2 lines.

Before:
```
ControllerType get controller => _controller!;
ControllerType? _controller;

final newController = Provider.of<ControllerType>(context);
if (newController == _controller) return;
_controller = newController;
```

After:
```
with ProvidedControllerMixin<ControllerType, WidgetType> // add mixin to state class
initController() // call in didChangeDependencies
```