### PR TITLE
Persist sorting order for Memory Profile table

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
@@ -25,8 +25,8 @@ import 'allocation_profile_table_view_controller.dart';
 /// instances, memory).
 const _defaultNumberFieldWidth = 90.0;
 
-class _FieldClassName extends ColumnData<ClassHeapStats> {
-  _FieldClassName()
+class _FieldClassNameColumn extends ColumnData<ClassHeapStats> {
+  _FieldClassNameColumn()
       : super(
           'Class',
           fixedWidthPx: scaleByFontFactor(200),
@@ -239,7 +239,7 @@ class _AllocationProfileTable extends StatefulWidget {
   );
 
   static final _columns = [
-    _FieldClassName(),
+    _FieldClassNameColumn(),
     _FieldInstanceCountColumn(heap: _HeapGeneration.total),
     _initialSortColumn,
     _FieldInternalSizeColumn(heap: _HeapGeneration.total),
@@ -277,14 +277,14 @@ class _AllocationProfileTable extends StatefulWidget {
 }
 
 class _AllocationProfileTableState extends State<_AllocationProfileTable> {
-  late SortDirection sortDirection;
-  late ColumnData<ClassHeapStats> sortColumn;
+  late SortDirection _sortDirection;
+  late ColumnData<ClassHeapStats> _sortColumn;
 
   @override
   void initState() {
     super.initState();
-    sortColumn = _AllocationProfileTable._initialSortColumn;
-    sortDirection = SortDirection.descending;
+    _sortColumn = _AllocationProfileTable._initialSortColumn;
+    _sortDirection = SortDirection.descending;
   }
 
   @override
@@ -323,8 +323,8 @@ class _AllocationProfileTableState extends State<_AllocationProfileTable> {
                             element.oldSpace.externalSize != 0;
                       },
                     ).toList(),
-                    sortColumn: sortColumn,
-                    sortDirection: sortDirection,
+                    sortColumn: _sortColumn,
+                    sortDirection: _sortDirection,
                     onSortChanged: (
                       sortColumn,
                       direction, {
@@ -332,7 +332,7 @@ class _AllocationProfileTableState extends State<_AllocationProfileTable> {
                     }) {
                       setState(() {
                         sortColumn = sortColumn;
-                        sortDirection = direction;
+                        _sortDirection = direction;
                       });
                     },
                     onItemSelected: (item) => null,

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
@@ -277,6 +277,8 @@ class _AllocationProfileTable extends StatefulWidget {
 }
 
 class _AllocationProfileTableState extends State<_AllocationProfileTable> {
+  // TODO(bkonyi): pull state into a TableController class.
+  // See https://github.com/flutter/devtools/issues/4365
   late SortDirection _sortDirection;
   late ColumnData<ClassHeapStats> _sortColumn;
 

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view.dart
@@ -330,8 +330,10 @@ class _AllocationProfileTableState extends State<_AllocationProfileTable> {
                       direction, {
                       secondarySortColumn,
                     }) {
-                      sortColumn = sortColumn;
-                      sortDirection = direction;
+                      setState(() {
+                        sortColumn = sortColumn;
+                        sortDirection = direction;
+                      });
                     },
                     onItemSelected: (item) => null,
                     keyFactory: (element) => Key(element!.classRef!.name!),

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_profile/allocation_profile_table_view_controller.dart
@@ -28,9 +28,7 @@ class AllocationProfileTableViewController extends DisposableController
 
   void initialize() {
     if (_initialized) {
-      throw StateError(
-        "'AllocationProfileController' has already been initialized.",
-      );
+      return;
     }
     autoDisposeStreamSubscription(
       serviceManager.service!.onGCEvent.listen((event) {


### PR DESCRIPTION
Also changes default sort column to total size.

Fixes https://github.com/flutter/devtools/issues/4300