### PR TITLE
Display request data in TextView if content type is not json

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -146,10 +146,22 @@ class HttpRequestView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final requestHeaders = data.requestHeaders;
+    final requestContentType = requestHeaders?['content-type'] ?? '';
+    Widget child;
+    if (requestContentType.contains('json')) {
+      child = JsonViewer(encodedJson: data.requestBody!);
+    } else {
+      child = Text(
+        data.requestBody!,
+        style: theme.fixedFontStyle,
+      );
+    }
     return Padding(
       padding: const EdgeInsets.all(denseSpacing),
       child: SingleChildScrollView(
-        child: JsonViewer(encodedJson: data.requestBody!),
+        child: child,
       ),
     );
   }


### PR DESCRIPTION
*Non json type http post data is being wrapped into JsonViewer which resulted in blank model.
This change add content type check on request body to use JsonViewer only when content type is json*

*List which issues are fixed by this PR. You must list at least one issue.*

*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*

## Pre-launch Checklist

- [y] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [y] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [y] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [y] I signed the [CLA].
- [y] I listed at least one issue that this PR fixes in the description above.
- [y] I updated/added relevant documentation (doc comments with `///`).
- [y] I added new tests to check the change I am making, or this PR is [test-exempt].
- [y] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
