### PR TITLE
Expand scollable area to fill entire console details section

### DIFF
--- a/packages/devtools_app/lib/src/shared/console.dart
+++ b/packages/devtools_app/lib/src/shared/console.dart
@@ -67,7 +67,8 @@ class ConsoleFrame extends StatelessWidget {
           child: Material(
             child: Stack(
               children: [
-                child,
+                // Fill the width of the console to expand the scrollable area.
+                Positioned.fill(child: child),
                 if (controls.isNotEmpty)
                   _ConsoleControls(
                     controls: controls,


### PR DESCRIPTION
Fixes issue where hovering over the far right of the "Details" section on the logging page would not capture scroll events.
