### PR TITLE
Provide the InspectorController through package:provider

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -30,6 +30,7 @@ export 'src/screens/inspector/inspector_screen.dart';
 export 'src/screens/inspector/inspector_service.dart';
 export 'src/screens/inspector/inspector_tree.dart';
 export 'src/screens/inspector/inspector_tree_controller.dart';
+export 'src/screens/inspector/primitives/inspector_common.dart';
 export 'src/screens/logging/logging_controller.dart';
 export 'src/screens/logging/logging_screen.dart';
 export 'src/screens/memory/memory_controller.dart';

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -21,6 +21,8 @@ import 'screens/debugger/debugger_controller.dart';
 import 'screens/debugger/debugger_screen.dart';
 import 'screens/inspector/inspector_controller.dart';
 import 'screens/inspector/inspector_screen.dart';
+import 'screens/inspector/inspector_tree_controller.dart';
+import 'screens/inspector/primitives/inspector_common.dart';
 import 'screens/logging/logging_controller.dart';
 import 'screens/logging/logging_screen.dart';
 import 'screens/memory/memory_controller.dart';
@@ -548,9 +550,13 @@ class CheckboxSetting extends StatelessWidget {
 List<DevToolsScreen> get defaultScreens {
   final vmDeveloperToolsController = VMDeveloperToolsController();
   return <DevToolsScreen>[
-    DevToolsScreen<InspectorSettingsController>(
+    DevToolsScreen<InspectorController>(
       const InspectorScreen(),
-      createController: () => InspectorSettingsController(),
+      createController: () => InspectorController(
+        inspectorTree: InspectorTreeController(),
+        detailsTree: InspectorTreeController(),
+        treeType: FlutterTreeType.widget,
+      ),
     ),
     DevToolsScreen<PerformanceController>(
       const PerformanceScreen(),

--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics.dart
@@ -13,9 +13,8 @@ import '../../ui/icons.dart';
 import '../debugger/debugger_controller.dart';
 import '../debugger/variables.dart';
 import 'diagnostics_node.dart';
-import 'inspector_controller.dart';
-import 'inspector_text_styles.dart' as inspector_text_styles;
 import 'inspector_tree.dart';
+import 'primitives/inspector_text_styles.dart' as inspector_text_styles;
 
 final _colorIconMaker = ColorIconMaker();
 final _customIconMaker = CustomIconMaker();
@@ -187,8 +186,12 @@ class DiagnosticsNodeDescription extends StatelessWidget {
 
     final defaultStyle = DefaultTextStyle.of(context).style;
     final baseStyle = style ?? defaultStyle;
-    TextStyle textStyle =
-        baseStyle.merge(textStyleForLevel(diagnosticLocal.level, colorScheme));
+    TextStyle textStyle = baseStyle.merge(
+      inspector_text_styles.textStyleForLevel(
+        diagnosticLocal.level,
+        colorScheme,
+      ),
+    );
     var descriptionTextStyle = textStyle;
     // TODO(jacobr): use TextSpans and SelectableText instead of Text.
     if (diagnosticLocal.isProperty) {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_breadcrumbs.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_breadcrumbs.dart
@@ -7,8 +7,8 @@ import 'package:flutter/material.dart';
 import '../../primitives/utils.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
-import 'inspector_text_styles.dart';
 import 'inspector_tree.dart';
+import 'primitives/inspector_text_styles.dart';
 
 class InspectorBreadcrumbNavigator extends StatelessWidget {
   const InspectorBreadcrumbNavigator({

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -22,6 +22,7 @@ import '../../shared/globals.dart';
 import '../debugger/debugger_model.dart';
 import 'diagnostics_node.dart';
 import 'inspector_service_polyfill.dart';
+import 'primitives/inspector_common.dart';
 
 const inspectorLibraryUri = 'package:flutter/src/widgets/widget_inspector.dart';
 
@@ -1416,12 +1417,6 @@ class ObjectGroup extends ObjectGroupBase {
     final directories = (invocationResult as List?)?.cast<Object>();
     return List.from(directories ?? []);
   }
-}
-
-enum FlutterTreeType {
-  widget, // ('Widget'),
-  renderObject // ('Render');
-// TODO(jacobr): add semantics, and layer trees.
 }
 
 abstract class InspectorServiceClient {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree.dart
@@ -19,7 +19,7 @@ import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import '../../ui/search.dart';
 import 'diagnostics_node.dart';
-import 'inspector_service.dart';
+import 'primitives/inspector_common.dart';
 
 /// Split text into two groups, word characters at the start of a string and all
 /// other characters.

--- a/packages/devtools_app/lib/src/screens/inspector/primitives/inspector_common.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/primitives/inspector_common.dart
@@ -1,0 +1,9 @@
+// Copyright 2018 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+enum FlutterTreeType {
+  widget, // ('Widget'),
+  renderObject // ('Render');
+// TODO(jacobr): add semantics, and layer trees.
+}

--- a/packages/devtools_app/lib/src/screens/inspector/primitives/inspector_text_styles.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/primitives/inspector_text_styles.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import '../../shared/theme.dart';
+import '../../../shared/theme.dart';
 
 TextStyle unimportant(ColorScheme colorScheme) => TextStyle(
       color: colorScheme.isLight ? Colors.grey.shade500 : Colors.grey.shade600,
@@ -38,3 +38,19 @@ TextStyle unimportantItalic(ColorScheme colorScheme) =>
         fontStyle: FontStyle.italic,
       ),
     );
+
+TextStyle textStyleForLevel(DiagnosticLevel level, ColorScheme colorScheme) {
+  switch (level) {
+    case DiagnosticLevel.hidden:
+      return unimportant(colorScheme);
+    case DiagnosticLevel.warning:
+      return warning(colorScheme);
+    case DiagnosticLevel.error:
+      return error(colorScheme);
+    case DiagnosticLevel.debug:
+    case DiagnosticLevel.info:
+    case DiagnosticLevel.fine:
+    default:
+      return regular;
+  }
+}

--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
@@ -15,7 +15,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../../primitives/sliver_iterable_child_delegate.dart';
 import '../../../shared/eval_on_dart_library.dart';
 import '../../../shared/theme.dart';
-import '../../inspector/inspector_text_styles.dart';
+import '../../inspector/primitives/inspector_text_styles.dart';
 import 'instance_details.dart';
 import 'instance_providers.dart';
 

--- a/packages/devtools_app/test/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_integration_test.dart
@@ -66,7 +66,7 @@ void main() async {
       await tester.pump(const Duration(seconds: 1));
       final InspectorScreenBodyState state =
           tester.state(find.byType(InspectorScreenBody));
-      final controller = state.inspectorController;
+      final controller = state.controller;
       while (!controller.flutterAppFrameReady) {
         await controller.maybeLoadUI();
         await tester.pumpAndSettle();
@@ -422,7 +422,7 @@ void main() async {
       await tester.pumpAndSettle(const Duration(seconds: 1));
       final InspectorScreenBodyState state =
           tester.state(find.byType(InspectorScreenBody));
-      final controller = state.inspectorController;
+      final controller = state.controller;
       while (!controller.flutterAppFrameReady) {
         await controller.maybeLoadUI();
         await tester.pumpAndSettle();

--- a/packages/devtools_app/test/inspector/inspector_screen_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_screen_test.dart
@@ -6,10 +6,13 @@ import 'dart:convert';
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/inspector/diagnostics_node.dart';
+import 'package:devtools_app/src/screens/inspector/inspector_controller.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_tree.dart';
+import 'package:devtools_app/src/screens/inspector/inspector_tree_controller.dart';
 import 'package:devtools_app/src/screens/inspector/layout_explorer/flex/flex.dart';
 import 'package:devtools_app/src/screens/inspector/layout_explorer/layout_explorer.dart';
+import 'package:devtools_app/src/screens/inspector/primitives/inspector_common.dart';
 import 'package:devtools_app/src/service/service_extensions.dart' as extensions;
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
@@ -25,6 +28,7 @@ void main() {
 
   late FakeServiceManager fakeServiceManager;
   late FakeServiceExtensionManager fakeExtensionManager;
+  late InspectorController inspectorController;
   const windowSize = Size(2600.0, 1200.0);
 
   final debuggerController = createMockDebuggerControllerWithDefaults();
@@ -33,6 +37,7 @@ void main() {
     return wrapWithControllers(
       Builder(builder: screen.build),
       debugger: debuggerController,
+      inspector: inspectorController,
     );
   }
 
@@ -52,6 +57,12 @@ void main() {
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(PreferencesController, PreferencesController());
     fakeServiceManager.consoleService.ensureServiceInitialized();
+
+    inspectorController = InspectorController(
+      inspectorTree: InspectorTreeController(),
+      detailsTree: InspectorTreeController(),
+      treeType: FlutterTreeType.widget,
+    )..firstInspectorTreeLoadCompleted = true;
   });
 
   void mockExtensions() {

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 import 'package:devtools_app/src/screens/inspector/diagnostics_node.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_service.dart';
+import 'package:devtools_app/src/screens/inspector/primitives/inspector_common.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/inspector/inspector_tree_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_tree_test.dart
@@ -5,9 +5,9 @@
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_breadcrumbs.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_controller.dart';
-import 'package:devtools_app/src/screens/inspector/inspector_service.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_tree.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_tree_controller.dart';
+import 'package:devtools_app/src/screens/inspector/primitives/inspector_common.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/preferences.dart';
@@ -20,10 +20,10 @@ import 'utils/inspector_tree.dart';
 
 void main() {
   late FakeServiceManager fakeServiceManager;
+  late InspectorController inspectorController;
 
   setUp(() {
     fakeServiceManager = FakeServiceManager();
-    firstInspectorTreeLoadCompleted = true;
     final app = fakeServiceManager.connectedApp!;
     when(app.isFlutterAppNow).thenReturn(true);
     when(app.isProfileBuildNow).thenReturn(false);
@@ -37,54 +37,67 @@ void main() {
       isProfileBuild: false,
       isWebApp: false,
     );
+
+    inspectorController = InspectorController(
+      inspectorTree: InspectorTreeController(),
+      detailsTree: InspectorTreeController(),
+      treeType: FlutterTreeType.widget,
+    )..firstInspectorTreeLoadCompleted = true;
   });
+
+  Future<void> pumpInspectorTree(
+    WidgetTester tester, {
+    required InspectorTreeController treeController,
+    bool isSummaryTree = false,
+  }) async {
+    final debuggerController = TestDebuggerController();
+    final summaryTreeController =
+        isSummaryTree ? null : InspectorTreeController();
+    await tester.pumpWidget(
+      wrapWithControllers(
+        inspector: inspectorController,
+        debugger: debuggerController,
+        InspectorTree(
+          treeController: treeController,
+          summaryTreeController: summaryTreeController,
+          isSummaryTree: isSummaryTree,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
 
   group('InspectorTreeController', () {
     testWidgets('Row with negative index regression test',
         (WidgetTester tester) async {
-      final controller = InspectorTreeController()
+      final treeController = InspectorTreeController()
         ..config = InspectorTreeConfig(
           summaryTree: false,
           treeType: FlutterTreeType.widget,
           onNodeAdded: (_, __) {},
           onClientActiveChange: (_) {},
         );
-      final debuggerController = TestDebuggerController();
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: controller,
-            debuggerController: debuggerController,
-            inspectorTreeController: InspectorTreeController(),
-          ),
-        ),
-      );
+      await pumpInspectorTree(tester, treeController: treeController);
 
-      expect(controller.getRow(const Offset(0, -100.0)), isNull);
-      expect(controller.getRowOffset(-1), equals(0));
+      expect(treeController.getRow(const Offset(0, -100.0)), isNull);
+      expect(treeController.getRowOffset(-1), equals(0));
 
-      expect(controller.getRow(const Offset(0, 0.0)), isNull);
-      expect(controller.getRowOffset(0), equals(0));
+      expect(treeController.getRow(const Offset(0, 0.0)), isNull);
+      expect(treeController.getRowOffset(0), equals(0));
 
-      controller.root = InspectorTreeNode()..appendChild(InspectorTreeNode());
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: controller,
-            debuggerController: debuggerController,
-            inspectorTreeController: InspectorTreeController(),
-          ),
-        ),
-      );
+      treeController.root = InspectorTreeNode()
+        ..appendChild(InspectorTreeNode());
 
-      expect(controller.getRow(const Offset(0, -20))!.index, 0);
-      expect(controller.getRowOffset(-1), equals(0));
-      expect(controller.getRow(const Offset(0, 0.0)), isNotNull);
-      expect(controller.getRowOffset(0), equals(0));
+      await pumpInspectorTree(tester, treeController: treeController);
+
+      expect(treeController.getRow(const Offset(0, -20))!.index, 0);
+      expect(treeController.getRowOffset(-1), equals(0));
+      expect(treeController.getRow(const Offset(0, 0.0)), isNotNull);
+      expect(treeController.getRowOffset(0), equals(0));
 
       // This operation would previously throw an exception in debug builds
       // and infinite loop in release builds.
-      controller.scrollToRect(const Rect.fromLTWH(0, -20, 100, 100));
+      treeController.scrollToRect(const Rect.fromLTWH(0, -20, 100, 100));
     });
   });
 
@@ -96,15 +109,7 @@ void main() {
       );
 
       final treeController = inspectorTreeControllerFromNode(diagnosticNode);
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: treeController,
-            debuggerController: TestDebuggerController(),
-            inspectorTreeController: InspectorTreeController(),
-          ),
-        ),
-      );
+      await pumpInspectorTree(tester, treeController: treeController);
 
       expect(find.richText('Text: "Content"'), findsOneWidget);
     });
@@ -123,15 +128,7 @@ void main() {
       );
 
       final treeController = inspectorTreeControllerFromNode(diagnosticNode);
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: treeController,
-            debuggerController: TestDebuggerController(),
-            inspectorTreeController: InspectorTreeController(),
-          ),
-        ),
-      );
+      await pumpInspectorTree(tester, treeController: treeController);
 
       expect(find.richText('Text: "Rich text"'), findsOneWidget);
     });
@@ -144,16 +141,7 @@ void main() {
       );
 
       final treeController = inspectorTreeControllerFromNode(diagnosticNode);
-
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: treeController,
-            debuggerController: TestDebuggerController(),
-            inspectorTreeController: InspectorTreeController(),
-          ),
-        ),
-      );
+      await pumpInspectorTree(tester, treeController: treeController);
 
       expect(find.richText('Text: "Multiline text  content"'), findsOneWidget);
     });
@@ -164,18 +152,8 @@ void main() {
         tester: tester,
       );
 
-      final controller = inspectorTreeControllerFromNode(diagnosticNode);
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: controller,
-            debuggerController: TestDebuggerController(),
-            inspectorTreeController: InspectorTreeController(),
-            // ignore: avoid_redundant_argument_values
-            isSummaryTree: false,
-          ),
-        ),
-      );
+      final treeController = inspectorTreeControllerFromNode(diagnosticNode);
+      await pumpInspectorTree(tester, treeController: treeController);
 
       expect(find.byType(InspectorBreadcrumbNavigator), findsOneWidget);
     });
@@ -186,15 +164,11 @@ void main() {
         tester: tester,
       );
 
-      final controller = inspectorTreeControllerFromNode(diagnosticNode);
-      await tester.pumpWidget(
-        wrap(
-          InspectorTree(
-            controller: controller,
-            debuggerController: TestDebuggerController(),
-            isSummaryTree: true,
-          ),
-        ),
+      final treeController = inspectorTreeControllerFromNode(diagnosticNode);
+      await pumpInspectorTree(
+        tester,
+        treeController: treeController,
+        isSummaryTree: true,
       );
 
       expect(find.byType(InspectorBreadcrumbNavigator), findsNothing);

--- a/packages/devtools_test/lib/src/wrappers.dart
+++ b/packages/devtools_test/lib/src/wrappers.dart
@@ -52,6 +52,7 @@ Widget wrapWithAnalytics(
 
 Widget wrapWithControllers(
   Widget widget, {
+  InspectorController? inspector,
   LoggingController? logging,
   MemoryController? memory,
   PerformanceController? performance,
@@ -66,6 +67,8 @@ Widget wrapWithControllers(
     Provider<BannerMessagesController>.value(
       value: bannerMessages ?? MockBannerMessagesController(),
     ),
+    if (inspector != null)
+      Provider<InspectorController>.value(value: inspector),
     if (logging != null) Provider<LoggingController>.value(value: logging),
     if (memory != null) Provider<MemoryController>.value(value: memory),
     if (performance != null)


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/3950.

this change results in the InspectorController only being created once (like the other controllers in DevTools), instead of being recreated on each time the inspector screen is created and destroyed.