### PR TITLE
Remove `package:archive` constraint

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -39,8 +39,7 @@ dependencies:
     sdk: flutter
   http: ^0.13.4
   image: ^3.0.2
-  # TODO: https://github.com/flutter/devtools/issues/4728 - remove constraint when archive is fixed
-  archive: <3.3.3
+  archive: ^3.3.4
   intl: '>=0.16.1 <0.18.0'
   js: ^0.6.1+1
   mime: ^1.0.0

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -39,7 +39,6 @@ dependencies:
     sdk: flutter
   http: ^0.13.4
   image: ^3.0.2
-  archive: ^3.3.4
   intl: '>=0.16.1 <0.18.0'
   js: ^0.6.1+1
   mime: ^1.0.0


### PR DESCRIPTION
The newest version of `package:archive` has been released, therefore it should be safe to remove the constraint.

See: https://github.com/brendan-duncan/archive/issues/221
