### PR TITLE
Hook up scroll-to-time-range functionality for Perfetto trace viewer

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
@@ -5,5 +5,8 @@
 import 'perfetto_controller.dart';
 
 class PerfettoControllerImpl extends PerfettoController {
-  PerfettoControllerImpl(super.performanceController);
+  PerfettoControllerImpl(
+    super.performanceController,
+    super.timelineEventsController,
+  );
 }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_desktop.dart
@@ -2,29 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../../../../../primitives/trace_event.dart';
-import '../../../../../primitives/utils.dart';
-import '../../../performance_controller.dart';
-import 'perfetto_event_processor.dart';
+import 'perfetto_controller.dart';
 
-class PerfettoController {
-  PerfettoController(this.performanceController) {
-    processor = PerfettoEventProcessor(performanceController);
-  }
-
-  final PerformanceController performanceController;
-
-  late final PerfettoEventProcessor processor;
-
-  void init() {}
-
-  void dispose() {}
-
-  Future<void> onBecomingActive() async {}
-
-  Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {}
-
-  Future<void> scrollToTimeRange(TimeRange timeRange) async {}
-
-  Future<void> clear() async {}
+class PerfettoControllerImpl extends PerfettoController {
+  PerfettoControllerImpl(super.performanceController);
 }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -188,7 +188,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingTraceEventsToLoad = List.from(devToolsTraceEvents);
       return;
     }
@@ -214,7 +214,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> scrollToTimeRange(TimeRange timeRange) async {
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingScrollToTimeRange = timeRange;
       return;
     }
@@ -242,7 +242,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   Future<void> _loadStyle(bool darkMode) async {
     if (!isExternalBuild) return;
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingLoadDarkMode = darkMode;
       return;
     }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -45,7 +45,7 @@ class PerfettoController extends DisposableController
 
   final PerformanceController performanceController;
 
-  late final viewId = 'embedded-perfetto-${_viewIdIncrementer++}';
+  final viewId = 'embedded-perfetto-${_viewIdIncrementer++}';
 
   /// Url when running Perfetto locally following the instructions here:
   /// https://perfetto.dev/docs/contributing/build-instructions#ui-development

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -38,7 +38,10 @@ var _viewIdIncrementer = 0;
 
 class PerfettoControllerImpl extends PerfettoController
     with AutoDisposeControllerMixin {
-  PerfettoControllerImpl(super.performanceController);
+  PerfettoControllerImpl(
+    super.performanceController,
+    super.timelineEventsController,
+  );
 
   @override
   late final viewId = 'embedded-perfetto-${_viewIdIncrementer++}';
@@ -188,7 +191,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingTraceEventsToLoad = List.from(devToolsTraceEvents);
       return;
     }
@@ -214,7 +217,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> scrollToTimeRange(TimeRange timeRange) async {
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingScrollToTimeRange = timeRange;
       return;
     }
@@ -242,7 +245,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   Future<void> _loadStyle(bool darkMode) async {
     if (!isExternalBuild) return;
-    if (!performanceController.timelineEventsController.isActiveFeature) {
+    if (!timelineEventsController.isActiveFeature) {
       pendingLoadDarkMode = darkMode;
       return;
     }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -13,8 +13,7 @@ import '../../../../../primitives/auto_dispose.dart';
 import '../../../../../primitives/trace_event.dart';
 import '../../../../../primitives/utils.dart';
 import '../../../../../shared/globals.dart';
-import '../../../performance_controller.dart';
-import 'perfetto_event_processor.dart';
+import 'perfetto_controller.dart';
 
 /// Flag to enable embedding an instance of the Perfetto UI running on
 /// localhost.
@@ -37,15 +36,12 @@ const _debugUseLocalPerfetto = false;
 /// [_viewIdIncrementer] is used to create.
 var _viewIdIncrementer = 0;
 
-class PerfettoController extends DisposableController
+class PerfettoControllerImpl extends PerfettoController
     with AutoDisposeControllerMixin {
-  PerfettoController(this.performanceController) {
-    processor = PerfettoEventProcessor(performanceController);
-  }
+  PerfettoControllerImpl(super.performanceController);
 
-  final PerformanceController performanceController;
-
-  final viewId = 'embedded-perfetto-${_viewIdIncrementer++}';
+  @override
+  late final viewId = 'embedded-perfetto-${_viewIdIncrementer++}';
 
   /// Url when running Perfetto locally following the instructions here:
   /// https://perfetto.dev/docs/contributing/build-instructions#ui-development
@@ -86,8 +82,6 @@ class PerfettoController extends DisposableController
   /// [post_message_handler.ts] will not try to handle this message and warn
   /// "Unknown postMessage() event received".
   static const _devtoolsThemeChange = 'DART-DEVTOOLS-THEME-CHANGE';
-
-  late final PerfettoEventProcessor processor;
 
   String get _perfettoUrl {
     if (_debugUseLocalPerfetto) {
@@ -138,6 +132,7 @@ class PerfettoController extends DisposableController
   /// [TimelineEventsController.isActiveFeature] is false).
   bool? pendingLoadDarkMode;
 
+  @override
   void init() {
     _perfettoIFrameReady = Completer();
     _perfettoHandlerReady = Completer();
@@ -176,6 +171,7 @@ class PerfettoController extends DisposableController
     }
   }
 
+  @override
   Future<void> onBecomingActive() async {
     if (pendingLoadDarkMode != null) {
       unawaited(_loadStyle(pendingLoadDarkMode!));
@@ -190,6 +186,7 @@ class PerfettoController extends DisposableController
     }
   }
 
+  @override
   Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {
     if (!performanceController.timelineEventsController.isActiveFeature) {
       pendingTraceEventsToLoad = List.from(devToolsTraceEvents);
@@ -215,6 +212,7 @@ class PerfettoController extends DisposableController
     });
   }
 
+  @override
   Future<void> scrollToTimeRange(TimeRange timeRange) async {
     if (!performanceController.timelineEventsController.isActiveFeature) {
       pendingScrollToTimeRange = timeRange;
@@ -336,6 +334,7 @@ class PerfettoController extends DisposableController
     }
   }
 
+  @override
   Future<void> clear() async {
     await loadTrace([]);
   }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -188,7 +188,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {
-    if (!timelineEventsController.isActiveFeature) {
+    if (!performanceController.timelineEventsController.isActiveFeature) {
       pendingTraceEventsToLoad = List.from(devToolsTraceEvents);
       return;
     }
@@ -214,7 +214,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   @override
   Future<void> scrollToTimeRange(TimeRange timeRange) async {
-    if (!timelineEventsController.isActiveFeature) {
+    if (!performanceController.timelineEventsController.isActiveFeature) {
       pendingScrollToTimeRange = timeRange;
       return;
     }
@@ -242,7 +242,7 @@ class PerfettoControllerImpl extends PerfettoController
 
   Future<void> _loadStyle(bool darkMode) async {
     if (!isExternalBuild) return;
-    if (!timelineEventsController.isActiveFeature) {
+    if (!performanceController.timelineEventsController.isActiveFeature) {
       pendingLoadDarkMode = darkMode;
       return;
     }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_desktop.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_desktop.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import '_perfetto_controller_desktop.dart';
+import 'perfetto_controller.dart';
 
 class Perfetto extends StatelessWidget {
   const Perfetto({

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter/material.dart';
 
-import '_perfetto_controller_web.dart';
+import 'perfetto_controller.dart';
 
 class Perfetto extends StatelessWidget {
   const Perfetto({

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto.dart
@@ -4,9 +4,8 @@
 
 import 'package:flutter/material.dart';
 
-import '_perfetto_controller_desktop.dart'
-    if (dart.library.html) '_perfetto_controller_web.dart';
 import '_perfetto_desktop.dart' if (dart.library.html) '_perfetto_web.dart';
+import 'perfetto_controller.dart';
 
 class EmbeddedPerfetto extends StatelessWidget {
   const EmbeddedPerfetto({Key? key, required this.perfettoController})

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
@@ -6,7 +6,6 @@ import '../../../../../primitives/auto_dispose.dart';
 import '../../../../../primitives/trace_event.dart';
 import '../../../../../primitives/utils.dart';
 import '../../../performance_controller.dart';
-import '../timeline_events_controller.dart';
 import '_perfetto_controller_desktop.dart'
     if (dart.library.html) '_perfetto_controller_web.dart';
 import 'perfetto_event_processor.dart';
@@ -18,15 +17,13 @@ PerfettoControllerImpl createPerfettoController(
 }
 
 abstract class PerfettoController extends DisposableController {
-  PerfettoController(PerformanceController performanceController)
-      : timelineEventsController =
-            performanceController.timelineEventsController {
+  PerfettoController(this.performanceController) {
     processor = PerfettoEventProcessor(performanceController);
   }
 
   String get viewId => '';
 
-  final TimelineEventsController timelineEventsController;
+  final PerformanceController performanceController;
 
   late final PerfettoEventProcessor processor;
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
@@ -6,6 +6,7 @@ import '../../../../../primitives/auto_dispose.dart';
 import '../../../../../primitives/trace_event.dart';
 import '../../../../../primitives/utils.dart';
 import '../../../performance_controller.dart';
+import '../timeline_events_controller.dart';
 import '_perfetto_controller_desktop.dart'
     if (dart.library.html) '_perfetto_controller_web.dart';
 import 'perfetto_event_processor.dart';
@@ -17,13 +18,15 @@ PerfettoControllerImpl createPerfettoController(
 }
 
 abstract class PerfettoController extends DisposableController {
-  PerfettoController(this.performanceController) {
+  PerfettoController(PerformanceController performanceController)
+      : timelineEventsController =
+            performanceController.timelineEventsController {
     processor = PerfettoEventProcessor(performanceController);
   }
 
   String get viewId => '';
 
-  final PerformanceController performanceController;
+  final TimelineEventsController timelineEventsController;
 
   late final PerfettoEventProcessor processor;
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
@@ -6,24 +6,32 @@ import '../../../../../primitives/auto_dispose.dart';
 import '../../../../../primitives/trace_event.dart';
 import '../../../../../primitives/utils.dart';
 import '../../../performance_controller.dart';
+import '../timeline_events_controller.dart';
 import '_perfetto_controller_desktop.dart'
     if (dart.library.html) '_perfetto_controller_web.dart';
 import 'perfetto_event_processor.dart';
 
 PerfettoControllerImpl createPerfettoController(
   PerformanceController performanceController,
+  TimelineEventsController timelineEventsController,
 ) {
-  return PerfettoControllerImpl(performanceController);
+  return PerfettoControllerImpl(
+    performanceController,
+    timelineEventsController,
+  );
 }
 
 abstract class PerfettoController extends DisposableController {
-  PerfettoController(this.performanceController) {
+  PerfettoController(
+    PerformanceController performanceController,
+    this.timelineEventsController,
+  ) {
     processor = PerfettoEventProcessor(performanceController);
   }
 
   String get viewId => '';
 
-  final PerformanceController performanceController;
+  final TimelineEventsController timelineEventsController;
 
   late final PerfettoEventProcessor processor;
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
@@ -1,0 +1,39 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../../../../primitives/auto_dispose.dart';
+import '../../../../../primitives/trace_event.dart';
+import '../../../../../primitives/utils.dart';
+import '../../../performance_controller.dart';
+import '_perfetto_controller_desktop.dart'
+    if (dart.library.html) '_perfetto_controller_web.dart';
+import 'perfetto_event_processor.dart';
+
+PerfettoControllerImpl createPerfettoController(
+  PerformanceController performanceController,
+) {
+  return PerfettoControllerImpl(performanceController);
+}
+
+abstract class PerfettoController extends DisposableController {
+  PerfettoController(this.performanceController) {
+    processor = PerfettoEventProcessor(performanceController);
+  }
+
+  String get viewId => '';
+
+  final PerformanceController performanceController;
+
+  late final PerfettoEventProcessor processor;
+
+  void init() {}
+
+  Future<void> onBecomingActive() async {}
+
+  Future<void> loadTrace(List<TraceEventWrapper> devToolsTraceEvents) async {}
+
+  Future<void> scrollToTimeRange(TimeRange timeRange) async {}
+
+  Future<void> clear() async {}
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -31,8 +31,7 @@ import '../../performance_utils.dart';
 import '../../simple_trace_example.dart';
 import '../flutter_frames/flutter_frame_model.dart';
 import 'legacy/legacy_event_processor.dart';
-import 'perfetto/_perfetto_controller_desktop.dart'
-    if (dart.library.html) 'perfetto/_perfetto_controller_web.dart';
+import 'perfetto/perfetto_controller.dart';
 import 'timeline_event_processor.dart';
 
 /// Debugging flag to load sample trace events from [simple_trace_example.dart].
@@ -48,7 +47,7 @@ class TimelineEventsController extends PerformanceFeatureController
     with AutoDisposeControllerMixin {
   TimelineEventsController(super.performanceController) {
     legacyController = LegacyTimelineEventsController(performanceController);
-    perfettoController = PerfettoController(performanceController);
+    perfettoController = createPerfettoController(performanceController);
     addAutoDisposeListener(_workTracker.active, () {
       final active = _workTracker.active.value;
       if (active) {

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -47,7 +47,7 @@ class TimelineEventsController extends PerformanceFeatureController
     with AutoDisposeControllerMixin {
   TimelineEventsController(super.performanceController) {
     legacyController = LegacyTimelineEventsController(performanceController);
-    perfettoController = createPerfettoController(performanceController);
+    perfettoController = createPerfettoController(performanceController, this);
     addAutoDisposeListener(_workTracker.active, () {
       final active = _workTracker.active.value;
       if (active) {

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -279,8 +279,7 @@ class TimelineEventsController extends PerformanceFeatureController
 
   Future<void> _processAllTraceEvents() async {
     if (_perfettoMode) {
-      // TODO(kenz): hook up Perfetto event processor to process events before
-      // loading.
+      await perfettoController.processor.processData(allTraceEvents);
       await perfettoController.loadTrace(allTraceEvents);
     } else {
       await legacyController.processTraceEvents(
@@ -310,7 +309,7 @@ class TimelineEventsController extends PerformanceFeatureController
     if (useLegacyTraceViewer.value) {
       await _legacySelectFrame(frame);
     } else if (FeatureFlags.embeddedPerfetto) {
-      // TODO(kenz): hook up scroll to frame for Perfetto viewer.
+      await _perfettoSelectFrame(frame);
     }
 
     debugTraceEventCallback(() {
@@ -325,6 +324,33 @@ class TimelineEventsController extends PerformanceFeatureController
       frame.timelineEventData.rasterEvent?.writeTraceToBuffer(buf);
       log(buf.toString());
     });
+  }
+
+  Future<void> _perfettoSelectFrame(FlutterFrame frame) async {
+    if (!offlineController.offlineMode.value) {
+      bool hasProcessedTimelineEventsForFrame =
+          perfettoController.processor.hasProcessedEventsForFrame(frame.id);
+      // No need to process events again if we are in offline mode - we have
+      // already processed all the available data.
+      if (!hasProcessedTimelineEventsForFrame) {
+        await processAllTraceEvents();
+      }
+
+      // If we still have not processed the timeline events for this frame,
+      // wait a short delay and try to process events again after the
+      // VM has been polled one more time.
+      hasProcessedTimelineEventsForFrame =
+          perfettoController.processor.hasProcessedEventsForFrame(frame.id);
+      if (!hasProcessedTimelineEventsForFrame) {
+        await _workTracker.track(
+          Future.delayed(_timelinePollingInterval, () async {
+            await _processAllTraceEvents();
+          }),
+        );
+      }
+    }
+
+    await perfettoController.scrollToTimeRange(frame.timeFromFrameTiming);
   }
 
   Future<void> _legacySelectFrame(FlutterFrame frame) async {
@@ -466,7 +492,10 @@ class TimelineEventsController extends PerformanceFeatureController
       uiThreadId: uiThreadId,
       rasterThreadId: rasterThreadId,
     );
-    // TODO(kenz): prime perfetto processor with thread ids here.
+    perfettoController.processor.primeThreadIds(
+      uiThreadId: uiThreadId,
+      rasterThreadId: rasterThreadId,
+    );
   }
 
   int _threadIdForEvents(
@@ -504,7 +533,8 @@ class TimelineEventsController extends PerformanceFeatureController
     await legacyController.setOfflineData(offlineData);
 
     if (offlineData.selectedFrame != null && _perfettoMode) {
-      // TODO(kenz): scroll the perfetto viewer to the selected time range.
+      await perfettoController
+          .scrollToTimeRange(offlineData.selectedFrame!.timeFromFrameTiming);
     }
   }
 


### PR DESCRIPTION
This PR hooks up the scroll to time range functionality and does some refactoring to support testing on the web. We cannot generate a mock for a class that uses conditional imports.

There is now an interface class PerfettoController and two impl classes PerfetoControllerImpl (one for desktop and one for web).

![perfetto-scroll-to-frame](https://user-images.githubusercontent.com/43759233/202325217-ab8d9881-3f23-4ec5-9e9b-b35183af6516.gif)

Tests will be written as a follow up.