### PR TITLE
Show async-loading debugger panel hovercards after 100ms

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -869,6 +869,7 @@ class _LineItemState extends State<LineItem>
       child = Stack(
         children: [
           HoverCardTooltip.async(
+            asyncTimeout: 100,
             asyncGenerateHoverCardData: _generateHoverCardData,
             enabled: () => true,
             child: Row(
@@ -907,6 +908,7 @@ class _LineItemState extends State<LineItem>
     } else {
       child = HoverCardTooltip.async(
         enabled: () => true,
+        asyncTimeout: 100,
         asyncGenerateHoverCardData: _generateHoverCardData,
         child: SelectableText.rich(
           searchAwareLineContents(),

--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -402,13 +402,12 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
           spinnerHoverCard != null &&
           !_hoverCardController.isHoverCardStillActive(spinnerHoverCard),
     );
+    final hoverCardDataCompleter = _hoverCardDataCompleter(hoverCardDataFuture);
     // If we have set the async hover card to show up only after a timeout,
     // then race the timeout against generating the hover card data. If
     // generating the data completes first, immediately show the hover card
     // (or return early if there is no data).
     if (asyncTimeout != null) {
-      final hoverCardDataCompleter =
-          _hoverCardDataCompleter(hoverCardDataFuture);
       await Future.any([
         _timeoutCompleter(asyncTimeout).future,
         hoverCardDataCompleter.future,
@@ -441,7 +440,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     );
 
     // The spinner is showing, we can now generate the HoverCardData
-    final hoverCardData = await hoverCardDataFuture;
+    final hoverCardData = await hoverCardDataCompleter.future;
 
     if (!_hoverCardController.isHoverCardStillActive(spinnerHoverCard)) {
       // The hovercard became stale while fetching it's data. So it should
@@ -453,6 +452,12 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
       _removeHoverCard(spinnerHoverCard);
       return;
     }
+
+    return _setHoverCardFromData(
+      hoverCardData,
+      context: context,
+      event: event,
+    );
   }
 
   void _setHoverCardFromData(

--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -263,6 +263,19 @@ class HoverCardController {
   }
 }
 
+typedef AsyncGenerateHoverCardDataFunc = Future<HoverCardData?> Function({
+  required PointerHoverEvent event,
+
+  /// Returns true if the HoverCard is no longer visible.
+  ///
+  /// Use this callback to short circuit long running tasks.
+  required bool Function() isHoverStale,
+});
+
+typedef SyncGenerateHoverCardDataFunc = HoverCardData Function(
+  PointerHoverEvent event,
+);
+
 /// A hover card based tooltip.
 class HoverCardTooltip extends StatefulWidget {
   /// A [HoverCardTooltip] that generates it's [HoverCardData] asynchronously.
@@ -277,6 +290,7 @@ class HoverCardTooltip extends StatefulWidget {
     required this.asyncGenerateHoverCardData,
     required this.child,
     this.disposable,
+    this.asyncTimeout,
   }) : generateHoverCardData = null;
 
   /// A [HoverCardTooltip] that generates it's [HoverCardData] synchronously.
@@ -288,7 +302,8 @@ class HoverCardTooltip extends StatefulWidget {
     required this.generateHoverCardData,
     required this.child,
     this.disposable,
-  }) : asyncGenerateHoverCardData = null;
+  })  : asyncGenerateHoverCardData = null,
+        asyncTimeout = null;
 
   static const _hoverDelay = Duration(milliseconds: 500);
   static double get defaultHoverWidth => scaleByFontFactor(450.0);
@@ -298,25 +313,19 @@ class HoverCardTooltip extends StatefulWidget {
 
   /// The callback that is used when the [HoverCard]'s data is only available
   /// asynchronously.
-  final Future<HoverCardData?> Function({
-    required PointerHoverEvent event,
-
-    /// Returns true if the HoverCard is no longer visible.
-    ///
-    /// Use this callback to short circuit long running tasks.
-    required bool Function() isHoverStale,
-  })? asyncGenerateHoverCardData;
+  final AsyncGenerateHoverCardDataFunc? asyncGenerateHoverCardData;
 
   /// The callback that is used when the [HoverCard]'s data is available
   /// synchronously.
-  final HoverCardData Function(
-    PointerHoverEvent event,
-  )? generateHoverCardData;
+  final SyncGenerateHoverCardDataFunc? generateHoverCardData;
 
   final Widget child;
 
   /// Disposable object to be disposed when the group is closed.
   final Disposable? disposable;
+
+  /// If set, will only show the async hovercard after the timeout has elapsed.
+  final int? asyncTimeout;
 
   @override
   _HoverCardTooltipState createState() => _HoverCardTooltipState();
@@ -343,6 +352,7 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
   }
 
   void _setHoverCard(HoverCard hoverCard) {
+    if (!mounted) return;
     _hoverCardController.set(hoverCard: hoverCard);
     _currentHoverCard = hoverCard;
   }
@@ -358,74 +368,138 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
     _removeTimer = null;
 
     if (!widget.enabled()) return;
+    final asyncGenerateHoverCardData = widget.asyncGenerateHoverCardData;
+    final generateHoverCardData = widget.generateHoverCardData;
+    final asyncTimeout = widget.asyncTimeout;
+
     _showTimer = Timer(HoverCardTooltip._hoverDelay, () async {
-      HoverCardData? hoverCardData;
-
-      if (widget.asyncGenerateHoverCardData != null) {
-        assert(widget.generateHoverCardData == null);
-        // The data on the card is fetched asynchronously, so show a spinner
-        // while we wait for it.
-        final spinnerHoverCard = HoverCard.fromHoverEvent(
+      if (asyncGenerateHoverCardData != null) {
+        assert(generateHoverCardData == null);
+        _showAsyncHoverCard(
+          asyncGenerateHoverCardData: asyncGenerateHoverCardData,
+          event: event,
+          asyncTimeout: asyncTimeout,
+        );
+      } else {
+        _setHoverCardFromData(
+          generateHoverCardData!(event),
           context: context,
-          contents: const CenteredCircularProgressIndicator(),
-          width: HoverCardTooltip.defaultHoverWidth,
           event: event,
-          hoverCardController: _hoverCardController,
-        );
-
-        _setHoverCard(
-          spinnerHoverCard,
-        );
-
-        // The spinner is showing, we can now generate the HoverCardData
-        hoverCardData = await widget.asyncGenerateHoverCardData!(
-          event: event,
-          isHoverStale: () =>
-              !_hoverCardController.isHoverCardStillActive(spinnerHoverCard),
-        );
-
-        if (!_hoverCardController.isHoverCardStillActive(spinnerHoverCard)) {
-          // The hovercard became stale while fetching it's data. So it should
-          // no longer be shown.
-          return;
-        }
-        if (hoverCardData == null) {
-          // No data was provided so remove the spinner
-          _removeHoverCard(spinnerHoverCard);
-          return;
-        }
-      } else {
-        assert(widget.generateHoverCardData != null);
-
-        hoverCardData = widget.generateHoverCardData!(event);
-      }
-
-      if (!mounted) return;
-
-      if (hoverCardData.position == HoverCardPosition.cursor) {
-        _setHoverCard(
-          HoverCard.fromHoverEvent(
-            context: context,
-            title: hoverCardData.title,
-            contents: hoverCardData.contents,
-            width: hoverCardData.width,
-            event: event,
-            hoverCardController: _hoverCardController,
-          ),
-        );
-      } else {
-        _setHoverCard(
-          HoverCard(
-            context: context,
-            title: hoverCardData.title,
-            contents: hoverCardData.contents,
-            width: hoverCardData.width,
-            position: _calculateTooltipPosition(hoverCardData.width),
-            hoverCardController: _hoverCardController,
-          ),
         );
       }
     });
+  }
+
+  void _showAsyncHoverCard({
+    required AsyncGenerateHoverCardDataFunc asyncGenerateHoverCardData,
+    required PointerHoverEvent event,
+    int? asyncTimeout,
+  }) async {
+    HoverCard? spinnerHoverCard;
+    final hoverCardDataFuture = asyncGenerateHoverCardData(
+      event: event,
+      isHoverStale: () =>
+          spinnerHoverCard != null &&
+          !_hoverCardController.isHoverCardStillActive(spinnerHoverCard),
+    );
+    // If we have set the async hover card to show up only after a timeout,
+    // then race the timeout against generating the hover card data. If
+    // generating the data completes first, immediately show the hover card
+    // (or return early if there is no data).
+    if (asyncTimeout != null) {
+      final hoverCardDataCompleter =
+          _hoverCardDataCompleter(hoverCardDataFuture);
+      await Future.any([
+        _timeoutCompleter(asyncTimeout).future,
+        hoverCardDataCompleter.future,
+      ]);
+
+      if (hoverCardDataCompleter.isCompleted) {
+        final data = await hoverCardDataCompleter.future;
+        // If we get no data back, then don't show a hover card.
+        if (data == null) return;
+        // Otherwise, show a hover card immediately.
+        return _setHoverCardFromData(
+          data,
+          context: context,
+          event: event,
+        );
+      }
+    }
+    // The data on the card is fetched asynchronously, so show a spinner
+    // while we wait for it.
+    spinnerHoverCard = HoverCard.fromHoverEvent(
+      context: context,
+      contents: const CenteredCircularProgressIndicator(),
+      width: HoverCardTooltip.defaultHoverWidth,
+      event: event,
+      hoverCardController: _hoverCardController,
+    );
+
+    _setHoverCard(
+      spinnerHoverCard,
+    );
+
+    // The spinner is showing, we can now generate the HoverCardData
+    final hoverCardData = await hoverCardDataFuture;
+
+    if (!_hoverCardController.isHoverCardStillActive(spinnerHoverCard)) {
+      // The hovercard became stale while fetching it's data. So it should
+      // no longer be shown.
+      return;
+    }
+    if (hoverCardData == null) {
+      // No data was provided so remove the spinner
+      _removeHoverCard(spinnerHoverCard);
+      return;
+    }
+  }
+
+  void _setHoverCardFromData(
+    HoverCardData hoverCardData, {
+    required BuildContext context,
+    required PointerHoverEvent event,
+  }) {
+    if (hoverCardData.position == HoverCardPosition.cursor) {
+      return _setHoverCard(
+        HoverCard.fromHoverEvent(
+          context: context,
+          title: hoverCardData.title,
+          contents: hoverCardData.contents,
+          width: hoverCardData.width,
+          event: event,
+          hoverCardController: _hoverCardController,
+        ),
+      );
+    }
+    return _setHoverCard(
+      HoverCard(
+        context: context,
+        title: hoverCardData.title,
+        contents: hoverCardData.contents,
+        width: hoverCardData.width,
+        position: _calculateTooltipPosition(hoverCardData.width),
+        hoverCardController: _hoverCardController,
+      ),
+    );
+  }
+
+  Completer _timeoutCompleter(int timeout) {
+    final completer = Completer();
+    Timer(Duration(milliseconds: timeout), () {
+      completer.complete();
+    });
+    return completer;
+  }
+
+  Completer<HoverCardData?> _hoverCardDataCompleter(
+      Future<HoverCardData?> hoverCardDataFuture) {
+    final completer = Completer<HoverCardData?>();
+    hoverCardDataFuture.then(
+      (data) => completer.complete(data),
+      onError: (_) => completer.complete(null),
+    );
+    return completer;
   }
 
   Offset _calculateTooltipPosition(double width) {

--- a/packages/devtools_app/lib/src/ui/hover.dart
+++ b/packages/devtools_app/lib/src/ui/hover.dart
@@ -493,7 +493,8 @@ class _HoverCardTooltipState extends State<HoverCardTooltip> {
   }
 
   Completer<HoverCardData?> _hoverCardDataCompleter(
-      Future<HoverCardData?> hoverCardDataFuture) {
+    Future<HoverCardData?> hoverCardDataFuture,
+  ) {
     final completer = Completer<HoverCardData?>();
     hoverCardDataFuture.then(
       (data) => completer.complete(data),


### PR DESCRIPTION
Currently in the debugger panel, when hovering on a symbol, we immediately show a hovercard with a spinner. Once the expression evaluation completes, we remove the spinner and show the result, or remove the hovercard entirely if the result is null. This means that a hovercard can appear with a spinner, only to be removed right after. 

This PR adds a heuristic to try to prevent that. We're assuming that when expression evaluation returns with null it does so fast-ish, and so we only show the hovercard with a spinner if we haven't received a result after 100ms.

I still need to add tests, but would appreciate a review on the implementation first :) 
