### PR TITLE
inspector add screenshot

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/diagnostics_node.dart
@@ -5,6 +5,8 @@
 library diagnostics_node;
 
 import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -694,7 +696,17 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
       await objectGroup.setSelectionInspector(valueRef, uiAlreadyUpdated);
     }
   }
+
+  Future<List<int>> screenShot() async {
+    final String? data = await inspectorService?.screenShot(valueRef) as String?;
+    if (data == null) {
+      return Uint8List.fromList([]);
+    } else {
+      return base64.decoder.convert(data);
+    }
+  }
 }
+
 
 class InspectorSourceLocation {
   InspectorSourceLocation(this.json, this.parent);

--- a/packages/devtools_app/lib/src/screens/inspector/easy_image_provider.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/easy_image_provider.dart
@@ -1,0 +1,52 @@
+import 'dart:typed_data';
+import 'dart:ui' as ui;
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
+
+class EasyImageProvider extends ImageProvider<EasyImageProvider> {
+  const EasyImageProvider(this.data, this.key, { this.scale = 1.0 });
+
+  /// The file to decode into an image.
+  final Uint8List data;
+
+  /// The scale to place in the [ImageInfo] object of the image.
+  final double scale;
+
+  final String? key;
+
+  @override
+  ImageStreamCompleter load(EasyImageProvider key, decode) {
+    return MultiFrameImageStreamCompleter(
+      codec: _loadAsync(key, decode),
+      scale: key.scale,
+      debugLabel: this.key,
+    );
+  }
+
+  Future<ui.Codec> _loadAsync(EasyImageProvider key, DecoderCallback decode) async {
+    assert(key == this);
+
+    return decode(data);
+  }
+
+  @override
+  Future<EasyImageProvider> obtainKey(ImageConfiguration configuration) {
+    return SynchronousFuture<EasyImageProvider>(this);
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other.runtimeType != runtimeType)
+      return false;
+    return other is EasyImageProvider
+        && other.data == data
+        && other.scale == scale;
+  }
+
+  @override
+  int get hashCode => hashValues(data.hashCode, scale);
+
+  @override
+  String toString() => '${objectRuntimeType(this, 'EasyImageProvider')}(${describeIdentity(data)}, scale: $scale)';
+}

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -1113,6 +1113,8 @@ abstract class ObjectGroupBase implements Disposable {
       false,
     );
   }
+
+  Future<Object?> screenShot(InspectorInstanceRef selection);
 }
 
 /// Class managing a group of inspector objects that can be freed by
@@ -1416,6 +1418,24 @@ class ObjectGroup extends ObjectGroupBase {
     );
     final directories = (invocationResult as List?)?.cast<Object>();
     return List.from(directories ?? []);
+  }
+
+  @override
+  Future<Object?> screenShot(InspectorInstanceRef selection) {
+    if (disposed) {
+      return Future.value();
+    }
+    if (useDaemonApi) {
+      return invokeServiceMethodDaemonParams('screenshot', {
+        'id': selection.id,
+        'width': 480,
+        'height': 640,
+      });
+    } else {
+      //Todo: Requires framework modification
+      return invokeServiceMethodObservatoryInspectorRef(
+          'screenshot', selection);
+    }
   }
 }
 


### PR DESCRIPTION
This pr is a screenshot of the current widget that can be displayed on the inspect screen when you double-click its widget. Below is its demo. Inside our company, this feature is very helpful in debugging.
It's still in the draft stage, not sure how you feel about this change, any thoughts on this can be discussed here.



https://user-images.githubusercontent.com/58758250/180193329-99c3a138-051e-45fe-ba39-386dda4e4ee7.mov




## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking


 for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
