### PR TITLE
Adding ArtificialRoot to non-deferred apps for diff table

### DIFF
--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -457,7 +457,7 @@ class AppSizeController {
     changeOldDiffFile(oldFile);
     changeNewDiffFile(newFile);
 
-    diffMap['n'] = 'Root';
+    diffMap['n'] = isDeferredApp.value ? 'Entire App' : 'Root';
 
     // TODO(peterdjlee): Try to move the non-active tree generation to separate isolates.
     _combinedDiffTreeRoot = generateDiffTree(

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -17,7 +17,7 @@ import '../../ui/colors.dart';
 import 'app_size_screen.dart';
 
 // Temporary feature flag for deferred loading.
-bool deferredLoadingSupportEnabled = false;
+bool deferredLoadingSupportEnabled = true;
 
 enum DiffTreeType {
   increaseOnly,
@@ -585,7 +585,7 @@ class AppSizeController {
     }
 
     // If none of the children matched the diff tree type
-    if (totalByteSize == 0) {
+    if (totalByteSize == 0 && !isDeferredApp.value) {
       return null;
     } else {
       return _buildNode(

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -17,7 +17,7 @@ import '../../ui/colors.dart';
 import 'app_size_screen.dart';
 
 // Temporary feature flag for deferred loading.
-bool deferredLoadingSupportEnabled = true;
+bool deferredLoadingSupportEnabled = false;
 
 enum DiffTreeType {
   increaseOnly,
@@ -538,10 +538,12 @@ class AppSizeController {
   }) {
     final isLeafNode = treeJson['children'] == null;
     if (!isLeafNode) {
-      return _buildNodeWithChildren(treeJson,
-          showDiff: true,
-          diffTreeType: diffTreeType,
-          skipNodesWithNoByteSizeChange: skipNodesWithNoByteSizeChange);
+      return _buildNodeWithChildren(
+        treeJson,
+        showDiff: true,
+        diffTreeType: diffTreeType,
+        skipNodesWithNoByteSizeChange: skipNodesWithNoByteSizeChange,
+      );
     } else {
       // TODO(peterdjlee): Investigate why there are leaf nodes with size of null.
       final byteSize = treeJson['value'];


### PR DESCRIPTION
When using the DiffTable to compare a non-deferred and deferred app, the main app roots are not at the same location. 

In order to get an accurate comparison between the two apps, the non-deferred app will add its own ArtificialRoot that deferred apps have. 