### PR TITLE
`fileNameFromUri` utility method

### DIFF
--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -1460,6 +1460,7 @@ bool isPrimativeInstanceKind(String? kind) {
 
 // TODO(mtaylee): Prefer to use this helper method whenever a call to
 // .split('/').last is made on a String (usually on URIs).
+// See https://github.com/flutter/devtools/issues/4360.
 /// Returns the file name from a URI or path string, by splitting the [uri] at
 /// the directory separators '/', and returning the last element.
 String? fileNameFromUri(String? uri) => uri?.split('/').last;

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -1460,4 +1460,6 @@ bool isPrimativeInstanceKind(String? kind) {
 
 // TODO(mtaylee): Prefer to use this helper method whenever a call to
 // .split('/').last is made on a String (usually on URIs).
+/// Returns the file name from a URI or path string, by splitting the [uri] at
+/// the directory separators '/', and returning the last element.
 String? fileNameFromUri(String? uri) => uri?.split('/').last;

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -1457,3 +1457,7 @@ bool isPrimativeInstanceKind(String? kind) {
       kind == InstanceKind.kNull ||
       kind == InstanceKind.kString;
 }
+
+// TODO(mtaylee): Prefer to use this helper method whenever a call to
+// .split('/').last is made on a String (usually on URIs).
+String? fileNameFromUri(String? uri) => uri?.split('/').last;


### PR DESCRIPTION
Adds the `fileNameFromUri` utility method to utils.dart, which returns the name of a file from an input URI or path string, by splitting it at the directory separators '/', and returning the last element.

**Related Issues:**
Use this method to fix issue #4360 
