### PR TITLE
Fix off-by-one error in syntax highlighting goldens + truncate to not include newlines

### DIFF
--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -6,38 +6,40 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
 >
 >/// Multiline dartdoc comment.
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >///
-#^^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 >/// ```
-#       ^ comment.block.documentation.dart variable.other.source.dart
-#^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^ comment.block.documentation.dart
 >/// doc
-#   ^^^^^ comment.block.documentation.dart variable.other.source.dart
-#^^^^^^^^^ comment.block.documentation.dart
+#   ^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^ comment.block.documentation.dart
 >/// ```
 #   ^ comment.block.documentation.dart variable.other.source.dart
-#^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^ comment.block.documentation.dart
 >///
-#^^^^^ comment.block.documentation.dart
->/// ...
 #^^^ comment.block.documentation.dart
+>/// ...
+#^^^^^^^ comment.block.documentation.dart
 >var a;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart
 >
 >/*
-#^^^ comment.block.dart
+#^^ comment.block.dart
 > * Old-style dartdoc
-#^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^ comment.block.dart
 > *
-#^^^^ comment.block.dart
+#^^ comment.block.dart
 > * ...
-#^^^^^^^^ comment.block.dart
+#^^^^^^ comment.block.dart
 > */
+#^^^ comment.block.dart
 >var b;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+#^^^^ comment.block.dart
 >
 >/* Inline block comment */
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
@@ -46,38 +48,43 @@
 #     ^ punctuation.terminator.dart
 >
 >/**
-#^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 > * Nested block
-#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^^^ comment.block.documentation.dart
+#^^ comment.block.documentation.dart
 > * /**
-#   ^^^^ comment.block.documentation.dart comment.block.documentation.dart
-#^^^^^^^^ comment.block.documentation.dart
+#   ^^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart
 > *  * Nested block
-#^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
-#^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
-#^^^^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^ comment.block.documentation.dart
 > */
+#^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 >var d;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+#^^^^^^ comment.block.documentation.dart
 >
 >/**
-#^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 > * Nested
-#^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^ comment.block.documentation.dart
 > *
-#^^^^ comment.block.documentation.dart
+#^^ comment.block.documentation.dart
 > * /* Inline */
 #   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
-#^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > */
+#^^^ comment.block.documentation.dart
 >var e;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+#^^^^ comment.block.documentation.dart
 >
 >/* Nested /* Inline */ */
 #^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
@@ -93,12 +100,13 @@
 #     ^ punctuation.terminator.dart
 >
 >/// Dartdoc with reference to [a].
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 #                              ^^^ comment.block.documentation.dart variable.name.source.dart
 >/// And a link to [example.org](http://example.org/).
 #                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >var h;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
+#^^ comment.block.documentation.dart
 >

--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -24,7 +24,6 @@
 >var a;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
-#^^^^^^ comment.block.documentation.dart
 >
 >/*
 #^^ comment.block.dart
@@ -39,7 +38,6 @@
 >var b;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
-#^^^^ comment.block.dart
 >
 >/* Inline block comment */
 #^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
@@ -60,15 +58,13 @@
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
-#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^ comment.block.documentation.dart
 > */
-#^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^ comment.block.documentation.dart
 >var d;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
-#^^^^^^ comment.block.documentation.dart
 >
 >/**
 #^^^ comment.block.documentation.dart
@@ -84,7 +80,6 @@
 >var e;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
-#^^^^ comment.block.documentation.dart
 >
 >/* Nested /* Inline */ */
 #^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
@@ -108,5 +103,3 @@
 >var h;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
-#^^ comment.block.documentation.dart
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -58,7 +58,7 @@
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
-#^^^ comment.block.documentation.dart comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^ comment.block.documentation.dart
 > */
 #^^^ comment.block.documentation.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/functions.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/functions.dart.golden
@@ -44,4 +44,3 @@
 #        ^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^ punctuation.terminator.dart
 >}
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
@@ -451,4 +451,3 @@
 #                                 ^ support.class.dart
 #                                  ^ keyword.operator.comparison.dart
 >}
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/literals.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/literals.dart.golden
@@ -103,4 +103,3 @@
 #                                  ^^^^ string.interpolated.single.dart
 #                                    ^ string.interpolated.single.dart variable.parameter.dart
 #                                       ^ punctuation.terminator.dart
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/operators.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/operators.dart.golden
@@ -208,4 +208,3 @@
 #                               ^^^^ constant.language.dart
 #                                    ^ punctuation.terminator.dart
 >}
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -45,28 +45,24 @@
 #     ^^^^^^^^^ entity.name.function.dart
 >  print('${() {
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^ string.interpolated.single.dart
-#               ^ string.interpolated.single.dart invalid.string.newline
+#        ^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
 #            ^^^^^ support.class.dart
-#                 ^^^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart invalid.string.newline
-#^^^^^^^^^^^^ string.interpolated.single.dart
+#                 ^^ string.interpolated.single.dart
+#^^^^^^^^^^^^^ string.interpolated.single.dart
 >  }}');
 #      ^ punctuation.terminator.dart
-#^^^^^ string.interpolated.single.dart
+#^^^^^^ string.interpolated.single.dart
 >  print('print(${() {
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
-#                     ^ string.interpolated.single.dart invalid.string.newline
+#        ^^^^^^^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
 #            ^^^^^ support.class.dart
-#                 ^^^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart invalid.string.newline
-#^^^^^^^^^^^^ string.interpolated.single.dart
+#                 ^^ string.interpolated.single.dart
+#^^^^^^^^^^^^^ string.interpolated.single.dart
 >  }()})');
 #         ^ punctuation.terminator.dart
-#^^^^^^^^ string.interpolated.single.dart
+#^^^^^^^^^ string.interpolated.single.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -49,20 +49,20 @@
 >    return 'Hello';
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^^^^^^^^^^ string.interpolated.single.dart
+#^^^^ string.interpolated.single.dart
 >  }}');
 #      ^ punctuation.terminator.dart
-#^^^^^^ string.interpolated.single.dart
+# string.interpolated.single.dart
 >  print('print(${() {
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^^^^^^^^^^ string.interpolated.single.dart
+#^^^^ string.interpolated.single.dart
 >  }()})');
 #         ^ punctuation.terminator.dart
-#^^^^^^^^^ string.interpolated.single.dart
+# string.interpolated.single.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
@@ -74,4 +74,3 @@
 #                 ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart variable.parameter.dart
 #                                      ^ punctuation.terminator.dart
 >}
->

--- a/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -49,20 +49,20 @@
 >    return 'Hello';
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^ string.interpolated.single.dart
+#^^^^^^^^^^^^ string.interpolated.single.dart
 >  }}');
 #      ^ punctuation.terminator.dart
-# string.interpolated.single.dart
+#^^^^^ string.interpolated.single.dart
 >  print('print(${() {
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^ string.interpolated.single.dart
+#^^^^^^^^^^^^ string.interpolated.single.dart
 >  }()})');
 #         ^ punctuation.terminator.dart
-# string.interpolated.single.dart
+#^^^^^^^^ string.interpolated.single.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -201,7 +201,7 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
     final line = lines[i];
     // We need the line length to wrap. If this isn't the last line, account for
     // the \n we split by.
-    final newlineLength = i == lines.length - 1 ? 0 : 1;
+    final newlineLength = (i == lines.length - 1) ? 0 : 1;
     final lineLengthWithNewline = line.length + newlineLength;
 
     buffer.writeln('>$line');

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -5,7 +5,6 @@
 @TestOn('vm')
 import 'dart:convert';
 import 'dart:io';
-import 'dart:math' as math;
 
 import 'package:collection/collection.dart';
 import 'package:devtools_app/src/screens/debugger/span_parser.dart';

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -215,12 +215,13 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
         // the remainder into the next.
         if (col + length > lineLengthWithNewline) {
           final thisLineLength = line.length - col;
+          final offsetToStartOfNextLine = lineLengthWithNewline - col;
           length = thisLineLength;
           spansByLine[i + 1] ??= [];
           spansByLine[i + 1]!.add(
             ScopeSpan.copy(
               scopes: span.scopes,
-              start: span.start + lineLengthWithNewline,
+              start: span.start + offsetToStartOfNextLine,
               end: span.end,
               line: span.line! + 1,
               column: 1,

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -196,7 +196,7 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
   final buffer = StringBuffer();
   final spansByLine = groupBy(spans, (ScopeSpan s) => s.line! - 1);
 
-  final lines = content.split('\n');
+  final lines = content.trim().split('\n');
   for (var i = 0; i < lines.length; i++) {
     final line = lines[i];
     // We need the line length to wrap. If this isn't the last line, account for
@@ -220,7 +220,7 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
           spansByLine[i + 1]!.add(
             ScopeSpan.copy(
               scopes: span.scopes,
-              start: span.start + thisLineLength,
+              start: span.start + lineLengthWithNewline,
               end: span.end,
               line: span.line! + 1,
               column: 1,


### PR DESCRIPTION
This fixes an off-by-one error in the golden-building for syntax highlighting tests (where column would end up being -1) that caused us to mark too many characters as being part of span. It also truncates the marking off the trailing newlines to make the output a bit easier to read (whether the span includes the newline or not has no impact on the results but looks odd in the goldens).

(this does not impact the actual syntax highlighting, only the tests and the golden representations).



## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
