### PR TITLE
Add skeleton for embedded perfetto trace viewer

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
@@ -1,0 +1,9 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class PerfettoController {
+  void init() {}
+
+  void dispose() {}
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -1,0 +1,69 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:html' as html;
+import 'dart:ui' as ui;
+
+import '../../../../../primitives/auto_dispose.dart';
+
+/// Flag to enable embedding an instance of the Perfetto UI running on
+/// localhost.
+///
+/// The version running on localhost will not include the DevTools styling
+/// modifications for dark mode, as those CSS changes are defined in
+/// [devtools_app/assets/perfetto] and will not be served with the Perfetto web
+/// app running locally.
+const _debugUseLocalPerfetto = false;
+
+class PerfettoController extends DisposableController
+    with AutoDisposeControllerMixin {
+  static const viewId = 'embedded-perfetto';
+
+  /// Url when running Perfetto locally following the instructions here:
+  /// https://perfetto.dev/docs/contributing/build-instructions#ui-development
+  static const _debugPerfettoUrl = 'http://127.0.0.1:10000/';
+
+  static const _perfettoPong = 'PONG';
+
+  String get perfettoUrl =>
+      _debugUseLocalPerfetto ? _debugPerfettoUrl : 'https://ui.perfetto.dev/';
+
+  late final html.IFrameElement _perfettoIFrame;
+
+  late final Completer<void> _perfettoReady;
+
+  void init() {
+    _perfettoReady = Completer();
+    _perfettoIFrame = html.IFrameElement()
+      ..src = perfettoUrl
+      ..allow = 'usb';
+    _perfettoIFrame.style
+      ..border = 'none'
+      ..height = '100%'
+      ..width = '100%';
+
+    // ignore: undefined_prefixed_name
+    ui.platformViewRegistry.registerViewFactory(
+      viewId,
+      (int viewId) => _perfettoIFrame,
+    );
+
+    html.window.addEventListener('message', _handleMessage);
+  }
+
+  void _handleMessage(html.Event e) {
+    if (e is html.MessageEvent) {
+      if (e.data == _perfettoPong && !_perfettoReady.isCompleted) {
+        _perfettoReady.complete();
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    html.window.removeEventListener('message', _handleMessage);
+    super.dispose();
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_desktop.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_desktop.dart
@@ -1,0 +1,29 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '_perfetto_controller_desktop.dart';
+
+class Perfetto extends StatelessWidget {
+  const Perfetto({
+    Key? key,
+    required this.perfettoController,
+  }) : super(key: key);
+
+  final PerfettoController perfettoController;
+
+  @override
+  Widget build(BuildContext context) {
+    // TODO(kenz): consider showing the legacy trace viewer for desktop
+    // platforms, or build a desktop only impl of embedding Perfetto if web view
+    // support for desktop is ever added.
+    return const Center(
+      child: Text(
+        'Cannot display the Perfetto trace viewer. IFrames are not supported on'
+        ' desktop platforms.',
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -1,0 +1,26 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '_perfetto_controller_web.dart';
+
+class Perfetto extends StatelessWidget {
+  const Perfetto({
+    Key? key,
+    required this.perfettoController,
+  }) : super(key: key);
+
+  final PerfettoController perfettoController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.white,
+      child: const HtmlElementView(
+        viewType: PerfettoController.viewId,
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto.dart
@@ -1,0 +1,25 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '_perfetto_controller_desktop.dart'
+    if (dart.library.html) '_perfetto_controller_web.dart';
+import '_perfetto_desktop.dart' if (dart.library.html) '_perfetto_web.dart';
+
+PerfettoController createPerfettoController() => PerfettoController();
+
+class EmbeddedPerfetto extends StatelessWidget {
+  const EmbeddedPerfetto({Key? key, required this.perfettoController})
+      : super(key: key);
+
+  final PerfettoController perfettoController;
+
+  @override
+  Widget build(BuildContext context) {
+    return Perfetto(
+      perfettoController: perfettoController,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -29,6 +29,7 @@ import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/profile_granularity.dart';
 import 'panes/controls/enhance_tracing/enhance_tracing_controller.dart';
 import 'panes/raster_metrics/raster_metrics_controller.dart';
+import 'panes/timeline_events/perfetto/perfetto.dart';
 import 'performance_model.dart';
 import 'performance_screen.dart';
 import 'performance_utils.dart';
@@ -38,6 +39,9 @@ import 'timeline_event_processor.dart';
 
 /// Debugging flag to load sample trace events from [simple_trace_example.dart].
 bool debugSimpleTrace = false;
+
+/// Flag to enable the embedded perfetto trace viewer.
+bool embeddedPerfettoEnabled = false;
 
 /// Flag to hide the frame analysis feature while it is under development.
 bool frameAnalysisSupported = true;
@@ -67,6 +71,8 @@ class PerformanceController extends DisposableController
   final enhanceTracingController = EnhanceTracingController();
 
   final rasterMetricsController = RasterMetricsController();
+
+  final perfettoController = createPerfettoController();
 
   final _exportController = ExportController();
 
@@ -180,6 +186,10 @@ class PerformanceController extends DisposableController
   }
 
   Future<void> _initHelper() async {
+    if (embeddedPerfettoEnabled) {
+      perfettoController.init();
+    }
+
     if (!offlineController.offlineMode.value) {
       await serviceManager.onServiceAvailable;
       await _initData();
@@ -931,6 +941,9 @@ class PerformanceController extends DisposableController
     _pollingTimer?.cancel();
     _timelinePollingRateLimiter?.dispose();
     cpuProfilerController.dispose();
+    if (embeddedPerfettoEnabled) {
+      perfettoController.dispose();
+    }
     enhanceTracingController.dispose();
     _firstFrameEventSubscription?.cancel();
     super.dispose();

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -140,6 +140,11 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
         controller.offlinePerformanceData != null &&
         controller.offlinePerformanceData!.frames.isNotEmpty;
 
+    final tabbedPerformanceView = TabbedPerformanceView(
+      controller: controller,
+      processing: processing,
+      processingProgress: processingProgress,
+    );
     final performanceScreen = Column(
       children: [
         if (!offlineController.offlineMode.value) _buildPerformanceControls(),
@@ -158,23 +163,21 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
             },
           ),
         Expanded(
-          child: Split(
-            axis: Axis.vertical,
-            initialFractions: const [0.7, 0.3],
-            children: [
-              TabbedPerformanceView(
-                controller: controller,
-                processing: processing,
-                processingProgress: processingProgress,
-              ),
-              ValueListenableBuilder<TimelineEvent?>(
-                valueListenable: controller.selectedTimelineEvent,
-                builder: (context, selectedEvent, _) {
-                  return EventDetails(selectedEvent);
-                },
-              ),
-            ],
-          ),
+          child: embeddedPerfettoEnabled
+              ? tabbedPerformanceView
+              : Split(
+                  axis: Axis.vertical,
+                  initialFractions: const [0.7, 0.3],
+                  children: [
+                    tabbedPerformanceView,
+                    ValueListenableBuilder<TimelineEvent?>(
+                      valueListenable: controller.selectedTimelineEvent,
+                      builder: (context, selectedEvent, _) {
+                        return EventDetails(selectedEvent);
+                      },
+                    ),
+                  ],
+                ),
         ),
       ],
     );

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -15,6 +15,7 @@ import '../../ui/search.dart';
 import '../../ui/tab.dart';
 import 'panes/frame_analysis/frame_analysis.dart';
 import 'panes/raster_metrics/raster_metrics.dart';
+import 'panes/timeline_events/perfetto/perfetto.dart';
 import 'panes/timeline_events/timeline_flame_chart.dart';
 import 'performance_controller.dart';
 import 'performance_model.dart';
@@ -82,13 +83,19 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
 
     final isFlutterApp = serviceManager.connectedApp!.isFlutterAppNow!;
     final tabViews = [
-      KeepAliveWrapper(
-        child: TimelineEventsView(
-          controller: controller,
-          processing: widget.processing,
-          processingProgress: widget.processingProgress,
-        ),
-      ),
+      embeddedPerfettoEnabled
+          ? KeepAliveWrapper(
+              child: EmbeddedPerfetto(
+                perfettoController: controller.perfettoController,
+              ),
+            )
+          : KeepAliveWrapper(
+              child: TimelineEventsView(
+                controller: controller,
+                processing: widget.processing,
+                processingProgress: widget.processingProgress,
+              ),
+            ),
       if (frameAnalysisSupported && isFlutterApp)
         KeepAliveWrapper(
           child: frameAnalysisView,
@@ -116,11 +123,13 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
         trailing: Row(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            _buildSearchField(searchFieldEnabled),
-            const FlameChartHelpButton(
-              gaScreen: PerformanceScreen.id,
-              gaSelection: analytics_constants.timelineFlameChartHelp,
-            ),
+            if (!embeddedPerfettoEnabled) ...[
+              _buildSearchField(searchFieldEnabled),
+              const FlameChartHelpButton(
+                gaScreen: PerformanceScreen.id,
+                gaSelection: analytics_constants.timelineFlameChartHelp,
+              ),
+            ],
             RefreshTimelineEventsButton(controller: controller),
           ],
         ),


### PR DESCRIPTION
Chucking this code up into pieces for ease of review. I will take bits and pieces from my local branch perfetto/ (https://github.com/flutter/devtools/compare/master...kenzieschmoll:perfetto?expand=1) and send them in separate PRs.

This is the first one and is intended to land the skeleton in the most "merge-friendly" way (even if some parts are currently unused). This PR intentionally does not have tests since those tests would have to change rapidly as we land this code in chunks. Thorough tests will be added before ever flipping `embeddedPerfettoEnabled` to true.