### PR TITLE
Fixes 2 bugs that were happening in the VM tools tabs

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
@@ -79,11 +79,13 @@ class IsolateStatisticsViewBody extends StatelessWidget {
           child: Column(
             children: [
               Flexible(
+                flex: 3,
                 child: GeneralIsolateStatisticsWidget(
                   controller: controller,
                 ),
               ),
               Flexible(
+                flex: 2,
                 child: IsolateMemoryStatisticsWidget(
                   controller: controller,
                 ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
@@ -79,13 +79,11 @@ class IsolateStatisticsViewBody extends StatelessWidget {
           child: Column(
             children: [
               Flexible(
-                flex: 3,
                 child: GeneralIsolateStatisticsWidget(
                   controller: controller,
                 ),
               ),
               Flexible(
-                flex: 2,
                 child: IsolateMemoryStatisticsWidget(
                   controller: controller,
                 ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -57,6 +57,7 @@ class VMInfoList extends StatelessWidget {
     // Create shadow variables locally to avoid extra null checks.
     final rowKeyValues = this.rowKeyValues;
     final table = this.table;
+    final listScrollController = ScrollController();
     return Column(
       children: [
         AreaPaneHeader(
@@ -64,27 +65,36 @@ class VMInfoList extends StatelessWidget {
           needsTopBorder: false,
         ),
         if (rowKeyValues != null)
-          ..._prettyRows(
-            context,
-            [
-              for (final row in rowKeyValues)
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    SelectableText(
-                      '${row.key.toString()}:',
-                      style: theme.fixedFontStyle,
-                    ),
-                    const SizedBox(width: denseSpacing),
-                    Flexible(
-                      child: SelectableText(
-                        row.value?.toString() ?? '--',
-                        style: theme.fixedFontStyle,
-                      ),
-                    ),
+          Expanded(
+            child: Scrollbar(
+              thumbVisibility: true,
+              controller: listScrollController,
+              child: ListView(
+                controller: listScrollController,
+                children: _prettyRows(
+                  context,
+                  [
+                    for (final row in rowKeyValues)
+                      Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: [
+                          SelectableText(
+                            '${row.key.toString()}:',
+                            style: theme.fixedFontStyle,
+                          ),
+                          const SizedBox(width: denseSpacing),
+                          Flexible(
+                            child: SelectableText(
+                              row.value?.toString() ?? '--',
+                              style: theme.fixedFontStyle,
+                            ),
+                          ),
+                        ],
+                      )
                   ],
-                )
-            ],
+                ),
+              ),
+            ),
           ),
         if (table != null) table,
       ],

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -16,7 +16,7 @@ extension VMPrivateViewExtension on VM {
   int get currentMemory => json!['_currentMemory'];
   int get currentRSS => json!['_currentRSS'];
   int get maxRSS => json!['_maxRSS'];
-  int get nativeZoneMemoryUsage => json!['_nativeZoneMemoryUsage'];
+  int? get nativeZoneMemoryUsage => json!['_nativeZoneMemoryUsage'];
 }
 
 /// An extension on [Isolate] which allows for access to VM internal fields.


### PR DESCRIPTION
Fixes the following bugs:

* On isolate_statistics_view.dart one of the tables was overflowing: adjusted flex factors to better distribute the space available. Also added a scrollbar to the VMInfoList widget so that the widget does not overflow when resizing into a smaller window.
* On vm_statistics_view.dart a type error was occurring (expected int but received null) when calling vm?.nativeZoneMemoryUsage (line 193): made the nativeZoneMemoryUsage nullable on the vm_service_private_extensions.dart file.
