### PR TITLE
Increase size of frame width in Flutter frames chart

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/flutter_frames_chart.dart
@@ -285,7 +285,7 @@ class FlutterFramesChartItem extends StatelessWidget {
     required this.displayRefreshRate,
   });
 
-  static const defaultFrameWidth = 24.0;
+  static const defaultFrameWidth = 28.0;
 
   static const selectedIndicatorHeight = 8.0;
 


### PR DESCRIPTION
This prevents the frame number text from getting cut off