### PR TITLE
Line is visible when paused at breakpoint

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -868,54 +868,41 @@ class _LineItemState extends State<LineItem>
       // TODO: support selecting text across multiples lines.
       child = Stack(
         children: [
-          HoverCardTooltip.async(
-            asyncTimeout: 100,
-            asyncGenerateHoverCardData: _generateHoverCardData,
-            enabled: () => true,
-            child: Row(
-              children: [
-                // Create a hidden copy of the first column-1 characters of the
-                // line as a hack to correctly compute where to place
-                // the cursor. Approximating by using column-1 spaces instead
-                // of the correct characters and style s would be risky as it leads
-                // to small errors if the font is not fixed size or the font
-                // styles vary depending on the syntax highlighting.
-                // TODO(jacobr): there might be some api exposed on SelectedText
-                // to allow us to render this as a proper overlay as similar
-                // functionality exists to render the selection handles properly.
-                Opacity(
-                  opacity: 0,
-                  child: RichText(
-                    text: truncateTextSpan(widget.lineContents, column - 1),
+          Row(
+            children: [
+              // Create a hidden copy of the first column-1 characters of the
+              // line as a hack to correctly compute where to place
+              // the cursor. Approximating by using column-1 spaces instead
+              // of the correct characters and style s would be risky as it leads
+              // to small errors if the font is not fixed size or the font
+              // styles vary depending on the syntax highlighting.
+              // TODO(jacobr): there might be some api exposed on SelectedText
+              // to allow us to render this as a proper overlay as similar
+              // functionality exists to render the selection handles properly.
+              Opacity(
+                opacity: .5,
+                child: RichText(
+                  text: truncateTextSpan(widget.lineContents, column - 1),
+                ),
+              ),
+              Transform.translate(
+                offset: const Offset(colLeftOffset, colBottomOffset),
+                child: Transform.rotate(
+                  angle: colIconRotate,
+                  child: Icon(
+                    Icons.label_important,
+                    size: colIconSize,
+                    color: breakpointColor,
                   ),
                 ),
-                Transform.translate(
-                  offset: const Offset(colLeftOffset, colBottomOffset),
-                  child: Transform.rotate(
-                    angle: colIconRotate,
-                    child: Icon(
-                      Icons.label_important,
-                      size: colIconSize,
-                      color: breakpointColor,
-                    ),
-                  ),
-                )
-              ],
-            ),
+              ),
+            ],
           ),
+          _hoverableLine(),
         ],
       );
     } else {
-      child = HoverCardTooltip.async(
-        enabled: () => true,
-        asyncTimeout: 100,
-        asyncGenerateHoverCardData: _generateHoverCardData,
-        child: SelectableText.rich(
-          searchAwareLineContents(),
-          scrollPhysics: const NeverScrollableScrollPhysics(),
-          maxLines: 1,
-        ),
-      );
+      child = _hoverableLine();
     }
 
     final backgroundColor = widget.focused
@@ -931,6 +918,17 @@ class _LineItemState extends State<LineItem>
       child: child,
     );
   }
+
+  Widget _hoverableLine() => HoverCardTooltip.async(
+        enabled: () => true,
+        asyncTimeout: 100,
+        asyncGenerateHoverCardData: _generateHoverCardData,
+        child: SelectableText.rich(
+          searchAwareLineContents(),
+          scrollPhysics: const NeverScrollableScrollPhysics(),
+          maxLines: 1,
+        ),
+      );
 
   TextSpan searchAwareLineContents() {
     final children = widget.lineContents.children;


### PR DESCRIPTION
Adds back in the hoverable line that accidentally went missing in https://github.com/flutter/devtools/pull/4627

This was reported in b/255959281


### Paused on a breakpoint before:

![Screen Shot 2022-10-27 at 5 03 28 PM](https://user-images.githubusercontent.com/21270878/198419509-44378f08-9ee3-4778-9eb5-8cdbd2e05f6d.png)
![Screen Shot 2022-10-27 at 5 03 19 PM](https://user-images.githubusercontent.com/21270878/198419575-57cb3b15-d77a-423d-8605-882efac5f8d3.png)


### Paused on a breakpoint now:

![Screen Shot 2022-10-27 at 4 59 58 PM](https://user-images.githubusercontent.com/21270878/198419542-36cdf39d-e220-4818-849a-e6026d13fa96.png)
![Screen Shot 2022-10-27 at 5 00 14 PM](https://user-images.githubusercontent.com/21270878/198419567-21de0e2b-9586-4561-bcdf-f9247e7432f4.png)

