### PR TITLE
Add a client API method to allow the server to ping a client to see if it's still responsive

### DIFF
--- a/packages/devtools_app/lib/src/shared/server_api_client.dart
+++ b/packages/devtools_app/lib/src/shared/server_api_client.dart
@@ -168,6 +168,9 @@ class DevToolsServerConnection {
       case 'notify':
         notify();
         return;
+      case 'ping':
+        ping();
+        return;
       default:
         print('Unknown request $method from server');
     }
@@ -207,5 +210,11 @@ class DevToolsServerConnection {
       'key': key,
       'value': value,
     });
+  }
+
+  /// Allows the server to ping the client to see that it is definitely still
+  /// active and doesn't just appear to be connected because of SSE timeouts.
+  void ping() {
+    _callMethod('pingResponse');
   }
 }


### PR DESCRIPTION
To fix https://github.com/Dart-Code/Dart-Code/issues/3966 (which I think is also related to https://github.com/Dart-Code/Dart-Code/issues/3964), we need the server to be able to ping a client to see whether it's still alive.

We previously used the clients SSE connection back to the server to know this, but since it has a 30 second timeout (to allow for reconnects if proxy drops it), we may end up assuming a client is still alive when the browser has been closed by the user.

This adds a `ping` method the server can call that just triggers a response that the server can use to verify a client is really active before doing something where it's critical we know _for sure_ the client is still active.

There's server work to go with this, but it's in the SDK. We can't land that work until this method is available (and rolled into the SDK).