### PR TITLE
CPU Profiler tab UI cleanup

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -154,25 +154,23 @@ class _CpuProfilerState extends State<CpuProfiler>
     final colorScheme = theme.colorScheme;
     final currentTab =
         widget.tabs.isNotEmpty ? widget.tabs[_tabController.index] : null;
-    final hasData =
-        data != CpuProfilerController.baseStateCpuProfileData && !data.isEmpty;
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
-        SizedBox(
-          height: defaultButtonHeight,
-          child: Row(
-            children: [
-              TabBar(
-                labelColor:
-                    textTheme.bodyText1?.color ?? colorScheme.defaultForeground,
-                isScrollable: true,
-                controller: _tabController,
-                tabs: widget.tabs,
-              ),
-              const Spacer(),
-              if (hasData) ...[
+        AreaPaneHeader(
+          needsTopBorder: false,
+          leftPadding: 0,
+          tall: true,
+          title: TabBar(
+            labelColor:
+                textTheme.bodyText1?.color ?? colorScheme.defaultForeground,
+            isScrollable: true,
+            controller: _tabController,
+            tabs: widget.tabs,
+          ),
+          actions: [
+            Row(
+              children: [
                 if (currentTab!.key != CpuProfiler.summaryTab) ...[
                   FilterButton(
                     onPressed: _showFilterDialog,
@@ -184,78 +182,64 @@ class _CpuProfilerState extends State<CpuProfiler>
                 ],
                 // TODO(kenz): support search for call tree and bottom up tabs as
                 // well. This will require implementing search for tree tables.
-                if (currentTab.key == CpuProfiler.flameChartTab)
-                  Row(
-                    children: [
-                      if (widget.searchFieldKey != null)
-                        _buildSearchField(hasData),
-                      FlameChartHelpButton(
-                        gaScreen: widget.standaloneProfiler
-                            ? analytics_constants.cpuProfiler
-                            : analytics_constants.performance,
-                        gaSelection:
-                            analytics_constants.cpuProfileFlameChartHelp,
-                        additionalInfo: [
-                          ...dialogSubHeader(Theme.of(context), 'Legend'),
-                          Legend(
-                            entries: [
-                              LegendEntry(
-                                'App code (code from your app and imported packages)',
-                                appCodeColor.background.colorFor(colorScheme),
-                              ),
-                              LegendEntry(
-                                'Native code (code from the native runtime - Android, iOS, etc.)',
-                                nativeCodeColor.background
-                                    .colorFor(colorScheme),
-                              ),
-                              LegendEntry(
-                                'Dart core libraries (code from the Dart SDK)',
-                                dartCoreColor.background.colorFor(colorScheme),
-                              ),
-                              LegendEntry(
-                                'Flutter Framework (code from the Flutter SDK)',
-                                flutterCoreColor.background
-                                    .colorFor(colorScheme),
-                              ),
-                            ],
+                if (currentTab.key == CpuProfiler.flameChartTab) ...[
+                  if (widget.searchFieldKey != null) _buildSearchField(),
+                  FlameChartHelpButton(
+                    gaScreen: widget.standaloneProfiler
+                        ? analytics_constants.cpuProfiler
+                        : analytics_constants.performance,
+                    gaSelection: analytics_constants.cpuProfileFlameChartHelp,
+                    additionalInfo: [
+                      ...dialogSubHeader(Theme.of(context), 'Legend'),
+                      Legend(
+                        entries: [
+                          LegendEntry(
+                            'App code (code from your app and imported packages)',
+                            appCodeColor.background.colorFor(colorScheme),
+                          ),
+                          LegendEntry(
+                            'Native code (code from the native runtime - Android, iOS, etc.)',
+                            nativeCodeColor.background.colorFor(colorScheme),
+                          ),
+                          LegendEntry(
+                            'Dart core libraries (code from the Dart SDK)',
+                            dartCoreColor.background.colorFor(colorScheme),
+                          ),
+                          LegendEntry(
+                            'Flutter Framework (code from the Flutter SDK)',
+                            flutterCoreColor.background.colorFor(colorScheme),
                           ),
                         ],
                       ),
                     ],
                   ),
+                ],
                 if (currentTab.key != CpuProfiler.flameChartTab &&
-                    currentTab.key != CpuProfiler.summaryTab)
-                  Row(
-                    children: [
-                      // TODO(kenz): add a switch to order samples by user tag here
-                      // instead of using the filter control. This will allow users
-                      // to see all the tags side by side in the tree tables.
-                      ExpandAllButton(
-                        onPressed: () {
-                          _performOnDataRoots(
-                            (root) => root.expandCascading(),
-                            currentTab,
-                          );
-                        },
-                      ),
-                      const SizedBox(width: denseSpacing),
-                      CollapseAllButton(
-                        onPressed: () {
-                          _performOnDataRoots(
-                            (root) => root.collapseCascading(),
-                            currentTab,
-                          );
-                        },
-                      ),
-                      // The standaloneProfiler does not need padding because it is
-                      // not wrapped in a bordered container.
-                      if (!widget.standaloneProfiler)
-                        const SizedBox(width: denseSpacing),
-                    ],
+                    currentTab.key != CpuProfiler.summaryTab) ...[
+                  // TODO(kenz): add a switch to order samples by user tag here
+                  // instead of using the filter control. This will allow users
+                  // to see all the tags side by side in the tree tables.
+                  ExpandAllButton(
+                    onPressed: () {
+                      _performOnDataRoots(
+                        (root) => root.expandCascading(),
+                        currentTab,
+                      );
+                    },
                   ),
+                  const SizedBox(width: denseSpacing),
+                  CollapseAllButton(
+                    onPressed: () {
+                      _performOnDataRoots(
+                        (root) => root.collapseCascading(),
+                        currentTab,
+                      );
+                    },
+                  ),
+                ],
               ],
-            ],
-          ),
+            ),
+          ],
         ),
         Expanded(
           child: TabBarView(
@@ -277,14 +261,14 @@ class _CpuProfilerState extends State<CpuProfiler>
     );
   }
 
-  Widget _buildSearchField(bool hasData) {
+  Widget _buildSearchField() {
     return Container(
       width: wideSearchTextWidth,
       height: defaultTextFieldHeight,
       child: buildSearchField(
         controller: widget.controller,
         searchFieldKey: widget.searchFieldKey!,
-        searchFieldEnabled: hasData,
+        searchFieldEnabled: true,
         shouldRequestFocus: false,
         supportsNavigation: true,
       ),
@@ -415,33 +399,36 @@ class UserTagDropdown extends StatelessWidget {
         final tooltip = userTags.isNotEmpty
             ? 'Filter the CPU profile by the given UserTag'
             : 'No UserTags found for this CPU profile';
-        return DevToolsTooltip(
-          message: tooltip,
-          child: RoundedDropDownButton<String>(
-            isDense: true,
-            style: Theme.of(context).textTheme.bodyText2,
-            value: userTag,
-            items: [
-              _buildMenuItem(
-                display: '$filterByTag ${CpuProfilerController.userTagNone}',
-                value: CpuProfilerController.userTagNone,
-              ),
-              // We don't want to show the 'Default' tag if it is the only
-              // tag available. The 'none' tag above is equivalent in this
-              // case.
-              if (!(userTags.length == 1 &&
-                  userTags.first == UserTag.defaultTag.label))
-                for (final tag in userTags)
-                  _buildMenuItem(
-                    display: '$filterByTag $tag',
-                    value: tag,
-                  ),
-            ],
-            onChanged: userTags.isEmpty ||
-                    (userTags.length == 1 &&
-                        userTags.first == UserTag.defaultTag.label)
-                ? null
-                : (String? tag) => _onUserTagChanged(tag!, context),
+        return SizedBox(
+          height: defaultButtonHeight,
+          child: DevToolsTooltip(
+            message: tooltip,
+            child: RoundedDropDownButton<String>(
+              isDense: true,
+              style: Theme.of(context).textTheme.bodyText2,
+              value: userTag,
+              items: [
+                _buildMenuItem(
+                  display: '$filterByTag ${CpuProfilerController.userTagNone}',
+                  value: CpuProfilerController.userTagNone,
+                ),
+                // We don't want to show the 'Default' tag if it is the only
+                // tag available. The 'none' tag above is equivalent in this
+                // case.
+                if (!(userTags.length == 1 &&
+                    userTags.first == UserTag.defaultTag.label))
+                  for (final tag in userTags)
+                    _buildMenuItem(
+                      display: '$filterByTag $tag',
+                      value: tag,
+                    ),
+              ],
+              onChanged: userTags.isEmpty ||
+                      (userTags.length == 1 &&
+                          userTags.first == UserTag.defaultTag.label)
+                  ? null
+                  : (String? tag) => _onUserTagChanged(tag!, context),
+            ),
           ),
         );
       },

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -152,8 +152,10 @@ class _CpuProfilerState extends State<CpuProfiler>
     final theme = Theme.of(context);
     final textTheme = theme.textTheme;
     final colorScheme = theme.colorScheme;
-    final currentTab =
-        widget.tabs.isNotEmpty ? widget.tabs[_tabController.index] : null;
+    if (widget.tabs.isEmpty) {
+      return Container();
+    }
+    final currentTab = widget.tabs[_tabController.index];
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: <Widget>[
@@ -171,7 +173,7 @@ class _CpuProfilerState extends State<CpuProfiler>
           actions: [
             Row(
               children: [
-                if (currentTab!.key != CpuProfiler.summaryTab) ...[
+                if (currentTab.key != CpuProfiler.summaryTab) ...[
                   FilterButton(
                     onPressed: _showFilterDialog,
                     isFilterActive: widget.controller.isToggleFilterActive,

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -171,76 +171,72 @@ class _CpuProfilerState extends State<CpuProfiler>
             tabs: widget.tabs,
           ),
           actions: [
-            Row(
-              children: [
-                if (currentTab.key != CpuProfiler.summaryTab) ...[
-                  FilterButton(
-                    onPressed: _showFilterDialog,
-                    isFilterActive: widget.controller.isToggleFilterActive,
-                  ),
-                  const SizedBox(width: denseSpacing),
-                  UserTagDropdown(widget.controller),
-                  const SizedBox(width: denseSpacing),
-                ],
-                // TODO(kenz): support search for call tree and bottom up tabs as
-                // well. This will require implementing search for tree tables.
-                if (currentTab.key == CpuProfiler.flameChartTab) ...[
-                  if (widget.searchFieldKey != null) _buildSearchField(),
-                  FlameChartHelpButton(
-                    gaScreen: widget.standaloneProfiler
-                        ? analytics_constants.cpuProfiler
-                        : analytics_constants.performance,
-                    gaSelection: analytics_constants.cpuProfileFlameChartHelp,
-                    additionalInfo: [
-                      ...dialogSubHeader(Theme.of(context), 'Legend'),
-                      Legend(
-                        entries: [
-                          LegendEntry(
-                            'App code (code from your app and imported packages)',
-                            appCodeColor.background.colorFor(colorScheme),
-                          ),
-                          LegendEntry(
-                            'Native code (code from the native runtime - Android, iOS, etc.)',
-                            nativeCodeColor.background.colorFor(colorScheme),
-                          ),
-                          LegendEntry(
-                            'Dart core libraries (code from the Dart SDK)',
-                            dartCoreColor.background.colorFor(colorScheme),
-                          ),
-                          LegendEntry(
-                            'Flutter Framework (code from the Flutter SDK)',
-                            flutterCoreColor.background.colorFor(colorScheme),
-                          ),
-                        ],
+            if (currentTab.key != CpuProfiler.summaryTab) ...[
+              FilterButton(
+                onPressed: _showFilterDialog,
+                isFilterActive: widget.controller.isToggleFilterActive,
+              ),
+              const SizedBox(width: denseSpacing),
+              UserTagDropdown(widget.controller),
+              const SizedBox(width: denseSpacing),
+            ],
+            // TODO(kenz): support search for call tree and bottom up tabs as
+            // well. This will require implementing search for tree tables.
+            if (currentTab.key == CpuProfiler.flameChartTab) ...[
+              if (widget.searchFieldKey != null) _buildSearchField(),
+              FlameChartHelpButton(
+                gaScreen: widget.standaloneProfiler
+                    ? analytics_constants.cpuProfiler
+                    : analytics_constants.performance,
+                gaSelection: analytics_constants.cpuProfileFlameChartHelp,
+                additionalInfo: [
+                  ...dialogSubHeader(Theme.of(context), 'Legend'),
+                  Legend(
+                    entries: [
+                      LegendEntry(
+                        'App code (code from your app and imported packages)',
+                        appCodeColor.background.colorFor(colorScheme),
+                      ),
+                      LegendEntry(
+                        'Native code (code from the native runtime - Android, iOS, etc.)',
+                        nativeCodeColor.background.colorFor(colorScheme),
+                      ),
+                      LegendEntry(
+                        'Dart core libraries (code from the Dart SDK)',
+                        dartCoreColor.background.colorFor(colorScheme),
+                      ),
+                      LegendEntry(
+                        'Flutter Framework (code from the Flutter SDK)',
+                        flutterCoreColor.background.colorFor(colorScheme),
                       ),
                     ],
                   ),
                 ],
-                if (currentTab.key != CpuProfiler.flameChartTab &&
-                    currentTab.key != CpuProfiler.summaryTab) ...[
-                  // TODO(kenz): add a switch to order samples by user tag here
-                  // instead of using the filter control. This will allow users
-                  // to see all the tags side by side in the tree tables.
-                  ExpandAllButton(
-                    onPressed: () {
-                      _performOnDataRoots(
-                        (root) => root.expandCascading(),
-                        currentTab,
-                      );
-                    },
-                  ),
-                  const SizedBox(width: denseSpacing),
-                  CollapseAllButton(
-                    onPressed: () {
-                      _performOnDataRoots(
-                        (root) => root.collapseCascading(),
-                        currentTab,
-                      );
-                    },
-                  ),
-                ],
-              ],
-            ),
+              ),
+            ],
+            if (currentTab.key != CpuProfiler.flameChartTab &&
+                currentTab.key != CpuProfiler.summaryTab) ...[
+              // TODO(kenz): add a switch to order samples by user tag here
+              // instead of using the filter control. This will allow users
+              // to see all the tags side by side in the tree tables.
+              ExpandAllButton(
+                onPressed: () {
+                  _performOnDataRoots(
+                    (root) => root.expandCascading(),
+                    currentTab,
+                  );
+                },
+              ),
+              const SizedBox(width: denseSpacing),
+              CollapseAllButton(
+                onPressed: () {
+                  _performOnDataRoots(
+                    (root) => root.collapseCascading(),
+                    currentTab,
+                  );
+                },
+              ),
+            ],
           ],
         ),
         Expanded(

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -177,27 +177,29 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
           ),
         const SizedBox(height: denseRowSpacing),
         Expanded(
-          child: ValueListenableBuilder<CpuProfileData?>(
-            valueListenable: controller.cpuProfilerController.dataNotifier,
-            builder: (context, cpuProfileData, _) {
-              if (cpuProfileData ==
-                      CpuProfilerController.baseStateCpuProfileData ||
-                  cpuProfileData == null) {
-                return _buildRecordingInfo();
-              }
-              if (cpuProfileData ==
-                  CpuProfilerController.emptyAppStartUpProfile) {
-                return emptyAppStartUpProfileView;
-              }
-              if (cpuProfileData.isEmpty) {
-                return emptyProfileView;
-              }
-              return CpuProfiler(
-                data: cpuProfileData,
-                controller: controller.cpuProfilerController,
-                searchFieldKey: profilerScreenSearchFieldKey,
-              );
-            },
+          child: OutlineDecoration(
+            child: ValueListenableBuilder<CpuProfileData?>(
+              valueListenable: controller.cpuProfilerController.dataNotifier,
+              builder: (context, cpuProfileData, _) {
+                if (cpuProfileData ==
+                        CpuProfilerController.baseStateCpuProfileData ||
+                    cpuProfileData == null) {
+                  return _buildRecordingInfo();
+                }
+                if (cpuProfileData ==
+                    CpuProfilerController.emptyAppStartUpProfile) {
+                  return emptyAppStartUpProfileView;
+                }
+                if (cpuProfileData.isEmpty) {
+                  return emptyProfileView;
+                }
+                return CpuProfiler(
+                  data: cpuProfileData,
+                  controller: controller.cpuProfilerController,
+                  searchFieldKey: profilerScreenSearchFieldKey,
+                );
+              },
+            ),
           ),
         ),
       ],

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -64,7 +64,7 @@ void main() {
         searchFieldKey: searchFieldKey,
       );
       await tester.pumpWidget(wrap(cpuProfiler));
-      expect(find.byType(TabBar), findsOneWidget);
+      expect(find.byType(TabBar), findsNothing);
       expect(find.byKey(CpuProfiler.dataProcessingKey), findsNothing);
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);


### PR DESCRIPTION
Adds an `OutlineDecoration` around the contents of the profile and places the various table controls into an `AreaPaneHeader`.

Also removes some unnecessary nested `Row`s

**Before:**
<img width="1332" alt="Screen Shot 2022-08-23 at 10 41 24 AM" src="https://user-images.githubusercontent.com/24210656/186188406-7545df4a-0c39-40fb-b352-595f65f28b7a.png">
<img width="1332" alt="Screen Shot 2022-08-23 at 10 41 29 AM" src="https://user-images.githubusercontent.com/24210656/186188411-abb153c6-22df-407f-a840-61cbca632de4.png">

**After:**
<img width="1332" alt="Screen Shot 2022-08-23 at 10 41 08 AM" src="https://user-images.githubusercontent.com/24210656/186188400-5f0219ec-2fdb-49b7-9f4e-f9937b7fd443.png">
<img width="1332" alt="Screen Shot 2022-08-23 at 10 41 05 AM" src="https://user-images.githubusercontent.com/24210656/186188393-1d564b3a-d4bb-4bcb-a8f2-105f9751cd58.png">

