### PR TITLE
Improve testing of `ProgramExplorer`

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -22,6 +22,7 @@ export 'src/screens/app_size/app_size_screen.dart';
 export 'src/screens/debugger/debugger_controller.dart';
 export 'src/screens/debugger/debugger_screen.dart';
 export 'src/screens/debugger/program_explorer_controller.dart';
+export 'src/screens/debugger/program_explorer_model.dart';
 export 'src/screens/debugger/span_parser.dart';
 export 'src/screens/debugger/syntax_highlighter.dart';
 export 'src/screens/inspector/diagnostics.dart';

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -21,9 +21,8 @@ class ProgramExplorerController extends DisposableController
   ProgramExplorerController({
     this.showCodeNodes = false,
     ListValueNotifier<VMServiceObjectNode>? rootObjectNodesOverride,
-  })  : 
-        _rootObjectNodes =
-            rootObjectNodesOverride ?? ListValueNotifier<VMServiceObjectNode>([]);
+  }) : _rootObjectNodes = rootObjectNodesOverride ??
+            ListValueNotifier<VMServiceObjectNode>([]);
 
   /// The outline view nodes for the currently selected library.
   ValueListenable<List<VMServiceObjectNode>> get outlineNodes => _outlineNodes;

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -20,9 +20,7 @@ class ProgramExplorerController extends DisposableController
   /// outline view.
   ProgramExplorerController({
     this.showCodeNodes = false,
-    ListValueNotifier<VMServiceObjectNode>? rootObjectNodesOverride,
-  }) : _rootObjectNodes = rootObjectNodesOverride ??
-            ListValueNotifier<VMServiceObjectNode>([]);
+  });
 
   /// The outline view nodes for the currently selected library.
   ValueListenable<List<VMServiceObjectNode>> get outlineNodes => _outlineNodes;
@@ -43,8 +41,9 @@ class ProgramExplorerController extends DisposableController
 
   /// The processed roots of the tree.
   ValueListenable<List<VMServiceObjectNode>> get rootObjectNodes =>
-      _rootObjectNodes;
-  final ListValueNotifier<VMServiceObjectNode> _rootObjectNodes;
+      rootObjectNodesInternal;
+  @visibleForTesting
+  final rootObjectNodesInternal = ListValueNotifier<VMServiceObjectNode>([]);
 
   ValueListenable<int> get selectedNodeIndex => _selectedNodeIndex;
   final _selectedNodeIndex = ValueNotifier<int>(0);
@@ -90,7 +89,7 @@ class ProgramExplorerController extends DisposableController
       this,
       libraries,
     );
-    _rootObjectNodes.replaceAll(nodes);
+    rootObjectNodesInternal.replaceAll(nodes);
     _initialized.value = true;
   }
 
@@ -108,8 +107,8 @@ class ProgramExplorerController extends DisposableController
     if (!initialized.value) {
       return;
     }
-    await _selectScriptNode(script, _rootObjectNodes.value);
-    _rootObjectNodes.notifyListeners();
+    await _selectScriptNode(script, rootObjectNodesInternal.value);
+    rootObjectNodesInternal.notifyListeners();
   }
 
   Future<void> _selectScriptNode(
@@ -138,7 +137,7 @@ class ProgramExplorerController extends DisposableController
     // Index tracks the position of the node in the flat-list representation of
     // the tree:
     var index = 0;
-    for (final node in _rootObjectNodes.value) {
+    for (final node in rootObjectNodesInternal.value) {
       final matchingNode = depthFirstTraversal(
         node,
         returnCondition: matchingNodeCondition,

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -20,7 +20,10 @@ class ProgramExplorerController extends DisposableController
   /// outline view.
   ProgramExplorerController({
     this.showCodeNodes = false,
-  });
+    ListValueNotifier<VMServiceObjectNode>? rootObjectNodesOverride,
+  })  : 
+        _rootObjectNodes =
+            rootObjectNodesOverride ?? ListValueNotifier<VMServiceObjectNode>([]);
 
   /// The outline view nodes for the currently selected library.
   ValueListenable<List<VMServiceObjectNode>> get outlineNodes => _outlineNodes;
@@ -30,6 +33,8 @@ class ProgramExplorerController extends DisposableController
   final _isLoadingOutline = ValueNotifier<bool>(false);
 
   /// The currently selected node in the Program Explorer file picker.
+  @visibleForTesting
+  VMServiceObjectNode? get scriptSelection => _scriptSelection;
   VMServiceObjectNode? _scriptSelection;
 
   /// The currently selected node in the Program Explorer outline.
@@ -40,7 +45,7 @@ class ProgramExplorerController extends DisposableController
   /// The processed roots of the tree.
   ValueListenable<List<VMServiceObjectNode>> get rootObjectNodes =>
       _rootObjectNodes;
-  final _rootObjectNodes = ListValueNotifier<VMServiceObjectNode>([]);
+  final ListValueNotifier<VMServiceObjectNode> _rootObjectNodes;
 
   ValueListenable<int> get selectedNodeIndex => _selectedNodeIndex;
   final _selectedNodeIndex = ValueNotifier<int>(0);

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -55,9 +55,9 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
 
   List<VMServiceObjectNode>? _outline;
   Future<List<VMServiceObjectNode>?> get outline async {
-    /*if (_outline != null) {
+    if (_outline != null) {
       return _outline;
-    }*/
+    }
 
     final root = VMServiceObjectNode(
       controller,

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -23,7 +23,7 @@ import 'program_explorer_controller.dart';
 class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
   VMServiceObjectNode(
     this.controller,
-    name,
+    String? name,
     this.object, {
     this.isSelectable = true,
   }) : name = name ?? '';
@@ -55,9 +55,10 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
 
   List<VMServiceObjectNode>? _outline;
   Future<List<VMServiceObjectNode>?> get outline async {
-    if (_outline != null) {
+    /*if (_outline != null) {
       return _outline;
-    }
+    }*/
+
     final root = VMServiceObjectNode(
       controller,
       '<root>',
@@ -113,7 +114,6 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
         root.addChild(clazzNode);
       }
     }
-
     for (final function in lib.functions!) {
       if (function.location?.script?.uri == uri) {
         final node = VMServiceObjectNode(
@@ -322,8 +322,8 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
     return this;
   }
 
-  void updateObject(Obj object) {
-    if (this.object is! Class && object is Class) {
+  void updateObject(Obj object, {bool forceUpdate = false}) {
+    if ((this.object is! Class || forceUpdate) && object is Class) {
       for (final function in object.functions?.cast<Func>() ?? <Func>[]) {
         final node = _createChild(function.name, function);
         _buildCodeNodes(function, node);
@@ -337,6 +337,9 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
   }
 
   Future<void> populateLocation() async {
+    if (location != null) {
+      return;
+    }
     ScriptRef? scriptRef = script;
     int? tokenPos = 0;
     if (object != null &&

--- a/packages/devtools_app/test/debugger/program_explorer_test.dart
+++ b/packages/devtools_app/test/debugger/program_explorer_test.dart
@@ -4,55 +4,166 @@
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/primitives/listenable.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer.dart';
+import 'package:devtools_app/src/screens/debugger/program_explorer_model.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/flex_split_column.dart';
 import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/notifications.dart';
 import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../test_data/vm_service_object_tree.dart';
+import '../test_utils/tree_utils.dart';
 
 void main() {
-  late MockProgramExplorerController mockProgramExplorerController;
+  group('Mock ProgramExplorer', () {
+    late MockProgramExplorerController mockProgramExplorerController;
 
-  setUp(() {
-    final fakeServiceManager = FakeServiceManager();
-    mockConnectedApp(
-      fakeServiceManager.connectedApp!,
-      isFlutterApp: true,
-      isProfileBuild: false,
-      isWebApp: false,
-    );
-    mockProgramExplorerController =
-        createMockProgramExplorerControllerWithDefaults();
-    setGlobal(IdeTheme, IdeTheme());
-    setGlobal(ServiceConnectionManager, fakeServiceManager);
-  });
+    setUp(() {
+      final fakeServiceManager = FakeServiceManager();
+      mockConnectedApp(
+        fakeServiceManager.connectedApp!,
+        isFlutterApp: true,
+        isProfileBuild: false,
+        isWebApp: false,
+      );
+      mockProgramExplorerController =
+          createMockProgramExplorerControllerWithDefaults();
+      setGlobal(IdeTheme, IdeTheme());
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+    });
 
-  testWidgets('builds when not initialized', (WidgetTester tester) async {
-    when(mockProgramExplorerController.initialized)
-        .thenReturn(const FixedValueListenable(false));
-    await tester.pumpWidget(
-      wrap(
-        ProgramExplorer(controller: mockProgramExplorerController),
-      ),
-    );
-    expect(find.byType(CenteredCircularProgressIndicator), findsOneWidget);
-  });
+    testWidgets('builds when not initialized', (WidgetTester tester) async {
+      when(mockProgramExplorerController.initialized)
+          .thenReturn(const FixedValueListenable(false));
+      await tester.pumpWidget(
+        wrap(
+          ProgramExplorer(controller: mockProgramExplorerController),
+        ),
+      );
+      expect(find.byType(CenteredCircularProgressIndicator), findsOneWidget);
+    });
 
-  testWidgets('builds when initialized', (WidgetTester tester) async {
-    await tester.pumpWidget(
-      wrap(
-        ProgramExplorer(controller: mockProgramExplorerController),
-      ),
-    );
-    expect(find.byType(AreaPaneHeader), findsNWidgets(2));
-    expect(find.text('File Explorer'), findsOneWidget);
-    expect(find.text('Outline'), findsOneWidget);
-    expect(find.byType(FlexSplitColumn), findsOneWidget);
+    testWidgets('builds when initialized', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrap(
+          ProgramExplorer(controller: mockProgramExplorerController),
+        ),
+      );
+      expect(find.byType(AreaPaneHeader), findsNWidgets(2));
+      expect(find.text('File Explorer'), findsOneWidget);
+      expect(find.text('Outline'), findsOneWidget);
+      expect(find.byType(FlexSplitColumn), findsOneWidget);
+    });
   });
 
   // TODO(https://github.com/flutter/devtools/issues/4227): write more thorough
   // tests for the ProgramExplorer widget.
+
+  group('Fake ProgramExplorer', () {
+    late final FakeServiceManager fakeServiceManager;
+
+    setUpAll(() {
+      fakeServiceManager = FakeServiceManager();
+
+      when(fakeServiceManager.connectedApp!.isProfileBuildNow)
+          .thenReturn(false);
+      when(fakeServiceManager.connectedApp!.isDartWebAppNow).thenReturn(false);
+
+      setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(IdeTheme, IdeTheme());
+      setGlobal(NotificationService, NotificationService());
+    });
+
+    Future<TestProgramExplorerController> initializeProgramExplorer(
+      WidgetTester tester,
+    ) async {
+      final programExplorerController = TestProgramExplorerController(
+        initializer: (controller) {
+          final libraryNode =
+              VMServiceObjectNode(controller, 'fooLib', testLib);
+          libraryNode.script = testScript;
+          libraryNode.location = ScriptLocation(testScript);
+          controller.rootObjectNodesOverride.add(libraryNode);
+        },
+      );
+      final explorer = ProgramExplorer(controller: programExplorerController);
+      programExplorerController.initialize();
+      await tester.pumpWidget(
+        wrap(
+          Builder(
+            builder: explorer.build,
+          ),
+        ),
+      );
+      expect(programExplorerController.initialized.value, true);
+      expect(programExplorerController.rootObjectNodes.value.numNodes, 1);
+      return programExplorerController;
+    }
+
+    testWidgets('correctly builds nodes', (WidgetTester tester) async {
+      final programExplorerController = await initializeProgramExplorer(tester);
+      final libNode = programExplorerController.rootObjectNodes.value.first;
+      final outline = (await libNode.outline)!;
+
+      // The outline should only contain a single Class node.
+      expect(outline.length, 1);
+      final clsNode = outline.first;
+      expect(clsNode.object, const TypeMatcher<Class>());
+      expect(clsNode.name, testClassRef.name);
+
+      // The class should contain a function and a field.
+      expect(clsNode.children.length, 2);
+      for (final child in clsNode.children) {
+        if (child.object is Func) {
+          expect(child.object, testFunction);
+        } else if (child.object is Field) {
+          expect(child.object, testField);
+        } else {
+          fail('Unexpected node type: ${child.object.runtimeType}');
+        }
+      }
+    });
+
+    testWidgets(
+      'selection',
+      (WidgetTester tester) async {
+        final programExplorerController =
+            await initializeProgramExplorer(tester);
+        final libNode = programExplorerController.rootObjectNodes.value.first;
+
+        // No node has been selected yet, so the outline should be empty.
+        expect(programExplorerController.outlineNodes.value.isEmpty, true);
+        expect(programExplorerController.scriptSelection, isNull);
+        expect(programExplorerController.outlineSelection.value, isNull);
+
+        // Select the library node and ensure the outline is populated.
+        await programExplorerController.selectNode(libNode);
+        expect(programExplorerController.scriptSelection, libNode);
+        expect(programExplorerController.outlineSelection.value, isNull);
+
+        // There should be three children total, one root with two children.
+        expect(programExplorerController.outlineNodes.value.length, 1);
+        expect(programExplorerController.outlineNodes.value.numNodes, 3);
+
+        // Select one of them and check that the outline selection has been
+        // updated.
+        final outlineNode = programExplorerController.outlineNodes.value.first;
+        programExplorerController.selectOutlineNode(outlineNode);
+        expect(programExplorerController.scriptSelection, libNode);
+        expect(programExplorerController.outlineSelection.value, outlineNode);
+
+        // Ensure that the outline view can be reset.
+        programExplorerController.resetOutline();
+        expect(programExplorerController.scriptSelection, libNode);
+        expect(programExplorerController.outlineSelection.value, isNull);
+      },
+    );
+  });
 }

--- a/packages/devtools_app/test/test_data/debugger/vm_service_object_tree.dart
+++ b/packages/devtools_app/test/test_data/debugger/vm_service_object_tree.dart
@@ -25,6 +25,10 @@ final testClassRef = ClassRef(
   id: '1234',
   name: 'FooClass',
   library: testLibRef,
+  location: SourceLocation(
+    script: testScript,
+    tokenPos: 0,
+  ),
 );
 
 final testClass = Class(
@@ -37,8 +41,8 @@ final testClass = Class(
   superType: testSuperType,
   fields: [testField],
   functions: [testFunction],
-  location: SourceLocation(script: testScript),
   id: '1234',
+  location: testClassRef.location,
 );
 
 final testScript = Script(
@@ -54,13 +58,18 @@ final testFunction = Func(
   isConst: false,
   implicit: false,
   location: SourceLocation(script: testScript),
+  signature: InstanceRef(id: '1234'),
   id: '1234',
 );
 
 final testField = Field(
   name: 'fooField',
   location: SourceLocation(script: testScript),
+  declaredType: InstanceRef(id: '1234'),
   owner: testClassRef,
+  isStatic: false,
+  isConst: false,
+  isFinal: false,
   id: '1234',
 );
 

--- a/packages/devtools_app/test/test_data/vm_service_object_tree.dart
+++ b/packages/devtools_app/test/test_data/vm_service_object_tree.dart
@@ -2,16 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/primitives/listenable.dart';
-import 'package:devtools_app/src/primitives/utils.dart';
-import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
-import 'package:devtools_app/src/screens/debugger/program_explorer_controller.dart';
-import 'package:devtools_app/src/screens/debugger/program_explorer_model.dart';
-import 'package:devtools_app/src/scripts/script_manager.dart';
-import 'package:devtools_app/src/shared/globals.dart';
-import 'package:devtools_test/devtools_test.dart';
-import 'package:flutter/foundation.dart';
-import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 
 final testLib = Library(

--- a/packages/devtools_app/test/test_data/vm_service_object_tree.dart
+++ b/packages/devtools_app/test/test_data/vm_service_object_tree.dart
@@ -1,0 +1,92 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/primitives/listenable.dart';
+import 'package:devtools_app/src/primitives/utils.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
+import 'package:devtools_app/src/screens/debugger/program_explorer_controller.dart';
+import 'package:devtools_app/src/screens/debugger/program_explorer_model.dart';
+import 'package:devtools_app/src/scripts/script_manager.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/foundation.dart';
+import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+final testLib = Library(
+  id: testLibRef.id!,
+  uri: testLibRef.uri!,
+  name: testLibRef.name!,
+  dependencies: <LibraryDependency>[],
+  classes: [testClass],
+  scripts: [testScript],
+  variables: [],
+  functions: [],
+);
+
+final testLibRef = LibraryRef(
+  name: 'fooLib',
+  uri: 'fooScript.dart',
+  id: '1234',
+);
+
+final testClassRef = ClassRef(
+  id: '1234',
+  name: 'FooClass',
+  library: testLibRef,
+);
+
+final testClass = Class(
+  name: testClassRef.name,
+  library: testClassRef.library,
+  isAbstract: false,
+  isConst: false,
+  traceAllocations: false,
+  superClass: testSuperClass,
+  superType: testSuperType,
+  fields: [testField],
+  functions: [testFunction],
+  location: SourceLocation(script: testScript),
+  id: '1234',
+);
+
+final testScript = Script(
+  uri: 'fooScript.dart',
+  library: testLibRef,
+  id: '1234',
+);
+
+final testFunction = Func(
+  name: 'fooFunction',
+  owner: testClassRef,
+  isStatic: false,
+  isConst: false,
+  implicit: false,
+  location: SourceLocation(script: testScript),
+  id: '1234',
+);
+
+final testField = Field(
+  name: 'fooField',
+  location: SourceLocation(script: testScript),
+  owner: testClassRef,
+  id: '1234',
+);
+
+final testInstance = Instance(
+  id: '1234',
+  name: 'fooInstance',
+);
+
+final testSuperClass = ClassRef(
+  name: 'fooSuperClass',
+  library: testLibRef,
+  id: '1234',
+);
+
+final testSuperType = InstanceRef(
+  kind: '',
+  id: '1234',
+  name: 'fooSuperType',
+);

--- a/packages/devtools_app/test/test_utils/tree_utils.dart
+++ b/packages/devtools_app/test/test_utils/tree_utils.dart
@@ -1,0 +1,18 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/primitives/trees.dart';
+
+extension TreeNodeList<T extends TreeNode<T>> on List<T> {
+  int get numNodes {
+    return fold<int>(0, (prev, next) {
+      int count = 0;
+      breadthFirstTraversal<T>(
+        next,
+        action: (node) => count++,
+      );
+      return prev + count;
+    });
+  }
+}

--- a/packages/devtools_test/lib/devtools_test.dart
+++ b/packages/devtools_test/lib/devtools_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+export 'src/mocks/fake_program_explorer_controller.dart';
 export 'src/mocks/fake_service_extension_manager.dart';
 export 'src/mocks/fake_service_manager.dart';
 export 'src/mocks/fake_vm_service_wrapper.dart';

--- a/packages/devtools_test/lib/src/mocks/fake_program_explorer_controller.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_program_explorer_controller.dart
@@ -1,0 +1,50 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
+
+class TestProgramExplorerController extends ProgramExplorerController {
+  factory TestProgramExplorerController({
+    required Function(TestProgramExplorerController) initializer,
+  }) =>
+      TestProgramExplorerController._(
+        initializer: initializer,
+        rootObjectNodesOverride: ListValueNotifier<VMServiceObjectNode>([]),
+      );
+
+  TestProgramExplorerController._({
+    required this.initializer,
+    required super.rootObjectNodesOverride,
+  }) : rootObjectNodesOverride = rootObjectNodesOverride!;
+
+  final ListValueNotifier<VMServiceObjectNode> rootObjectNodesOverride;
+
+  @override
+  ValueListenable<bool> get initialized => _initialized;
+  final _initialized = ValueNotifier<bool>(false);
+
+  final Function(TestProgramExplorerController) initializer;
+
+  @override
+  void initialize() {
+    if (_initialized.value) {
+      return;
+    }
+    initializer(this);
+    _initialized.value = true;
+  }
+
+  @override
+  Future<void> populateNode(VMServiceObjectNode node) async {
+    // Since the data is hard coded and fully populated, we can completely
+    // bypass all the service related code. However, we need to still build
+    // the child nodes, which is done by calling
+    // `VMServiceObjectNode.updateObject`. We need to "force" the update since
+    // there are optimizations to avoid re-building the nodes if the root node
+    // already contains a full VM service object (i.e., not a reference type).
+    node.updateObject(node.object as Obj, forceUpdate: true);
+  }
+}

--- a/packages/devtools_test/lib/src/mocks/fake_program_explorer_controller.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_program_explorer_controller.dart
@@ -7,20 +7,9 @@ import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
 class TestProgramExplorerController extends ProgramExplorerController {
-  factory TestProgramExplorerController({
-    required Function(TestProgramExplorerController) initializer,
-  }) =>
-      TestProgramExplorerController._(
-        initializer: initializer,
-        rootObjectNodesOverride: ListValueNotifier<VMServiceObjectNode>([]),
-      );
-
-  TestProgramExplorerController._({
+  TestProgramExplorerController({
     required this.initializer,
-    required super.rootObjectNodesOverride,
-  }) : rootObjectNodesOverride = rootObjectNodesOverride!;
-
-  final ListValueNotifier<VMServiceObjectNode> rootObjectNodesOverride;
+  });
 
   @override
   ValueListenable<bool> get initialized => _initialized;


### PR DESCRIPTION
Adds a `FakeProgramExplorerController` that retains the vast majority of the functionality of `ProgramExplorerController` while allowing for fake data to be injected, removing all service requests.

Makes progress on https://github.com/flutter/devtools/issues/4227.