### PR TITLE
Some renamings in preferences.

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
@@ -130,7 +130,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
 
     return HoverCardTooltip(
       enabled: () =>
-          preferences.inspectorPreferences.hoverEvalModeEnabled.value &&
+          preferences.inspector.hoverEvalModeEnabled.value &&
           diagnosticLocal.inspectorService != null,
       onHover: (event) async {
         final group = inspectorService.createObjectGroup('hover');

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -348,7 +348,7 @@ class FlutterInspectorSettingsDialog extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           CheckboxSetting(
-            notifier: preferences.inspectorPreferences.hoverEvalModeEnabled
+            notifier: preferences.inspector.hoverEvalModeEnabled
                 as ValueNotifier<bool?>,
             title: 'Enable hover inspection',
             description:

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -69,11 +69,11 @@ class InspectorPreferencesController {
   static const _hoverEvalModeStorageId = 'inspector.hoverEvalMode';
 
   Future<void> init() async {
-    String? value = await storage.getValue(_hoverEvalModeStorageId);
+    String? hoverEvalMode = await storage.getValue(_hoverEvalModeStorageId);
 
     // When embedded, default hoverEvalMode to off
-    value ??= (!ideTheme.embed).toString();
-    toggleHoverEvalMode(value == 'true');
+    hoverEvalMode ??= (!ideTheme.embed).toString();
+    setHoverEvalMode(hoverEvalMode == 'true');
 
     _hoverEvalMode.addListener(() {
       storage.setValue(
@@ -86,7 +86,7 @@ class InspectorPreferencesController {
   }
 
   /// Change the value for the hover eval mode setting.
-  void toggleHoverEvalMode(bool enableHoverEvalMode) {
+  void setHoverEvalMode(bool enableHoverEvalMode) {
     _hoverEvalMode.value = enableHoverEvalMode;
   }
 }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -17,9 +17,8 @@ class PreferencesController {
   ValueListenable<bool> get vmDeveloperModeEnabled => _vmDeveloperMode;
   ValueListenable<bool> get denseModeEnabled => _denseMode;
 
-  InspectorPreferencesController get inspectorPreferences =>
-      _inspectorPreferences;
-  final _inspectorPreferences = InspectorPreferencesController();
+  InspectorPreferencesController get inspector => _inspector;
+  final _inspector = InspectorPreferencesController();
 
   Future<void> init() async {
     // Get the current values and listen for and write back changes.
@@ -41,7 +40,7 @@ class PreferencesController {
       storage.setValue('ui.denseMode', '${_denseMode.value}');
     });
 
-    await _inspectorPreferences.init();
+    await _inspector.init();
 
     setGlobal(PreferencesController, this);
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -69,11 +69,12 @@ class InspectorPreferencesController {
   static const _hoverEvalModeStorageId = 'inspector.hoverEvalMode';
 
   Future<void> init() async {
-    String? hoverEvalMode = await storage.getValue(_hoverEvalModeStorageId);
+    String? hoverEvalModeEnabledValue =
+        await storage.getValue(_hoverEvalModeStorageId);
 
     // When embedded, default hoverEvalMode to off
-    hoverEvalMode ??= (!ideTheme.embed).toString();
-    setHoverEvalMode(hoverEvalMode == 'true');
+    hoverEvalModeEnabledValue ??= (!ideTheme.embed).toString();
+    setHoverEvalMode(hoverEvalModeEnabledValue == 'true');
 
     _hoverEvalMode.addListener(() {
       storage.setValue(

--- a/packages/devtools_app/test/inspector/diagnostics_test.dart
+++ b/packages/devtools_app/test/inspector/diagnostics_test.dart
@@ -62,7 +62,7 @@ void main() {
       late DiagnosticsNodeDescription diagnosticsNodeDescription;
 
       setUp(() {
-        preferences.inspector.toggleHoverEvalMode(true);
+        preferences.inspector.setHoverEvalMode(true);
         diagnosticsNodeDescription = DiagnosticsNodeDescription(
           diagnostic,
           debuggerController: MockDebuggerController(),
@@ -80,7 +80,7 @@ void main() {
 
       testWidgets('can be disabled from preferences',
           (WidgetTester tester) async {
-        preferences.inspector.toggleHoverEvalMode(false);
+        preferences.inspector.setHoverEvalMode(false);
 
         await tester.pumpWidget(wrap(diagnosticsNodeDescription));
 

--- a/packages/devtools_app/test/inspector/diagnostics_test.dart
+++ b/packages/devtools_app/test/inspector/diagnostics_test.dart
@@ -62,7 +62,7 @@ void main() {
       late DiagnosticsNodeDescription diagnosticsNodeDescription;
 
       setUp(() {
-        preferences.inspectorPreferences.toggleHoverEvalMode(true);
+        preferences.inspector.toggleHoverEvalMode(true);
         diagnosticsNodeDescription = DiagnosticsNodeDescription(
           diagnostic,
           debuggerController: MockDebuggerController(),
@@ -80,7 +80,7 @@ void main() {
 
       testWidgets('can be disabled from preferences',
           (WidgetTester tester) async {
-        preferences.inspectorPreferences.toggleHoverEvalMode(false);
+        preferences.inspector.toggleHoverEvalMode(false);
 
         await tester.pumpWidget(wrap(diagnosticsNodeDescription));
 

--- a/packages/devtools_app/test/inspector/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_screen_test.dart
@@ -306,7 +306,7 @@ void main() {
       const startingHoverEvalModeValue = false;
 
       setUp(() {
-        preferences.inspector.toggleHoverEvalMode(startingHoverEvalModeValue);
+        preferences.inspector.setHoverEvalMode(startingHoverEvalModeValue);
       });
 
       testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/inspector/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_screen_test.dart
@@ -306,8 +306,7 @@ void main() {
       const startingHoverEvalModeValue = false;
 
       setUp(() {
-        preferences.inspectorPreferences
-            .toggleHoverEvalMode(startingHoverEvalModeValue);
+        preferences.inspector.toggleHoverEvalMode(startingHoverEvalModeValue);
       });
 
       testWidgetsWithWindowSize(
@@ -333,7 +332,7 @@ void main() {
         await tester.tap(hoverModeCheckBox);
         await tester.pumpAndSettle();
         expect(
-          preferences.inspectorPreferences.hoverEvalModeEnabled.value,
+          preferences.inspector.hoverEvalModeEnabled.value,
           !startingHoverEvalModeValue,
         );
       });

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -76,7 +76,7 @@ void main() {
 
       group('init', () {
         setUp(() {
-          controller.toggleHoverEvalMode(false);
+          controller.setHoverEvalMode(false);
         });
 
         test('enables hover mode by default', () async {
@@ -100,7 +100,7 @@ void main() {
           valueChanged = true;
         });
 
-        controller.toggleHoverEvalMode(newHoverModeValue);
+        controller.setHoverEvalMode(newHoverModeValue);
 
         final storedHoverModeValue =
             await storage.getValue('inspector.hoverEvalMode');


### PR DESCRIPTION
Rename field preferences.inspectorPreferences to preferences.inspector for better conciseness. 
Rename toggle.. to set.. because toggle should not take parameter.
Rename 'value' to hoverEvalModeEnabledValue, because other values will be here.