### PR TITLE
Initial implementation of `VmCodeDisplay` in program explorer

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -245,6 +245,9 @@ class ProgramStructureIcon extends StatelessWidget {
     } else if (object is ScriptRef) {
       icon = libraryIcon;
       color = colorScheme.stringSyntaxColor;
+    } else if (object is CodeRef) {
+      icon = Icons.code;
+      color = colorScheme.controlFlowSyntaxColor;
     } else {
       icon = containerIcon;
     }
@@ -429,12 +432,14 @@ class ProgramExplorer extends StatelessWidget {
     this.onSelected,
     this.title = 'File Explorer',
     this.onNodeSelected,
+    this.displayCodeNodes = false,
   });
 
   final ProgramExplorerController controller;
   final void Function(ScriptLocation)? onSelected;
   final String title;
   final void Function(VMServiceObjectNode)? onNodeSelected;
+  final bool displayCodeNodes;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -293,8 +293,18 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
 
   void updateObject(Obj object) {
     if (this.object is! Class && object is Class) {
-      for (final function in object.functions ?? []) {
-        _createChild(function.name, function);
+      for (final function in object.functions ?? <Func>[]) {
+        final node = _createChild(function.name, function);
+        final code = (function as Func).code;
+        if (code != null) {
+        node.addChild(
+          VMServiceObjectNode(
+            controller,
+            code.name,
+            code,
+          ),
+        );
+        }
       }
       for (final field in object.fields ?? []) {
         _createChild(field.name, field);
@@ -343,6 +353,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
     final classNodes = <VMServiceObjectNode>[];
     final functionNodes = <VMServiceObjectNode>[];
     final variableNodes = <VMServiceObjectNode>[];
+    final codeNodes = <VMServiceObjectNode>[];
 
     final packageAndCoreLibLibraryNodes = <VMServiceObjectNode>[];
     final packageAndCoreLibDirectoryNodes = <VMServiceObjectNode>[];
@@ -384,6 +395,10 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
           case FieldRef:
           case Field:
             variableNodes.add(child);
+            break;
+          case CodeRef:
+          case Code:
+            codeNodes.add(child);
             break;
           default:
             throw StateError('Unexpected type: ${child.object.runtimeType}');
@@ -439,6 +454,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
         ...classNodes,
         ...functionNodes,
         ...variableNodes,
+        ...codeNodes,
         // We treat core libraries and packages as their own category as users
         // are likely more interested in code within their own project.
         // TODO(bkonyi): do we need custom google3 heuristics here?

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view.dart
@@ -44,7 +44,8 @@ class _ObjectInspectorViewState extends State<_ObjectInspectorView> {
   void initState() {
     super.initState();
     controller = ObjectInspectorViewController();
-    programExplorerController = ProgramExplorerController()..initialize();
+    programExplorerController = ProgramExplorerController(showCodeNodes: true)
+      ..initialize();
     return;
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -56,6 +56,8 @@ class ObjectInspectorViewController extends DisposableController
       object = ScriptObject(ref: objRef);
     } else if (objRef is InstanceRef) {
       object = InstanceObject(ref: objRef);
+    } else if (objRef is CodeRef) {
+      object = CodeObject(ref: objRef);
     }
 
     await object?.initialize();

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
@@ -10,6 +10,7 @@ import '../../shared/common_widgets.dart';
 import '../../shared/history_viewport.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_class_display.dart';
+import 'vm_code_display.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 
@@ -96,6 +97,11 @@ Widget buildObjectDisplay(VmObject obj) {
   }
   if (obj is InstanceObject) {
     return const VMInfoCard(title: 'TO-DO: Display Instance object data');
+  }
+  if (obj is CodeObject) {
+    return VmCodeDisplay(
+      code: obj,
+    );
   }
   return const SizedBox.shrink();
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
@@ -88,7 +88,9 @@ class _InstructionColumn extends _CodeColumnData
   }
 
   TextSpan _buildInstructionSpanRegExp(
-      ColorScheme colorScheme, StringScanner scanner) {
+    ColorScheme colorScheme,
+    StringScanner scanner,
+  ) {
     return TextSpan(
       text: _getLastMatch(scanner),
       style: TextStyle(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
@@ -67,7 +67,8 @@ class _DartObjectColumn extends _CodeColumnData {
   _DartObjectColumn() : super.wide('Object');
 
   @override
-  String getValue(Instruction dataObject) => _objectToDisplayValue(dataObject.object);
+  String getValue(Instruction dataObject) =>
+      _objectToDisplayValue(dataObject.object);
 
   // TODO(bkonyi): verify this covers all cases.
   String _objectToDisplayValue(Object? object) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
@@ -126,7 +126,7 @@ class _InstructionColumn extends _CodeColumnData
     final addressRegExp = RegExp(r'0x[a-fA-F0-9]+');
     final numericRegExp = RegExp(r'\d+');
     final spans = <TextSpan>[];
-    
+
     final scanner = StringScanner(instruction);
     final colorScheme = Theme.of(context).colorScheme;
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
@@ -1,0 +1,24 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'vm_object_model.dart';
+
+/// A widget for the object inspector historyViewport displaying information
+/// related to class objects in the Dart VM.
+class VmCodeDisplay extends StatelessWidget {
+  const VmCodeDisplay({
+    required this.code,
+  });
+
+  final CodeObject code;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [],
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -14,7 +14,7 @@ import 'object_inspector_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
 
-const displayObjectInspector = false;
+const displayObjectInspector = true;
 
 abstract class VMDeveloperView {
   const VMDeveloperView(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -14,7 +14,7 @@ import 'object_inspector_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
 
-const displayObjectInspector = true;
+const displayObjectInspector = false;
 
 abstract class VMDeveloperView {
   const VMDeveloperView(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_object_model.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_object_model.dart
@@ -144,3 +144,15 @@ class InstanceObject extends VmObject {
   @override
   String? get name => obj.name;
 }
+
+class CodeObject extends VmObject {
+  CodeObject({required super.ref});
+
+  Code get obj => _obj as Code;
+
+  @override
+  SourceLocation? get _sourceLocation => null;
+
+  @override
+  String? get name => obj.name;
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -6,8 +6,9 @@ import 'package:vm_service/vm_service.dart';
 
 /// NOTE: this file contains extensions to classes provided by
 /// `package:vm_service` in order to expose VM internal fields in a controlled
-/// fashion. Objects and extensions in this class should not be used outside of
-/// the `vm_developer` directory.
+/// fashion. Objects and extensions in this class should not be used in
+/// contexts where [PreferencesController.vmDeveloperModeEnabled] is not set to
+/// `true`.
 
 /// An extension on [VM] which allows for access to VM internal fields.
 extension VMPrivateViewExtension on VM {
@@ -33,7 +34,9 @@ extension IsolatePrivateViewExtension on Isolate {
   int get oldSpaceCapacity => json!['_heaps']['old']['capacity'];
 }
 
+/// An extension on [Class] which allows for access to VM internal fields.
 extension ClassPrivateViewExtension on Class {
+  /// The internal name of the [Class].
   String get vmName => json!['_vmName'];
 }
 
@@ -59,6 +62,8 @@ class HeapStats {
   final int externalSize;
 }
 
+/// An extension on [ClassHeapStats] which allows for access to VM internal
+/// fields.
 extension ClassHeapStatsPrivateViewExtension on ClassHeapStats {
   static const newSpaceKey = '_new';
   static const oldSpaceKey = '_old';
@@ -69,4 +74,110 @@ extension ClassHeapStatsPrivateViewExtension on ClassHeapStats {
   HeapStats get oldSpace => json!.containsKey(oldSpaceKey)
       ? HeapStats.parse(json![oldSpaceKey].cast<int>())
       : const HeapStats.empty();
+}
+
+/// An extension on [ObjRef] which allows for access to VM internal fields.
+extension ObjRefPrivateViewExtension on ObjRef {
+  static const _icDataType = 'ICData';
+
+  /// The internal type of the object.
+  ///
+  /// The type of non-public service objects can be determined using this
+  /// value.
+  String get vmType => json!['_vmType']!;
+
+  /// `true` if this object is an instance of [ICData].
+  bool get isICData => vmType == _icDataType;
+
+  /// Casts the current [ObjRef] into an instance of [ICData].
+  ICData get asICData => ICData.parse(json!);
+}
+
+/// A representation of the Dart VM's Inline Cache (IC).
+///
+/// For more information:
+///  - [Slava's Dart VM intro](https://mrale.ph/dartvm/)
+///  - [Dart VM implementation](https://github.com/dart-lang/sdk/blob/2d064faf748d6c7700f08d223fb76c84c4335c5f/runtime/vm/raw_object.h#L2103)
+class ICData {
+  ICData.parse(Map<String, dynamic> json) : selector = json['_selector'];
+
+  final String selector;
+}
+
+/// A single assembly instruction from a [Func]'s generated code disassembly.
+class Instruction {
+  Instruction.parse(List data)
+      : address = data[0],
+        unknown = data[1],
+        instruction = data[2] {
+    if (data[3] == null) {
+      object = null;
+      return;
+    }
+    final rawObject = data[3] as Map<String, dynamic>;
+    if (rawObject['type'].contains('Instance')) {
+      object = InstanceRef.parse(rawObject);
+    } else {
+      object = createServiceObject(data[3], const <String>[]) as ObjRef;
+    }
+  }
+
+  /// The instruction's address in memory.
+  final String address;
+
+  /// TODO(bkonyi): figure out what this value is for.
+  final String unknown;
+
+  /// The [String] representation of the assembly instruction.
+  final String instruction;
+
+  /// The Dart object this instruction is acting upon directly.
+  late final ObjRef? object;
+
+  List toJson() => [
+        address,
+        unknown,
+        instruction,
+        object?.json,
+      ];
+}
+
+/// The full disassembly of generated [Code] for a function.
+class Disassembly {
+  Disassembly.parse(List disassembly) {
+    for (int i = 0; i < disassembly.length; i += 4) {
+      instructions.add(
+        Instruction.parse(disassembly.getRange(i, i + 4).toList()),
+      );
+    }
+  }
+
+  /// The list of [Instructions] that make up the generated code.
+  final instructions = <Instruction>[];
+
+  List toJson() => [
+        for (final i in instructions) ...i.toJson(),
+      ];
+}
+
+/// An extension on [Func] which allows for access to VM internal fields.
+
+extension FunctionPrivateViewExtension on Func {
+  static const _unoptimizedCodeKey = '_unoptimizedCode';
+
+  /// The unoptimized [CodeRef] associated with the [Func].
+  CodeRef? get unoptimizedCode => CodeRef.parse(json![_unoptimizedCodeKey]);
+  set unoptimizedCode(CodeRef? code) => json![_unoptimizedCodeKey] = code?.json;
+}
+
+/// An extension on [Code] which allows for access to VM internal fields.
+
+extension CodePrivateViewExtension on Code {
+  static const _disassemblyKey = '_disassembly';
+
+  /// Returns the disassembly of the [Code], which is the generated assembly
+  /// instructions for the code's function.
+  Disassembly get disassembly => Disassembly.parse(json![_disassemblyKey]);
+  set disassembly(Disassembly disassembly) =>
+      json![_disassemblyKey] = disassembly.toJson();
 }

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -1,0 +1,77 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_code_display.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
+import 'package:devtools_app/src/shared/table.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+void main() {
+  late MockCodeObject mockCodeObject;
+
+  const windowSize = Size(4000.0, 4000.0);
+
+  group('VmCodeDisplay', () {
+    setUpAll(() {
+      setGlobal(IdeTheme, IdeTheme());
+
+      mockCodeObject = MockCodeObject();
+      final testCode = Code(
+        id: 'code-obj',
+        kind: 'Dart',
+        name: 'testFuncCode',
+      );
+      testCode.json = {};
+      final offset = pow(2, 20) as int;
+      testCode.disassembly = Disassembly.parse(<dynamic>[
+        for (int i = 0; i < 1000; ++i) ...[
+          (i * 4 + offset).toRadixString(16),
+          'unknown',
+          'noop',
+          null,
+        ]
+      ]);
+
+      when(mockCodeObject.obj).thenReturn(testCode);
+    });
+
+    void verifyAddressOrder(List<Instruction> data) {
+      int lastAddress = 0;
+      for (final instr in data) {
+        final currentAddress = int.parse(instr.address, radix: 16);
+        expect(currentAddress > lastAddress, isTrue);
+        lastAddress = currentAddress;
+      }
+    }
+
+    testWidgetsWithWindowSize(
+        'displays CodeTable instructions in order of increasing address',
+        windowSize, (WidgetTester tester) async {
+      await tester.pumpWidget(wrap(VmCodeDisplay(code: mockCodeObject)));
+
+      expect(find.byType(CodeTable), findsOneWidget);
+      final FlatTableState<Instruction> state =
+          tester.state(find.byType(FlatTable<Instruction>));
+
+      // Ensure ordering is correct.
+      verifyAddressOrder(state.data);
+
+      final columns = state.widget.columns;
+
+      // Make sure the table can't be sorted differently.
+      for (final column in columns) {
+        await tester.tap(find.text(column.title));
+        await tester.pumpAndSettle();
+        verifyAddressOrder(state.data);
+      }
+    });
+  });
+}

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -23,6 +23,7 @@ import 'package:vm_service/vm_service.dart';
   VmServiceWrapper,
   ObjectGroupBase,
   ClassObject,
+  CodeObject,
   ui.Image,
 ])
 void main() {}


### PR DESCRIPTION
- Adds support for displaying code objects in the `ProgramExplorer` widget
- Adds initial implementation for displaying code objects in the `VM Tools` `Objects` view.

**Screenshot:**
<img width="1600" alt="Screen Shot 2022-07-22 at 12 25 26 PM" src="https://user-images.githubusercontent.com/24210656/180482827-b892c5c6-52ca-45b0-8824-ec2f14267e49.png">