### PR TITLE
Add unsafe_html lint to DevTools

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -136,6 +136,7 @@ linter:
     - unnecessary_statements
     - unnecessary_this
     - unrelated_type_equality_checks
+    - unsafe_html
     - use_rethrow_when_possible
     # - use_setters_to_change_properties # not yet tested
     # - use_string_buffers # https://github.com/dart-lang/linter/pull/664

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -42,6 +42,8 @@ class PerfettoController extends DisposableController
   void init() {
     _perfettoReady = Completer();
     _perfettoIFrame = html.IFrameElement()
+      // This url is safe because we built it ourselves and it does not include
+      // any user input.
       // ignore: unsafe_html
       ..src = perfettoUrl
       ..allow = 'usb';

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -42,6 +42,7 @@ class PerfettoController extends DisposableController
   void init() {
     _perfettoReady = Completer();
     _perfettoIFrame = html.IFrameElement()
+      // ignore: unsafe_html
       ..src = perfettoUrl
       ..allow = 'usb';
     _perfettoIFrame.style


### PR DESCRIPTION
Ignoring the one exception case, but enabling this lint to catch other violations.