### PR TITLE
Show "No files found." message in file search if results are empty

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/file_search.dart
@@ -16,6 +16,8 @@ import 'debugger_model.dart';
 
 const int numOfMatchesToShow = 10;
 
+const noResultsMsg = 'No files found.';
+
 final _fileNamesCache = <String, String>{};
 
 class FileSearchField extends StatefulWidget {
@@ -100,7 +102,9 @@ class FileSearchFieldState extends State<FileSearchField>
 
     final searchResults = _createSearchResults(currentQuery, scripts);
     if (searchResults.scriptRefs.isEmpty) {
-      autoCompleteController.searchAutoComplete.value = [];
+      autoCompleteController.searchAutoComplete.value = [
+        AutoCompleteMatch(noResultsMsg),
+      ];
     } else {
       searchResults.topMatches.scriptRefs.forEach(_addScriptRefToCache);
       autoCompleteController.searchAutoComplete.value =
@@ -126,6 +130,10 @@ class FileSearchFieldState extends State<FileSearchField>
   }
 
   void _onSelection(String scriptUri) {
+    if (scriptUri == noResultsMsg) {
+      _onClose();
+      return;
+    }
     final scriptRef = _scriptsCache[scriptUri]!;
     widget.codeViewController.showScriptLocation(ScriptLocation(scriptRef));
     _onClose();

--- a/packages/devtools_app/test/debugger/file_search_test.dart
+++ b/packages/devtools_app/test/debugger/file_search_test.dart
@@ -233,7 +233,15 @@ void main() {
     );
 
     autoCompleteController.search = 'caterpie';
-    expect(autoCompleteController.searchAutoComplete.value, equals([]));
+    expect(
+      getAutoCompleteMatch(
+        autoCompleteController.searchAutoComplete.value,
+        preserveCases: true,
+      ),
+      equals([
+        'No files found.',
+      ]),
+    );
   });
 
   testWidgetsWithWindowSize(
@@ -418,15 +426,29 @@ void main() {
         ],
       ),
     );
+
+    autoCompleteController.search = 'food cartwheel';
+    expect(
+      getAutoCompleteMatch(autoCompleteController.searchAutoComplete.value,
+          preserveCases: true),
+      equals(
+        [
+          'No files found.',
+        ],
+      ),
+    );
   });
 }
 
-List<String> getAutoCompleteMatch(List<AutoCompleteMatch> matches) {
+List<String> getAutoCompleteMatch(List<AutoCompleteMatch> matches,
+    {bool preserveCases = false}) {
   return matches
       .map(
         (match) => match.transformAutoCompleteMatch<String>(
-          transformMatchedSegment: (segment) => segment.toUpperCase(),
-          transformUnmatchedSegment: (segment) => segment.toLowerCase(),
+          transformMatchedSegment: (segment) =>
+              preserveCases ? segment : segment.toUpperCase(),
+          transformUnmatchedSegment: (segment) =>
+              preserveCases ? segment : segment.toLowerCase(),
           combineSegments: (segments) => segments.join(),
         ),
       )

--- a/packages/devtools_app/test/debugger/file_search_test.dart
+++ b/packages/devtools_app/test/debugger/file_search_test.dart
@@ -429,8 +429,10 @@ void main() {
 
     autoCompleteController.search = 'food cartwheel';
     expect(
-      getAutoCompleteMatch(autoCompleteController.searchAutoComplete.value,
-          preserveCases: true),
+      getAutoCompleteMatch(
+        autoCompleteController.searchAutoComplete.value,
+        preserveCases: true,
+      ),
       equals(
         [
           'No files found.',
@@ -440,8 +442,10 @@ void main() {
   });
 }
 
-List<String> getAutoCompleteMatch(List<AutoCompleteMatch> matches,
-    {bool preserveCases = false}) {
+List<String> getAutoCompleteMatch(
+  List<AutoCompleteMatch> matches, {
+  bool preserveCases = false,
+}) {
   return matches
       .map(
         (match) => match.transformAutoCompleteMatch<String>(


### PR DESCRIPTION
Helps the case where an app has only 1 file (eg, `main.dart`). If you click on file search, it tells you that there are no other files. 

![no results](https://user-images.githubusercontent.com/21270878/198733388-aa346e44-c9d7-4d1c-9969-f3e1f953a620.gif)
