### PR TITLE
Minor improvements for leak tracker.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/leaks/instrumentation/model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/leaks/instrumentation/model.dart
@@ -128,7 +128,6 @@ ${leaks.map((e) => e.toYaml('$indent    ')).join()}
   String toYaml(String indent) {
     final result = StringBuffer();
     result.writeln('$indent$type:');
-    result.writeln('$indent  type: $type');
     result.writeln('$indent  identityHashCode: $code');
     if (details.isNotEmpty) {
       result.writeln('$indent  details: $details');

--- a/packages/devtools_app/lib/src/screens/memory/panes/leaks/instrumentation/model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/leaks/instrumentation/model.dart
@@ -130,7 +130,16 @@ ${leaks.map((e) => e.toYaml('$indent    ')).join()}
     result.writeln('$indent$type:');
     result.writeln('$indent  identityHashCode: $code');
     if (details.isNotEmpty) {
-      result.writeln('$indent  details: $details');
+      result.writeln('$indent  details:');
+      final detailsIndent = '$indent    ';
+      result.write(
+        details
+            .map(
+              (t) =>
+                  '$detailsIndent- ${_indentNewLines(t, '  $detailsIndent')}\n',
+            )
+            .join(),
+      );
     }
 
     if (detailedPath != null) {
@@ -140,5 +149,9 @@ ${leaks.map((e) => e.toYaml('$indent    ')).join()}
       result.writeln('$indent  retainingPath: $retainingPath');
     }
     return result.toString();
+  }
+
+  static String _indentNewLines(String text, String indent) {
+    return text.replaceAll('\n', '\n$indent').trimRight();
   }
 }


### PR DESCRIPTION
Update YAML formatting:
1. Remove redundant type
2. Account for multiline content in `details`