### PR TITLE
Fix Network recordings after hot restart

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -13,6 +13,7 @@ import '../../http/http_request_data.dart';
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
 import '../../shared/table.dart';
@@ -137,6 +138,11 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   Widget build(BuildContext context) {
+    addAutoDisposeListener(serviceManager.isolateManager.mainIsolate, () {
+      if (serviceManager.isolateManager.mainIsolate.value != null) {
+        controller.startRecording();
+      }
+    });
     return Column(
       children: [
         _NetworkProfilerControls(controller: controller),

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -126,6 +126,9 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
     super.didChangeDependencies();
     if (!initController()) return;
     controller.startRecording();
+
+    cancelListeners();
+
     addAutoDisposeListener(serviceManager.isolateManager.mainIsolate, () {
       if (serviceManager.isolateManager.mainIsolate.value != null) {
         controller.startRecording();

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -126,6 +126,11 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
     super.didChangeDependencies();
     if (!initController()) return;
     controller.startRecording();
+    addAutoDisposeListener(serviceManager.isolateManager.mainIsolate, () {
+      if (serviceManager.isolateManager.mainIsolate.value != null) {
+        controller.startRecording();
+      }
+    });
   }
 
   @override
@@ -138,11 +143,6 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    addAutoDisposeListener(serviceManager.isolateManager.mainIsolate, () {
-      if (serviceManager.isolateManager.mainIsolate.value != null) {
-        controller.startRecording();
-      }
-    });
     return Column(
       children: [
         _NetworkProfilerControls(controller: controller),


### PR DESCRIPTION
![](https://media.giphy.com/media/xUA7aU2BsefszQ503e/giphy-downsized.gif)

Fixes https://github.com/flutter/devtools/issues/3777

On hot restart, network recordings would stop working.

calling `startRecording` after the mainIsolate changes helps fix this issue.

