### PR TITLE
Add isolate selection support to memory screen + other minor UI fixes

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
@@ -80,15 +80,6 @@ class AllocationTableViewState extends State<AllocationTableView>
     super.didChangeDependencies();
     if (!initController()) return;
 
-    // Make sure that we actually initialize the tracker tree rather than
-    // relying on `controller.updateClassStackTraces` to be updated.
-    // TODO: find out why AllocationTableView isn't persisting when switching
-    // between the 'Analysis' and 'Allocations' tabs.
-    trackerData.createTrackerTree(
-      controller.trackAllocations,
-      controller.allocationSamples,
-    );
-
     cancelListeners();
 
     // TODO(terry): setState should be called to set our state not change the

--- a/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_allocation_table_view.dart
@@ -10,6 +10,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
+import '../../shared/common_widgets.dart';
 import '../../shared/split.dart';
 import '../../shared/table.dart';
 import '../../shared/table_data.dart';
@@ -63,7 +64,6 @@ class AllocationTableViewState extends State<AllocationTableView>
   @override
   void initState() {
     super.initState();
-
     // Setup the columns.
     columns.addAll([
       FieldTrack(),
@@ -79,6 +79,15 @@ class AllocationTableViewState extends State<AllocationTableView>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!initController()) return;
+
+    // Make sure that we actually initialize the tracker tree rather than
+    // relying on `controller.updateClassStackTraces` to be updated.
+    // TODO: find out why AllocationTableView isn't persisting when switching
+    // between the 'Analysis' and 'Allocations' tabs.
+    trackerData.createTrackerTree(
+      controller.trackAllocations,
+      controller.allocationSamples,
+    );
 
     cancelListeners();
 
@@ -178,17 +187,19 @@ class AllocationTableViewState extends State<AllocationTableView>
 
     if (controller.monitorAllocations.isEmpty) {
       // Display help text on how to monitor classes constructed.
-      return Center(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            const Text('Click the track button '),
-            trackImage(context),
-            const Text(
-              ' to begin monitoring changes in '
-              'memory instances (classes constructed).',
-            ),
-          ],
+      return OutlineDecoration(
+        child: Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Click the track button '),
+              trackImage(context),
+              const Text(
+                ' to begin monitoring changes in '
+                'memory instances (classes constructed).',
+              ),
+            ],
+          ),
         ),
       );
     }
@@ -218,7 +229,7 @@ class AllocationTableViewState extends State<AllocationTableView>
       minSizes: const [200, 0],
       axis: Axis.vertical,
       children: [
-        controller.allocationsFieldsTable!,
+        OutlineDecoration(child: controller.allocationsFieldsTable!),
         trackerData.createTrackingTable(
           context,
           controller,

--- a/packages/devtools_app/lib/src/screens/memory/memory_charts.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_charts.dart
@@ -160,8 +160,7 @@ class ChartsValues {
 
   List<Map<String, bool>> get extensionEvents {
     if (_extensionEvents.isEmpty) {
-      final events =
-          _event[extensionEventsJsonName] as List<Map<String, bool>>;
+      final events = _event[extensionEventsJsonName] as List<Map<String, bool>>;
       _extensionEvents.addAll(events);
     }
     return _extensionEvents;

--- a/packages/devtools_app/lib/src/screens/memory/memory_charts.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_charts.dart
@@ -113,9 +113,9 @@ class ChartsValues {
 
   final int timestamp;
 
-  final _event = <String, Object>{};
+  final _event = <String, bool>{};
 
-  final _extensionEvents = <Map<String, Object>>[];
+  final _extensionEvents = <Map<String, bool>>[];
 
   Map<String, Object> get vmData => _vm;
 
@@ -158,10 +158,10 @@ class ChartsValues {
   int get extensionEventsLength =>
       hasExtensionEvents ? extensionEvents.length : 0;
 
-  List<Map<String, Object>> get extensionEvents {
+  List<Map<String, bool>> get extensionEvents {
     if (_extensionEvents.isEmpty) {
       final events =
-          _event[extensionEventsJsonName] as List<Map<String, Object>>;
+          _event[extensionEventsJsonName] as List<Map<String, bool>>;
       _extensionEvents.addAll(events);
     }
     return _extensionEvents;

--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -905,10 +905,11 @@ class MemoryController extends DisposableController
   }
 
   Future<HeapSnapshotGraph?> snapshotMemory() async {
-    if (serviceManager.isolateManager.selectedIsolate.value == null)
+    final isolate = serviceManager.isolateManager.selectedIsolate.value;
+    if (isolate == null)
       return null;
     return await serviceManager.service?.getHeapSnapshotGraph(
-      serviceManager.isolateManager.selectedIsolate.value!,
+      isolate,
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -906,8 +906,7 @@ class MemoryController extends DisposableController
 
   Future<HeapSnapshotGraph?> snapshotMemory() async {
     final isolate = serviceManager.isolateManager.selectedIsolate.value;
-    if (isolate == null)
-      return null;
+    if (isolate == null) return null;
     return await serviceManager.service?.getHeapSnapshotGraph(
       isolate,
     );

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -435,9 +435,7 @@ class HeapTreeViewState extends State<HeapTree>
                     _buildSnapshotControls(themeData.textTheme),
                     const SizedBox(height: denseRowSpacing),
                     Expanded(
-                      child: OutlineDecoration(
-                        child: buildSnapshotTables(snapshotDisplay),
-                      ),
+                      child: buildSnapshotTables(snapshotDisplay),
                     ),
                   ],
                 ),
@@ -447,7 +445,9 @@ class HeapTreeViewState extends State<HeapTree>
                   children: [
                     _buildAllocationsControls(),
                     const SizedBox(height: denseRowSpacing),
-                    const Expanded(child: AllocationTableView()),
+                    const Expanded(
+                      child: AllocationTableView(),
+                    ),
                   ],
                 ),
               ],
@@ -461,14 +461,16 @@ class HeapTreeViewState extends State<HeapTree>
   Widget buildSnapshotTables(Widget? snapshotDisplay) {
     if (snapshotDisplay == null) {
       // Display help text about how to collect data.
-      return Center(
-        child: Row(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: const [
-            Text('Click the take heap snapshot button '),
-            Icon(Icons.camera),
-            Text(' to collect a graph of memory objects.'),
-          ],
+      return OutlineDecoration(
+        child: Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: const [
+              Text('Click the take heap snapshot button '),
+              Icon(Icons.camera),
+              Text(' to collect a graph of memory objects.'),
+            ],
+          ),
         ),
       );
     }
@@ -489,7 +491,7 @@ class HeapTreeViewState extends State<HeapTree>
               // TODO(terry): Need better focus handling between 2 tables & up/down
               //              arrows in the right-side field instance view table.
               snapshotDisplay,
-              rightSideTable,
+              OutlineDecoration(child: rightSideTable),
             ],
           );
   }
@@ -1451,7 +1453,7 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
   @override
   Widget build(BuildContext context) {
     final root = controller.buildTreeFromAllData();
-
+    Widget result;
     if (root != null && root.children.isNotEmpty) {
       // Snapshots and analyses exists display the trees.
       controller.groupByTreeTable = TreeTable<Reference>(
@@ -1464,11 +1466,12 @@ class MemoryHeapTableState extends State<MemoryHeapTable>
         selectionNotifier: controller.selectionSnapshotNotifier,
       );
 
-      return controller.groupByTreeTable;
+      result = controller.groupByTreeTable;
     } else {
       // Nothing collected yet (snapshots/analyses) - return an empty area.
-      return const SizedBox();
+      result = const SizedBox();
     }
+    return OutlineDecoration(child: result);
   }
 }
 
@@ -1502,9 +1505,6 @@ class _LibraryRefColumn extends TreeColumnData<Reference> {
   String getTooltip(Reference dataObject) {
     return dataObject.name ?? '';
   }
-
-  @override
-  double get fixedWidthPx => 250.0;
 }
 
 class _ClassOrInstanceCountColumn extends ColumnData<Reference> {

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -430,25 +430,29 @@ class HeapTreeViewState extends State<HeapTree>
               controller: _tabController,
               children: [
                 // Analysis Tab
-                Column(
-                  children: [
-                    _buildSnapshotControls(themeData.textTheme),
-                    const SizedBox(height: denseRowSpacing),
-                    Expanded(
-                      child: buildSnapshotTables(snapshotDisplay),
-                    ),
-                  ],
+                KeepAliveWrapper(
+                  child: Column(
+                    children: [
+                      _buildSnapshotControls(themeData.textTheme),
+                      const SizedBox(height: denseRowSpacing),
+                      Expanded(
+                        child: buildSnapshotTables(snapshotDisplay),
+                      ),
+                    ],
+                  ),
                 ),
 
                 // Allocations Tab
-                Column(
-                  children: [
-                    _buildAllocationsControls(),
-                    const SizedBox(height: denseRowSpacing),
-                    const Expanded(
-                      child: AllocationTableView(),
-                    ),
-                  ],
+                KeepAliveWrapper(
+                  child: Column(
+                    children: [
+                      _buildAllocationsControls(),
+                      const SizedBox(height: denseRowSpacing),
+                      const Expanded(
+                        child: AllocationTableView(),
+                      ),
+                    ],
+                  ),
                 ),
               ],
             ),

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_treemap.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_treemap.dart
@@ -85,8 +85,9 @@ class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
 
   @override
   Widget build(BuildContext context) {
+    Widget result;
     if (_sizes == null) {
-      return Column(
+      result = Column(
         children: [
           const SizedBox(height: denseRowSpacing),
           Expanded(
@@ -96,23 +97,24 @@ class MemoryHeapTreemapState extends State<MemoryHeapTreemap>
           ),
         ],
       );
+    } else {
+      result = Padding(
+        padding: const EdgeInsets.only(top: denseRowSpacing),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return Treemap.fromRoot(
+              rootNode: root,
+              levelsVisible: 2,
+              isOutermostLevel: true,
+              width: constraints.maxWidth,
+              height: constraints.maxHeight,
+              onRootChangedCallback: _onRootChanged,
+            );
+          },
+        ),
+      );
     }
-
-    return Padding(
-      padding: const EdgeInsets.only(top: denseRowSpacing),
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          return Treemap.fromRoot(
-            rootNode: root,
-            levelsVisible: 2,
-            isOutermostLevel: true,
-            width: constraints.maxWidth,
-            height: constraints.maxHeight,
-            onRootChangedCallback: _onRootChanged,
-          );
-        },
-      ),
-    );
+    return OutlineDecoration(child: result);
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_screen.dart
@@ -2,12 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../analytics/analytics.dart' as ga;
 import '../../charts/chart_controller.dart';
 import '../../primitives/auto_dispose_mixin.dart';
+import '../../primitives/listenable.dart';
 import '../../primitives/utils.dart';
 import '../../shared/banner_messages.dart';
 import '../../shared/common_widgets.dart';
@@ -44,6 +46,10 @@ class MemoryScreen extends Screen {
   static const id = 'memory';
 
   static const hoverKeyName = 'Chart Hover';
+
+  @override
+  ValueListenable<bool> get showIsolateSelector =>
+      const FixedValueListenable<bool>(true);
 
   @override
   String get docPageId => id;

--- a/packages/devtools_app/lib/src/screens/memory/memory_snapshot_models.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_snapshot_models.dart
@@ -378,8 +378,8 @@ class SnapshotReference extends Reference {
     final timestamp = snapshot.collectedTimestamp;
     final displayTimestamp = MemoryController.formattedTimestamp(timestamp);
     return snapshot.autoSnapshot
-        ? 'Snapshot $displayTimestamp Auto'
-        : 'Snapshot $displayTimestamp';
+        ? 'Snapshot (${snapshot.snapshotGraph.name}) $displayTimestamp Auto'
+        : 'Snapshot (${snapshot.snapshotGraph.name}) $displayTimestamp';
   }
 
   final Snapshot snapshot;

--- a/packages/devtools_app/lib/src/screens/memory/memory_tracker_model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_tracker_model.dart
@@ -8,6 +8,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/trees.dart';
 import '../../primitives/utils.dart';
+import '../../shared/common_widgets.dart';
 import '../../shared/split.dart';
 import '../../shared/table.dart';
 import '../../shared/table_data.dart';
@@ -141,7 +142,8 @@ class TreeTracker {
     Map<String, ClassRef> classesTracked,
     List<AllocationSamples> allocationSamples,
   ) {
-    final tree1Local = tree1 = TrackerClass('_ROOT_tracking');
+    tree1 ??= TrackerClass('_ROOT_tracking');
+    final tree1Local = tree1!;
 
     tree1Local.children.clear();
 
@@ -297,19 +299,21 @@ class TreeTracker {
       minSizes: const [trackInstancesViewWidth, callstackViewWidth],
       axis: Axis.horizontal,
       children: [
-        TreeTable<Tracker>(
-          columns: [
-            treeColumn,
-            _TrackerCountColumn(),
-          ],
-          dataRoots: tree1Local.children,
-          treeColumn: treeColumn,
-          keyFactory: (d) {
-            return Key(d.name);
-          },
-          sortColumn: treeColumn,
-          sortDirection: SortDirection.ascending,
-          selectionNotifier: selectionNotifier,
+        OutlineDecoration(
+          child: TreeTable<Tracker>(
+            columns: [
+              treeColumn,
+              _TrackerCountColumn(),
+            ],
+            dataRoots: tree1Local.children,
+            treeColumn: treeColumn,
+            keyFactory: (d) {
+              return Key(d.name);
+            },
+            sortColumn: treeColumn,
+            sortDirection: SortDirection.ascending,
+            selectionNotifier: selectionNotifier,
+          ),
         ),
         trackerAllocation == null
             ? allocationCallStackInstructions(context)

--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -497,8 +497,8 @@ class ServiceConnectionManager {
     if (uri == null) return false;
     assert(_serviceAvailable.isCompleted);
     assert(serviceManager.isolateManager.mainIsolate.value != null);
-    final isolate = isolateManager.mainIsolateDebuggerState!.isolateNow!;
-    return (isolate.libraries ?? [])
+    final isolate = isolateManager.mainIsolateDebuggerState!.isolateNow;
+    return (isolate?.libraries ?? [])
         .map((ref) => ref.uri)
         .toList()
         .any((u) => u?.startsWith(uri) == true);

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -191,6 +191,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     // Simulate a snapshot that takes .5 seconds.
     await Future.delayed(const Duration(milliseconds: 500));
     final result = MockHeapSnapshotGraph();
+    when(result.name).thenReturn('name');
     when(result.classes).thenReturn([]);
     when(result.objects).thenReturn([]);
     when(result.externalProperties).thenReturn([]);


### PR DESCRIPTION
While the live feed appears to display the sum of all memory consumption of each isolate, the heap snapshot mechanism only collects a snapshot for the currently selected isolate. Since there was no isolate picker enabled for the memory screen and no indication that snapshots are isolate dependent, there was no way to differentiate between snapshots and where they came from.

This change enables the isolate picker for the memory screen and displays the name of the active isolate corresponding to each snapshot to make it clearer that the snapshots correspond to individual isolates.

In addition, this change makes some minor UI tweaks, particularly with respect to how borders are drawn around the various components (e.g., there was no borders around widgets in a `Split`, making the actual footprint of the draggable bar unclear.

Finally, there's a fix for an issue where switching between the 'Analysis' and 'Allocations' tabs with classes selected for tracking would result in a null assertion being hit when trying to generate the 'Tracking' table. It seems that the `AllocationTableView` isn't kept
alive when switching tabs, causing a rebuild where we assumed some state was already initialized.

**Original Borders**
<img width="1792" alt="image" src="https://user-images.githubusercontent.com/24210656/172458231-b32a97ba-69cc-4923-9983-945e892ffbb7.png">

**Updated Borders + Isolate Selection**
<img width="1525" alt="image" src="https://user-images.githubusercontent.com/24210656/172458126-f44eea9a-4e04-413d-83f0-8b5f36cc5ba4.png">
