### PR TITLE
Handle nested scopes better when parsing code for syntax highlighting

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
@@ -605,7 +605,11 @@ class ScopeStack {
     assert(last.scope == scope);
     assert(last.location.position <= end.position);
 
-    _produceSpan(scopes, end: end);
+    // Only produce a span if the scope we're popping is not still in the stack
+    // somewhere.
+    if (!stack.any((item) => item.scope == scope)) {
+      _produceSpan(scopes, end: end);
+    }
   }
 
   void popAll(ScopeStackLocation location) {

--- a/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
@@ -106,7 +106,7 @@ class ScopeSpan {
   /// The one-based column number.
   int get column => startLocation.column + 1;
 
-  final List<String?> scopes;
+  final List<String> scopes;
 
   bool contains(int token) => (start <= token) && (token < end);
 
@@ -548,8 +548,8 @@ class _IncludeMatcher extends _Matcher {
 class ScopeStack {
   ScopeStack();
 
-  final Queue<ScopeStackItem> stack = Queue();
-  final List<ScopeSpan> spans = [];
+  final stack = Queue<ScopeStackItem>();
+  final spans = <ScopeSpan>[];
 
   /// Location where the next produced span should begin.
   ScopeStackLocation _nextLocation = ScopeStackLocation.zero;

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -70,11 +70,11 @@ class SyntaxHighlighter {
     if (scopes.isEmpty) {
       return const TextStyle();
     } else if (scopes.length == 1) {
-      return _scopeStyles[scopes.first!] ?? const TextStyle();
+      return _scopeStyles[scopes.first] ?? const TextStyle();
     } else {
       var style = const TextStyle();
       for (final scope in scopes) {
-        style = style.merge(_scopeStyles[scope!] ?? const TextStyle());
+        style = style.merge(_scopeStyles[scope] ?? const TextStyle());
       }
       return style;
     }

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -67,7 +67,7 @@ class SyntaxHighlighter {
     }
     final scopes = _spanStack.last.scopes;
 
-    if (scopes == null || scopes.isEmpty) {
+    if (scopes.isEmpty) {
       return const TextStyle();
     } else if (scopes.length == 1) {
       return _scopeStyles[scopes.first!] ?? const TextStyle();

--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -12,11 +12,12 @@
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
 >/// doc
-#^^^^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 #   ^^^^ comment.block.documentation.dart variable.other.source.dart
 >/// ```
-#^^^^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 #   ^ comment.block.documentation.dart variable.other.source.dart
+#    ^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...
@@ -53,13 +54,10 @@
 #^^ comment.block.documentation.dart
 > * /**
 #^^^^^^ comment.block.documentation.dart
-#   ^^^ comment.block.documentation.dart comment.block.documentation.dart
 > *  * Nested block
-#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 #^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 > *  */
 #^^^^^^ comment.block.documentation.dart
-#^^^^^^ comment.block.documentation.dart comment.block.documentation.dart
 > */
 #^^^ comment.block.documentation.dart
 >var d;
@@ -73,7 +71,7 @@
 > *
 #^^ comment.block.documentation.dart
 > * /* Inline */
-#^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^ comment.block.documentation.dart
 #   ^^^^^^^^^^^^ comment.block.documentation.dart comment.block.dart
 > */
 #^^^ comment.block.documentation.dart
@@ -82,8 +80,8 @@
 #     ^ punctuation.terminator.dart
 >
 >/* Nested /* Inline */ */
-#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
-#          ^^^^^^^^^^^^ comment.block.dart comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
+#                      ^^^ comment.block.dart
 >var f;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart
@@ -95,11 +93,13 @@
 #     ^ punctuation.terminator.dart
 >
 >/// Dartdoc with reference to [a].
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 #                              ^^^ comment.block.documentation.dart variable.name.source.dart
+#                                 ^ comment.block.documentation.dart
 >/// And a link to [example.org](http://example.org/).
-#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+#^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 #                  ^^^^^^^^^^^^^ comment.block.documentation.dart variable.name.source.dart
+#                               ^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
 >var h;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/comments.dart.golden
@@ -80,8 +80,7 @@
 #     ^ punctuation.terminator.dart
 >
 >/* Nested /* Inline */ */
-#^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
-#                      ^^^ comment.block.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.dart
 >var f;
 #^^^ storage.type.primitive.dart
 #     ^ punctuation.terminator.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/handles_eof_gracefully.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/handles_eof_gracefully.golden
@@ -1,0 +1,2 @@
+>/** there's no end to this comment
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/keywords.dart.golden
@@ -7,23 +7,34 @@
 >
 >library foo;
 #^^^^^^^ meta.declaration.dart keyword.other.import.dart
+#       ^^^^ meta.declaration.dart
 #           ^ meta.declaration.dart punctuation.terminator.dart
 >
 >import 'dart:async' deferred as deferredAsync show Future;
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
 #       ^^^^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                   ^^^^^^^^^^ meta.declaration.dart
 #                             ^^ meta.declaration.dart keyword.other.import.dart
+#                               ^^^^^^^^^^^^^^^ meta.declaration.dart
 #                                              ^^^^ meta.declaration.dart keyword.other.import.dart
+#                                                  ^^^^^^^ meta.declaration.dart
 #                                                         ^ meta.declaration.dart punctuation.terminator.dart
 >import 'dart:io' as a show File hide Directory;
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
 #       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
+#                ^ meta.declaration.dart
 #                 ^^ meta.declaration.dart keyword.other.import.dart
+#                   ^^^ meta.declaration.dart
 #                      ^^^^ meta.declaration.dart keyword.other.import.dart
+#                          ^^^^^^ meta.declaration.dart
 #                                ^^^^ meta.declaration.dart keyword.other.import.dart
+#                                    ^^^^^^^^^^ meta.declaration.dart
 #                                              ^ meta.declaration.dart punctuation.terminator.dart
 >export 'dart:io';
 #^^^^^^ meta.declaration.dart keyword.other.import.dart
+#      ^ meta.declaration.dart
 #       ^^^^^^^^^ meta.declaration.dart string.interpolated.single.dart
 #                ^ meta.declaration.dart punctuation.terminator.dart
 >

--- a/packages/devtools_app/test/goldens/syntax_highlighting/literals.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/literals.dart.golden
@@ -27,8 +27,9 @@
 #            ^ keyword.operator.assignment.dart
 #               ^^ string.interpolated.single.dart
 #                 ^ punctuation.comma.dart
-#                   ^^^^ string.interpolated.single.dart
+#                   ^^ string.interpolated.single.dart
 #                     ^ string.interpolated.single.dart variable.parameter.dart
+#                      ^ string.interpolated.single.dart
 #                        ^ punctuation.terminator.dart
 >const list4 = <String>['', '$a'];
 #^^^^^ storage.modifier.dart
@@ -38,8 +39,9 @@
 #                     ^ keyword.operator.comparison.dart
 #                       ^^ string.interpolated.single.dart
 #                         ^ punctuation.comma.dart
-#                           ^^^^ string.interpolated.single.dart
+#                           ^^ string.interpolated.single.dart
 #                             ^ string.interpolated.single.dart variable.parameter.dart
+#                              ^ string.interpolated.single.dart
 #                                ^ punctuation.terminator.dart
 >
 >const set1 = {};
@@ -58,8 +60,9 @@
 #           ^ keyword.operator.assignment.dart
 #              ^^ string.interpolated.single.dart
 #                ^ punctuation.comma.dart
-#                  ^^^^ string.interpolated.single.dart
+#                  ^^ string.interpolated.single.dart
 #                    ^ string.interpolated.single.dart variable.parameter.dart
+#                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const set4 = <String>{'', '$a'};
 #^^^^^ storage.modifier.dart
@@ -69,8 +72,9 @@
 #                    ^ keyword.operator.comparison.dart
 #                      ^^ string.interpolated.single.dart
 #                        ^ punctuation.comma.dart
-#                          ^^^^ string.interpolated.single.dart
+#                          ^^ string.interpolated.single.dart
 #                            ^ string.interpolated.single.dart variable.parameter.dart
+#                             ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >
 >const map1 = <String, String>{};
@@ -87,8 +91,9 @@
 #           ^ keyword.operator.assignment.dart
 #              ^^ string.interpolated.single.dart
 #                ^ keyword.operator.ternary.dart
-#                  ^^^^ string.interpolated.single.dart
+#                  ^^ string.interpolated.single.dart
 #                    ^ string.interpolated.single.dart variable.parameter.dart
+#                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const map3 = <String, String>{'': '$a'};
 #^^^^^ storage.modifier.dart
@@ -100,6 +105,7 @@
 #                            ^ keyword.operator.comparison.dart
 #                              ^^ string.interpolated.single.dart
 #                                ^ keyword.operator.ternary.dart
-#                                  ^^^^ string.interpolated.single.dart
+#                                  ^^ string.interpolated.single.dart
 #                                    ^ string.interpolated.single.dart variable.parameter.dart
+#                                     ^ string.interpolated.single.dart
 #                                       ^ punctuation.terminator.dart

--- a/packages/devtools_app/test/goldens/syntax_highlighting/open_code_block.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/open_code_block.golden
@@ -1,0 +1,16 @@
+>/// This is an open code block:
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart
+>/// ```dart
+#^^^^^^^^^^^ comment.block.documentation.dart
+>///
+#^^^ comment.block.documentation.dart
+>/// This should not cause parsing to fail.
+#^^^ comment.block.documentation.dart
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+>
+>void main() {
+#^^^^ storage.type.primitive.dart
+#     ^^^^ entity.name.function.dart
+>  // But scope should end when parent scope is closed.
+#  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.line.double-slash.dart
+>}

--- a/packages/devtools_app/test/goldens/syntax_highlighting/operators.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/operators.dart.golden
@@ -58,8 +58,7 @@
 #                              ^ constant.numeric.dart
 #                               ^ punctuation.terminator.dart
 >  a ??= b;
-#    ^ keyword.operator.ternary.dart
-#     ^ keyword.operator.ternary.dart
+#    ^^ keyword.operator.ternary.dart
 #      ^ keyword.operator.assignment.dart
 #         ^ punctuation.terminator.dart
 >  b += 1;
@@ -200,11 +199,9 @@
 #        ^ keyword.operator.assignment.dart
 #          ^ keyword.operator.logical.dart
 #              ^^ keyword.operator.comparison.dart
-#                   ^ keyword.operator.bitwise.dart
-#                    ^ keyword.operator.bitwise.dart
+#                   ^^ keyword.operator.bitwise.dart
 #                      ^^^^^ constant.language.dart
-#                            ^ keyword.operator.bitwise.dart
-#                             ^ keyword.operator.bitwise.dart
+#                            ^^ keyword.operator.bitwise.dart
 #                               ^^^^ constant.language.dart
 #                                    ^ punctuation.terminator.dart
 >}

--- a/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -21,22 +21,29 @@
 >
 >  print('the value of \$i is $i');
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^^ string.interpolated.single.dart constant.character.escape.dart
+#                        ^^^^^^ string.interpolated.single.dart
 #                              ^ string.interpolated.single.dart variable.parameter.dart
+#                               ^ string.interpolated.single.dart
 #                                 ^ punctuation.terminator.dart
 >  print('the value after \$i is ${i + 1}');
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#        ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                         ^^ string.interpolated.single.dart constant.character.escape.dart
+#                           ^^^^^^^ string.interpolated.single.dart
 #                                  ^^^^^ string.interpolated.single.dart variable.parameter.dart
+#                                       ^^ string.interpolated.single.dart
 #                                          ^ punctuation.terminator.dart
 >  print('the value of \$i + \$j is ${i + j}');
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^^ string.interpolated.single.dart constant.character.escape.dart
+#                        ^^^^ string.interpolated.single.dart
 #                            ^^ string.interpolated.single.dart constant.character.escape.dart
+#                              ^^^^^^^ string.interpolated.single.dart
 #                                     ^^^^^ string.interpolated.single.dart variable.parameter.dart
+#                                          ^^ string.interpolated.single.dart
 #                                             ^ punctuation.terminator.dart
 >}
 >
@@ -65,12 +72,14 @@
 #         ^ punctuation.terminator.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#        ^^^ string.interpolated.single.dart
 #           ^^^^^^^^^^^^^ string.interpolated.single.dart variable.parameter.dart
+#                        ^^ string.interpolated.single.dart
 #                           ^ punctuation.terminator.dart
 >  print('print(${(() => 'Hello')()})');
 #  ^^^^^ entity.name.function.dart
-#        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
+#        ^^^^^^^^^ string.interpolated.single.dart
 #                 ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart variable.parameter.dart
+#                                  ^^^ string.interpolated.single.dart
 #                                      ^ punctuation.terminator.dart
 >}

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -42,18 +42,20 @@ void main() {
   });
 
   group('SpanParser', () {
+    final updateGoldens = autoUpdateGoldenFiles;
+
     /// Expects parsing [content] using produces the output in [goldenFile].
     void expectSpansMatchGolden(
       String content,
       List<ScopeSpan> spans,
       File goldenFile,
     ) {
-      if (!goldenFile.existsSync() && !autoUpdateGoldenFiles) {
+      if (!goldenFile.existsSync() && !updateGoldens) {
         fail('Missing golden file: ${goldenFile.path}');
       }
 
       final actual = _buildGoldenText(content, spans);
-      if (autoUpdateGoldenFiles) {
+      if (updateGoldens) {
         goldenFile.writeAsStringSync(actual);
       } else {
         final expected = goldenFile.readAsStringSync();

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -26,22 +26,15 @@ void main() {
 }
 ''';
 
-void spanTester({
-  required ScopeSpan span,
-  required List<String> scopes,
-  required int line,
-  required int column,
-  required int length,
-}) {
-  expect(span.scopes, scopes);
-  expect(span.line, line);
-  expect(span.column, column);
-  expect(span.length, length);
-}
-
 void main() {
   final grammarFile = File(path.join('assets', 'dart_syntax.json')).absolute;
   late Grammar grammar;
+
+  final Directory testDataDirectory =
+      Directory(path.join('test', 'test_data', 'syntax_highlighting')).absolute;
+  final Directory goldenDirectory =
+      Directory(path.join('test', 'goldens', 'syntax_highlighting')).absolute;
+
   setUpAll(() async {
     expect(grammarFile.existsSync(), true);
     final grammarJson = json.decode(await grammarFile.readAsString());
@@ -49,112 +42,52 @@ void main() {
   });
 
   group('SpanParser', () {
+    /// Expects parsing [content] using produces the output in [goldenFile].
+    void expectSpansMatchGolden(
+      String content,
+      List<ScopeSpan> spans,
+      File goldenFile,
+    ) {
+      if (!goldenFile.existsSync() && !autoUpdateGoldenFiles) {
+        fail('Missing golden file: ${goldenFile.path}');
+      }
+
+      final actual = _buildGoldenText(content, spans);
+      if (autoUpdateGoldenFiles) {
+        goldenFile.writeAsStringSync(actual);
+      } else {
+        final expected = goldenFile.readAsStringSync();
+        expect(_normalize(actual), _normalize(expected));
+      }
+    }
+
+    File goldenFileFor(String name) {
+      final goldenPath = path.join(goldenDirectory.path, '$name.golden');
+      return File(goldenPath);
+    }
+
     // Multiline rules allow for matching spans that do not close with a match to
     // the 'end' pattern in the case that EOF has been reached.
     test('handles EOF gracefully', () {
+      final goldenFile = goldenFileFor('handles_eof_gracefully');
       final spans = SpanParser.parse(grammar, missingEnd);
-      expect(spans.length, 1);
-      spanTester(
-        span: spans[0],
-        scopes: ['comment.block.documentation.dart'],
-        line: 1,
-        column: 1,
-        length: 35,
-      );
+      expectSpansMatchGolden(missingEnd, spans, goldenFile);
+
+      // Check the span ends where expected.
+      final span = spans.single;
+      expect(span.scopes, ['comment.block.documentation.dart']);
+      expect(span.line, 1);
+      expect(span.column, 1);
+      expect(span.length, 35);
     });
 
     test('handles malformed input', () {
+      final goldenFile = goldenFileFor('open_code_block');
       final spans = SpanParser.parse(grammar, openCodeBlock);
-      expect(spans.length, 7);
-
-      // Represents the span covering all lines starting with '///'
-      spanTester(
-        span: spans[0],
-        scopes: ['comment.block.documentation.dart'],
-        line: 1,
-        column: 1,
-        length: 91,
-      );
-
-      // Immediately following '```dart'
-      spanTester(
-        span: spans[1],
-        scopes: [
-          'comment.block.documentation.dart',
-          'variable.other.source.dart',
-        ],
-        line: 2,
-        column: 12,
-        length: 1,
-      );
-
-      // Whitespace after 3rd '///' line.
-      spanTester(
-        span: spans[2],
-        scopes: [
-          'comment.block.documentation.dart',
-          'variable.other.source.dart',
-        ],
-        line: 3,
-        column: 4,
-        length: 1,
-      );
-
-      // 'This should not cause parsing to fail.'
-      spanTester(
-        span: spans[3],
-        scopes: [
-          'comment.block.documentation.dart',
-          'variable.other.source.dart',
-        ],
-        line: 4,
-        column: 4,
-        length: 40,
-      );
-
-      // void
-      spanTester(
-        span: spans[4],
-        scopes: [
-          'storage.type.primitive.dart',
-        ],
-        line: 6,
-        column: 1,
-        length: 4,
-      );
-
-      // main
-      spanTester(
-        span: spans[5],
-        scopes: [
-          'entity.name.function.dart',
-        ],
-        line: 6,
-        column: 6,
-        length: 4,
-      );
-
-      // '// But scope should end when parent scope is closed.'
-      spanTester(
-        span: spans[6],
-        scopes: [
-          'comment.line.double-slash.dart',
-        ],
-        line: 7,
-        column: 3,
-        length: 52,
-      );
+      expectSpansMatchGolden(openCodeBlock, spans, goldenFile);
     });
 
     group('golden', () {
-      final updateGoldens = autoUpdateGoldenFiles;
-      final Directory testDataDirectory =
-          Directory(path.join('test', 'test_data', 'syntax_highlighting'))
-              .absolute;
-      final Directory goldenDirectory =
-          Directory(path.join('test', 'goldens', 'syntax_highlighting'))
-              .absolute;
-
       // Perform golden tests on the test_data/syntax_highlighting folder.
       // These goldens are updated using the usual Flutter --update-goldens
       // flag:
@@ -166,26 +99,12 @@ void main() {
           .where((file) => path.extension(file.path) == '.dart');
 
       for (final testFile in testFiles) {
-        final goldenPath = path.join(
-          goldenDirectory.path,
-          '${path.basename(testFile.path)}.golden',
-        );
-        final goldenFile = File(goldenPath);
+        final goldenFile = goldenFileFor(path.basename(testFile.path));
         test(path.basename(testFile.path), () {
-          if (!goldenFile.existsSync() && !updateGoldens) {
-            fail('Missing golden file: ${goldenFile.path}');
-          }
-
           final content = testFile.readAsStringSync();
           final spans = SpanParser.parse(grammar, content);
-          final actual = _buildGoldenText(content, spans);
 
-          if (updateGoldens) {
-            goldenFile.writeAsStringSync(actual);
-          } else {
-            final expected = goldenFile.readAsStringSync();
-            expect(_normalize(actual), _normalize(expected));
-          }
+          expectSpansMatchGolden(content, spans, goldenFile);
         });
       }
     });
@@ -194,7 +113,7 @@ void main() {
 
 String _buildGoldenText(String content, List<ScopeSpan> spans) {
   final buffer = StringBuffer();
-  final spansByLine = groupBy(spans, (ScopeSpan s) => s.line! - 1);
+  final spansByLine = groupBy(spans, (ScopeSpan s) => s.line - 1);
 
   final lines = content.trim().split('\n');
   for (var i = 0; i < lines.length; i++) {
@@ -208,7 +127,7 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
     final lineSpans = spansByLine[i];
     if (lineSpans != null) {
       for (final span in lineSpans) {
-        final col = span.column! - 1;
+        final col = span.column - 1;
         var length = span.length;
 
         // Spans may roll over onto the next line, so truncate them and insert
@@ -222,12 +141,14 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
           // order is preserved.
           spansByLine[i + 1]!.insert(
             0,
-            ScopeSpan.copy(
+            ScopeSpan(
               scopes: span.scopes,
-              start: span.start + offsetToStartOfNextLine,
-              end: span.end,
-              line: span.line! + 1,
-              column: 1,
+              startLocation: ScopeStackLocation(
+                position: span.start + offsetToStartOfNextLine,
+                line: span.line + 1,
+                column: 0,
+              ),
+              endLocation: span.endLocation,
             ),
           );
         } else if (col + length > line.length) {

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -168,7 +168,7 @@ String _buildGoldenText(String content, List<ScopeSpan> spans) {
         buffer.write(' ' * col);
         buffer.write('^' * length);
         buffer.write(' ');
-        buffer.writeln(span.scopes!.join(' '));
+        buffer.writeln(span.scopes.join(' '));
       }
     }
   }


### PR DESCRIPTION
@bkonyi ~~I'm not ready to land this yet (I want to do some more manual testing, and compare the results to an npm tool that produces the same), but it ended up much larger than I'd planned so I thought it made sense to raise open for some feedback.~~

The goal here was to resolve some issues with overlapping/nested tokens. Previously we would produce nested tokens like this:

```
>  print('the value of \$i is $i');
#  ^^^^^ entity.name.function.dart
#        ^^^^^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
#                      ^^ string.interpolated.single.dart constant.character.escape.dart
#                              ^ string.interpolated.single.dart variable.parameter.dart
#                                 ^ punctuation.terminator.dart
```

The goal is to produce a simple flat list (which is consistent with another npm tool I use, allowing us to compare the output as an extra test). The new output for the above is:

```
>  print('the value of \$i is $i');
#  ^^^^^ entity.name.function.dart
#        ^^^^^^^^^^^^^^ string.interpolated.single.dart
#                      ^^ string.interpolated.single.dart constant.character.escape.dart
#                        ^^^^^^ string.interpolated.single.dart
#                              ^ string.interpolated.single.dart variable.parameter.dart
#                               ^ string.interpolated.single.dart
#                                 ^ punctuation.terminator.dart
```

Previously we would use the stack only to store the string scope names which made it difficult to produce the spans "in between" when popping the nested tokens. So I change this so the stack now drives all of the produced tokens. Instead of producing tokens directly, we always push/pop from the stack on boundaries (although there's an `add()` helper that just pushes and pops for when we want to produce an exact token). This allows us to produce those "in between" tokens (because any time we push a new scope, we can produce a token for the gap between the last token and the new token).

I added a new class to make it easier to pass around a "location" (an offset position, line number, and column number) because we now need to know the line/col for the _ends_ of tokens to support the functionality above (when we pop a token, we need to produce the next token starting at the previous tokens end).

I also moved the two remaining tests to use the "golden" format for convenience (since the results of one changed slightly with this change because it had nested tokens). I kept the source for them in the test file because our bots run `dart analyze` and the code is invalid, but the goldens now live in the `goldens` folder along with the rest.

I'll aim to test this more (and compare to the npm tool) tomorrow. If you can think of any cases this might not handle correctly, let me know and I can add additional tests (first in `master` so we can get the previous results for them, and then rebase this so we can see the impact of the changes).