### PR TITLE
Add missing `textSelectionColor` 

### DIFF
--- a/packages/devtools_app/lib/src/shared/theme.dart
+++ b/packages/devtools_app/lib/src/shared/theme.dart
@@ -54,6 +54,7 @@ ThemeData _darkTheme(IdeTheme ideTheme) {
     backgroundColor: background,
     indicatorColor: devtoolsBlue[400]!,
     selectedRowColor: devtoolsGrey[600]!,
+    textSelectionColor: Colors.black,
   );
 }
 
@@ -69,6 +70,7 @@ ThemeData _lightTheme(IdeTheme ideTheme) {
     backgroundColor: background,
     indicatorColor: Colors.yellowAccent[400]!,
     selectedRowColor: devtoolsBlue[600]!,
+    textSelectionColor: Colors.white,
   );
 }
 
@@ -79,6 +81,7 @@ ThemeData _baseTheme({
   required Color backgroundColor,
   required Color indicatorColor,
   required Color selectedRowColor,
+  required Color textSelectionColor,
 }) {
   return theme.copyWith(
     primaryColor: primaryColor,
@@ -113,6 +116,9 @@ ThemeData _baseTheme({
         minimumSize: Size(buttonMinWidth, defaultButtonHeight),
         fixedSize: Size.fromHeight(defaultButtonHeight),
       ),
+    ),
+    textSelectionTheme: TextSelectionThemeData(
+      selectionColor: textSelectionColor,
     ),
   );
 }


### PR DESCRIPTION
We are using `theme.selectedTextStyle` in [`breakpoints.dart`](https://github.com/flutter/devtools/blob/278272dae6bd2d067426ff11cf7077a5ddfdbc74/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart#L76-L79) and [`call_stack.dart`](https://github.com/flutter/devtools/blob/278272dae6bd2d067426ff11cf7077a5ddfdbc74/packages/devtools_app/lib/src/screens/debugger/call_stack.dart#L72) but its properties are not set and therefore are all `null`. One consequence of this is that the circles next to breakpoints don't show up when we select them (because we are passing in `null` as color). 

This PR explicitly sets the color property to fix the selected breakpoints UI.

Before:
![Screen Shot 2022-06-03 at 3 30 56 PM](https://user-images.githubusercontent.com/21270878/171963501-d5403dd9-3340-4aa0-9172-702ee9fd3d61.png)
![Screen Shot 2022-06-03 at 3 29 38 PM](https://user-images.githubusercontent.com/21270878/171963542-687d0d9d-f609-4d35-8235-b35d20950f87.png)

After:
![Screen Shot 2022-06-03 at 3 30 49 PM](https://user-images.githubusercontent.com/21270878/171963507-aa082029-94ec-4f6a-8da3-e6b0aec8b1ff.png)
![Screen Shot 2022-06-03 at 3 29 45 PM](https://user-images.githubusercontent.com/21270878/171963523-41f4e5ad-b28d-4428-9aeb-f0f9430829e5.png)


