### PR TITLE
Fix potential race condition when expanding variables

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -37,10 +37,10 @@ class Variables extends StatelessWidget {
     );
   }
 
-  void onItemPressed(DartObjectNode v, DebuggerController controller) {
+  void onItemPressed(DartObjectNode v, DebuggerController controller) async {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
-      v.children.forEach(buildVariablesTree);
+      await Future.wait(v.children.map(buildVariablesTree));
     }
   }
 }
@@ -76,10 +76,10 @@ class ExpandableVariable extends StatelessWidget {
     );
   }
 
-  void onItemPressed(DartObjectNode v, DebuggerController controller) {
+  void onItemPressed(DartObjectNode v, DebuggerController controller) async {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
-      v.children.forEach(buildVariablesTree);
+      await Future.wait(v.children.map(buildVariablesTree));
     }
   }
 }

--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -33,11 +33,14 @@ class Variables extends StatelessWidget {
       dataRootsListenable: controller.variables,
       dataDisplayProvider: (variable, onPressed) =>
           displayProvider(context, variable, onPressed, controller),
-      onItemSelected: (variable) => onItemPressed(variable, controller),
+      onItemSelected: (variable) async => onItemPressed(variable, controller),
     );
   }
 
-  void onItemPressed(DartObjectNode v, DebuggerController controller) async {
+  Future<void> onItemPressed(
+    DartObjectNode v,
+    DebuggerController controller,
+  ) async {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
       await Future.wait(v.children.map(buildVariablesTree));
@@ -72,11 +75,15 @@ class ExpandableVariable extends StatelessWidget {
       shrinkWrap: true,
       dataDisplayProvider: (variable, onPressed) =>
           displayProvider(context, variable, onPressed, debuggerController),
-      onItemSelected: (variable) => onItemPressed(variable, debuggerController),
+      onItemSelected: (variable) async =>
+          onItemPressed(variable, debuggerController),
     );
   }
 
-  void onItemPressed(DartObjectNode v, DebuggerController controller) async {
+  Future<void> onItemPressed(
+    DartObjectNode v,
+    DebuggerController controller,
+  ) async {
     // On expansion, lazily build the variables tree for performance reasons.
     if (v.isExpanded) {
       await Future.wait(v.children.map(buildVariablesTree));


### PR DESCRIPTION
![](https://media.giphy.com/media/87WdvlESoa640/giphy-downsized.gif)

These buildVariablesTree call weren't getting waited on. So if they tool a little longer, the variable would expand, but it's data wouldn't refresh on the screen properly.

Open question: @kenzieschmoll should we add analytics timers here to see how long variable expansion takes?


 