### PR TITLE
Calculate the width of a table's columns more accurately

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/column_widths.dart
+++ b/packages/devtools_app/lib/src/shared/table/column_widths.dart
@@ -119,14 +119,14 @@ extension TreeColumnWidthExtension<T extends TreeNode<T>>
         // our tree tables. This will almost certainly cause overflows if we
         // try to use non-monospace fonts.
         //
-        // `fontFactor` was determined through trial and error to roughly
+        // `characterWidth` was determined through trial and error to roughly
         // approximate the width of a single character.
-        const fontFactor = 9.0;
+        const characterWidth = 9.0;
         double longestWidth = 0;
         for (var node in flattenedList) {
           final width = column.getNodeIndentPx(node) +
               (column.getDisplayValue(node).length *
-                  scaleByFontFactor(fontFactor));
+                  scaleByFontFactor(characterWidth));
           if (width > longestWidth) {
             longestWidth = width;
           }

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -962,6 +962,52 @@ void main() {
       expect(find.byWidget(table), findsOneWidget);
     });
 
+    testWidgets('displays wide data with many columns',
+        (WidgetTester tester) async {
+      const strings = <String>[
+        'All work',
+        'and no play',
+        'makes Ben',
+        'a dull boy',
+        // ignore: no_adjacent_strings_in_list
+        'The quick brown fox jumped over the lazy dog, although the fox '
+        "couldn't jump very high and the dog was very, very small, so it really"
+        " wasn't much of an achievement on the fox's part, so I'm not sure why "
+        "we're even talking about it."
+      ];
+      final root = TestData('Root', 0);
+      var current = root;
+      for (int i = 0; i < 1000; ++i) {
+        final next = TestData(strings[i % strings.length], i);
+        current.addChild(next);
+        current = next;
+      }
+      final table = TreeTable<TestData>(
+        columns: [
+          _NumberColumn(),
+          _CombinedColumn(),
+          treeColumn,
+          _CombinedColumn(),
+        ],
+        dataRoots: [root],
+        dataKey: 'test-data',
+        treeColumn: treeColumn,
+        keyFactory: (d) => Key(d.name),
+        defaultSortColumn: treeColumn,
+        defaultSortDirection: SortDirection.ascending,
+      );
+      await tester.pumpWidget(
+        wrap(
+          SizedBox(
+            width: 200.0,
+            height: 200.0,
+            child: table,
+          ),
+        ),
+      );
+      expect(find.byWidget(table), findsOneWidget);
+    });
+
     testWidgets('properly collapses and expands the tree',
         (WidgetTester tester) async {
       final table = TreeTable<TestData>(

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -1088,7 +1088,7 @@ void main() {
       await tester.pumpWidget(wrap(table));
       final TreeTableState state = tester.state(find.byWidget(table));
       expect(state.tableController.columnWidths[0], equals(400));
-      expect(state.tableController.columnWidths[1], equals(500));
+      expect(state.tableController.columnWidths[1], equals(63));
       final tree = state.tableController.dataRoots[0];
       expect(tree.children[0].name, equals('Bar'));
       expect(tree.children[0].children[0].name, equals('Baz'));

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -970,10 +970,10 @@ void main() {
         'makes Ben',
         'a dull boy',
         // ignore: no_adjacent_strings_in_list
-        'The quick brown fox jumped over the lazy dog, although the fox '
-        "couldn't jump very high and the dog was very, very small, so it really"
-        " wasn't much of an achievement on the fox's part, so I'm not sure why "
-        "we're even talking about it."
+        'The quick brown fox jumps over the lazy dog, although the fox '
+            "can't jump very high and the dog is very, very small, so it really"
+            " isn't much of an achievement on the fox's part, so I'm not sure why "
+            "we're even talking about it."
       ];
       final root = TestData('Root', 0);
       var current = root;
@@ -996,6 +996,7 @@ void main() {
         defaultSortColumn: treeColumn,
         defaultSortDirection: SortDirection.ascending,
       );
+      // This test will throw an exception if the table overflows.
       await tester.pumpWidget(
         wrap(
           SizedBox(


### PR DESCRIPTION
This change updates the column width calculations for `TreeTable` to waste less space in tree columns. Previously, we were using a hard coded value of 500 plus the indent of the deepest level to determine the overall width of the tree column, which often left a significant amount of empty space.

Column width calculations for tree columns now assume that the contents of each node will be text with monospaced fonts and uses the length of the maximum displayed string plus its indent levels.

Fixes https://github.com/flutter/devtools/issues/2047

**Before:**
<img width="1333" alt="image" src="https://user-images.githubusercontent.com/24210656/201388929-de9dab9f-c163-4922-8b49-08d0c0bc49e8.png">

**After:**
<img width="1289" alt="image" src="https://user-images.githubusercontent.com/24210656/201388838-72e8fb51-9673-45c9-b1ac-36f37ba43220.png">
