### PR TITLE
Polish UI for `VmExpansionTile`

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -326,18 +326,31 @@ class VmExpansionTile extends StatelessWidget {
     final titleRow = AreaPaneHeader(
       title: Text(title),
       needsTopBorder: false,
+      needsBottomBorder: false,
+      // We'll set the color in the Card so the InkWell shows a consistent
+      // color when the user hovers over the ExpansionTile.
+      backgroundColor: Colors.transparent,
     );
+    final theme = Theme.of(context);
     return Card(
+      color: theme.titleSolidBackgroundColor,
       child: ListTileTheme(
-        data: ListTileTheme.of(context).copyWith(dense: true),
-        child: ExpansionTile(
-          title: titleRow,
-          onExpansionChanged: onExpanded,
-          tilePadding: const EdgeInsets.only(
-            left: densePadding,
-            right: defaultSpacing,
+        data: ListTileTheme.of(context).copyWith(
+          dense: true,
+        ),
+        child: Theme(
+          // Prevents divider lines appearing at the top and bottom of the
+          // expanded ExpansionTile.
+          data: theme.copyWith(dividerColor: Colors.transparent),
+          child: ExpansionTile(
+            title: titleRow,
+            onExpansionChanged: onExpanded,
+            tilePadding: const EdgeInsets.only(
+              left: densePadding,
+              right: defaultSpacing,
+            ),
+            children: children,
           ),
-          children: children,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -781,6 +781,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
     this.leftPadding = defaultSpacing,
     this.rightPadding = densePadding,
     this.tall = false,
+    this.backgroundColor,
   }) : super(key: key);
 
   final Widget title;
@@ -792,6 +793,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
   final double leftPadding;
   final double rightPadding;
   final bool tall;
+  final Color? backgroundColor;
 
   @override
   Widget build(BuildContext context) {
@@ -806,7 +808,7 @@ class AreaPaneHeader extends StatelessWidget implements PreferredSizeWidget {
                 needsBottomBorder ? defaultBorderSide(theme) : BorderSide.none,
             left: needsLeftBorder ? defaultBorderSide(theme) : BorderSide.none,
           ),
-          color: theme.titleSolidBackgroundColor,
+          color: backgroundColor ?? theme.titleSolidBackgroundColor,
         ),
         padding: EdgeInsets.only(left: leftPadding, right: rightPadding),
         alignment: Alignment.centerLeft,


### PR DESCRIPTION
Makes the widget a solid color and removes top/bottom divider lines.

![image](https://user-images.githubusercontent.com/24210656/187984024-2f386bb0-ba18-4b59-ac63-c4df6a4c6377.png)

![image](https://user-images.githubusercontent.com/24210656/187984269-bcfaeae6-6700-4fb1-9f5b-653742a2ee15.png)