### PR TITLE
Search FileExplorer and Outline nodes

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -306,8 +306,6 @@ class ProgramExplorerController extends DisposableController
     final service = serviceManager.service!;
     final isolateId = serviceManager.isolateManager.selectedIsolate.value!.id!;
 
-    ScriptRef? targetScript;
-
     // If `object` is a library, it will always be a root node and is simple to
     // find.
     if (object is LibraryRef) {
@@ -318,6 +316,7 @@ class ProgramExplorerController extends DisposableController
 
     // Otherwise, we need to find the target script to determine the library
     // the target node is listed under.
+    ScriptRef? targetScript;
     if (object is ClassRef) {
       targetScript = object.location?.script;
     } else if (object is FieldRef) {
@@ -335,7 +334,7 @@ class ProgramExplorerController extends DisposableController
       targetScript = object.classRef?.location?.script;
     }
     if (targetScript == null) {
-      throw StateError('Could not find script }');
+      throw StateError('Could not find script');
     }
 
     final scriptObj =

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -56,15 +56,22 @@ class ObjectInspectorViewController extends DisposableController
     final currentObjectValue = objectHistory.current.value;
 
     if (currentObjectValue != null) {
-      final scriptRef = currentObjectValue.scriptRef;
+      final scriptRef = currentObjectValue.scriptRef ??
+          (await programExplorerController
+                  .searchFileExplorer(currentObjectValue.obj))
+              ?.script;
 
       if (scriptRef != null) {
         await programExplorerController.selectScriptNode(scriptRef);
       }
 
-      if (currentObjectValue.outlineNode != null) {
-        final outlineNode = currentObjectValue.outlineNode!;
+      final outlineNode = currentObjectValue.outlineNode ??
+          programExplorerController.breadthFirstSearchObject(
+            currentObjectValue.obj,
+            programExplorerController.outlineNodes.value,
+          );
 
+      if (outlineNode != null) {
         programExplorerController
           ..selectOutlineNode(outlineNode)
           ..expandToNode(outlineNode);

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector_view_controller.dart
@@ -59,7 +59,7 @@ class ObjectInspectorViewController extends DisposableController
       final scriptRef = currentObjectValue.scriptRef ??
           (await programExplorerController
                   .searchFileExplorer(currentObjectValue.obj))
-              ?.script;
+              .script;
 
       if (scriptRef != null) {
         await programExplorerController.selectScriptNode(scriptRef);
@@ -163,11 +163,10 @@ class ObjectInspectorViewController extends DisposableController
     objectHistory.clear();
 
     final scriptRefs = scriptManager.sortedScripts.value;
-
     final service = serviceManager.service!;
-
-    final isolate = await service
-        .getIsolate(serviceManager.isolateManager.selectedIsolate.value!.id!);
+    final isolate = await service.getIsolate(
+      serviceManager.isolateManager.selectedIsolate.value!.id!,
+    );
 
     final mainScriptRef = scriptRefs.firstWhereOrNull((ref) {
       return ref.uri == isolate.rootLib?.uri;
@@ -175,11 +174,9 @@ class ObjectInspectorViewController extends DisposableController
 
     if (mainScriptRef != null) {
       _currentScriptRef = mainScriptRef;
-
-      final parts = mainScriptRef.uri!.split('/')..removeLast();
-
       await programExplorerController.selectScriptNode(mainScriptRef);
 
+      final parts = mainScriptRef.uri!.split('/')..removeLast();
       final libraries = isolate.libraries!;
 
       if (parts.isEmpty) {
@@ -189,12 +186,17 @@ class ObjectInspectorViewController extends DisposableController
           }
         }
       }
-
       await pushObject(mainScriptRef);
     }
   }
 
   void setCurrentScript(ScriptRef scriptRef) {
     _currentScriptRef = scriptRef;
+  }
+
+  Future<void> findAndSelectNodeForObject(ObjRef obj) async {
+    final node = await programExplorerController.searchFileExplorer(obj);
+    setCurrentScript(node.location!.scriptRef);
+    await pushObject(obj);
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_viewport.dart
@@ -56,58 +56,70 @@ class ObjectViewport extends StatelessWidget {
       },
     );
   }
+
+  @visibleForTesting
+  static String viewportTitle(VmObject? object) {
+    if (object == null) {
+      return 'No object selected.';
+    }
+
+    return '${object.obj.type} ${object.name ?? '<name>'}';
+  }
+
+  /// Calls the object VM statistics card builder according to the VM Object type.
+  @visibleForTesting
+  Widget buildObjectDisplay(VmObject obj) {
+    if (obj is ClassObject) {
+      return VmClassDisplay(
+        controller: controller,
+        clazz: obj,
+      );
+    }
+    if (obj is FuncObject) {
+      return VmFuncDisplay(
+        controller: controller,
+        function: obj,
+      );
+    }
+    if (obj is FieldObject) {
+      return VmFieldDisplay(
+        controller: controller,
+        field: obj,
+      );
+    }
+    if (obj is LibraryObject) {
+      return VmLibraryDisplay(
+        controller: controller,
+        library: obj,
+      );
+    }
+    if (obj is ScriptObject) {
+      return VmScriptDisplay(
+        controller: controller,
+        script: obj,
+      );
+    }
+    if (obj is InstanceObject) {
+      return const VMInfoCard(title: 'TO-DO: Display Instance object data');
+    }
+    if (obj is CodeObject) {
+      return VmCodeDisplay(
+        controller: controller,
+        code: obj,
+      );
+    }
+    return const SizedBox.shrink();
+  }
 }
 
-@visibleForTesting
-String viewportTitle(VmObject? object) {
-  if (object == null) {
-    return 'No object selected.';
-  }
-
-  return '${object.obj.type} ${object.name ?? '<name>'}';
-}
-
-/// Calls the object VM statistics card builder according to the VM Object type.
-@visibleForTesting
-Widget buildObjectDisplay(VmObject obj) {
-  if (obj is ClassObject) {
-    return VmClassDisplay(
-      clazz: obj,
-    );
-  }
-  if (obj is FuncObject) {
-    return VmFuncDisplay(function: obj);
-  }
-  if (obj is FieldObject) {
-    return VmFieldDisplay(field: obj);
-  }
-  if (obj is LibraryObject) {
-    return VmLibraryDisplay(library: obj);
-  }
-  if (obj is ScriptObject) {
-    return VmScriptDisplay(script: obj);
-  }
-  if (obj is InstanceObject) {
-    return const VMInfoCard(title: 'TO-DO: Display Instance object data');
-  }
-  if (obj is CodeObject) {
-    return VmCodeDisplay(
-      code: obj,
-    );
-  }
-  return const SizedBox.shrink();
-}
-
-/// Manages the history of selected ObjRefs to make them accessible on a
+/// Manages the history of selected `ObjRef`s to make them accessible on a
 /// HistoryViewport.
 class ObjectHistory extends HistoryManager<VmObject> {
   void pushEntry(VmObject object) {
     if (object.obj == current.value?.obj) return;
-
     while (hasNext) {
       pop();
     }
-
     push(object);
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 
@@ -17,9 +18,11 @@ const displayClassInstances = false;
 /// related to class objects in the Dart VM.
 class VmClassDisplay extends StatelessWidget {
   const VmClassDisplay({
+    required this.controller,
     required this.clazz,
   });
 
+  final ObjectInspectorViewController controller;
   final ClassObject clazz;
 
   @override
@@ -29,7 +32,7 @@ class VmClassDisplay extends StatelessWidget {
         Flexible(
           child: VmObjectDisplayBasicLayout(
             object: clazz,
-            generalDataRows: _classDataRows(clazz),
+            generalDataRows: _classDataRows(context, clazz),
           ),
         ),
         if (displayClassInstances)
@@ -47,11 +50,22 @@ class VmClassDisplay extends StatelessWidget {
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the class object [clazz].
   List<MapEntry<String, WidgetBuilder>> _classDataRows(
+    BuildContext context,
     ClassObject clazz,
   ) {
+    final superClass = clazz.obj.superClass;
     return [
-      ...vmObjectGeneralDataRows(clazz),
-      selectableTextBuilderMapEntry('Superclass', clazz.obj.superClass?.name),
+      ...vmObjectGeneralDataRows(
+        context,
+        controller,
+        clazz,
+      ),
+      if (superClass != null)
+        serviceObjectLinkBuilderMapEntry<ClassRef>(
+          controller: controller,
+          key: 'Superclass',
+          object: superClass,
+        ),
       selectableTextBuilderMapEntry('SuperType', clazz.obj.superType?.name),
       selectableTextBuilderMapEntry(
         'Currently allocated instances',

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_class_display.dart
@@ -32,7 +32,7 @@ class VmClassDisplay extends StatelessWidget {
         Flexible(
           child: VmObjectDisplayBasicLayout(
             object: clazz,
-            generalDataRows: _classDataRows(context, clazz),
+            generalDataRows: _classDataRows(clazz),
           ),
         ),
         if (displayClassInstances)
@@ -50,13 +50,11 @@ class VmClassDisplay extends StatelessWidget {
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the class object [clazz].
   List<MapEntry<String, WidgetBuilder>> _classDataRows(
-    BuildContext context,
     ClassObject clazz,
   ) {
     final superClass = clazz.obj.superClass;
     return [
       ...vmObjectGeneralDataRows(
-        context,
         controller,
         clazz,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_code_display.dart
@@ -10,6 +10,7 @@ import '../../primitives/utils.dart';
 import '../../shared/table.dart';
 import '../../shared/table_data.dart';
 import '../../shared/theme.dart';
+import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
 import 'vm_service_private_extensions.dart';
 
@@ -224,9 +225,11 @@ class _DartObjectColumn extends _CodeColumnData {
 /// related to [Code] objects in the Dart VM.
 class VmCodeDisplay extends StatelessWidget {
   const VmCodeDisplay({
+    required this.controller,
     required this.code,
   });
 
+  final ObjectInspectorViewController controller;
   final CodeObject code;
 
   @override

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -631,7 +631,8 @@ class VmServiceObjectLink<T> extends StatelessWidget {
         if (lib.uri!.startsWith('dart') || preferUri) {
           text = lib.uri!;
         } else {
-          text = lib.name!.isEmpty ? lib.uri! : lib.name!;
+          final name = lib.name;
+          text = name!.isEmpty ? lib.uri! : name;
         }
       } else if (object is FieldRef) {
         final field = object as FieldRef;
@@ -742,7 +743,6 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
 }
 
 List<MapEntry<String, WidgetBuilder>> vmObjectGeneralDataRows(
-  BuildContext context,
   ObjectInspectorViewController controller,
   VmObject object,
 ) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -10,6 +13,7 @@ import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/table.dart';
 import '../../shared/theme.dart';
+import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
 import 'vm_service_private_extensions.dart';
 
@@ -69,6 +73,27 @@ MapEntry<String, WidgetBuilder> selectableTextBuilderMapEntry(
     (context) => SelectableText(
       value ?? '--',
       style: Theme.of(context).fixedFontStyle,
+    ),
+  );
+}
+
+MapEntry<String, WidgetBuilder>
+    serviceObjectLinkBuilderMapEntry<T extends ObjRef>({
+  required ObjectInspectorViewController controller,
+  required String key,
+  required T object,
+  bool preferUri = false,
+  String Function(T)? textBuilder,
+}) {
+  return MapEntry(
+    key,
+    (context) => VmServiceObjectLink<T>(
+      object: object,
+      textBuilder: textBuilder,
+      preferUri: preferUri,
+      onTap: (object) async {
+        await controller.findAndSelectNodeForObject(object);
+      },
     ),
   );
 }
@@ -243,31 +268,6 @@ String? _objectName(ObjRef? objectRef) {
   }
 
   return objectRefName;
-}
-
-/// Returns the owner name of a Field or Func object, if [object] is a
-/// FuncObject, it returns the complete (qualified) name of the owner.
-String? _ownerName(VmObject object) {
-  assert(object is FieldObject || object is FuncObject);
-  final owner = (object as dynamic).obj.owner as ObjRef?;
-
-  if (owner == null) {
-    return object.script?.uri;
-  }
-
-  if (object is FieldObject) {
-    if (owner is ClassRef || owner is LibraryRef) {
-      return _objectName(owner);
-    }
-  } else if (object is FuncObject) {
-    if (owner is LibraryRef) {
-      return _objectName(owner);
-    } else {
-      return qualifiedName(owner);
-    }
-  }
-
-  throw Exception('Unexpected owner type: ${owner.type}');
 }
 
 /// Returns the name of a function, qualified with the name of
@@ -609,6 +609,63 @@ class InboundReferencesWidget extends StatelessWidget {
   }
 }
 
+class VmServiceObjectLink<T> extends StatelessWidget {
+  const VmServiceObjectLink({
+    required this.object,
+    required this.onTap,
+    this.preferUri = false,
+    this.textBuilder,
+  });
+
+  final T object;
+  final bool preferUri;
+  final String Function(T)? textBuilder;
+  final FutureOr<void> Function(T) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    String text = '';
+    if (textBuilder == null) {
+      if (object is LibraryRef) {
+        final lib = object as LibraryRef;
+        if (lib.uri!.startsWith('dart') || preferUri) {
+          text = lib.uri!;
+        } else {
+          text = lib.name!.isEmpty ? lib.uri! : lib.name!;
+        }
+      } else if (object is FieldRef) {
+        final field = object as FieldRef;
+        text = field.name!;
+      } else if (object is FuncRef) {
+        final func = object as FuncRef;
+        text = func.name!;
+      } else if (object is ScriptRef) {
+        final script = object as ScriptRef;
+        text = script.uri!;
+      } else if (object is ClassRef) {
+        final cls = object as ClassRef;
+        text = cls.name!;
+      }
+    } else {
+      text = textBuilder!(object);
+    }
+
+    final theme = Theme.of(context);
+    return SelectableText.rich(
+      TextSpan(
+        text: text,
+        style: theme.linkTextStyle.apply(
+          fontFamily: theme.fixedFontStyle.fontFamily,
+        ),
+        recognizer: TapGestureRecognizer()
+          ..onTap = () async {
+            await onTap(object);
+          },
+      ),
+    );
+  }
+}
+
 /// A widget for the object inspector historyViewport containing the main
 /// layout of information widgets related to VM object types.
 class VmObjectDisplayBasicLayout extends StatelessWidget {
@@ -685,6 +742,8 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
 }
 
 List<MapEntry<String, WidgetBuilder>> vmObjectGeneralDataRows(
+  BuildContext context,
+  ObjectInspectorViewController controller,
   VmObject object,
 ) {
   return [
@@ -715,19 +774,25 @@ List<MapEntry<String, WidgetBuilder>> vmObjectGeneralDataRows(
       ),
     ),
     if (object is ClassObject || object is ScriptObject)
-      selectableTextBuilderMapEntry(
-        'Library',
-        _objectName((object.obj as dynamic).library),
+      serviceObjectLinkBuilderMapEntry<LibraryRef>(
+        controller: controller,
+        key: 'Library',
+        object: (object.obj as dynamic).library,
       ),
     if (object is FieldObject || object is FuncObject)
-      selectableTextBuilderMapEntry(
-        'Owner',
-        _ownerName(object),
+      serviceObjectLinkBuilderMapEntry<ObjRef>(
+        controller: controller,
+        key: 'Owner',
+        object: (object.obj as dynamic).owner,
       ),
     if (object is! ScriptObject && object is! LibraryObject)
-      selectableTextBuilderMapEntry(
-        'Script',
-        '${fileNameFromUri(object.script?.uri) ?? ''}:${object.pos?.toString() ?? ''}',
+      serviceObjectLinkBuilderMapEntry<ScriptRef>(
+        controller: controller,
+        key: 'Script',
+        object: object.script!,
+        textBuilder: (script) {
+          return '${fileNameFromUri(script.uri) ?? ''}:${object.pos?.toString() ?? ''}';
+        },
       ),
   ];
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 import 'vm_service_private_extensions.dart';
@@ -13,26 +14,33 @@ import 'vm_service_private_extensions.dart';
 /// related to field objects in the Dart VM.
 class VmFieldDisplay extends StatelessWidget {
   const VmFieldDisplay({
+    required this.controller,
     required this.field,
   });
 
+  final ObjectInspectorViewController controller;
   final FieldObject field;
 
   @override
   Widget build(BuildContext context) {
     return VmObjectDisplayBasicLayout(
       object: field,
-      generalDataRows: _fieldDataRows(field),
+      generalDataRows: _fieldDataRows(context, field),
     );
   }
 
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the field object [field].
   List<MapEntry<String, WidgetBuilder>> _fieldDataRows(
+    BuildContext context,
     FieldObject field,
   ) {
     return [
-      ...vmObjectGeneralDataRows(field),
+      ...vmObjectGeneralDataRows(
+        context,
+        controller,
+        field,
+      ),
       selectableTextBuilderMapEntry(
         'Observed types',
         _fieldObservedTypes(field),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_field_display.dart
@@ -25,19 +25,17 @@ class VmFieldDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return VmObjectDisplayBasicLayout(
       object: field,
-      generalDataRows: _fieldDataRows(context, field),
+      generalDataRows: _fieldDataRows(field),
     );
   }
 
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the field object [field].
   List<MapEntry<String, WidgetBuilder>> _fieldDataRows(
-    BuildContext context,
     FieldObject field,
   ) {
     return [
       ...vmObjectGeneralDataRows(
-        context,
         controller,
         field,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -29,7 +29,6 @@ class VmFuncDisplay extends StatelessWidget {
     return VmObjectDisplayBasicLayout(
       object: function,
       generalDataRows: vmObjectGeneralDataRows(
-        context,
         controller,
         function,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_function_display.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 import 'vm_service_private_extensions.dart';
@@ -16,16 +17,22 @@ import 'vm_service_private_extensions.dart';
 /// related to function (Func type) objects in the Dart VM.
 class VmFuncDisplay extends StatelessWidget {
   const VmFuncDisplay({
+    required this.controller,
     required this.function,
   });
 
+  final ObjectInspectorViewController controller;
   final FuncObject function;
 
   @override
   Widget build(BuildContext context) {
     return VmObjectDisplayBasicLayout(
       object: function,
-      generalDataRows: vmObjectGeneralDataRows(function),
+      generalDataRows: vmObjectGeneralDataRows(
+        context,
+        controller,
+        function,
+      ),
       sideCardDataRows: _functionDetailRows(function),
       sideCardTitle: 'Function Details',
     );

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
@@ -26,7 +26,7 @@ class VmLibraryDisplay extends StatelessWidget {
     final dependencies = library.obj.dependencies;
     return VmObjectDisplayBasicLayout(
       object: library,
-      generalDataRows: _libraryDataRows(context, library),
+      generalDataRows: _libraryDataRows(library),
       expandableWidgets: [
         if (dependencies != null)
           LibraryDependencies(dependencies: dependencies)
@@ -37,12 +37,10 @@ class VmLibraryDisplay extends StatelessWidget {
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the library object [library].
   List<MapEntry<String, WidgetBuilder>> _libraryDataRows(
-    BuildContext context,
     LibraryObject library,
   ) {
     return [
       ...vmObjectGeneralDataRows(
-        context,
         controller,
         library,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_library_display.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/theme.dart';
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 
@@ -14,16 +15,18 @@ import 'vm_object_model.dart';
 class VmLibraryDisplay extends StatelessWidget {
   const VmLibraryDisplay({
     required this.library,
+    required this.controller,
   });
 
   final LibraryObject library;
+  final ObjectInspectorViewController controller;
 
   @override
   Widget build(BuildContext context) {
     final dependencies = library.obj.dependencies;
     return VmObjectDisplayBasicLayout(
       object: library,
-      generalDataRows: _libraryDataRows(library),
+      generalDataRows: _libraryDataRows(context, library),
       expandableWidgets: [
         if (dependencies != null)
           LibraryDependencies(dependencies: dependencies)
@@ -34,15 +37,21 @@ class VmLibraryDisplay extends StatelessWidget {
   /// Generates a list of key-value pairs (map entries) containing the general
   /// information of the library object [library].
   List<MapEntry<String, WidgetBuilder>> _libraryDataRows(
+    BuildContext context,
     LibraryObject library,
   ) {
     return [
-      ...vmObjectGeneralDataRows(library),
-      selectableTextBuilderMapEntry(
-        'URI',
-        (library.obj.uri?.isEmpty ?? false)
-            ? library.script?.uri
-            : library.obj.uri,
+      ...vmObjectGeneralDataRows(
+        context,
+        controller,
+        library,
+      ),
+      serviceObjectLinkBuilderMapEntry<ObjRef>(
+        controller: controller,
+        key: 'URI',
+        preferUri: true,
+        object:
+            (library.obj.uri?.isEmpty ?? false) ? library.script! : library.obj,
       ),
       selectableTextBuilderMapEntry(
         'VM Name',

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -3,7 +3,9 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart';
 
+import 'object_inspector_view_controller.dart';
 import 'vm_developer_common_widgets.dart';
 import 'vm_object_model.dart';
 
@@ -12,28 +14,36 @@ import 'vm_object_model.dart';
 class VmScriptDisplay extends StatelessWidget {
   const VmScriptDisplay({
     required this.script,
+    required this.controller,
   });
 
   final ScriptObject script;
+  final ObjectInspectorViewController controller;
 
   @override
   Widget build(BuildContext context) {
     return VmObjectDisplayBasicLayout(
       object: script,
-      generalDataRows: _scriptDataRows(script),
+      generalDataRows: _scriptDataRows(context, script),
     );
   }
 
   /// Generates a list of key-value pairs (map entries) containing the general
   /// VM information of the Script object [script].
   List<MapEntry<String, WidgetBuilder>> _scriptDataRows(
+    BuildContext context,
     ScriptObject field,
   ) {
     return [
-      ...vmObjectGeneralDataRows(field),
-      selectableTextBuilderMapEntry(
-        'URI',
-        script.obj.uri,
+      ...vmObjectGeneralDataRows(
+        context,
+        controller,
+        field,
+      ),
+      serviceObjectLinkBuilderMapEntry<ScriptRef>(
+        controller: controller,
+        key: 'URI',
+        object: script.obj,
       ),
       selectableTextBuilderMapEntry(
         'Load time',

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_script_display.dart
@@ -24,19 +24,17 @@ class VmScriptDisplay extends StatelessWidget {
   Widget build(BuildContext context) {
     return VmObjectDisplayBasicLayout(
       object: script,
-      generalDataRows: _scriptDataRows(context, script),
+      generalDataRows: _scriptDataRows(script),
     );
   }
 
   /// Generates a list of key-value pairs (map entries) containing the general
   /// VM information of the Script object [script].
   List<MapEntry<String, WidgetBuilder>> _scriptDataRows(
-    BuildContext context,
     ScriptObject field,
   ) {
     return [
       ...vmObjectGeneralDataRows(
-        context,
         controller,
         field,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -264,6 +264,7 @@ enum FunctionKind {
 
 /// An extension on [Code] which allows for access to VM internal fields.
 extension CodePrivateViewExtension on Code {
+  static const _functionKey = 'function';
   static const _disassemblyKey = '_disassembly';
 
   /// Returns the disassembly of the [Code], which is the generated assembly
@@ -274,7 +275,7 @@ extension CodePrivateViewExtension on Code {
 
   /// Returns the function from which this code object was generated.
   FuncRef? get function {
-    final functionJson = json!['function'] as Map<String, dynamic>;
+    final functionJson = json![_functionKey] as Map<String, dynamic>;
     return FuncRef.parse(functionJson);
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -271,6 +271,12 @@ extension CodePrivateViewExtension on Code {
   Disassembly get disassembly => Disassembly.parse(json![_disassemblyKey]);
   set disassembly(Disassembly disassembly) =>
       json![_disassemblyKey] = disassembly.toJson();
+
+  /// Returns the function from which this code object was generated.
+  FuncRef? get function {
+    final functionJson = json!['function'] as Map<String, dynamic>;
+    return FuncRef.parse(functionJson);
+  }
 }
 
 /// An extension on [Field] which allows for access to VM internal fields.

--- a/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/object_viewport_test.dart
@@ -46,7 +46,7 @@ void main() {
     await tester.pumpWidget(
       wrap(ObjectViewport(controller: testObjectInspectorViewController)),
     );
-    expect(viewportTitle(null), 'No object selected.');
+    expect(ObjectViewport.viewportTitle(null), 'No object selected.');
     expect(find.text('No object selected.'), findsOneWidget);
     expect(find.byTooltip('Refresh'), findsOneWidget);
     expect(find.byType(HistoryViewport<VmObject>), findsOneWidget);
@@ -67,7 +67,7 @@ void main() {
       await tester.pumpWidget(
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
-      expect(viewportTitle(mockClassObject), 'Class FooClass');
+      expect(ObjectViewport.viewportTitle(mockClassObject), 'Class FooClass');
       expect(find.text('Class FooClass'), findsOneWidget);
       expect(find.byType(VmClassDisplay), findsOneWidget);
     });
@@ -90,7 +90,7 @@ void main() {
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
 
-      expect(viewportTitle(mockFieldObject), 'Field fooField');
+      expect(ObjectViewport.viewportTitle(mockFieldObject), 'Field fooField');
       expect(find.text('Field fooField'), findsOneWidget);
       expect(find.byType(VmFieldDisplay), findsOneWidget);
     });
@@ -118,7 +118,10 @@ void main() {
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
 
-      expect(viewportTitle(mockFuncObject), 'Function fooFunction');
+      expect(
+        ObjectViewport.viewportTitle(mockFuncObject),
+        'Function fooFunction',
+      );
       expect(find.text('Function fooFunction'), findsOneWidget);
       expect(find.byType(VmFuncDisplay), findsOneWidget);
     });
@@ -139,7 +142,10 @@ void main() {
       await tester.pumpWidget(
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
-      expect(viewportTitle(mockScriptObject), 'Script fooScript.dart');
+      expect(
+        ObjectViewport.viewportTitle(mockScriptObject),
+        'Script fooScript.dart',
+      );
       expect(find.text('Script fooScript.dart'), findsOneWidget);
       expect(find.byType(VmScriptDisplay), findsOneWidget);
     });
@@ -160,7 +166,7 @@ void main() {
       await tester.pumpWidget(
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
-      expect(viewportTitle(mockLibraryObject), 'Library fooLib');
+      expect(ObjectViewport.viewportTitle(mockLibraryObject), 'Library fooLib');
       expect(find.text('Library fooLib'), findsOneWidget);
       expect(find.byType(VmLibraryDisplay), findsOneWidget);
     });
@@ -176,7 +182,10 @@ void main() {
       await tester.pumpWidget(
         wrap(ObjectViewport(controller: testObjectInspectorViewController)),
       );
-      expect(viewportTitle(testInstanceObject), 'Instance FooInstance');
+      expect(
+        ObjectViewport.viewportTitle(testInstanceObject),
+        'Instance FooInstance',
+      );
       expect(find.text('Instance FooInstance'), findsOneWidget);
       expect(find.byType(VMInfoCard), findsOneWidget);
     });

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
@@ -23,7 +23,7 @@ void main() {
   late Class testClassCopy;
 
   setUp(() {
-    setUpProgramExplorerDependencies();
+    setUpMockScriptManager();
     setGlobal(IdeTheme, IdeTheme());
     mockClassObject = MockClassObject();
 

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_class_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -22,8 +23,8 @@ void main() {
   late Class testClassCopy;
 
   setUp(() {
+    setUpProgramExplorerDependencies();
     setGlobal(IdeTheme, IdeTheme());
-
     mockClassObject = MockClassObject();
 
     final json = testClass.toJson();
@@ -37,7 +38,14 @@ void main() {
 
   testWidgetsWithWindowSize('builds class display', windowSize,
       (WidgetTester tester) async {
-    await tester.pumpWidget(wrap(VmClassDisplay(clazz: mockClassObject)));
+    await tester.pumpWidget(
+      wrap(
+        VmClassDisplay(
+          clazz: mockClassObject,
+          controller: ObjectInspectorViewController(),
+        ),
+      ),
+    );
 
     expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
     expect(find.byType(VMInfoCard), findsOneWidget);

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -5,6 +5,7 @@
 import 'dart:math';
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_code_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -15,13 +16,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../vm_developer_test_utils.dart';
+
 void main() {
   late MockCodeObject mockCodeObject;
 
   const windowSize = Size(4000.0, 4000.0);
 
   group('VmCodeDisplay', () {
-    setUpAll(() {
+    setUp(() {
+      setUpProgramExplorerDependencies();
       setGlobal(IdeTheme, IdeTheme());
 
       mockCodeObject = MockCodeObject();
@@ -56,7 +60,14 @@ void main() {
     testWidgetsWithWindowSize(
         'displays CodeTable instructions in order of increasing address',
         windowSize, (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(VmCodeDisplay(code: mockCodeObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmCodeDisplay(
+            code: mockCodeObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.byType(CodeTable), findsOneWidget);
       final FlatTableState<Instruction> state =

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -25,7 +25,7 @@ void main() {
 
   group('VmCodeDisplay', () {
     setUp(() {
-      setUpProgramExplorerDependencies();
+      setUpMockScriptManager();
       setGlobal(IdeTheme, IdeTheme());
 
       mockCodeObject = MockCodeObject();

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -26,7 +26,7 @@ void main() {
   late InstanceRef fieldStaticValue;
 
   setUp(() {
-    setUpProgramExplorerDependencies();
+    setUpMockScriptManager();
     setGlobal(IdeTheme, IdeTheme());
 
     mockFieldObject = MockFieldObject();

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_field_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
@@ -25,6 +26,7 @@ void main() {
   late InstanceRef fieldStaticValue;
 
   setUp(() {
+    setUpProgramExplorerDependencies();
     setGlobal(IdeTheme, IdeTheme());
 
     mockFieldObject = MockFieldObject();
@@ -48,7 +50,14 @@ void main() {
   group('field data display tests', () {
     testWidgetsWithWindowSize('basic layout', windowSize,
         (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(VmFieldDisplay(field: mockFieldObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFieldDisplay(
+            field: mockFieldObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
       expect(find.byType(VMInfoCard), findsOneWidget);
@@ -75,7 +84,14 @@ void main() {
       when(mockFieldObject.guardNullable).thenReturn(true);
       when(mockFieldObject.guardClassKind).thenReturn(GuardClassKind.single);
 
-      await tester.pumpWidget(wrap(VmFieldDisplay(field: mockFieldObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFieldDisplay(
+            field: mockFieldObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
       expect(find.text('FooClass - null observed'), findsOneWidget);
     });
 
@@ -86,7 +102,14 @@ void main() {
       when(mockFieldObject.guardNullable).thenReturn(false);
       when(mockFieldObject.guardClassKind).thenReturn(GuardClassKind.dynamic);
 
-      await tester.pumpWidget(wrap(VmFieldDisplay(field: mockFieldObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFieldDisplay(
+            field: mockFieldObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
       expect(find.text('various - null not observed'), findsOneWidget);
     });
 
@@ -97,7 +120,14 @@ void main() {
       when(mockFieldObject.guardNullable).thenReturn(null);
       when(mockFieldObject.guardClassKind).thenReturn(GuardClassKind.unknown);
 
-      await tester.pumpWidget(wrap(VmFieldDisplay(field: mockFieldObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFieldDisplay(
+            field: mockFieldObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
       expect(
         find.text('none'),
         findsOneWidget,
@@ -108,7 +138,14 @@ void main() {
         (WidgetTester tester) async {
       testFieldCopy.staticValue = testClass;
 
-      await tester.pumpWidget(wrap(VmFieldDisplay(field: mockFieldObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFieldDisplay(
+            field: mockFieldObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.text('Static Value:'), findsNothing);
     });

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_function_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
@@ -23,6 +24,7 @@ void main() {
   late Func testFunctionCopy;
 
   setUp(() {
+    setUpProgramExplorerDependencies();
     setGlobal(IdeTheme, IdeTheme());
 
     mockFuncObject = MockFuncObject();
@@ -49,7 +51,14 @@ void main() {
   group('function display test', () {
     testWidgetsWithWindowSize('basic layout', windowSize,
         (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(VmFuncDisplay(function: mockFuncObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFuncDisplay(
+            function: mockFuncObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
       expect(find.byType(VMInfoCard), findsNWidgets(2));
@@ -90,7 +99,14 @@ void main() {
         (WidgetTester tester) async {
       when(mockFuncObject.kind).thenReturn(null);
 
-      await tester.pumpWidget(wrap(VmFuncDisplay(function: mockFuncObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmFuncDisplay(
+            function: mockFuncObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.text('Unrecognized function kind: null'), findsOneWidget);
     });

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
@@ -24,7 +24,7 @@ void main() {
   late Func testFunctionCopy;
 
   setUp(() {
-    setUpProgramExplorerDependencies();
+    setUpMockScriptManager();
     setGlobal(IdeTheme, IdeTheme());
 
     mockFuncObject = MockFuncObject();

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_library_display.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
@@ -27,6 +28,7 @@ void main() {
     const windowSize = Size(4000.0, 4000.0);
 
     setUpAll(() {
+      setUpProgramExplorerDependencies();
       mockLibraryObject = MockLibraryObject();
 
       final json = testLib.toJson();
@@ -41,8 +43,14 @@ void main() {
 
     testWidgetsWithWindowSize(' - basic layout', windowSize,
         (WidgetTester tester) async {
-      await tester
-          .pumpWidget(wrap(VmLibraryDisplay(library: mockLibraryObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmLibraryDisplay(
+            library: mockLibraryObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
       expect(find.byType(VMInfoCard), findsOneWidget);
@@ -66,8 +74,14 @@ void main() {
         (WidgetTester tester) async {
       testLibCopy.dependencies = null;
 
-      await tester
-          .pumpWidget(wrap(VmLibraryDisplay(library: mockLibraryObject)));
+      await tester.pumpWidget(
+        wrap(
+          VmLibraryDisplay(
+            library: mockLibraryObject,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
 
       expect(find.byType(LibraryDependencies), findsNothing);
     });

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
@@ -28,7 +28,7 @@ void main() {
     const windowSize = Size(4000.0, 4000.0);
 
     setUpAll(() {
-      setUpProgramExplorerDependencies();
+      setUpMockScriptManager();
       mockLibraryObject = MockLibraryObject();
 
       final json = testLib.toJson();

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_script_display.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -37,7 +38,15 @@ void main() {
 
   testWidgetsWithWindowSize('builds script display', windowSize,
       (WidgetTester tester) async {
-    await tester.pumpWidget(wrap(VmScriptDisplay(script: mockScriptObject)));
+    final controller = ObjectInspectorViewController();
+    await tester.pumpWidget(
+      wrap(
+        VmScriptDisplay(
+          controller: controller,
+          script: mockScriptObject,
+        ),
+      ),
+    );
 
     expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
     expect(find.byType(VMInfoCard), findsOneWidget);

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
@@ -24,7 +24,7 @@ void main() {
 
   setUp(() {
     setGlobal(IdeTheme, IdeTheme());
-
+    setUpMockScriptManager();
     mockScriptObject = MockScriptObject();
 
     final json = testScript.toJson();

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -2,12 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app/src/primitives/listenable.dart';
 import 'package:devtools_app/src/primitives/utils.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
 import 'package:devtools_app/src/screens/debugger/program_explorer_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_viewport.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_object_model.dart';
+import 'package:devtools_app/src/scripts/script_manager.dart';
+import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mockito/mockito.dart';
@@ -167,6 +170,14 @@ class TestInstanceObject extends InstanceObject {
 
   @override
   String? get name => 'FooInstance';
+}
+
+void setUpProgramExplorerDependencies() {
+  final mockScriptManager = MockScriptManager();
+  when(mockScriptManager.sortedScripts).thenReturn(
+    FixedValueListenable<List<ScriptRef>>([testScript]),
+  );
+  setGlobal(ScriptManager, mockScriptManager);
 }
 
 void mockVmObject(VmObject object) {

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -172,7 +172,7 @@ class TestInstanceObject extends InstanceObject {
   String? get name => 'FooInstance';
 }
 
-void setUpProgramExplorerDependencies() {
+void setUpMockScriptManager() {
   final mockScriptManager = MockScriptManager();
   when(mockScriptManager.sortedScripts).thenReturn(
     FixedValueListenable<List<ScriptRef>>([testScript]),


### PR DESCRIPTION
From the original PR (https://github.com/flutter/devtools/pull/4387):

"Implements the `searchFileExplorer` and `breadthFirstSearchObject` methods in the ProgramExplorerController.
The `searchFileExplorer` searches and returns the script or library node in the FileExplorer which is the source location of a target object.
The `breadthFirstSearchObject` performs a breath first search on a list of roots and returns the first node whose object is the same as the target object. It is used as a helper of `searchFileExplorer` or to search an object in the ProgramExplorer `outlineNodes.value`.

These two methods are currently used in the ObjectInspectorViewController `_onCurrentObjectChanged` method to find the corresponding FileExplorer and outline nodes if the current object does not have associated `scriptRefs` or `outlineNode` values.
Consider using these methods for pushing objects that are not accessed directly through the ProgramExplorer, but instead through a linking button or widget."