### PR TITLE
Make UI jank hints aware of the enhance tracing state for a frame

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/frame_analysis.dart
+++ b/packages/devtools_app/lib/src/screens/performance/frame_analysis.dart
@@ -352,6 +352,9 @@ class _EnhanceTracingHint extends StatelessWidget {
     ThemeData theme,
   ) {
     final phaseType = phase.type;
+    // TODO(kenz): when [enhanceTracingState] is not available, use heuristics
+    // to detect whether tracing was enhanced for a frame (e.g. the depth or
+    // quanity of child events under build / layout / paint).
     final tracingEnhanced =
         enhanceTracingState?.enhancedFor(phaseType) ?? false;
     switch (phaseType) {

--- a/packages/devtools_app/lib/src/screens/performance/frame_analysis.dart
+++ b/packages/devtools_app/lib/src/screens/performance/frame_analysis.dart
@@ -14,6 +14,7 @@ import '../../ui/colors.dart';
 import '../../ui/utils.dart';
 import 'panes/controls/enhance_tracing/enhance_tracing.dart';
 import 'panes/controls/enhance_tracing/enhance_tracing_controller.dart';
+import 'panes/controls/enhance_tracing/enhance_tracing_model.dart';
 import 'performance_controller.dart';
 import 'performance_model.dart';
 import 'performance_utils.dart';

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
@@ -4,12 +4,10 @@
 
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
-
 import '../../../../../primitives/auto_dispose.dart';
 import '../../../../../service/service_extensions.dart' as extensions;
 import '../../../../../shared/globals.dart';
-import '../../../performance_model.dart';
+import 'enhance_tracing_model.dart';
 
 final enhanceTracingExtensions = [
   extensions.profileWidgetBuilds,
@@ -68,33 +66,5 @@ class EnhanceTracingController extends DisposableController
   void dispose() {
     showMenuStreamController.close();
     super.dispose();
-  }
-}
-
-@immutable
-class EnhanceTracingState {
-  const EnhanceTracingState({
-    required this.builds,
-    required this.layouts,
-    required this.paints,
-  });
-
-  final bool builds;
-  final bool layouts;
-  final bool paints;
-
-  bool get enhanced => builds || layouts || paints;
-
-  bool enhancedFor(FramePhaseType type) {
-    switch (type) {
-      case FramePhaseType.build:
-        return builds;
-      case FramePhaseType.layout:
-        return layouts;
-      case FramePhaseType.paint:
-        return paints;
-      default:
-        return false;
-    }
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_model.dart
@@ -1,0 +1,35 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+
+import '../../../performance_model.dart';
+
+@immutable
+class EnhanceTracingState {
+  const EnhanceTracingState({
+    required this.builds,
+    required this.layouts,
+    required this.paints,
+  });
+
+  final bool builds;
+  final bool layouts;
+  final bool paints;
+
+  bool get enhanced => builds || layouts || paints;
+
+  bool enhancedFor(FramePhaseType type) {
+    switch (type) {
+      case FramePhaseType.build:
+        return builds;
+      case FramePhaseType.layout:
+        return layouts;
+      case FramePhaseType.paint:
+        return paints;
+      default:
+        return false;
+    }
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -8,6 +8,7 @@ import 'dart:math' as math;
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
 import 'package:pedantic/pedantic.dart';
+import 'package:vm_service/vm_service.dart' show Event;
 
 import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
@@ -201,12 +202,24 @@ class PerformanceController extends DisposableController
           await serviceManager.queryDisplayRefreshRate ?? defaultRefreshRate;
       data?.displayRefreshRate = _displayRefreshRate.value;
 
+      enhanceTracingController.init();
+
+      // Listen for the first 'Flutter.Frame' event we receive from this point
+      // on so that we know the start id for frames that we can assign the
+      // current [FlutterFrame.enhanceTracingState].
+      _listenForFirstLiveFrame();
+
       // Listen for Flutter.Frame events with frame timing data.
       // Listen for Flutter.RebuiltWidgets events.
       autoDisposeStreamSubscription(
         serviceManager.service!.onExtensionEventWithHistory.listen((event) {
           if (event.extensionKind == 'Flutter.Frame') {
             final frame = FlutterFrame.parse(event.extensionData!.data);
+            // We can only assign [FlutterFrame.enhanceTracingState] for frames
+            // with ids after [_firstLiveFrameId].
+            if (_firstLiveFrameId != null && frame.id >= _firstLiveFrameId!) {
+              frame.enhanceTracingState = enhanceTracingController.tracingState;
+            }
             addFrame(frame);
           } else if (event.extensionKind == 'Flutter.RebuiltWidgets') {
             rebuildCountModel.processRebuildEvent(event.extensionData!.data);
@@ -251,6 +264,42 @@ class PerformanceController extends DisposableController
             displayRefreshRate: await serviceManager.queryDisplayRefreshRate,
           )
         : PerformanceData();
+  }
+
+  /// The id of the first 'Flutter.Frame' event that occurs after the DevTools
+  /// performance page is opened.
+  ///
+  /// For frames with this id and greater, we can assign
+  /// [FlutterFrame.enhanceTracingState]. For frames with an earlier id, we
+  /// do not know the value of [FlutterFrame.enhanceTracingState], and we will
+  /// use other heuristics.
+  int? _firstLiveFrameId;
+
+  /// Stream subscription on the 'Extension' stream that listens for the first
+  /// 'Flutter.Frame' event.
+  ///
+  /// This stream should be initialized and cancelled in
+  /// [_listenForFirstLiveFrame], unless we never receive any 'Flutter.Frame'
+  /// events, in which case the subscription will be canceled in [dispose].
+  StreamSubscription<Event>? _firstFrameEventSubscription;
+
+  /// Listens on the 'Extension' stream (without history) for 'Flutter.Frame'
+  /// events.
+  ///
+  /// This method assigns [_firstLiveFrameId] when the first 'Flutter.Frame'
+  /// event is received, and then cancels the stream subscription.
+  void _listenForFirstLiveFrame() {
+    _firstFrameEventSubscription =
+        serviceManager.service!.onExtensionEvent.listen(
+      (event) {
+        if (event.extensionKind == 'Flutter.Frame' &&
+            _firstLiveFrameId == null) {
+          _firstLiveFrameId = FlutterFrame.parse(event.extensionData!.data).id;
+          _firstFrameEventSubscription!.cancel();
+          _firstFrameEventSubscription = null;
+        }
+      },
+    );
   }
 
   Future<void> _pullTraceEventsFromVmTimeline({
@@ -883,6 +932,7 @@ class PerformanceController extends DisposableController
     _timelinePollingRateLimiter?.dispose();
     cpuProfilerController.dispose();
     enhanceTracingController.dispose();
+    _firstFrameEventSubscription?.cancel();
     super.dispose();
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -39,6 +39,8 @@ import 'timeline_event_processor.dart';
 /// Debugging flag to load sample trace events from [simple_trace_example.dart].
 bool debugSimpleTrace = false;
 
+// TODO(https://github.com/flutter/devtools/issues/4287): add more tests before
+// enabling this feature.
 /// Flag to hide the frame analysis feature while it is under development.
 bool frameAnalysisSupported = false;
 

--- a/packages/devtools_app/lib/src/screens/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_model.dart
@@ -14,7 +14,7 @@ import '../../primitives/utils.dart';
 import '../../service/service_manager.dart';
 import '../../ui/search.dart';
 import '../profiler/cpu_profile_model.dart';
-import 'panes/controls/enhance_tracing/enhance_tracing_controller.dart';
+import 'panes/controls/enhance_tracing/enhance_tracing_model.dart';
 import 'performance_utils.dart';
 import 'timeline_event_processor.dart';
 

--- a/packages/devtools_app/test/performance/performance_controller_test.dart
+++ b/packages/devtools_app/test/performance/performance_controller_test.dart
@@ -5,6 +5,7 @@
 @TestOn('vm')
 import 'dart:async';
 
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
 import 'package:devtools_app/src/primitives/trace_event.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
@@ -38,6 +39,7 @@ void main() async {
       when(fakeServiceManager.connectedApp!.initialized)
           .thenReturn(initializedCompleter);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(IdeTheme, IdeTheme());
     });
 
     setUp(() async {


### PR DESCRIPTION
For a frame with jank hints, we now change the enhance tracing hint dependent on whether the tracing was already enhanced for the selected frame.
<img width="823" alt="Screen Shot 2022-07-22 at 11 07 19 AM" src="https://user-images.githubusercontent.com/43759233/180578008-a4c992f6-0d18-418c-b1e4-2342929a72af.png">

For a janky frame where enhance tracing was not already enabled, we will continue to point them to the Enhance Tracing feature.