### PR TITLE
Fix shader time calculation with `shallowNodesWithCondition`  TreeNode method

### DIFF
--- a/packages/devtools_app/lib/src/primitives/trees.dart
+++ b/packages/devtools_app/lib/src/primitives/trees.dart
@@ -167,17 +167,41 @@ abstract class TreeNode<T extends TreeNode<T>> {
     return childWithCondition != null;
   }
 
-  List<T> childrenWithCondition(bool condition(T node)) {
-    final _children = <T>[];
+  /// Returns a list of nodes in this tree that match [condition].
+  ///
+  /// This list may include the root.
+  List<T> nodesWithCondition(bool condition(T node)) {
+    final _nodes = <T>[];
     breadthFirstTraversal<T>(
       this as T,
       action: (node) {
         if (condition(node)) {
-          _children.add(node);
+          _nodes.add(node);
         }
       },
     );
-    return _children;
+    return _nodes;
+  }
+
+  /// Returns a list of shallow nodes that match [condition], meaning that if
+  /// a node matches [condition], none of its children will be included in the
+  /// returned list, even if those children happen to match [condition].
+  ///
+  /// In other words, only the top-most node in each tree branch that matches
+  /// [condition] will be included in the returned list. This list may include
+  /// the root.
+  List<T> shallowNodesWithCondition(bool condition(T node)) {
+    final _nodes = <T>[];
+    depthFirstTraversal<T>(
+      this as T,
+      action: (T node) {
+        if (condition(node)) {
+          _nodes.add(node);
+        }
+      },
+      exploreChildrenCondition: (T node) => !condition(node),
+    );
+    return _nodes;
   }
 
   T? firstChildWithCondition(bool condition(T node)) {

--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_analysis_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_analysis_model.dart
@@ -43,7 +43,7 @@ class FrameAnalysis {
       return FramePhase.build(events: <SyncTimelineEvent>[]);
     }
     final buildEvents = uiEvent
-        .childrenWithCondition(
+        .nodesWithCondition(
           (event) =>
               event.name
                   ?.caseInsensitiveEquals(FramePhaseType.build.eventName) ??

--- a/packages/devtools_app/test/shared/trees_test.dart
+++ b/packages/devtools_app/test/shared/trees_test.dart
@@ -9,7 +9,8 @@ void main() {
   group('TreeNode', () {
     test('depth', () {
       expect(testTreeNode.depth, equals(4));
-      expect(treeNode2.depth, equals(1));
+      expect(treeNode1.depth, equals(1));
+      expect(treeNode2.depth, equals(2));
       expect(treeNode3.depth, equals(3));
     });
 
@@ -111,24 +112,44 @@ void main() {
       expect(child.parent, equals(parent));
     });
 
-    test('childrenWithCondition', () {
-      var nodes = testTreeNode.childrenWithCondition((TestTreeNode node) {
+    test('nodesWithCondition', () {
+      var nodes = testTreeNode.nodesWithCondition((TestTreeNode node) {
         return node.id.isEven;
       });
       var nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
-      expect(nodeIds, equals([0, 2, 4, 6, 8]));
+      expect(nodeIds, equals([0, 2, 10, 12, 4, 6, 8]));
 
-      nodes = testTreeNode.childrenWithCondition((TestTreeNode node) {
+      nodes = testTreeNode.nodesWithCondition((TestTreeNode node) {
         return node.tag == 'test-tag';
       });
       nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
       expect(nodeIds, equals([0, 3, 9]));
 
-      nodes = testTreeNode.childrenWithCondition((TestTreeNode node) {
+      nodes = testTreeNode.nodesWithCondition((TestTreeNode node) {
         return node.parent?.id == 5;
       });
       nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
       expect(nodeIds, equals([6, 7, 8, 9]));
+    });
+
+    test('shallowNodesWithCondition', () {
+      var nodes = testTreeNode.shallowNodesWithCondition((TestTreeNode node) {
+        return node.id.isEven;
+      });
+      var nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
+      expect(nodeIds, equals([0]));
+
+      nodes = testTreeNode.shallowNodesWithCondition((TestTreeNode node) {
+        return node.id.isEven && node.id != 0;
+      });
+      nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
+      expect(nodeIds, equals([2, 4, 6, 8]));
+
+      nodes = testTreeNode.shallowNodesWithCondition((TestTreeNode node) {
+        return node.id.isOdd;
+      });
+      nodeIds = nodes.map((TestTreeNode node) => node.id).toList();
+      expect(nodeIds, equals([1, 11, 3]));
     });
 
     test('containsChildWithCondition', () {
@@ -155,7 +176,7 @@ void main() {
     test('firstSubNodeAtLevel', () {
       expect(testTreeNode.firstChildNodeAtLevel(0), equals(treeNode0));
       expect(testTreeNode.firstChildNodeAtLevel(1), equals(treeNode1));
-      expect(testTreeNode.firstChildNodeAtLevel(2), equals(treeNode4));
+      expect(testTreeNode.firstChildNodeAtLevel(2), equals(treeNode10));
       expect(testTreeNode.firstChildNodeAtLevel(3), equals(treeNode6));
       expect(testTreeNode.firstChildNodeAtLevel(4), isNull);
 
@@ -189,6 +210,8 @@ void main() {
           '''
 0
   2
+    10
+    12
   4
   6
   8
@@ -200,15 +223,24 @@ void main() {
     test('filterTree when root should be filtered out', () {
       final List<TestTreeNode> filteredTreeRoots =
           testTreeNode.filterWhere((node) => node.id.isOdd);
-      expect(filteredTreeRoots.length, equals(2));
-      final firstRoot = filteredTreeRoots.first;
-      final lastRoot = filteredTreeRoots.last;
+      expect(filteredTreeRoots.length, equals(3));
+      final firstRoot = filteredTreeRoots[0];
+      final middleRoot = filteredTreeRoots[1];
+      final lastRoot = filteredTreeRoots[2];
 
       expect(
         firstRoot.toString(),
         equals(
           '''
 1
+''',
+        ),
+      );
+      expect(
+        middleRoot.toString(),
+        equals(
+          '''
+11
 ''',
         ),
       );
@@ -227,7 +259,7 @@ void main() {
 
     test('filterTree when zero nodes match', () {
       final List<TestTreeNode> filteredTreeRoots =
-          testTreeNode.filterWhere((node) => node.id > 10);
+          testTreeNode.filterWhere((node) => node.id > 15);
       expect(filteredTreeRoots, isEmpty);
     });
 
@@ -411,10 +443,18 @@ final treeNode6 = TestTreeNode(6);
 final treeNode7 = TestTreeNode(7);
 final treeNode8 = TestTreeNode(8);
 final treeNode9 = TestTreeNode(9, tag: 'test-tag');
+final treeNode10 = TestTreeNode(10);
+final treeNode11 = TestTreeNode(11);
+final treeNode12 = TestTreeNode(12);
 final TestTreeNode testTreeNode = treeNode0
   ..addAllChildren([
     treeNode1,
-    treeNode2,
+    treeNode2
+      ..addAllChildren([
+        treeNode10,
+        treeNode11,
+        treeNode12,
+      ]),
     treeNode3
       ..addAllChildren([
         treeNode4,

--- a/packages/devtools_app/test/test_data/performance.dart
+++ b/packages/devtools_app/test/test_data/performance.dart
@@ -720,7 +720,17 @@ final endGpuRasterizerDrawWithShaderJankTrace = testTraceEventWrapper({
 final rasterTimelineEventWithSubtleShaderJank =
     testSyncTimelineEvent(gpuRasterizerDrawWithSubtleShaderJankTrace)
       ..type = TimelineEventType.raster
-      ..addEndEvent(endGpuRasterizerDrawWithSubtleShaderJankTrace);
+      ..addEndEvent(endGpuRasterizerDrawWithSubtleShaderJankTrace)
+      ..addChild(
+        subtleShaderJankChildEvent..addChild(subtleShaderJankGrandchildEvent),
+      );
+final subtleShaderJankChildEvent = testSyncTimelineEvent(shaderJankChildTrace)
+  ..type = TimelineEventType.raster
+  ..addEndEvent(endShaderJankChildTrace);
+final subtleShaderJankGrandchildEvent =
+    testSyncTimelineEvent(shaderJankGrandchildTrace)
+      ..type = TimelineEventType.raster
+      ..addEndEvent(endShaderJankGrandchildTrace);
 final gpuRasterizerDrawWithSubtleShaderJankTrace = testTraceEventWrapper({
   'name': 'GPURasterizer::Draw',
   'cat': 'Embedder',
@@ -738,6 +748,44 @@ final endGpuRasterizerDrawWithSubtleShaderJankTrace = testTraceEventWrapper({
   'tid': testRasterThreadId,
   'pid': 94955,
   'ts': 173938744000,
+  'ph': 'E',
+  'args': {}
+});
+final shaderJankChildTrace = testTraceEventWrapper({
+  'name': 'GPURasterizer::Draw',
+  'cat': 'Embedder',
+  'tid': testRasterThreadId,
+  'pid': 94955,
+  'ts': 173938741000,
+  'ph': 'B',
+  'args': {}
+});
+final endShaderJankChildTrace = testTraceEventWrapper({
+  'name': 'GPURasterizer::Draw',
+  'cat': 'Embedder',
+  'tid': testRasterThreadId,
+  'pid': 94955,
+  'ts': 173938743000,
+  'ph': 'E',
+  'args': {}
+});
+final shaderJankGrandchildTrace = testTraceEventWrapper({
+  'name': 'GPURasterizer::Draw',
+  'cat': 'Embedder',
+  'tid': testRasterThreadId,
+  'pid': 94955,
+  'ts': 173938741500,
+  'ph': 'B',
+  'args': {
+    'devtoolsTag': 'shaders',
+  }
+});
+final endShaderJankGrandchildTrace = testTraceEventWrapper({
+  'name': 'GPURasterizer::Draw',
+  'cat': 'Embedder',
+  'tid': testRasterThreadId,
+  'pid': 94955,
+  'ts': 173938742500,
   'ph': 'E',
   'args': {}
 });


### PR DESCRIPTION
This fixes an unresolved TODO and is in preparation for another PR that will use the `shallowNodesWithCondition` functionality.