### PR TITLE
InspectorService may not always be present

### DIFF
--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -84,7 +84,7 @@ class InspectorPreferencesController extends DisposableController
   ValueListenable<bool> get isRefreshingCustomPubRootDirectories =>
       _customPubRootDirectoriesAreBusy;
   InspectorService? get _inspectorService =>
-      serviceManager.inspectorService as InspectorService;
+      serviceManager.inspectorService as InspectorService?;
 
   final _hoverEvalMode = ValueNotifier<bool>(false);
   final _customPubRootDirectories = ListValueNotifier<String>([]);

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -82,7 +82,7 @@ class InspectorPreferencesController extends DisposableController
       _customPubRootDirectories;
   ValueListenable<bool> get isRefreshingCustomPubRootDirectories =>
       _customPubRootDirectoriesAreBusy;
-  InspectorService get inspectorService =>
+  InspectorService? get inspectorService =>
       serviceManager.inspectorService as InspectorService;
 
   final _hoverEvalMode = ValueNotifier<bool>(false);
@@ -195,7 +195,8 @@ class InspectorPreferencesController extends DisposableController
   ) async {
     if (!serviceManager.hasConnection) return;
     await _customPubRootDirectoryBusyTracker(() async {
-      await inspectorService.addPubRootDirectories(pubRootDirectories);
+      if (inspectorService == null) return;
+      await inspectorService!.addPubRootDirectories(pubRootDirectories);
       await _refreshPubRootDirectoriesFromService();
     });
   }
@@ -205,15 +206,17 @@ class InspectorPreferencesController extends DisposableController
   ) async {
     if (!serviceManager.hasConnection) return;
     await _customPubRootDirectoryBusyTracker(() async {
-      await inspectorService.removePubRootDirectories(pubRootDirectories);
+      if (inspectorService == null) return;
+      await inspectorService!.removePubRootDirectories(pubRootDirectories);
       await _refreshPubRootDirectoriesFromService();
     });
   }
 
   Future<void> _refreshPubRootDirectoriesFromService() async {
     await _customPubRootDirectoryBusyTracker(() async {
+      if (inspectorService == null) return;
       final freshPubRootDirectories =
-          await inspectorService.getPubRootDirectories();
+          await inspectorService!.getPubRootDirectories();
       if (freshPubRootDirectories != null) {
         final newSet = Set<String>.from(freshPubRootDirectories);
         final oldSet = Set<String>.from(_customPubRootDirectories.value);

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
+import '../analytics/constants.dart';
 import '../primitives/auto_dispose.dart';
 import '../primitives/utils.dart';
 import '../screens/inspector/inspector_service.dart';
@@ -82,7 +83,7 @@ class InspectorPreferencesController extends DisposableController
       _customPubRootDirectories;
   ValueListenable<bool> get isRefreshingCustomPubRootDirectories =>
       _customPubRootDirectoriesAreBusy;
-  InspectorService? get inspectorService =>
+  InspectorService? get _inspectorService =>
       serviceManager.inspectorService as InspectorService;
 
   final _hoverEvalMode = ValueNotifier<bool>(false);
@@ -195,8 +196,10 @@ class InspectorPreferencesController extends DisposableController
   ) async {
     if (!serviceManager.hasConnection) return;
     await _customPubRootDirectoryBusyTracker(() async {
+      final inspectorService = _inspectorService;
       if (inspectorService == null) return;
-      await inspectorService!.addPubRootDirectories(pubRootDirectories);
+
+      await inspectorService.addPubRootDirectories(pubRootDirectories);
       await _refreshPubRootDirectoriesFromService();
     });
   }
@@ -206,17 +209,21 @@ class InspectorPreferencesController extends DisposableController
   ) async {
     if (!serviceManager.hasConnection) return;
     await _customPubRootDirectoryBusyTracker(() async {
-      if (inspectorService == null) return;
-      await inspectorService!.removePubRootDirectories(pubRootDirectories);
+      final localInspectorService = _inspectorService;
+      if (localInspectorService == null) return;
+
+      await localInspectorService.removePubRootDirectories(pubRootDirectories);
       await _refreshPubRootDirectoriesFromService();
     });
   }
 
   Future<void> _refreshPubRootDirectoriesFromService() async {
     await _customPubRootDirectoryBusyTracker(() async {
-      if (inspectorService == null) return;
+      final localInspectorService = _inspectorService;
+      if (localInspectorService == null) return;
+
       final freshPubRootDirectories =
-          await inspectorService!.getPubRootDirectories();
+          await localInspectorService.getPubRootDirectories();
       if (freshPubRootDirectories != null) {
         final newSet = Set<String>.from(freshPubRootDirectories);
         final oldSet = Set<String>.from(_customPubRootDirectories.value);

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -6,7 +6,6 @@ import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 
-import '../analytics/constants.dart';
 import '../primitives/auto_dispose.dart';
 import '../primitives/utils.dart';
 import '../screens/inspector/inspector_service.dart';


### PR DESCRIPTION
![](https://media.giphy.com/media/26gs78HRO8sOuhTkQ/giphy-downsized.gif)

While following the docs to roll devtools to g3, i noticed a failure in the preferences code. The inspector service was being called, but it was set to null.

This PR makes the getter optional to account for the fact that there won't always be an inspector, and as such we won't want to call those operations.

NOTE: I've tested these changes in g3 to make sure they fix the error.