### PR TITLE
Add step to switch to master.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -217,14 +217,20 @@ flutter test test/ --update-goldens
 
 To run master version of DevTools with all experimental features enabled:
 
-1. Start DevTools
+1. Make sure your Flutter is on the channel `master`:
+
+```
+flutter channel master
+```
+
+2. Start DevTools
 ```
 git clone git@github.com:flutter/devtools.git
 cd devtools/packages/devtools_app
 flutter run -d chrome --dart-define=enable_experiments=true
 ```
 
-2. Paste URL of your application (for example [Gallery](#connect-to-application)) to the connection textbox.
+3. Paste URL of your application (for example [Gallery](#connect-to-application)) to the connection textbox.
 
 ## third_party dependencies
 


### PR DESCRIPTION
Actually it should be Google3 version, but it is too complicated to instruct to get to right version. We will have just master here hoping it will cover 99% of cases, and we will support the remaining 1%.
