### PR TITLE
Adding new Github release note validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,33 @@
+*Replace this paragraph with a description of what this PR is changing or adding, and why. Consider including before/after screenshots.*
+
+*List which issues are fixed by this PR. You must list at least one issue.*
+
+*If you had to change anything in the [flutter/tests] repo, include a link to the migration guide as per the [breaking change policy].*
+
+<!-- Uncomment and modify the following section if your PR does not require changes to the release notes -->
+<!-- 
+> NO RELEASE NOTE CHANGES: <REASON GOES HERE>
+ -->
+
+## Pre-launch Checklist
+
+- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
+- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
+- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
+- [ ] I signed the [CLA].
+- [ ] I listed at least one issue that this PR fixes in the description above.
+- [ ] I updated/added relevant documentation (doc comments with `///`).
+- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
+- [ ] All existing and new tests are passing.
+
+If you need help, consider asking for advice on the #hackers-new channel on [Discord].
+
+<!-- Links -->
+[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
+[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
+[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
+[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
+[CLA]: https://cla.developers.google.com/
+[flutter/tests]: https://github.com/flutter/tests
+[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
+[Discord]: https://github.com/flutter/flutter/wiki/Chat

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@
 name: devtools
 
 on:
-  # pull_request:
+  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,7 +5,7 @@
 name: devtools
 
 on:
-  pull_request:
+  # pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -1,0 +1,85 @@
+name: Release Notes
+
+on:
+  pull_request:
+    types: [ assigned, opened, synchronize, reopened, edited ]
+env:
+  CURRENT_RELEASE_JSON_FILE_PATH: tool/release_notes/release_notes.json
+jobs:
+  release-preparedness:
+    runs-on: ubuntu-latest
+    name: Verify PR Release Note Requirements
+    steps:
+
+      - name: Get Pull Request Number
+        id: get-pull-request-number
+        run: |
+          PULL_REQUEST_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "PULL_REQUEST_NUMBER=$PULL_REQUEST_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Check if we have modified release_notes.json 
+        id: get-modified-files
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{steps.get-pull-request-number.outputs.PULL_REQUEST_NUMBER}}
+        run: |
+          FILES_RESPONSE=$(gh api /repos/flutter/devtools/pulls/$PULL_NUMBER/files)
+          echo "FILES_RESPONSE: $FILES_RESPONSE"
+          
+          HAS_CHANGED_RELEASE_NOTES=$(echo $FILES_RESPONSE | jq '.[].filename' | jq -s '. | any(. == env.CURRENT_RELEASE_JSON_FILE_PATH)')
+          echo "HAS_CHANGED_RELEASE_NOTES=$HAS_CHANGED_RELEASE_NOTES" >> $GITHUB_OUTPUT
+
+      - name: Get PR Description
+        id: check-release-note-exceptions
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PULL_NUMBER: ${{steps.get-pull-request-number.outputs.PULL_REQUEST_NUMBER}}
+        run: |
+          PULLS_RESPONSE=$(gh api /repos/flutter/devtools/pulls/$PULL_NUMBER)
+          DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
+          echo $DESCRIPTION_BODY
+          if $(echo $DESCRIPTION_BODY | grep -q "> NO RELEASE NOTE CHANGES:"); then
+            HAS_RELEASE_NOTE_EXCEPTION_STRING=true
+          else
+            HAS_RELEASE_NOTE_EXCEPTION_STRING=false
+          fi
+          echo "HAS_RELEASE_NOTE_EXCEPTION_STRING=$HAS_RELEASE_NOTE_EXCEPTION_STRING" >> $GITHUB_OUTPUT
+
+      - name: Check Release Preparedness requirements
+        env:
+          HAS_CHANGED_RELEASE_NOTES: ${{steps.get-modified-files.outputs.HAS_CHANGED_RELEASE_NOTES}}
+          HAS_RELEASE_NOTE_EXCEPTION_STRING: ${{steps.check-release-note-exceptions.outputs.HAS_RELEASE_NOTE_EXCEPTION_STRING}}
+        run: |
+          if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] ; then
+            echo "Release Preparedness check failed"
+            echo "::error file=$CURRENT_RELEASE_JSON_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes Weren\'t Modified'::Please add a release note entry or a reason to your description using: \`> NO RELEASE NOTE CHANGES: [reason goes here]\`"
+            exit 1
+          fi
+
+  release-note-validation:
+    runs-on: ubuntu-latest
+    name: Release Note Validation
+    steps:
+      - name: Get Pull Request Number
+        id: get-pull-request-number
+        run: |
+          PULL_REQUEST_NUMBER=$(jq --raw-output .pull_request.number "$GITHUB_EVENT_PATH")
+          echo "PULL_REQUEST_NUMBER=$PULL_REQUEST_NUMBER" >> $GITHUB_OUTPUT
+      - uses: dart-lang/setup-dart@9a04e6d73cca37bd455e0608d7e5092f881fd603
+      - uses: actions/checkout@v3
+      - name: Verify the release note integrity
+        run: |
+          cd tool/
+          dart pub get
+          dart release_note_helper.dart verify -f "../$CURRENT_RELEASE_JSON_FILE_PATH"
+
+      - name: Check PR Urls
+        env:
+          PULL_NUMBER: ${{steps.get-pull-request-number.outputs.PULL_REQUEST_NUMBER}}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          cd tool/
+          dart pub get
+          dart ./release_note_helper.dart pr-url \
+            -f "../$CURRENT_RELEASE_JSON_FILE_PATH" \
+            -u https://github.com/flutter/devtools/pull/$PULL_NUMBER 

--- a/packages/devtools_app/lib/src/framework/release_notes/README.md
+++ b/packages/devtools_app/lib/src/framework/release_notes/README.md
@@ -1,9 +1,9 @@
-## Writing DevTools release notes
+## Generating Release notes
 - Release notes for DevTools are hosted on the flutter website (see [archive](https://docs.flutter.dev/development/tools/devtools/release-notes)).
-- To add release notes for the latest release, create a PR with the appropriate changes for your release
-    - The [release notes template](release-notes-template.md) can be used as a starting point
-    - see example [PR](https://github.com/flutter/website/pull/6791).
+- To add release notes for the latest release, create a PR with the appropriate changes for your release.
+    - To generate the release notes run:
 
+        `dart tool/release_note_helper.dart markdown -f tool/release_notes/release_notes.json`
 - Test these changes locally before creating the PR.
     - See [README.md](https://github.com/flutter/website/blob/main/README.md)
 for getting setup to run the Flutter website locally.

--- a/packages/devtools_shared/lib/src/utils/semantic_version.dart
+++ b/packages/devtools_shared/lib/src/utils/semantic_version.dart
@@ -14,6 +14,16 @@ class SemanticVersion with CompareMixin {
     this.preReleaseMajor,
     this.preReleaseMinor,
   });
+  
+  factory SemanticVersion.fromJson(Map<String, dynamic> json) {
+    return SemanticVersion(
+      major: json['major'],
+      minor: json['minor'],
+      patch: json['patch'],
+      preReleaseMajor: json['preReleaseMajor'],
+      preReleaseMinor: json['preReleaseMinor'],
+    );
+  }
 
   factory SemanticVersion.parse(String? versionString) {
     if (versionString == null) return SemanticVersion();
@@ -147,6 +157,14 @@ class SemanticVersion with CompareMixin {
 
     return -1;
   }
+
+  Map<String, dynamic> toJson() => {
+        'major': major,
+        'minor': minor,
+        'patch': patch,
+        'preReleaseMajor': preReleaseMajor,
+        'preReleaseMinor': preReleaseMinor,
+      };
 
   @override
   String toString() {

--- a/packages/devtools_shared/test/semantic_version_test.dart
+++ b/packages/devtools_shared/test/semantic_version_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:test/test.dart';
 
@@ -205,6 +207,15 @@ void main() {
         ).toString(),
         equals('1.1.1-0.1'),
       );
+    });
+
+    test('json', () {
+      final version = SemanticVersion(
+          major: 1, minor: 2, patch: 3, preReleaseMajor: 4, preReleaseMinor: 5);
+      final encodedVersion = jsonEncode(version);
+      final decodedVersion =
+          SemanticVersion.fromJson(jsonDecode(encodedVersion));
+      expect(version.compareTo(decodedVersion), equals(0));
     });
   });
 }

--- a/packages/devtools_shared/test/semantic_version_test.dart
+++ b/packages/devtools_shared/test/semantic_version_test.dart
@@ -211,7 +211,12 @@ void main() {
 
     test('json', () {
       final version = SemanticVersion(
-          major: 1, minor: 2, patch: 3, preReleaseMajor: 4, preReleaseMinor: 5);
+        major: 1,
+        minor: 2,
+        patch: 3,
+        preReleaseMajor: 4,
+        preReleaseMinor: 5,
+      );
       final encodedVersion = jsonEncode(version);
       final decodedVersion =
           SemanticVersion.fromJson(jsonDecode(encodedVersion));

--- a/tool/README.md
+++ b/tool/README.md
@@ -33,7 +33,27 @@ git checkout -b release_$(date +%s);
 
 #### Update the DevTools version number
 
+##### Releasing a clean version
 Run the `tool/update_version.dart` script to update the DevTools version.
+- When doing a release, the pre-releases can be stripped with:
+   ```shell
+   dart tool/update_version.dart auto --type release
+   ```
+- Create a PR with this cleaned version number to denote the official release of Devtools under that number
+
+Verify:
+* that this script updated the pubspecs under packages/
+* updated all references to those packages.
+*  make sure that the version constant in `packages/devtools_app/lib/devtools.dart` was updated
+
+These packages always have their version numbers updated in lock, so we don't have to worry about versioning.
+
+##### Updating to the next version
+After merging a cleaned version of the current release, you can then perform a `patch`, `minor`, or `major` update.
+This version can be pushed up in a separate PR to denote the start of this next version.
+
+> NOTE: In the future these two released commits will automatically be handled by GitHub.
+
 - For regular monthly releases, use `minor`:
    ```shell
    dart tool/update_version.dart auto --type minor
@@ -46,15 +66,6 @@ Run the `tool/update_version.dart` script to update the DevTools version.
    ```shell
    dart tool/update_version.dart auto --type patch
    ```
-
-Verify:
-* that this script updated the pubspecs under packages/
-* updated all references to those packages.
-*  make sure that the version constant in `packages/devtools_app/lib/devtools.dart` was updated
-
-These packages always have their version numbers updated in lock, so we don't have to worry about versioning.
-
-> Note: Updating to a new `dev` version will automatically prepare the version for a new `minor` release (eg, `2.17.0` will become `2.18.0-dev.0`). To update to a `major` or `patch` release instead, specify either `dev,patch` or `dev,major` (eg, `dart tool/update_version.dart auto --type dev,patch`).
 
 #### Update the CHANGELOG.md (for non-dev releases)
 

--- a/tool/lib/release_note_classes.dart
+++ b/tool/lib/release_note_classes.dart
@@ -145,5 +145,3 @@ class ReleaseNote {
 
   Map<String, dynamic> toJson() => _$ReleaseNoteToJson(this);
 }
-// # Sementic line breaks of 80 chars or fewer
-// # each line requires an PR command

--- a/tool/lib/release_note_classes.dart
+++ b/tool/lib/release_note_classes.dart
@@ -1,3 +1,7 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'dart:io';
 
 import 'package:devtools_shared/devtools_shared.dart';
@@ -6,29 +10,8 @@ import 'package:json_annotation/json_annotation.dart';
 part 'release_note_classes.g.dart';
 
 @JsonSerializable()
-class ReleaseNotes {
-  ReleaseNotes({
-    required this.releases,
-  });
 
-  List<Release> releases;
-
-  String toMarkdown() {
-    String markdown = '';
-    for (var release in releases) {
-      markdown += release.toMarkdown();
-      markdown += '\n';
-    }
-    return markdown;
-  }
-
-  factory ReleaseNotes.fromJson(Map<String, dynamic> json) =>
-      _$ReleaseNotesFromJson(json);
-
-  Map<String, dynamic> toJson() => _$ReleaseNotesToJson(this);
-}
-
-@JsonSerializable()
+/// Stores all of the release note [sections] for a given [version].
 class Release {
   Release({
     required this.version,
@@ -67,6 +50,8 @@ class Release {
 }
 
 @JsonSerializable()
+
+/// Represents a section of release [notes] with a given [name].
 class ReleaseSection {
   ReleaseSection({
     required this.name,
@@ -87,6 +72,12 @@ class ReleaseSection {
 }
 
 @JsonSerializable()
+
+/// An individual release note entry, with a given [message].
+///
+/// The names of images relating to the releaseNote can be passed
+/// in [imageNames]. WThe GitHub pull request url that the message is added to,
+/// can be reflected through [githubPullRequestUrls].
 class ReleaseNote {
   ReleaseNote({
     required this.message,

--- a/tool/lib/release_note_classes.dart
+++ b/tool/lib/release_note_classes.dart
@@ -1,6 +1,5 @@
 import 'dart:io';
 
-import 'package:devtools_repo/repo_tool.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:json_annotation/json_annotation.dart';
 
@@ -51,13 +50,13 @@ class Release {
   String toMarkdown() {
     String markdown = '';
     markdown += '# DevTools $version release notes\n\n';
-    sections.forEach((section) {
+    for (var section in sections) {
       markdown += '# ${section.name}\n\n';
       for (var note in section.notes) {
         markdown += note.toMarkdown();
       }
       markdown += '\n';
-    });
+    }
     return markdown;
   }
 

--- a/tool/lib/release_note_classes.dart
+++ b/tool/lib/release_note_classes.dart
@@ -1,0 +1,149 @@
+import 'dart:io';
+
+import 'package:devtools_repo/repo_tool.dart';
+import 'package:devtools_shared/devtools_shared.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'release_note_classes.g.dart';
+
+@JsonSerializable()
+class ReleaseNotes {
+  ReleaseNotes({
+    required this.releases,
+  });
+
+  List<Release> releases;
+
+  String toMarkdown() {
+    String markdown = '';
+    for (var release in releases) {
+      markdown += release.toMarkdown();
+      markdown += '\n';
+    }
+    return markdown;
+  }
+
+  factory ReleaseNotes.fromJson(Map<String, dynamic> json) =>
+      _$ReleaseNotesFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReleaseNotesToJson(this);
+}
+
+@JsonSerializable()
+class Release {
+  Release({
+    required this.version,
+    required this.sections,
+  }) {
+    for (var element in sections) {
+      _sectionMap[element.name] = element;
+    }
+  }
+
+  final SemanticVersion version;
+  List<ReleaseSection> sections = [];
+  final Map<String, ReleaseSection> _sectionMap = {};
+
+  void addNote(String sectionName, ReleaseNote note) {
+    _sectionMap[sectionName]!.notes.add(note);
+  }
+
+  String toMarkdown() {
+    String markdown = '';
+    markdown += '# DevTools $version release notes\n\n';
+    sections.forEach((section) {
+      markdown += '# ${section.name}\n\n';
+      for (var note in section.notes) {
+        markdown += note.toMarkdown();
+      }
+      markdown += '\n';
+    });
+    return markdown;
+  }
+
+  factory Release.fromJson(Map<String, dynamic> json) =>
+      _$ReleaseFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReleaseToJson(this);
+}
+
+@JsonSerializable()
+class ReleaseSection {
+  ReleaseSection({
+    required this.name,
+    List<ReleaseNote>? notes,
+  }) : notes = notes ?? [];
+
+  ReleaseSection.emptyNotes({
+    required this.name,
+  }) : notes = [];
+
+  final String name;
+  final List<ReleaseNote> notes;
+
+  factory ReleaseSection.fromJson(Map<String, dynamic> json) =>
+      _$ReleaseSectionFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReleaseSectionToJson(this);
+}
+
+@JsonSerializable()
+class ReleaseNote {
+  ReleaseNote({
+    required this.message,
+    this.imageNames,
+    this.githubPullRequestUrls,
+  }) {
+    if (imageNames != null) {
+      for (var name in imageNames!) {
+        final path = "release_notes/files/$name";
+        //TODO: get the proper path?
+        if (!File(path).existsSync()) {
+          throw Exception(
+              "Could not find image file $path for note: \n${toMarkdown()}");
+        }
+      }
+    }
+  }
+
+  List<String>? githubPullRequestUrls;
+  final String message;
+  final List<String>? imageNames;
+
+  String toMarkdown() {
+    String markdown = '';
+    markdown += '- $message';
+    if (githubPullRequestUrls != null) {
+      List<String> prUrls = [];
+      for (var url in githubPullRequestUrls!) {
+        final match = RegExp(
+                r'^https://github.com/flutter/devtools/pull/(?<pr_number>\d+)$')
+            .firstMatch(url);
+        if (match == null) {
+          throw Exception(
+              "Invalid github PR Url($url) found in message: $message}");
+        }
+        final prNumber = match.namedGroup('pr_number');
+        prUrls.add('[#$prNumber]($url)');
+      }
+      markdown += ' - ${prUrls.join(", ")}';
+    }
+
+    markdown += '\n';
+
+    if (imageNames != null) {
+      for (var imageName in imageNames!) {
+        markdown += '![](files/$imageName)\n';
+      }
+    }
+
+    return markdown;
+  }
+
+  factory ReleaseNote.fromJson(Map<String, dynamic> json) =>
+      _$ReleaseNoteFromJson(json);
+
+  Map<String, dynamic> toJson() => _$ReleaseNoteToJson(this);
+}
+// # Sementic line breaks of 80 chars or fewer
+// # each line requires an PR command

--- a/tool/lib/release_note_classes.g.dart
+++ b/tool/lib/release_note_classes.g.dart
@@ -6,17 +6,6 @@ part of 'release_note_classes.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-ReleaseNotes _$ReleaseNotesFromJson(Map<String, dynamic> json) => ReleaseNotes(
-      releases: (json['releases'] as List<dynamic>)
-          .map((e) => Release.fromJson(e as Map<String, dynamic>))
-          .toList(),
-    );
-
-Map<String, dynamic> _$ReleaseNotesToJson(ReleaseNotes instance) =>
-    <String, dynamic>{
-      'releases': instance.releases,
-    };
-
 Release _$ReleaseFromJson(Map<String, dynamic> json) => Release(
       version:
           SemanticVersion.fromJson(json['version'] as Map<String, dynamic>),

--- a/tool/lib/release_note_classes.g.dart
+++ b/tool/lib/release_note_classes.g.dart
@@ -1,0 +1,62 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'release_note_classes.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+ReleaseNotes _$ReleaseNotesFromJson(Map<String, dynamic> json) => ReleaseNotes(
+      releases: (json['releases'] as List<dynamic>)
+          .map((e) => Release.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ReleaseNotesToJson(ReleaseNotes instance) =>
+    <String, dynamic>{
+      'releases': instance.releases,
+    };
+
+Release _$ReleaseFromJson(Map<String, dynamic> json) => Release(
+      version:
+          SemanticVersion.fromJson(json['version'] as Map<String, dynamic>),
+      sections: (json['sections'] as List<dynamic>)
+          .map((e) => ReleaseSection.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ReleaseToJson(Release instance) => <String, dynamic>{
+      'version': instance.version,
+      'sections': instance.sections,
+    };
+
+ReleaseSection _$ReleaseSectionFromJson(Map<String, dynamic> json) =>
+    ReleaseSection(
+      name: json['name'] as String,
+      notes: (json['notes'] as List<dynamic>?)
+          ?.map((e) => ReleaseNote.fromJson(e as Map<String, dynamic>))
+          .toList(),
+    );
+
+Map<String, dynamic> _$ReleaseSectionToJson(ReleaseSection instance) =>
+    <String, dynamic>{
+      'name': instance.name,
+      'notes': instance.notes,
+    };
+
+ReleaseNote _$ReleaseNoteFromJson(Map<String, dynamic> json) => ReleaseNote(
+      message: json['message'] as String,
+      imageNames: (json['imageNames'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+      githubPullRequestUrls: (json['githubPullRequestUrls'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList(),
+    );
+
+Map<String, dynamic> _$ReleaseNoteToJson(ReleaseNote instance) =>
+    <String, dynamic>{
+      'githubPullRequestUrls': instance.githubPullRequestUrls,
+      'message': instance.message,
+      'imageNames': instance.imageNames,
+    };

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -9,9 +9,14 @@ dependencies:
   cli_util: ^0.3.3
   devtools_shared: ^2.18.0
   http: ^0.13.3
+  json_annotation: ^4.4.0
   lints: any
   path: ^1.8.0
 
 dependency_overrides:
   devtools_shared:
     path: ../packages/devtools_shared
+
+dev_dependencies:
+  build_runner: ^2.0.0
+  json_serializable: ^6.0.0

--- a/tool/release_note_helper.dart
+++ b/tool/release_note_helper.dart
@@ -31,11 +31,6 @@ class MarkDownCommand extends Command {
 
   MarkDownCommand() {
     argParser.addOption(
-      'version',
-      abbr: 'v',
-      help: 'The released version to print the markdown for.',
-    );
-    argParser.addOption(
       'file',
       abbr: 'f',
       mandatory: true,
@@ -46,7 +41,6 @@ class MarkDownCommand extends Command {
   @override
   void run() async {
     final filePath = argResults!['file'].toString();
-    final version = argResults?['version']?.toString();
 
     final fileContents = await File(filePath).readAsString();
     Release release = Release.fromJson(jsonDecode(fileContents));
@@ -75,9 +69,8 @@ class VerifyCommand extends Command {
   @override
   void run() async {
     final filePath = argResults!['file'].toString();
-    final url = argResults!['file'].toString();
-    print("The filepath $filePath");
     final fileContents = await File(filePath).readAsString();
+
     // This step will fail if the json is not valid, or can't be unserialized
     Release.fromJson(jsonDecode(fileContents));
 

--- a/tool/release_note_helper.dart
+++ b/tool/release_note_helper.dart
@@ -1,0 +1,148 @@
+#!/usr/bin/env dart
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'lib/release_note_classes.dart';
+
+void main(List<String> args) {
+  final runner = CommandRunner(
+    'release_note_helper',
+    'Helps manage version notes for release.',
+  )
+    ..addCommand(VerifyCommand())
+    ..addCommand(MarkDownCommand())
+    ..addCommand(BackfillPullRequestUrlCommand());
+
+  runner.run(args).catchError((error) {
+    if (error is! UsageException) throw error;
+    print(error);
+    exit(64); // Exit code 64 indicates a usage error.
+  });
+  return;
+}
+
+class MarkDownCommand extends Command {
+  @override
+  final name = 'markdown';
+  @override
+  final description = 'Prints all versions listed in the `file`, in markdown.';
+
+  MarkDownCommand() {
+    argParser.addOption(
+      'version',
+      abbr: 'v',
+      help: 'The released version to print the markdown for.',
+    );
+    argParser.addOption(
+      'file',
+      abbr: 'f',
+      mandatory: true,
+      help: 'The json release file to operate on.',
+    );
+  }
+
+  @override
+  void run() async {
+    final filePath = argResults!['file'].toString();
+    final version = argResults?['version']?.toString();
+
+    final fileContents = await File(filePath).readAsString();
+    Release release = Release.fromJson(jsonDecode(fileContents));
+
+    print(release.toMarkdown());
+  }
+}
+
+class VerifyCommand extends Command {
+  @override
+  final name = 'verify';
+  @override
+  final description =
+      'Verifies that the release_notes.json file is still readable with the serializable dart classes.';
+
+  VerifyCommand() {
+    argParser.addOption(
+      'file',
+      abbr: 'f',
+      mandatory: true,
+      help:
+          'The json release file to verify. The file will be decoded and parsed to ensure that it\'s format is still what is expected.',
+    );
+  }
+
+  @override
+  void run() async {
+    final filePath = argResults!['file'].toString();
+    final url = argResults!['file'].toString();
+    print("The filepath $filePath");
+    final fileContents = await File(filePath).readAsString();
+    // This step will fail if the json is not valid, or can't be unserialized
+    Release.fromJson(jsonDecode(fileContents));
+
+    print('Release notes were successfully decoded and serialized');
+  }
+}
+
+class BackfillPullRequestUrlCommand extends Command {
+  @override
+  final name = 'pr-url';
+
+  @override
+  final description =
+      'Checks if all entries in the release notes have pr urls. If a -u <url> '
+      'parameter is passed along, any entries missing a pr url, will be given '
+      'that pr url.';
+
+  BackfillPullRequestUrlCommand() {
+    argParser.addOption(
+      'url',
+      abbr: 'u',
+      mandatory: false,
+      help:
+          'Add the url to any note, that does NOT already have an URL assigned to it.',
+    );
+    argParser.addOption(
+      'file',
+      abbr: 'f',
+      mandatory: true,
+      help: 'The json release file to operate on.',
+    );
+  }
+
+  @override
+  void run() async {
+    final filePath = argResults!['file'].toString();
+    final url = argResults!['url']?.toString();
+
+    final file = File(filePath);
+    final fileContents = await file.readAsString();
+    // This step will fail if the json is not valid, or can't be unserialized
+    final release = Release.fromJson(jsonDecode(fileContents));
+
+    var foundMissingPrUrl = false;
+    for (var section in release.sections) {
+      for (var note in section.notes) {
+        if (note.githubPullRequestUrls == null ||
+            note.githubPullRequestUrls!.isEmpty) {
+          foundMissingPrUrl = true;
+          if (url != null) {
+            note.githubPullRequestUrls = [url];
+          }
+        }
+      }
+    }
+    if (foundMissingPrUrl) {
+      if (url != null) {
+        final encoder = JsonEncoder.withIndent("  ");
+        await file.writeAsString(encoder.convert(
+          release.toJson(),
+        ));
+      }
+      print('Missing PR urls found in $filePath');
+      exit(1);
+    }
+    print('No Missing PR Urls Found.');
+  }
+}

--- a/tool/release_note_helper.dart
+++ b/tool/release_note_helper.dart
@@ -1,4 +1,6 @@
-#!/usr/bin/env dart
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 import 'dart:convert';
 import 'dart:io';

--- a/tool/release_notes/release_notes.json
+++ b/tool/release_notes/release_notes.json
@@ -1,0 +1,43 @@
+{
+  "version": {
+    "major": 2,
+    "minor": 19,
+    "patch": 0,
+    "preReleaseMajor": null,
+    "preReleaseMinor": null
+  },
+  "sections": [
+    {
+      "name": "General updates",
+      "notes": []
+    },
+    {
+      "name": "Inspector update",
+      "notes": []
+    },
+    {
+      "name": "Performance updates",
+      "notes": []
+    },
+    {
+      "name": "CPU profiler updates",
+      "notes": []
+    },
+    {
+      "name": "Memory updates",
+      "notes": []
+    },
+    {
+      "name": "Network profiler updates",
+      "notes": []
+    },
+    {
+      "name": "Logging updates",
+      "notes": []
+    },
+    {
+      "name": "App size tool updates",
+      "notes": []
+    }
+  ]
+}

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -332,9 +332,12 @@ class AutoUpdateCommand extends Command {
           'release': 'strips any pre-release versions from the version.',
           'dev':
               'bumps the version to the next dev pre-release value (minor by default).',
-          'patch': 'bumps the version to the next patch value',
-          'minor': 'bumps the version to the next minor value',
-          'major': 'bumps the version to the next major value',
+          'patch':
+              'bumps the version to the next patch value, and sets the dev version to 0.',
+          'minor':
+              'bumps the version to the next minor value, and sets the dev version to 0.',
+          'major':
+              'bumps the version to the next major value, and sets the dev version to 0.',
         },
         mandatory: true,
         help: 'Bumps the devtools version by the selected type.');
@@ -361,6 +364,8 @@ class AutoUpdateCommand extends Command {
         // Doing a proper version update so cycle the release notes
         await resetReleaseNotes(
             newVersion: SemanticVersion.parse(currentVersion));
+
+        newVersion = incrementDevVersion(newVersion!);
     }
     if (newVersion == null) {
       throw 'Failed to determine the newVersion.';

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -365,10 +365,10 @@ class AutoUpdateCommand extends Command {
         await resetReleaseNotes(
             newVersion: SemanticVersion.parse(currentVersion));
 
-        newVersion = incrementDevVersion(newVersion!);
-    }
-    if (newVersion == null) {
-      throw 'Failed to determine the newVersion.';
+        if (newVersion == null) {
+          throw 'Failed to determine the newVersion.';
+        }
+        newVersion = incrementDevVersion(newVersion);
     }
     performTheVersionUpdate(
       currentVersion: currentVersion,


### PR DESCRIPTION
![](https://media.giphy.com/media/3oxRmBArPQ1aR48Vbi/giphy-downsized.gif)



# Adding workflow for release note management
This PR sets up a workflow that will ensure Developers modify our release notes file, or add a reason to their description describing why they aren't modifying the release notes file.
## Demo
http://screencast/cast/NTk4NDcwNjEwMjI5NjU3NnwwNDJiNjVjMy1iOQ

# Changes to the version release process.
 Since we are going to be doing dev release versions, I've updated the `update_version.dart` helper to reflect the version lifecycle.
The release process can now be broken down as:
- During normal dev releases, the dev version will be bumped and pushed up in a PR
- To perform a patch, minor or major release:
    - A PR will be pushed up with a clean version (with no `-dev` prereleases)
    - Afterwards a PR will be pushed up with the major, minor or patch version bump
> NOTE: in the future this will be handled automatically in github so that no PRs are necessary

# TODO
- [] Unit testing the `release_note_classes.dart` classes



