### PR TITLE
Change invert path icon to swap

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
@@ -77,7 +77,7 @@ class _PathControlPane extends StatelessWidget {
             onPressed: () => controller.invert.value = !controller.invert.value,
             isSelected: invert,
             message: 'Invert the path',
-            icon: Icons.turn_left,
+            icon: Icons.swap_horiz,
           ),
         ),
       ],


### PR DESCRIPTION
turn_left is unavailable in g3. The Swap icon also is more intuitive for this action, IMO. 