### PR TITLE
Fix bug with `msText` util

### DIFF
--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -123,19 +123,19 @@ String printGB(num bytes, {int fractionDigits = 1, bool includeUnit = false}) {
 ///
 /// [includeUnit] - whether to include 'ms' at the end of the returned value
 /// [fractionDigits] - how many fraction digits should appear after the decimal
-/// [allowZeroValues] - when true, this method may return zero (e.g. '0.0 ms').
-/// When false, this method will return a minimum value with the less than
-/// operator (e.g. '< 0.1 ms'). The value returned will always respect the
-/// specified [fractionDigits].
+/// [allowRoundingToZero] - when true, this method may return zero for a very
+/// small number (e.g. '0.0 ms'). When false, this method will return a minimum
+/// value with the less than operator for very small values (e.g. '< 0.1 ms').
+/// The value returned will always respect the specified [fractionDigits].
 String msText(
   Duration dur, {
   bool includeUnit = true,
   int fractionDigits = 1,
-  bool allowZeroValues = true,
+  bool allowRoundingToZero = true,
 }) {
   var durationStr = (dur.inMicroseconds / 1000).toStringAsFixed(fractionDigits);
 
-  if (!allowZeroValues) {
+  if (dur != Duration.zero && !allowRoundingToZero) {
     final zeroRegexp = RegExp(r'[0]+[.][0]+');
     if (zeroRegexp.hasMatch(durationStr)) {
       final buf = StringBuffer('< 0.');

--- a/packages/devtools_app/test/shared/utils_test.dart
+++ b/packages/devtools_app/test/shared/utils_test.dart
@@ -95,7 +95,7 @@ void main() {
         equals('0.0 ms'),
       );
       expect(
-        msText(const Duration(microseconds: 0), allowRoundingToZero: false),
+        msText(Duration.zero, allowRoundingToZero: false),
         equals('0.0 ms'),
       );
       expect(

--- a/packages/devtools_app/test/shared/utils_test.dart
+++ b/packages/devtools_app/test/shared/utils_test.dart
@@ -95,14 +95,18 @@ void main() {
         equals('0.0 ms'),
       );
       expect(
-        msText(const Duration(microseconds: 1), allowZeroValues: false),
+        msText(const Duration(microseconds: 0), allowRoundingToZero: false),
+        equals('0.0 ms'),
+      );
+      expect(
+        msText(const Duration(microseconds: 1), allowRoundingToZero: false),
         equals('< 0.1 ms'),
       );
       expect(
         msText(
           const Duration(microseconds: 1),
           fractionDigits: 2,
-          allowZeroValues: false,
+          allowRoundingToZero: false,
         ),
         equals('< 0.01 ms'),
       );


### PR DESCRIPTION
without this change, `msText` didn't respect true zero values when `allowZeroValues` was false.