### PR TITLE
Fix layoutPhase calculation

### DIFF
--- a/packages/devtools_app/test/performance/frame_analysis_model_test.dart
+++ b/packages/devtools_app/test/performance/frame_analysis_model_test.dart
@@ -29,7 +29,7 @@ void main() {
     test('layoutPhase', () {
       final layoutPhase = frameAnalysis.layoutPhase;
       expect(layoutPhase.events.length, equals(1));
-      expect(layoutPhase.duration.inMicroseconds, equals(211));
+      expect(layoutPhase.duration.inMicroseconds, equals(128));
     });
 
     test('paintPhase', () {


### PR DESCRIPTION
Build time that was part of layout time was previously double counted. After this PR, the layout phase duration will only include layout time that was not spent in Build.