### PR TITLE
Update the desktop storage file to use the same file path as production devtools

### DIFF
--- a/packages/devtools_app/lib/src/config_specific/framework_initialize/_framework_initialize_desktop.dart
+++ b/packages/devtools_app/lib/src/config_specific/framework_initialize/_framework_initialize_desktop.dart
@@ -55,7 +55,7 @@ class FlutterDesktopStorage implements Storage {
   }
 
   static File get _preferencesFile =>
-      File(path.join(_userHomeDir(), '.devtools'));
+      File(path.join(_userHomeDir(), '.flutter-devtools/.devtools'));
 
   static String _userHomeDir() {
     final String envKey =

--- a/packages/devtools_app/lib/src/shared/server_api_client.dart
+++ b/packages/devtools_app/lib/src/shared/server_api_client.dart
@@ -199,12 +199,16 @@ class DevToolsServerConnection {
     _callMethod('disconnected');
   }
 
+  /// Retrieves a preference value from the DevTools configuration file at
+  /// ~/.flutter-devtools/.devtools.
   Future<String> getPreferenceValue(String key) {
     return _callMethod('getPreferenceValue', {
       'key': key,
     });
   }
 
+  /// Sets a preference value in the DevTools configuration file at
+  /// ~/.flutter-devtools/.devtools.
   Future setPreferenceValue(String key, String value) async {
     await _callMethod('setPreferenceValue', {
       'key': key,


### PR DESCRIPTION
The DevTools server uses `~/.flutter-devtools/.devtools` to store preferences and metadata. The desktop storage file was incorrectly using `~/.devtools` (which we used to use from the server as well). The desktop storage is only used for development, but this makes our development storage behavior consistent with our production app.