### PR TITLE
Use a broadcast stream controller for the enhance tracing button

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
@@ -18,7 +18,7 @@ final enhanceTracingExtensions = [
 
 class EnhanceTracingController extends DisposableController
     with AutoDisposeControllerMixin {
-  final showMenuStreamController = StreamController<void>();
+  final showMenuStreamController = StreamController<void>.broadcast();
 
   late EnhanceTracingState tracingState;
 


### PR DESCRIPTION
This fixes a bug where opening the Performance page, opening a different page, and then re-opening a performance page would throw an exception for the StreamController's stream being listened to twice. Using a broadcast stream allows us to add multiple listeners.