### PR TITLE
Update BETA_TESTING.md

### DIFF
--- a/BETA_TESTING.md
+++ b/BETA_TESTING.md
@@ -10,18 +10,15 @@ If you want to make code changes, follow [contributing guidance](https://github.
 
 2. In your terminal `cd` to a folder where you want to clone devtools, and that does not have subfolder `devtools` yet.
 
-3. Start DevTools:
+3. Start DevTools by cloning the repo, getting Flutter of right version into subdirectory and starting the application:
 
 ```bash
-# Clone the repo:
-git clone https://github.com/flutter/devtools.git;
+git clone https://github.com/flutter/devtools
 
-# Get local Flutter of the correct version:
-./devtools/tool/update_flutter_sdk.sh;
+./devtools/tool/update_flutter_sdk.sh
 
-# Start the application:
-cd devtools/packages/devtools_app;
-../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true;
+cd devtools/packages/devtools_app
+../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true
 ```
 
 4. Paste the URL of your application (for example [Gallery](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#connect-to-application)) to the connection textbox.
@@ -33,14 +30,12 @@ cd devtools/packages/devtools_app;
 2. Refresh and run DevTools (it will delete all your local changes!):
 
 ```bash
-# Checkout the master branch and ensure it is at the most recent change:
 git checkout master;
-git reset --hard origin/master; # this line will remove all local changes or commits on your branch
+git reset --hard origin/master
 
-# Make sure all dependencies have correct version:
-./tool/update_flutter_sdk.sh;
-cd packages/devtools_app;
-../../tool/flutter-sdk/bin/flutter pub upgrade;
+./tool/update_flutter_sdk.sh
+cd packages/devtools_app
+../../tool/flutter-sdk/bin/flutter pub upgrade
 
 # Start the application:
 ../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true;

--- a/BETA_TESTING.md
+++ b/BETA_TESTING.md
@@ -18,7 +18,7 @@ git clone https://github.com/flutter/devtools
 ./devtools/tool/update_flutter_sdk.sh
 
 cd devtools/packages/devtools_app
-../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true
+../../tool/flutter-sdk/bin/flutter run -d chrome
 ```
 
 4. Paste the URL of your application (for example [Gallery](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#connect-to-application)) to the connection textbox.
@@ -30,15 +30,14 @@ cd devtools/packages/devtools_app
 2. Refresh and run DevTools (it will delete all your local changes!):
 
 ```bash
-git checkout master;
+git checkout master
 git reset --hard origin/master
 
 ./tool/update_flutter_sdk.sh
 cd packages/devtools_app
 ../../tool/flutter-sdk/bin/flutter pub upgrade
 
-# Start the application:
-../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true;
+../../tool/flutter-sdk/bin/flutter run -d chrome
 ```
 
 3. Paste the URL of your application (for example [Gallery](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#connect-to-application)) to the connection textbox.


### PR DESCRIPTION
1. In some shells `#` and `.git` are interpreted as mistake
2. ';' looks weird for some users and is not necessary 
3. We do not need flags to enable beta features, as they are enabled in non-release mode by default now
4. Added instructions to install jq