### PR TITLE
Fix Eager Inspector Refresh

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -126,7 +126,8 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       }
     });
     addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
-      if (serviceManager.hasConnection) {
+      if (serviceManager.hasConnection &&
+          !controller.firstInspectorTreeLoadCompleted) {
         _refreshInspector();
       }
     });

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -127,7 +127,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     });
     addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
       if (serviceManager.hasConnection &&
-          !controller.firstInspectorTreeLoadCompleted) {
+          controller.firstInspectorTreeLoadCompleted) {
         _refreshInspector();
       }
     });

--- a/packages/devtools_app/lib/src/shared/editable_list.dart
+++ b/packages/devtools_app/lib/src/shared/editable_list.dart
@@ -190,7 +190,7 @@ class EditableListActionBar extends StatelessWidget {
 }
 
 class _EditableListContentView extends StatelessWidget {
-  const _EditableListContentView({
+  _EditableListContentView({
     Key? key,
     required this.entries,
     required this.onEntryRemoved,
@@ -198,10 +198,12 @@ class _EditableListContentView extends StatelessWidget {
 
   final ListValueNotifier<String> entries;
   final Function(String) onEntryRemoved;
+  final ScrollController _listContentScrollController = ScrollController();
 
   @override
   Widget build(BuildContext context) {
     return Scrollbar(
+      controller: _listContentScrollController,
       thumbVisibility: true,
       child: ListView.builder(
         itemCount: entries.value.length,

--- a/packages/devtools_app/lib/src/shared/editable_list.dart
+++ b/packages/devtools_app/lib/src/shared/editable_list.dart
@@ -206,6 +206,7 @@ class _EditableListContentView extends StatelessWidget {
       controller: _listContentScrollController,
       thumbVisibility: true,
       child: ListView.builder(
+        controller: _listContentScrollController,
         itemCount: entries.value.length,
         itemBuilder: (context, index) {
           return EditableListRow(

--- a/packages/devtools_app/lib/src/shared/editable_list.dart
+++ b/packages/devtools_app/lib/src/shared/editable_list.dart
@@ -92,6 +92,7 @@ class _EditableListState extends State<EditableList> {
               onEntryAdded: widget.onEntryAdded,
               onRefresh: widget.onRefreshTriggered,
             ),
+            const SizedBox(height: denseSpacing),
             Expanded(
               child: _EditableListContentView(
                 entries: widget.entries,
@@ -161,7 +162,9 @@ class EditableListActionBar extends StatelessWidget {
             onPressed: () {
               _addNewItem();
             },
-            child: const Text('Add'),
+            child: const Text(
+              'Add',
+            ), // TODO:(https://github.com/flutter/devtools/issues/4381)
           ),
           isRefreshing?.value ?? false
               ? Container(
@@ -198,17 +201,16 @@ class _EditableListContentView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return RoundedOutlinedBorder(
-      child: Scrollbar(
-        child: ListView.builder(
-          itemCount: entries.value.length,
-          itemBuilder: (context, index) {
-            return EditableListRow(
-              entry: entries.value[index],
-              onEntryRemoved: onEntryRemoved,
-            );
-          },
-        ),
+    return Scrollbar(
+      thumbVisibility: true,
+      child: ListView.builder(
+        itemCount: entries.value.length,
+        itemBuilder: (context, index) {
+          return EditableListRow(
+            entry: entries.value[index],
+            onEntryRemoved: onEntryRemoved,
+          );
+        },
       ),
     );
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -181,6 +181,14 @@ class InspectorPreferencesController extends DisposableController
 
     _customPubRootDirectories.clear();
     await loadCustomPubRootDirectories();
+
+    if (_customPubRootDirectories.value.isEmpty) {
+      // If there are no pub root directories set on the first connection
+      // then try inferring them.
+      final localInspectorService = _inspectorService;
+      await localInspectorService?.inferPubRootDirectoryIfNeeded();
+      await loadCustomPubRootDirectories();
+    }
   }
 
   void _persistCustomPubRootDirectoriesToStorage() {

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -200,6 +200,13 @@ class InspectorPreferencesController extends DisposableController
   Future<void> addPubRootDirectories(
     List<String> pubRootDirectories,
   ) async {
+    // TODO(https://github.com/flutter/devtools/issues/4380):
+    // Add validation to EditableList Input.
+    // Directories of just / will break the inspector tree local package checks.
+    pubRootDirectories.removeWhere(
+      (element) => element.replaceAll(RegExp('\/'), '').trim() == '',
+    );
+
     if (!serviceManager.hasConnection) return;
     await _customPubRootDirectoryBusyTracker(() async {
       final inspectorService = _inspectorService;

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -204,7 +204,7 @@ class InspectorPreferencesController extends DisposableController
     // Add validation to EditableList Input.
     // Directories of just / will break the inspector tree local package checks.
     pubRootDirectories.removeWhere(
-      (element) => element.replaceAll(RegExp('\/'), '').trim() == '',
+      (element) => RegExp('^[/\\s]*\$').firstMatch(element) != null,
     );
 
     if (!serviceManager.hasConnection) return;

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -185,8 +185,7 @@ class InspectorPreferencesController extends DisposableController
     if (_customPubRootDirectories.value.isEmpty) {
       // If there are no pub root directories set on the first connection
       // then try inferring them.
-      final localInspectorService = _inspectorService;
-      await localInspectorService?.inferPubRootDirectoryIfNeeded();
+      await _inspectorService?.inferPubRootDirectoryIfNeeded();
       await loadCustomPubRootDirectories();
     }
   }


### PR DESCRIPTION
![](https://media.giphy.com/media/26gsccje7r5WUrXsA/giphy-downsized.gif)

Fixes https://github.com/flutter/devtools/issues/4375

Wait for the first tree load before trying to refresh the tree from a pub root directory change. Any refreshes that happen this early aren't important yet any ways.

UPDATE: this now also adds a call to `inferpubRootDirectories` if the first time we connect there are no directories set
