### PR TITLE
Fix getPubRootDirectories so it works over Dart Debug Extension

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -461,9 +461,11 @@ class InspectorService extends InspectorServiceBase {
       'getPubRootDirectories',
     );
 
-    return (response as List<dynamic>)
-        .map<String>((e) => e.toString())
-        .toList();
+    if (response is! List<dynamic>) {
+      return [];
+    }
+
+    return response.map<String>((e) => e.toString()).toList();
   }
 
   /// As we aren't running from an IDE, we don't know exactly what the pub root

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -461,8 +461,6 @@ class InspectorService extends InspectorServiceBase {
       'getPubRootDirectories',
     );
 
-    if (response.runtimeType != List) return [];
-
     return (response as List<dynamic>)
         .map<String>((e) => e.toString())
         .toList();


### PR DESCRIPTION
![](https://media.giphy.com/media/l1J9qrAVNHt1bDi2A/giphy.gif)

I was able to determine that the pub root directories were not being returned to devtools because they were being returned as a `JSArray<dynamic>`. This PR removes the type check that was overly specific, and blocked the return of those values.

I chose not to try to catch any type casting exceptions yet, as I'm unsure of a specific case where we need this yet. So for now, if we get a non-list type, then this code may fail.

