### PR TITLE
Fix ordering of spans in syntax highlighting goldens

### DIFF
--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -12,11 +12,11 @@
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
 >/// doc
+#^^^^^^^ comment.block.documentation.dart
 #   ^^^^ comment.block.documentation.dart variable.other.source.dart
-#^^^^^^^ comment.block.documentation.dart
 >/// ```
-#   ^ comment.block.documentation.dart variable.other.source.dart
 #^^^^^^^ comment.block.documentation.dart
+#   ^ comment.block.documentation.dart variable.other.source.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...
@@ -52,14 +52,14 @@
 > *
 #^^ comment.block.documentation.dart
 > * /**
-#   ^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^ comment.block.documentation.dart
+#   ^^^ comment.block.documentation.dart comment.block.documentation.dart
 > *  * Nested block
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
-#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^ comment.block.documentation.dart
+#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 > */
 #^^^ comment.block.documentation.dart
 >var d;
@@ -73,8 +73,8 @@
 > *
 #^^ comment.block.documentation.dart
 > * /* Inline */
-#   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
 #^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
 > */
 #^^^ comment.block.documentation.dart
 >var e;
@@ -98,8 +98,8 @@
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 #                              ^^^ comment.block.documentation.dart variable.name.source.dart
 >/// And a link to [example.org](http://example.org/).
-#                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
 >var h;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -47,22 +47,22 @@
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
+#^^^^^^^^^^^^ string.interpolated.single.dart
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^^^^^^^^^ string.interpolated.single.dart
 >  }}');
-#      ^ punctuation.terminator.dart
 #^^^^^ string.interpolated.single.dart
+#      ^ punctuation.terminator.dart
 >  print('print(${() {
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^ string.interpolated.single.dart
 >    return 'Hello';
+#^^^^^^^^^^^^ string.interpolated.single.dart
 #            ^^^^^ support.class.dart
 #                 ^^ string.interpolated.single.dart
-#^^^^^^^^^^^^ string.interpolated.single.dart
 >  }()})');
-#         ^ punctuation.terminator.dart
 #^^^^^^^^ string.interpolated.single.dart
+#         ^ punctuation.terminator.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -218,7 +218,10 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
           final offsetToStartOfNextLine = lineLengthWithNewline - col;
           length = thisLineLength;
           spansByLine[i + 1] ??= [];
-          spansByLine[i + 1]!.add(
+          // Insert the wrapped span before other spans on the next line so the
+          // order is preserved.
+          spansByLine[i + 1]!.insert(
+            0,
             ScopeSpan.copy(
               scopes: span.scopes,
               start: span.start + offsetToStartOfNextLine,


### PR DESCRIPTION
Wrapped spans were being added to the end of the list for the next line, but should be at the start. This is just a testing/golden issue and has no change to the actual parsing.