### PR TITLE
keep in line with g3's needs

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -69,6 +69,7 @@ export 'src/shared/connected_app.dart';
 export 'src/shared/console_service.dart';
 export 'src/shared/error_badge_manager.dart';
 export 'src/shared/globals.dart';
+export 'src/shared/notifications.dart';
 export 'src/shared/preferences.dart';
 export 'src/shared/routing.dart';
 export 'src/shared/screen.dart';

--- a/packages/devtools_app/test/logging/logging_screen_data_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_data_test.dart
@@ -8,7 +8,6 @@ import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/logging/_log_details.dart';
 import 'package:devtools_app/src/screens/logging/_logs_table.dart';
-import 'package:devtools_app/src/shared/notifications.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/shared/editable_list_test.dart
+++ b/packages/devtools_app/test/shared/editable_list_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/editable_list.dart';
-import 'package:devtools_app/src/shared/notifications.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
![](https://media.giphy.com/media/dxgw87smVD5ANGmE15/giphy-downsized.gif)

An internal google tool depends on our notifications, so this export is getting added back in a recent roll.

I'm adding this here to make sure we don't lose the change, for our next roll