### PR TITLE
Revert async calculations.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/leaks/diagnostics/model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/leaks/diagnostics/model.dart
@@ -51,7 +51,7 @@ class NotGCedAnalyzerTask {
     List<LeakReport> reports,
   ) async {
     return NotGCedAnalyzerTask(
-      heap: await AdaptedHeapData.fromHeapSnapshot(graph),
+      heap: AdaptedHeapData.fromHeapSnapshot(graph),
       reports: reports,
     );
   }

--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/model.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/model.dart
@@ -4,7 +4,6 @@
 
 import 'package:vm_service/vm_service.dart';
 
-import '../../../../primitives/utils.dart';
 import '../../primitives/class_name.dart';
 import '../../primitives/memory_utils.dart';
 
@@ -44,15 +43,12 @@ class AdaptedHeapData {
     );
   }
 
-  static Future<AdaptedHeapData> fromHeapSnapshot(
+  static AdaptedHeapData fromHeapSnapshot(
     HeapSnapshotGraph graph,
-  ) async {
-    final listOfFutures = graph.objects.map((e) async {
-      await delayForBatchProcessing();
+  ) {
+    final objects = graph.objects.map((e) {
       return AdaptedHeapObject.fromHeapSnapshotObject(e);
     }).toList();
-
-    final objects = await Future.wait(listOfFutures);
 
     return AdaptedHeapData(objects);
   }


### PR DESCRIPTION
Async calculations how they are implemented now take 10 times (5 sec) longer than sync. 
We will do it smarter if we get signal it impacts  users.

For now reverting.

Details: https://github.com/flutter/devtools/pull/4680
