### PR TITLE
Pin github actions to hash, add dependabot for actions as well

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+# See Dependabot documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,6 +10,9 @@ on:
     branches:
       - master
 
+# Declare default permissions as read only.
+permissions: read-all
+
 # When updating this version, also update the version in
 # flutter-version.txt.
 #
@@ -30,7 +33,7 @@ jobs:
           - pinned
     steps:
       - name: git clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - name: tool/bots.sh
         env:
           BOT: main
@@ -47,7 +50,7 @@ jobs:
           - pinned
     steps:
       - name: git clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
       - name: tool/bots.sh
         env:
           BOT: packages
@@ -68,7 +71,7 @@ jobs:
           - master
     steps:
       - name: git clone
-        uses: actions/checkout@v2
+        uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
 
       - name: tool/bots.sh
         env:
@@ -78,7 +81,7 @@ jobs:
         run: ./tool/bots.sh
 
       - name: image failures
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@34622df80861c3ed63eb2bff892de2f1fbf4c9da
         if: failure() # Only if failure then failures directory exists.
         with:
           # TODO(terry): matrix.os currently empty. If we run tests on other
@@ -101,7 +104,7 @@ jobs:
 #          - master
 #    steps:
 #      - name: git clone
-#        uses: actions/checkout@v2
+#        uses: actions/checkout@d171c3b028d844f2bf14e9fdec0c58114451e4bf
 #      - name: tool/bots.sh
 #        env:
 #          BOT: ${{ matrix.bot }}


### PR DESCRIPTION
* Adds dependabot for github actions
* Pins current github actions that are utilized to a hash
* This resolves the following code scanning vulnerabilities:
   * https://github.com/flutter/devtools/security/code-scanning/8
   * https://github.com/flutter/devtools/security/code-scanning/7
   * https://github.com/flutter/devtools/security/code-scanning/6
   * https://github.com/flutter/devtools/security/code-scanning/5
   * https://github.com/flutter/devtools/security/code-scanning/4
   * https://github.com/flutter/devtools/security/code-scanning/3
## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
