### PR TITLE
Profiler ellipsis and alignment fix

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_columns.dart
@@ -79,17 +79,11 @@ class TotalTimeColumn extends ColumnData<CpuStackFrame> {
 
 class MethodNameColumn extends TreeColumnData<CpuStackFrame> {
   MethodNameColumn() : super('Method');
-
-  static const maxMethodNameLength = 75;
-
   @override
   dynamic getValue(CpuStackFrame dataObject) => dataObject.name;
 
   @override
   String getDisplayValue(CpuStackFrame dataObject) {
-    if (dataObject.name.length > maxMethodNameLength) {
-      return dataObject.name.substring(0, maxMethodNameLength) + '...';
-    }
     return dataObject.name;
   }
 

--- a/packages/devtools_app/lib/src/service/resolved_uri_manager.dart
+++ b/packages/devtools_app/lib/src/service/resolved_uri_manager.dart
@@ -25,6 +25,7 @@ class ResolvedUriManager {
   /// [isolateId] The id of the isolate that the [uris] were generated on.
   /// [uris] List of uris to fetch package uris for.
   Future<void> fetchPackageUris(String isolateId, List<String> uris) async {
+    if (uris.isEmpty) return;
     if (_packagePathMappings != null) {
       final packageUris =
           (await serviceManager.service!.lookupPackageUris(isolateId, uris))

--- a/packages/devtools_app/lib/src/shared/table.dart
+++ b/packages/devtools_app/lib/src/shared/table.dart
@@ -1302,6 +1302,18 @@ class _TableRowState<T> extends State<TableRow<T>>
     }
   }
 
+  TextAlign _textAlignmentFor(ColumnData<T> column) {
+    switch (column.alignment) {
+      case ColumnAlignment.center:
+        return TextAlign.center;
+      case ColumnAlignment.right:
+        return TextAlign.right;
+      case ColumnAlignment.left:
+      default:
+        return TextAlign.left;
+    }
+  }
+
   MainAxisAlignment _mainAxisAlignmentFor(ColumnData<T> column) {
     switch (column.alignment) {
       case ColumnAlignment.center:
@@ -1379,6 +1391,7 @@ class _TableRowState<T> extends State<TableRow<T>>
             overflow: TextOverflow.ellipsis,
             style: contentTextStyle(column),
             maxLines: 1,
+            textAlign: _textAlignmentFor(column),
           );
         }
 


### PR DESCRIPTION
![](https://media.giphy.com/media/3oEduKVQdG4c0JVPSo/giphy-downsized.gif)

Fixes https://github.com/flutter/devtools/issues/2960

## Demo
NOTE: I made the `Source` column smaller **just for the demo**, so it would be easier to trigger the ellipsis

https://user-images.githubusercontent.com/1386322/171882974-8169a736-95cc-45f2-b379-4abc84a0ec62.mp4

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
