### PR TITLE
Use PointerInterceptor in dialogs to allow clicks over an iFrame

### DIFF
--- a/packages/devtools_app/lib/src/shared/dialogs.dart
+++ b/packages/devtools_app/lib/src/shared/dialogs.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 
 import 'common_widgets.dart';
 import 'theme.dart';
@@ -42,27 +43,29 @@ class DevToolsDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return AlertDialog(
-      scrollable: scrollable,
-      title: Column(
-        children: [
-          titleContent,
-          includeDivider
-              ? const PaddedDivider(
-                  padding: EdgeInsets.only(bottom: denseRowSpacing),
-                )
-              : const SizedBox(height: defaultSpacing),
-        ],
+    return PointerInterceptor(
+      child: AlertDialog(
+        scrollable: scrollable,
+        title: Column(
+          children: [
+            titleContent,
+            includeDivider
+                ? const PaddedDivider(
+                    padding: EdgeInsets.only(bottom: denseRowSpacing),
+                  )
+                : const SizedBox(height: defaultSpacing),
+          ],
+        ),
+        contentPadding: const EdgeInsets.fromLTRB(
+          contentPadding,
+          0,
+          contentPadding,
+          contentPadding,
+        ),
+        content: content,
+        actions: actions,
+        buttonPadding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
       ),
-      contentPadding: const EdgeInsets.fromLTRB(
-        contentPadding,
-        0,
-        contentPadding,
-        contentPadding,
-      ),
-      content: content,
-      actions: actions,
-      buttonPadding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
     );
   }
 }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -45,6 +45,7 @@ dependencies:
   path: ^1.8.0
   perfetto_compiled:
     path: ../../third_party/packages/perfetto_compiled
+  pointer_interceptor: ^0.9.3+3
   provider: ^6.0.2
   # Only used for debug mode logic.
   shared_preferences: ^2.0.15


### PR DESCRIPTION
This allows dialogs to accept mouse events when the dialog is rendered over the top of the Perfetto iFrame.