### PR TITLE
Add "Code Preview" section to Object Inspector views

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -19,6 +19,8 @@ export 'src/primitives/trees.dart';
 export 'src/primitives/utils.dart';
 export 'src/screens/app_size/app_size_controller.dart';
 export 'src/screens/app_size/app_size_screen.dart';
+export 'src/screens/debugger/breakpoint_manager.dart';
+export 'src/screens/debugger/codeview_controller.dart';
 export 'src/screens/debugger/debugger_controller.dart';
 export 'src/screens/debugger/debugger_screen.dart';
 export 'src/screens/debugger/program_explorer_controller.dart';

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -9,6 +9,7 @@ import '../config_specific/import_export/import_export.dart';
 import '../config_specific/logger/logger.dart';
 import '../primitives/message_bus.dart';
 import '../primitives/utils.dart';
+import '../screens/debugger/breakpoint_manager.dart';
 import '../scripts/script_manager.dart';
 import '../service/service.dart';
 import '../service/service_manager.dart';
@@ -30,6 +31,7 @@ class FrameworkCore {
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(ScriptManager, ScriptManager());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
   }
 
   static void init() {
@@ -60,6 +62,7 @@ class FrameworkCore {
           service,
           onClosed: finishedCompleter.future,
         );
+        breakpointManager.initialize();
         return true;
       } catch (e, st) {
         log('$e\n$st', LogLevel.error);

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -801,6 +801,7 @@ class LineRange {
   @override
   int get hashCode => Object.hash(begin, end);
 }
+
 extension SortDirectionExtension on SortDirection {
   SortDirection reverse() {
     return this == SortDirection.ascending

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -778,19 +778,29 @@ enum SortDirection {
   descending,
 }
 
-class LineRange extends Range {
-  const LineRange(super.begin, super.end);
+/// A Range-like class that works for inclusive ranges of lines in source code.
+class LineRange {
+  const LineRange(this.begin, this.end) : assert(begin <= end);
 
-  @override
-  int get begin => super.begin.toInt();
+  final int begin;
+  final int end;
 
-  @override
-  int get end => super.end.toInt();
-
-  @override
   int get size => end - begin + 1;
-}
 
+  bool contains(num target) => target >= begin && target <= end;
+
+  @override
+  String toString() => 'LineRange($begin, $end)';
+
+  @override
+  bool operator ==(other) {
+    if (other is! LineRange) return false;
+    return begin == other.begin && end == other.end;
+  }
+
+  @override
+  int get hashCode => Object.hash(begin, end);
+}
 extension SortDirectionExtension on SortDirection {
   SortDirection reverse() {
     return this == SortDirection.ascending

--- a/packages/devtools_app/lib/src/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/primitives/utils.dart
@@ -778,6 +778,19 @@ enum SortDirection {
   descending,
 }
 
+class LineRange extends Range {
+  const LineRange(super.begin, super.end);
+
+  @override
+  int get begin => super.begin.toInt();
+
+  @override
+  int get end => super.end.toInt();
+
+  @override
+  int get size => end - begin + 1;
+}
+
 extension SortDirectionExtension on SortDirection {
   SortDirection reverse() {
     return this == SortDirection.ascending

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -16,11 +16,9 @@ class BreakpointManager extends Disposer {
 
   final bool initialSwitchToIsolate;
 
-  VmServiceWrapper get _service {
-    return serviceManager.service!;
-  }
+  VmServiceWrapper get _service => serviceManager.service!;
 
-  final Map<String, List<SourcePosition>> _breakPositionsMap = {};
+  final _breakPositionsMap = <String, List<SourcePosition>>{};
 
   final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
 

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -12,7 +12,6 @@ import '../../shared/globals.dart';
 import 'debugger_model.dart';
 
 class BreakpointManager extends Disposer {
-
   BreakpointManager({this.initialSwitchToIsolate = true});
 
   final bool initialSwitchToIsolate;

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -1,0 +1,292 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:collection/collection.dart';
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../primitives/auto_dispose.dart';
+import '../../service/vm_service_wrapper.dart';
+import '../../shared/globals.dart';
+import 'debugger_model.dart';
+
+class BreakpointManager extends Disposer {
+
+  BreakpointManager({this.initialSwitchToIsolate = true});
+
+  final bool initialSwitchToIsolate;
+
+  VmServiceWrapper get _service {
+    return serviceManager.service!;
+  }
+
+  final Map<String, List<SourcePosition>> _breakPositionsMap = {};
+
+  final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
+
+  ValueListenable<List<Breakpoint>> get breakpoints => _breakpoints;
+
+  final _breakpointsWithLocation =
+      ValueNotifier<List<BreakpointAndSourcePosition>>([]);
+
+  ValueListenable<List<BreakpointAndSourcePosition>>
+      get breakpointsWithLocation => _breakpointsWithLocation;
+
+  IsolateRef? _isolateRef;
+
+  String get _isolateRefId => _isolateRef?.id ?? '';
+
+  void initialize() {
+    final isolate = serviceManager.isolateManager.selectedIsolate.value;
+    if (initialSwitchToIsolate && isolate != null) {
+      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
+    }
+
+    addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
+      switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
+    });
+    autoDisposeStreamSubscription(
+      _service.onDebugEvent.listen(_handleDebugEvent),
+    );
+    autoDisposeStreamSubscription(
+      _service.onIsolateEvent.listen(_handleIsolateEvent),
+    );
+  }
+
+  void switchToIsolate(IsolateRef? isolateRef) async {
+    _isolateRef = isolateRef;
+
+    if (isolateRef == null) {
+      _breakpoints.value.clear();
+      _breakpointsWithLocation.value.clear();
+      return;
+    }
+
+    final isolate = await _service.getIsolate(_isolateRefId);
+    if (isolate.id != _isolateRefId) {
+      // Current request is obsolete.
+      return;
+    }
+
+    _breakpoints.value = isolate.breakpoints ?? [];
+
+    // Build _breakpointsWithLocation from _breakpoints.
+    // ignore: unawaited_futures
+    Future.wait(
+      _breakpoints.value.map(breakpointManager.createBreakpointWithLocation),
+    ).then((list) {
+      if (isolate.id != _isolateRefId) {
+        // Current request is obsolete.
+        return;
+      }
+      _breakpointsWithLocation.value = list.toList()..sort();
+    });
+  }
+
+  void clearCache() {
+    _breakPositionsMap.clear();
+    _breakpoints.value = [];
+    _breakpointsWithLocation.value = [];
+  }
+
+  Future<void> clearBreakpoints() async {
+    final breakpoints = _breakpoints.value.toList();
+    await Future.forEach(breakpoints, (Breakpoint breakpoint) {
+      return removeBreakpoint(breakpoint);
+    });
+  }
+
+  Future<Breakpoint> addBreakpoint(String scriptId, int line) =>
+      _service.addBreakpoint(_isolateRefId, scriptId, line);
+
+  Future<void> removeBreakpoint(Breakpoint breakpoint) =>
+      _service.removeBreakpoint(_isolateRefId, breakpoint.id!);
+
+  Future<void> toggleBreakpoint(ScriptRef script, int line) async {
+    if (serviceManager.isolateManager.selectedIsolate.value == null) {
+      // Can't toggle breakpoints if we don't have an isolate.
+      return;
+    }
+    // The VM doesn't support debugging for system isolates and will crash on
+    // a failed assert in debug mode. Disable the toggle breakpoint
+    // functionality for system isolates.
+    if (serviceManager.isolateManager.selectedIsolate.value!.isSystemIsolate!) {
+      return;
+    }
+
+    final bp = breakpointsWithLocation.value.firstWhereOrNull((bp) {
+      return bp.scriptRef == script && bp.line == line;
+    });
+
+    if (bp != null) {
+      await removeBreakpoint(bp.breakpoint);
+    } else {
+      try {
+        await addBreakpoint(script.id!, line);
+      } catch (_) {
+        // ignore errors setting breakpoints
+      }
+    }
+  }
+
+  void _updateAfterIsolateReload(
+    Event reloadEvent,
+  ) async {
+    // TODO(devoncarew): We need to coordinate this with other debugger clients
+    // as well as pause before re-setting the breakpoints.
+    // Refresh the list of scripts.
+    final previousScriptRefs = scriptManager.sortedScripts.value;
+    final currentScriptRefs =
+        await scriptManager.retrieveAndSortScripts(_isolateRef!);
+    final removedScripts =
+        Set.of(previousScriptRefs).difference(Set.of(currentScriptRefs));
+    final addedScripts =
+        Set.of(currentScriptRefs).difference(Set.of(previousScriptRefs));
+    final breakpointsToRemove = <BreakpointAndSourcePosition>[];
+
+    // Find all breakpoints set in files where we have newer versions of those
+    // files.
+    for (final scriptRef in removedScripts) {
+      for (final bp in breakpointsWithLocation.value) {
+        if (bp.scriptRef == scriptRef) {
+          breakpointsToRemove.add(bp);
+        }
+      }
+    }
+
+    await Future.wait([
+      // Remove the breakpoints.
+      for (final bp in breakpointsToRemove) removeBreakpoint(bp.breakpoint),
+      // Add them back to the newer versions of those scripts.
+      for (final scriptRef in addedScripts) ...[
+        for (final bp in breakpointsToRemove)
+          if (scriptRef.uri == bp.scriptUri)
+            addBreakpoint(scriptRef.id!, bp.line!),
+      ],
+    ]);
+  }
+
+  /// Return the list of valid positions for breakpoints for a given script.
+  Future<List<SourcePosition>> getBreakablePositions(
+    IsolateRef? isolateRef,
+    Script script,
+  ) async {
+    final key = script.id;
+    if (key == null) return [];
+    if (!_breakPositionsMap.containsKey(key)) {
+      _breakPositionsMap[key] =
+          await _getBreakablePositions(isolateRef, script);
+    }
+
+    return _breakPositionsMap[key] ?? [];
+  }
+
+  Future<List<SourcePosition>> _getBreakablePositions(
+    IsolateRef? isolateRef,
+    Script script,
+  ) async {
+    final report = await _service.getSourceReport(
+      isolateRef?.id ?? '',
+      [SourceReportKind.kPossibleBreakpoints],
+      scriptId: script.id,
+      forceCompile: true,
+    );
+
+    final positions = <SourcePosition>[];
+
+    for (SourceReportRange range in report.ranges!) {
+      final possibleBreakpoints = range.possibleBreakpoints;
+      if (possibleBreakpoints != null) {
+        for (int tokenPos in possibleBreakpoints) {
+          positions.add(SourcePosition.calculatePosition(script, tokenPos));
+        }
+      }
+    }
+
+    return positions;
+  }
+
+  Future<BreakpointAndSourcePosition> createBreakpointWithLocation(
+    Breakpoint breakpoint,
+  ) async {
+    if (breakpoint.resolved!) {
+      final bp = BreakpointAndSourcePosition.create(breakpoint);
+      return scriptManager.getScript(bp.scriptRef!).then((Script script) {
+        final pos = SourcePosition.calculatePosition(script, bp.tokenPos!);
+        return BreakpointAndSourcePosition.create(breakpoint, pos);
+      });
+    } else {
+      return BreakpointAndSourcePosition.create(breakpoint);
+    }
+  }
+
+  void _handleIsolateEvent(Event event) {
+    final eventId = event.isolate?.id;
+    if (eventId != _isolateRefId) return;
+    switch (event.kind) {
+      case EventKind.kIsolateReload:
+        _updateAfterIsolateReload(event);
+        break;
+    }
+  }
+
+  void _handleDebugEvent(Event event) {
+    if (event.isolate!.id != _isolateRefId) return;
+
+    switch (event.kind) {
+      // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'
+      // that knows how to notify when performing a list edit operation.
+      case EventKind.kBreakpointAdded:
+        final breakpoint = event.breakpoint!;
+        _breakpoints.value = [..._breakpoints.value, breakpoint];
+
+        // ignore: unawaited_futures
+        breakpointManager.createBreakpointWithLocation(breakpoint).then((bp) {
+          final list = [
+            ..._breakpointsWithLocation.value,
+            bp,
+          ]..sort();
+
+          _breakpointsWithLocation.value = list;
+        });
+
+        break;
+      case EventKind.kBreakpointResolved:
+        final breakpoint = event.breakpoint!;
+        _breakpoints.value = [
+          for (var b in _breakpoints.value)
+            if (b != event.breakpoint) b,
+          breakpoint
+        ];
+
+        // ignore: unawaited_futures
+        breakpointManager.createBreakpointWithLocation(breakpoint).then((bp) {
+          final list = _breakpointsWithLocation.value.toList();
+          // Remote the bp with the older, unresolved information from the list.
+          list.removeWhere((breakpoint) => bp.breakpoint.id == bp.id);
+          // Add the bp with the newer, resolved information.
+          list.add(bp);
+          list.sort();
+          _breakpointsWithLocation.value = list;
+        });
+
+        break;
+
+      case EventKind.kBreakpointRemoved:
+        final breakpoint = event.breakpoint;
+
+        _breakpoints.value = [
+          for (var b in _breakpoints.value)
+            if (b != breakpoint) b
+        ];
+
+        _breakpointsWithLocation.value = [
+          for (var b in _breakpointsWithLocation.value)
+            if (b.breakpoint != breakpoint) b
+        ];
+
+        break;
+    }
+  }
+}

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import 'common.dart';
@@ -34,7 +35,7 @@ class _BreakpointsState extends State<Breakpoints>
   Widget build(BuildContext context) {
     return DualValueListenableBuilder<List<BreakpointAndSourcePosition>,
         BreakpointAndSourcePosition?>(
-      firstListenable: controller.breakpointsWithLocation,
+      firstListenable: breakpointManager.breakpointsWithLocation,
       secondListenable: controller.selectedBreakpoint,
       builder: (context, breakpoints, selectedBreakpoint, _) {
         return ListView.builder(

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -488,7 +488,7 @@ class _CodeViewState extends State<CodeView>
             widget.codeViewController.toggleFileOpenerVisibility(true),
         child: Text(
           'Open a file ($openFileKeySetDescription)',
-          style: theme.textTheme.titleMedium,
+          style: theme.textTheme.subtitle1,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -130,6 +130,20 @@ class _CodeViewState extends State<CodeView>
   }
 
   @override
+  void didUpdateWidget(CodeView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    if (widget.codeViewController != oldWidget.codeViewController) {
+      cancelListeners();
+
+      addAutoDisposeListener(
+        widget.codeViewController.scriptLocation,
+        _handleScriptLocationChanged,
+      );
+    }
+  }
+
+  @override
   void dispose() {
     gutterController.dispose();
     textController.dispose();

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -67,6 +67,10 @@ class CodeView extends StatefulWidget {
   final ScriptLocation? initialPosition;
   final ScriptRef? scriptRef;
   final ParsedScript? parsedScript;
+  // TODO(bkonyi): consider changing this to (or adding support for)
+  // `highlightedLineRange`, which would tell the code view to display the
+  // the script's source in its entirety, with lines outside of the range being
+  // rendered as if they have been greyed out.
   final LineRange? lineRange;
   final bool enableFileExplorer;
   final bool enableSearch;

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -378,104 +378,100 @@ class _CodeViewState extends State<CodeView>
       if (lines.isNotEmpty) {
         return DefaultTextStyle(
           style: theme.fixedFontStyle,
-          child: Expanded(
-            child: Scrollbar(
-              key: CodeView.debuggerCodeViewVerticalScrollbarKey,
-              controller: textController,
-              thumbVisibility: true,
-              // Only listen for vertical scroll notifications (ignore those
-              // from the nested horizontal SingleChildScrollView):
-              notificationPredicate: (ScrollNotification notification) =>
-                  notification.depth == 1,
-              child: ValueListenableBuilder<StackFrameAndSourcePosition?>(
-                valueListenable: widget
-                        .debuggerController?.selectedStackFrame ??
-                    const FixedValueListenable<StackFrameAndSourcePosition?>(
-                        null),
-                builder: (context, frame, _) {
-                  final pausedFrame = frame == null
-                      ? null
-                      : (frame.scriptRef == scriptRef ? frame : null);
+          child: Scrollbar(
+            key: CodeView.debuggerCodeViewVerticalScrollbarKey,
+            controller: textController,
+            thumbVisibility: true,
+            // Only listen for vertical scroll notifications (ignore those
+            // from the nested horizontal SingleChildScrollView):
+            notificationPredicate: (ScrollNotification notification) =>
+                notification.depth == 1,
+            child: ValueListenableBuilder<StackFrameAndSourcePosition?>(
+              valueListenable: widget.debuggerController?.selectedStackFrame ??
+                  const FixedValueListenable<StackFrameAndSourcePosition?>(
+                    null,
+                  ),
+              builder: (context, frame, _) {
+                final pausedFrame = frame == null
+                    ? null
+                    : (frame.scriptRef == scriptRef ? frame : null);
 
-                  return Row(
-                    children: [
-                      ValueListenableBuilder<List<BreakpointAndSourcePosition>>(
-                        valueListenable:
-                            breakpointManager.breakpointsWithLocation,
-                        builder: (context, breakpoints, _) {
-                          return Gutter(
-                            gutterWidth: gutterWidth,
-                            scrollController: gutterController,
-                            lineCount: widget.lineRange?.size ?? lines.length,
-                            lineOffset: (widget.lineRange?.begin ?? 1) - 1,
-                            pausedFrame: pausedFrame,
-                            breakpoints: breakpoints
-                                .where((bp) => bp.scriptRef == scriptRef)
-                                .toList(),
-                            executableLines: parsedScript != null
-                                ? parsedScript!.executableLines
-                                : <int>{},
-                            onPressed: _onPressed,
-                            // Disable dots for possible breakpoint locations.
-                            allowInteraction: 
-                            !(widget.debuggerController?.isSystemIsolate ?? false),
+                return Row(
+                  children: [
+                    ValueListenableBuilder<List<BreakpointAndSourcePosition>>(
+                      valueListenable:
+                          breakpointManager.breakpointsWithLocation,
+                      builder: (context, breakpoints, _) {
+                        return Gutter(
+                          gutterWidth: gutterWidth,
+                          scrollController: gutterController,
+                          lineCount: widget.lineRange?.size ?? lines.length,
+                          lineOffset: (widget.lineRange?.begin ?? 1) - 1,
+                          pausedFrame: pausedFrame,
+                          breakpoints: breakpoints
+                              .where((bp) => bp.scriptRef == scriptRef)
+                              .toList(),
+                          executableLines: parsedScript != null
+                              ? parsedScript!.executableLines
+                              : <int>{},
+                          onPressed: _onPressed,
+                          // Disable dots for possible breakpoint locations.
+                          allowInteraction:
+                              !(widget.debuggerController?.isSystemIsolate ??
+                                  false),
+                        );
+                      },
+                    ),
+                    const SizedBox(width: denseSpacing),
+                    Expanded(
+                      child: LayoutBuilder(
+                        builder: (context, constraints) {
+                          final double fileWidth = calculateTextSpanWidth(
+                            findLongestTextSpan(lines),
+                          );
+
+                          return Scrollbar(
+                            key:
+                                CodeView.debuggerCodeViewHorizontalScrollbarKey,
+                            thumbVisibility: true,
+                            controller: horizontalController,
+                            child: SingleChildScrollView(
+                              scrollDirection: Axis.horizontal,
+                              controller: horizontalController,
+                              child: SizedBox(
+                                height: constraints.maxHeight,
+                                width: math.max(
+                                  constraints.maxWidth,
+                                  fileWidth,
+                                ),
+                                child: Lines(
+                                  height: constraints.maxHeight,
+                                  codeViewController: widget.codeViewController,
+                                  scrollController: textController,
+                                  lines: lines,
+                                  pausedFrame: pausedFrame,
+                                  searchMatchesNotifier:
+                                      widget.codeViewController.searchMatches,
+                                  activeSearchMatchNotifier: widget
+                                      .codeViewController.activeSearchMatch,
+                                ),
+                              ),
+                            ),
                           );
                         },
                       ),
-                      const SizedBox(width: denseSpacing),
-                      Expanded(
-                        child: LayoutBuilder(
-                          builder: (context, constraints) {
-                            final double fileWidth = calculateTextSpanWidth(
-                              findLongestTextSpan(lines),
-                            );
-
-                            return Scrollbar(
-                              key: CodeView
-                                  .debuggerCodeViewHorizontalScrollbarKey,
-                              thumbVisibility: true,
-                              controller: horizontalController,
-                              child: SingleChildScrollView(
-                                scrollDirection: Axis.horizontal,
-                                controller: horizontalController,
-                                child: SizedBox(
-                                  height: constraints.maxHeight,
-                                  width: math.max(
-                                    constraints.maxWidth,
-                                    fileWidth,
-                                  ),
-                                  child: Lines(
-                                    height: constraints.maxHeight,
-                                    codeViewController:
-                                        widget.codeViewController,
-                                    scrollController: textController,
-                                    lines: lines,
-                                    pausedFrame: pausedFrame,
-                                    searchMatchesNotifier:
-                                        widget.codeViewController.searchMatches,
-                                    activeSearchMatchNotifier: widget
-                                        .codeViewController.activeSearchMatch,
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
-                  );
-                },
-              ),
+                    ),
+                  ],
+                );
+              },
             ),
           ),
         );
       } else {
-        return Expanded(
-          child: Center(
-            child: Text(
-              'No source available',
-              style: theme.textTheme.titleMedium,
-            ),
+        return Center(
+          child: Text(
+            'No source available',
+            style: theme.textTheme.titleMedium,
           ),
         );
       }
@@ -501,15 +497,14 @@ class _CodeViewState extends State<CodeView>
             enabled: widget.codeViewController.scriptsHistory.hasScripts,
           ),
         ],
-        contentBuilder: contentBuilder,
+        contentBuilder: (context, ScriptRef? scriptRef) {
+          return Expanded(
+            child: contentBuilder(context, scriptRef),
+          );
+        },
       );
     }
-    // TODO(bkonyi): this is a hack to deal with some Expanded elements
-    return Column(
-      children: [
-        contentBuilder(context, widget.scriptRef),
-      ],
-    );
+    return contentBuilder(context, widget.scriptRef);
   }
 
   Widget buildFileSearchField() {

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -20,7 +20,6 @@ import '../../shared/dialogs.dart';
 import '../../shared/globals.dart';
 import '../../shared/history_viewport.dart';
 import '../../shared/object_tree.dart';
-import '../../shared/split.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import '../../ui/colors.dart';
@@ -32,82 +31,13 @@ import 'codeview_controller.dart';
 import 'common.dart';
 import 'debugger_controller.dart';
 import 'debugger_model.dart';
-import 'debugger_screen.dart';
 import 'file_search.dart';
 import 'key_sets.dart';
-import 'program_explorer.dart';
 import 'program_explorer_model.dart';
 import 'variables.dart';
 
 final debuggerCodeViewSearchKey =
     GlobalKey(debugLabel: 'DebuggerCodeViewSearchKey');
-
-class CodeArea extends StatelessWidget {
-  const CodeArea({
-    required this.controller,
-    this.debuggerController,
-  });
-
-  final CodeViewController controller;
-  final DebuggerController? debuggerController;
-
-  void _onNodeSelected(VMServiceObjectNode? node) {
-    final location = node?.location;
-    if (location != null) {
-      controller.showScriptLocation(location);
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: controller.fileExplorerVisible,
-      builder: (context, visible, child) {
-        if (visible) {
-          // TODO(devoncarew): Animate this opening and closing.
-          return Split(
-            axis: Axis.horizontal,
-            initialFractions: const [0.70, 0.30],
-            children: [
-              child!,
-              ProgramExplorer(
-                controller: controller.programExplorerController,
-                onNodeSelected: _onNodeSelected,
-              ),
-            ],
-          );
-        } else {
-          return child!;
-        }
-      },
-      child: DualValueListenableBuilder<ScriptRef?, ParsedScript?>(
-        firstListenable: controller.currentScriptRef,
-        secondListenable: controller.currentParsedScript,
-        builder: (context, scriptRef, parsedScript, _) {
-          // TODO(bkonyi)
-          /*
-          if (scriptRef != null && parsedScript != null && !_shownFirstScript) {
-            ga.timeEnd(DebuggerScreen.id, analytics_constants.pageReady);
-            serviceManager.sendDwdsEvent(
-              screen: DebuggerScreen.id,
-              action: analytics_constants.pageReady,
-            );
-            _shownFirstScript = true;
-          }
-          */
-          return CodeView(
-            key: DebuggerScreenBody.codeViewKey,
-            codeViewController: controller,
-            debuggerController: debuggerController,
-            scriptRef: scriptRef,
-            parsedScript: parsedScript,
-            onSelected: breakpointManager.toggleBreakpoint,
-          );
-        },
-      ),
-    );
-  }
-}
 
 // TODO(kenz): consider moving lines / pausedPositions calculations to the
 // controller.

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -415,7 +415,7 @@ class _CodeViewState extends State<CodeView>
         return Center(
           child: Text(
             'No source available',
-            style: theme.textTheme.titleMedium,
+            style: theme.textTheme.subtitle1,
           ),
         );
       }

--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -25,6 +25,12 @@ class CodeViewController extends DisposableController
     scriptsHistory.current.addListener(_scriptHistoryListener);
   }
 
+  @override
+  void dispose() {
+    super.dispose();
+    scriptsHistory.current.removeListener(_scriptHistoryListener);
+  }
+
   ValueListenable<ScriptLocation?> get scriptLocation => _scriptLocation;
   final _scriptLocation = ValueNotifier<ScriptLocation?>(null);
 

--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -1,0 +1,266 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../config_specific/logger/logger.dart';
+import '../../primitives/auto_dispose.dart';
+import '../../primitives/history_manager.dart';
+import '../../shared/globals.dart';
+import '../../ui/search.dart';
+import 'debugger_model.dart';
+import 'program_explorer_controller.dart';
+import 'syntax_highlighter.dart';
+
+class CodeViewController extends DisposableController
+    with AutoDisposeControllerMixin, SearchControllerMixin<SourceToken> {
+  CodeViewController() {
+    _scriptHistoryListener = () {
+      final currentScriptValue = scriptsHistory.current.value;
+      if (currentScriptValue != null)
+        _showScriptLocation(ScriptLocation(currentScriptValue));
+    };
+    scriptsHistory.current.addListener(_scriptHistoryListener);
+  }
+
+  ValueListenable<ScriptLocation?> get scriptLocation => _scriptLocation;
+  final _scriptLocation = ValueNotifier<ScriptLocation?>(null);
+
+  ValueListenable<ScriptRef?> get currentScriptRef => _currentScriptRef;
+  final _currentScriptRef = ValueNotifier<ScriptRef?>(null);
+
+  ValueListenable<ParsedScript?> get currentParsedScript => parsedScript;
+  @visibleForTesting
+  final parsedScript = ValueNotifier<ParsedScript?>(null);
+
+  ValueListenable<bool> get showSearchInFileField => _showSearchInFileField;
+  final _showSearchInFileField = ValueNotifier<bool>(false);
+
+  ValueListenable<bool> get showFileOpener => _showFileOpener;
+  final _showFileOpener = ValueNotifier<bool>(false);
+
+  ValueListenable<bool> get fileExplorerVisible => _librariesVisible;
+  final _librariesVisible = ValueNotifier(false);
+
+  final programExplorerController = ProgramExplorerController();
+
+  final ScriptsHistory scriptsHistory = ScriptsHistory();
+  late VoidCallback _scriptHistoryListener;
+
+  void clearState() {
+    // It would be nice to not clear the script history but it is currently
+    // coupled to ScriptRef objects so that is unsafe.
+    scriptsHistory.clear();
+    _currentScriptRef.value = null;
+    _scriptLocation.value = null;
+    _librariesVisible.value = false;
+  }
+
+  void clearScriptHistory() {
+    scriptsHistory.clear();
+  }
+
+  /// Callback to be called when the debugger screen is first loaded.
+  ///
+  /// We delay calling this method until the debugger screen is first loaded
+  /// for performance reasons. None of the code here needs to be called when
+  /// DevTools first connects to an app, and doing so inhibits DevTools from
+  /// connecting to low-end devices.
+  Future<void> maybeSetupProgramExplorer() async {
+    await _maybeSetUpProgramExplorer();
+    addAutoDisposeListener(currentScriptRef, _maybeSetUpProgramExplorer);
+  }
+
+  Future<void> _maybeSetUpProgramExplorer() async {
+    if (!programExplorerController.initialized.value) {
+      programExplorerController
+        ..initListeners()
+        ..initialize();
+    }
+    if (currentScriptRef.value != null) {
+      await programExplorerController.selectScriptNode(currentScriptRef.value);
+      programExplorerController.resetOutline();
+    }
+  }
+
+  Future<Script?> getScriptForRef(ScriptRef ref) async {
+    final cachedScript = scriptManager.getScriptCached(ref);
+    if (cachedScript == null) {
+      return await scriptManager.getScript(ref);
+    }
+    return cachedScript;
+  }
+
+  /// Jump to the given ScriptRef and optional SourcePosition.
+  void showScriptLocation(ScriptLocation scriptLocation) {
+    // TODO(elliette): This is here so that when a program is selected in the
+    // program explorer, the file opener will close (if it was open). Instead,
+    // give the program explorer focus so that the focus changes so the file
+    // opener will close automatically when its focus is lost.
+    toggleFileOpenerVisibility(false);
+
+    _showScriptLocation(scriptLocation);
+
+    // Update the scripts history (and make sure we don't react to the
+    // subsequent event).
+    scriptsHistory.current.removeListener(_scriptHistoryListener);
+    scriptsHistory.pushEntry(scriptLocation.scriptRef);
+    scriptsHistory.current.addListener(_scriptHistoryListener);
+  }
+
+  /// Resets the current script information before invoking [showScriptLocation].
+  void resetScriptLocation(ScriptLocation scriptLocation) {
+    _scriptLocation.value = null;
+    _currentScriptRef.value = null;
+    parsedScript.value = null;
+    showScriptLocation(scriptLocation);
+  }
+
+  /// Show the given script location (without updating the script navigation
+  /// history).
+  void _showScriptLocation(ScriptLocation scriptLocation) {
+    _currentScriptRef.value = scriptLocation.scriptRef;
+    if (_currentScriptRef.value == null) {
+      log('Trying to show a location with a null script ref', LogLevel.error);
+    }
+
+    _parseCurrentScript();
+
+    // We want to notify regardless of the previous scriptLocation, temporarily
+    // set to null to ensure that happens.
+    _scriptLocation.value = null;
+    _scriptLocation.value = scriptLocation;
+  }
+
+  /// Parses the current script into executable lines and prepares the script
+  /// for syntax highlighting.
+  Future<void> _parseCurrentScript() async {
+    // Return early if the current script has not changed.
+    if (parsedScript.value?.script.id == _currentScriptRef.value?.id) return;
+
+    final scriptRef = _currentScriptRef.value;
+    if (scriptRef == null) return;
+    final script = await getScriptForRef(scriptRef);
+
+    // Create a new SyntaxHighlighter with the script's source in preparation
+    // for building the code view.
+    final highlighter = SyntaxHighlighter(source: script?.source ?? '');
+
+    // Gather the data to display breakable lines.
+    var executableLines = <int>{};
+
+    if (script != null) {
+      try {
+        final isolateRef = serviceManager.isolateManager.selectedIsolate.value;
+        final positions = await breakpointManager.getBreakablePositions(
+          isolateRef,
+          script,
+        );
+        executableLines = Set.from(positions.map((p) => p.line));
+      } catch (e) {
+        // Ignore - not supported for all vm service implementations.
+        log('$e');
+      }
+      parsedScript.value = ParsedScript(
+        script: script,
+        highlighter: highlighter,
+        executableLines: executableLines,
+      );
+    }
+  }
+
+  /// Make the 'Libraries' view on the right-hand side of the screen visible or
+  /// hidden.
+  void toggleLibrariesVisible() {
+    toggleFileOpenerVisibility(false);
+    _librariesVisible.value = !_librariesVisible.value;
+  }
+
+  void toggleSearchInFileVisibility(bool visible) {
+    _showSearchInFileField.value = visible;
+    if (!visible) {
+      resetSearch();
+    }
+  }
+
+  void toggleFileOpenerVisibility(bool visible) {
+    _showFileOpener.value = visible;
+  }
+
+  // TODO(kenz): search through previous matches when possible.
+  @override
+  List<SourceToken> matchesForSearch(
+    String search, {
+    bool searchPreviousMatches = false,
+  }) {
+    if (search.isEmpty || parsedScript.value == null) {
+      return [];
+    }
+    final matches = <SourceToken>[];
+    final caseInsensitiveSearch = search.toLowerCase();
+
+    final currentScript = parsedScript.value!;
+    for (int i = 0; i < currentScript.lines.length; i++) {
+      final line = currentScript.lines[i].toLowerCase();
+      final matchesForLine = caseInsensitiveSearch.allMatches(line);
+      if (matchesForLine.isNotEmpty) {
+        matches.addAll(
+          matchesForLine.map(
+            (m) => SourceToken(
+              position: SourcePosition(line: i, column: m.start),
+              length: m.end - m.start,
+            ),
+          ),
+        );
+      }
+    }
+    return matches;
+  }
+}
+
+/// Maintains the navigation history of the debugger's code area - which files
+/// were opened, whether it's possible to navigate forwards and backwards in the
+/// history, ...
+class ScriptsHistory extends HistoryManager<ScriptRef> {
+  // TODO(devoncarew): This class should also record and restore scroll
+  // positions.
+
+  final _openedScripts = <ScriptRef>{};
+
+  bool get hasScripts => _openedScripts.isNotEmpty;
+
+  void pushEntry(ScriptRef ref) {
+    if (ref == current.value) return;
+
+    while (hasNext) {
+      pop();
+    }
+
+    _openedScripts.remove(ref);
+    _openedScripts.add(ref);
+
+    push(ref);
+  }
+
+  Iterable<ScriptRef> get openedScripts => _openedScripts.toList().reversed;
+}
+
+class ParsedScript {
+  ParsedScript({
+    required this.script,
+    required this.highlighter,
+    required this.executableLines,
+  }) : lines = (script.source?.split('\n') ?? const []).toList();
+
+  final Script script;
+
+  final SyntaxHighlighter highlighter;
+
+  final Set<int> executableLines;
+
+  final List<String> lines;
+
+  int get lineCount => lines.length;
+}

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -119,8 +119,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
 
   Widget _librariesButton() {
     return ValueListenableBuilder<bool>(
-      valueListenable:
-          controller.codeViewController.fileExplorerVisible,
+      valueListenable: controller.codeViewController.fileExplorerVisible,
       builder: (context, visible, _) {
         return RoundedOutlinedBorder(
           child: Container(
@@ -128,8 +127,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
             child: DebuggerButton(
               title: 'File Explorer',
               icon: Icons.folder,
-              onPressed:
-                  controller.codeViewController.toggleLibrariesVisible,
+              onPressed: controller.codeViewController.toggleLibrariesVisible,
             ),
           ),
         );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -119,7 +119,8 @@ class _DebuggingControlsState extends State<DebuggingControls>
 
   Widget _librariesButton() {
     return ValueListenableBuilder<bool>(
-      valueListenable: controller.fileExplorerVisible,
+      valueListenable:
+          controller.debuggerCodeViewController.fileExplorerVisible,
       builder: (context, visible, _) {
         return RoundedOutlinedBorder(
           child: Container(
@@ -127,7 +128,8 @@ class _DebuggingControlsState extends State<DebuggingControls>
             child: DebuggerButton(
               title: 'File Explorer',
               icon: Icons.folder,
-              onPressed: controller.toggleLibrariesVisible,
+              onPressed:
+                  controller.debuggerCodeViewController.toggleLibrariesVisible,
             ),
           ),
         );

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -120,7 +120,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
   Widget _librariesButton() {
     return ValueListenableBuilder<bool>(
       valueListenable:
-          controller.debuggerCodeViewController.fileExplorerVisible,
+          controller.codeViewController.fileExplorerVisible,
       builder: (context, visible, _) {
         return RoundedOutlinedBorder(
           child: Container(
@@ -129,7 +129,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
               title: 'File Explorer',
               icon: Icons.folder,
               onPressed:
-                  controller.debuggerCodeViewController.toggleLibrariesVisible,
+                  controller.codeViewController.toggleLibrariesVisible,
             ),
           ),
         );

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -440,8 +440,7 @@ class DebuggerController extends DisposableController
     );
 
     // Redirect the current editor screen if necessary.
-    if (removedScripts
-        .contains(codeViewController.currentScriptRef.value)) {
+    if (removedScripts.contains(codeViewController.currentScriptRef.value)) {
       final uri = codeViewController.currentScriptRef.value!.uri;
       final newScriptRef =
           addedScripts.firstWhereOrNull((script) => script.uri == uri);

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -9,19 +9,15 @@ import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../config_specific/logger/logger.dart';
 import '../../primitives/auto_dispose.dart';
-import '../../primitives/history_manager.dart';
 import '../../primitives/message_bus.dart';
 import '../../primitives/utils.dart';
 import '../../service/isolate_state.dart';
 import '../../service/vm_service_wrapper.dart';
 import '../../shared/globals.dart';
 import '../../shared/object_tree.dart';
-import '../../ui/search.dart';
+import 'codeview_controller.dart';
 import 'debugger_model.dart';
-import 'program_explorer_controller.dart';
-import 'syntax_highlighter.dart';
 
 // TODO(devoncarew): Add some delayed resume value notifiers (to be used to
 // help debounce stepping operations).
@@ -31,24 +27,19 @@ final _log = DebugTimingLogger('debugger', mute: true);
 
 /// Responsible for managing the debug state of the app.
 class DebuggerController extends DisposableController
-    with AutoDisposeControllerMixin, SearchControllerMixin<SourceToken> {
+    with AutoDisposeControllerMixin {
   // `initialSwitchToIsolate` can be set to false for tests to skip the logic
   // in `switchToIsolate`.
   DebuggerController({this.initialSwitchToIsolate = true}) {
-    programExplorerController = ProgramExplorerController();
     autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable.listen(_handleConnectionAvailable),
     );
     if (serviceManager.hasService) {
       initialize();
     }
-    _scriptHistoryListener = () {
-      final currentScriptValue = scriptsHistory.current.value;
-      if (currentScriptValue != null)
-        _showScriptLocation(ScriptLocation(currentScriptValue));
-    };
-    scriptsHistory.current.addListener(_scriptHistoryListener);
   }
+
+  final debuggerCodeViewController = CodeViewController();
 
   bool _firstDebuggerScreenLoaded = false;
 
@@ -60,21 +51,7 @@ class DebuggerController extends DisposableController
   /// connecting to low-end devices.
   Future<void> onFirstDebuggerScreenLoad() async {
     if (!_firstDebuggerScreenLoaded) {
-      await _maybeSetUpProgramExplorer();
-      addAutoDisposeListener(currentScriptRef, _maybeSetUpProgramExplorer);
-      _firstDebuggerScreenLoaded = true;
-    }
-  }
-
-  Future<void> _maybeSetUpProgramExplorer() async {
-    if (!programExplorerController.initialized.value) {
-      programExplorerController
-        ..initListeners()
-        ..initialize();
-    }
-    if (currentScriptRef.value != null) {
-      await programExplorerController.selectScriptNode(currentScriptRef.value);
-      programExplorerController.resetOutline();
+      await debuggerCodeViewController.maybeSetupProgramExplorer();
     }
   }
 
@@ -85,22 +62,15 @@ class DebuggerController extends DisposableController
     _hasTruncatedFrames.value = false;
     _getStackOperation?.cancel();
     _getStackOperation = null;
-    // It would be nice to not clear the script history but it is currently
-    // coupled to ScriptRef objects so that is unsafe.
-    scriptsHistory.clear();
+
     isolateRef = null;
     _isPaused.value = false;
     _resuming.value = false;
     _lastEvent = null;
-    _currentScriptRef.value = null;
-    _scriptLocation.value = null;
     _stackFramesWithLocation.value = [];
     _selectedStackFrame.value = null;
     _variables.value = [];
-    _breakpoints.value = [];
-    _breakpointsWithLocation.value = [];
     _selectedBreakpoint.value = null;
-    _librariesVisible.value = false;
     _firstDebuggerScreenLoaded = false;
   }
 
@@ -155,11 +125,6 @@ class DebuggerController extends DisposableController
   final libraryMemberAndImportsAutocompleteCache =
       <LibraryRef, Future<Set<String?>>>{};
 
-  late final ProgramExplorerController programExplorerController;
-
-  final ScriptsHistory scriptsHistory = ScriptsHistory();
-  late VoidCallback _scriptHistoryListener;
-
   final _isPaused = ValueNotifier<bool>(false);
 
   ValueListenable<bool> get isPaused => _isPaused;
@@ -174,110 +139,7 @@ class DebuggerController extends DisposableController
 
   Event? get lastEvent => _lastEvent;
 
-  final _currentScriptRef = ValueNotifier<ScriptRef?>(null);
-
-  ValueListenable<ScriptRef?> get currentScriptRef => _currentScriptRef;
-
-  @visibleForTesting
-  final parsedScript = ValueNotifier<ParsedScript?>(null);
-
-  ValueListenable<ParsedScript?> get currentParsedScript => parsedScript;
-
-  ValueListenable<bool> get showSearchInFileField => _showSearchInFileField;
-
-  final _showSearchInFileField = ValueNotifier<bool>(false);
-
-  ValueListenable<ScriptLocation?> get scriptLocation => _scriptLocation;
-
-  final _scriptLocation = ValueNotifier<ScriptLocation?>(null);
-
-  ValueListenable<bool> get showFileOpener => _showFileOpener;
-
-  final _showFileOpener = ValueNotifier<bool>(false);
-
   final _clazzCache = <ClassRef, Class>{};
-
-  /// Jump to the given ScriptRef and optional SourcePosition.
-  void showScriptLocation(ScriptLocation scriptLocation) {
-    // TODO(elliette): This is here so that when a program is selected in the
-    // program explorer, the file opener will close (if it was open). Instead,
-    // give the program explorer focus so that the focus changes so the file
-    // opener will close automatically when its focus is lost.
-    toggleFileOpenerVisibility(false);
-
-    _showScriptLocation(scriptLocation);
-
-    // Update the scripts history (and make sure we don't react to the
-    // subsequent event).
-    scriptsHistory.current.removeListener(_scriptHistoryListener);
-    scriptsHistory.pushEntry(scriptLocation.scriptRef);
-    scriptsHistory.current.addListener(_scriptHistoryListener);
-  }
-
-  /// Resets the current script information before invoking [showScriptLocation].
-  void resetScriptLocation(ScriptLocation scriptLocation) {
-    _scriptLocation.value = null;
-    _currentScriptRef.value = null;
-    parsedScript.value = null;
-    showScriptLocation(scriptLocation);
-  }
-
-  /// Show the given script location (without updating the script navigation
-  /// history).
-  void _showScriptLocation(ScriptLocation scriptLocation) {
-    _currentScriptRef.value = scriptLocation.scriptRef;
-    if (_currentScriptRef.value == null) {
-      log('Trying to show a location with a null script ref', LogLevel.error);
-    }
-
-    _parseCurrentScript();
-
-    // We want to notify regardless of the previous scriptLocation, temporarily
-    // set to null to ensure that happens.
-    _scriptLocation.value = null;
-    _scriptLocation.value = scriptLocation;
-  }
-
-  Future<Script?> getScriptForRef(ScriptRef ref) async {
-    final cachedScript = scriptManager.getScriptCached(ref);
-    if (cachedScript == null) {
-      return await scriptManager.getScript(ref);
-    }
-    return cachedScript;
-  }
-
-  /// Parses the current script into executable lines and prepares the script
-  /// for syntax highlighting.
-  Future<void> _parseCurrentScript() async {
-    // Return early if the current script has not changed.
-    if (parsedScript.value?.script.id == _currentScriptRef.value?.id) return;
-
-    final scriptRef = _currentScriptRef.value;
-    if (scriptRef == null) return;
-    final script = await getScriptForRef(scriptRef);
-
-    // Create a new SyntaxHighlighter with the script's source in preparation
-    // for building the code view.
-    final highlighter = SyntaxHighlighter(source: script?.source ?? '');
-
-    // Gather the data to display breakable lines.
-    var executableLines = <int>{};
-
-    if (script != null) {
-      try {
-        final positions = await getBreakablePositions(script);
-        executableLines = Set.from(positions.map((p) => p.line));
-      } catch (e) {
-        // Ignore - not supported for all vm service implementations.
-        log('$e');
-      }
-      parsedScript.value = ParsedScript(
-        script: script,
-        highlighter: highlighter,
-        executableLines: executableLines,
-      );
-    }
-  }
 
   /// Find the owner library for a ClassRef, FuncRef, or LibraryRef.
   ///
@@ -329,16 +191,6 @@ class DebuggerController extends DisposableController
 
   ValueListenable<List<DartObjectNode>> get variables => _variables;
 
-  final _breakpoints = ValueNotifier<List<Breakpoint>>([]);
-
-  ValueListenable<List<Breakpoint>> get breakpoints => _breakpoints;
-
-  final _breakpointsWithLocation =
-      ValueNotifier<List<BreakpointAndSourcePosition>>([]);
-
-  ValueListenable<List<BreakpointAndSourcePosition>>
-      get breakpointsWithLocation => _breakpointsWithLocation;
-
   final _selectedBreakpoint = ValueNotifier<BreakpointAndSourcePosition?>(null);
 
   ValueListenable<BreakpointAndSourcePosition?> get selectedBreakpoint =>
@@ -348,17 +200,6 @@ class DebuggerController extends DisposableController
       ValueNotifier<String>(ExceptionPauseMode.kUnhandled);
 
   ValueListenable<String?> get exceptionPauseMode => _exceptionPauseMode;
-
-  final _librariesVisible = ValueNotifier(false);
-
-  ValueListenable<bool> get fileExplorerVisible => _librariesVisible;
-
-  /// Make the 'Libraries' view on the right-hand side of the screen visible or
-  /// hidden.
-  void toggleLibrariesVisible() {
-    toggleFileOpenerVisibility(false);
-    _librariesVisible.value = !_librariesVisible.value;
-  }
 
   IsolateRef? isolateRef;
 
@@ -379,11 +220,9 @@ class DebuggerController extends DisposableController
 
     _clearCaches();
 
-    scriptsHistory.clear();
+    debuggerCodeViewController.clearScriptHistory();
 
     if (ref == null) {
-      _breakpoints.value = [];
-      _breakpointsWithLocation.value = [];
       await _getStackOperation?.cancel();
       _populateFrameInfo([], truncated: false);
       return;
@@ -404,19 +243,6 @@ class DebuggerController extends DisposableController
       // Current request is obsolete.
       return;
     }
-
-    _breakpoints.value = isolate.breakpoints ?? [];
-
-    // Build _breakpointsWithLocation from _breakpoints.
-    // ignore: unawaited_futures
-    Future.wait(_breakpoints.value.map(_createBreakpointWithLocation))
-        .then((list) {
-      if (isolate.id != _isolateRefId) {
-        // Current request is obsolete.
-        return;
-      }
-      _breakpointsWithLocation.value = list.toList()..sort();
-    });
 
     _exceptionPauseMode.value =
         isolate.exceptionPauseMode ?? ExceptionPauseMode.kUnhandled;
@@ -523,46 +349,6 @@ class DebuggerController extends DisposableController
     );
   }
 
-  Future<void> clearBreakpoints() async {
-    final breakpoints = _breakpoints.value.toList();
-    await Future.forEach(breakpoints, (Breakpoint breakpoint) {
-      return removeBreakpoint(breakpoint);
-    });
-  }
-
-  Future<Breakpoint> addBreakpoint(String scriptId, int line) =>
-      _service.addBreakpoint(_isolateRefId, scriptId, line);
-
-  Future<void> removeBreakpoint(Breakpoint breakpoint) =>
-      _service.removeBreakpoint(_isolateRefId, breakpoint.id!);
-
-  Future<void> toggleBreakpoint(ScriptRef script, int line) async {
-    if (serviceManager.isolateManager.selectedIsolate.value == null) {
-      // Can't toggle breakpoints if we don't have an isolate.
-      return;
-    }
-    // The VM doesn't support debugging for system isolates and will crash on
-    // a failed assert in debug mode. Disable the toggle breakpoint
-    // functionality for system isolates.
-    if (serviceManager.isolateManager.selectedIsolate.value!.isSystemIsolate!) {
-      return;
-    }
-
-    final bp = breakpointsWithLocation.value.firstWhereOrNull((bp) {
-      return bp.scriptRef == script && bp.line == line;
-    });
-
-    if (bp != null) {
-      await removeBreakpoint(bp.breakpoint);
-    } else {
-      try {
-        await addBreakpoint(script.id!, line);
-      } catch (_) {
-        // ignore errors setting breakpoints
-      }
-    }
-  }
-
   Future<void> setIsolatePauseMode(String mode) async {
     await _service.setIsolatePauseMode(
       _isolateRefId,
@@ -613,63 +399,6 @@ class DebuggerController extends DisposableController
         _resuming.value = false;
         _pause(true, pauseEvent: event);
         break;
-      // TODO(djshuckerow): switch the _breakpoints notifier to a 'ListNotifier'
-      // that knows how to notify when performing a list edit operation.
-      case EventKind.kBreakpointAdded:
-        final breakpoint = event.breakpoint!;
-        _breakpoints.value = [..._breakpoints.value, breakpoint];
-
-        // ignore: unawaited_futures
-        _createBreakpointWithLocation(breakpoint).then((bp) {
-          final list = [
-            ..._breakpointsWithLocation.value,
-            bp,
-          ]..sort();
-
-          _breakpointsWithLocation.value = list;
-        });
-
-        break;
-      case EventKind.kBreakpointResolved:
-        final breakpoint = event.breakpoint!;
-        _breakpoints.value = [
-          for (var b in _breakpoints.value)
-            if (b != event.breakpoint) b,
-          breakpoint
-        ];
-
-        // ignore: unawaited_futures
-        _createBreakpointWithLocation(breakpoint).then((bp) {
-          final list = _breakpointsWithLocation.value.toList();
-          // Remote the bp with the older, unresolved information from the list.
-          list.removeWhere((breakpoint) => bp.breakpoint.id == bp.id);
-          // Add the bp with the newer, resolved information.
-          list.add(bp);
-          list.sort();
-          _breakpointsWithLocation.value = list;
-        });
-
-        break;
-
-      case EventKind.kBreakpointRemoved:
-        final breakpoint = event.breakpoint;
-
-        // Update _selectedBreakpoint if necessary.
-        if (_selectedBreakpoint.value?.breakpoint == breakpoint) {
-          _selectedBreakpoint.value = null;
-        }
-
-        _breakpoints.value = [
-          for (var b in _breakpoints.value)
-            if (b != breakpoint) b
-        ];
-
-        _breakpointsWithLocation.value = [
-          for (var b in _breakpointsWithLocation.value)
-            if (b.breakpoint != breakpoint) b
-        ];
-
-        break;
     }
   }
 
@@ -710,12 +439,10 @@ class DebuggerController extends DisposableController
       ),
     );
 
-    // Update breakpoints.
-    _updateBreakpointsAfterReload(removedScripts, addedScripts);
-
     // Redirect the current editor screen if necessary.
-    if (removedScripts.contains(currentScriptRef.value)) {
-      final uri = currentScriptRef.value!.uri;
+    if (removedScripts
+        .contains(debuggerCodeViewController.currentScriptRef.value)) {
+      final uri = debuggerCodeViewController.currentScriptRef.value!.uri;
       final newScriptRef =
           addedScripts.firstWhereOrNull((script) => script.uri == uri);
 
@@ -732,42 +459,8 @@ class DebuggerController extends DisposableController
   /// cache, in order to reduce flashing in the editor view.
   void _populateScriptAndShowLocation(ScriptRef scriptRef) {
     scriptManager.getScript(scriptRef).then((script) {
-      showScriptLocation(ScriptLocation(scriptRef));
+      debuggerCodeViewController.showScriptLocation(ScriptLocation(scriptRef));
     });
-  }
-
-  void _updateBreakpointsAfterReload(
-    Set<ScriptRef> removedScripts,
-    Set<ScriptRef> addedScripts,
-  ) {
-    // TODO(devoncarew): We need to coordinate this with other debugger clients
-    // as well as pause before re-setting the breakpoints.
-
-    final breakpointsToRemove = <BreakpointAndSourcePosition>[];
-
-    // Find all breakpoints set in files where we have newer versions of those
-    // files.
-    for (final scriptRef in removedScripts) {
-      for (final bp in breakpointsWithLocation.value) {
-        if (bp.scriptRef == scriptRef) {
-          breakpointsToRemove.add(bp);
-        }
-      }
-    }
-
-    // Remove the breakpoints.
-    for (final bp in breakpointsToRemove) {
-      removeBreakpoint(bp.breakpoint);
-    }
-
-    // Add them back to the newer versions of those scripts.
-    for (final scriptRef in addedScripts) {
-      for (final bp in breakpointsToRemove) {
-        if (scriptRef.uri == bp.scriptUri) {
-          addBreakpoint(scriptRef.id!, bp.line!);
-        }
-      }
-    }
   }
 
   final _hasTruncatedFrames = ValueNotifier<bool>(false);
@@ -869,7 +562,7 @@ class DebuggerController extends DisposableController
 
   void _clearCaches() {
     _lastEvent = null;
-    _breakPositionsMap.clear();
+    breakpointManager.clearCache();
     _clearAutocompleteCaches();
   }
 
@@ -901,20 +594,6 @@ class DebuggerController extends DisposableController
     }
   }
 
-  Future<BreakpointAndSourcePosition> _createBreakpointWithLocation(
-    Breakpoint breakpoint,
-  ) async {
-    if (breakpoint.resolved!) {
-      final bp = BreakpointAndSourcePosition.create(breakpoint);
-      return scriptManager.getScript(bp.scriptRef!).then((Script script) {
-        final pos = SourcePosition.calculatePosition(script, bp.tokenPos!);
-        return BreakpointAndSourcePosition.create(breakpoint, pos);
-      });
-    } else {
-      return BreakpointAndSourcePosition.create(breakpoint);
-    }
-  }
-
   Future<StackFrameAndSourcePosition> _createStackFrameWithLocation(
     Frame frame,
   ) async {
@@ -936,9 +615,9 @@ class DebuggerController extends DisposableController
     if (scriptRef == null) return;
 
     if (bp.sourcePosition == null) {
-      showScriptLocation(ScriptLocation(scriptRef));
+      debuggerCodeViewController.showScriptLocation(ScriptLocation(scriptRef));
     } else {
-      showScriptLocation(
+      debuggerCodeViewController.showScriptLocation(
         ScriptLocation(scriptRef, location: bp.sourcePosition),
       );
     }
@@ -956,7 +635,9 @@ class DebuggerController extends DisposableController
     final scriptRef = frame?.scriptRef;
     final position = frame?.position;
     if (scriptRef != null && position != null) {
-      showScriptLocation(ScriptLocation(scriptRef, location: position));
+      debuggerCodeViewController.showScriptLocation(
+        ScriptLocation(scriptRef, location: position),
+      );
     }
   }
 
@@ -1010,109 +691,6 @@ class DebuggerController extends DisposableController
 
     return frames;
   }
-
-  final Map<String, List<SourcePosition>> _breakPositionsMap = {};
-
-  /// Return the list of valid positions for breakpoints for a given script.
-  Future<List<SourcePosition>> getBreakablePositions(Script script) async {
-    final key = script.id;
-    if (key == null) return [];
-    if (!_breakPositionsMap.containsKey(key)) {
-      _breakPositionsMap[key] = await _getBreakablePositions(script);
-    }
-
-    return _breakPositionsMap[key] ?? [];
-  }
-
-  Future<List<SourcePosition>> _getBreakablePositions(Script script) async {
-    final report = await _service.getSourceReport(
-      _isolateRefId,
-      [SourceReportKind.kPossibleBreakpoints],
-      scriptId: script.id,
-      forceCompile: true,
-    );
-
-    final positions = <SourcePosition>[];
-
-    for (SourceReportRange range in report.ranges!) {
-      final possibleBreakpoints = range.possibleBreakpoints;
-      if (possibleBreakpoints != null) {
-        for (int tokenPos in possibleBreakpoints) {
-          positions.add(SourcePosition.calculatePosition(script, tokenPos));
-        }
-      }
-    }
-
-    return positions;
-  }
-
-  void toggleSearchInFileVisibility(bool visible) {
-    _showSearchInFileField.value = visible;
-    if (!visible) {
-      resetSearch();
-    }
-  }
-
-  void toggleFileOpenerVisibility(bool visible) {
-    _showFileOpener.value = visible;
-  }
-
-  // TODO(kenz): search through previous matches when possible.
-  @override
-  List<SourceToken> matchesForSearch(
-    String search, {
-    bool searchPreviousMatches = false,
-  }) {
-    if (search.isEmpty || parsedScript.value == null) {
-      return [];
-    }
-    final matches = <SourceToken>[];
-    final caseInsensitiveSearch = search.toLowerCase();
-
-    final currentScript = parsedScript.value!;
-    for (int i = 0; i < currentScript.lines.length; i++) {
-      final line = currentScript.lines[i].toLowerCase();
-      final matchesForLine = caseInsensitiveSearch.allMatches(line);
-      if (matchesForLine.isNotEmpty) {
-        matches.addAll(
-          matchesForLine.map(
-            (m) => SourceToken(
-              position: SourcePosition(line: i, column: m.start),
-              length: m.end - m.start,
-            ),
-          ),
-        );
-      }
-    }
-    return matches;
-  }
-}
-
-/// Maintains the navigation history of the debugger's code area - which files
-/// were opened, whether it's possible to navigate forwards and backwards in the
-/// history, ...
-class ScriptsHistory extends HistoryManager<ScriptRef> {
-  // TODO(devoncarew): This class should also record and restore scroll
-  // positions.
-
-  final _openedScripts = <ScriptRef>{};
-
-  bool get hasScripts => _openedScripts.isNotEmpty;
-
-  void pushEntry(ScriptRef ref) {
-    if (ref == current.value) return;
-
-    while (hasNext) {
-      pop();
-    }
-
-    _openedScripts.remove(ref);
-    _openedScripts.add(ref);
-
-    push(ref);
-  }
-
-  Iterable<ScriptRef> get openedScripts => _openedScripts.toList().reversed;
 }
 
 /// Store and manipulate the expression evaluation history.
@@ -1169,22 +747,4 @@ class _StackInfo {
 
   final List<StackFrameAndSourcePosition> frames;
   final bool truncated;
-}
-
-class ParsedScript {
-  ParsedScript({
-    required this.script,
-    required this.highlighter,
-    required this.executableLines,
-  }) : lines = (script.source?.split('\n') ?? const []).toList();
-
-  final Script script;
-
-  final SyntaxHighlighter highlighter;
-
-  final Set<int> executableLines;
-
-  final List<String> lines;
-
-  int get lineCount => lines.length;
 }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -214,6 +214,14 @@ class DebuggerController extends DisposableController
     scriptsHistory.current.addListener(_scriptHistoryListener);
   }
 
+  /// Resets the current script information before invoking [showScriptLocation].
+  void resetScriptLocation(ScriptLocation scriptLocation) {
+    _scriptLocation.value = null;
+    _currentScriptRef.value = null;
+    parsedScript.value = null;
+    showScriptLocation(scriptLocation);
+  }
+
   /// Show the given script location (without updating the script navigation
   /// history).
   void _showScriptLocation(ScriptLocation scriptLocation) {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -39,7 +39,7 @@ class DebuggerController extends DisposableController
     }
   }
 
-  final debuggerCodeViewController = CodeViewController();
+  final codeViewController = CodeViewController();
 
   bool _firstDebuggerScreenLoaded = false;
 
@@ -51,7 +51,7 @@ class DebuggerController extends DisposableController
   /// connecting to low-end devices.
   Future<void> onFirstDebuggerScreenLoad() async {
     if (!_firstDebuggerScreenLoaded) {
-      await debuggerCodeViewController.maybeSetupProgramExplorer();
+      await codeViewController.maybeSetupProgramExplorer();
     }
   }
 
@@ -220,7 +220,7 @@ class DebuggerController extends DisposableController
 
     _clearCaches();
 
-    debuggerCodeViewController.clearScriptHistory();
+    codeViewController.clearScriptHistory();
 
     if (ref == null) {
       await _getStackOperation?.cancel();
@@ -441,8 +441,8 @@ class DebuggerController extends DisposableController
 
     // Redirect the current editor screen if necessary.
     if (removedScripts
-        .contains(debuggerCodeViewController.currentScriptRef.value)) {
-      final uri = debuggerCodeViewController.currentScriptRef.value!.uri;
+        .contains(codeViewController.currentScriptRef.value)) {
+      final uri = codeViewController.currentScriptRef.value!.uri;
       final newScriptRef =
           addedScripts.firstWhereOrNull((script) => script.uri == uri);
 
@@ -459,7 +459,7 @@ class DebuggerController extends DisposableController
   /// cache, in order to reduce flashing in the editor view.
   void _populateScriptAndShowLocation(ScriptRef scriptRef) {
     scriptManager.getScript(scriptRef).then((script) {
-      debuggerCodeViewController.showScriptLocation(ScriptLocation(scriptRef));
+      codeViewController.showScriptLocation(ScriptLocation(scriptRef));
     });
   }
 
@@ -615,9 +615,9 @@ class DebuggerController extends DisposableController
     if (scriptRef == null) return;
 
     if (bp.sourcePosition == null) {
-      debuggerCodeViewController.showScriptLocation(ScriptLocation(scriptRef));
+      codeViewController.showScriptLocation(ScriptLocation(scriptRef));
     } else {
-      debuggerCodeViewController.showScriptLocation(
+      codeViewController.showScriptLocation(
         ScriptLocation(scriptRef, location: bp.sourcePosition),
       );
     }
@@ -635,7 +635,7 @@ class DebuggerController extends DisposableController
     final scriptRef = frame?.scriptRef;
     final position = frame?.position;
     if (scriptRef != null && position != null) {
-      debuggerCodeViewController.showScriptLocation(
+      codeViewController.showScriptLocation(
         ScriptLocation(scriptRef, location: position),
       );
     }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -121,7 +121,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    final codeViewController = controller.debuggerCodeViewController;
+    final codeViewController = controller.codeViewController;
     return Split(
       axis: Axis.horizontal,
       initialFractions: const [0.25, 0.75],
@@ -192,7 +192,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   void _onNodeSelected(VMServiceObjectNode? node) {
     final location = node?.location;
     if (location != null) {
-      controller.debuggerCodeViewController.showScriptLocation(location);
+      controller.codeViewController.showScriptLocation(location);
     }
   }
 
@@ -277,9 +277,9 @@ class GoToLineNumberAction extends Action<GoToLineNumberIntent> {
   void invoke(GoToLineNumberIntent intent) {
     showGoToLineDialog(
       intent._context,
-      intent._controller.debuggerCodeViewController,
+      intent._controller.codeViewController,
     );
-    intent._controller.debuggerCodeViewController
+    intent._controller.codeViewController
       ..toggleFileOpenerVisibility(false)
       ..toggleSearchInFileVisibility(false);
   }
@@ -294,7 +294,7 @@ class SearchInFileIntent extends Intent {
 class SearchInFileAction extends Action<SearchInFileIntent> {
   @override
   void invoke(SearchInFileIntent intent) {
-    intent._controller.debuggerCodeViewController
+    intent._controller.codeViewController
       ..toggleSearchInFileVisibility(true)
       ..toggleFileOpenerVisibility(false);
   }
@@ -309,7 +309,7 @@ class EscapeIntent extends Intent {
 class EscapeAction extends Action<EscapeIntent> {
   @override
   void invoke(EscapeIntent intent) {
-    intent._controller.debuggerCodeViewController
+    intent._controller.codeViewController
       ..toggleSearchInFileVisibility(false)
       ..toggleFileOpenerVisibility(false);
   }
@@ -324,7 +324,7 @@ class OpenFileIntent extends Intent {
 class OpenFileAction extends Action<OpenFileIntent> {
   @override
   void invoke(OpenFileIntent intent) {
-    intent._controller.debuggerCodeViewController
+    intent._controller.codeViewController
       ..toggleFileOpenerVisibility(true)
       ..toggleSearchInFileVisibility(false);
   }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -121,13 +121,7 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
 
   @override
   Widget build(BuildContext context) {
-    final codeArea = CodeArea(
-      controller: controller.debuggerCodeViewController,
-      debuggerController: controller,
-    );
-
     final codeViewController = controller.debuggerCodeViewController;
-
     return Split(
       axis: Axis.horizontal,
       initialFractions: const [0.25, 0.75],
@@ -163,8 +157,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                   firstListenable: codeViewController.currentScriptRef,
                   secondListenable: codeViewController.currentParsedScript,
                   builder: (context, scriptRef, parsedScript, _) {
-                    // TODO(bkonyi)
-
                     if (scriptRef != null &&
                         parsedScript != null &&
                         !_shownFirstScript) {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -161,7 +161,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                         parsedScript != null &&
                         !_shownFirstScript) {
                       ga.timeEnd(
-                          DebuggerScreen.id, analytics_constants.pageReady);
+                        DebuggerScreen.id,
+                        analytics_constants.pageReady,
+                      );
                       serviceManager.sendDwdsEvent(
                         screen: DebuggerScreen.id,
                         action: analytics_constants.pageReady,

--- a/packages/devtools_app/lib/src/screens/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/file_search.dart
@@ -11,7 +11,7 @@ import '../../primitives/auto_dispose_mixin.dart';
 import '../../primitives/utils.dart';
 import '../../shared/globals.dart';
 import '../../ui/search.dart';
-import 'debugger_controller.dart';
+import 'codeview_controller.dart';
 import 'debugger_model.dart';
 
 const int numOfMatchesToShow = 10;
@@ -20,10 +20,10 @@ final _fileNamesCache = <String, String>{};
 
 class FileSearchField extends StatefulWidget {
   const FileSearchField({
-    required this.debuggerController,
+    required this.codeViewController,
   });
 
-  final DebuggerController debuggerController;
+  final CodeViewController codeViewController;
 
   @override
   FileSearchFieldState createState() => FileSearchFieldState();
@@ -127,13 +127,13 @@ class FileSearchFieldState extends State<FileSearchField>
 
   void _onSelection(String scriptUri) {
     final scriptRef = _scriptsCache[scriptUri]!;
-    widget.debuggerController.showScriptLocation(ScriptLocation(scriptRef));
+    widget.codeViewController.showScriptLocation(ScriptLocation(scriptRef));
     _onClose();
   }
 
   void _onClose() {
     autoCompleteController.closeAutoCompleteOverlay();
-    widget.debuggerController.toggleFileOpenerVisibility(false);
+    widget.codeViewController.toggleFileOpenerVisibility(false);
     _fileNamesCache.clear();
     _scriptsCache.clear();
   }

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import '../../primitives/utils.dart';
 import '../../shared/theme.dart';
 import 'span_parser.dart';
 
@@ -22,6 +23,7 @@ class SyntaxHighlighter {
   }
 
   final String source;
+  late String _processedSource;
 
   final _spanStack = ListQueue<ScopeSpan>();
 
@@ -43,15 +45,26 @@ class SyntaxHighlighter {
     }
   }
 
-  TextSpan highlight(BuildContext context) {
+  /// Returns the highlighted [source] in [TextSpan] form.
+  ///
+  /// If [lineRange] is provided, only the lines between
+  /// `[lineRange.begin, lineRange.end)` will be returned.
+  TextSpan highlight(BuildContext context, {LineRange? lineRange}) {
     // Generate the styling for the various scopes based on the current theme.
     _scopeStyles = _buildSyntaxColorTable(Theme.of(context));
     _currentPosition = 0;
+    _processedSource = source;
+    if (lineRange != null) {
+      _processedSource = _processedSource
+          .split('\n')
+          .sublist(lineRange.begin - 1, lineRange.end - 1)
+          .join('\n');
+    }
     return TextSpan(
       children: _highlightLoopHelper(
         currentScope: null,
-        loopCondition: () => _currentPosition < source.length,
-        scopes: SpanParser.parse(_grammar!, source),
+        loopCondition: () => _currentPosition < _processedSource.length,
+        scopes: SpanParser.parse(_grammar!, _processedSource),
       ),
     );
   }
@@ -107,7 +120,7 @@ class SyntaxHighlighter {
       if (scopes.isNotEmpty && scopes.first.contains(_currentPosition)) {
         // Encountered the next scoped span. Close the current span and enter
         // the next.
-        final text = source.substring(
+        final text = _processedSource.substring(
           currentScopeBegin!,
           _currentPosition,
         );
@@ -139,7 +152,7 @@ class SyntaxHighlighter {
     }
     // Reached the end of the text covered by the current span. Close the span
     // and exit the scope.
-    final text = source.substring(
+    final text = _processedSource.substring(
       currentScopeBegin!,
       _currentPosition,
     );
@@ -158,10 +171,11 @@ class SyntaxHighlighter {
   }
 
   bool _atNewline() =>
-      String.fromCharCode(source.codeUnitAt(_currentPosition)) == '\n';
+      String.fromCharCode(_processedSource.codeUnitAt(_currentPosition)) ==
+      '\n';
 
   int? _processNewlines(List<TextSpan> sourceSpans, int currentScopeBegin) {
-    final text = source.substring(
+    final text = _processedSource.substring(
       currentScopeBegin,
       _currentPosition,
     );
@@ -169,7 +183,7 @@ class SyntaxHighlighter {
       sourceSpans.add(
         TextSpan(
           style: _getStyleForSpan(),
-          text: source.substring(
+          text: _processedSource.substring(
             currentScopeBegin,
             _currentPosition,
           ),
@@ -181,8 +195,9 @@ class SyntaxHighlighter {
     do {
       sourceSpans.add(const TextSpan(text: '\n'));
       ++_currentPosition;
-    } while ((_currentPosition < source.length) &&
-        (String.fromCharCode(source.codeUnitAt(_currentPosition)) == '\n'));
+    } while ((_currentPosition < _processedSource.length) &&
+        (String.fromCharCode(_processedSource.codeUnitAt(_currentPosition)) ==
+            '\n'));
     return _currentPosition;
   }
 

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -48,7 +48,7 @@ class SyntaxHighlighter {
   /// Returns the highlighted [source] in [TextSpan] form.
   ///
   /// If [lineRange] is provided, only the lines between
-  /// `[lineRange.begin, lineRange.end)` will be returned.
+  /// `[lineRange.begin, lineRange.end]` will be returned.
   TextSpan highlight(BuildContext context, {LineRange? lineRange}) {
     // Generate the styling for the various scopes based on the current theme.
     _scopeStyles = _buildSyntaxColorTable(Theme.of(context));
@@ -57,7 +57,7 @@ class SyntaxHighlighter {
     if (lineRange != null) {
       _processedSource = _processedSource
           .split('\n')
-          .sublist(lineRange.begin - 1, lineRange.end - 1)
+          .sublist(lineRange.begin - 1, lineRange.end)
           .join('\n');
     }
     return TextSpan(

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -50,8 +50,6 @@ class ObjectInspectorViewController extends DisposableController
       programExplorerController
         ..initialize()
         ..initListeners();
-      // TODO(bkonyi):
-//      codeViewController.initialize();
       selectAndPushMainScript();
       _initialized = true;
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -8,7 +8,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose.dart';
 import '../../shared/globals.dart';
-import '../debugger/debugger_controller.dart';
+import '../debugger/codeview_controller.dart';
 import '../debugger/program_explorer_controller.dart';
 import 'object_viewport.dart';
 import 'vm_object_model.dart';
@@ -32,7 +32,7 @@ class ObjectInspectorViewController extends DisposableController
   final programExplorerController =
       ProgramExplorerController(showCodeNodes: true);
 
-  final debuggerController = DebuggerController();
+  final codeViewController = CodeViewController();
 
   final objectHistory = ObjectHistory();
 
@@ -50,7 +50,8 @@ class ObjectInspectorViewController extends DisposableController
       programExplorerController
         ..initialize()
         ..initListeners();
-      debuggerController.initialize();
+        // TODO(bkonyi):
+//      codeViewController.initialize();
       selectAndPushMainScript();
       _initialized = true;
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -50,7 +50,7 @@ class ObjectInspectorViewController extends DisposableController
       programExplorerController
         ..initialize()
         ..initListeners();
-        // TODO(bkonyi):
+      // TODO(bkonyi):
 //      codeViewController.initialize();
       selectAndPushMainScript();
       _initialized = true;

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -8,6 +8,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/auto_dispose.dart';
 import '../../shared/globals.dart';
+import '../debugger/debugger_controller.dart';
 import '../debugger/program_explorer_controller.dart';
 import 'object_viewport.dart';
 import 'vm_object_model.dart';
@@ -31,6 +32,8 @@ class ObjectInspectorViewController extends DisposableController
   final programExplorerController =
       ProgramExplorerController(showCodeNodes: true);
 
+  final debuggerController = DebuggerController();
+
   final objectHistory = ObjectHistory();
 
   Isolate? isolate;
@@ -47,6 +50,7 @@ class ObjectInspectorViewController extends DisposableController
       programExplorerController
         ..initialize()
         ..initListeners();
+      debuggerController.initialize();
       selectAndPushMainScript();
       _initialized = true;
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
@@ -112,7 +112,64 @@ class ObjectViewport extends StatelessWidget {
   }
 }
 
-/// Manages the history of selected `ObjRef`s to make them accessible on a
+@visibleForTesting
+String viewportTitle(VmObject? object) {
+  if (object == null) {
+    return 'No object selected.';
+  }
+
+  return '${object.obj.type} ${object.name ?? '<name>'}';
+}
+
+/// Calls the object VM statistics card builder according to the VM Object type.
+@visibleForTesting
+Widget buildObjectDisplay(
+  ObjectInspectorViewController controller,
+  VmObject obj,
+) {
+  if (obj is ClassObject) {
+    return VmClassDisplay(
+      controller: controller,
+      clazz: obj,
+    );
+  }
+  if (obj is FuncObject) {
+    return VmFuncDisplay(
+      controller: controller,
+      function: obj,
+    );
+  }
+  if (obj is FieldObject) {
+    return VmFieldDisplay(
+      controller: controller,
+      field: obj,
+    );
+  }
+  if (obj is LibraryObject) {
+    return VmLibraryDisplay(
+      controller: controller,
+      library: obj,
+    );
+  }
+  if (obj is ScriptObject) {
+    return VmScriptDisplay(
+      controller: controller,
+      script: obj,
+    );
+  }
+  if (obj is InstanceObject) {
+    return const VMInfoCard(title: 'TO-DO: Display Instance object data');
+  }
+  if (obj is CodeObject) {
+    return VmCodeDisplay(
+      controller: controller,
+      code: obj,
+    );
+  }
+  return const SizedBox.shrink();
+}
+
+/// Manages the history of selected ObjRefs to make them accessible on a
 /// HistoryViewport.
 class ObjectHistory extends HistoryManager<VmObject> {
   void pushEntry(VmObject object) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../shared/common_widgets.dart';
+import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -27,20 +29,33 @@ class VmClassDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
+    return Split(
+      axis: Axis.vertical,
+      initialFractions: const [0.5, 0.5],
       children: [
-        Flexible(
-          child: VmObjectDisplayBasicLayout(
-            object: clazz,
-            generalDataRows: _classDataRows(clazz),
+        OutlineDecoration.onlyBottom(
+          child: Row(
+            children: [
+              Flexible(
+                child: VmObjectDisplayBasicLayout(
+                  object: clazz,
+                  generalDataRows: _classDataRows(clazz),
+                ),
+              ),
+              if (displayClassInstances)
+                Flexible(
+                  child: ClassInstancesWidget(
+                    instances: clazz.instances,
+                  ),
+                ),
+            ],
           ),
         ),
-        if (displayClassInstances)
-          Flexible(
-            child: ClassInstancesWidget(
-              instances: clazz.instances,
-            ),
-          ),
+        ObjectInspectorCodeView(
+          debuggerController: controller.debuggerController,
+          script: clazz.scriptRef!,
+          object: clazz.ref,
+        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../shared/common_widgets.dart';
-import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -29,34 +27,26 @@ class VmClassDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Split(
-      axis: Axis.vertical,
-      initialFractions: const [0.5, 0.5],
-      children: [
-        OutlineDecoration.onlyBottom(
-          child: Row(
-            children: [
-              Flexible(
-                child: VmObjectDisplayBasicLayout(
-                  object: clazz,
-                  generalDataRows: _classDataRows(clazz),
-                ),
-              ),
-              if (displayClassInstances)
-                Flexible(
-                  child: ClassInstancesWidget(
-                    instances: clazz.instances,
-                  ),
-                ),
-            ],
+    return ObjectInspectorCodeView(
+      codeViewController: controller.codeViewController,
+      script: clazz.scriptRef!,
+      object: clazz.ref,
+      child: Row(
+        children: [
+          Flexible(
+            child: VmObjectDisplayBasicLayout(
+              object: clazz,
+              generalDataRows: _classDataRows(clazz),
+            ),
           ),
-        ),
-        ObjectInspectorCodeView(
-          codeViewController: controller.codeViewController,
-          script: clazz.scriptRef!,
-          object: clazz.ref,
-        ),
-      ],
+          if (displayClassInstances)
+            Flexible(
+              child: ClassInstancesWidget(
+                instances: clazz.instances,
+              ),
+            ),
+        ],
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -52,7 +52,7 @@ class VmClassDisplay extends StatelessWidget {
           ),
         ),
         ObjectInspectorCodeView(
-          debuggerController: controller.debuggerController,
+          codeViewController: controller.codeViewController,
           script: clazz.scriptRef!,
           object: clazz.ref,
         ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -11,10 +11,11 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
 import '../../shared/table.dart';
 import '../../shared/theme.dart';
 import '../debugger/codeview.dart';
-import '../debugger/debugger_controller.dart';
+import '../debugger/codeview_controller.dart';
 import '../debugger/debugger_model.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
@@ -805,12 +806,12 @@ List<MapEntry<String, WidgetBuilder>> vmObjectGeneralDataRows(
 /// [object]'s owner's code will be displayed instead.
 class ObjectInspectorCodeView extends StatefulWidget {
   ObjectInspectorCodeView({
-    required this.debuggerController,
+    required this.codeViewController,
     required this.script,
     required this.object,
   }) : super(key: ValueKey(object));
 
-  final DebuggerController debuggerController;
+  final CodeViewController codeViewController;
   final ScriptRef script;
   final ObjRef object;
 
@@ -823,8 +824,8 @@ class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
   @override
   void didChangeDependencies() async {
     super.didChangeDependencies();
-    if (widget.script != widget.debuggerController.currentScriptRef.value) {
-      widget.debuggerController.resetScriptLocation(
+    if (widget.script != widget.codeViewController.currentScriptRef.value) {
+      widget.codeViewController.resetScriptLocation(
         ScriptLocation(widget.script),
       );
     }
@@ -833,7 +834,7 @@ class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder<ParsedScript?>(
-      valueListenable: widget.debuggerController.currentParsedScript,
+      valueListenable: widget.codeViewController.currentParsedScript,
       builder: (context, currentParsedScript, _) {
         LineRange? lineRange;
         if (currentParsedScript != null) {
@@ -882,14 +883,14 @@ class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
             ),
             Expanded(
               child: CodeView(
-                controller: widget.debuggerController,
+                codeViewController: widget.codeViewController,
                 scriptRef: widget.script,
                 parsedScript: currentParsedScript,
                 enableFileExplorer: false,
                 enableHistory: false,
                 enableSearch: false,
                 lineRange: lineRange,
-                onSelected: widget.debuggerController.toggleBreakpoint,
+                onSelected: breakpointManager.toggleBreakpoint,
               ),
             ),
           ],

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -839,16 +839,29 @@ class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
         if (currentParsedScript != null) {
           final obj = widget.object;
           SourceLocation? location;
-          if (obj is ClassRef || obj is FuncRef || obj is FieldRef) {
-            final dynObj = obj as dynamic;
-            location = dynObj.location!;
+          if (obj is ClassRef) {
+            location = obj.location!;
+          } else if (obj is FuncRef) {
+            location = obj.location!;
             // If there's no line associated with the location, we're likely
             // dealing with an artificial field / method like a constructor.
             // We'll display the owner's code instead of showing nothing,
             // although showing a "No Source Available" message is another
             // option.
-            if (location!.line == null) {
-              location = dynObj.owner.location;
+            final owner = obj.owner;
+            if (location.line == null && obj.owner is ClassRef) {
+              location = owner!.location;
+            }
+          } else if (obj is FieldRef) {
+            location = obj.location!;
+            // If there's no line associated with the location, we're likely
+            // dealing with an artificial field / method like a constructor.
+            // We'll display the owner's code instead of showing nothing,
+            // although showing a "No Source Available" message is another
+            // option.
+            final owner = obj.owner;
+            if (location.line == null && owner is ClassRef) {
+              location = owner.location;
             }
           }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -14,7 +14,7 @@ import 'object_inspector_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
 
-bool displayObjectInspector = false;
+bool displayObjectInspector = true;
 
 abstract class VMDeveloperView {
   const VMDeveloperView(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -14,7 +14,7 @@ import 'object_inspector_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics_view.dart';
 
-bool displayObjectInspector = true;
+bool displayObjectInspector = false;
 
 abstract class VMDeveloperView {
   const VMDeveloperView(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../shared/common_widgets.dart';
-import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -25,22 +23,14 @@ class VmFieldDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Split(
-      axis: Axis.vertical,
-      initialFractions: const [0.5, 0.5],
-      children: [
-        OutlineDecoration.onlyBottom(
-          child: VmObjectDisplayBasicLayout(
-            object: field,
-            generalDataRows: _fieldDataRows(field),
-          ),
-        ),
-        ObjectInspectorCodeView(
-          codeViewController: controller.codeViewController,
-          script: field.scriptRef!,
-          object: field.obj,
-        ),
-      ],
+    return ObjectInspectorCodeView(
+      codeViewController: controller.codeViewController,
+      script: field.scriptRef!,
+      object: field.obj,
+      child: VmObjectDisplayBasicLayout(
+        object: field,
+        generalDataRows: _fieldDataRows(field),
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../shared/common_widgets.dart';
+import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -23,9 +25,23 @@ class VmFieldDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return VmObjectDisplayBasicLayout(
-      object: field,
-      generalDataRows: _fieldDataRows(field),
+    final debuggerController = controller.debuggerController;
+    return Split(
+      axis: Axis.vertical,
+      initialFractions: const [0.5, 0.5],
+      children: [
+        OutlineDecoration.onlyBottom(
+          child: VmObjectDisplayBasicLayout(
+            object: field,
+            generalDataRows: _fieldDataRows(field),
+          ),
+        ),
+        ObjectInspectorCodeView(
+          debuggerController: debuggerController,
+          script: field.scriptRef!,
+          object: field.obj,
+        ),
+      ],
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
@@ -25,7 +25,6 @@ class VmFieldDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final debuggerController = controller.debuggerController;
     return Split(
       axis: Axis.vertical,
       initialFractions: const [0.5, 0.5],
@@ -37,7 +36,7 @@ class VmFieldDisplay extends StatelessWidget {
           ),
         ),
         ObjectInspectorCodeView(
-          debuggerController: debuggerController,
+          codeViewController: controller.codeViewController,
           script: field.scriptRef!,
           object: field.obj,
         ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../shared/common_widgets.dart';
+import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -26,14 +28,26 @@ class VmFuncDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return VmObjectDisplayBasicLayout(
-      object: function,
-      generalDataRows: vmObjectGeneralDataRows(
-        controller,
-        function,
-      ),
-      sideCardDataRows: _functionDetailRows(function),
-      sideCardTitle: 'Function Details',
+
+    final debuggerController = controller.debuggerController;
+    return Split(
+      axis: Axis.vertical,
+      initialFractions: const [0.5, 0.5],
+      children: [
+        OutlineDecoration.onlyBottom(
+          child: VmObjectDisplayBasicLayout(
+            object: function,
+            generalDataRows: vmObjectGeneralDataRows(controller, function),
+            sideCardDataRows: _functionDetailRows(function),
+            sideCardTitle: 'Function Details',
+          ),
+        ),
+        ObjectInspectorCodeView(
+          debuggerController: debuggerController,
+          script: function.scriptRef!,
+          object: function.obj,
+        ),
+      ],
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -28,7 +28,6 @@ class VmFuncDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     final debuggerController = controller.debuggerController;
     return Split(
       axis: Axis.vertical,

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../shared/common_widgets.dart';
-import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -28,24 +26,16 @@ class VmFuncDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Split(
-      axis: Axis.vertical,
-      initialFractions: const [0.5, 0.5],
-      children: [
-        OutlineDecoration.onlyBottom(
-          child: VmObjectDisplayBasicLayout(
-            object: function,
-            generalDataRows: vmObjectGeneralDataRows(controller, function),
-            sideCardDataRows: _functionDetailRows(function),
-            sideCardTitle: 'Function Details',
-          ),
-        ),
-        ObjectInspectorCodeView(
-          codeViewController: controller.codeViewController,
-          script: function.scriptRef!,
-          object: function.obj,
-        ),
-      ],
+    return ObjectInspectorCodeView(
+      codeViewController: controller.codeViewController,
+      script: function.scriptRef!,
+      object: function.obj,
+      child: VmObjectDisplayBasicLayout(
+        object: function,
+        generalDataRows: vmObjectGeneralDataRows(controller, function),
+        sideCardDataRows: _functionDetailRows(function),
+        sideCardTitle: 'Function Details',
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -28,7 +28,6 @@ class VmFuncDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final debuggerController = controller.debuggerController;
     return Split(
       axis: Axis.vertical,
       initialFractions: const [0.5, 0.5],
@@ -42,7 +41,7 @@ class VmFuncDisplay extends StatelessWidget {
           ),
         ),
         ObjectInspectorCodeView(
-          debuggerController: debuggerController,
+          codeViewController: controller.codeViewController,
           script: function.scriptRef!,
           object: function.obj,
         ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
@@ -5,6 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../shared/common_widgets.dart';
+import '../../shared/split.dart';
 import '../../shared/theme.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
@@ -14,22 +16,36 @@ import 'vm_object_model.dart';
 /// related to library objects in the Dart VM.
 class VmLibraryDisplay extends StatelessWidget {
   const VmLibraryDisplay({
-    required this.library,
     required this.controller,
+    required this.library,
   });
 
-  final LibraryObject library;
   final ObjectInspectorViewController controller;
+  final LibraryObject library;
 
   @override
   Widget build(BuildContext context) {
+    final debuggerController = controller.debuggerController;
     final dependencies = library.obj.dependencies;
-    return VmObjectDisplayBasicLayout(
-      object: library,
-      generalDataRows: _libraryDataRows(library),
-      expandableWidgets: [
-        if (dependencies != null)
-          LibraryDependencies(dependencies: dependencies)
+    return Split(
+      axis: Axis.vertical,
+      initialFractions: const [0.5, 0.5],
+      children: [
+        OutlineDecoration.onlyBottom(
+          child: VmObjectDisplayBasicLayout(
+            object: library,
+            generalDataRows: _libraryDataRows(library),
+            expandableWidgets: [
+              if (dependencies != null)
+                LibraryDependencies(dependencies: dependencies)
+            ],
+          ),
+        ),
+        ObjectInspectorCodeView(
+          debuggerController: debuggerController,
+          script: library.scriptRef!,
+          object: library.obj,
+        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
@@ -25,7 +25,6 @@ class VmLibraryDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final debuggerController = controller.debuggerController;
     final dependencies = library.obj.dependencies;
     return Split(
       axis: Axis.vertical,
@@ -42,7 +41,7 @@ class VmLibraryDisplay extends StatelessWidget {
           ),
         ),
         ObjectInspectorCodeView(
-          debuggerController: debuggerController,
+          codeViewController: controller.codeViewController,
           script: library.scriptRef!,
           object: library.obj,
         ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../shared/common_widgets.dart';
-import '../../shared/split.dart';
 import '../../shared/theme.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
@@ -26,26 +24,18 @@ class VmLibraryDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final dependencies = library.obj.dependencies;
-    return Split(
-      axis: Axis.vertical,
-      initialFractions: const [0.5, 0.5],
-      children: [
-        OutlineDecoration.onlyBottom(
-          child: VmObjectDisplayBasicLayout(
-            object: library,
-            generalDataRows: _libraryDataRows(library),
-            expandableWidgets: [
-              if (dependencies != null)
-                LibraryDependencies(dependencies: dependencies)
-            ],
-          ),
-        ),
-        ObjectInspectorCodeView(
-          codeViewController: controller.codeViewController,
-          script: library.scriptRef!,
-          object: library.obj,
-        ),
-      ],
+    return ObjectInspectorCodeView(
+      codeViewController: controller.codeViewController,
+      script: library.scriptRef!,
+      object: library.obj,
+      child: VmObjectDisplayBasicLayout(
+        object: library,
+        generalDataRows: _libraryDataRows(library),
+        expandableWidgets: [
+          if (dependencies != null)
+            LibraryDependencies(dependencies: dependencies)
+        ],
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -24,7 +24,6 @@ class VmScriptDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final debuggerController = controller.debuggerController;
     final scriptRef = script.scriptRef!;
     return Split(
       initialFractions: const [0.5, 0.5],
@@ -40,7 +39,7 @@ class VmScriptDisplay extends StatelessWidget {
           ),
         ),
         ObjectInspectorCodeView(
-          debuggerController: debuggerController,
+          codeViewController: controller.codeViewController,
           script: scriptRef,
           object: scriptRef,
         ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -5,11 +5,8 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-<<<<<<< HEAD
-=======
 import '../../shared/common_widgets.dart';
 import '../../shared/split.dart';
->>>>>>> 99b20824 (Add "Code Preview" section to Object Inspector views)
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -5,6 +5,11 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+<<<<<<< HEAD
+=======
+import '../../shared/common_widgets.dart';
+import '../../shared/split.dart';
+>>>>>>> 99b20824 (Add "Code Preview" section to Object Inspector views)
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -13,23 +18,41 @@ import 'vm_object_model.dart';
 /// related to script objects in the Dart VM.
 class VmScriptDisplay extends StatelessWidget {
   const VmScriptDisplay({
-    required this.script,
     required this.controller,
+    required this.script,
   });
 
-  final ScriptObject script;
   final ObjectInspectorViewController controller;
+  final ScriptObject script;
 
   @override
   Widget build(BuildContext context) {
-    return VmObjectDisplayBasicLayout(
-      object: script,
-      generalDataRows: _scriptDataRows(script),
+    final debuggerController = controller.debuggerController;
+    final scriptRef = script.scriptRef!;
+    return Split(
+      initialFractions: const [0.5, 0.5],
+      axis: Axis.vertical,
+      children: [
+        OutlineDecoration(
+          showLeft: false,
+          showRight: false,
+          showTop: false,
+          child: VmObjectDisplayBasicLayout(
+            object: script,
+            generalDataRows: _scriptDataRows(script),
+          ),
+        ),
+        ObjectInspectorCodeView(
+          debuggerController: debuggerController,
+          script: scriptRef,
+          object: scriptRef,
+        ),
+      ],
     );
   }
 
   /// Generates a list of key-value pairs (map entries) containing the general
-  /// VM information of the Script object [script].
+  /// VM information of the Script object [widget.script].
   List<MapEntry<String, WidgetBuilder>> _scriptDataRows(
     ScriptObject field,
   ) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -5,8 +5,6 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../shared/common_widgets.dart';
-import '../../shared/split.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
@@ -25,25 +23,14 @@ class VmScriptDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final scriptRef = script.scriptRef!;
-    return Split(
-      initialFractions: const [0.5, 0.5],
-      axis: Axis.vertical,
-      children: [
-        OutlineDecoration(
-          showLeft: false,
-          showRight: false,
-          showTop: false,
-          child: VmObjectDisplayBasicLayout(
-            object: script,
-            generalDataRows: _scriptDataRows(script),
-          ),
-        ),
-        ObjectInspectorCodeView(
-          codeViewController: controller.codeViewController,
-          script: scriptRef,
-          object: scriptRef,
-        ),
-      ],
+    return ObjectInspectorCodeView(
+      codeViewController: controller.codeViewController,
+      script: scriptRef,
+      object: scriptRef,
+      child: VmObjectDisplayBasicLayout(
+        object: script,
+        generalDataRows: _scriptDataRows(script),
+      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1156,15 +1156,66 @@ class OutlinedRowGroup extends StatelessWidget {
 }
 
 class OutlineDecoration extends StatelessWidget {
-  const OutlineDecoration({Key? key, this.child}) : super(key: key);
+  const OutlineDecoration({
+    Key? key,
+    this.child,
+    this.showTop = true,
+    this.showBottom = true,
+    this.showLeft = true,
+    this.showRight = true,
+  }) : super(key: key);
+
+  factory OutlineDecoration.onlyBottom({required Widget? child}) =>
+      OutlineDecoration(
+        showTop: false,
+        showLeft: false,
+        showRight: false,
+        child: child,
+      );
+
+  factory OutlineDecoration.onlyTop({required Widget? child}) =>
+      OutlineDecoration(
+        showBottom: false,
+        showLeft: false,
+        showRight: false,
+        child: child,
+      );
+
+  factory OutlineDecoration.onlyLeft({required Widget? child}) =>
+      OutlineDecoration(
+        showBottom: false,
+        showTop: false,
+        showRight: false,
+        child: child,
+      );
+
+  factory OutlineDecoration.onlyRight({required Widget? child}) =>
+      OutlineDecoration(
+        showBottom: false,
+        showTop: false,
+        showLeft: false,
+        child: child,
+      );
+
+  final bool showTop;
+  final bool showBottom;
+  final bool showLeft;
+  final bool showRight;
 
   final Widget? child;
 
   @override
   Widget build(BuildContext context) {
+    final color = Theme.of(context).focusColor;
+    final border = BorderSide(color: color);
     return Container(
       decoration: BoxDecoration(
-        border: Border.all(color: Theme.of(context).focusColor),
+        border: Border(
+          left: showLeft ? border : BorderSide.none,
+          right: showRight ? border : BorderSide.none,
+          top: showTop ? border : BorderSide.none,
+          bottom: showBottom ? border : BorderSide.none,
+        ),
       ),
       child: child,
     );

--- a/packages/devtools_app/lib/src/shared/globals.dart
+++ b/packages/devtools_app/lib/src/shared/globals.dart
@@ -7,6 +7,7 @@ import '../config_specific/import_export/import_export.dart';
 import '../extension_points/extensions_base.dart';
 import '../primitives/message_bus.dart';
 import '../primitives/storage.dart';
+import '../screens/debugger/breakpoint_manager.dart';
 import '../scripts/script_manager.dart';
 import '../service/service_manager.dart';
 import '../shared/notifications.dart';
@@ -39,6 +40,8 @@ OfflineModeController get offlineController => globals[OfflineModeController];
 IdeTheme get ideTheme => globals[IdeTheme];
 
 NotificationService get notificationService => globals[NotificationService];
+
+BreakpointManager get breakpointManager => globals[BreakpointManager];
 
 void setGlobal(Type clazz, dynamic instance) {
   globals[clazz] = instance;

--- a/packages/devtools_app/test/debugger/debugger_codeview_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_codeview_test.dart
@@ -54,8 +54,7 @@ void main() {
         .thenReturn(ValueNotifier<int>(0));
 
     scriptsHistory.pushEntry(mockScript!);
-    final mockCodeViewController =
-        debuggerController.codeViewController;
+    final mockCodeViewController = debuggerController.codeViewController;
     when(mockCodeViewController.currentScriptRef)
         .thenReturn(ValueNotifier(mockScriptRef));
     when(mockCodeViewController.currentParsedScript)

--- a/packages/devtools_app/test/debugger/debugger_codeview_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_codeview_test.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/codeview.dart';
+import 'package:devtools_app/src/screens/debugger/codeview_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
@@ -23,17 +25,22 @@ void main() {
   const mockScriptRefFileUri = 'the/path/mapped/to/script/ref/uri';
   late FakeServiceManager fakeServiceManager;
   late MockDebuggerController debuggerController;
+  late MockCodeViewController codeViewController;
   late ScriptsHistory scriptsHistory;
 
   const smallWindowSize = Size(1000.0, 1000.0);
 
   setUpAll(() {
+    setGlobal(BreakpointManager, BreakpointManager());
     fakeServiceManager = FakeServiceManager(
       service: FakeServiceManager.createFakeService(
         resolvedUriMap: {mockScriptRefFileUri: mockScriptRef.uri!},
       ),
     );
-    debuggerController = createMockDebuggerControllerWithDefaults();
+    codeViewController = createMockCodeViewControllerWithDefaults();
+    debuggerController = createMockDebuggerControllerWithDefaults(
+      mockCodeViewController: codeViewController,
+    );
     scriptsHistory = ScriptsHistory();
 
     when(fakeServiceManager.connectedApp!.isProfileBuildNow).thenReturn(false);
@@ -47,16 +54,13 @@ void main() {
         .thenReturn(ValueNotifier<int>(0));
 
     scriptsHistory.pushEntry(mockScript!);
-    when(debuggerController.currentScriptRef)
+    final mockCodeViewController =
+        debuggerController.debuggerCodeViewController;
+    when(mockCodeViewController.currentScriptRef)
         .thenReturn(ValueNotifier(mockScriptRef));
-    when(debuggerController.currentParsedScript)
+    when(mockCodeViewController.currentParsedScript)
         .thenReturn(ValueNotifier(mockParsedScript));
-    when(debuggerController.showSearchInFileField)
-        .thenReturn(ValueNotifier(false));
-    when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
-    when(debuggerController.scriptsHistory).thenReturn(scriptsHistory);
-    when(debuggerController.searchMatches).thenReturn(ValueNotifier([]));
-    when(debuggerController.activeSearchMatch).thenReturn(ValueNotifier(null));
+    when(mockCodeViewController.scriptsHistory).thenReturn(scriptsHistory);
   });
 
   Future<void> pumpDebuggerScreen(
@@ -79,7 +83,7 @@ void main() {
     // TODO(elliette): https://github.com/flutter/flutter/pull/88152 fixes
     // this so that forcing a scroll event is no longer necessary. Remove
     // once the change is in the stable release.
-    debuggerController.showScriptLocation(
+    codeViewController.showScriptLocation(
       ScriptLocation(
         mockScriptRef,
         location: const SourcePosition(line: 50, column: 50),
@@ -104,7 +108,7 @@ void main() {
 
   group('fetchScriptLocationFullFilePath', () {
     testWidgets('gets the full path', (WidgetTester tester) async {
-      when(debuggerController.scriptLocation).thenReturn(
+      when(codeViewController.scriptLocation).thenReturn(
         ValueNotifier(
           ScriptLocation(
             mockScriptRef,
@@ -114,14 +118,14 @@ void main() {
       );
 
       final filePath =
-          await fetchScriptLocationFullFilePath(debuggerController);
+          await fetchScriptLocationFullFilePath(codeViewController);
 
       expect(filePath, equals(mockScriptRefFileUri));
     });
 
     testWidgets('gets the path if immediately available',
         (WidgetTester tester) async {
-      when(debuggerController.scriptLocation).thenReturn(
+      when(codeViewController.scriptLocation).thenReturn(
         ValueNotifier(
           ScriptLocation(
             mockScriptRef,
@@ -136,14 +140,14 @@ void main() {
       );
 
       final filePath =
-          await fetchScriptLocationFullFilePath(debuggerController);
+          await fetchScriptLocationFullFilePath(codeViewController);
 
       expect(filePath, equals(mockScriptRefFileUri));
     });
 
     testWidgets('returns null if package not found',
         (WidgetTester tester) async {
-      when(debuggerController.scriptLocation).thenReturn(
+      when(codeViewController.scriptLocation).thenReturn(
         ValueNotifier(
           ScriptLocation(
             ScriptRef(
@@ -156,7 +160,7 @@ void main() {
       );
 
       final filePath =
-          await fetchScriptLocationFullFilePath(debuggerController);
+          await fetchScriptLocationFullFilePath(codeViewController);
 
       expect(filePath, isNull);
     });

--- a/packages/devtools_app/test/debugger/debugger_codeview_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_codeview_test.dart
@@ -55,7 +55,7 @@ void main() {
 
     scriptsHistory.pushEntry(mockScript!);
     final mockCodeViewController =
-        debuggerController.debuggerCodeViewController;
+        debuggerController.codeViewController;
     when(mockCodeViewController.currentScriptRef)
         .thenReturn(ValueNotifier(mockScriptRef));
     when(mockCodeViewController.currentParsedScript)

--- a/packages/devtools_app/test/debugger/debugger_controller_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_controller_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/screens/debugger/codeview_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -209,12 +210,10 @@ void main() {
   });
 
   group('search', () {
-    late DebuggerController debuggerController;
+    late CodeViewController debuggerController;
 
     setUp(() {
-      debuggerController = TestDebuggerController(
-        initialSwitchToIsolate: false,
-      );
+      debuggerController = TestCodeViewController();
       debuggerController.parsedScript.value = ParsedScript(
         script: testScript,
         highlighter: mockSyntaxHighlighter,

--- a/packages/devtools_app/test/debugger/debugger_evalution_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_evalution_test.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:devtools_app/src/primitives/utils.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/evaluate.dart';
 import 'package:devtools_app/src/shared/eval_on_dart_library.dart';
@@ -25,9 +26,10 @@ void main() {
   late DebuggerController debuggerController;
   late EvalOnDartLibrary eval;
   setUp(() async {
+    setGlobal(BreakpointManager, BreakpointManager());
     isAlive = Disposable();
     await env.setupEnvironment();
-    debuggerController = TestDebuggerController();
+    debuggerController = DebuggerController();
     eval = EvalOnDartLibrary(
       'package:flutter_app/src/autocomplete.dart',
       serviceManager.service!,

--- a/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
@@ -54,7 +54,8 @@ void main() {
     )
   ];
   final codeViewController = debuggerController.debuggerCodeViewController;
-  when(mockBreakpointManager.breakpoints).thenReturn(ValueNotifier(breakpoints));
+  when(mockBreakpointManager.breakpoints)
+      .thenReturn(ValueNotifier(breakpoints));
   when(mockBreakpointManager.breakpointsWithLocation)
       .thenReturn(ValueNotifier(breakpointsWithLocation));
 

--- a/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
@@ -53,7 +53,7 @@ void main() {
       const SourcePosition(line: 10, column: 1),
     )
   ];
-  final codeViewController = debuggerController.debuggerCodeViewController;
+  final codeViewController = debuggerController.codeViewController;
   when(mockBreakpointManager.breakpoints)
       .thenReturn(ValueNotifier(breakpoints));
   when(mockBreakpointManager.breakpointsWithLocation)

--- a/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_breakpoints_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
@@ -18,7 +19,7 @@ import 'package:vm_service/vm_service.dart';
 
 void main() {
   const windowSize = Size(4000.0, 4000.0);
-
+  final mockBreakpointManager = MockBreakpointManager();
   final fakeServiceManager = FakeServiceManager();
   final scriptManager = MockScriptManager();
   when(fakeServiceManager.connectedApp!.isProfileBuildNow).thenReturn(false);
@@ -27,6 +28,7 @@ void main() {
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(ScriptManager, scriptManager);
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BreakpointManager, mockBreakpointManager);
   fakeServiceManager.consoleService.ensureServiceInitialized();
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
@@ -51,14 +53,14 @@ void main() {
       const SourcePosition(line: 10, column: 1),
     )
   ];
-
-  when(debuggerController.breakpoints).thenReturn(ValueNotifier(breakpoints));
-  when(debuggerController.breakpointsWithLocation)
+  final codeViewController = debuggerController.debuggerCodeViewController;
+  when(mockBreakpointManager.breakpoints).thenReturn(ValueNotifier(breakpoints));
+  when(mockBreakpointManager.breakpointsWithLocation)
       .thenReturn(ValueNotifier(breakpointsWithLocation));
 
   when(scriptManager.sortedScripts).thenReturn(ValueNotifier([]));
-  when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
-  when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+  when(codeViewController.scriptLocation).thenReturn(ValueNotifier(null));
+  when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   Future<void> pumpDebuggerScreen(
     WidgetTester tester,

--- a/packages/devtools_app/test/debugger/debugger_screen_call_stack_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_call_stack_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
@@ -31,6 +32,7 @@ void main() {
     setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
     setGlobal(ScriptManager, scriptManager);
     fakeServiceManager.consoleService.ensureServiceInitialized();
     when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
@@ -128,7 +130,8 @@ void main() {
     when(debuggerController.stackFramesWithLocation)
         .thenReturn(ValueNotifier(stackFramesWithLocation));
     when(debuggerController.isPaused).thenReturn(ValueNotifier(true));
-    when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+    final codeViewController = debuggerController.debuggerCodeViewController;
+    when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
     await pumpDebuggerScreen(tester, debuggerController);
 
     expect(find.text('Call Stack'), findsOneWidget);

--- a/packages/devtools_app/test/debugger/debugger_screen_call_stack_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_call_stack_test.dart
@@ -130,7 +130,7 @@ void main() {
     when(debuggerController.stackFramesWithLocation)
         .thenReturn(ValueNotifier(stackFramesWithLocation));
     when(debuggerController.isPaused).thenReturn(ValueNotifier(true));
-    final codeViewController = debuggerController.debuggerCodeViewController;
+    final codeViewController = debuggerController.codeViewController;
     when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
     await pumpDebuggerScreen(tester, debuggerController);
 

--- a/packages/devtools_app/test/debugger/debugger_screen_explorer_hidden_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_explorer_hidden_test.dart
@@ -31,7 +31,7 @@ void main() {
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
-  final codeViewController = debuggerController.debuggerCodeViewController;
+  final codeViewController = debuggerController.codeViewController;
 
   final scripts = [
     ScriptRef(uri: 'package:/test/script.dart', id: 'test-script')

--- a/packages/devtools_app/test/debugger/debugger_screen_explorer_hidden_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_explorer_hidden_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
@@ -25,20 +26,22 @@ void main() {
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(ScriptManager, scriptManager);
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BreakpointManager, BreakpointManager());
   fakeServiceManager.consoleService.ensureServiceInitialized();
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
+  final codeViewController = debuggerController.debuggerCodeViewController;
 
   final scripts = [
     ScriptRef(uri: 'package:/test/script.dart', id: 'test-script')
   ];
 
   when(scriptManager.sortedScripts).thenReturn(ValueNotifier(scripts));
-  when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+  when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   // File Explorer view is hidden
-  when(debuggerController.fileExplorerVisible).thenReturn(ValueNotifier(false));
+  when(codeViewController.fileExplorerVisible).thenReturn(ValueNotifier(false));
 
   Future<void> pumpDebuggerScreen(
     WidgetTester tester,

--- a/packages/devtools_app/test/debugger/debugger_screen_explorer_visible_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_explorer_visible_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer_model.dart';
@@ -27,13 +28,17 @@ void main() {
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
   setGlobal(ScriptManager, scriptManager);
+  setGlobal(BreakpointManager, BreakpointManager());
   fakeServiceManager.consoleService.ensureServiceInitialized();
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final mockProgramExplorerController =
       createMockProgramExplorerControllerWithDefaults();
-  final debuggerController = createMockDebuggerControllerWithDefaults(
+  final mockCodeViewController = createMockCodeViewControllerWithDefaults(
     mockProgramExplorerController: mockProgramExplorerController,
+  );
+  final debuggerController = createMockDebuggerControllerWithDefaults(
+    mockCodeViewController: mockCodeViewController,
   );
   final scripts = [
     ScriptRef(uri: 'package:test/script.dart', id: 'test-script')
@@ -45,17 +50,18 @@ void main() {
     ValueNotifier(
       [
         VMServiceObjectNode(
-          debuggerController.programExplorerController,
+          mockCodeViewController.programExplorerController,
           'package:test',
           null,
         ),
       ],
     ),
   );
-  when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+  when(mockCodeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   // File Explorer view is shown
-  when(debuggerController.fileExplorerVisible).thenReturn(ValueNotifier(true));
+  when(mockCodeViewController.fileExplorerVisible)
+      .thenReturn(ValueNotifier(true));
 
   Future<void> pumpDebuggerScreen(
     WidgetTester tester,

--- a/packages/devtools_app/test/debugger/debugger_screen_paused_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_paused_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/controls.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
@@ -29,11 +30,13 @@ void main() {
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(ScriptManager, scriptManager);
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BreakpointManager, BreakpointManager());
   fakeServiceManager.consoleService.ensureServiceInitialized();
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
-  when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+  final codeViewController = debuggerController.debuggerCodeViewController;
+  when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   when(debuggerController.isPaused).thenReturn(ValueNotifier(true));
   when(debuggerController.stackFramesWithLocation).thenReturn(

--- a/packages/devtools_app/test/debugger/debugger_screen_paused_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_paused_test.dart
@@ -35,7 +35,7 @@ void main() {
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
-  final codeViewController = debuggerController.debuggerCodeViewController;
+  final codeViewController = debuggerController.codeViewController;
   when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   when(debuggerController.isPaused).thenReturn(ValueNotifier(true));

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/console.dart';
 import 'package:devtools_app/src/screens/debugger/controls.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
@@ -30,11 +31,13 @@ void main() {
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(ScriptManager, scriptManager);
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BreakpointManager, BreakpointManager());
   fakeServiceManager.consoleService.ensureServiceInitialized();
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
-  when(debuggerController.showFileOpener).thenReturn(ValueNotifier(false));
+  final codeViewController = debuggerController.debuggerCodeViewController;
+  when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   Future<void> pumpConsole(
     WidgetTester tester,

--- a/packages/devtools_app/test/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_test.dart
@@ -36,7 +36,7 @@ void main() {
   when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
       .thenReturn(ValueNotifier<int>(0));
   final debuggerController = createMockDebuggerControllerWithDefaults();
-  final codeViewController = debuggerController.debuggerCodeViewController;
+  final codeViewController = debuggerController.codeViewController;
   when(codeViewController.showFileOpener).thenReturn(ValueNotifier(false));
 
   Future<void> pumpConsole(

--- a/packages/devtools_app/test/debugger/debugger_screen_variables_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_variables_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
@@ -30,6 +31,7 @@ void main() {
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(ScriptManager, scriptManager);
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
     fakeServiceManager.consoleService.ensureServiceInitialized();
     when(fakeServiceManager.errorBadgeManager.errorCountNotifier('debugger'))
         .thenReturn(ValueNotifier<int>(0));

--- a/packages/devtools_app/test/debugger/eval_field_test.dart
+++ b/packages/devtools_app/test/debugger/eval_field_test.dart
@@ -227,8 +227,7 @@ class _EvalFieldTestObjects {
 Future<_EvalFieldTestObjects> _setupEvalFieldObjects(
   WidgetTester tester,
 ) async {
-  final debuggerController =
-      DebuggerController(initialSwitchToIsolate: false);
+  final debuggerController = DebuggerController(initialSwitchToIsolate: false);
 
   final evalField = ExpressionEvalField(
     controller: debuggerController,

--- a/packages/devtools_app/test/debugger/eval_field_test.dart
+++ b/packages/devtools_app/test/debugger/eval_field_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/evaluate.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -19,6 +20,7 @@ void main() {
       manager = FakeServiceManager(service: service);
       setGlobal(ServiceConnectionManager, manager);
       setGlobal(IdeTheme, getIdeTheme());
+      setGlobal(BreakpointManager, BreakpointManager());
     });
 
     testWidgets(
@@ -226,7 +228,7 @@ Future<_EvalFieldTestObjects> _setupEvalFieldObjects(
   WidgetTester tester,
 ) async {
   final debuggerController =
-      TestDebuggerController(initialSwitchToIsolate: false);
+      DebuggerController(initialSwitchToIsolate: false);
 
   final evalField = ExpressionEvalField(
     controller: debuggerController,

--- a/packages/devtools_app/test/debugger/eval_field_test.dart
+++ b/packages/devtools_app/test/debugger/eval_field_test.dart
@@ -2,9 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/evaluate.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/ui/search.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/packages/devtools_app/test/debugger/file_search_test.dart
+++ b/packages/devtools_app/test/debugger/file_search_test.dart
@@ -13,7 +13,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
 void main() {
-  final debuggerController = createMockDebuggerControllerWithDefaults();
+  final codeViewController = createMockCodeViewControllerWithDefaults();
   final scriptManager = MockScriptManager();
 
   Widget buildFileSearch() {
@@ -21,7 +21,7 @@ void main() {
       home: Scaffold(
         body: Card(
           child: FileSearchField(
-            debuggerController: debuggerController,
+            codeViewController: codeViewController,
           ),
         ),
       ),

--- a/packages/devtools_app/test/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_integration_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_service.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -47,6 +48,7 @@ void main() async {
     }
   };
 
+  setGlobal(BreakpointManager, BreakpointManager());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
 

--- a/packages/devtools_app/test/inspector/inspector_tree_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_tree_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
+import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_breadcrumbs.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_controller.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_tree.dart';
@@ -33,6 +35,7 @@ void main() {
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(PreferencesController, PreferencesController());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
     mockConnectedApp(
       fakeServiceManager.connectedApp!,
       isFlutterApp: true,
@@ -52,7 +55,7 @@ void main() {
     required InspectorTreeController treeController,
     bool isSummaryTree = false,
   }) async {
-    final debuggerController = TestDebuggerController();
+    final debuggerController = DebuggerController();
     final summaryTreeController =
         isSummaryTree ? null : InspectorTreeController();
     await tester.pumpWidget(

--- a/packages/devtools_app/test/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/network/network_profiler_test.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/http/http.dart';
 import 'package:devtools_app/src/http/http_request_data.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/network/network_controller.dart';
 import 'package:devtools_app/src/screens/network/network_model.dart';
@@ -60,6 +61,7 @@ void main() {
     httpProfile = loadHttpProfile();
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BreakpointManager, BreakpointManager());
   });
 
   group('Network Profiler', () {

--- a/packages/devtools_app/test/provider/provider_screen_integration_test.dart
+++ b/packages/devtools_app/test/provider/provider_screen_integration_test.dart
@@ -4,6 +4,7 @@
 
 @TestOn('vm')
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/provider/instance_viewer/instance_details.dart';
 import 'package:devtools_app/src/screens/provider/instance_viewer/instance_providers.dart';
 import 'package:devtools_app/src/screens/provider/provider_nodes.dart';
@@ -28,6 +29,8 @@ void main() async {
 
   setUp(() async {
     setGlobal(IdeTheme, getIdeTheme());
+    setGlobal(BreakpointManager, BreakpointManager());
+
     await env.setupEnvironment(
       config: const FlutterRunConfiguration(withDebugger: true),
     );

--- a/packages/devtools_app/test/shared/visible_screens_test.dart
+++ b/packages/devtools_app/test/shared/visible_screens_test.dart
@@ -4,8 +4,10 @@
 
 import 'package:devtools_app/src/app.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/primitives/listenable.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
 import 'package:devtools_app/src/screens/app_size/app_size_screen.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
 import 'package:devtools_app/src/screens/inspector/inspector_screen.dart';
 import 'package:devtools_app/src/screens/logging/logging_screen.dart';
@@ -14,6 +16,7 @@ import 'package:devtools_app/src/screens/network/network_screen.dart';
 import 'package:devtools_app/src/screens/performance/performance_screen.dart';
 import 'package:devtools_app/src/screens/profiler/profiler_screen.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_tools_screen.dart';
+import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/framework_controller.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -22,6 +25,8 @@ import 'package:devtools_app/src/shared/screen.dart';
 import 'package:devtools_app/src/shared/version.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
 
 void main() {
   group('visible_screens', () {
@@ -30,9 +35,15 @@ void main() {
     setUp(() async {
       fakeServiceManager = FakeServiceManager(availableLibraries: []);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
+      setGlobal(BreakpointManager, BreakpointManager());
       setGlobal(FrameworkController, FrameworkController());
       setGlobal(PreferencesController, PreferencesController());
       setGlobal(OfflineModeController, OfflineModeController());
+      final scriptManager = MockScriptManager();
+      when(scriptManager.sortedScripts).thenReturn(
+        const FixedValueListenable<List<ScriptRef>>([]),
+      );
+      setGlobal(ScriptManager, scriptManager);
 
       await whenValueNonNull(serviceManager.isolateManager.selectedIsolate);
     });

--- a/packages/devtools_app/test/test_data/memory/leaks/leaking_demo_app.yaml
+++ b/packages/devtools_app/test/test_data/memory/leaks/leaking_demo_app.yaml
@@ -7,7 +7,6 @@ not-gced:
   victims: 1
   objects:
     MyTrackedClass:
-      type: MyTrackedClass
       identityHashCode: 602745562
       retainingPath:
         - /Root-0
@@ -30,6 +29,5 @@ not-gced:
       total-victims: 1
       victims:
         MyTrackedClass:
-          type: MyTrackedClass
           identityHashCode: 254077742
           retainingPath: /Root-0/Isolate-0/WidgetsFlutterBinding-235266188/BuildOwner-800677189/_InternalLinkedHashMap-0/_List-0/InheritedElement-934004911/_HashMap-3265445665/_List-0/_HashMapEntry-4138455891/MultiChildRenderObjectElement-930100091/SingleChildRenderObjectElement-738570971/MultiChildRenderObjectElement-95169238/StatefulElement-324739411/_LeakingWidgetState-452071513/MyClass-3721699850/MyTrackedClass-602745562/MyTrackedClass-254077742/

--- a/packages/devtools_app/test/test_data/memory/leaks/leaking_demo_app.yaml
+++ b/packages/devtools_app/test/test_data/memory/leaks/leaking_demo_app.yaml
@@ -7,6 +7,7 @@ not-gced:
   victims: 1
   objects:
     MyTrackedClass:
+      type: MyTrackedClass
       identityHashCode: 602745562
       retainingPath:
         - /Root-0
@@ -29,5 +30,6 @@ not-gced:
       total-victims: 1
       victims:
         MyTrackedClass:
+          type: MyTrackedClass
           identityHashCode: 254077742
           retainingPath: /Root-0/Isolate-0/WidgetsFlutterBinding-235266188/BuildOwner-800677189/_InternalLinkedHashMap-0/_List-0/InheritedElement-934004911/_HashMap-3265445665/_List-0/_HashMapEntry-4138455891/MultiChildRenderObjectElement-930100091/SingleChildRenderObjectElement-738570971/MultiChildRenderObjectElement-95169238/StatefulElement-324739411/_LeakingWidgetState-452071513/MyClass-3721699850/MyTrackedClass-602745562/MyTrackedClass-254077742/

--- a/packages/devtools_app/test/test_infra/flutter_test_environment.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_environment.dart
@@ -125,6 +125,7 @@ class FlutterTestEnvironment {
       setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
       setGlobal(MessageBus, MessageBus());
       setGlobal(ScriptManager, ScriptManager());
+      setGlobal(BreakpointManager, BreakpointManager());
 
       // Clear out VM service calls from the test driver.
       // ignore: invalid_use_of_visible_for_testing_member

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_class_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
@@ -11,12 +12,11 @@ import 'package:devtools_app/src/screens/vm_developer/vm_function_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_library_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_object_model.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_script_display.dart';
-import 'package:devtools_app/src/scripts/script_manager.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/history_viewport.dart';
 import 'package:devtools_test/devtools_test.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart' hide Stack;
@@ -27,17 +27,15 @@ void main() {
 
   late FakeServiceManager fakeServiceManager;
 
-  late MockScriptManager scriptManager;
+  const windowSize = Size(2560.0, 1338.0);
 
   setUp(() {
     fakeServiceManager = FakeServiceManager();
 
-    scriptManager = MockScriptManager();
-    when(scriptManager.sortedScripts).thenReturn(ValueNotifier(<ScriptRef>[]));
-
+    setUpMockScriptManager();
     setGlobal(ServiceConnectionManager, fakeServiceManager);
-    setGlobal(ScriptManager, scriptManager);
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(BreakpointManager, BreakpointManager());
 
     testObjectInspectorViewController = TestObjectInspectorViewController();
   });
@@ -61,7 +59,8 @@ void main() {
       mockVmObject(mockClassObject);
     });
 
-    testWidgets('viewport shows class display', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('viewport shows class display', windowSize,
+        (WidgetTester tester) async {
       testObjectInspectorViewController.fakeObjectHistory
           .setCurrentObject(mockClassObject);
       await tester.pumpWidget(
@@ -82,7 +81,8 @@ void main() {
       mockVmObject(mockFieldObject);
     });
 
-    testWidgets('viewport shows field display', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('viewport shows field display', windowSize,
+        (WidgetTester tester) async {
       testObjectInspectorViewController.fakeObjectHistory
           .setCurrentObject(mockFieldObject);
 
@@ -110,7 +110,8 @@ void main() {
       mockVmObject(mockFuncObject);
       when(mockFuncObject.obj).thenReturn(testFunctionCopy);
     });
-    testWidgets('viewport shows function display', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('viewport shows function display', windowSize,
+        (WidgetTester tester) async {
       testObjectInspectorViewController.fakeObjectHistory
           .setCurrentObject(mockFuncObject);
 
@@ -136,7 +137,8 @@ void main() {
       mockVmObject(mockScriptObject);
     });
 
-    testWidgets('viewport shows script display', (WidgetTester tester) async {
+    testWidgetsWithWindowSize('viewport shows script display', windowSize,
+        (WidgetTester tester) async {
       testObjectInspectorViewController.fakeObjectHistory
           .setCurrentObject(mockScriptObject);
       await tester.pumpWidget(

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_class_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -24,7 +26,9 @@ void main() {
 
   setUp(() {
     setUpMockScriptManager();
+    setGlobal(BreakpointManager, BreakpointManager());
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
     mockClassObject = MockClassObject();
 
     final json = testClass.toJson();

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -2,7 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_field_display.dart';
@@ -27,6 +29,8 @@ void main() {
 
   setUp(() {
     setUpMockScriptManager();
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
+    setGlobal(BreakpointManager, BreakpointManager());
     setGlobal(IdeTheme, IdeTheme());
 
     mockFieldObject = MockFieldObject();
@@ -45,6 +49,7 @@ void main() {
 
     mockVmObject(mockFieldObject);
     when(mockFieldObject.obj).thenReturn(testFieldCopy);
+    when(mockFieldObject.scriptRef).thenReturn(testScript);
   });
 
   group('field data display tests', () {

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -2,13 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_field_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
@@ -3,10 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_function_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -25,7 +27,9 @@ void main() {
 
   setUp(() {
     setUpMockScriptManager();
+    setGlobal(BreakpointManager, BreakpointManager());
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
 
     mockFuncObject = MockFuncObject();
 

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_library_display.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -19,6 +21,8 @@ import '../vm_developer_test_utils.dart';
 void main() {
   setUp(() {
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(BreakpointManager, BreakpointManager());
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
   });
   group('test build library display', () {
     late Library testLibCopy;
@@ -39,6 +43,7 @@ void main() {
       mockVmObject(mockLibraryObject);
       when(mockLibraryObject.obj).thenReturn(testLibCopy);
       when(mockLibraryObject.vmName).thenReturn('fooDartLibrary');
+      when(mockLibraryObject.scriptRef).thenReturn(testScript);
     });
 
     testWidgetsWithWindowSize(' - basic layout', windowSize,

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_script_display.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -24,6 +26,8 @@ void main() {
 
   setUp(() {
     setGlobal(IdeTheme, IdeTheme());
+    setGlobal(BreakpointManager, BreakpointManager());
+    setGlobal(ServiceConnectionManager, FakeServiceManager());
     setUpMockScriptManager();
     mockScriptObject = MockScriptObject();
 
@@ -34,6 +38,7 @@ void main() {
 
     mockVmObject(mockScriptObject);
     when(mockScriptObject.obj).thenReturn(testScriptCopy);
+    when(mockScriptObject.scriptRef).thenReturn(testScriptCopy);
   });
 
   testWidgetsWithWindowSize('builds script display', windowSize,

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -10,7 +10,6 @@ import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_cont
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_object_model.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -10,6 +10,7 @@ import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_cont
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_object_model.dart';
 import 'package:devtools_app/src/scripts/script_manager.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/foundation.dart';
@@ -177,12 +178,13 @@ void setUpMockScriptManager() {
   when(mockScriptManager.sortedScripts).thenReturn(
     FixedValueListenable<List<ScriptRef>>([testScript]),
   );
+  when(mockScriptManager.getScriptCached(any)).thenReturn(testScript);
   setGlobal(ScriptManager, mockScriptManager);
 }
 
 void mockVmObject(VmObject object) {
   when(object.outlineNode).thenReturn(null);
-  when(object.scriptRef).thenReturn(null);
+  when(object.scriptRef).thenReturn(testScript);
   when(object.script).thenReturn(testScript);
   when(object.pos).thenReturn(testPos);
   when(object.fetchingReachableSize).thenReturn(ValueNotifier<bool>(false));

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -36,7 +36,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
       }
     }
   }
-  
+
   static final _defaultProfile = CpuSamples.parse({
     'samplePeriod': 50,
     'maxStackDepth': 12,
@@ -418,6 +418,20 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     return Future.value(
       HttpTimelineLoggingState(enabled: httpEnableTimelineLoggingResult),
     );
+  }
+
+  @override
+  Future<SourceReport> getSourceReport(
+    String isolateId,
+    List<String> reports, {
+    String? scriptId,
+    int? tokenPos,
+    int? endTokenPos,
+    bool? forceCompile,
+    bool? reportLines,
+    List<String>? libraryFilters,
+  }) async {
+    return SourceReport(ranges: [], scripts: []);
   }
 
   @override

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -34,5 +34,7 @@ import 'package:vm_service/vm_service.dart';
   ScriptObject,
   LibraryObject,
   ui.Image,
+  CodeViewController,
+  BreakpointManager,
 ])
 void main() {}

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -39,34 +39,49 @@ MockProgramExplorerController
   return controller;
 }
 
-MockDebuggerController createMockDebuggerControllerWithDefaults({
+MockCodeViewController createMockCodeViewControllerWithDefaults({
   MockProgramExplorerController? mockProgramExplorerController,
+}) {
+  final codeViewController = MockCodeViewController();
+  when(codeViewController.fileExplorerVisible).thenReturn(ValueNotifier(false));
+  when(codeViewController.currentScriptRef).thenReturn(ValueNotifier(null));
+  when(codeViewController.scriptLocation).thenReturn(ValueNotifier(null));
+  when(codeViewController.currentParsedScript)
+      .thenReturn(ValueNotifier<ParsedScript?>(null));
+  when(codeViewController.searchMatches).thenReturn(ValueNotifier([]));
+  when(codeViewController.activeSearchMatch).thenReturn(ValueNotifier(null));
+  mockProgramExplorerController ??=
+      createMockProgramExplorerControllerWithDefaults();
+  when(codeViewController.programExplorerController).thenReturn(
+    mockProgramExplorerController,
+  );
+
+  return codeViewController;
+}
+
+MockDebuggerController createMockDebuggerControllerWithDefaults({
+  MockCodeViewController? mockCodeViewController,
 }) {
   final debuggerController = MockDebuggerController();
   when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
   when(debuggerController.resuming).thenReturn(ValueNotifier(false));
-  when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
   when(debuggerController.isSystemIsolate).thenReturn(false);
-  when(debuggerController.breakpointsWithLocation)
-      .thenReturn(ValueNotifier([]));
-  when(debuggerController.fileExplorerVisible).thenReturn(ValueNotifier(false));
-  when(debuggerController.currentScriptRef).thenReturn(ValueNotifier(null));
+
   when(debuggerController.selectedBreakpoint).thenReturn(ValueNotifier(null));
   when(debuggerController.stackFramesWithLocation)
       .thenReturn(ValueNotifier([]));
   when(debuggerController.selectedStackFrame).thenReturn(ValueNotifier(null));
   when(debuggerController.hasTruncatedFrames).thenReturn(ValueNotifier(false));
-  when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
+
   when(debuggerController.exceptionPauseMode)
       .thenReturn(ValueNotifier('Unhandled'));
   when(debuggerController.variables).thenReturn(ValueNotifier([]));
-  when(debuggerController.currentParsedScript)
-      .thenReturn(ValueNotifier<ParsedScript?>(null));
-  mockProgramExplorerController ??=
-      createMockProgramExplorerControllerWithDefaults();
-  when(debuggerController.programExplorerController).thenReturn(
-    mockProgramExplorerController,
+
+  mockCodeViewController ??= createMockCodeViewControllerWithDefaults();
+  when(debuggerController.debuggerCodeViewController).thenReturn(
+    mockCodeViewController,
   );
+
   return debuggerController;
 }
 

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -78,7 +78,7 @@ MockDebuggerController createMockDebuggerControllerWithDefaults({
   when(debuggerController.variables).thenReturn(ValueNotifier([]));
 
   mockCodeViewController ??= createMockCodeViewControllerWithDefaults();
-  when(debuggerController.debuggerCodeViewController).thenReturn(
+  when(debuggerController.codeViewController).thenReturn(
     mockCodeViewController,
   );
 

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -209,10 +209,6 @@ class MockDebuggerControllerLegacy extends Mock implements DebuggerController {
     when(debuggerController.variables).thenReturn(ValueNotifier([]));
     return debuggerController;
   }
-
-  @override
-  final ProgramExplorerController programExplorerController =
-      MockProgramExplorerControllerLegacy.withDefaults();
 }
 
 class MockScriptManagerLegacy extends Mock implements ScriptManager {}

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -181,10 +181,7 @@ class MockProfilerScreenController extends Mock
 
 class MockStorage extends Mock implements Storage {}
 
-class TestDebuggerController extends DebuggerController {
-  TestDebuggerController({bool initialSwitchToIsolate = true})
-      : super(initialSwitchToIsolate: initialSwitchToIsolate);
-
+class TestCodeViewController extends CodeViewController {
   @override
   ProgramExplorerController get programExplorerController =>
       _explorerController;
@@ -200,25 +197,16 @@ class MockDebuggerControllerLegacy extends Mock implements DebuggerController {
     final debuggerController = MockDebuggerControllerLegacy();
     when(debuggerController.isPaused).thenReturn(ValueNotifier(false));
     when(debuggerController.resuming).thenReturn(ValueNotifier(false));
-    when(debuggerController.breakpoints).thenReturn(ValueNotifier([]));
     when(debuggerController.isSystemIsolate).thenReturn(false);
-    when(debuggerController.breakpointsWithLocation)
-        .thenReturn(ValueNotifier([]));
-    when(debuggerController.fileExplorerVisible)
-        .thenReturn(ValueNotifier(false));
-    when(debuggerController.currentScriptRef).thenReturn(ValueNotifier(null));
     when(debuggerController.selectedBreakpoint).thenReturn(ValueNotifier(null));
     when(debuggerController.stackFramesWithLocation)
         .thenReturn(ValueNotifier([]));
     when(debuggerController.selectedStackFrame).thenReturn(ValueNotifier(null));
     when(debuggerController.hasTruncatedFrames)
         .thenReturn(ValueNotifier(false));
-    when(debuggerController.scriptLocation).thenReturn(ValueNotifier(null));
     when(debuggerController.exceptionPauseMode)
         .thenReturn(ValueNotifier('Unhandled'));
     when(debuggerController.variables).thenReturn(ValueNotifier([]));
-    when(debuggerController.currentParsedScript)
-        .thenReturn(ValueNotifier<ParsedScript?>(null));
     return debuggerController;
   }
 


### PR DESCRIPTION
Adds support for displaying code associated with a given VM service object. Dart code for only the given object will be displayed (e.g., a subset of the containing script's source for functions, fields, and classes), but will display the original range of line numbers.

In addition, users can use the "Code Preview" view to view and set breakpoints on executable lines, just as if they were interacting with the code view in the debugger.

![image](https://user-images.githubusercontent.com/24210656/188940692-52d1153d-d862-4fd9-9cc5-9f859d04df7a.png)

