### PR TITLE
Add missing text style in the Frame Analysis frame hints

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
@@ -194,6 +194,7 @@ class EnhanceTracingHint extends StatelessWidget {
           text: 'Since "$settingTitle" was enabled while this frame was drawn, '
               'you should be able to see timeline events for each '
               '$eventDescription.',
+          style: theme.regularTextStyle,
         ),
       ];
     }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4804