### PR TITLE
Fix bug with itemBuilder in table code

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -1504,12 +1504,27 @@ class _TableRowState<T> extends State<TableRow<T>>
     } else {
       final parts = List.generate(
         widget.columns.length,
-        (index) => _TableRowPartDisplayType.column,
+        (_) => _TableRowPartDisplayType.column,
       ).joinWith(_TableRowPartDisplayType.columnSpacer);
       rowDisplayParts.addAll(parts);
     }
 
-    var columnIndexTracker = 0;
+    // Maps the indices from [rowDisplayParts] to the corresponding index of
+    // each column in [widget.columns].
+    final columnIndexMap = <int, int>{};
+    // Add scope to guarantee [columnIndexTracker] is not used outside of this
+    // block.
+    {
+      var columnIndexTracker = 0;
+      for (int i = 0; i < rowDisplayParts.length; i++) {
+        final type = rowDisplayParts[i];
+        if (type == _TableRowPartDisplayType.column) {
+          columnIndexMap[i] = columnIndexTracker;
+          columnIndexTracker++;
+        }
+      }
+    }
+
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
       child: ListView.builder(
@@ -1520,11 +1535,10 @@ class _TableRowState<T> extends State<TableRow<T>>
           final displayTypeForIndex = rowDisplayParts[i];
           switch (displayTypeForIndex) {
             case _TableRowPartDisplayType.column:
-              final current = columnIndexTracker;
-              columnIndexTracker++;
+              final index = columnIndexMap[i]!;
               return columnFor(
-                widget.columns[current],
-                widget.columnWidths[current],
+                widget.columns[index],
+                widget.columnWidths[index],
               );
             case _TableRowPartDisplayType.columnSpacer:
               return const SizedBox(


### PR DESCRIPTION
We were assuming `ListView.itemBuilder` only ever traversed items in increasing order. When scrolling right (forward), this works fine, but scrolling left (back) caused us to over increment the counter. The proper fix here is to store a mapping of the indices we need to use for columns instead of incrementing a counter inside the itemBuilder.