### PR TITLE
Fix `CodeView`'s scrollable area

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -362,10 +362,6 @@ class _CodeViewState extends State<CodeView>
                         Expanded(
                           child: LayoutBuilder(
                             builder: (context, constraints) {
-                              final double fileWidth = calculateTextSpanWidth(
-                                findLongestTextSpan(lines),
-                              );
-
                               return Scrollbar(
                                 key: CodeView
                                     .debuggerCodeViewHorizontalScrollbarKey,
@@ -376,7 +372,7 @@ class _CodeViewState extends State<CodeView>
                                   controller: horizontalController,
                                   child: SizedBox(
                                     height: constraints.maxHeight,
-                                    width: fileWidth,
+                                    width: constraints.maxWidth,
                                     child: Lines(
                                       height: constraints.maxHeight,
                                       debugController: widget.controller,

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -362,6 +362,9 @@ class _CodeViewState extends State<CodeView>
                         Expanded(
                           child: LayoutBuilder(
                             builder: (context, constraints) {
+                              final double fileWidth = calculateTextSpanWidth(
+                                findLongestTextSpan(lines),
+                              );
                               return Scrollbar(
                                 key: CodeView
                                     .debuggerCodeViewHorizontalScrollbarKey,
@@ -372,7 +375,10 @@ class _CodeViewState extends State<CodeView>
                                   controller: horizontalController,
                                   child: SizedBox(
                                     height: constraints.maxHeight,
-                                    width: constraints.maxWidth,
+                                    width: math.max(
+                                      constraints.maxWidth,
+                                      fileWidth,
+                                    ),
                                     child: Lines(
                                       height: constraints.maxHeight,
                                       debugController: widget.controller,

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -365,6 +365,7 @@ class _CodeViewState extends State<CodeView>
                               final double fileWidth = calculateTextSpanWidth(
                                 findLongestTextSpan(lines),
                               );
+
                               return Scrollbar(
                                 key: CodeView
                                     .debuggerCodeViewHorizontalScrollbarKey,


### PR DESCRIPTION
Currently, the `CodeView`'s scrollable area is only as wide as the longest line in the currently selected script, resulting in arguably unexpected behavior when trying to scroll while hovering over the right side of the code area.

This change makes each line in the `CodeView` take up the maximum amount of horizontal space possible, making the scrollable area consist of the entire code viewport.