### PR TITLE
Fix Scrollbar error with ProgramExplorer

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -313,7 +313,7 @@ class _FileExplorer extends StatefulWidget {
 }
 
 class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
-  final ScrollController _scrollController = ScrollController();
+  late final ScrollController _scrollController;
 
   double get selectedNodeOffset => widget.controller.selectedNodeIndex.value ==
           -1
@@ -323,6 +323,7 @@ class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
   @override
   void initState() {
     super.initState();
+    _scrollController = ScrollController();
     addAutoDisposeListener(
       widget.controller.selectedNodeIndex,
       _maybeScrollToSelectedNode,
@@ -330,27 +331,30 @@ class _FileExplorerState extends State<_FileExplorer> with AutoDisposeMixin {
   }
 
   @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return Scrollbar(
-      thumbVisibility: true,
-      controller: _scrollController,
-      child: TreeView<VMServiceObjectNode>(
-        itemExtent: _programExplorerRowHeight,
-        dataRootsListenable: widget.controller.rootObjectNodes,
-        onItemSelected: widget.onItemSelected,
-        onItemExpanded: widget.onItemExpanded,
-        scrollController: _scrollController,
-        dataDisplayProvider: (node, onTap) {
-          return _ProgramExplorerRow(
-            controller: widget.controller,
-            node: node,
-            onTap: () {
-              widget.controller.selectNode(node);
-              onTap();
-            },
-          );
-        },
-      ),
+    return TreeView<VMServiceObjectNode>(
+      itemExtent: _programExplorerRowHeight,
+      dataRootsListenable: widget.controller.rootObjectNodes,
+      onItemSelected: widget.onItemSelected,
+      onItemExpanded: widget.onItemExpanded,
+      scrollController: _scrollController,
+      includeScrollbar: true,
+      dataDisplayProvider: (node, onTap) {
+        return _ProgramExplorerRow(
+          controller: widget.controller,
+          node: node,
+          onTap: () {
+            widget.controller.selectNode(node);
+            onTap();
+          },
+        );
+      },
     );
   }
 
@@ -420,7 +424,7 @@ class _ProgramOutlineView extends StatelessWidget {
 /// filtering.
 class ProgramExplorer extends StatelessWidget {
   const ProgramExplorer({
-    required Key key,
+    Key? key,
     required this.controller,
     this.onSelected,
     this.title = 'File Explorer',

--- a/packages/devtools_app/lib/src/shared/tree.dart
+++ b/packages/devtools_app/lib/src/shared/tree.dart
@@ -23,6 +23,7 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
     this.onTraverse,
     this.emptyTreeViewBuilder,
     this.scrollController,
+    this.includeScrollbar = false,
   });
 
   final ValueListenable<List<T>> dataRootsListenable;
@@ -57,6 +58,8 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
 
   final ScrollController? scrollController;
 
+  final bool includeScrollbar;
+
   @override
   _TreeViewState<T> createState() => _TreeViewState<T>();
 }
@@ -78,7 +81,7 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
   @override
   Widget build(BuildContext context) {
     if (items.isEmpty) return _emptyTreeViewBuilder();
-    return ListView.builder(
+    final content = ListView.builder(
       itemCount: items.length,
       itemExtent: widget.itemExtent,
       shrinkWrap: widget.shrinkWrap,
@@ -95,6 +98,14 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
         );
       },
     );
+    if (widget.includeScrollbar) {
+      return Scrollbar(
+        thumbVisibility: true,
+        controller: widget.scrollController,
+        child: content,
+      );
+    }
+    return content;
   }
 
   Widget _emptyTreeViewBuilder() {

--- a/packages/devtools_app/test/debugger/program_explorer_test.dart
+++ b/packages/devtools_app/test/debugger/program_explorer_test.dart
@@ -1,0 +1,58 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/primitives/listenable.dart';
+import 'package:devtools_app/src/screens/debugger/program_explorer.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/src/shared/common_widgets.dart';
+import 'package:devtools_app/src/shared/flex_split_column.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
+void main() {
+  late MockProgramExplorerController mockProgramExplorerController;
+
+  setUp(() {
+    final fakeServiceManager = FakeServiceManager();
+    mockConnectedApp(
+      fakeServiceManager.connectedApp!,
+      isFlutterApp: true,
+      isProfileBuild: false,
+      isWebApp: false,
+    );
+    mockProgramExplorerController =
+        createMockProgramExplorerControllerWithDefaults();
+    setGlobal(IdeTheme, IdeTheme());
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
+  });
+
+  testWidgets('builds when not initialized', (WidgetTester tester) async {
+    when(mockProgramExplorerController.initialized)
+        .thenReturn(const FixedValueListenable(false));
+    await tester.pumpWidget(
+      wrap(
+        ProgramExplorer(controller: mockProgramExplorerController),
+      ),
+    );
+    expect(find.byType(CenteredCircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('builds when initialized', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      wrap(
+        ProgramExplorer(controller: mockProgramExplorerController),
+      ),
+    );
+    expect(find.byType(AreaPaneHeader), findsNWidgets(2));
+    expect(find.text('File Explorer'), findsOneWidget);
+    expect(find.text('Outline'), findsOneWidget);
+    expect(find.byType(FlexSplitColumn), findsOneWidget);
+  });
+
+  // TODO(https://github.com/flutter/devtools/issues/4227): write more thorough
+  // tests for the ProgramExplorer widget.
+}


### PR DESCRIPTION
Fixes an error with the program explorer regarding scroll controllers: 
```
══╡ EXCEPTION CAUGHT BY SCHEDULER LIBRARY ╞═════════════════════════════════════════════════════════
The following assertion was thrown during a scheduler callback:
The Scrollbar's ScrollController has no ScrollPosition attached.
A Scrollbar cannot be painted without a ScrollPosition.
The Scrollbar attempted to use the provided ScrollController. This ScrollController should be
associated with the ScrollView that the Scrollbar is being applied to.When providing your own
ScrollController, ensure both the Scrollbar and the Scrollable widget use the same one.

When the exception was thrown, this was the stack:
#0      RawScrollbarState._debugCheckHasValidScrollPosition.<anonymous closure> (package:flutter/src/widgets/scrollbar.dart:1503:9)
#1      RawScrollbarState._debugCheckHasValidScrollPosition (package:flutter/src/widgets/scrollbar.dart:1528:6)
#2      RawScrollbarState._debugScheduleCheckHasValidScrollPosition.<anonymous closure> (package:flutter/src/widgets/scrollbar.dart:1456:14)
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1175:15)
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1113:9)
#5      AutomatedTestWidgetsFlutterBinding.pump.<anonymous closure> (package:flutter_test/src/binding.dart:1057:9)
#8      TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:71:41)
#9      AutomatedTestWidgetsFlutterBinding.pump (package:flutter_test/src/binding.dart:1043:27)
#10     WidgetTester.pumpWidget.<anonymous closure> (package:flutter_test/src/widget_tester.dart:554:22)
#13     TestAsyncUtils.guard (package:flutter_test/src/test_async_utils.dart:71:41)
#14     WidgetTester.pumpWidget (package:flutter_test/src/widget_tester.dart:551:27)
#15     main.<anonymous closure> (file:///Users/mtaylee/Dash/devtools/packages/devtools_app/test/vm_developer/object_inspector_view_test.dart:33:18)
#16     testWidgets.<anonymous closure>.<anonymous closure> (package:flutter_test/src/widget_tester.dart:171:29)
<asynchronous suspension>
<asynchronous suspension>
(elided 5 frames from dart:async and package:stack_trace)
```

Filed https://github.com/flutter/devtools/issues/4227 to add more tests for this feature, as it is not well tested currently. This issue is blocking @[migueltylee](https://github.com/migueltylee)'s PR https://github.com/flutter/devtools/pull/4195.