### PR TITLE
fix analyzer errors

### DIFF
--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -140,7 +140,7 @@ class _InitializerState extends State<Initializer>
           analytics_constants.devToolsMain,
           analytics_constants.appDisconnected,
         );
-        Overlay.of(context)!.insert(_createDisconnectedOverlay());
+        Overlay.of(context).insert(_createDisconnectedOverlay());
 
         addAutoDisposeListener(serviceManager.connectedState, () {
           final connectedState = serviceManager.connectedState.value;

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -67,7 +67,7 @@ class _NotificationsState extends State<_Notifications> with AutoDisposeMixin {
         builder: _buildOverlay,
       );
       SchedulerBinding.instance.scheduleFrameCallback((_) {
-        Overlay.of(context)!.insert(_overlayEntry!);
+        Overlay.of(context).insert(_overlayEntry!);
       });
 
       addAutoDisposeListener(

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_control_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_control_pane.dart
@@ -194,7 +194,7 @@ class _ChartControlPaneState extends State<ChartControlPane>
       }
     }
 
-    final OverlayState overlayState = Overlay.of(context)!;
+    final OverlayState overlayState = Overlay.of(context);
     _legendOverlayEntry ??= OverlayEntry(
       builder: (context) => Positioned(
         top: position.dy + box.size.height + legendYOffset,

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_pane.dart
@@ -323,7 +323,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
 
     final hoverHeading = colorScheme.hoverTitleTextStyle;
 
-    final OverlayState overlayState = Overlay.of(context)!;
+    final OverlayState overlayState = Overlay.of(context);
     _hoverOverlayEntry ??= OverlayEntry(
       builder: (context) => Positioned(
         top: position.dy + _hoverYOffset,

--- a/packages/devtools_app/lib/src/service/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/service/service_extension_widgets.dart
@@ -671,7 +671,7 @@ class _ServiceExtensionCheckboxGroupButtonState
   void _insertOverlay(BuildContext context) {
     final offset = _calculateOverlayPosition(widget.overlayWidth, context);
     _overlay?.remove();
-    Overlay.of(context)!.insert(
+    Overlay.of(context).insert(
       _overlay = OverlayEntry(
         maintainState: true,
         builder: (context) {
@@ -704,7 +704,7 @@ class _ServiceExtensionCheckboxGroupButtonState
 
   Offset _calculateOverlayPosition(double width, BuildContext context) {
     final overlayBox =
-        Overlay.of(context)!.context.findRenderObject() as RenderBox;
+        Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;
 
     final maxX = overlayBox.size.width - width;

--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -120,7 +120,7 @@ class HoverCard {
     double? maxCardHeight,
   }) {
     maxCardHeight ??= maxHoverCardHeight;
-    final overlayState = Overlay.of(context)!;
+    final overlayState = Overlay.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final focusColor = Theme.of(context).focusColor;
     final hoverHeading = colorScheme.hoverTitleTextStyle;
@@ -422,7 +422,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
 
   Offset _calculateTooltipPosition(double width) {
     final overlayBox =
-        Overlay.of(context)!.context.findRenderObject() as RenderBox;
+        Overlay.of(context).context.findRenderObject() as RenderBox;
     final box = context.findRenderObject() as RenderBox;
 
     final maxX = overlayBox.size.width - _hoverMargin - width;

--- a/packages/devtools_app/lib/src/ui/search.dart
+++ b/packages/devtools_app/lib/src/ui/search.dart
@@ -585,7 +585,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       maxWidth: maxWidth,
     );
 
-    Overlay.of(context)!.insert(autoCompleteOverlay!);
+    Overlay.of(context).insert(autoCompleteOverlay!);
   }
 
   /// Until an expression parser, poor man's way of finding the parts for


### PR DESCRIPTION
![](https://media.giphy.com/media/2fNJsZ4uClCGrGcNWH/giphy-downsized.gif)
https://github.com/flutter/flutter/commit/2051f09c68de6f0a6f435457b18ac63df7d08858 replaces `of` with `maybeOf`  and `of` now returns a non-optional value.

Updating  our code since the analyzer is preventing a roll to g3