### PR TITLE
Fix start-paused issue with inspector tab

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -151,6 +151,11 @@ class InspectorController extends DisposableController
           .hasServiceExtension(extensions.toggleSelectWidgetMode.extension);
 
   void _onClientChange(bool added) {
+    if (!added && _clientCount == 0) {
+      // Don't try to remove clients if there are none
+      return;
+    }
+
     _clientCount += added ? 1 : -1;
     assert(_clientCount >= 0);
     if (_clientCount == 1) {


### PR DESCRIPTION
![](https://media.giphy.com/media/3o72F0Bvsi8CLuY5KE/giphy.gif) 
Fixes https://github.com/flutter/devtools/issues/2081

The inspector tab was having issues  cleaning up if a client was never added.

I've added a fail safe to the removal code to make it safe to call even when there is nothing to remove.