### PR TITLE
Add some notes about configuring VS Code to run DevTools from local code

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,26 @@ When you make changes on disk, you can hit `r` in your command-line to rebuild t
 refresh in your browser to see the changes. Hit `q` in the command line to terminate both the
 `flutter run` instance and the devtools server instance.
 
+## Development (VS Code Integration)
+
+To test integration with VS Code, you can instruct the Dart extension to run DevTools and the server from local code. You will need to have the Dart SDK source set up (see [dart-lang/sdk/CONTRIBUTING.md](https://github.com/dart-lang/sdk/blob/main/CONTRIBUTING.md#getting-the-code)) and you will need version v3.47 or newer of the Dart extension for VS Code.
+
+Open your VS Code settings (Run the **Preferences: Open User Settings (JSON)** command from the command palette (`F1`)) and add the following to your settings:
+
+```js
+"dart.customDevTools": {
+	"script": "/path/to/devtools/tool/build_e2e.dart",
+	"cwd": "/path/to/devtools",
+	"env": {
+		"LOCAL_DART_SDK": "/path/to/dart-sdk/sdk"
+	}
+},
+```
+
+This instructs VS Code to run the `tool/build_e2e.dart` script instead of running `dart devtools`. You must set the `cwd` and `LOCAL_DART_SDK` env variable correctly for the script to work.
+
+Next, restart VS Code (or run the **Developer: Reload Window** command from the command palette (`F1`)) and DevTools will be run from your local code. After making any code changes to DevTools or the server, you will need to re-run the **Developer: Reload Window** command to rebuild and restart the server.
+
 ### Desktop Embedder
 
 You can also run the app in the Flutter desktop embedder on linux or macos.


### PR DESCRIPTION
This adds some notes about running DevTools from local code in VS Code to test interactions with the server and embedded views.

It requires changes to the Dart extension that so far are only in the pre-release versions of the Dart extension (although I'd recommend any devs here use that version to help find any issues before they reach all users), v3.47:

<img src="https://user-images.githubusercontent.com/1078012/155162164-d81940cb-9576-4468-8c03-a4bc2fd599c9.png" alt="Dart/Flutter pre-release versions" width="570" height="330" />

(note: although the screenshots shows both, there isn't currently a pre-release version of Flutter, the stable version is latest).

It would be useful to have someone other than me verify these steps work for them before landing (although be aware when testing this myself, I saw some [caching issues](https://github.com/flutter/devtools/issues/3896) that might complicated that).