### PR TITLE
Handle possible `null` values when expanding variables 

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -130,7 +130,7 @@ Widget displayProvider(
   }
   TextStyle variableDisplayStyle() {
     final style = theme.subtleFixedFontStyle;
-    switch (variable.ref!.instanceRef!.kind) {
+    switch (variable.ref?.instanceRef?.kind) {
       case InstanceKind.kString:
         return style.apply(
           color: theme.colorScheme.stringSyntaxColor,
@@ -150,8 +150,9 @@ Widget displayProvider(
   }
 
   final hasName = variable.name?.isNotEmpty ?? false;
+  final variableValue = variable.displayValue ?? 'Unknown';
   return DevToolsTooltip(
-    message: variable.displayValue,
+    message: variableValue,
     waitDuration: tooltipWaitLong,
     child: SelectableText.rich(
       TextSpan(
@@ -168,7 +169,7 @@ Widget displayProvider(
               style: theme.fixedFontStyle,
             ),
           TextSpan(
-            text: variable.displayValue,
+            text: variableValue,
             style: variableDisplayStyle(),
           ),
         ],


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4793

A few errors were being thrown if variables contained any `null` values, which caused the expanded variable list to be a grey box. Now, we show `"Unknown"` if we are missing a the variable display name. 

![Screenshot 2022-11-21 at 2 19 35 PM](https://user-images.githubusercontent.com/21270878/203170020-af487c7e-c988-41b1-bb45-1e800c0479d5.png)

Before:

![Screenshot 2022-11-18 at 10 33 32 AM](https://user-images.githubusercontent.com/21270878/203170074-10f42e43-46ea-4de6-be93-97d4d38a5d84.png)
