### PR TITLE
Add riverpod tool

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -32,6 +32,7 @@ import 'screens/performance/performance_screen.dart';
 import 'screens/profiler/profiler_screen.dart';
 import 'screens/profiler/profiler_screen_controller.dart';
 import 'screens/provider/provider_screen.dart';
+import 'screens/riverpod/riverpod_screen.dart';
 import 'screens/vm_developer/vm_developer_tools_controller.dart';
 import 'screens/vm_developer/vm_developer_tools_screen.dart';
 import 'service/service_extension_widgets.dart';
@@ -578,6 +579,7 @@ List<DevToolsScreen> get defaultScreens {
       createController: () => LoggingController(),
     ),
     DevToolsScreen<void>(const ProviderScreen(), createController: () {}),
+    DevToolsScreen<void>(const RiverpodScreen(), createController: () {}),
     DevToolsScreen<AppSizeController>(
       const AppSizeScreen(),
       createController: () => AppSizeController(),

--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
@@ -98,10 +98,13 @@ class InstanceViewer extends ConsumerStatefulWidget {
     Key? key,
     required this.rootPath,
     required this.showInternalProperties,
+    this.editable = true,
   }) : super(key: key);
 
   final InstancePath rootPath;
   final bool showInternalProperties;
+  /// If `false` disables editing capability, defaults to `true`.
+  final bool editable;
 
   @override
   _InstanceViewerState createState() => _InstanceViewerState();
@@ -187,6 +190,7 @@ class _InstanceViewerState extends ConsumerState<InstanceViewer> {
       isExpanded: isExpanded,
       title: instance.map(
         enumeration: (instance) => _EditableField(
+          editable: widget.editable,
           setter: instance.setter,
           initialEditString: '${instance.type}.${instance.value}',
           child: Text.rich(
@@ -202,11 +206,13 @@ class _InstanceViewerState extends ConsumerState<InstanceViewer> {
           ),
         ),
         nill: (instance) => _EditableField(
+          editable: widget.editable,
           setter: instance.setter,
           initialEditString: 'null',
           child: const Text('null', style: TextStyle(color: nullColor)),
         ),
         string: (instance) => _EditableField(
+          editable: widget.editable,
           setter: instance.setter,
           initialEditString: '"${instance.displayString}"',
           child: Text.rich(
@@ -223,6 +229,7 @@ class _InstanceViewerState extends ConsumerState<InstanceViewer> {
           ),
         ),
         number: (instance) => _EditableField(
+          editable: widget.editable,
           setter: instance.setter,
           initialEditString: instance.displayString,
           child: Text(
@@ -231,6 +238,7 @@ class _InstanceViewerState extends ConsumerState<InstanceViewer> {
           ),
         ),
         boolean: (instance) => _EditableField(
+          editable: widget.editable,
           setter: instance.setter,
           initialEditString: instance.displayString,
           child: Text(
@@ -475,11 +483,13 @@ class _EditableField extends StatefulWidget {
     required this.setter,
     required this.child,
     required this.initialEditString,
+    required this.editable,
   }) : super(key: key);
 
   final Widget child;
   final String initialEditString;
   final Future<void> Function(String)? setter;
+  final bool editable;
 
   @override
   _EditableFieldState createState() => _EditableFieldState();
@@ -504,7 +514,7 @@ class _EditableFieldState extends State<_EditableField> {
 
   @override
   Widget build(BuildContext context) {
-    if (widget.setter == null) return widget.child;
+    if (!widget.editable || widget.setter == null) return widget.child;
 
     final colorScheme = Theme.of(context).colorScheme;
 

--- a/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
@@ -176,7 +176,7 @@ class _ContainerListState extends ConsumerState<ContainerList> {
                       padding: tilePadding,
                       child: Expanded(
                         child: Text(
-                          'Container #${node.id}',
+                          'ProviderContainer #${node.id}',
                           overflow: TextOverflow.ellipsis,
                         ),
                       ),

--- a/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
@@ -175,7 +175,10 @@ class _ContainerListState extends ConsumerState<ContainerList> {
                       key: Key('container-${node.id}'),
                       padding: tilePadding,
                       child: Expanded(
-                        child: Text('Container #${node.id}'),
+                        child: Text(
+                          'Container #${node.id}',
+                          overflow: TextOverflow.ellipsis,
+                        ),
                       ),
                     ),
                   ProvidersList(

--- a/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
@@ -1,0 +1,161 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../../devtools_app.dart';
+import '../provider/instance_viewer/eval.dart';
+import 'nodes/container_node.dart';
+import 'providers_list.dart';
+import 'riverpod_eval.dart';
+
+final _containerIdsProvider = AutoDisposeFutureProvider<List<String>>(
+  (ref) async {
+    // recompute the list of containers on hot-restart
+    ref.watch(hotRestartEventProvider);
+    // cause the list of containers to be re-evaluated when notified of a change
+    ref.watch(_riverpodContainerListChanged);
+
+    final riverpodEval = await ref.watch(riverpodEvalFunctionProvider.future);
+    final containerIdRefs = await riverpodEval('containerNodes.keys.toList()');
+
+    return [
+      for (final idInstance in containerIdRefs.elements!)
+        idInstance.valueAsString!,
+    ];
+  },
+  name: '_containerIdsProvider',
+);
+
+const _riverpodEvents = [
+  'riverpod:container_list_changed',
+  'riverpod:provider_changed',
+];
+final _riverpodContainerListChanged = StreamProvider.autoDispose<void>(
+  (ref) async* {
+    final service = await ref.watch(serviceProvider.future);
+
+    yield* service.onExtensionEvent.where((event) {
+      return _riverpodEvents.contains(event.extensionKind);
+    });
+  },
+  name: '_riverpodContainerListChanged',
+);
+
+final _containerNodeProvider =
+    FutureProvider.autoDispose.family<ContainerNode, String>(
+  (ref, id) async {
+    // recompute the container information on hot-restart
+    ref.watch(hotRestartEventProvider);
+    // cause the container to be re-evaluated when notified of a change
+    ref.watch(_riverpodContainerListChanged);
+
+    final riverpodEval = await ref.watch(riverpodEvalFunctionProvider.future);
+    final providerElementsInstance = await riverpodEval(
+      'containerNodes["$id"]',
+    );
+
+    final evalField = await ref.watch(evalFieldFunctionProvider.future);
+    final riverpodNodes = await evalField(
+      'riverpodNodes',
+      providerElementsInstance,
+    );
+
+    final providers = await Future.wait(
+      riverpodNodes.associations!.map((a) => a.value).cast<InstanceRef>().map(
+        (element) async {
+          final evalInstance = await ref.watch(
+            evalInstanceFunctionProvider.future,
+          );
+          final riverpodNodeInstance = await evalInstance(element);
+
+          return ref.watch(
+            evalRiverpodNodeProvider(riverpodNodeInstance).future,
+          );
+        },
+      ),
+    );
+
+    return ContainerNode(
+      id: id,
+      providers: providers,
+    );
+  },
+  name: '_containerNodeProvider',
+);
+
+/// Combines [_containerIdsProvider] with [_containerNodeProvider] to obtain all
+/// the [ContainerNode]s at once.
+final containerNodesProvider = AutoDisposeFutureProvider<List<ContainerNode>>(
+  (ref) async {
+    final ids = await ref.watch(_containerIdsProvider.future);
+
+    final nodes = await Future.wait<ContainerNode>(
+      ids.map((id) => ref.watch(_containerNodeProvider(id).future)),
+    );
+
+    return nodes.toList();
+  },
+  name: 'containerNodesProvider',
+);
+
+const tilePadding = EdgeInsets.only(
+  left: defaultSpacing,
+  right: densePadding,
+  top: densePadding,
+  bottom: densePadding,
+);
+
+class ContainerList extends ConsumerStatefulWidget {
+  const ContainerList({Key? key}) : super(key: key);
+
+  @override
+  _ContainerListState createState() => _ContainerListState();
+}
+
+class _ContainerListState extends ConsumerState<ContainerList> {
+  final scrollController = ScrollController();
+
+  @override
+  void dispose() {
+    scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final nodes = ref.watch(containerNodesProvider);
+
+    return nodes.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (err, stack) => const Padding(
+        padding: tilePadding,
+        child: Text('<unknown error>'),
+      ),
+      data: (nodes) {
+        return Scrollbar(
+          controller: scrollController,
+          thumbVisibility: true,
+          child: ListView.builder(
+            primary: false,
+            controller: scrollController,
+            itemCount: nodes.length,
+            itemBuilder: (context, index) {
+              final node = nodes[index];
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Container(
+                    key: Key('container-${node.id}'),
+                    padding: tilePadding,
+                    child: Text('Container #${node.id}'),
+                  ),
+                  ProvidersList(nodes: node.providers)
+                ],
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/container_list.dart
@@ -174,7 +174,9 @@ class _ContainerListState extends ConsumerState<ContainerList> {
                     Container(
                       key: Key('container-${node.id}'),
                       padding: tilePadding,
-                      child: Text('Container #${node.id}'),
+                      child: Expanded(
+                        child: Text('Container #${node.id}'),
+                      ),
                     ),
                   ProvidersList(
                     nodes: node.providers,

--- a/packages/devtools_app/lib/src/screens/riverpod/nodes/container_node.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/nodes/container_node.dart
@@ -8,4 +8,11 @@ class ContainerNode {
 
   final String id;
   final List<RiverpodNode> providers;
+
+  ContainerNode copy({required List<RiverpodNode> providers}) {
+    return ContainerNode(
+      id: id,
+      providers: providers,
+    );
+  }
 }

--- a/packages/devtools_app/lib/src/screens/riverpod/nodes/container_node.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/nodes/container_node.dart
@@ -1,0 +1,11 @@
+import 'riverpod_node.dart';
+
+class ContainerNode {
+  const ContainerNode({
+    required this.id,
+    required this.providers,
+  });
+
+  final String id;
+  final List<RiverpodNode> providers;
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
@@ -3,7 +3,7 @@ class RiverpodNode {
     required this.id,
     required this.containerId,
     required this.stateId,
-    required this.type,
+    required this.argumentId,
     required this.name,
     required this.mightBeOutdated,
   });
@@ -11,21 +11,16 @@ class RiverpodNode {
   final String id;
   final String containerId;
   final String stateId;
-  final String type;
-  final String? name;
+  final String? argumentId;
+  final String name;
   final bool mightBeOutdated;
-
-  String get title {
-    final typeString = '$type()';
-    return name != null ? '$name - $typeString' : typeString;
-  }
 
   RiverpodNode copy({required String stateId}) {
     return RiverpodNode(
       id: id,
       containerId: containerId,
       stateId: stateId,
-      type: type,
+      argumentId: argumentId,
       name: name,
       mightBeOutdated: mightBeOutdated,
     );

--- a/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
@@ -1,0 +1,22 @@
+class RiverpodNode {
+  RiverpodNode({
+    required this.id,
+    required this.containerId,
+    required this.stateId,
+    required this.type,
+    required this.name,
+    required this.mightBeOutdated,
+  });
+
+  final String id;
+  final String containerId;
+  final String stateId;
+  final String type;
+  final String? name;
+  final bool mightBeOutdated;
+
+  String get title {
+    final typeString = '$type()';
+    return name != null ? '$name - $typeString' : typeString;
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/nodes/riverpod_node.dart
@@ -19,4 +19,15 @@ class RiverpodNode {
     final typeString = '$type()';
     return name != null ? '$name - $typeString' : typeString;
   }
+
+  RiverpodNode copy({required String stateId}) {
+    return RiverpodNode(
+      id: id,
+      containerId: containerId,
+      stateId: stateId,
+      type: type,
+      name: name,
+      mightBeOutdated: mightBeOutdated,
+    );
+  }
 }

--- a/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
@@ -67,7 +67,12 @@ class ContrainerProviderNodeElement extends ConsumerWidget {
         padding: tilePadding,
         child: Row(
           children: [
-            Expanded(child: Text(node.name)),
+            Expanded(
+              child: Text(
+                node.name,
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
             if (node.mightBeOutdated)
               const Padding(
                 padding: EdgeInsets.only(left: 8.0),

--- a/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../devtools_app.dart';
+import 'container_list.dart';
+import 'nodes/riverpod_node.dart';
+import 'selected_provider.dart';
+
+class ProvidersList extends StatelessWidget {
+  const ProvidersList({
+    Key? key,
+    required this.nodes,
+  }) : super(key: key);
+
+  final List<RiverpodNode> nodes;
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          for (final node in nodes)
+            ContrainerProviderNodeElement(
+              index: nodes.indexOf(node),
+              key: Key('riverpod-${node.id}'),
+              node: node,
+            )
+        ],
+      ),
+    );
+  }
+}
+
+class ContrainerProviderNodeElement extends ConsumerWidget {
+  const ContrainerProviderNodeElement({
+    Key? key,
+    required this.node,
+    required this.index,
+  }) : super(key: key);
+
+  final RiverpodNode node;
+  final int index;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isSelected = ref.watch(selectedNodeStateProvider)?.id == node.id;
+
+    final colorScheme = Theme.of(context).colorScheme;
+    final backgroundColor =
+        isSelected ? colorScheme.selectedRowBackgroundColor : null;
+
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () {
+        ref.read(selectedNodeStateProvider.notifier).state = node;
+      },
+      child: Container(
+        color: backgroundColor,
+        padding: tilePadding,
+        child: Row(
+          children: [
+            Text(node.title),
+            if (node.mightBeOutdated)
+              const Padding(
+                padding: EdgeInsets.only(left: 8.0),
+                child: Tooltip(
+                  message: "This provider's state might be out of date.",
+                  child: Icon(
+                    Icons.warning,
+                    size: 18,
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
@@ -67,7 +67,7 @@ class ContrainerProviderNodeElement extends ConsumerWidget {
         padding: tilePadding,
         child: Row(
           children: [
-            Text(node.name),
+            Expanded(child: Text(node.name)),
             if (node.mightBeOutdated)
               const Padding(
                 padding: EdgeInsets.only(left: 8.0),

--- a/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/providers_list.dart
@@ -10,26 +10,32 @@ class ProvidersList extends StatelessWidget {
   const ProvidersList({
     Key? key,
     required this.nodes,
+    required this.addPadding,
   }) : super(key: key);
 
   final List<RiverpodNode> nodes;
+  final bool addPadding;
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-      padding: const EdgeInsets.only(left: 20),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          for (final node in nodes)
-            ContrainerProviderNodeElement(
-              index: nodes.indexOf(node),
-              key: Key('riverpod-${node.id}'),
-              node: node,
-            )
-        ],
-      ),
+    final child = Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final node in nodes)
+          ContrainerProviderNodeElement(
+            index: nodes.indexOf(node),
+            key: Key('riverpod-${node.id}'),
+            node: node,
+          )
+      ],
     );
+
+    return addPadding
+        ? Padding(
+            padding: const EdgeInsets.only(left: 20),
+            child: child,
+          )
+        : child;
   }
 }
 
@@ -61,7 +67,7 @@ class ContrainerProviderNodeElement extends ConsumerWidget {
         padding: tilePadding,
         child: Row(
           children: [
-            Text(node.title),
+            Text(node.name),
             if (node.mightBeOutdated)
               const Padding(
                 padding: EdgeInsets.only(left: 8.0),

--- a/packages/devtools_app/lib/src/screens/riverpod/refresh_state_button.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/refresh_state_button.dart
@@ -14,13 +14,14 @@ class RefreshNotifier {
   void refresh() => _controller.add(null);
 }
 
-final _refreshNotifierProvider = Provider(
+@visibleForTesting
+final refreshNotifierProvider = Provider(
   (ref) => RefreshNotifier(),
-  name: '_refreshNotifierProvider',
+  name: 'refreshNotifierProvider',
 );
 
 final refreshProvider = StreamProvider(
-  (ref) => ref.read(_refreshNotifierProvider).stream,
+  (ref) => ref.read(refreshNotifierProvider).stream,
   name: 'refreshProvider',
 );
 
@@ -36,7 +37,7 @@ class RefreshStateButton extends ConsumerWidget {
       child: OutlinedIconButton(
         icon: Icons.refresh,
         onPressed: () {
-          ref.read(_refreshNotifierProvider).refresh();
+          ref.read(refreshNotifierProvider).refresh();
         },
       ),
     );

--- a/packages/devtools_app/lib/src/screens/riverpod/refresh_state_button.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/refresh_state_button.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../devtools_app.dart';
+
+class RefreshNotifier {
+  RefreshNotifier();
+
+  final _controller = StreamController<void>();
+  Stream<void> get stream => _controller.stream;
+
+  void refresh() => _controller.add(null);
+}
+
+final _refreshNotifierProvider = Provider(
+  (ref) => RefreshNotifier(),
+  name: '_refreshNotifierProvider',
+);
+
+final refreshProvider = StreamProvider(
+  (ref) => ref.read(_refreshNotifierProvider).stream,
+  name: 'refreshProvider',
+);
+
+class RefreshStateButton extends ConsumerWidget {
+  const RefreshStateButton({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Tooltip(
+      message: 'Refresh selected provider value',
+      child: OutlinedIconButton(
+        icon: Icons.refresh,
+        onPressed: () {
+          ref.read(_refreshNotifierProvider).refresh();
+        },
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_eval.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_eval.dart
@@ -1,0 +1,82 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../shared/eval_on_dart_library.dart';
+import '../provider/instance_viewer/eval.dart';
+import 'nodes/riverpod_node.dart';
+
+final _riverpodEvalProvider =
+    libraryEvalProvider('package:riverpod/src/provider.dart');
+
+final riverpodEvalFunctionProvider = FutureProvider.autoDispose(
+  (ref) async {
+    final isAlive = Disposable();
+    ref.onDispose(isAlive.dispose);
+
+    final eval = await ref.watch(_riverpodEvalProvider.future);
+
+    return (String query) => eval.evalInstance(
+          'RiverpodBinding.debugInstance.$query',
+          isAlive: isAlive,
+        );
+  },
+  name: 'riverpodEvalFunctionProvider',
+);
+
+final evalFieldFunctionProvider = FutureProvider.autoDispose(
+  (ref) async {
+    final isAlive = Disposable();
+    ref.onDispose(isAlive.dispose);
+
+    final eval = await ref.watch(_riverpodEvalProvider.future);
+
+    return (String name, Instance instance) => eval.safeGetInstance(
+          instance.fields!.firstWhere((e) => e.decl?.name == name).value
+              as InstanceRef,
+          isAlive,
+        );
+  },
+  name: 'evalFieldFunctionProvider',
+);
+
+final evalRiverpodNodeProvider = FutureProvider.autoDispose.family(
+  (ref, Instance instance) async {
+    final evalField = await ref.watch(evalFieldFunctionProvider.future);
+
+    Future<MapEntry<String, Instance>> mapEntryForKey(String key) async {
+      return MapEntry(key, await evalField(key, instance));
+    }
+
+    final fieldsMap = Map.fromEntries(
+      await Future.wait([
+        for (final field in instance.fields!) mapEntryForKey(field.decl!.name!)
+      ]),
+    );
+
+    return RiverpodNode(
+      id: fieldsMap['id']!.valueAsString!,
+      containerId: fieldsMap['containerId']!.valueAsString!,
+      name: fieldsMap['name']!.kind == InstanceKind.kNull
+          ? null
+          : fieldsMap['name']!.valueAsString,
+      type: fieldsMap['type']!.valueAsString!,
+      stateId: fieldsMap['state']!.id!,
+      mightBeOutdated: fieldsMap['mightBeOutdated']!.valueAsString == 'true',
+    );
+  },
+  name: 'evalRiverpodNodeProvider',
+);
+
+final evalInstanceFunctionProvider = FutureProvider.autoDispose(
+  (ref) async {
+    final isAlive = Disposable();
+    ref.onDispose(isAlive.dispose);
+    final eval = await ref.watch(_riverpodEvalProvider.future);
+
+    return (InstanceRef instanceRef) => eval.safeGetInstance(
+          instanceRef,
+          isAlive,
+        );
+  },
+  name: 'evalInstanceFunctionProvider',
+);

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_eval.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_eval.dart
@@ -56,11 +56,11 @@ final evalRiverpodNodeProvider = FutureProvider.autoDispose.family(
     return RiverpodNode(
       id: fieldsMap['id']!.valueAsString!,
       containerId: fieldsMap['containerId']!.valueAsString!,
-      name: fieldsMap['name']!.kind == InstanceKind.kNull
-          ? null
-          : fieldsMap['name']!.valueAsString,
-      type: fieldsMap['type']!.valueAsString!,
+      name: fieldsMap['name']!.valueAsString!,
       stateId: fieldsMap['state']!.id!,
+      argumentId: fieldsMap['argument']?.kind == InstanceKind.kNull
+          ? null
+          : fieldsMap['argument']?.id,
       mightBeOutdated: fieldsMap['mightBeOutdated']!.valueAsString == 'true',
     );
   },

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../devtools_app.dart';
+import 'container_list.dart';
+import 'riverpod_eval.dart';
+import 'selected_provider.dart';
+
+final _supportsDevToolProvider = FutureProvider.autoDispose<bool>(
+  (ref) async {
+    try {
+      final riverpodEval = await ref.watch(riverpodEvalFunctionProvider.future);
+      final supportsDevToolRef = await riverpodEval('supportsDevTool');
+
+      return supportsDevToolRef.valueAsString == 'true';
+    } catch (_) {
+      return false;
+    }
+  },
+  name: '_supportsDevToolProvider',
+);
+
+class RiverpodScreen extends Screen {
+  const RiverpodScreen()
+      : super.conditional(
+          id: id,
+          requiresLibrary: 'package:riverpod/',
+          title: 'Riverpod',
+          requiresDebugBuild: true,
+          icon: Icons.attach_file,
+        );
+
+  static const id = 'riverpod';
+
+  @override
+  Widget build(BuildContext context) {
+    return const RiverpodScreenWrapper();
+  }
+}
+
+class RiverpodScreenWrapper extends ConsumerWidget {
+  const RiverpodScreenWrapper({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return ref.watch(_supportsDevToolProvider).maybeWhen(
+          orElse: () => const Text('Loading...'),
+          data: (supportsDevTool) {
+            if (!supportsDevTool) {
+              return const Text(
+                "The version of riverpod package that you're using does not "
+                'support devtools, please update to a compatible version.',
+              );
+            }
+
+            final splitAxis = Split.axisFor(context, 0.85);
+
+            return Split(
+              axis: splitAxis,
+              initialFractions: const [0.33, 0.67],
+              children: [
+                OutlineDecoration(
+                  child: Column(
+                    children: const [
+                      AreaPaneHeader(
+                        needsTopBorder: false,
+                        title: Text('Containers'),
+                      ),
+                      Expanded(
+                        child: ContainerList(),
+                      ),
+                    ],
+                  ),
+                ),
+                const SelectedProviderPanel(),
+              ],
+            );
+          },
+        );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
@@ -52,7 +52,7 @@ class RiverpodScreenWrapper extends ConsumerWidget {
                         title: Text(
                           multiContainer.maybeWhen(
                             data: (multiContainer) =>
-                                multiContainer ? 'Containers' : 'Providers',
+                                multiContainer ? 'ProviderContainers' : 'Providers',
                             orElse: () => '',
                           ),
                         ),

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
@@ -3,22 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../../devtools_app.dart';
 import 'container_list.dart';
-import 'riverpod_eval.dart';
 import 'selected_provider.dart';
-
-final _supportsDevToolProvider = FutureProvider.autoDispose<bool>(
-  (ref) async {
-    try {
-      final riverpodEval = await ref.watch(riverpodEvalFunctionProvider.future);
-      final supportsDevToolRef = await riverpodEval('supportsDevTool');
-
-      return supportsDevToolRef.valueAsString == 'true';
-    } catch (_) {
-      return false;
-    }
-  },
-  name: '_supportsDevToolProvider',
-);
 
 class RiverpodScreen extends Screen {
   const RiverpodScreen()
@@ -43,14 +28,12 @@ class RiverpodScreenWrapper extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return ref.watch(_supportsDevToolProvider).maybeWhen(
-          orElse: () => const Text('Loading...'),
+    return ref.watch(supportsDevToolProvider).when(
+          loading: () => const Text('Loading...'),
+          error: (_, __) => const _UnsupportedMessage(),
           data: (supportsDevTool) {
             if (!supportsDevTool) {
-              return const Text(
-                "The version of riverpod package that you're using does not "
-                'support devtools, please update to a compatible version.',
-              );
+              return const _UnsupportedMessage();
             }
 
             final splitAxis = Split.axisFor(context, 0.85);
@@ -77,5 +60,20 @@ class RiverpodScreenWrapper extends ConsumerWidget {
             );
           },
         );
+  }
+}
+
+class _UnsupportedMessage extends StatelessWidget {
+  const _UnsupportedMessage()
+      : super(
+          key: const Key('riverpod-unsupported-message'),
+        );
+
+  @override
+  Widget build(BuildContext context) {
+    return const Text(
+      "The version of riverpod package that you're using does not "
+      'support devtools, please update to a compatible version.',
+    );
   }
 }

--- a/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/riverpod_screen.dart
@@ -28,6 +28,8 @@ class RiverpodScreenWrapper extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
+    final multiContainer = ref.watch(multiContainerProvider);
+
     return ref.watch(supportsDevToolProvider).when(
           loading: () => const Text('Loading...'),
           error: (_, __) => const _UnsupportedMessage(),
@@ -44,12 +46,18 @@ class RiverpodScreenWrapper extends ConsumerWidget {
               children: [
                 OutlineDecoration(
                   child: Column(
-                    children: const [
+                    children: [
                       AreaPaneHeader(
                         needsTopBorder: false,
-                        title: Text('Containers'),
+                        title: Text(
+                          multiContainer.maybeWhen(
+                            data: (multiContainer) =>
+                                multiContainer ? 'Containers' : 'Providers',
+                            orElse: () => '',
+                          ),
+                        ),
                       ),
-                      Expanded(
+                      const Expanded(
                         child: ContainerList(),
                       ),
                     ],

--- a/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
@@ -57,7 +57,7 @@ class SelectedProviderPanel extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final selectedNode = ref.watch(selectedNodeProvider);
     final detailsTitleText =
-        selectedNode != null ? selectedNode.title : '[No provider selected]';
+        selectedNode != null ? selectedNode.name : '[No provider selected]';
 
     return OutlineDecoration(
       child: Column(
@@ -70,16 +70,87 @@ class SelectedProviderPanel extends ConsumerWidget {
               RefreshStateButton(),
             ],
           ),
-          if (selectedNode != null)
-            Expanded(
-              child: InstanceViewer(
-                rootPath: InstancePath.fromInstanceId(
-                  selectedNode.stateId,
-                ),
-                showInternalProperties: ref.watch(showInternalsProvider),
-              ),
-            )
+          if (selectedNode != null) _Content(selectedNode: selectedNode),
         ],
+      ),
+    );
+  }
+}
+
+class _Content extends ConsumerWidget {
+  const _Content({
+    Key? key,
+    required this.selectedNode,
+  }) : super(key: key);
+
+  final RiverpodNode selectedNode;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return selectedNode.argumentId != null
+        ? Expanded(
+            child: Split(
+              axis: Axis.vertical,
+              initialFractions: const [0.2, 0.8],
+              children: [
+                _ViewerWithLabel(
+                  instanceId: selectedNode.argumentId!,
+                  label: 'Family argument:',
+                ),
+                _ViewerWithLabel(
+                  instanceId: selectedNode.stateId,
+                  label: 'State:',
+                )
+              ],
+            ),
+          )
+        : _ViewerBody(
+            instanceId: selectedNode.stateId,
+          );
+  }
+}
+
+class _ViewerWithLabel extends ConsumerWidget {
+  const _ViewerWithLabel({
+    Key? key,
+    required this.instanceId,
+    required this.label,
+  }) : super(key: key);
+
+  final String instanceId;
+  final String label;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.all(8.0),
+          child: Text(label),
+        ),
+        _ViewerBody(instanceId: instanceId),
+      ],
+    );
+  }
+}
+
+class _ViewerBody extends ConsumerWidget {
+  const _ViewerBody({
+    Key? key,
+    required this.instanceId,
+  }) : super(key: key);
+
+  final String instanceId;
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    return Expanded(
+      child: InstanceViewer(
+        rootPath: InstancePath.fromInstanceId(
+          instanceId,
+        ),
+        showInternalProperties: ref.watch(showInternalsProvider),
       ),
     );
   }

--- a/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
@@ -94,6 +94,7 @@ class _Content extends ConsumerWidget {
               initialFractions: const [0.2, 0.8],
               children: [
                 _ViewerWithLabel(
+                  editable: false,
                   instanceId: selectedNode.argumentId!,
                   label: 'Family argument:',
                 ),
@@ -115,10 +116,12 @@ class _ViewerWithLabel extends ConsumerWidget {
     Key? key,
     required this.instanceId,
     required this.label,
+    this.editable = true,
   }) : super(key: key);
 
   final String instanceId;
   final String label;
+  final bool editable;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -129,7 +132,7 @@ class _ViewerWithLabel extends ConsumerWidget {
           padding: const EdgeInsets.all(8.0),
           child: Text(label),
         ),
-        _ViewerBody(instanceId: instanceId),
+        _ViewerBody(instanceId: instanceId, editable: editable),
       ],
     );
   }
@@ -139,14 +142,17 @@ class _ViewerBody extends ConsumerWidget {
   const _ViewerBody({
     Key? key,
     required this.instanceId,
+    this.editable = true,
   }) : super(key: key);
 
   final String instanceId;
+  final bool editable;
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Expanded(
       child: InstanceViewer(
+        editable: editable,
         rootPath: InstancePath.fromInstanceId(
           instanceId,
         ),

--- a/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../devtools_app.dart';
+import '../provider/instance_viewer/eval.dart';
+import '../provider/instance_viewer/instance_details.dart';
+import '../provider/instance_viewer/instance_viewer.dart';
+import 'nodes/riverpod_node.dart';
+import 'refresh_state_button.dart';
+import 'riverpod_eval.dart';
+import 'settings_dialog_button.dart';
+
+final selectedNodeStateProvider = StateProvider<RiverpodNode?>(
+  (ref) => null,
+  name: 'selectedNodeStateProvider',
+);
+
+final _updatedRiverpodNodeProvider =
+    FutureProvider.autoDispose.family<RiverpodNode?, RiverpodNode>(
+  (ref, RiverpodNode node) async {
+    // recompute the value on hot restart
+    ref.watch(hotRestartEventProvider);
+    // refresh the value when the refresh button is pressed
+    ref.watch(refreshProvider);
+
+    final riverpodEval = await ref.watch(riverpodEvalFunctionProvider.future);
+    final nodeRef = await riverpodEval(
+      'getProvider("${node.containerId}", "${node.id}")',
+    );
+
+    return ref.watch(evalRiverpodNodeProvider(nodeRef).future);
+  },
+  name: '_updatedRiverpodNodeProvider',
+);
+
+final _selectedNodeProvider = Provider.autoDispose(
+  (ref) {
+    final selectedNode = ref.watch(selectedNodeStateProvider);
+    if (selectedNode == null) {
+      return null;
+    }
+    final refreshedNode =
+        ref.watch(_updatedRiverpodNodeProvider(selectedNode)).valueOrNull;
+    return refreshedNode;
+  },
+  name: '_selectedNodeProvider',
+);
+
+class SelectedProviderPanel extends ConsumerWidget {
+  const SelectedProviderPanel({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final selectedNode = ref.watch(_selectedNodeProvider);
+    final detailsTitleText =
+        selectedNode != null ? selectedNode.title : '[No provider selected]';
+
+    return OutlineDecoration(
+      child: Column(
+        children: [
+          AreaPaneHeader(
+            needsTopBorder: false,
+            title: Text(detailsTitleText),
+            actions: const [
+              SettingsDialogButton(),
+              RefreshStateButton(),
+            ],
+          ),
+          if (selectedNode != null)
+            Expanded(
+              child: InstanceViewer(
+                rootPath: InstancePath.fromInstanceId(
+                  selectedNode.stateId,
+                ),
+                showInternalProperties: ref.watch(showInternalsProvider),
+              ),
+            )
+        ],
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/selected_provider.dart
@@ -15,7 +15,8 @@ final selectedNodeStateProvider = StateProvider<RiverpodNode?>(
   name: 'selectedNodeStateProvider',
 );
 
-final _updatedRiverpodNodeProvider =
+@visibleForTesting
+final updatedRiverpodNodeProvider =
     FutureProvider.autoDispose.family<RiverpodNode?, RiverpodNode>(
   (ref, RiverpodNode node) async {
     // recompute the value on hot restart
@@ -30,20 +31,21 @@ final _updatedRiverpodNodeProvider =
 
     return ref.watch(evalRiverpodNodeProvider(nodeRef).future);
   },
-  name: '_updatedRiverpodNodeProvider',
+  name: 'updatedRiverpodNodeProvider',
 );
 
-final _selectedNodeProvider = Provider.autoDispose(
+@visibleForTesting
+final selectedNodeProvider = Provider.autoDispose(
   (ref) {
     final selectedNode = ref.watch(selectedNodeStateProvider);
     if (selectedNode == null) {
       return null;
     }
     final refreshedNode =
-        ref.watch(_updatedRiverpodNodeProvider(selectedNode)).valueOrNull;
+        ref.watch(updatedRiverpodNodeProvider(selectedNode)).valueOrNull;
     return refreshedNode;
   },
-  name: '_selectedNodeProvider',
+  name: 'selectedNodeProvider',
 );
 
 class SelectedProviderPanel extends ConsumerWidget {
@@ -53,7 +55,7 @@ class SelectedProviderPanel extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final selectedNode = ref.watch(_selectedNodeProvider);
+    final selectedNode = ref.watch(selectedNodeProvider);
     final detailsTitleText =
         selectedNode != null ? selectedNode.title : '[No provider selected]';
 

--- a/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
@@ -42,8 +42,9 @@ class _StateInspectorSettingsDialog extends ConsumerWidget {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           InkWell(
-            onTap: () =>
-                ref.read(showInternalsProvider.notifier).update((state) => !state),
+            onTap: () => ref
+                .read(showInternalsProvider.notifier)
+                .update((state) => !state),
             child: Row(
               children: [
                 Checkbox(

--- a/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../../devtools_app.dart';
+import '../../shared/dialogs.dart';
+
+final showInternalsProvider = StateProvider<bool>(
+  (ref) => false,
+  name: 'showInternalsProvider',
+);
+
+class SettingsDialogButton extends StatelessWidget {
+  const SettingsDialogButton({
+    Key? key,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return SettingsOutlinedButton(
+      onPressed: () {
+        showDialog(
+          context: context,
+          builder: (_) => _StateInspectorSettingsDialog(),
+        );
+      },
+    );
+  }
+}
+
+class _StateInspectorSettingsDialog extends ConsumerWidget {
+  static const title = 'State inspector configurations';
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final theme = Theme.of(context);
+
+    return DevToolsDialog(
+      title: dialogTitleText(theme, title),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          InkWell(
+            onTap: () =>
+                ref.read(showInternalsProvider.notifier).update((state) => !state),
+            child: Row(
+              children: [
+                Checkbox(
+                  value: ref.watch(showInternalsProvider),
+                  onChanged: (_) => ref
+                      .read(showInternalsProvider.notifier)
+                      .update((state) => !state),
+                ),
+                const Text(
+                  'Show private properties inherited from SDKs/packages',
+                ),
+              ],
+            ),
+          )
+        ],
+      ),
+      actions: [
+        DialogCloseButton(),
+      ],
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
+++ b/packages/devtools_app/lib/src/screens/riverpod/settings_dialog_button.dart
@@ -37,6 +37,7 @@ class _StateInspectorSettingsDialog extends ConsumerWidget {
     return DevToolsDialog(
       title: dialogTitleText(theme, title),
       content: Column(
+        key: const Key('state-inspector-settings-dialog'),
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [

--- a/packages/devtools_app/test/fixtures/riverpod_app/lib/main.dart
+++ b/packages/devtools_app/test/fixtures/riverpod_app/lib/main.dart
@@ -26,6 +26,11 @@ final counterProvider = StateNotifierProvider<Counter, int>(
   name: 'counterProvider',
 );
 
+final secondCounterProvider = StateNotifierProvider<Counter, int>(
+  (ref) => Counter(),
+  name: 'secondCounterProvider',
+);
+
 class MyApp extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -41,6 +46,10 @@ class MyApp extends ConsumerWidget {
               const Text('You clicked this many times on the button:'),
               Text(
                 ref.watch(counterProvider).toString(),
+                style: Theme.of(context).textTheme.headline4,
+              ),
+              Text(
+                ref.watch(secondCounterProvider).toString(),
                 style: Theme.of(context).textTheme.headline4,
               ),
             ],

--- a/packages/devtools_app/test/fixtures/riverpod_app/lib/main.dart
+++ b/packages/devtools_app/test/fixtures/riverpod_app/lib/main.dart
@@ -21,7 +21,10 @@ void main() {
   );
 }
 
-final counterProvider = StateNotifierProvider<Counter, int>((ref) => Counter());
+final counterProvider = StateNotifierProvider<Counter, int>(
+  (ref) => Counter(),
+  name: 'counterProvider',
+);
 
 class MyApp extends ConsumerWidget {
   @override

--- a/packages/devtools_app/test/fixtures/riverpod_app/pubspec.yaml
+++ b/packages/devtools_app/test/fixtures/riverpod_app/pubspec.yaml
@@ -9,7 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_riverpod: ^2.0.0-dev.5
+  flutter_riverpod: 
+    path: /Users/adson.leal/dev/personal/riverpod/packages/flutter_riverpod # TODO: need to use an actual version
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_app/test/riverpod/riverpod_screen_integration_test.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_screen_integration_test.dart
@@ -1,0 +1,107 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/riverpod/container_list.dart';
+import 'package:devtools_app/src/shared/eval_on_dart_library.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_infra/flutter_test_driver.dart' show FlutterRunConfiguration;
+import '../test_infra/flutter_test_driver.dart';
+import '../test_infra/flutter_test_environment.dart';
+import 'riverpod_test_helpers.dart';
+
+void main() async {
+  final FlutterTestEnvironment env = FlutterTestEnvironment(
+    const FlutterRunConfiguration(withDebugger: true),
+    testAppDirectory: 'test/fixtures/riverpod_app',
+  );
+
+  late EvalOnDartLibrary evalOnDartLibrary;
+  late Disposable isAlive;
+
+  setUp(() async {
+    setGlobal(IdeTheme, getIdeTheme());
+    await env.setupEnvironment(
+      config: const FlutterRunConfiguration(withDebugger: true),
+    );
+    await serviceManager.service!.allFuturesCompleted;
+
+    isAlive = Disposable();
+    evalOnDartLibrary = EvalOnDartLibrary(
+      'package:riverpod_app/main.dart',
+      env.service,
+    );
+  });
+
+  tearDown(() async {
+    isAlive.dispose();
+    evalOnDartLibrary.dispose();
+    await env.tearDownEnvironment(force: true);
+  });
+
+  Future<void> tapIncrement() {
+    return evalOnDartLibrary.asyncEval(
+      'await tester.tap(find.byKey(Key("increment"))).then((_) => tester.pump())',
+      isAlive: isAlive,
+    );
+  }
+
+  test(
+    'should load containerNodesProvider with providers sorted by name',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final sub = container.listen(
+        containerNodesProvider.future,
+        (prev, next) {},
+      );
+
+      await tapIncrement();
+
+      await expectLater(
+        sub.read(),
+        completion([
+          matchContainerNode(
+            id: '0',
+            providers: [
+              matchRiverpodNode(
+                id: '0',
+                containerId: '0',
+                title:
+                    'counterProvider - StateNotifierProvider<Counter, int>()',
+              ),
+              matchRiverpodNode(
+                id: '1',
+                containerId: '0',
+                title:
+                    'counterProvider.notifier - _NotifierProvider<Counter, int>()',
+              ),
+            ],
+          ),
+        ]),
+      );
+    },
+    timeout: const Timeout.factor(8),
+  );
+
+  test(
+    'should return true for supportsDevToolProvider',
+    () async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final sub = container.listen(
+        supportsDevToolProvider.future,
+        (prev, next) {},
+      );
+
+      await expectLater(sub.read(), completion(isTrue));
+    },
+    timeout: const Timeout.factor(8),
+  );
+}

--- a/packages/devtools_app/test/riverpod/riverpod_screen_integration_test.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_screen_integration_test.dart
@@ -61,8 +61,6 @@ void main() async {
         (prev, next) {},
       );
 
-      await tapIncrement();
-
       await expectLater(
         sub.read(),
         completion([
@@ -72,14 +70,12 @@ void main() async {
               matchRiverpodNode(
                 id: '0',
                 containerId: '0',
-                title:
-                    'counterProvider - StateNotifierProvider<Counter, int>()',
+                name: 'counterProvider',
               ),
               matchRiverpodNode(
                 id: '1',
                 containerId: '0',
-                title:
-                    'counterProvider.notifier - _NotifierProvider<Counter, int>()',
+                name: 'secondCounterProvider',
               ),
             ],
           ),

--- a/packages/devtools_app/test/riverpod/riverpod_screen_test.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_screen_test.dart
@@ -56,24 +56,24 @@ void main() {
 
   group('ProviderScreen', () {
     testWidgetsWithWindowSize(
-      'shows multiple containers',
+      'shows multiple containers with header',
       windowSize,
       (tester) async {
         final provider0 = RiverpodNode(
           id: '0',
           containerId: '0',
           stateId: 'stateId',
-          type: 'String',
           name: 'provider0',
           mightBeOutdated: false,
+          argumentId: null,
         );
         final provider1 = RiverpodNode(
           id: '1',
           containerId: '1',
           stateId: 'stateId',
-          type: 'String',
           name: 'provider1',
           mightBeOutdated: false,
+          argumentId: null,
         );
         await tester.pumpWidget(
           ProviderScope(
@@ -97,7 +97,12 @@ void main() {
             child: riverpodScreen,
           ),
         );
+        await tester.pumpAndSettle();
 
+        await expectLater(
+          find.text('Containers'),
+          findsOneWidget,
+        );
         await expectLater(
           find.text('Container #0'),
           findsOneWidget,
@@ -107,11 +112,70 @@ void main() {
           findsOneWidget,
         );
         await expectLater(
-          find.text(provider0.title),
+          find.text(provider0.name),
           findsOneWidget,
         );
         await expectLater(
-          find.text(provider1.title),
+          find.text(provider1.name),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows single container with header',
+      windowSize,
+      (tester) async {
+        final provider0 = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: 'stateId',
+          name: 'provider0',
+          mightBeOutdated: false,
+          argumentId: null,
+        );
+        final provider1 = RiverpodNode(
+          id: '1',
+          containerId: '1',
+          stateId: 'stateId',
+          name: 'provider1',
+          mightBeOutdated: false,
+          argumentId: null,
+        );
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(
+                    id: '0',
+                    providers: [provider0, provider1],
+                  ),
+                ]),
+              ),
+            ],
+            child: riverpodScreen,
+          ),
+        );
+        await tester.pumpAndSettle();
+
+        await expectLater(
+          find.text('Providers'),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text('Container #0'),
+          findsNothing,
+        );
+        await expectLater(
+          find.text(provider0.name),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text(provider1.name),
           findsOneWidget,
         );
       },
@@ -136,9 +200,9 @@ void main() {
                         id: '0',
                         containerId: '0',
                         stateId: 'stateId',
-                        type: 'String',
                         name: 'provider0',
                         mightBeOutdated: true,
+                        argumentId: null,
                       )
                     ],
                   ),
@@ -278,9 +342,9 @@ void main() {
           id: '0',
           containerId: '0',
           stateId: instanceId,
-          type: 'String',
           name: 'firstProvider',
           mightBeOutdated: false,
+          argumentId: null,
         );
 
         await tester.pumpWidget(
@@ -312,12 +376,86 @@ void main() {
         );
 
         await expectLater(
-          find.text(provider.title),
+          find.text(provider.name),
           findsNWidgets(2),
         );
         await expectLater(
           find.byType(InstanceViewer),
           findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows selected family provider value and argument',
+      windowSize,
+      (tester) async {
+        const instanceId = 'fake_state';
+        const argumentId = 'fake_argument';
+        const state = 'this is a fake value';
+        final provider = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: instanceId,
+          name: 'firstProvider',
+          mightBeOutdated: false,
+          argumentId: argumentId,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(id: '0', providers: [provider])
+                ]),
+              ),
+              selectedNodeProvider.overrideWithValue(provider),
+              instanceProvider(
+                const InstancePath.fromInstanceId(instanceId),
+              ).overrideWithValue(
+                AsyncValue.data(
+                  InstanceDetails.string(
+                    state,
+                    instanceRefId: instanceId,
+                    setter: null,
+                  ),
+                ),
+              ),
+              instanceProvider(
+                const InstancePath.fromInstanceId(argumentId),
+              ).overrideWithValue(
+                AsyncValue.data(
+                  InstanceDetails.string(
+                    state,
+                    instanceRefId: argumentId,
+                    setter: null,
+                  ),
+                ),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.text(provider.name),
+          findsNWidgets(2),
+        );
+        await expectLater(
+          find.text('State:'),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text('Family argument:'),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.byType(InstanceViewer),
+          findsNWidgets(2),
         );
       },
     );
@@ -333,9 +471,9 @@ void main() {
           id: '0',
           containerId: '0',
           stateId: instanceId,
-          type: 'String',
           name: 'firstProvider',
           mightBeOutdated: false,
+          argumentId: null,
         );
 
         await tester.pumpWidget(
@@ -384,9 +522,9 @@ void main() {
           id: '0',
           containerId: '0',
           stateId: instanceId,
-          type: 'String',
           name: 'firstProvider',
           mightBeOutdated: false,
+          argumentId: null,
         );
 
         await tester.pumpWidget(
@@ -437,9 +575,9 @@ void main() {
         id: '0',
         containerId: '0',
         stateId: firstStateId,
-        type: 'String',
         name: 'provider0',
         mightBeOutdated: false,
+        argumentId: null,
       );
       final updatedProvider = provider.copy(stateId: secondStateId);
 

--- a/packages/devtools_app/test/riverpod/riverpod_screen_test.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_screen_test.dart
@@ -1,0 +1,494 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/provider/instance_viewer/instance_details.dart';
+import 'package:devtools_app/src/screens/provider/instance_viewer/instance_providers.dart';
+import 'package:devtools_app/src/screens/provider/instance_viewer/instance_viewer.dart';
+import 'package:devtools_app/src/screens/riverpod/container_list.dart';
+import 'package:devtools_app/src/screens/riverpod/nodes/container_node.dart';
+import 'package:devtools_app/src/screens/riverpod/nodes/riverpod_node.dart';
+import 'package:devtools_app/src/screens/riverpod/refresh_state_button.dart';
+import 'package:devtools_app/src/screens/riverpod/riverpod_screen.dart';
+import 'package:devtools_app/src/screens/riverpod/selected_provider.dart';
+import 'package:devtools_app/src/screens/riverpod/settings_dialog_button.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
+@TestOn('vm')
+import 'package:devtools_app/src/shared/banner_messages.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+class RefreshNotifierMock extends Mock implements RefreshNotifier {}
+
+void main() {
+  // Set a wide enough screen width that we do not run into overflow.
+  const windowSize = Size(2225.0, 1000.0);
+
+  late Widget riverpodScreen;
+  late BannerMessagesController bannerMessagesController;
+
+  setUpAll(() => loadFonts());
+
+  setUp(() {
+    setGlobal(IdeTheme, getIdeTheme());
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
+  });
+
+  setUp(() {
+    bannerMessagesController = BannerMessagesController();
+
+    riverpodScreen = Container(
+      color: Colors.grey,
+      child: Directionality(
+        textDirection: TextDirection.ltr,
+        child: wrapWithControllers(
+          const BannerMessages(screen: RiverpodScreen()),
+          bannerMessages: bannerMessagesController,
+        ),
+      ),
+    );
+  });
+
+  group('ProviderScreen', () {
+    testWidgetsWithWindowSize(
+      'shows multiple containers',
+      windowSize,
+      (tester) async {
+        final provider0 = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: 'stateId',
+          type: 'String',
+          name: 'provider0',
+          mightBeOutdated: false,
+        );
+        final provider1 = RiverpodNode(
+          id: '1',
+          containerId: '1',
+          stateId: 'stateId',
+          type: 'String',
+          name: 'provider1',
+          mightBeOutdated: false,
+        );
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(
+                    id: '0',
+                    providers: [provider0],
+                  ),
+                  ContainerNode(
+                    id: '1',
+                    providers: [provider1],
+                  ),
+                ]),
+              ),
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.text('Container #0'),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text('Container #1'),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text(provider0.title),
+          findsOneWidget,
+        );
+        await expectLater(
+          find.text(provider1.title),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows alert when provider might be outdated',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(
+                    id: '0',
+                    providers: [
+                      RiverpodNode(
+                        id: '0',
+                        containerId: '0',
+                        stateId: 'stateId',
+                        type: 'String',
+                        name: 'provider0',
+                        mightBeOutdated: true,
+                      )
+                    ],
+                  ),
+                ]),
+              ),
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.byIcon(Icons.warning),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows _UnsupportedMessage if supportsDevToolProvider returns false',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(false),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.byKey(const Key('riverpod-unsupported-message')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows _UnsupportedMessage if supportsDevToolProvider throws error',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.error('fake_error'),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.byKey(const Key('riverpod-unsupported-message')),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows ContainerList if supportsDevToolProvider returns true',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.byType(ContainerList),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+
+  group('selected provider', () {
+    testWidgetsWithWindowSize(
+      'shows no provider selected message when there is no provider selected',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.text('[No provider selected]'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows no provider selected message when there is no provider selected',
+      windowSize,
+      (tester) async {
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.text('[No provider selected]'),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'shows selected provider value',
+      windowSize,
+      (tester) async {
+        const instanceId = 'fake_state';
+        const state = 'this is a fake value';
+        final provider = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: instanceId,
+          type: 'String',
+          name: 'firstProvider',
+          mightBeOutdated: false,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(id: '0', providers: [provider])
+                ]),
+              ),
+              selectedNodeProvider.overrideWithValue(provider),
+              instanceProvider(
+                const InstancePath.fromInstanceId(instanceId),
+              ).overrideWithValue(
+                AsyncValue.data(
+                  InstanceDetails.string(
+                    state,
+                    instanceRefId: instanceId,
+                    setter: null,
+                  ),
+                ),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await expectLater(
+          find.text(provider.title),
+          findsNWidgets(2),
+        );
+        await expectLater(
+          find.byType(InstanceViewer),
+          findsOneWidget,
+        );
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'refresh tap should call refresh',
+      windowSize,
+      (tester) async {
+        const instanceId = 'fake_state';
+        const state = 'this is a fake value';
+        final refreshNotifier = RefreshNotifierMock();
+        final provider = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: instanceId,
+          type: 'String',
+          name: 'firstProvider',
+          mightBeOutdated: false,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              refreshNotifierProvider.overrideWithValue(refreshNotifier),
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(id: '0', providers: [provider])
+                ]),
+              ),
+              selectedNodeProvider.overrideWithValue(provider),
+              instanceProvider(
+                const InstancePath.fromInstanceId(instanceId),
+              ).overrideWithValue(
+                AsyncValue.data(
+                  InstanceDetails.string(
+                    state,
+                    instanceRefId: instanceId,
+                    setter: null,
+                  ),
+                ),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await tester.tap(find.byType(RefreshStateButton));
+
+        verify(refreshNotifier.refresh()).called(1);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'settings tap should show settings dialog',
+      windowSize,
+      (tester) async {
+        const instanceId = 'fake_state';
+        const state = 'this is a fake value';
+        final refreshNotifier = RefreshNotifierMock();
+        final provider = RiverpodNode(
+          id: '0',
+          containerId: '0',
+          stateId: instanceId,
+          type: 'String',
+          name: 'firstProvider',
+          mightBeOutdated: false,
+        );
+
+        await tester.pumpWidget(
+          ProviderScope(
+            overrides: [
+              refreshNotifierProvider.overrideWithValue(refreshNotifier),
+              supportsDevToolProvider.overrideWithValue(
+                const AsyncValue.data(true),
+              ),
+              containerNodesProvider.overrideWithValue(
+                AsyncValue.data([
+                  ContainerNode(id: '0', providers: [provider])
+                ]),
+              ),
+              selectedNodeProvider.overrideWithValue(provider),
+              instanceProvider(
+                const InstancePath.fromInstanceId(instanceId),
+              ).overrideWithValue(
+                AsyncValue.data(
+                  InstanceDetails.string(
+                    state,
+                    instanceRefId: instanceId,
+                    setter: null,
+                  ),
+                ),
+              )
+            ],
+            child: riverpodScreen,
+          ),
+        );
+
+        await tester.tap(find.byType(SettingsDialogButton));
+        await tester.pumpAndSettle();
+
+        await expectLater(
+          find.byKey(const Key('state-inspector-settings-dialog')),
+          findsOneWidget,
+        );
+      },
+    );
+  });
+
+  group('refreshProvider', () {
+    test('should refresh selected provider', () async {
+      const firstStateId = 'fake/1';
+      const secondStateId = 'fake/1';
+      final provider = RiverpodNode(
+        id: '0',
+        containerId: '0',
+        stateId: firstStateId,
+        type: 'String',
+        name: 'provider0',
+        mightBeOutdated: false,
+      );
+      final updatedProvider = provider.copy(stateId: secondStateId);
+
+      final container = ProviderContainer(
+        overrides: [
+          containerNodesProvider.overrideWithValue(
+            AsyncValue.data([
+              ContainerNode(
+                id: '0',
+                providers: [provider],
+              ),
+            ]),
+          ),
+          updatedRiverpodNodeProvider(provider).overrideWithValue(
+            AsyncValue.data(provider),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final selectedNodeSub = container.listen<RiverpodNode?>(
+        selectedNodeProvider,
+        (prev, next) {},
+      );
+
+      expect(selectedNodeSub.read(), isNull);
+
+      container.read(selectedNodeStateProvider.notifier).state = provider;
+      await container.pump();
+
+      expect(selectedNodeSub.read(), equals(provider));
+
+      container.updateOverrides([
+        containerNodesProvider.overrideWithValue(
+          AsyncValue.data([
+            ContainerNode(
+              id: '0',
+              providers: [updatedProvider],
+            ),
+          ]),
+        ),
+        updatedRiverpodNodeProvider(provider).overrideWithValue(
+          AsyncValue.data(updatedProvider),
+        ),
+      ]);
+      container.read(refreshNotifierProvider).refresh();
+      await container.pump();
+
+      expect(selectedNodeSub.read(), equals(updatedProvider));
+    });
+  });
+}

--- a/packages/devtools_app/test/riverpod/riverpod_test_helpers.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_test_helpers.dart
@@ -14,16 +14,16 @@ TypeMatcher<ContainerNode> matchContainerNode({
 TypeMatcher<RiverpodNode> matchRiverpodNode({
   required String id,
   required String containerId,
-  required String title,
+  required String name,
 }) {
   return isA<RiverpodNode>()
       .having((r) => r.id, 'id', equals(id))
       .having((r) => r.containerId, 'containerId', equals(containerId))
       .having(
-        (r) => r.title,
-        'title',
+        (r) => r.name,
+        'name',
         equals(
-          title,
+          name,
         ),
       );
 }

--- a/packages/devtools_app/test/riverpod/riverpod_test_helpers.dart
+++ b/packages/devtools_app/test/riverpod/riverpod_test_helpers.dart
@@ -1,0 +1,29 @@
+import 'package:devtools_app/src/screens/riverpod/nodes/container_node.dart';
+import 'package:devtools_app/src/screens/riverpod/nodes/riverpod_node.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+TypeMatcher<ContainerNode> matchContainerNode({
+  required String id,
+  required List<Matcher> providers,
+}) {
+  return isA<ContainerNode>()
+      .having((r) => r.id, 'id', equals(id))
+      .having((e) => e.providers, 'providers', providers);
+}
+
+TypeMatcher<RiverpodNode> matchRiverpodNode({
+  required String id,
+  required String containerId,
+  required String title,
+}) {
+  return isA<RiverpodNode>()
+      .having((r) => r.id, 'id', equals(id))
+      .having((r) => r.containerId, 'containerId', equals(containerId))
+      .having(
+        (r) => r.title,
+        'title',
+        equals(
+          title,
+        ),
+      );
+}

--- a/packages/devtools_app/test/shared/instance_viewer_test.dart
+++ b/packages/devtools_app/test/shared/instance_viewer_test.dart
@@ -286,6 +286,8 @@ void main() {
 
       await tester.pump();
 
+      await expectLater(find.byType(TextField), findsOneWidget);
+
       await expectLater(
         find.byType(MaterialApp),
         matchesDevToolsGolden('../goldens/instance_viewer/edit.png'),
@@ -300,6 +302,72 @@ void main() {
         find.byType(MaterialApp),
         matchesDevToolsGolden('../goldens/instance_viewer/edit_esc.png'),
       );
+    });
+
+    testWidgets('should disable edit when editable is false', (tester) async {
+      const objPath = InstancePath.fromInstanceId('obj');
+      final propertyPath = objPath.pathForChild(
+        const PathToProperty.objectProperty(
+          name: 'first',
+          ownerUri: '',
+          ownerName: '',
+        ),
+      );
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            instanceProvider(objPath).overrideWithValue(
+              AsyncValue.data(
+                ObjectInstance(
+                  [
+                    ObjectField(
+                      name: 'first',
+                      isFinal: false,
+                      ownerName: '',
+                      ownerUri: '',
+                      eval: FakeEvalOnDartLibrary(),
+                      ref: Result.error(Error(), StackTrace.empty),
+                      isDefinedByDependency: false,
+                    ),
+                  ],
+                  hash: 0,
+                  instanceRefId: 'object',
+                  setter: null,
+                  evalForInstance: FakeEvalOnDartLibrary(),
+                  type: 'MyClass',
+                ),
+              ),
+            ),
+            instanceProvider(propertyPath).overrideWithValue(
+              AsyncValue.data(
+                InstanceDetails.number(
+                  '0',
+                  instanceRefId: '0',
+                  setter: (value) async {},
+                ),
+              ),
+            ),
+          ],
+          child: const MaterialApp(
+            home: Scaffold(
+              body: InstanceViewer(
+                editable: false,
+                showInternalProperties: true,
+                rootPath: objPath,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.byKey(ValueKey(propertyPath)));
+
+      await tester.pump();
+
+      await expectLater(find.byType(TextField), findsNothing);
     });
 
     testWidgets('renders <loading> while an instance is fetched',

--- a/packages/devtools_test/lib/src/wrappers.dart
+++ b/packages/devtools_test/lib/src/wrappers.dart
@@ -6,6 +6,7 @@ import 'package:devtools_app/devtools_app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:meta/meta.dart';
 import 'package:provider/provider.dart';
 
 import 'mocks/mocks.dart';
@@ -127,6 +128,7 @@ void testWidgetsWithContext(
 }
 
 /// Runs a test with the size of the app window under test to [windowSize].
+@isTest
 void testWidgetsWithWindowSize(
   String name,
   Size windowSize,


### PR DESCRIPTION
This PR adds support to `Riverpod`, the code is heavily based on the current `Provider` implementation. It uses provider's `InstanceViewer` widget to show the state values.


https://user-images.githubusercontent.com/11666470/175167035-4027eb48-7f7b-44e6-bb83-af7e8d8feaaf.mp4

The discussion about this solution can be [found at riverpod's repo](https://github.com/rrousselGit/riverpod/issues/1039#issuecomment-1163572176).

***TODO: this PR is still a Draft, the tests will be added before opening it for real.***

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
