### PR TITLE
add key and value types to VmInfoCard mapEntries

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
@@ -148,11 +148,11 @@ class GeneralIsolateStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'General',
       rowKeyValues: [
-        stringWidgetMapEntry('Name', isolate?.name),
-        stringWidgetMapEntry('Started at', _startTime(isolate)),
-        stringWidgetMapEntry('Uptime', _uptime(isolate)),
-        stringWidgetMapEntry('Root Library', isolate?.rootLib?.uri),
-        stringWidgetMapEntry('ID', isolate?.id),
+        selectableTextMapEntry('Name', isolate?.name),
+        selectableTextMapEntry('Started at', _startTime(isolate)),
+        selectableTextMapEntry('Uptime', _uptime(isolate)),
+        selectableTextMapEntry('Root Library', isolate?.rootLib?.uri),
+        selectableTextMapEntry('ID', isolate?.id),
       ],
     );
   }
@@ -183,21 +183,21 @@ class IsolateMemoryStatisticsWidget extends StatelessWidget {
           child: VMInfoCard(
             title: 'Memory',
             rowKeyValues: [
-              stringWidgetMapEntry(
+              selectableTextMapEntry(
                 'Dart Heap',
                 _buildMemoryString(
                   isolate?.dartHeapSize,
                   isolate?.dartHeapCapacity,
                 ),
               ),
-              stringWidgetMapEntry(
+              selectableTextMapEntry(
                 'New Space',
                 _buildMemoryString(
                   isolate?.newSpaceUsage,
                   isolate?.newSpaceUsage,
                 ),
               ),
-              stringWidgetMapEntry(
+              selectableTextMapEntry(
                 'Old Space',
                 _buildMemoryString(
                   isolate?.oldSpaceUsage,

--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
@@ -148,11 +148,11 @@ class GeneralIsolateStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'General',
       rowKeyValues: [
-        MapEntry('Name', isolate?.name),
-        MapEntry('Started at', _startTime(isolate)),
-        MapEntry('Uptime', _uptime(isolate)),
-        MapEntry('Root Library', isolate?.rootLib?.uri),
-        MapEntry('ID', isolate?.id),
+        stringWidgetMapEntry('Name', isolate?.name),
+        stringWidgetMapEntry('Started at', _startTime(isolate)),
+        stringWidgetMapEntry('Uptime', _uptime(isolate)),
+        stringWidgetMapEntry('Root Library', isolate?.rootLib?.uri),
+        stringWidgetMapEntry('ID', isolate?.id),
       ],
     );
   }
@@ -183,21 +183,21 @@ class IsolateMemoryStatisticsWidget extends StatelessWidget {
           child: VMInfoCard(
             title: 'Memory',
             rowKeyValues: [
-              MapEntry(
+              stringWidgetMapEntry(
                 'Dart Heap',
                 _buildMemoryString(
                   isolate?.dartHeapSize,
                   isolate?.dartHeapCapacity,
                 ),
               ),
-              MapEntry(
+              stringWidgetMapEntry(
                 'New Space',
                 _buildMemoryString(
                   isolate?.newSpaceUsage,
                   isolate?.newSpaceUsage,
                 ),
               ),
-              MapEntry(
+              stringWidgetMapEntry(
                 'Old Space',
                 _buildMemoryString(
                   isolate?.oldSpaceUsage,

--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics_view.dart
@@ -148,11 +148,11 @@ class GeneralIsolateStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'General',
       rowKeyValues: [
-        selectableTextMapEntry('Name', isolate?.name),
-        selectableTextMapEntry('Started at', _startTime(isolate)),
-        selectableTextMapEntry('Uptime', _uptime(isolate)),
-        selectableTextMapEntry('Root Library', isolate?.rootLib?.uri),
-        selectableTextMapEntry('ID', isolate?.id),
+        selectableTextBuilderMapEntry('Name', isolate?.name),
+        selectableTextBuilderMapEntry('Started at', _startTime(isolate)),
+        selectableTextBuilderMapEntry('Uptime', _uptime(isolate)),
+        selectableTextBuilderMapEntry('Root Library', isolate?.rootLib?.uri),
+        selectableTextBuilderMapEntry('ID', isolate?.id),
       ],
     );
   }
@@ -183,21 +183,21 @@ class IsolateMemoryStatisticsWidget extends StatelessWidget {
           child: VMInfoCard(
             title: 'Memory',
             rowKeyValues: [
-              selectableTextMapEntry(
+              selectableTextBuilderMapEntry(
                 'Dart Heap',
                 _buildMemoryString(
                   isolate?.dartHeapSize,
                   isolate?.dartHeapCapacity,
                 ),
               ),
-              selectableTextMapEntry(
+              selectableTextBuilderMapEntry(
                 'New Space',
                 _buildMemoryString(
                   isolate?.newSpaceUsage,
                   isolate?.newSpaceUsage,
                 ),
               ),
-              selectableTextMapEntry(
+              selectableTextBuilderMapEntry(
                 'Old Space',
                 _buildMemoryString(
                   isolate?.oldSpaceUsage,

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -170,7 +170,9 @@ class ClassInstancesWidget extends StatelessWidget {
       title: 'Class Instances',
       rowKeyValues: [
         stringWidgetMapEntry(
-            'Currently allocated', instances?.totalCount?.toString()),
+          'Currently allocated',
+          instances?.totalCount?.toString(),
+        ),
         stringWidgetMapEntry('Strongly reachable', 'TO-DO'),
         stringWidgetMapEntry('All direct instances', 'TO-DO'),
         stringWidgetMapEntry('All instances of subclasses', 'TO-DO'),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -78,7 +78,7 @@ class ClassInfoWidget extends StatelessWidget implements PreferredSizeWidget {
     required this.classDataRows,
   });
 
-  final List<MapEntry<String, Widget>> classDataRows;
+  final List<MapEntry<String, Widget Function(BuildContext)>> classDataRows;
 
   @override
   Widget build(BuildContext context) {
@@ -99,10 +99,12 @@ class ClassInfoWidget extends StatelessWidget implements PreferredSizeWidget {
       );
 }
 
-List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
+List<MapEntry<String, Widget Function(BuildContext)>> _classDataRows(
+  ClassObject clazz,
+) {
   return [
-    selectableTextMapEntry('Object Class', clazz.obj.type),
-    selectableTextMapEntry(
+    selectableTextBuilderMapEntry('Object Class', clazz.obj.type),
+    selectableTextBuilderMapEntry(
       'Shallow Size',
       prettyPrintBytes(
         clazz.obj.size ?? 0,
@@ -113,7 +115,7 @@ List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
     ),
     MapEntry(
       'Reachable Size',
-      ValueListenableBuilder<bool>(
+      (context) => ValueListenableBuilder<bool>(
         valueListenable: clazz.fetchingReachableSize,
         builder: (context, fetching, _) => fetching
             ? const CircularProgressIndicator()
@@ -125,7 +127,7 @@ List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
     ),
     MapEntry(
       'Retained Size',
-      ValueListenableBuilder<bool>(
+      (context) => ValueListenableBuilder<bool>(
         valueListenable: clazz.fetchingRetainedSize,
         builder: (context, fetching, _) => fetching
             ? const CircularProgressIndicator()
@@ -135,19 +137,19 @@ List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
               ),
       ),
     ),
-    selectableTextMapEntry(
+    selectableTextBuilderMapEntry(
       'Library',
       clazz.obj.library?.name?.isEmpty ?? false
           ? clazz.script?.uri
           : clazz.obj.library?.name,
     ),
-    selectableTextMapEntry(
+    selectableTextBuilderMapEntry(
       'Script',
       '${fileNameFromUri(clazz.script?.uri) ?? ''}:${clazz.pos?.toString() ?? ''}',
     ),
-    selectableTextMapEntry('Superclass', clazz.obj.superClass?.name),
-    selectableTextMapEntry('SuperType', clazz.obj.superType?.name),
-    selectableTextMapEntry(
+    selectableTextBuilderMapEntry('Superclass', clazz.obj.superClass?.name),
+    selectableTextBuilderMapEntry('SuperType', clazz.obj.superType?.name),
+    selectableTextBuilderMapEntry(
       'Currently allocated instances',
       clazz.instances?.totalCount?.toString(),
     ),
@@ -169,16 +171,16 @@ class ClassInstancesWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Class Instances',
       rowKeyValues: [
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry(
           'Currently allocated',
           instances?.totalCount?.toString(),
         ),
-        selectableTextMapEntry('Strongly reachable', 'TO-DO'),
-        selectableTextMapEntry('All direct instances', 'TO-DO'),
-        selectableTextMapEntry('All instances of subclasses', 'TO-DO'),
-        selectableTextMapEntry('All instances of implementors', 'TO-DO'),
-        selectableTextMapEntry('Reachable size', 'TO-DO'),
-        selectableTextMapEntry('Retained size', 'TO-DO'),
+        selectableTextBuilderMapEntry('Strongly reachable', 'TO-DO'),
+        selectableTextBuilderMapEntry('All direct instances', 'TO-DO'),
+        selectableTextBuilderMapEntry('All instances of subclasses', 'TO-DO'),
+        selectableTextBuilderMapEntry('All instances of implementors', 'TO-DO'),
+        selectableTextBuilderMapEntry('Reachable size', 'TO-DO'),
+        selectableTextBuilderMapEntry('Retained size', 'TO-DO'),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -101,8 +101,8 @@ class ClassInfoWidget extends StatelessWidget implements PreferredSizeWidget {
 
 List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
   return [
-    stringWidgetMapEntry('Object Class', clazz.obj.type),
-    stringWidgetMapEntry(
+    selectableTextMapEntry('Object Class', clazz.obj.type),
+    selectableTextMapEntry(
       'Shallow Size',
       prettyPrintBytes(
         clazz.obj.size ?? 0,
@@ -135,19 +135,19 @@ List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
               ),
       ),
     ),
-    stringWidgetMapEntry(
+    selectableTextMapEntry(
       'Library',
       clazz.obj.library?.name?.isEmpty ?? false
           ? clazz.script?.uri
           : clazz.obj.library?.name,
     ),
-    stringWidgetMapEntry(
+    selectableTextMapEntry(
       'Script',
       '${fileNameFromUri(clazz.script?.uri) ?? ''}:${clazz.pos?.toString() ?? ''}',
     ),
-    stringWidgetMapEntry('Superclass', clazz.obj.superClass?.name),
-    stringWidgetMapEntry('SuperType', clazz.obj.superType?.name),
-    stringWidgetMapEntry(
+    selectableTextMapEntry('Superclass', clazz.obj.superClass?.name),
+    selectableTextMapEntry('SuperType', clazz.obj.superType?.name),
+    selectableTextMapEntry(
       'Currently allocated instances',
       clazz.instances?.totalCount?.toString(),
     ),
@@ -169,16 +169,16 @@ class ClassInstancesWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Class Instances',
       rowKeyValues: [
-        stringWidgetMapEntry(
+        selectableTextMapEntry(
           'Currently allocated',
           instances?.totalCount?.toString(),
         ),
-        stringWidgetMapEntry('Strongly reachable', 'TO-DO'),
-        stringWidgetMapEntry('All direct instances', 'TO-DO'),
-        stringWidgetMapEntry('All instances of subclasses', 'TO-DO'),
-        stringWidgetMapEntry('All instances of implementors', 'TO-DO'),
-        stringWidgetMapEntry('Reachable size', 'TO-DO'),
-        stringWidgetMapEntry('Retained size', 'TO-DO'),
+        selectableTextMapEntry('Strongly reachable', 'TO-DO'),
+        selectableTextMapEntry('All direct instances', 'TO-DO'),
+        selectableTextMapEntry('All instances of subclasses', 'TO-DO'),
+        selectableTextMapEntry('All instances of implementors', 'TO-DO'),
+        selectableTextMapEntry('Reachable size', 'TO-DO'),
+        selectableTextMapEntry('Retained size', 'TO-DO'),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -78,7 +78,7 @@ class ClassInfoWidget extends StatelessWidget implements PreferredSizeWidget {
     required this.classDataRows,
   });
 
-  final List<MapEntry<String, Object?>> classDataRows;
+  final List<MapEntry<String, Widget>> classDataRows;
 
   @override
   Widget build(BuildContext context) {
@@ -99,10 +99,10 @@ class ClassInfoWidget extends StatelessWidget implements PreferredSizeWidget {
       );
 }
 
-List<MapEntry<String, Object?>> _classDataRows(ClassObject clazz) {
+List<MapEntry<String, Widget>> _classDataRows(ClassObject clazz) {
   return [
-    MapEntry('Object Class', clazz.obj.type),
-    MapEntry(
+    stringWidgetMapEntry('Object Class', clazz.obj.type),
+    stringWidgetMapEntry(
       'Shallow Size',
       prettyPrintBytes(
         clazz.obj.size ?? 0,
@@ -135,21 +135,21 @@ List<MapEntry<String, Object?>> _classDataRows(ClassObject clazz) {
               ),
       ),
     ),
-    MapEntry(
+    stringWidgetMapEntry(
       'Library',
       clazz.obj.library?.name?.isEmpty ?? false
           ? clazz.script?.uri
           : clazz.obj.library?.name,
     ),
-    MapEntry(
+    stringWidgetMapEntry(
       'Script',
       '${fileNameFromUri(clazz.script?.uri) ?? ''}:${clazz.pos?.toString() ?? ''}',
     ),
-    MapEntry('Superclass', clazz.obj.superClass?.name),
-    MapEntry('SuperType', clazz.obj.superType?.name),
-    MapEntry(
+    stringWidgetMapEntry('Superclass', clazz.obj.superClass?.name),
+    stringWidgetMapEntry('SuperType', clazz.obj.superType?.name),
+    stringWidgetMapEntry(
       'Currently allocated instances',
-      clazz.instances?.totalCount,
+      clazz.instances?.totalCount?.toString(),
     ),
   ];
 }
@@ -169,13 +169,14 @@ class ClassInstancesWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Class Instances',
       rowKeyValues: [
-        MapEntry('Currently allocated', instances?.totalCount),
-        const MapEntry('Strongly reachable', 'TO-DO'),
-        const MapEntry('All direct instances', 'TO-DO'),
-        const MapEntry('All instances of subclasses', 'TO-DO'),
-        const MapEntry('All instances of implementors', 'TO-DO'),
-        const MapEntry('Reachable size', 'TO-DO'),
-        const MapEntry('Retained size', 'TO-DO'),
+        stringWidgetMapEntry(
+            'Currently allocated', instances?.totalCount?.toString()),
+        stringWidgetMapEntry('Strongly reachable', 'TO-DO'),
+        stringWidgetMapEntry('All direct instances', 'TO-DO'),
+        stringWidgetMapEntry('All instances of subclasses', 'TO-DO'),
+        stringWidgetMapEntry('All instances of implementors', 'TO-DO'),
+        stringWidgetMapEntry('Reachable size', 'TO-DO'),
+        stringWidgetMapEntry('Retained size', 'TO-DO'),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -21,7 +21,7 @@ import 'vm_service_private_extensions.dart';
 ///
 /// `table` is a widget (typically a table) that is to be displayed after the
 /// rows specified for `rowKeyValues`.
-class VMInfoCard extends StatelessWidget {
+class VMInfoCard extends StatelessWidget implements PreferredSizeWidget {
   const VMInfoCard({
     required this.title,
     this.rowKeyValues,
@@ -29,7 +29,7 @@ class VMInfoCard extends StatelessWidget {
   });
 
   final String title;
-  final List<MapEntry>? rowKeyValues;
+  final List<MapEntry<String, Widget>>? rowKeyValues;
   final Widget? table;
 
   @override
@@ -42,6 +42,33 @@ class VMInfoCard extends StatelessWidget {
       ),
     );
   }
+
+  @override
+  Size get preferredSize {
+    if (table != null) {
+      return Size.infinite;
+    }
+    return Size.fromHeight(
+      areaPaneHeaderHeight +
+          (rowKeyValues?.length ?? 0) * defaultRowHeight +
+          defaultSpacing,
+    );
+  }
+}
+
+MapEntry<String, Widget> stringWidgetMapEntry(
+  String key,
+  String? value,
+) {
+  return MapEntry(
+    key,
+    Builder(
+      builder: (context) => SelectableText(
+        value ?? '--',
+        style: Theme.of(context).fixedFontStyle,
+      ),
+    ),
+  );
 }
 
 class VMInfoList extends StatelessWidget {
@@ -52,7 +79,7 @@ class VMInfoList extends StatelessWidget {
   });
 
   final String title;
-  final List<MapEntry>? rowKeyValues;
+  final List<MapEntry<String, Widget>>? rowKeyValues;
   final Widget? table;
 
   @override
@@ -88,12 +115,7 @@ class VMInfoList extends StatelessWidget {
                           ),
                           const SizedBox(width: denseSpacing),
                           Flexible(
-                            child: row.value is Widget
-                                ? row.value
-                                : SelectableText(
-                                    row.value?.toString() ?? '--',
-                                    style: theme.fixedFontStyle,
-                                  ),
+                            child: row.value,
                           ),
                         ],
                       )

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -29,7 +29,7 @@ class VMInfoCard extends StatelessWidget implements PreferredSizeWidget {
   });
 
   final String title;
-  final List<MapEntry<String, Widget>>? rowKeyValues;
+  final List<MapEntry<String, Widget Function(BuildContext)>>? rowKeyValues;
   final Widget? table;
 
   @override
@@ -56,17 +56,15 @@ class VMInfoCard extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-MapEntry<String, Widget> selectableTextMapEntry(
+MapEntry<String, Widget Function(BuildContext)> selectableTextBuilderMapEntry(
   String key,
   String? value,
 ) {
   return MapEntry(
     key,
-    Builder(
-      builder: (context) => SelectableText(
-        value ?? '--',
-        style: Theme.of(context).fixedFontStyle,
-      ),
+    (context) => SelectableText(
+      value ?? '--',
+      style: Theme.of(context).fixedFontStyle,
     ),
   );
 }
@@ -79,7 +77,7 @@ class VMInfoList extends StatelessWidget {
   });
 
   final String title;
-  final List<MapEntry<String, Widget>>? rowKeyValues;
+  final List<MapEntry<String, Widget Function(BuildContext)>>? rowKeyValues;
   final Widget? table;
 
   @override
@@ -115,7 +113,7 @@ class VMInfoList extends StatelessWidget {
                           ),
                           const SizedBox(width: denseSpacing),
                           Flexible(
-                            child: row.value,
+                            child: Builder(builder: row.value),
                           ),
                         ],
                       )

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -56,7 +56,7 @@ class VMInfoCard extends StatelessWidget implements PreferredSizeWidget {
   }
 }
 
-MapEntry<String, Widget> stringWidgetMapEntry(
+MapEntry<String, Widget> selectableTextMapEntry(
   String key,
   String? value,
 ) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
@@ -124,10 +124,10 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'VM',
       rowKeyValues: [
-        stringWidgetMapEntry('Name', vm?.name),
-        stringWidgetMapEntry('Version', vm?.version),
-        stringWidgetMapEntry('Embedder', vm?.embedder),
-        stringWidgetMapEntry(
+        selectableTextMapEntry('Name', vm?.name),
+        selectableTextMapEntry('Version', vm?.version),
+        selectableTextMapEntry('Embedder', vm?.embedder),
+        selectableTextMapEntry(
           'Started',
           vm == null
               ? null
@@ -135,8 +135,8 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
                   DateTime.fromMillisecondsSinceEpoch(vm.startTime!),
                 ),
         ),
-        stringWidgetMapEntry('Profiler Mode', vm?.profilerMode),
-        stringWidgetMapEntry(
+        selectableTextMapEntry('Profiler Mode', vm?.profilerMode),
+        selectableTextMapEntry(
           'Current Memory',
           prettyPrintBytes(
             vm?.currentMemory,
@@ -166,28 +166,28 @@ class ProcessStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Process',
       rowKeyValues: [
-        stringWidgetMapEntry('PID', vm?.pid?.toString()),
-        stringWidgetMapEntry(
+        selectableTextMapEntry('PID', vm?.pid?.toString()),
+        selectableTextMapEntry(
           'Host CPU',
           vm == null ? null : '${vm.hostCPU} (${vm.architectureBits}-bits)',
         ),
-        stringWidgetMapEntry('Target CPU', vm?.targetCPU),
-        stringWidgetMapEntry('Operating System', vm?.operatingSystem),
-        stringWidgetMapEntry(
+        selectableTextMapEntry('Target CPU', vm?.targetCPU),
+        selectableTextMapEntry('Operating System', vm?.operatingSystem),
+        selectableTextMapEntry(
           'Max Memory (RSS)',
           prettyPrintBytes(
             vm?.maxRSS,
             includeUnit: true,
           ),
         ),
-        stringWidgetMapEntry(
+        selectableTextMapEntry(
           'Current Memory (RSS)',
           prettyPrintBytes(
             vm?.currentRSS,
             includeUnit: true,
           ),
         ),
-        stringWidgetMapEntry(
+        selectableTextMapEntry(
           'Zone Memory',
           prettyPrintBytes(
             vm?.nativeZoneMemoryUsage,

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
@@ -124,10 +124,10 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'VM',
       rowKeyValues: [
-        selectableTextMapEntry('Name', vm?.name),
-        selectableTextMapEntry('Version', vm?.version),
-        selectableTextMapEntry('Embedder', vm?.embedder),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry('Name', vm?.name),
+        selectableTextBuilderMapEntry('Version', vm?.version),
+        selectableTextBuilderMapEntry('Embedder', vm?.embedder),
+        selectableTextBuilderMapEntry(
           'Started',
           vm == null
               ? null
@@ -135,8 +135,8 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
                   DateTime.fromMillisecondsSinceEpoch(vm.startTime!),
                 ),
         ),
-        selectableTextMapEntry('Profiler Mode', vm?.profilerMode),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry('Profiler Mode', vm?.profilerMode),
+        selectableTextBuilderMapEntry(
           'Current Memory',
           prettyPrintBytes(
             vm?.currentMemory,
@@ -166,28 +166,28 @@ class ProcessStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Process',
       rowKeyValues: [
-        selectableTextMapEntry('PID', vm?.pid?.toString()),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry('PID', vm?.pid?.toString()),
+        selectableTextBuilderMapEntry(
           'Host CPU',
           vm == null ? null : '${vm.hostCPU} (${vm.architectureBits}-bits)',
         ),
-        selectableTextMapEntry('Target CPU', vm?.targetCPU),
-        selectableTextMapEntry('Operating System', vm?.operatingSystem),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry('Target CPU', vm?.targetCPU),
+        selectableTextBuilderMapEntry('Operating System', vm?.operatingSystem),
+        selectableTextBuilderMapEntry(
           'Max Memory (RSS)',
           prettyPrintBytes(
             vm?.maxRSS,
             includeUnit: true,
           ),
         ),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry(
           'Current Memory (RSS)',
           prettyPrintBytes(
             vm?.currentRSS,
             includeUnit: true,
           ),
         ),
-        selectableTextMapEntry(
+        selectableTextBuilderMapEntry(
           'Zone Memory',
           prettyPrintBytes(
             vm?.nativeZoneMemoryUsage,

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics_view.dart
@@ -124,10 +124,10 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'VM',
       rowKeyValues: [
-        MapEntry('Name', vm?.name),
-        MapEntry('Version', vm?.version),
-        MapEntry('Embedder', vm?.embedder),
-        MapEntry(
+        stringWidgetMapEntry('Name', vm?.name),
+        stringWidgetMapEntry('Version', vm?.version),
+        stringWidgetMapEntry('Embedder', vm?.embedder),
+        stringWidgetMapEntry(
           'Started',
           vm == null
               ? null
@@ -135,8 +135,8 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
                   DateTime.fromMillisecondsSinceEpoch(vm.startTime!),
                 ),
         ),
-        MapEntry('Profiler Mode', vm?.profilerMode),
-        MapEntry(
+        stringWidgetMapEntry('Profiler Mode', vm?.profilerMode),
+        stringWidgetMapEntry(
           'Current Memory',
           prettyPrintBytes(
             vm?.currentMemory,
@@ -166,28 +166,28 @@ class ProcessStatisticsWidget extends StatelessWidget {
     return VMInfoCard(
       title: 'Process',
       rowKeyValues: [
-        MapEntry('PID', vm?.pid),
-        MapEntry(
+        stringWidgetMapEntry('PID', vm?.pid?.toString()),
+        stringWidgetMapEntry(
           'Host CPU',
           vm == null ? null : '${vm.hostCPU} (${vm.architectureBits}-bits)',
         ),
-        MapEntry('Target CPU', vm?.targetCPU),
-        MapEntry('Operating System', vm?.operatingSystem),
-        MapEntry(
+        stringWidgetMapEntry('Target CPU', vm?.targetCPU),
+        stringWidgetMapEntry('Operating System', vm?.operatingSystem),
+        stringWidgetMapEntry(
           'Max Memory (RSS)',
           prettyPrintBytes(
             vm?.maxRSS,
             includeUnit: true,
           ),
         ),
-        MapEntry(
+        stringWidgetMapEntry(
           'Current Memory (RSS)',
           prettyPrintBytes(
             vm?.currentRSS,
             includeUnit: true,
           ),
         ),
-        MapEntry(
+        stringWidgetMapEntry(
           'Zone Memory',
           prettyPrintBytes(
             vm?.nativeZoneMemoryUsage,


### PR DESCRIPTION
Adds the type of MapEntry key and value to the VMInfoCard widget parameter 'rowKeyValues' - MapEntry<String,Widget>. It was previously not specified and thus, it was considered as dynamic by the compiler. 
Also added the implementation of PreferredSizeWidget to VMInfoCard.

**Issues fixed:**
The compiler now knows what type to expect for the key-value pairs in the VMInfoCard.