### PR TITLE
Remove dependency on memory_controller from allocation profile pane.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -488,7 +488,11 @@ class HeapTreeViewState extends State<HeapTree>
               children: [
                 // Profile Tab
                 if (enableNewAllocationProfileTable)
-                  KeepAliveWrapper(child: AllocationProfileTableView()),
+                  KeepAliveWrapper(
+                    child: AllocationProfileTableView(
+                      controller: controller.allocationProfileController,
+                    ),
+                  ),
                 // Analysis Tab
                 KeepAliveWrapper(
                   child: Column(

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
@@ -16,7 +16,6 @@ import '../../../../shared/table_data.dart';
 import '../../../../shared/theme.dart';
 import '../../../../shared/utils.dart';
 import '../../../vm_developer/vm_service_private_extensions.dart';
-import '../../memory_controller.dart';
 import '../../primitives/ui.dart';
 import 'allocation_profile_table_view_controller.dart';
 
@@ -181,23 +180,21 @@ class _FieldSizeColumn extends ColumnData<ClassHeapStats> {
 /// for refreshing the data on a garbage collection (GC) event and exporting
 /// [AllocationProfile]'s to a CSV formatted file.
 class AllocationProfileTableView extends StatefulWidget {
+  const AllocationProfileTableView({super.key, required this.controller});
+
   @override
   State<AllocationProfileTableView> createState() =>
       AllocationProfileTableViewState();
+
+  final AllocationProfileTableViewController controller;
 }
 
-class AllocationProfileTableViewState extends State<AllocationProfileTableView>
-    with ProvidedControllerMixin<MemoryController, AllocationProfileTableView> {
-  late AllocationProfileTableViewController allocationProfileController;
-
+class AllocationProfileTableViewState
+    extends State<AllocationProfileTableView> {
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    if (!initController()) {
-      return;
-    }
-    allocationProfileController = controller.allocationProfileController
-      ..initialize();
+    widget.controller.initialize();
   }
 
   @override
@@ -205,14 +202,14 @@ class AllocationProfileTableViewState extends State<AllocationProfileTableView>
     return Column(
       children: [
         _AllocationProfileTableControls(
-          allocationProfileController: allocationProfileController,
+          allocationProfileController: widget.controller,
         ),
         const SizedBox(
           height: denseRowSpacing,
         ),
         Expanded(
           child: _AllocationProfileTable(
-            allocationProfileController: allocationProfileController,
+            allocationProfileController: widget.controller,
           ),
         ),
       ],


### PR DESCRIPTION
memory_controller gives too much power and should not be passed to the profile pane.