### PR TITLE
Added edge case when popping history on a one-item stack

### DIFF
--- a/packages/devtools_app/lib/src/primitives/history_manager.dart
+++ b/packages/devtools_app/lib/src/primitives/history_manager.dart
@@ -65,6 +65,11 @@ class HistoryManager<T> {
   void pop() {
     if (_history.isEmpty) throw StateError('no history available');
 
+    if (_history.length == 1) {
+      clear();
+      return;
+    }
+
     _history.removeLast();
 
     // If the currently selected item was popped, update the selection to the

--- a/packages/devtools_app/test/shared/history_manager_test.dart
+++ b/packages/devtools_app/test/shared/history_manager_test.dart
@@ -81,5 +81,30 @@ void main() {
       history.moveBack();
       expect(history.current.value, ref1);
     });
+
+    test('pop entries', () {
+      history.push(ref1);
+      history.push(ref2);
+      history.push(ref3);
+
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.current.value, ref3);
+
+      history.pop();
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, true);
+      expect(history.current.value, ref2);
+
+      history.pop();
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, false);
+      expect(history.current.value, ref1);
+
+      history.pop();
+      expect(history.hasNext, false);
+      expect(history.hasPrevious, false);
+      expect(history.current.value, null);
+    });
   });
 }


### PR DESCRIPTION
Added the case when calling pop() on the historyManager when there is only one item in the stack.

Otherwise, when calling pop() on a single item historyManager an index out of bounds error would occur. That happened because current was assigned the value of _history[_historyIndex] and _historyIndex was -1.