### PR TITLE
Move feature flags to one location.

### DIFF
--- a/packages/devtools_app/lib/src/primitives/feature_flags.dart
+++ b/packages/devtools_app/lib/src/primitives/feature_flags.dart
@@ -5,7 +5,6 @@
 // It is ok to have enum-like static only classes.
 // ignore: avoid_classes_with_only_static_members
 /// Flags to hide features under construction.
-///
 class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/4335
   static bool newAllocationProfileTable = false;

--- a/packages/devtools_app/lib/src/primitives/feature_flags.dart
+++ b/packages/devtools_app/lib/src/primitives/feature_flags.dart
@@ -7,6 +7,9 @@
 /// Flags to hide features under construction.
 ///
 class FeatureFlags {
+  /// https://github.com/flutter/devtools/issues/4335
   static bool newAllocationProfileTable = false;
+
+  /// https://github.com/flutter/devtools/issues/3949
   static bool memoryDiffing = false;
 }

--- a/packages/devtools_app/lib/src/primitives/feature_flags.dart
+++ b/packages/devtools_app/lib/src/primitives/feature_flags.dart
@@ -1,0 +1,12 @@
+// Copyright 2020 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// It is ok to have enum-like static only classes.
+// ignore: avoid_classes_with_only_static_members
+/// Flags to hide features under construction.
+///
+class FeatureFlags {
+  static bool newAllocationProfileTable = false;
+  static bool memoryDiffing = false;
+}

--- a/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_heap_tree_view.dart
@@ -14,6 +14,7 @@ import '../../analytics/analytics.dart' as ga;
 import '../../analytics/constants.dart' as analytics_constants;
 import '../../config_specific/logger/logger.dart' as logger;
 import '../../primitives/auto_dispose_mixin.dart';
+import '../../primitives/feature_flags.dart';
 import '../../primitives/utils.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/globals.dart';
@@ -37,11 +38,6 @@ import 'panes/allocation_tracing/allocation_profile_tracing_view.dart';
 import 'panes/diff/diff_pane.dart';
 import 'panes/leaks/leaks_pane.dart';
 import 'primitives/memory_utils.dart';
-
-// TODO(bkonyi): enable new allocation profile table when we're ready to remove
-// the existing allocations table.
-@visibleForTesting
-bool enableNewAllocationProfileTable = false;
 
 const memorySearchFieldKeyName = 'MemorySearchFieldKey';
 
@@ -206,7 +202,7 @@ class HeapTreeViewState extends State<HeapTree>
 
   void _initTabs() {
     _tabs = [
-      if (enableNewAllocationProfileTable) ...[
+      if (FeatureFlags.newAllocationProfileTable) ...[
         DevToolsTab.create(
           key: dartHeapTableProfileKey,
           tabName: 'Profile',
@@ -228,7 +224,7 @@ class HeapTreeViewState extends State<HeapTree>
         gaPrefix: _gaPrefix,
         tabName: 'Allocations',
       ),
-      if (shouldShowDiffPane)
+      if (FeatureFlags.memoryDiffing)
         DevToolsTab.create(
           key: diffTabKey,
           gaPrefix: _gaPrefix,
@@ -497,7 +493,7 @@ class HeapTreeViewState extends State<HeapTree>
               controller: _tabController,
               children: [
                 // Profile Tab
-                if (enableNewAllocationProfileTable) ...[
+                if (FeatureFlags.newAllocationProfileTable) ...[
                   KeepAliveWrapper(
                     child: AllocationProfileTableView(
                       controller: controller.allocationProfileController,
@@ -532,7 +528,7 @@ class HeapTreeViewState extends State<HeapTree>
                   ),
                 ),
                 // Diff tab.
-                if (shouldShowDiffPane)
+                if (FeatureFlags.memoryDiffing)
                   const KeepAliveWrapper(child: DiffPane()),
                 // Leaks tab.
                 if (controller.shouldShowLeaksTab.value)

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/diff_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/diff_pane.dart
@@ -12,12 +12,6 @@ import 'widgets/snapshot_control_pane.dart';
 import 'widgets/snapshot_list.dart';
 import 'widgets/snapshot_view.dart';
 
-/// While this pane is under construction, we do not want our users to see it.
-///
-/// Flip this flag locally to test the pane and flip back before checking in.
-/// TODO: before removing this flag add widget/golden testing for the diff pane.
-bool shouldShowDiffPane = false;
-
 class DiffPane extends StatefulWidget {
   const DiffPane({Key? key}) : super(key: key);
 

--- a/packages/devtools_app/test/memory/allocation_profile/allocation_profile_table_view_test.dart
+++ b/packages/devtools_app/test/memory/allocation_profile/allocation_profile_table_view_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/primitives/feature_flags.dart';
 import 'package:devtools_app/src/screens/memory/memory_controller.dart';
 import 'package:devtools_app/src/screens/memory/memory_heap_tree_view.dart';
 import 'package:devtools_app/src/screens/memory/memory_screen.dart';
@@ -64,12 +65,12 @@ void main() {
 
   test('Allocation profile disabled by default', () {
     // TODO(bkonyi): remove this check once we enable the tab by default.
-    expect(enableNewAllocationProfileTable, isFalse);
+    expect(FeatureFlags.newAllocationProfileTable, isFalse);
   });
 
   group('Allocation Profile Table', () {
-    setUpAll(() => enableNewAllocationProfileTable = true);
-    tearDownAll(() => enableNewAllocationProfileTable = false);
+    setUpAll(() => FeatureFlags.newAllocationProfileTable = true);
+    tearDownAll(() => FeatureFlags.newAllocationProfileTable = false);
 
     setUp(() async {
       setGlobal(OfflineModeController, OfflineModeController());

--- a/packages/devtools_app/test/memory/allocation_tracing/allocation_profile_tracing_view_test.dart
+++ b/packages/devtools_app/test/memory/allocation_tracing/allocation_profile_tracing_view_test.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/primitives/feature_flags.dart';
 import 'package:devtools_app/src/primitives/trees.dart';
 import 'package:devtools_app/src/screens/memory/memory_controller.dart';
 import 'package:devtools_app/src/screens/memory/memory_heap_tree_view.dart';
@@ -91,21 +92,21 @@ void main() {
 
   test('Allocation tracing disabled by default', () {
     // TODO(bkonyi): remove this check once we enable the tab by default.
-    expect(enableNewAllocationProfileTable, isFalse);
+    expect(FeatureFlags.newAllocationProfileTable, isFalse);
   });
 
   group('Allocation Tracing', () {
     late final CpuSamples allocationTracingProfile;
 
     setUpAll(() {
-      enableNewAllocationProfileTable = true;
+      FeatureFlags.newAllocationProfileTable = true;
       final rawProfile = File(
         'test/test_data/memory/allocation_tracing/allocation_trace.json',
       ).readAsStringSync();
       allocationTracingProfile = CpuSamples.parse(jsonDecode(rawProfile))!;
     });
 
-    tearDownAll(() => enableNewAllocationProfileTable = false);
+    tearDownAll(() => FeatureFlags.newAllocationProfileTable = false);
 
     setUp(() async {
       setGlobal(NotificationService, NotificationService());

--- a/packages/devtools_app/test/memory/diff/diff_pane_test.dart
+++ b/packages/devtools_app/test/memory/diff/diff_pane_test.dart
@@ -2,11 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/screens/memory/panes/diff/diff_pane.dart';
+import 'package:devtools_app/src/primitives/feature_flags.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   test('Diff tab is off yet.', () {
-    expect(shouldShowDiffPane, false);
+    expect(FeatureFlags.memoryDiffing, false);
   });
 }

--- a/packages/devtools_app/test/scenes/memory/offline.dart
+++ b/packages/devtools_app/test/scenes/memory/offline.dart
@@ -1,9 +1,8 @@
 import 'package:devtools_app/src/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/config_specific/import_export/import_export.dart';
+import 'package:devtools_app/src/primitives/feature_flags.dart';
 import 'package:devtools_app/src/screens/memory/memory_controller.dart';
-import 'package:devtools_app/src/screens/memory/memory_heap_tree_view.dart';
 import 'package:devtools_app/src/screens/memory/memory_screen.dart';
-import 'package:devtools_app/src/screens/memory/panes/diff/diff_pane.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/notifications.dart';
@@ -33,8 +32,8 @@ class MemoryOfflineScene extends Scene {
 
   @override
   Future<void> setUp() async {
-    enableNewAllocationProfileTable = true;
-    shouldShowDiffPane = true;
+    FeatureFlags.newAllocationProfileTable = true;
+    FeatureFlags.memoryDiffing = true;
 
     await ensureInspectorDependencies();
     setGlobal(OfflineModeController, OfflineModeController());
@@ -73,7 +72,7 @@ class MemoryOfflineScene extends Scene {
   String get title => '$MemoryOfflineScene';
 
   void tearDown() {
-    enableNewAllocationProfileTable = false;
-    shouldShowDiffPane = false;
+    FeatureFlags.newAllocationProfileTable = false;
+    FeatureFlags.memoryDiffing = false;
   }
 }


### PR DESCRIPTION
to make it easier to:
- turn them on for experiments
- observe what is under construction at the moment