### PR TITLE
Add `Clear` button to `Allocation Tracing` tab

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
@@ -40,8 +40,18 @@ class AllocationProfileTracingViewState
         Row(
           children: [
             RefreshButton(
+              tooltip: 'Request the set of updated allocation traces',
               onPressed: () async {
                 await controller.refresh();
+              },
+            ),
+            const SizedBox(
+              width: denseSpacing,
+            ),
+            ClearButton(
+              tooltip: 'Clear the set of previously collected traces',
+              onPressed: () async {
+                await controller.clear();
               },
             ),
             const _ProfileHelpLink(),

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
@@ -217,8 +217,8 @@ class AllocationProfileTracingViewController extends DisposableController
     // Note: we need to provide `timeExtentMicros` to `getAllocationTraces`,
     // otherwise the VM will respond with all samples, not just the samples
     // collected after `_lastClearTimeMicros`. We'll just use the maximum
-    // signed 64-bit value in place of "infinity".
-    const int64Max = 0x7FFFFFFFFFFFFFFF;
+    // Javascript integer value (2^53 - 1) to represent "infinity". 
+    const int64Max = 0x1FFFFFFFFFFFFF;
     // Request the allocation profile for the traced class.
     final trace = await service.getAllocationTraces(
       isolateId,

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
@@ -218,13 +218,12 @@ class AllocationProfileTracingViewController extends DisposableController
     // otherwise the VM will respond with all samples, not just the samples
     // collected after `_lastClearTimeMicros`. We'll just use the maximum
     // Javascript integer value (2^53 - 1) to represent "infinity".
-    const int64Max = 0x1FFFFFFFFFFFFF;
     // Request the allocation profile for the traced class.
     final trace = await service.getAllocationTraces(
       isolateId,
       classId: cls.id!,
       timeOriginMicros: _lastClearTimeMicros,
-      timeExtentMicros: int64Max,
+      timeExtentMicros: maxJsInt,
     );
 
     final profileData = await CpuProfileData.generateFromCpuSamples(

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view_controller.dart
@@ -217,7 +217,7 @@ class AllocationProfileTracingViewController extends DisposableController
     // Note: we need to provide `timeExtentMicros` to `getAllocationTraces`,
     // otherwise the VM will respond with all samples, not just the samples
     // collected after `_lastClearTimeMicros`. We'll just use the maximum
-    // Javascript integer value (2^53 - 1) to represent "infinity". 
+    // Javascript integer value (2^53 - 1) to represent "infinity".
     const int64Max = 0x1FFFFFFFFFFFFF;
     // Request the allocation profile for the traced class.
     final trace = await service.getAllocationTraces(


### PR DESCRIPTION
Allows for resetting the state of previously collected allocation samples. Pressing the clear button resets the instance counts to zero, deletes old profiles. Pressing refresh after a clear will only fetch samples collected after the clear button was last pressed.

![image](https://user-images.githubusercontent.com/24210656/192587837-823e4f63-1b34-4b30-8bfe-4fd3580c30bb.png)
