### PR TITLE
Add myself to tool dir and cleanup globs

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,22 +1,25 @@
 *                   @flutter/devtools-reviewers
 
 # Inspector Files
-**/inspector/**     @CoderDake
+inspector/          @CoderDake
 
 # Network Files
-**/network/**       @kenzieschmoll @bkonyi
+network/            @kenzieschmoll @bkonyi
 
 # Performance Files
-**/performance/**   @kenzieschmoll
+performance/        @kenzieschmoll
 
 # CPU Profiler files
-**/profiler/**      @kenzieschmoll
+profiler/           @kenzieschmoll
 
 # Memory files
-**/memory/**        @bkonyi @polina-c
+memory/             @bkonyi @polina-c
 
 # Debugger files
-**/debugger/**      @elliette
+debugger/           @elliette
 
 # VM Developer files
-**/vm_developer/**  @bkonyi
+vm_developer/       @bkonyi
+
+# Tooling files
+/tool/              @CoderDake


### PR DESCRIPTION
![](https://media.giphy.com/media/xULW8DrI6tfOCfRtRK/giphy-downsized.gif)

- Adding myself as an owner on the tool dir
- removed `**` globs in other parts since according to the [Code owner docs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) they are not necessary to match the whole directory