### PR TITLE
Deferred nodes are gray scaled on TreeMap

### DIFF
--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -472,7 +472,9 @@ class _TreemapState extends State<Treemap> {
   Container buildCell() {
     return Container(
       decoration: BoxDecoration(
-        color: widget.rootNode!.displayColor,
+        color: widget.rootNode!.isDeferred
+            ? Colors.grey
+            : widget.rootNode!.displayColor,
         border: Border.all(color: Colors.black87),
       ),
       child: Center(

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -605,10 +605,7 @@ class TreemapNode extends TreeNode<TreemapNode> {
 
   Color get displayColor {
     if (!showDiff) {
-      if (isDeferred)
-        return Colors.grey;
-      else
-        return mainUiColor;
+      return isDeferred ? treemapDeferredColor : mainUiColor;
     }
     if (byteSize < 0) {
       return treemapDecreaseColor;

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -591,6 +591,7 @@ class TreemapNode extends TreeNode<TreemapNode> {
     this.byteSize = 0,
     this.childrenMap = const <String, TreemapNode>{},
     this.showDiff = false,
+    this.isDeferred = false,
   });
 
   final String name;
@@ -598,6 +599,7 @@ class TreemapNode extends TreeNode<TreemapNode> {
   int byteSize;
 
   final bool showDiff;
+  final bool isDeferred;
 
   int get unsignedByteSize => byteSize.abs();
 
@@ -745,8 +747,8 @@ class MultiCellPainter extends CustomPainter {
     );
 
     final rectPaint = Paint();
-    //CAROLYN - here I would change the rectPainColor if node is deferred - need to add a checker
-    rectPaint.color = node.displayColor;
+    final paintColor = node.isDeferred ? Colors.grey : node.displayColor;
+    rectPaint.color = paintColor;
     canvas.drawRect(bounds, rectPaint);
 
     final borderPaint = Paint()

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -472,9 +472,7 @@ class _TreemapState extends State<Treemap> {
   Container buildCell() {
     return Container(
       decoration: BoxDecoration(
-        color: widget.rootNode!.isDeferred
-            ? Colors.grey
-            : widget.rootNode!.displayColor,
+        color: widget.rootNode!.displayColor,
         border: Border.all(color: Colors.black87),
       ),
       child: Center(
@@ -606,7 +604,12 @@ class TreemapNode extends TreeNode<TreemapNode> {
   int get unsignedByteSize => byteSize.abs();
 
   Color get displayColor {
-    if (!showDiff) return mainUiColor;
+    if (!showDiff) {
+      if (isDeferred)
+        return Colors.grey;
+      else
+        return mainUiColor;
+    }
     if (byteSize < 0) {
       return treemapDecreaseColor;
     } else {
@@ -749,8 +752,7 @@ class MultiCellPainter extends CustomPainter {
     );
 
     final rectPaint = Paint();
-    final paintColor = node.isDeferred ? Colors.grey : node.displayColor;
-    rectPaint.color = paintColor;
+    rectPaint.color = node.displayColor;
     canvas.drawRect(bounds, rectPaint);
 
     final borderPaint = Paint()

--- a/packages/devtools_app/lib/src/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/charts/treemap.dart
@@ -745,6 +745,7 @@ class MultiCellPainter extends CustomPainter {
     );
 
     final rectPaint = Paint();
+    //CAROLYN - here I would change the rectPainColor if node is deferred - need to add a checker
     rectPaint.color = node.displayColor;
     canvas.drawRect(bounds, rectPaint);
 

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -489,7 +489,8 @@ class AppSizeController {
       childrenMap[child.name] = child;
     }
 
-    final bool isDeferred = treeJson['isDeferred'] != null;
+    final bool isDeferred =
+        treeJson['isDeferred'] != null && treeJson['isDeferred'];
 
     return TreemapNode(
       name: name,

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -489,11 +489,14 @@ class AppSizeController {
       childrenMap[child.name] = child;
     }
 
+    final bool isDeferred = treeJson['isDeferred'] != null;
+
     return TreemapNode(
       name: name,
       byteSize: byteSize,
       childrenMap: childrenMap,
       showDiff: showDiff,
+      isDeferred: isDeferred,
     )..addAllChildren(children);
   }
 }

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -77,6 +77,8 @@ const treemapDecreaseColor = Color(0xFF77102F);
 const tableIncreaseColor = Color(0xFF73BF43);
 const tableDecreaseColor = Color(0xFFEE284F);
 
+const treemapDeferredColor = Color(0xFFC5CAE9);
+
 const appCodeColor = ThemedColorPair(
   background: ThemedColor(
     light: Color(0xFFFA7B17),

--- a/packages/devtools_app/lib/src/ui/colors.dart
+++ b/packages/devtools_app/lib/src/ui/colors.dart
@@ -77,7 +77,7 @@ const treemapDecreaseColor = Color(0xFF77102F);
 const tableIncreaseColor = Color(0xFF73BF43);
 const tableDecreaseColor = Color(0xFFEE284F);
 
-const treemapDeferredColor = Color(0xFFC5CAE9);
+const treemapDeferredColor = Color(0xFFBDBDBD);
 
 const appCodeColor = ThemedColorPair(
   background: ThemedColor(


### PR DESCRIPTION
On TreeMap UI, deferred nodes are gray scaled to help visibly distinguish between the main app vs deferred chunks. 

**Originals**
![Screen Shot 2022-07-25 at 4 41 30 PM](https://user-images.githubusercontent.com/67798872/180892744-46778893-7dd2-4a79-bd89-4554d36ef714.png)
![Screen Shot 2022-07-25 at 4 41 49 PM](https://user-images.githubusercontent.com/67798872/180892775-5ed63f7d-46b3-4f75-b8f0-3d41df1f9bee.png)

**New Deferred Graying**
![Screen Shot 2022-07-25 at 4 58 01 PM](https://user-images.githubusercontent.com/67798872/180894377-c68cb3b2-5312-4884-8f43-4deed54d64a7.png)
![Screen Shot 2022-07-25 at 4 57 45 PM](https://user-images.githubusercontent.com/67798872/180894388-9aee963d-0e11-4474-943c-4f103e8aa911.png)



