### PR TITLE
Comment out _updateLocalClasses code 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -388,25 +388,26 @@ class InspectorService extends InspectorServiceBase {
   }
 
   Future<void> _updateLocalClasses() async {
-    localClasses.clear();
-    if (_rootDirectories.value.isNotEmpty) {
-      final isolate = inspectorLibrary.isolate!;
-      for (var libraryRef in isolate.libraries!) {
-        if (isLocalUri(libraryRef.uri!)) {
-          try {
-            final Library library = await inspectorLibrary.service
-                .getObject(isolate.id!, libraryRef.id!) as Library;
-            for (var classRef in library.classes!) {
-              localClasses[classRef.name!] = classRef;
-            }
-          } catch (e) {
-            // Workaround until https://github.com/flutter/devtools/issues/3110
-            // is fixed.
-            assert(serviceManager.connectedApp!.isDartWebAppNow!);
-          }
-        }
-      }
-    }
+    // TODO(https://github.com/flutter/devtools/issues/4393)
+    // localClasses.clear();
+    // if (_rootDirectories.value.isNotEmpty) {
+    //   final isolate = inspectorLibrary.isolate!;
+    //   for (var libraryRef in isolate.libraries!) {
+    //     if (isLocalUri(libraryRef.uri!)) {
+    //       try {
+    //         final Library library = await inspectorLibrary.service
+    //             .getObject(isolate.id!, libraryRef.id!) as Library;
+    //         for (var classRef in library.classes!) {
+    //           localClasses[classRef.name!] = classRef;
+    //         }
+    //       } catch (e) {
+    //         // Workaround until https://github.com/flutter/devtools/issues/3110
+    //         // is fixed.
+    //         assert(serviceManager.connectedApp!.isDartWebAppNow!);
+    //       }
+    //     }
+    //   }
+    // }
   }
 
   @visibleForTesting

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_service.dart
@@ -254,6 +254,8 @@ class InspectorService extends InspectorServiceBase {
 
   @override
   bool isLocalClass(RemoteDiagnosticsNode node) {
+    // TODO(https://github.com/flutter/devtools/issues/4393): localClasses is
+    // not currently being filled.
     if (node.widgetRuntimeType == null) return false;
     // widgetRuntimeType may contain some generic type arguments which we need
     // to strip out. If widgetRuntimeType is "FooWidget<Bar>" then we are only

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -185,8 +185,10 @@ class InspectorPreferencesController extends DisposableController
     if (_customPubRootDirectories.value.isEmpty) {
       // If there are no pub root directories set on the first connection
       // then try inferring them.
-      await _inspectorService?.inferPubRootDirectoryIfNeeded();
-      await loadCustomPubRootDirectories();
+      await _customPubRootDirectoryBusyTracker(() async {
+        await _inspectorService?.inferPubRootDirectoryIfNeeded();
+        await loadCustomPubRootDirectories();
+      });
     }
   }
 

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -119,113 +119,117 @@ void main() async {
         );
       });
 
-      test('local classes', () async {
-        await env.setupEnvironment();
-        final inspectorServiceLocal = inspectorService!;
+      test(
+        'local classes',
+        () async {
+          await env.setupEnvironment();
+          final inspectorServiceLocal = inspectorService!;
 
-        final group = inspectorServiceLocal.createObjectGroup('test-group');
-        // These tests are moot if widget creation is not tracked.
-        expect(await inspectorServiceLocal.isWidgetCreationTracked(), isTrue);
-        await inspectorServiceLocal.addPubRootDirectories([]);
-        final List<String> rootDirectories =
-            await inspectorServiceLocal.inferPubRootDirectoryIfNeeded();
-        expect(rootDirectories.length, 1);
-        expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
-        final originalRootDirectories = rootDirectories.toList();
-        try {
-          expect(
-            (inspectorServiceLocal.localClasses.keys.toList()..sort()),
-            equals(
-              [
-                'AnotherClass',
-                'ExportedClass',
-                'FooClass',
-                'MyApp',
-                'MyOtherWidget',
-                'NotAWidget',
-                '_PrivateClass',
-                '_PrivateExportedClass',
-              ],
-            ),
-          );
+          final group = inspectorServiceLocal.createObjectGroup('test-group');
+          // These tests are moot if widget creation is not tracked.
+          expect(await inspectorServiceLocal.isWidgetCreationTracked(), isTrue);
+          await inspectorServiceLocal.addPubRootDirectories([]);
+          final List<String> rootDirectories =
+              await inspectorServiceLocal.inferPubRootDirectoryIfNeeded();
+          expect(rootDirectories.length, 1);
+          expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
+          final originalRootDirectories = rootDirectories.toList();
+          try {
+            expect(
+              (inspectorServiceLocal.localClasses.keys.toList()..sort()),
+              equals(
+                [
+                  'AnotherClass',
+                  'ExportedClass',
+                  'FooClass',
+                  'MyApp',
+                  'MyOtherWidget',
+                  'NotAWidget',
+                  '_PrivateClass',
+                  '_PrivateExportedClass',
+                ],
+              ),
+            );
 
-          await inspectorServiceLocal
-              .addPubRootDirectories(['${rootDirectories.first}/lib/src']);
-          // Adding src does not change the directory as local classes are
-          // computed at the library level.
-          expect(
-            (inspectorServiceLocal.localClasses.keys.toList()..sort()),
-            equals(
-              [
-                'AnotherClass',
-                'ExportedClass',
-                'FooClass',
-                'MyApp',
-                'MyOtherWidget',
-                'NotAWidget',
-                '_PrivateClass',
-                '_PrivateExportedClass'
-              ],
-            ),
-          );
+            await inspectorServiceLocal
+                .addPubRootDirectories(['${rootDirectories.first}/lib/src']);
+            // Adding src does not change the directory as local classes are
+            // computed at the library level.
+            expect(
+              (inspectorServiceLocal.localClasses.keys.toList()..sort()),
+              equals(
+                [
+                  'AnotherClass',
+                  'ExportedClass',
+                  'FooClass',
+                  'MyApp',
+                  'MyOtherWidget',
+                  'NotAWidget',
+                  '_PrivateClass',
+                  '_PrivateExportedClass'
+                ],
+              ),
+            );
 
-          expect(
-            inspectorServiceLocal.rootPackages.toList(),
-            equals(['flutter_app']),
-          );
-          expect(inspectorServiceLocal.rootPackagePrefixes.toList(), isEmpty);
+            expect(
+              inspectorServiceLocal.rootPackages.toList(),
+              equals(['flutter_app']),
+            );
+            expect(inspectorServiceLocal.rootPackagePrefixes.toList(), isEmpty);
 
-          await inspectorServiceLocal.addPubRootDirectories(
-            ['/usr/jacobr/foo/lib', '/usr/jacobr/bar/lib/bla'],
-          );
-          expect(
-            inspectorServiceLocal.rootPackages.toList(),
-            equals(['foo', 'bar']),
-          );
-          expect(inspectorServiceLocal.rootPackagePrefixes.toList(), isEmpty);
+            await inspectorServiceLocal.addPubRootDirectories(
+              ['/usr/jacobr/foo/lib', '/usr/jacobr/bar/lib/bla'],
+            );
+            expect(
+              inspectorServiceLocal.rootPackages.toList(),
+              equals(['foo', 'bar']),
+            );
+            expect(inspectorServiceLocal.rootPackagePrefixes.toList(), isEmpty);
 
-          expect(
-            inspectorServiceLocal.isLocalUri('package:foo/src/bar.dart'),
-            isTrue,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri('package:foo.bla/src/bar.dart'),
-            isFalse,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri('package:foos/src/bar.dart'),
-            isFalse,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri('package:bar/src/bar.dart'),
-            isTrue,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri(
-              'package:bar.core/src/bar.dart',
-            ),
-            isFalse,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri(
-              'package:bar.core.bla/src/bar.dart',
-            ),
-            isFalse,
-          );
-          expect(
-            inspectorServiceLocal.isLocalUri(
-              'package:bar.cores/src/bar.dart',
-            ),
-            isFalse,
-          );
-        } finally {
-          // Restore.
-          await inspectorServiceLocal
-              .addPubRootDirectories(originalRootDirectories);
+            expect(
+              inspectorServiceLocal.isLocalUri('package:foo/src/bar.dart'),
+              isTrue,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri('package:foo.bla/src/bar.dart'),
+              isFalse,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri('package:foos/src/bar.dart'),
+              isFalse,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri('package:bar/src/bar.dart'),
+              isTrue,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri(
+                'package:bar.core/src/bar.dart',
+              ),
+              isFalse,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri(
+                'package:bar.core.bla/src/bar.dart',
+              ),
+              isFalse,
+            );
+            expect(
+              inspectorServiceLocal.isLocalUri(
+                'package:bar.cores/src/bar.dart',
+              ),
+              isFalse,
+            );
+          } finally {
+            // Restore.
+            await inspectorServiceLocal
+                .addPubRootDirectories(originalRootDirectories);
 
-          await group.dispose();
-        }
-      });
+            await group.dispose();
+          }
+        },
+        skip: true, // TODO(https://github.com/flutter/devtools/issues/4393)
+      );
 
       test('local classes for bazel projects', () async {
         await env.setupEnvironment();


### PR DESCRIPTION
![](https://media.giphy.com/media/bTXAX2QFvQ33a/giphy.gif)

The `_updateLocalClasses` code hits the inspector service with a lot of `getObject` calls. especially in larger projects.
`isLocalClass` isn't really fully set up in the UI Yet anyways, so we don't need to fetch all of the classes yet anyways.

I've left a TODO for our future selves when we come back to this and need to reenable the fetch.

In this PR I've also wrapped the `inferPubrootDirectory` code in a busy tracker so that the pub root directory spinner will spin when we are trying to infer pub root directories.

# Testing
I've tested this code internally and it has drastically reduce slowness on startup