### PR TITLE
VM Developer Tools screen IndexedStack & other changes

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -51,6 +51,7 @@ export 'src/screens/profiler/profile_granularity.dart';
 export 'src/screens/profiler/profiler_screen.dart';
 export 'src/screens/profiler/profiler_screen_controller.dart';
 export 'src/screens/provider/provider_screen.dart';
+export 'src/screens/vm_developer/vm_developer_tools_controller.dart';
 export 'src/screens/vm_developer/vm_developer_tools_screen.dart';
 export 'src/screens/vm_developer/vm_object_model.dart';
 export 'src/scripts/script_manager.dart';

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -598,7 +598,7 @@ List<DevToolsScreen> get defaultScreens {
       createController: () => AppSizeController(),
     ),
     DevToolsScreen<VMDeveloperToolsController>(
-      VMDeveloperToolsScreen(controller: vmDeveloperToolsController),
+      const VMDeveloperToolsScreen(),
       controller: vmDeveloperToolsController,
     ),
     // Show the sample DevTools screen.

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view.dart
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
 import '../../shared/split.dart';
 import '../debugger/program_explorer.dart';
 import '../debugger/program_explorer_model.dart';
 import 'object_inspector_view_controller.dart';
 import 'object_viewport.dart';
+import 'vm_developer_tools_controller.dart';
 import 'vm_developer_tools_screen.dart';
 
 /// Displays a program explorer and a history viewport that displays
@@ -38,10 +40,12 @@ class _ObjectInspectorViewState extends State<_ObjectInspectorView> {
   late final ObjectInspectorViewController controller;
 
   @override
-  void initState() {
-    super.initState();
-    controller = ObjectInspectorViewController()..init();
-    return;
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    final vmDeveloperToolsController =
+        Provider.of<VMDeveloperToolsController>(context);
+    controller = vmDeveloperToolsController.objectInspectorViewController!
+      ..init();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -16,18 +16,6 @@ import 'vm_object_model.dart';
 /// the object history and the object viewport.
 class ObjectInspectorViewController extends DisposableController
     with AutoDisposeControllerMixin {
-  ObjectInspectorViewController() {
-    addAutoDisposeListener(
-      scriptManager.sortedScripts,
-      selectAndPushMainScript,
-    );
-
-    addAutoDisposeListener(
-      objectHistory.current,
-      _onCurrentObjectChanged,
-    );
-  }
-
   final programExplorerController =
       ProgramExplorerController(showCodeNodes: true);
 
@@ -40,10 +28,30 @@ class ObjectInspectorViewController extends DisposableController
   ValueListenable<bool> get refreshing => _refreshing;
   final _refreshing = ValueNotifier<bool>(false);
 
+  ValueListenable<bool> get initialized => _initialized;
+  final _initialized = ValueNotifier<bool>(false);
+
   void init() {
-    programExplorerController
-      ..initialize()
-      ..initListeners();
+    if (!initialized.value) {
+      programExplorerController
+        ..initialize()
+        ..initListeners();
+      initListeners();
+      selectAndPushMainScript();
+      _initialized.value = true;
+    }
+  }
+
+  void initListeners() {
+    addAutoDisposeListener(
+      scriptManager.sortedScripts,
+      selectAndPushMainScript,
+    );
+
+    addAutoDisposeListener(
+      objectHistory.current,
+      _onCurrentObjectChanged,
+    );
   }
 
   Future<void> _onCurrentObjectChanged() async {

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -16,6 +16,18 @@ import 'vm_object_model.dart';
 /// the object history and the object viewport.
 class ObjectInspectorViewController extends DisposableController
     with AutoDisposeControllerMixin {
+  ObjectInspectorViewController() {
+    addAutoDisposeListener(
+      scriptManager.sortedScripts,
+      selectAndPushMainScript,
+    );
+
+    addAutoDisposeListener(
+      objectHistory.current,
+      _onCurrentObjectChanged,
+    );
+  }
+
   final programExplorerController =
       ProgramExplorerController(showCodeNodes: true);
 
@@ -28,30 +40,16 @@ class ObjectInspectorViewController extends DisposableController
   ValueListenable<bool> get refreshing => _refreshing;
   final _refreshing = ValueNotifier<bool>(false);
 
-  ValueListenable<bool> get initialized => _initialized;
-  final _initialized = ValueNotifier<bool>(false);
+  bool _initialized = false;
 
   void init() {
-    if (!initialized.value) {
+    if (!_initialized) {
       programExplorerController
         ..initialize()
         ..initListeners();
-      initListeners();
       selectAndPushMainScript();
-      _initialized.value = true;
+      _initialized = true;
     }
-  }
-
-  void initListeners() {
-    addAutoDisposeListener(
-      scriptManager.sortedScripts,
-      selectAndPushMainScript,
-    );
-
-    addAutoDisposeListener(
-      objectHistory.current,
-      _onCurrentObjectChanged,
-    );
   }
 
   Future<void> _onCurrentObjectChanged() async {

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
@@ -102,7 +102,7 @@ Widget buildObjectDisplay(VmObject obj) {
 /// HistoryViewport.
 class ObjectHistory extends HistoryManager<VmObject> {
   void pushEntry(VmObject object) {
-    if (object == current.value) return;
+    if (object.obj == current.value?.obj) return;
 
     while (hasNext) {
       pop();

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -7,11 +7,7 @@ import 'package:flutter/foundation.dart';
 import 'vm_developer_tools_screen.dart';
 
 class VMDeveloperToolsController {
-  ValueListenable<int> get selectedIndex => _selectedIndex;
-  final _selectedIndex = ValueNotifier<int>(0);
-
-  void selectIndex(int index) {
-    _selectedIndex.value = index;
+  void onSelectedIndex(int index) {
     _showIsolateSelector.value =
         VMDeveloperToolsScreenBody.views[index].showIsolateSelector;
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -16,10 +16,9 @@ class VMDeveloperToolsController {
 
   void selectIndex(int index) {
     _selectedIndex.value = index;
-    _showIsolateSelector.value =
+    showIsolateSelector.value =
         VMDeveloperToolsScreenBody.views[index].showIsolateSelector;
   }
 
-  ValueListenable<bool> get showIsolateSelector => _showIsolateSelector;
-  final _showIsolateSelector = ValueNotifier<bool>(false);
+  static final showIsolateSelector = ValueNotifier<bool>(false);
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -7,7 +7,11 @@ import 'package:flutter/foundation.dart';
 import 'vm_developer_tools_screen.dart';
 
 class VMDeveloperToolsController {
-  void onSelectedIndex(int index) {
+  ValueListenable<int> get selectedIndex => _selectedIndex;
+  final _selectedIndex = ValueNotifier<int>(0);
+
+  void selectIndex(int index) {
+    _selectedIndex.value = index;
     _showIsolateSelector.value =
         VMDeveloperToolsScreenBody.views[index].showIsolateSelector;
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -4,11 +4,15 @@
 
 import 'package:flutter/foundation.dart';
 
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_tools_screen.dart';
 
 class VMDeveloperToolsController {
   ValueListenable<int> get selectedIndex => _selectedIndex;
   final _selectedIndex = ValueNotifier<int>(0);
+
+  final objectInspectorViewController =
+      displayObjectInspector ? ObjectInspectorViewController() : null;
 
   void selectIndex(int index) {
     _selectedIndex.value = index;

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -41,9 +41,8 @@ abstract class VMDeveloperView {
 }
 
 class VMDeveloperToolsScreen extends Screen {
-  const VMDeveloperToolsScreen({
-    required this.controller,
-  }) : super.conditional(
+  const VMDeveloperToolsScreen()
+      : super.conditional(
           id: id,
           title: 'VM Tools',
           icon: Icons.settings_applications,
@@ -52,11 +51,9 @@ class VMDeveloperToolsScreen extends Screen {
 
   static const id = 'vm-tools';
 
-  final VMDeveloperToolsController controller;
-
   @override
   ValueListenable<bool> get showIsolateSelector =>
-      controller.showIsolateSelector;
+      VMDeveloperToolsController.showIsolateSelector;
 
   @override
   Widget build(BuildContext context) => const VMDeveloperToolsScreenBody();

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
+import '../../shared/common_widgets.dart';
 import '../../shared/screen.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
@@ -78,47 +79,67 @@ class VMDeveloperToolsScreenBody extends StatefulWidget {
 class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
     with
         AutoDisposeMixin,
+        AutomaticKeepAliveClientMixin<VMDeveloperToolsScreenBody>,
         ProvidedControllerMixin<VMDeveloperToolsController,
             VMDeveloperToolsScreenBody> {
+  int _selectedIndex = 0;
+  late List<Widget> _views;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     initController();
   }
 
+  void onDestinationSelected(int i) {
+    setState(() => _selectedIndex = i);
+    controller.onSelectedIndex(i);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    _views = [
+      for (final view in VMDeveloperToolsScreenBody.views) view.build(context)
+    ];
+  }
+
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<int>(
-      valueListenable: controller.selectedIndex,
-      builder: (context, selectedIndex, _) {
-        return Row(
-          children: [
-            if (VMDeveloperToolsScreenBody.views.length > 1)
-              NavigationRail(
-                selectedIndex: selectedIndex,
-                elevation: 10.0,
-                labelType: NavigationRailLabelType.all,
-                onDestinationSelected: controller.selectIndex,
-                destinations: [
-                  for (final view in VMDeveloperToolsScreenBody.views)
-                    NavigationRailDestination(
-                      label: Text(view.title),
-                      icon: Icon(view.icon),
-                    )
-                ],
+    super.build(context);
+    return KeepAliveWrapper(
+      child: Row(
+        children: [
+          if (VMDeveloperToolsScreenBody.views.length > 1)
+            NavigationRail(
+              selectedIndex: _selectedIndex,
+              elevation: 10.0,
+              labelType: NavigationRailLabelType.all,
+              onDestinationSelected: onDestinationSelected,
+              destinations: [
+                for (final view in VMDeveloperToolsScreenBody.views)
+                  NavigationRailDestination(
+                    label: Text(view.title),
+                    icon: Icon(view.icon),
+                  )
+              ],
+            ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.only(
+                left: defaultSpacing,
               ),
-            Expanded(
-              child: Padding(
-                padding: const EdgeInsets.only(
-                  left: defaultSpacing,
-                ),
-                child: VMDeveloperToolsScreenBody.views[selectedIndex]
-                    .build(context),
+              child: IndexedStack(
+                index: _selectedIndex,
+                children: _views,
               ),
-            )
-          ],
-        );
-      },
+            ),
+          )
+        ],
+      ),
     );
   }
+
+  @override
+  bool get wantKeepAlive => true;
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -14,7 +14,7 @@ import 'object_inspector_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
 
-const displayObjectInspector = false;
+bool displayObjectInspector = false;
 
 abstract class VMDeveloperView {
   const VMDeveloperView(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
-import '../../shared/common_widgets.dart';
 import '../../shared/screen.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
@@ -79,67 +78,52 @@ class VMDeveloperToolsScreenBody extends StatefulWidget {
 class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
     with
         AutoDisposeMixin,
-        AutomaticKeepAliveClientMixin<VMDeveloperToolsScreenBody>,
         ProvidedControllerMixin<VMDeveloperToolsController,
             VMDeveloperToolsScreenBody> {
-  int _selectedIndex = 0;
-  late List<Widget> _views;
-
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
     initController();
   }
 
-  void onDestinationSelected(int i) {
-    setState(() => _selectedIndex = i);
-    controller.onSelectedIndex(i);
-  }
-
-  @override
-  void initState() {
-    super.initState();
-    _views = [
-      for (final view in VMDeveloperToolsScreenBody.views) view.build(context)
-    ];
-  }
-
   @override
   Widget build(BuildContext context) {
-    super.build(context);
-    return KeepAliveWrapper(
-      child: Row(
-        children: [
-          if (VMDeveloperToolsScreenBody.views.length > 1)
-            NavigationRail(
-              selectedIndex: _selectedIndex,
-              elevation: 10.0,
-              labelType: NavigationRailLabelType.all,
-              onDestinationSelected: onDestinationSelected,
-              destinations: [
-                for (final view in VMDeveloperToolsScreenBody.views)
-                  NavigationRailDestination(
-                    label: Text(view.title),
-                    icon: Icon(view.icon),
-                  ),
-              ],
-            ),
-          Expanded(
-            child: Padding(
-              padding: const EdgeInsets.only(
-                left: defaultSpacing,
+    return ValueListenableBuilder<int>(
+      valueListenable: controller.selectedIndex,
+      builder: (context, selectedIndex, _) {
+        return Row(
+          children: [
+            if (VMDeveloperToolsScreenBody.views.length > 1)
+              NavigationRail(
+                selectedIndex: selectedIndex,
+                elevation: 10.0,
+                labelType: NavigationRailLabelType.all,
+                onDestinationSelected: controller.selectIndex,
+                destinations: [
+                  for (final view in VMDeveloperToolsScreenBody.views)
+                    NavigationRailDestination(
+                      label: Text(view.title),
+                      icon: Icon(view.icon),
+                    )
+                ],
               ),
-              child: IndexedStack(
-                index: _selectedIndex,
-                children: _views,
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.only(
+                  left: defaultSpacing,
+                ),
+                child: IndexedStack(
+                  index: selectedIndex,
+                  children: [
+                    for (final view in VMDeveloperToolsScreenBody.views)
+                      view.build(context)
+                  ],
+                ),
               ),
-            ),
-          ),
-        ],
-      ),
+            )
+          ],
+        );
+      },
     );
   }
-
-  @override
-  bool get wantKeepAlive => true;
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -121,7 +121,7 @@ class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
                   NavigationRailDestination(
                     label: Text(view.title),
                     icon: Icon(view.icon),
-                  )
+                  ),
               ],
             ),
           Expanded(
@@ -134,7 +134,7 @@ class _VMDeveloperToolsScreenState extends State<VMDeveloperToolsScreenBody>
                 children: _views,
               ),
             ),
-          )
+          ),
         ],
       ),
     );

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_object_model.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_object_model.dart
@@ -64,15 +64,13 @@ abstract class VmObject {
       _inboundReferences;
   final _inboundReferences = ValueNotifier<InboundReferences?>(null);
 
-  Future<void> fetchObject() async {
-    final isolateRef = serviceManager.isolateManager.selectedIsolate.value!;
-    _isolate = await _service.getIsolate(isolateRef.id!);
-    _obj = await _service.getObject(_isolate!.id!, ref.id!);
-  }
-
   @mustCallSuper
   Future<void> initialize() async {
-    await fetchObject();
+    _isolate = serviceManager.isolateManager.selectedIsolate.value!;
+
+    _obj = ref is Obj
+        ? ref as Obj
+        : await _service.getObject(_isolate!.id!, ref.id!);
 
     if (_sourceLocation != null) {
       _sourceScript = await _service.getObject(
@@ -216,7 +214,8 @@ class FieldObject extends VmObject {
   }
 }
 
-//TODO(mtaylee): finish class implementation.
+/// Stores a 'Library' VM object and provides an interface for obtaining the
+/// Dart VM information related to this object.
 class LibraryObject extends VmObject {
   LibraryObject({required super.ref, super.scriptRef, super.outlineNode});
 

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
@@ -2,11 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_developer_tools_controller.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_developer_tools_screen.dart';
+import 'package:devtools_app/src/scripts/script_manager.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/notifications.dart';
+import 'package:devtools_app/src/shared/split.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
@@ -3,16 +3,10 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
-import 'package:devtools_app/src/screens/vm_developer/vm_developer_tools_controller.dart';
-import 'package:devtools_app/src/scripts/script_manager.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/notifications.dart';
-import 'package:devtools_app/src/shared/split.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_inspector_view_test.dart
@@ -2,13 +2,16 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_developer_tools_controller.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/notifications.dart';
 import 'package:devtools_app/src/shared/split.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -24,25 +27,34 @@ void main() {
   late MockScriptManager scriptManager;
 
   setUp(() {
+    displayObjectInspector = true;
     objectInspector = ObjectInspectorView();
-
     fakeServiceManager = FakeServiceManager();
-
     scriptManager = MockScriptManager();
-    when(scriptManager.sortedScripts).thenReturn(ValueNotifier(<ScriptRef>[]));
 
+    when(scriptManager.sortedScripts).thenReturn(ValueNotifier(<ScriptRef>[]));
     when(fakeServiceManager.connectedApp!.isProfileBuildNow).thenReturn(false);
     when(fakeServiceManager.connectedApp!.isDartWebAppNow).thenReturn(false);
 
     setGlobal(ServiceConnectionManager, fakeServiceManager);
-
     setGlobal(ScriptManager, scriptManager);
-
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(NotificationService, NotificationService());
+  });
+
+  tearDown(() {
+    displayObjectInspector = false;
   });
 
   testWidgets('builds screen', (WidgetTester tester) async {
-    await tester.pumpWidget(wrap(Builder(builder: objectInspector.build)));
+    await tester.pumpWidget(
+      wrapWithControllers(
+        Builder(
+          builder: objectInspector.build,
+        ),
+        vmDeveloperTools: VMDeveloperToolsController(),
+      ),
+    );
     expect(find.byType(Split), findsNWidgets(2));
     expect(find.byType(ProgramExplorer), findsOneWidget);
     expect(find.byType(ObjectViewport), findsOneWidget);

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
@@ -195,6 +195,10 @@ void main() {
       obj1 = MockClassObject();
       obj2 = MockClassObject();
       obj3 = MockClassObject();
+
+      when(obj1.obj).thenReturn(Class(id: '1'));
+      when(obj2.obj).thenReturn(Class(id: '2'));
+      when(obj3.obj).thenReturn(Class(id: '3'));
     });
 
     test('initial values', () {

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -132,8 +132,6 @@ class TestInboundReferences extends InboundReferences {
   Map<String, dynamic>? get json => <String, dynamic>{};
 }
 
-class TestProgramExplorerController extends ProgramExplorerController {}
-
 class TestObjectInspectorViewController extends ObjectInspectorViewController {
   @override
   ObjectHistory get objectHistory => fakeObjectHistory;
@@ -157,51 +155,6 @@ class FakeObjectHistory extends ObjectHistory {
   void setCurrentObject(VmObject object) {
     _current = object;
   }
-}
-
-class TestScriptObject extends ScriptObject {
-  TestScriptObject({required super.ref, required this.testScript});
-
-  Script testScript;
-
-  @override
-  Script get obj => testScript;
-}
-
-class TestFuncObject extends FuncObject {
-  TestFuncObject({required super.ref, required this.testFunc});
-
-  Func testFunc;
-
-  @override
-  Func get obj => testFunc;
-
-  @override
-  String? get name => 'FooFunction';
-}
-
-class TestFieldObject extends FieldObject {
-  TestFieldObject({required super.ref, required this.testField});
-
-  Field testField;
-
-  @override
-  Field get obj => testField;
-
-  @override
-  String? get name => 'FooField';
-}
-
-class TestLibraryObject extends LibraryObject {
-  TestLibraryObject({required super.ref, required this.testLibrary});
-
-  Library testLibrary;
-
-  @override
-  Library get obj => testLibrary;
-
-  @override
-  String? get name => 'FooLib';
 }
 
 class TestInstanceObject extends InstanceObject {

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -26,6 +26,7 @@ import 'package:vm_service/vm_service.dart';
   VmService,
   VmServiceWrapper,
   ObjectGroupBase,
+  VmObject,
   ClassObject,
   CodeObject,
   FieldObject,

--- a/packages/devtools_test/lib/src/wrappers.dart
+++ b/packages/devtools_test/lib/src/wrappers.dart
@@ -62,6 +62,7 @@ Widget wrapWithControllers(
   BannerMessagesController? bannerMessages,
   AppSizeController? appSize,
   AnalyticsController? analytics,
+  VMDeveloperToolsController? vmDeveloperTools,
 }) {
   final _providers = [
     Provider<BannerMessagesController>.value(
@@ -80,6 +81,8 @@ Widget wrapWithControllers(
     if (appSize != null) Provider<AppSizeController>.value(value: appSize),
     if (analytics != null)
       Provider<AnalyticsController>.value(value: analytics),
+    if (vmDeveloperTools != null)
+      Provider<VMDeveloperToolsController>.value(value: vmDeveloperTools),
   ];
   return wrap(
     wrapWithNotifications(


### PR DESCRIPTION
~~This PR removes the ValueListenableBuilder that was being used in the build method of `_VMDeveloperToolsScreenState` and uses the widget's state to switch between the VmDeveloperViews.
It also adds the `AutomaticKeepAliveClientMixin<VMDeveloperToolsScreenBody>` so that the screen stays alive when switching between the main DevTools tabs.~~

**UPDATE:**
This PR includes the `ObjectInspectorViewController` in the `VmDeveloperToolsController` to retain the data (mainly the ProgramExplorerController and the object history) when switching between the main DevTools tabs. It also adds an IndexedStack to maintain the state of the VmDeveloperView's that are accessed from the VmDeveloperToolsScreen `NavigationRail`.

Other minor changes are:
- Removing test classes that were no longer being used from vm_developer_test_utils.dart.
- In vm_object_model.dart: avoid making a getObject service call if the selected node from the ProgramExplorer already contains the full Obj (not an ObjRef).