### PR TITLE
Turn on Frame Analysis feature by default and add more analytics

### DIFF
--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -73,6 +73,7 @@ const trackPaints = 'trackPaints';
 const trackPaintsDocs = 'trackPaintsDocs';
 const trackLayouts = 'trackLayouts';
 const trackLayoutsDocs = 'trackLayoutsDocs';
+const smallEnhanceTracingButton = 'enhanceTracingButtonSmall';
 const disableClipLayersOption = 'disableClipLayers';
 const disableClipLayersOptionDocs = 'disableClipLayersDocs';
 const disableOpacityLayersOption = 'disableOpacityLayers';

--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../../../analytics/analytics.dart' as ga;
 import '../../../../analytics/constants.dart' as analytics_constants;
 import '../../../../primitives/utils.dart';
 import '../../../../service/service_extensions.dart' as extensions;
@@ -234,7 +235,13 @@ class SmallEnhanceTracingButton extends StatelessWidget {
       label: EnhanceTracingButton.title,
       icon: EnhanceTracingButton.icon,
       color: Theme.of(context).colorScheme.toggleButtonsTitle,
-      onPressed: enhanceTracingController.showEnhancedTracingMenu,
+      onPressed: () {
+        ga.select(
+          analytics_constants.performance,
+          analytics_constants.smallEnhanceTracingButton,
+        );
+        enhanceTracingController.showEnhancedTracingMenu();
+      },
     );
   }
 }
@@ -416,7 +423,8 @@ class _ExpensiveOperationHint extends StatelessWidget {
               display: 'negatively affect your app\'s performance',
               url: docsUrl,
               gaScreenName: gaScreenName,
-              gaSelectedItemDescription: gaSelectedItemDescription,
+              gaSelectedItemDescription:
+                  'frameAnalysis_$gaSelectedItemDescription',
             ),
           ),
           TextSpan(

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -39,10 +39,8 @@ import 'timeline_event_processor.dart';
 /// Debugging flag to load sample trace events from [simple_trace_example.dart].
 bool debugSimpleTrace = false;
 
-// TODO(https://github.com/flutter/devtools/issues/4287): add more tests before
-// enabling this feature.
 /// Flag to hide the frame analysis feature while it is under development.
-bool frameAnalysisSupported = false;
+bool frameAnalysisSupported = true;
 
 /// Flag to hide the raster metrics feature while it is under development.
 bool rasterMetricsSupported = true;


### PR DESCRIPTION
This feature is now ready to ship. It provides hints to do the following:
- point users to the "Enhance Tracing" when a frame phase is the leading cause of slow UI time
- point users to the "Raster Metrics" tab for frames with raster jank
- point users to documentation when expensive operations like `Canvas.saveLayer()`, intrinsics calculations, and shader compilation are contributing to jank.

It also provides a visual breakdown of where the time in a frame was spent.

We have analytics set up to track clicks on documentation links as well as on the small EnhanceTracing button that is part of the hints.

Example analysis view for a janky frame:

![Screen Shot 2022-08-03 at 4 04 44 PM](https://user-images.githubusercontent.com/43759233/182728449-17b2d403-5654-43b5-b95f-30f4ab5fa788.png)

