### PR TITLE
Save last VM Service URI on landing screen in debug mode only.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   mime: ^1.0.0
   path: ^1.8.0
   provider: ^6.0.2
+  # Only used for debug mode logic.
+  shared_preferences: ^2.0.15
   sse: ^4.0.0
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0


### PR DESCRIPTION
I found it annoying to have to paste the VM Service URI of the sample app I was using into DevTools after hot restarting or re-running devtools.

Only for debug mode, I've tweaked DevTools to save the last VM Service URI used. This will save us time as long as most of the time when debugging devtools we just want to connect to the previous sample app. I haven't enabled this in profile or release builds as I don't think the previously used VM Service URI is useful unless you are iterating on the DevTools app.

The extra package added as a dependency already exists in g3 and should be dead code that is compiled out of release builds.