### PR TITLE
Small reorg for heap related code.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/heap_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/heap_diff.dart
@@ -5,7 +5,6 @@
 import 'package:flutter/foundation.dart';
 
 import '../../../shared/heap/heap.dart';
-import '../../../shared/heap/model.dart';
 
 /// Stores already calculated comparisons for heap couples.
 class HeapDiffStore {

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../../shared/common_widgets.dart';
 import '../../../../../shared/split.dart';
-import '../../../shared/heap/model.dart';
+import '../../../shared/heap/heap.dart';
 import '../controller/diff_pane_controller.dart';
 import '../controller/item_controller.dart';
 import 'class_details.dart';

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/stats_table.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/stats_table.dart
@@ -9,7 +9,7 @@ import '../../../../../primitives/utils.dart';
 import '../../../../../shared/table.dart';
 import '../../../../../shared/table_data.dart';
 import '../../../../../shared/utils.dart';
-import '../../../shared/heap/model.dart';
+import '../../../shared/heap/heap.dart';
 import '../controller/diff_pane_controller.dart';
 import '../controller/item_controller.dart';
 

--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/heap.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/heap.dart
@@ -11,26 +11,52 @@ class AdaptedHeap {
   final AdaptedHeapData data;
 
   late final HeapStatistics stats = _heapStatistics(data);
+
+  static HeapStatistics _heapStatistics(AdaptedHeapData data) {
+    final result = <String, HeapStatsRecord>{};
+    if (!data.isSpanningTreeBuilt) buildSpanningTree(data);
+
+    for (var object in data.objects) {
+      final heapClass = object.heapClass;
+
+      // We do not show objects that will be garbage collected soon.
+      if (object.retainedSize == null || heapClass.isSentinel) continue;
+
+      final fullName = heapClass.fullName;
+      if (!result.containsKey(fullName)) {
+        result[fullName] = HeapStatsRecord(heapClass);
+      }
+      final stats = result[fullName]!;
+      stats.retainedSize += object.retainedSize ?? 0;
+      stats.shallowSize += object.shallowSize;
+      stats.instanceCount++;
+    }
+    return HeapStatistics(result);
+  }
 }
 
-HeapStatistics _heapStatistics(AdaptedHeapData data) {
-  final result = <String, HeapStatsRecord>{};
-  if (!data.isSpanningTreeBuilt) buildSpanningTree(data);
+class HeapStatistics {
+  HeapStatistics(this.recordsByClass);
 
-  for (var object in data.objects) {
-    final heapClass = object.heapClass;
+  /// Maps full class name to stats record of this class.
+  final Map<String, HeapStatsRecord> recordsByClass;
+  late final List<HeapStatsRecord> records =
+      recordsByClass.values.toList(growable: false);
+}
 
-    // We do not show objects that will be garbage collected soon.
-    if (object.retainedSize == null || heapClass.isSentinel) continue;
+class HeapStatsRecord {
+  HeapStatsRecord(this.heapClass);
 
-    final fullName = heapClass.fullName;
-    if (!result.containsKey(fullName)) {
-      result[fullName] = HeapStatsRecord(heapClass);
-    }
-    final stats = result[fullName]!;
-    stats.retainedSize += object.retainedSize ?? 0;
-    stats.shallowSize += object.shallowSize;
-    stats.instanceCount++;
-  }
-  return HeapStatistics(result);
+  final HeapClass heapClass;
+  int instanceCount = 0;
+  int shallowSize = 0;
+  int retainedSize = 0;
+
+  HeapStatsRecord negative() => HeapStatsRecord(heapClass)
+    ..instanceCount = -instanceCount
+    ..shallowSize = -shallowSize
+    ..retainedSize = -retainedSize;
+
+  bool get isZero =>
+      shallowSize == 0 && retainedSize == 0 && instanceCount == 0;
 }

--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/model.dart
@@ -174,23 +174,6 @@ class AdaptedHeapObject {
   String get name => '${heapClass.library}/$shortName';
 }
 
-class HeapStatsRecord {
-  HeapStatsRecord(this.heapClass);
-
-  final HeapClass heapClass;
-  int instanceCount = 0;
-  int shallowSize = 0;
-  int retainedSize = 0;
-
-  HeapStatsRecord negative() => HeapStatsRecord(heapClass)
-    ..instanceCount = -instanceCount
-    ..shallowSize = -shallowSize
-    ..retainedSize = -retainedSize;
-
-  bool get isZero =>
-      shallowSize == 0 && retainedSize == 0 && instanceCount == 0;
-}
-
 /// This class is needed to make the snapshot taking operation mockable.
 class SnapshotTaker {
   Future<AdaptedHeapData?> take() async {
@@ -232,13 +215,4 @@ class HeapClass {
     assert(false, 'Unexpected library for $className: $library.');
     return false;
   }
-}
-
-class HeapStatistics {
-  HeapStatistics(this.recordsByClass);
-
-  /// Maps full class name to stats record of this class.
-  final Map<String, HeapStatsRecord> recordsByClass;
-  late final List<HeapStatsRecord> records =
-      recordsByClass.values.toList(growable: false);
 }


### PR DESCRIPTION
Move heap statistic code to heap.dart, to emphasize the code is higher level than simple objects in model.dart.

No functional changes here.