### PR TITLE
Stop hiding log messages from non-stdout sources

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/_message_column.dart
+++ b/packages/devtools_app/lib/src/screens/logging/_message_column.dart
@@ -85,7 +85,7 @@ class MessageColumn extends ColumnData<LogData>
           ),
         ],
       );
-    } else if (data.kind == 'stdout') {
+    } else
       return RichText(
         text: TextSpan(
           children: processAnsiTerminalCodes(
@@ -98,8 +98,5 @@ class MessageColumn extends ColumnData<LogData>
         overflow: TextOverflow.ellipsis,
         maxLines: 1,
       );
-    } else {
-      return const SizedBox.shrink();
-    }
   }
 }


### PR DESCRIPTION
We were showing nothing in the message column for all logs that didn't have the type 'stdout'. This excluded things like logs from dart developer, gc logs, stderr, etc. 

Fixes https://github.com/flutter/devtools/issues/4130