### PR TITLE
Fix Debugger HoverCards

### DIFF
--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -347,6 +347,10 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     _currentHoverCard = hoverCard;
   }
 
+  void _removeHoverCard(HoverCard hoverCard) {
+    _hoverCardController.removeHoverCard(hoverCard);
+  }
+
   void _onHover(PointerHoverEvent event) {
     _showTimer?.cancel();
     _showTimer = null;
@@ -385,38 +389,41 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
           // no longer be shown.
           return;
         }
+        if (hoverCardData == null) {
+          // No data was provided so remove the spinner
+          _removeHoverCard(spinnerHoverCard);
+          return;
+        }
       } else {
         assert(widget.generateHoverCardData != null);
 
         hoverCardData = widget.generateHoverCardData!(event);
       }
 
-      if (hoverCardData != null) {
-        if (!mounted) return;
+      if (!mounted) return;
 
-        if (hoverCardData.position == HoverCardPosition.cursor) {
-          _setHoverCard(
-            HoverCard.fromHoverEvent(
-              context: context,
-              title: hoverCardData.title,
-              contents: hoverCardData.contents,
-              width: hoverCardData.width,
-              event: event,
-              hoverCardController: _hoverCardController,
-            ),
-          );
-        } else {
-          _setHoverCard(
-            HoverCard(
-              context: context,
-              title: hoverCardData.title,
-              contents: hoverCardData.contents,
-              width: hoverCardData.width,
-              position: _calculateTooltipPosition(hoverCardData.width),
-              hoverCardController: _hoverCardController,
-            ),
-          );
-        }
+      if (hoverCardData.position == HoverCardPosition.cursor) {
+        _setHoverCard(
+          HoverCard.fromHoverEvent(
+            context: context,
+            title: hoverCardData.title,
+            contents: hoverCardData.contents,
+            width: hoverCardData.width,
+            event: event,
+            hoverCardController: _hoverCardController,
+          ),
+        );
+      } else {
+        _setHoverCard(
+          HoverCard(
+            context: context,
+            title: hoverCardData.title,
+            contents: hoverCardData.contents,
+            width: hoverCardData.width,
+            position: _calculateTooltipPosition(hoverCardData.width),
+            hoverCardController: _hoverCardController,
+          ),
+        );
       }
     });
   }


### PR DESCRIPTION
![](https://media.giphy.com/media/3o7btOG8nSTxBMuuT6/giphy-downsized.gif)
 
 > Make sure to turn off white space diff when reviewing this one
## Problem:
- debugger hovercards pop up but then don't disappear afterwards

## Solution:
Upgrade the debugger hovercards to use the new and improved HoverCardTooltips that automatically handle appearing and disappearing

### Extra Bug Fix:
- if null was returned from `asyncGenerateHoverCardData` then the spinner wasn't disappearing afterwards. So I've fixed hoverCardTooltip so that it removes the spinner when null is returned.

## Testing
- Compared the way that hovercards looked and behaved on master to the new hovercards.
    - they seem to have the same 
- Checked widget inspector hovering to ensure it is still working well