### PR TITLE
Connect the TreeTable and TreeMap 

### DIFF
--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -51,6 +51,9 @@ class AppSizeController {
   ValueListenable<TreemapNode?> get analysisRoot => _analysisRoot;
   final _analysisRoot = ValueNotifier<TreemapNode?>(null);
 
+  ValueListenable<TreemapNode?> get originalRoot => _originalRoot;
+  final _originalRoot = ValueNotifier<TreemapNode?>(null);
+
   void changeAnalysisRoot(TreemapNode? newRoot) {
     _analysisRoot.value = newRoot;
     if (newRoot == null) return;
@@ -218,6 +221,7 @@ class AppSizeController {
 
     // Build a tree with [TreemapNode] from [processedJsonMap].
     final newRoot = generateTree(processedJson)!;
+    _originalRoot.value = newRoot;
 
     changeAnalysisRoot(newRoot);
 

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
@@ -273,6 +273,7 @@ class _AnalysisViewState extends State<AnalysisView>
         AutoDisposeMixin,
         ProvidedControllerMixin<AppSizeController, AnalysisView> {
   TreemapNode? analysisRoot;
+  TreemapNode? originalRoot;
 
   @override
   void didChangeDependencies() {
@@ -280,9 +281,12 @@ class _AnalysisViewState extends State<AnalysisView>
     if (!initController()) return;
 
     analysisRoot = controller.analysisRoot.value;
+    originalRoot = controller.originalRoot.value;
+
     addAutoDisposeListener(controller.analysisRoot, () {
       setState(() {
         analysisRoot = controller.analysisRoot.value;
+        originalRoot = controller.originalRoot.value;
       });
     });
 
@@ -294,7 +298,7 @@ class _AnalysisViewState extends State<AnalysisView>
     return Column(
       children: [
         Expanded(
-          child: analysisRoot != null
+          child: analysisRoot != null && originalRoot != null
               ? _buildTreemapAndTableSplitView()
               : _buildImportFileView(),
         ),
@@ -325,7 +329,7 @@ class _AnalysisViewState extends State<AnalysisView>
                   children: [
                     Flexible(
                       child: AppSizeAnalysisTable(
-                        rootNode: analysisRoot!,
+                        rootNode: originalRoot!,
                         controller: controller,
                       ),
                     ),

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
@@ -324,7 +324,10 @@ class _AnalysisViewState extends State<AnalysisView>
                 Row(
                   children: [
                     Flexible(
-                      child: AppSizeAnalysisTable(rootNode: analysisRoot!),
+                      child: AppSizeAnalysisTable(
+                        rootNode: analysisRoot!,
+                        controller: controller,
+                      ),
                     ),
                     if (analysisCallGraphRoot != null)
                       Flexible(

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_table.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_table.dart
@@ -11,8 +11,11 @@ import '../../shared/table_data.dart';
 import '../../shared/utils.dart';
 import '../../ui/colors.dart';
 
+import 'app_size_controller.dart';
+
 class AppSizeAnalysisTable extends StatelessWidget {
-  factory AppSizeAnalysisTable({required TreemapNode rootNode}) {
+  factory AppSizeAnalysisTable(
+      {required TreemapNode rootNode, required AppSizeController controller}) {
     final treeColumn = _NameColumn(currentRootLevel: rootNode.level);
     final sizeColumn = _SizeColumn();
     final columns = List<ColumnData<TreemapNode>>.unmodifiable([
@@ -42,6 +45,8 @@ class AppSizeAnalysisTable extends StatelessWidget {
   final ColumnData<TreemapNode> sortColumn;
   final List<ColumnData<TreemapNode>> columns;
 
+  final AppSizeController controller;
+
   @override
   Widget build(BuildContext context) {
     return TreeTable<TreemapNode>(
@@ -51,6 +56,7 @@ class AppSizeAnalysisTable extends StatelessWidget {
       keyFactory: (node) => PageStorageKey<String>(node.name),
       sortColumn: sortColumn,
       sortDirection: SortDirection.descending,
+      onChange: controller.changeAnalysisRoot,
       autoExpandRoots: true,
     );
   }

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_table.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_table.dart
@@ -29,6 +29,7 @@ class AppSizeAnalysisTable extends StatelessWidget {
       treeColumn,
       sizeColumn,
       columns,
+      controller,
     );
   }
 
@@ -37,6 +38,7 @@ class AppSizeAnalysisTable extends StatelessWidget {
     this.treeColumn,
     this.sortColumn,
     this.columns,
+    this.controller,
   );
 
   final TreemapNode rootNode;
@@ -56,7 +58,7 @@ class AppSizeAnalysisTable extends StatelessWidget {
       keyFactory: (node) => PageStorageKey<String>(node.name),
       sortColumn: sortColumn,
       sortDirection: SortDirection.descending,
-      onChange: controller.changeAnalysisRoot,
+      onAnalysisRootChange: controller.changeAnalysisRoot,
       autoExpandRoots: true,
     );
   }

--- a/packages/devtools_app/lib/src/shared/table.dart
+++ b/packages/devtools_app/lib/src/shared/table.dart
@@ -348,7 +348,7 @@ class TreeTable<T extends TreeNode<T>> extends StatefulWidget {
     required this.sortDirection,
     this.secondarySortColumn,
     this.selectionNotifier,
-    required this.onChange,
+    this.onAnalysisRootChange,
     this.autoExpandRoots = false,
   })  : assert(columns.contains(treeColumn)),
         assert(columns.contains(sortColumn)),
@@ -374,7 +374,7 @@ class TreeTable<T extends TreeNode<T>> extends StatefulWidget {
 
   final ValueNotifier<Selection<T>>? selectionNotifier;
 
-  final void Function(T? node) onChange;
+  final void Function(T? node)? onAnalysisRootChange;
 
   final bool autoExpandRoots;
 
@@ -489,9 +489,6 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       nodeIndex: nodeIndex,
     );
 
-    widget.onChange(node);
-    //add changeAnalysisRoot (node)
-
     _toggleNode(node);
   }
 
@@ -499,6 +496,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
     if (!node.isExpandable) {
       node.leaf();
       _updateItems();
+      widget.onAnalysisRootChange!(node);
       return;
     }
 

--- a/packages/devtools_app/lib/src/shared/table.dart
+++ b/packages/devtools_app/lib/src/shared/table.dart
@@ -348,6 +348,7 @@ class TreeTable<T extends TreeNode<T>> extends StatefulWidget {
     required this.sortDirection,
     this.secondarySortColumn,
     this.selectionNotifier,
+    required this.onChange,
     this.autoExpandRoots = false,
   })  : assert(columns.contains(treeColumn)),
         assert(columns.contains(sortColumn)),
@@ -372,6 +373,8 @@ class TreeTable<T extends TreeNode<T>> extends StatefulWidget {
   final ColumnData<T>? secondarySortColumn;
 
   final ValueNotifier<Selection<T>>? selectionNotifier;
+
+  final void Function(T? node) onChange;
 
   final bool autoExpandRoots;
 
@@ -485,6 +488,9 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       node: node,
       nodeIndex: nodeIndex,
     );
+
+    widget.onChange(node);
+    //add changeAnalysisRoot (node)
 
     _toggleNode(node);
   }

--- a/packages/devtools_app/lib/src/shared/table.dart
+++ b/packages/devtools_app/lib/src/shared/table.dart
@@ -13,6 +13,7 @@ import '../primitives/flutter_widgets/linked_scroll_controller.dart';
 import '../primitives/listenable.dart';
 import '../primitives/trees.dart';
 import '../primitives/utils.dart';
+import '../screens/app_size/code_size_attribution.dart';
 import '../ui/colors.dart';
 import '../ui/search.dart';
 import 'collapsible_mixin.dart';
@@ -503,8 +504,11 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   }
 
   void _toggleNode(T node) {
-    widget.onAnalysisRootChange!(node);
+    //TODO: not a great way to check for null
 
+    if (node is! DominatorTreeNode) {
+      widget.onAnalysisRootChange!(node);
+    }
     if (!node.isExpandable) {
       node.leaf();
       _updateItems();

--- a/packages/devtools_app/lib/src/shared/table.dart
+++ b/packages/devtools_app/lib/src/shared/table.dart
@@ -493,13 +493,14 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   }
 
   void _toggleNode(T node) {
+    widget.onAnalysisRootChange!(node);
+
     if (!node.isExpandable) {
       node.leaf();
       _updateItems();
-      widget.onAnalysisRootChange!(node);
+
       return;
     }
-
     setState(() {
       if (!node.isExpandable) return;
       animatingNode = node;


### PR DESCRIPTION
**Previously**
When interacting with the TreeMap, the TreeTable would re-root and expand its nodes according to the selection. However, when interacting with the TreeTable, the TreeMap would not update with it. 

**Changes**
Added new function (onAnalysisRootChange) to handle changing analysisRoot when updating the table so that the map also updates. Removed TreeTable re-rooting according to analysisRoot and replacing the root to be originalRoot. Only allow the map to be updated by TreeTable and not Dominator Tree. 

**Next Steps**
Need to add a scrolling and expanding functionality for when the map is being interacted with. Add better checking to determine if analysisRoot should be updated.

