### PR TITLE
Add "Code view" support to CPU Profiler

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -485,7 +485,7 @@ class PerformanceController extends DisposableController
       _data.cpuProfileData = cpuProfilerController.dataNotifier.value;
     } else {
       if (!storedProfileForFrame.processed) {
-        await storedProfileForFrame.processData(
+        await storedProfileForFrame.process(
           transformer: cpuProfilerController.transformer,
           processId: 'Flutter frame ${frame.id} - stored profile ',
         );

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -25,6 +25,7 @@ import '../../service/service_manager.dart';
 import '../../shared/globals.dart';
 import '../../ui/search.dart';
 import '../profiler/cpu_profile_controller.dart';
+import '../profiler/cpu_profile_model.dart';
 import '../profiler/cpu_profile_service.dart';
 import '../profiler/cpu_profile_transformer.dart';
 import '../profiler/profile_granularity.dart';
@@ -371,8 +372,9 @@ class PerformanceController extends DisposableController
     _selectedTimelineEventNotifier.value = event;
 
     if (event.isUiEvent && updateProfiler) {
-      final storedProfile =
-          cpuProfilerController.cpuProfileStore.lookupProfile(time: event.time);
+      final storedProfile = cpuProfilerController.cpuProfileStore.lookupProfile(
+        time: event.time,
+      );
       if (storedProfile != null) {
         await cpuProfilerController.processAndSetData(
           storedProfile,
@@ -465,8 +467,10 @@ class PerformanceController extends DisposableController
 
     if (_currentFrameBeingSelected != frame) return;
 
-    final storedProfileForFrame = cpuProfilerController.cpuProfileStore
-        .lookupProfile(time: frame.timeFromEventFlows);
+    final storedProfileForFrame =
+        cpuProfilerController.cpuProfileStore.lookupProfile(
+      time: frame.timeFromEventFlows,
+    );
     if (storedProfileForFrame == null) {
       cpuProfilerController.reset();
       if (!offlineController.offlineMode.value &&
@@ -481,13 +485,15 @@ class PerformanceController extends DisposableController
       _data.cpuProfileData = cpuProfilerController.dataNotifier.value;
     } else {
       if (!storedProfileForFrame.processed) {
-        await cpuProfilerController.transformer.processData(
-          storedProfileForFrame,
+        await storedProfileForFrame.processData(
+          transformer: cpuProfilerController.transformer,
           processId: 'Flutter frame ${frame.id} - stored profile ',
         );
       }
       if (_currentFrameBeingSelected != frame) return;
-      _data.cpuProfileData = storedProfileForFrame;
+      _data.cpuProfileData = storedProfileForFrame.getActive(
+        cpuProfilerController.viewType.value,
+      );
       cpuProfilerController.loadProcessedData(
         storedProfileForFrame,
         storeAsUserTagNone: true,
@@ -880,7 +886,11 @@ class PerformanceController extends DisposableController
     final offlineCpuProfileData = _offlineData.cpuProfileData;
     if (offlineCpuProfileData != null) {
       cpuProfilerController.loadProcessedData(
-        offlineCpuProfileData,
+        CpuProfilePair(
+          functionProfile: offlineCpuProfileData,
+          // TODO(bkonyi): do we care about offline code profiles?
+          codeProfile: null,
+        ),
         storeAsUserTagNone: true,
       );
     }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
@@ -434,7 +434,7 @@ class CpuProfilerController
     if (storeAsUserTagNone) {
       cpuProfileStore.storeProfile(
         data,
-        label: _wrapWithFilterSuffix(userTagNone),
+        label: userTagNone,
       );
     }
   }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
@@ -434,7 +434,7 @@ class CpuProfilerController
     if (storeAsUserTagNone) {
       cpuProfileStore.storeProfile(
         data,
-        label: userTagNone,
+        label: _wrapWithFilterSuffix(userTagNone),
       );
     }
   }
@@ -507,8 +507,9 @@ class CpuProfilerController
 
   void updateView(CpuProfilerViewType view) {
     _viewType.value = view;
-    _dataNotifier.value =
-        cpuProfileStore.lookupProfile(label: userTagNone)?.getActive(view);
+    _dataNotifier.value = cpuProfileStore
+        .lookupProfile(label: _wrapWithFilterSuffix(userTagNone))
+        ?.getActive(view);
   }
 
   void selectCpuStackFrame(CpuStackFrame? stackFrame) {

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_controller.dart
@@ -225,7 +225,7 @@ class CpuProfilerController
     required bool shouldRefreshSearchMatches,
     required bool isCodeProfile,
   }) async {
-    await cpuProfiles.processData(
+    await cpuProfiles.process(
       transformer: transformer,
       processId: processId,
     );
@@ -241,7 +241,7 @@ class CpuProfilerController
     }
     if (shouldApplyFilters) {
       cpuProfiles = applyToggleFilters(cpuProfiles);
-      await cpuProfiles.processData(
+      await cpuProfiles.process(
         transformer: transformer,
         processId: processId,
       );
@@ -413,7 +413,7 @@ class CpuProfilerController
     }
 
     if (!appStartUpProfile.processed) {
-      await appStartUpProfile.processData(
+      await appStartUpProfile.process(
         transformer: transformer,
         processId: 'appStartUpProfile',
       );
@@ -468,7 +468,7 @@ class CpuProfilerController
     );
     if (filteredDataForTag != null) {
       if (!filteredDataForTag.processed) {
-        await filteredDataForTag.processData(
+        await filteredDataForTag.process(
           transformer: transformer,
           processId: profileLabel,
         );
@@ -492,7 +492,7 @@ class CpuProfilerController
 
     data = applyToggleFilters(data);
     if (!data.processed) {
-      await data.processData(
+      await data.process(
         transformer: transformer,
         processId: 'data with toggle filters applied',
       );
@@ -507,11 +507,8 @@ class CpuProfilerController
 
   void updateView(CpuProfilerViewType view) {
     _viewType.value = view;
-    _dataNotifier.value = cpuProfileStore
-        .lookupProfile(
-          label: _wrapWithFilterSuffix(userTagNone),
-        )
-        ?.getActive(view);
+    _dataNotifier.value =
+        cpuProfileStore.lookupProfile(label: userTagNone)?.getActive(view);
   }
 
   void selectCpuStackFrame(CpuStackFrame? stackFrame) {

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -15,7 +15,69 @@ import '../../primitives/utils.dart';
 import '../../shared/globals.dart';
 import '../../shared/profiler_utils.dart';
 import '../../ui/search.dart';
+import '../vm_developer/vm_service_private_extensions.dart';
+import 'cpu_profile_controller.dart';
 import 'cpu_profile_transformer.dart';
+
+class CpuProfilePair {
+  const CpuProfilePair({
+    required this.functionProfile,
+    required this.codeProfile,
+  });
+
+  factory CpuProfilePair.fromUserTag(CpuProfilePair original, String tag) {
+    final function = CpuProfileData.fromUserTag(original.functionProfile, tag);
+    CpuProfileData? code;
+    if (original.codeProfile != null) {
+      code = CpuProfileData.fromUserTag(original.codeProfile!, tag);
+    }
+    return CpuProfilePair(functionProfile: function, codeProfile: code);
+  }
+
+  factory CpuProfilePair.filterFrom(
+    CpuProfilePair original,
+    bool Function(CpuStackFrame) callback,
+  ) {
+    final function =
+        CpuProfileData.filterFrom(original.functionProfile, callback);
+    CpuProfileData? code;
+    if (original.codeProfile != null) {
+      code = CpuProfileData.filterFrom(original.codeProfile!, callback);
+    }
+    return CpuProfilePair(functionProfile: function, codeProfile: code);
+  }
+
+  final CpuProfileData functionProfile;
+  final CpuProfileData? codeProfile;
+
+  bool get isEmpty => functionProfile.isEmpty;
+  bool get processed => functionProfile.processed;
+  CpuProfileMetaData get profileMetaData => functionProfile.profileMetaData;
+
+  CpuProfileData getActive(CpuProfilerViewType activeType) {
+    if (activeType == CpuProfilerViewType.function) {
+      return functionProfile;
+    }
+    return codeProfile!;
+  }
+
+  CpuProfileData? getInactive(CpuProfilerViewType activeType) {
+    if (activeType == CpuProfilerViewType.function) {
+      return codeProfile;
+    }
+    return functionProfile;
+  }
+
+  Future<void> processData({
+    required CpuProfileTransformer transformer,
+    required String processId,
+  }) async {
+    await transformer.processData(functionProfile, processId: processId);
+    if (codeProfile != null) {
+      await transformer.processData(codeProfile!, processId: processId);
+    }
+  }
+}
 
 /// Data model for DevTools CPU profile.
 class CpuProfileData {
@@ -80,9 +142,9 @@ class CpuProfileData {
     final stackTraceEvents =
         (json[traceEventsKey] ?? []).cast<Map<String, dynamic>>();
     final samples = stackTraceEvents
-        .map((trace) => CpuSample.parse(trace))
+        .map((trace) => CpuSampleEvent.parse(trace))
         .toList()
-        .cast<CpuSample>();
+        .cast<CpuSampleEvent>();
 
     return CpuProfileData._(
       stackFrames: stackFrames,
@@ -205,15 +267,15 @@ class CpuProfileData {
     CpuProfileData originalData,
     bool Function(CpuStackFrame) includeFilter,
   ) {
-    final filteredCpuSamples = <CpuSample>[];
+    final filteredCpuSamples = <CpuSampleEvent>[];
     void includeSampleOrWalkUp(
-      CpuSample sample,
+      CpuSampleEvent sample,
       Map<String, Object> sampleJson,
       CpuStackFrame stackFrame,
     ) {
       if (includeFilter(stackFrame)) {
         filteredCpuSamples.add(
-          CpuSample(
+          CpuSampleEvent(
             leafId: stackFrame.id,
             userTag: sample.userTag,
             traceJson: sampleJson,
@@ -307,6 +369,7 @@ class CpuProfileData {
   static Future<CpuProfileData> generateFromCpuSamples({
     required String isolateId,
     required vm_service.CpuSamples cpuSamples,
+    bool buildCodeTree = false,
   }) async {
     // The root ID is associated with an artificial frame / node that is the root
     // of all stacks, regardless of entrypoint. This should never be seen in the
@@ -355,9 +418,11 @@ class CpuProfileData {
       }
     }
 
-    final root = _CpuProfileTimelineTree.fromCpuSamples(cpuSamples);
+    final root = _CpuProfileTimelineTree.fromCpuSamples(
+      cpuSamples,
+      buildCodeTree: buildCodeTree,
+    );
     processStackFrame(current: root, parent: null);
-
     // Build the trace events.
     for (final sample in cpuSamples.samples ?? <vm_service.CpuSample>[]) {
       final tree = _CpuProfileTimelineTree.getTreeFromSample(sample)!;
@@ -454,7 +519,7 @@ class CpuProfileData {
 
   final Map<String, CpuStackFrame> stackFrames;
 
-  final List<CpuSample> cpuSamples;
+  final List<CpuSampleEvent> cpuSamples;
 
   final CpuProfileMetaData profileMetaData;
 
@@ -554,19 +619,19 @@ class CpuProfileMetaData extends ProfileMetaData {
   }
 }
 
-class CpuSample extends TraceEvent {
-  CpuSample({
+class CpuSampleEvent extends TraceEvent {
+  CpuSampleEvent({
     required this.leafId,
     this.userTag,
     required Map<String, dynamic> traceJson,
   }) : super(traceJson);
 
-  factory CpuSample.parse(Map<String, dynamic> traceJson) {
+  factory CpuSampleEvent.parse(Map<String, dynamic> traceJson) {
     final leafId = traceJson[CpuProfileData.stackFrameIdKey];
     final userTag = traceJson[TraceEvent.argsKey] != null
         ? traceJson[TraceEvent.argsKey][CpuProfileData.userTagKey]
         : null;
-    return CpuSample(
+    return CpuSampleEvent(
       leafId: leafId,
       userTag: userTag,
       traceJson: traceJson,
@@ -839,12 +904,12 @@ class CpuProfileStore {
   ///
   /// This label will contain information regarding any toggle filters or user
   /// tag filters applied to the profile.
-  final _profilesByLabel = <String, CpuProfileData>{};
+  final _profilesByLabel = <String, CpuProfilePair>{};
 
   /// Store of CPU profiles keyed by a time range.
   ///
   /// These time ranges are allowed to overlap.
-  final _profilesByTime = <TimeRange, CpuProfileData>{};
+  final _profilesByTime = <TimeRange, CpuProfilePair>{};
 
   /// Lookup a profile from either cache: [_profilesByLabel] or
   /// [_profilesByTime].
@@ -859,7 +924,10 @@ class CpuProfileStore {
   /// generated, cached in [_profilesByTime] and then returned. This method will
   /// return null if no profiles are cached for [time] or if a sub profile
   /// cannot be generated for [time].
-  CpuProfileData? lookupProfile({String? label, TimeRange? time}) {
+  CpuProfilePair? lookupProfile({
+    String? label,
+    TimeRange? time,
+  }) {
     assert((label == null) != (time == null));
 
     if (label != null) {
@@ -875,7 +943,11 @@ class CpuProfileStore {
     return _profilesByTime[time];
   }
 
-  void storeProfile(CpuProfileData profile, {String? label, TimeRange? time}) {
+  void storeProfile(
+    CpuProfilePair profile, {
+    String? label,
+    TimeRange? time,
+  }) {
     assert((label == null) != (time == null));
     if (label != null) {
       _profilesByLabel[label] = profile;
@@ -889,7 +961,18 @@ class CpuProfileStore {
     final encompassingTimeRange = _encompassingTimeRange(time);
     if (encompassingTimeRange != null) {
       final encompassingProfile = _profilesByTime[encompassingTimeRange]!;
-      final subProfile = CpuProfileData.subProfile(encompassingProfile, time);
+      final subProfile = CpuProfilePair(
+        functionProfile: CpuProfileData.subProfile(
+          encompassingProfile.functionProfile,
+          time,
+        ),
+        codeProfile: encompassingProfile.codeProfile == null
+            ? null
+            : CpuProfileData.subProfile(
+                encompassingProfile.codeProfile!,
+                time,
+              ),
+      );
       _profilesByTime[time] = subProfile;
     }
   }
@@ -916,15 +999,21 @@ class CpuProfileStore {
 
 class _CpuProfileTimelineTree {
   factory _CpuProfileTimelineTree.fromCpuSamples(
-    vm_service.CpuSamples cpuSamples,
-  ) {
-    final root = _CpuProfileTimelineTree._fromIndex(cpuSamples, kRootIndex);
+    vm_service.CpuSamples cpuSamples, {
+    bool buildCodeTree = false,
+  }) {
+    final root = _CpuProfileTimelineTree._fromIndex(
+      cpuSamples,
+      kRootIndex,
+      buildCodeTree,
+    );
     _CpuProfileTimelineTree current;
     // TODO(bkonyi): handle truncated?
-    for (final sample in cpuSamples.samples ?? []) {
+    for (final sample in cpuSamples.samples ?? <vm_service.CpuSample>[]) {
       current = root;
+      final stack = buildCodeTree ? sample.codeStack : sample.stack!;
       // Build an inclusive trie.
-      for (final index in sample.stack!.reversed) {
+      for (final index in stack.reversed) {
         current = current._getChild(index);
       }
       _timelineTreeExpando[sample] = current;
@@ -932,19 +1021,33 @@ class _CpuProfileTimelineTree {
     return root;
   }
 
-  _CpuProfileTimelineTree._fromIndex(this.samples, this.index);
+  _CpuProfileTimelineTree._fromIndex(this.samples, this.index, this.isCodeTree);
 
   static final _timelineTreeExpando = Expando<_CpuProfileTimelineTree>();
   static const kRootIndex = -1;
   static const kNoFrameId = -1;
   final vm_service.CpuSamples samples;
   final int index;
+  final bool isCodeTree;
   int frameId = kNoFrameId;
 
-  String? get name => samples.functions![index].function.name;
+  dynamic get _function {
+    if (isCodeTree) {
+      return samples.codes[index].code!.function!;
+    }
+    return samples.functions![index].function;
+  }
+
+  String? get name {
+    if (isCodeTree) {
+      return samples.codes[index].code!.name;
+    }
+    return _function.name;
+  }
 
   String? get className {
-    final function = samples.functions![index].function;
+    if (isCodeTree) return null;
+    final function = _function;
     if (function is vm_service.FuncRef) {
       final owner = function.owner;
       if (owner is vm_service.ClassRef) {
@@ -954,10 +1057,18 @@ class _CpuProfileTimelineTree {
     return null;
   }
 
-  String? get resolvedUrl => samples.functions![index].resolvedUrl;
+  String? get resolvedUrl {
+    if (isCodeTree) {
+      // TODO(bkonyi): not sure if this is a resolved URL or not, but it's not
+      // critical since this is only displayed when VM developer mode is
+      // enabled.
+      return samples.codes[index].code!.function!.location?.script!.uri;
+    }
+    return samples.functions![index].resolvedUrl;
+  }
 
   int? get sourceLine {
-    final function = samples.functions![index].function;
+    final function = _function;
     try {
       return function.location?.line;
     } catch (_) {
@@ -988,7 +1099,8 @@ class _CpuProfileTimelineTree {
         break;
       }
     }
-    final child = _CpuProfileTimelineTree._fromIndex(samples, index);
+    final child =
+        _CpuProfileTimelineTree._fromIndex(samples, index, isCodeTree);
     if (i < length) {
       children.insert(i, child);
     } else {

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_service.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_service.dart
@@ -30,7 +30,7 @@ extension CpuProfilerExtension on VmServiceWrapper {
     bool buildCodeProfile = false;
     // If the samples contain a code stack, we should attach them to the
     // `CpuSample` objects.
-    if (rawSamples.first.containsKey(kCodeStack)) {
+    if (rawSamples.isNotEmpty && rawSamples.first.containsKey(kCodeStack)) {
       buildCodeProfile = true;
       final samples = cpuSamples.samples!;
       for (int i = 0; i < samples.length; ++i) {

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -121,7 +121,7 @@ class CpuProfileTransformer {
   }
 
   void _setExclusiveSampleCountsAndTags(CpuProfileData cpuProfileData) {
-    for (CpuSample sample in cpuProfileData.cpuSamples) {
+    for (CpuSampleEvent sample in cpuProfileData.cpuSamples) {
       final leafId = sample.leafId;
       final stackFrame = cpuProfileData.stackFrames[leafId];
       assert(

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -179,6 +179,21 @@ class _CpuProfilerState extends State<CpuProfiler>
               const SizedBox(width: denseSpacing),
               UserTagDropdown(widget.controller),
               const SizedBox(width: denseSpacing),
+              ValueListenableBuilder<bool>(
+                valueListenable: preferences.vmDeveloperModeEnabled,
+                builder: (context, vmDeveloperModeEnabled, _) {
+                  if (!vmDeveloperModeEnabled) {
+                    return Container();
+                  }
+                  return Row(
+                    children: [
+                      ModeDropdown(widget.controller),
+                      const SizedBox(width: denseSpacing),
+                    ],
+                  );
+                },
+              ),
+              const SizedBox(width: denseSpacing),
             ],
             // TODO(kenz): support search for call tree and bottom up tabs as
             // well. This will require implementing search for tree tables.
@@ -239,12 +254,17 @@ class _CpuProfilerState extends State<CpuProfiler>
             ],
           ],
         ),
-        Expanded(
-          child: TabBarView(
-            physics: defaultTabBarViewPhysics,
-            controller: _tabController,
-            children: _buildProfilerViews(),
-          ),
+        ValueListenableBuilder<CpuProfilerViewType>(
+          valueListenable: widget.controller.viewType,
+          builder: (context, viewType, _) {
+            return Expanded(
+              child: TabBarView(
+                physics: defaultTabBarViewPhysics,
+                controller: _tabController,
+                children: _buildProfilerViews(),
+              ),
+            );
+          },
         ),
       ],
     );
@@ -449,5 +469,61 @@ class UserTagDropdown extends StatelessWidget {
     } catch (e) {
       notificationService.push(e.toString());
     }
+  }
+}
+
+/// DropdownButton that controls the value of
+/// [ProfilerScreenController.viewType].
+class ModeDropdown extends StatelessWidget {
+  const ModeDropdown(this.controller);
+
+  final CpuProfilerController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    const mode = 'View:';
+    return ValueListenableBuilder<CpuProfilerViewType>(
+      valueListenable: controller.viewType,
+      builder: (context, viewType, _) {
+        final tooltip = viewType == CpuProfilerViewType.function
+            ? 'Display the profile in terms of the Dart call stack '
+                '(i.e., inlined frames are expanded)'
+            : 'Display the profile in terms of native stack frames '
+                '(i.e., inlined frames are not expanded, display code objects '
+                'rather than individual functions)';
+        return SizedBox(
+          height: defaultButtonHeight,
+          child: DevToolsTooltip(
+            message: tooltip,
+            child: RoundedDropDownButton<CpuProfilerViewType>(
+              isDense: true,
+              style: Theme.of(context).textTheme.bodyMedium,
+              value: viewType,
+              items: [
+                _buildMenuItem(
+                  display: '$mode ${CpuProfilerViewType.function}',
+                  value: CpuProfilerViewType.function,
+                ),
+                _buildMenuItem(
+                  display: '$mode ${CpuProfilerViewType.code}',
+                  value: CpuProfilerViewType.code,
+                ),
+              ],
+              onChanged: (type) => controller.updateView(type!),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  DropdownMenuItem<CpuProfilerViewType> _buildMenuItem({
+    required String display,
+    required CpuProfilerViewType value,
+  }) {
+    return DropdownMenuItem<CpuProfilerViewType>(
+      value: value,
+      child: Text(display),
+    );
   }
 }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -183,17 +183,14 @@ class _CpuProfilerState extends State<CpuProfiler>
                 valueListenable: preferences.vmDeveloperModeEnabled,
                 builder: (context, vmDeveloperModeEnabled, _) {
                   if (!vmDeveloperModeEnabled) {
-                    return Container();
+                    return const SizedBox();
                   }
-                  return Row(
-                    children: [
-                      ModeDropdown(widget.controller),
-                      const SizedBox(width: denseSpacing),
-                    ],
+                  return Padding(
+                    padding: const EdgeInsets.only(right: denseSpacing),
+                    child: ModeDropdown(widget.controller),
                   );
                 },
               ),
-              const SizedBox(width: denseSpacing),
             ],
             // TODO(kenz): support search for call tree and bottom up tabs as
             // well. This will require implementing search for tree tables.

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -239,7 +239,10 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
       processId: 'offline data processing',
     );
     controller.cpuProfilerController.loadProcessedData(
-      offlineData,
+      CpuProfilePair(
+        functionProfile: offlineData,
+        codeProfile: null,
+      ),
       storeAsUserTagNone: true,
     );
   }

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen_controller.dart
@@ -30,6 +30,20 @@ class ProfilerScreenController extends DisposableController
       addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
         switchToIsolate(serviceManager.isolateManager.selectedIsolate.value);
       });
+
+      addAutoDisposeListener(preferences.vmDeveloperModeEnabled, () {
+        if (preferences.vmDeveloperModeEnabled.value) {
+          // If VM developer mode was just enabled, clear the profile store
+          // since the existing entries won't have code profiles and cannot be
+          // constructed from function profiles.
+          cpuProfilerController.cpuProfileStore.clear();
+          cpuProfilerController.reset();
+        }
+        // Always reset to the function view when the VM developer mode state
+        // changes. The selector is hidden when VM developer mode is disabled
+        // and data for code profiles won't be requested.
+        cpuProfilerController.updateView(CpuProfilerViewType.function);
+      });
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -409,6 +409,7 @@ class ProfileCode {
     this.inclusiveTicks,
     this.exclusiveTicks,
     this.code,
+    this.ticks,
   });
 
   ProfileCode._fromJson(Map<String, dynamic> json) {
@@ -416,6 +417,7 @@ class ProfileCode {
     inclusiveTicks = json['inclusiveTicks'] ?? -1;
     exclusiveTicks = json['exclusiveTicks'] ?? -1;
     code = createServiceObject(json['code'], const ['@Code']) as CodeRef?;
+    ticks = json['ticks'];
   }
   static ProfileCode? parse(Map<String, dynamic>? json) =>
       json == null ? null : ProfileCode._fromJson(json);
@@ -433,6 +435,8 @@ class ProfileCode {
   /// The function captured during profiling.
   CodeRef? code;
 
+  List? ticks;
+
   Map<String, dynamic> toJson() {
     final json = <String, dynamic>{};
     json.addAll({
@@ -440,6 +444,7 @@ class ProfileCode {
       'inclusiveTicks': inclusiveTicks ?? -1,
       'exclusiveTicks': exclusiveTicks ?? -1,
       'code': code?.toJson(),
+      'ticks': ticks,
     });
     return json;
   }

--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -11,6 +11,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../primitives/utils.dart';
 import '../screens/vm_developer/vm_service_private_extensions.dart';
+import '../shared/globals.dart';
 import 'json_to_service_cache.dart';
 
 class VmServiceWrapper implements VmService {
@@ -245,11 +246,19 @@ class VmServiceWrapper implements VmService {
   ) async {
     return trackFuture(
       'getCpuSamples',
-      _vmService.getCpuSamples(
-        isolateId,
-        timeOriginMicros,
-        timeExtentMicros,
-      ),
+      _vmService.callMethod(
+        'getCpuSamples',
+        isolateId: isolateId,
+        args: {
+          'timeOriginMicros': timeOriginMicros,
+          'timeExtentMicros': timeExtentMicros,
+          // Requests the code profile in addition to the function profile when
+          // running with VM developer mode enabled. This data isn't accessible
+          // in non-VM developer mode, so not requesting the code profile will
+          // save on space and network usage.
+          '_code': preferences.vmDeveloperModeEnabled.value,
+        },
+      ).then((e) => e as CpuSamples),
     );
   }
 

--- a/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
@@ -29,14 +29,14 @@ void main() {
     });
 
     test('empty frame regression test', () {
-      final cpuProfileEmtpyData =
+      final cpuProfileEmptyData =
           CpuProfileData.parse(cpuProfileResponseEmptyJson);
       expect(
-        cpuProfileEmtpyData.profileMetaData.time!.end!.inMilliseconds,
+        cpuProfileEmptyData.profileMetaData.time!.end!.inMilliseconds,
         47377796,
       );
       final filtered =
-          CpuProfileData.filterFrom(cpuProfileEmtpyData, (_) => true);
+          CpuProfileData.filterFrom(cpuProfileEmptyData, (_) => true);
       expect(filtered.profileMetaData.time!.end!.inMilliseconds, 0);
     });
 

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
@@ -88,7 +88,9 @@ void main() {
       )!;
       final filteredData = controller.dataNotifier.value!;
       expect(
-          originalData.functionProfile.stackFrames.values.length, equals(17));
+        originalData.functionProfile.stackFrames.values.length,
+        equals(17),
+      );
       expect(filteredData.stackFrames.values.length, equals(12));
 
       // The native frame filter is applied by default.

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
@@ -87,12 +87,15 @@ void main() {
         label: CpuProfilerController.userTagNone,
       )!;
       final filteredData = controller.dataNotifier.value!;
-      expect(originalData.stackFrames.values.length, equals(17));
+      expect(
+          originalData.functionProfile.stackFrames.values.length, equals(17));
       expect(filteredData.stackFrames.values.length, equals(12));
 
       // The native frame filter is applied by default.
-      final originalNativeFrames =
-          originalData.stackFrames.values.where((sf) => sf.isNative).toList();
+      final originalNativeFrames = originalData
+          .functionProfile.stackFrames.values
+          .where((sf) => sf.isNative)
+          .toList();
       final filteredNativeFrames =
           filteredData.stackFrames.values.where((sf) => sf.isNative).toList();
       expect(originalNativeFrames.length, equals(5));
@@ -236,7 +239,10 @@ void main() {
         processId: 'test',
       );
       controller.loadProcessedData(
-        cpuProfileDataWithTags,
+        CpuProfilePair(
+          functionProfile: cpuProfileDataWithTags,
+          codeProfile: null,
+        ),
         storeAsUserTagNone: true,
       );
 
@@ -312,7 +318,10 @@ void main() {
         processId: 'test',
       );
       controller.loadProcessedData(
-        cpuProfileDataWithTags,
+        CpuProfilePair(
+          functionProfile: cpuProfileDataWithTags,
+          codeProfile: null,
+        ),
         storeAsUserTagNone: true,
       );
 

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_controller_test.dart
@@ -7,6 +7,7 @@ import 'package:devtools_app/src/screens/profiler/cpu_profile_controller.dart';
 import 'package:devtools_app/src/screens/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/preferences.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -30,6 +31,7 @@ void main() {
     setUp(() {
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(OfflineModeController, OfflineModeController());
+      setGlobal(PreferencesController, PreferencesController());
       controller = CpuProfilerController();
     });
 

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -264,7 +264,10 @@ void main() {
         );
         // Call this to force the value of `_dataByTag[userTagNone]` to be set.
         controller.cpuProfilerController.loadProcessedData(
-          cpuProfileData,
+          CpuProfilePair(
+            functionProfile: cpuProfileData,
+            codeProfile: null,
+          ),
           storeAsUserTagNone: true,
         );
       });

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -18,6 +18,7 @@ import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/notifications.dart';
+import 'package:devtools_app/src/shared/preferences.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -48,6 +49,7 @@ void main() {
     setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(PreferencesController, PreferencesController());
     setGlobal(IdeTheme, IdeTheme());
   });
 

--- a/packages/devtools_app/test/cpu_profiler/profiler_screen_controller_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/profiler_screen_controller_test.dart
@@ -6,6 +6,7 @@ import 'package:devtools_app/src/config_specific/import_export/import_export.dar
 import 'package:devtools_app/src/screens/profiler/profiler_screen_controller.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/preferences.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -19,6 +20,7 @@ void main() {
     setUp(() {
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(OfflineModeController, OfflineModeController());
+      setGlobal(PreferencesController, PreferencesController());
       controller = ProfilerScreenController();
     });
 

--- a/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
@@ -70,6 +70,7 @@ void main() {
       expect(find.byKey(ProfilerScreen.recordingStatusKey), findsNothing);
       expect(find.byType(CircularProgressIndicator), findsNothing);
       expect(find.byType(CpuProfiler), findsNothing);
+      expect(find.byType(ModeDropdown), findsNothing);
     }
 
     Future<void> pumpProfilerScreenBody(

--- a/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
@@ -12,6 +12,7 @@ import 'package:devtools_app/src/service/vm_flags.dart' as vm_flags;
 import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/notifications.dart';
+import 'package:devtools_app/src/shared/preferences.dart';
 import 'package:devtools_app/src/ui/vm_flag_widgets.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -46,6 +47,7 @@ void main() {
       setGlobal(OfflineModeController, OfflineModeController());
       setGlobal(IdeTheme, IdeTheme());
       setGlobal(NotificationService, NotificationService());
+      setGlobal(PreferencesController, PreferencesController());
       screen = const ProfilerScreen();
     });
 

--- a/packages/devtools_app/test/performance/performance_controller_test.dart
+++ b/packages/devtools_app/test/performance/performance_controller_test.dart
@@ -13,6 +13,7 @@ import 'package:devtools_app/src/screens/performance/performance_controller.dart
 import 'package:devtools_app/src/screens/performance/performance_model.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/globals.dart';
+import 'package:devtools_app/src/shared/preferences.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
@@ -40,6 +41,7 @@ void main() async {
           .thenReturn(initializedCompleter);
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(IdeTheme, IdeTheme());
+      setGlobal(PreferencesController, PreferencesController());
     });
 
     setUp(() async {


### PR DESCRIPTION
The current CPU profiler view renders CPU profiles in terms of Dart functions. This is useful for the general Dart developer who is interested in determining where time is being spent during execution, but does not necessarily provide an accurate picture when profiling performance of generated code. This is because compiler developers are interested in the amount of time spent executing portions of generated code, which can include inlined functions.

This PR adds an option in the CPU Profiler tab to display the CPU profile without expanding inlined functions. When the "Code" view is enabled, instead of building the CPU profile with a function tree the tree is instead built based on `Code` objects from the VM.

This functionality is only enabled when VM developer mode is turned on, and the extra data required to compute the code-based CPU profile is only requested from the VM in this mode.

Related issue: https://github.com/flutter/devtools/issues/3861

<img width="1626" alt="image" src="https://user-images.githubusercontent.com/24210656/196791934-2113bcb0-7779-4e92-a855-6dccaac85d62.png">
