### PR TITLE
Empty tree root analytics

### DIFF
--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -42,6 +42,9 @@ const discordLink = 'discord';
 // Inspector UX actions:
 const refresh = 'refresh';
 const refreshEmptyTree = 'refreshEmptyTree';
+const userRefreshResultsInEmptyTree = 'userRefreshResultsInEmptyTree';
+const recomputeTreeRootResultsInEmptyRoot =
+    'recomputeTreeRootResultsInEmptyRoot';
 const debugPaint = 'debugPaint';
 const debugPaintDocs = 'debugPaintDocs';
 const paintBaseline = 'paintBaseline';

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -43,6 +43,7 @@ const discordLink = 'discord';
 const refresh = 'refresh';
 const refreshEmptyTree = 'refreshEmptyTree';
 const userRefreshResultsInEmptyTree = 'userRefreshResultsInEmptyTree';
+const firstInspectorTreeRefreshIsEmpty = 'firstInspectorTreeRefreshIsEmpty';
 const recomputeTreeRootResultsInEmptyRoot =
     'recomputeTreeRootResultsInEmptyRoot';
 const debugPaint = 'debugPaint';

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -43,8 +43,8 @@ const discordLink = 'discord';
 const refresh = 'refresh';
 const refreshEmptyTree = 'refreshEmptyTree';
 const userRefreshResultsInEmptyTree = 'userRefreshResultsInEmptyTree';
-const recomputeTreeRootResultsInEmptyRoot =
-    'recomputeTreeRootResultsInEmptyRoot';
+const emptyRootAfterRecomputeTreeRoot =
+    'emptyRootAfterRecomputeTreeRoot';
 const debugPaint = 'debugPaint';
 const debugPaintDocs = 'debugPaintDocs';
 const paintBaseline = 'paintBaseline';

--- a/packages/devtools_app/lib/src/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/analytics/constants.dart
@@ -43,7 +43,6 @@ const discordLink = 'discord';
 const refresh = 'refresh';
 const refreshEmptyTree = 'refreshEmptyTree';
 const userRefreshResultsInEmptyTree = 'userRefreshResultsInEmptyTree';
-const firstInspectorTreeRefreshIsEmpty = 'firstInspectorTreeRefreshIsEmpty';
 const recomputeTreeRootResultsInEmptyRoot =
     'recomputeTreeRootResultsInEmptyRoot';
 const debugPaint = 'debugPaint';

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -473,7 +473,7 @@ class InspectorController extends DisposableController
       if (visibleToUser && rootNode.children.isEmpty) {
         ga.select(
           analytics_constants.inspector,
-          analytics_constants.recomputeTreeRootResultsInEmptyRoot,
+          analytics_constants.emptyRootAfterRecomputeTreeRoot,
           nonInteraction: true,
         );
       }

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -21,6 +21,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../analytics/analytics.dart' as ga;
 import '../../config_specific/logger/logger.dart';
 import '../../config_specific/url/url.dart';
 import '../../primitives/auto_dispose.dart';
@@ -467,6 +468,10 @@ class InspectorController extends DisposableController
         expandProperties: false,
       );
       inspectorTree.root = rootNode;
+
+      if (visibleToUser && rootNode.children.isEmpty) {
+        ga.reportError('Empty Inspector Widget Tree presented to user');
+      }
 
       refreshSelection(newSelection, detailsSelection, setSubtreeRoot);
     } catch (error) {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -22,6 +22,7 @@ import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../analytics/analytics.dart' as ga;
+import '../../analytics/constants.dart' as analytics_constants;
 import '../../config_specific/logger/logger.dart';
 import '../../config_specific/url/url.dart';
 import '../../primitives/auto_dispose.dart';
@@ -470,7 +471,11 @@ class InspectorController extends DisposableController
       inspectorTree.root = rootNode;
 
       if (visibleToUser && rootNode.children.isEmpty) {
-        ga.reportError('Empty Inspector Widget Tree presented to user');
+        ga.select(
+          analytics_constants.inspector,
+          analytics_constants.recomputeTreeRootResultsInEmptyRoot,
+          nonInteraction: true,
+        );
       }
 
       refreshSelection(newSelection, detailsSelection, setSubtreeRoot);

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -125,10 +125,11 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         searchPreventClose = false;
       }
     });
-    addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
+    addAutoDisposeListener(preferences.inspector.customPubRootDirectories,
+        () async {
       if (serviceManager.hasConnection &&
           controller.firstInspectorTreeLoadCompleted) {
-        _refreshInspector();
+        await controller.onForceRefresh();
       }
     });
   }
@@ -326,7 +327,16 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         );
         controller.firstInspectorTreeLoadCompleted = true;
       }
+
       await controller.onForceRefresh();
+
+      if (controller.inspectorTree.root?.children != null &&
+          controller.inspectorTree.root!.children.isEmpty) {
+        ga.select(
+          analytics_constants.inspector,
+          analytics_constants.userRefreshResultsInEmptyTree,
+        );
+      }
     });
   }
 }

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -329,13 +329,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       // completed, this could indicate a slow load time or that the inspector
       // failed to load the tree once available.
       if (!controller.firstInspectorTreeLoadCompleted) {
-        if (controller.inspectorTree.root?.children != null &&
-            controller.inspectorTree.root!.children.isEmpty) {
-          ga.select(
-            analytics_constants.inspector,
-            analytics_constants.firstInspectorTreeRefreshIsEmpty,
-          );
-        }
         // We do not want to complete this timing operation because the force
         // refresh will skew the results.
         ga.cancelTimingOperation(

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -323,8 +323,6 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   Future<void> _refreshInspector() async {
     ga.select(analytics_constants.inspector, analytics_constants.refresh);
     await blockWhileInProgress(() async {
-      await controller.onForceRefresh();
-
       // If the user is force refreshing the inspector before the first load has
       // completed, this could indicate a slow load time or that the inspector
       // failed to load the tree once available.
@@ -341,6 +339,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         );
         controller.firstInspectorTreeLoadCompleted = true;
       }
+      await controller.onForceRefresh();
     });
   }
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/26gs6qd1I4qTHUWiI/giphy-downsized.gif)
Fixes https://github.com/flutter/devtools/issues/4544

Add analytics events for:
- every time the inspector tree is loaded and is empty
- any time the user refreshes the tree and the tree comes back empty