### PR TITLE
Fix syntax highlighting for endCaptures

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
@@ -475,7 +475,7 @@ class _MultilineMatcher extends _Matcher {
     if (end != null && !scanner.scan(end!)) {
       return null;
     }
-    return _processCaptureHelper(scanner, beginCaptures, line, column);
+    return _processCaptureHelper(scanner, endCaptures, line, column);
   }
 
   List<ScopeSpan> _processCaptureHelper(

--- a/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
@@ -7,25 +7,25 @@
 >
 >library foo;
 #^^^^^^^ meta.declaration.dart keyword.other.import.dart
-#           ^ meta.declaration.dart keyword.other.import.dart
+#           ^ meta.declaration.dart punctuation.terminator.dart
 >
 >import 'dart:async' deferred as deferredAsync show Future;
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
 #       ^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
 #                             ^^ meta.declaration.dart keyword.other.import.dart
 #                                              ^^^^ meta.declaration.dart keyword.other.import.dart
-#                                                         ^ meta.declaration.dart keyword.other.import.dart
+#                                                         ^ meta.declaration.dart punctuation.terminator.dart
 >import 'dart:io' as a show File hide Directory;
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
 #       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
 #                 ^^ meta.declaration.dart keyword.other.import.dart
 #                      ^^^^ meta.declaration.dart keyword.other.import.dart
 #                                ^^^^ meta.declaration.dart keyword.other.import.dart
-#                                              ^ meta.declaration.dart keyword.other.import.dart
+#                                              ^ meta.declaration.dart punctuation.terminator.dart
 >export 'dart:io';
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
 #       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
-#                ^ meta.declaration.dart keyword.other.import.dart
+#                ^ meta.declaration.dart punctuation.terminator.dart
 >
 >abstract class A {}
 #^^^^^^^^ keyword.declaration.dart


### PR DESCRIPTION
Minor issue that was using `beginCaptures` when processing `end`, resulting in the wrong scope for terminators in directives.