### PR TITLE
Fixes broken file opener and search

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -230,11 +230,11 @@ class _CodeViewState extends State<CodeView>
 
     return DualValueListenableBuilder<bool, bool>(
       firstListenable: widget.enableFileExplorer
-          ? const FixedValueListenable<bool>(false)
-          : widget.codeViewController.showFileOpener,
+          ? widget.codeViewController.showFileOpener
+          : const FixedValueListenable<bool>(false),
       secondListenable: widget.enableSearch
-          ? const FixedValueListenable<bool>(false)
-          : widget.codeViewController.showSearchInFileField,
+          ? widget.codeViewController.showSearchInFileField
+          : const FixedValueListenable<bool>(false),
       builder: (context, showFileOpener, showSearch, _) {
         return Stack(
           children: [

--- a/packages/devtools_app/macos/Runner.xcodeproj/project.pbxproj
+++ b/packages/devtools_app/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 48;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -192,7 +192,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0920;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1300;
 				ORGANIZATIONNAME = "Google LLC";
 				TargetAttributes = {
 					33CC10EC2044A3C60003C045 = {
@@ -245,6 +245,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/packages/devtools_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/packages/devtools_app/macos/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1000"
+   LastUpgradeVersion = "1300"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4524

The ternaries are backwards, so we weren't showing the file opener / file search if they were enabled. 

Will add test cases for both in follow-up PR so that we don't accidentally disable them in the future.
