### PR TITLE
Fix formatting for memory values in heap tree view

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -1702,7 +1702,11 @@ class _ShallowSizeColumn extends ColumnData<Reference> {
             dataObject.isAllocation) &&
         value is! int) return '';
 
-    return NumberFormat.compact().format(value);
+    return prettyPrintBytes(
+      value as int,
+      kbFractionDigits: 1,
+      includeUnit: true,
+    )!;
   }
 
   @override


### PR DESCRIPTION
We were previously using a compact numeric format from package:intl that converted values to shortened base-10 strings. Using `prettyPrintBytes` will give better formatting.

```
Value       Before        After
--------------------------------
0           0             0 B
1000        1K            1000 B
1024        1K            1 KB
2^20        1M            1 MB
2^30        1B            1 GB
```