### PR TITLE
Hide the tree guidelines toggle for the CPU flame chart

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -178,7 +178,8 @@ class _CpuProfilerState extends State<CpuProfiler>
                 isFilterActive: widget.controller.isToggleFilterActive,
               ),
               const SizedBox(width: denseSpacing),
-              const DisplayTreeGuidelinesToggle(),
+              if (currentTab.key != CpuProfiler.flameChartTab)
+                const DisplayTreeGuidelinesToggle(),
               const SizedBox(width: denseSpacing),
               UserTagDropdown(widget.controller),
               const SizedBox(width: denseSpacing),

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -303,6 +303,9 @@ void main() {
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsNothing);
       expect(find.byType(CpuBottomUpTable), findsOneWidget);
+      expect(find.byType(FilterButton), findsOneWidget);
+      expect(find.byType(DisplayTreeGuidelinesToggle), findsOneWidget);
+      expect(find.byType(UserTagDropdown), findsOneWidget);
       expect(find.byType(ExpandAllButton), findsOneWidget);
       expect(find.byType(CollapseAllButton), findsOneWidget);
       expect(find.byType(FlameChartHelpButton), findsNothing);
@@ -314,6 +317,8 @@ void main() {
       expect(find.byType(CpuProfileFlameChart), findsNothing);
       expect(find.byType(CpuCallTreeTable), findsOneWidget);
       expect(find.byType(CpuBottomUpTable), findsNothing);
+      expect(find.byType(FilterButton), findsOneWidget);
+      expect(find.byType(DisplayTreeGuidelinesToggle), findsOneWidget);
       expect(find.byType(UserTagDropdown), findsOneWidget);
       expect(find.byType(ExpandAllButton), findsOneWidget);
       expect(find.byType(CollapseAllButton), findsOneWidget);
@@ -326,6 +331,8 @@ void main() {
       expect(find.byType(CpuProfileFlameChart), findsOneWidget);
       expect(find.byType(CpuCallTreeTable), findsNothing);
       expect(find.byType(CpuBottomUpTable), findsNothing);
+      expect(find.byType(FilterButton), findsOneWidget);
+      expect(find.byType(DisplayTreeGuidelinesToggle), findsNothing);
       expect(find.byType(UserTagDropdown), findsOneWidget);
       expect(find.byType(ExpandAllButton), findsNothing);
       expect(find.byType(CollapseAllButton), findsNothing);


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4790