### PR TITLE
Fix beta testing instructions.

### DIFF
--- a/BETA_TESTING.md
+++ b/BETA_TESTING.md
@@ -10,18 +10,15 @@ If you want to make code changes, follow [contributing guidance](https://github.
 
 2. In your terminal `cd` to a folder where you want to clone devtools, and that does not have subfolder `devtools` yet.
 
-3. Start DevTools:
+3. Clone the repo, get needed Flutter version to local folder and start DevTools:
 
 ```bash
-# Clone the repo:
-git clone https://github.com/flutter/devtools.git;
+git clone https://github.com/flutter/devtools.git
 
-# Get local Flutter of the correct version:
-./devtools/tool/update_flutter_sdk.sh;
+./devtools/tool/update_flutter_sdk.sh
 
-# Start the application:
-cd devtools/packages/devtools_app;
-../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true;
+cd devtools/packages/devtools_app
+../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true
 ```
 
 4. Paste the URL of your application (for example [Gallery](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#connect-to-application)) to the connection textbox.
@@ -33,17 +30,14 @@ cd devtools/packages/devtools_app;
 2. Refresh and run DevTools (it will delete all your local changes!):
 
 ```bash
-# Checkout the master branch and ensure it is at the most recent change:
-git checkout master;
-git reset --hard origin/master; # this line will remove all local changes or commits on your branch
+git checkout master
+git reset --hard origin/master
 
-# Make sure all dependencies have correct version:
-./tool/update_flutter_sdk.sh;
-cd packages/devtools_app;
-../../tool/flutter-sdk/bin/flutter pub upgrade;
+./tool/update_flutter_sdk.sh
+cd packages/devtools_app
+../../tool/flutter-sdk/bin/flutter pub upgrade
 
-# Start the application:
-../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true;
+../../tool/flutter-sdk/bin/flutter run -d chrome --dart-define=enable_experiments=true
 ```
 
 3. Paste the URL of your application (for example [Gallery](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md#connect-to-application)) to the connection textbox.

--- a/tool/latest_flutter_candidate.sh
+++ b/tool/latest_flutter_candidate.sh
@@ -4,6 +4,15 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+# Any subsequent commands failure will cause this script to exit immediately
+set -e
+
+if ! command -v jq &> /dev/null
+then
+    echo "jq could not be found. If you are on mac you can install this with `brew install jq`"
+    exit 1
+fi
+
 RESPONSE=$(gh api --paginate /repos/flutter/flutter/branches)
 
 CANDIDATES=$(echo "$RESPONSE" | jq '.[].name' | grep candidate)

--- a/tool/update_flutter_sdk.sh
+++ b/tool/update_flutter_sdk.sh
@@ -44,7 +44,7 @@ PATH="$FLUTTER_DIR/bin":$PATH
 echo "STATUS: Updating 'tool/flutter-sdk' to branch '$REQUIRED_FLUTTER_BRANCH'."
 
 if [ -d "$FLUTTER_DIR" ]; then
-  echo "STATUS: 'tool/flutter-sdk' directory already exists"
+  echo "STATUS: 'tool/$FLUTTER_DIR' directory already exists"
 
   # switch to the specified version
   pushd $FLUTTER_DIR
@@ -53,11 +53,11 @@ if [ -d "$FLUTTER_DIR" ]; then
   ./bin/flutter --version
   popd
 else
-  echo "STATUS: 'tool/flutter-sdk' directory does not exist - cloning it now"
+  echo "STATUS: 'tool/$FLUTTER_DIR' directory does not exist - cloning it now"
 
   # clone the flutter repo and switch to the specified version
-  git clone https://github.com/flutter/flutter flutter-sdk
-  pushd flutter-sdk
+  git clone https://github.com/flutter/flutter "$FLUTTER_DIR"
+  pushd "$FLUTTER_DIR"
   git checkout $REQUIRED_FLUTTER_BRANCH
   ./bin/flutter --version
   popd


### PR DESCRIPTION
1. In some shells # and .git are interpreted as mistake
2. ';' looks weird for some users and is not necessary
3. We do not need flags to enable beta features, as they are enabled in non-release mode by default now
4. Added instructions to install jq