### PR TITLE
Add initial support for non-query param navigation state

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -148,13 +148,19 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
   }
 
   /// Gets the page for a given page/path and args.
-  Page _getPage(BuildContext context, String? page, Map<String, String?> args) {
+  Page _getPage(
+    BuildContext context,
+    String? page,
+    Map<String, String?> args,
+    DevToolsNavigationState? state,
+  ) {
     // Provide the appropriate page route.
     if (pages.containsKey(page)) {
       Widget widget = pages[page!]!(
         context,
         page,
         args,
+        state,
       );
       assert(
         () {
@@ -163,6 +169,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
               context,
               page,
               args,
+              state,
             ),
           );
           return true;
@@ -185,6 +192,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     BuildContext context,
     String? page,
     Map<String, String?> params,
+    DevToolsNavigationState? state,
   ) {
     final vmServiceUri = params['uri'];
 
@@ -262,7 +270,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
       homePageId: _buildTabbedPage,
       for (final screen in widget.screens)
         screen.screen.screenId: _buildTabbedPage,
-      snapshotPageId: (_, __, args) {
+      snapshotPageId: (_, __, args, ___) {
         final snapshotArgs = SnapshotArguments.fromArgs(args);
         return DevToolsScaffold.withChild(
           key: UniqueKey(),
@@ -273,7 +281,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
           ),
         );
       },
-      appSizePageId: (_, __, ___) {
+      appSizePageId: (_, __, ___, ____) {
         return DevToolsScaffold.withChild(
           key: const Key('appsize'),
           ideTheme: ideTheme,
@@ -407,11 +415,12 @@ class DevToolsScreen<C> {
 }
 
 /// A [WidgetBuilder] that takes an additional map of URL query parameters and
-/// args.
+/// args, as well a state not included in the URL.
 typedef UrlParametersBuilder = Widget Function(
   BuildContext,
   String?,
   Map<String, String?>,
+  DevToolsNavigationState?,
 );
 
 /// Displays the checked mode banner in the bottom end corner instead of the

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -226,6 +226,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
           routerDelegate.navigateIfNotCurrent(
             _currentScreen.screenId,
             routerDelegate.currentConfiguration?.args,
+            routerDelegate.currentConfiguration?.state,
           );
         });
       });

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -168,56 +168,65 @@ class _CodeViewState extends State<CodeView>
       return;
     }
 
-    if (!verticalController.hasAttachedControllers) {
-      // TODO(devoncarew): I'm uncertain why this occurs.
-      log('LinkedScrollControllerGroup has no attached controllers');
-      return;
-    }
-    final line = widget.codeViewController.scriptLocation.value?.location?.line;
-    if (line == null) {
-      // Don't scroll to top if we're just rebuilding the code view for the
-      // same script.
-      if (_lastScriptRef?.uri != scriptRef?.uri) {
-        // Default to scrolling to the top of the script.
+    void updateScrollPositionImpl() {
+      if (!verticalController.hasAttachedControllers) {
+        // TODO(devoncarew): I'm uncertain why this occurs.
+        log('LinkedScrollControllerGroup has no attached controllers');
+        return;
+      }
+      final line =
+          widget.codeViewController.scriptLocation.value?.location?.line;
+      if (line == null) {
+        // Don't scroll to top if we're just rebuilding the code view for the
+        // same script.
+        if (_lastScriptRef?.uri != scriptRef?.uri) {
+          // Default to scrolling to the top of the script.
+          if (animate) {
+            unawaited(
+              verticalController.animateTo(
+                0,
+                duration: longDuration,
+                curve: defaultCurve,
+              ),
+            );
+          } else {
+            verticalController.jumpTo(0);
+          }
+          _lastScriptRef = scriptRef;
+        }
+        return;
+      }
+
+      final position = verticalController.position;
+      final extent = position.extentInside;
+
+      // TODO(devoncarew): Adjust this so we don't scroll if we're already in the
+      // middle third of the screen.
+      final lineCount = parsedScript?.lineCount;
+      if (lineCount != null && lineCount * CodeView.rowHeight > extent) {
+        final lineIndex = line - 1;
+        final scrollPosition = lineIndex * CodeView.rowHeight -
+            ((extent - CodeView.rowHeight) / 2);
         if (animate) {
           unawaited(
             verticalController.animateTo(
-              0,
+              scrollPosition,
               duration: longDuration,
               curve: defaultCurve,
             ),
           );
         } else {
-          verticalController.jumpTo(0);
+          verticalController.jumpTo(scrollPosition);
         }
-        _lastScriptRef = scriptRef;
       }
-      return;
+      _lastScriptRef = scriptRef;
     }
 
-    final position = verticalController.position;
-    final extent = position.extentInside;
-
-    // TODO(devoncarew): Adjust this so we don't scroll if we're already in the
-    // middle third of the screen.
-    final lineCount = parsedScript?.lineCount;
-    if (lineCount != null && lineCount * CodeView.rowHeight > extent) {
-      final lineIndex = line - 1;
-      final scrollPosition =
-          lineIndex * CodeView.rowHeight - ((extent - CodeView.rowHeight) / 2);
-      if (animate) {
-        unawaited(
-          verticalController.animateTo(
-            scrollPosition,
-            duration: longDuration,
-            curve: defaultCurve,
-          ),
-        );
-      } else {
-        verticalController.jumpTo(scrollPosition);
-      }
-    }
-    _lastScriptRef = scriptRef;
+    verticalController.hasAttachedControllers
+        ? updateScrollPositionImpl()
+        : WidgetsBinding.instance.addPostFrameCallback(
+            (_) => updateScrollPositionImpl(),
+          );
   }
 
   void _onPressed(int line) {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -16,6 +16,7 @@ import '../../service/isolate_state.dart';
 import '../../service/vm_service_wrapper.dart';
 import '../../shared/globals.dart';
 import '../../shared/object_tree.dart';
+import '../../shared/routing.dart';
 import 'codeview_controller.dart';
 import 'debugger_model.dart';
 
@@ -30,10 +31,16 @@ class DebuggerController extends DisposableController
     with AutoDisposeControllerMixin {
   // `initialSwitchToIsolate` can be set to false for tests to skip the logic
   // in `switchToIsolate`.
-  DebuggerController({this.initialSwitchToIsolate = true}) {
+  DebuggerController({
+    DevToolsRouterDelegate? routerDelegate,
+    this.initialSwitchToIsolate = true,
+  }) {
     autoDisposeStreamSubscription(
       serviceManager.onConnectionAvailable.listen(_handleConnectionAvailable),
     );
+    if (routerDelegate != null) {
+      codeViewController.subscribeToRouterEvents(routerDelegate);
+    }
     if (serviceManager.hasService) {
       initialize();
     }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -119,9 +119,6 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!initController()) return;
-    controller.codeViewController.subscribeToRouterEvents(
-      DevToolsRouterDelegate.of(context),
-    );
     unawaited(controller.onFirstDebuggerScreenLoad());
   }
 

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -17,6 +17,7 @@ import '../../primitives/listenable.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/flex_split_column.dart';
 import '../../shared/globals.dart';
+import '../../shared/routing.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
 import '../../shared/theme.dart';
@@ -118,6 +119,9 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!initController()) return;
+    controller.codeViewController.subscribeToRouterEvents(
+      DevToolsRouterDelegate.of(context),
+    );
     unawaited(controller.onFirstDebuggerScreenLoad());
   }
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_columns.dart
@@ -2,9 +2,18 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart';
+
 import '../../primitives/utils.dart';
+import '../../shared/globals.dart';
+import '../../shared/routing.dart';
+import '../../shared/table/table.dart';
 import '../../shared/table/table_data.dart';
 import '../../shared/utils.dart';
+import '../debugger/codeview_controller.dart';
+import '../debugger/debugger_screen.dart';
+import '../vm_developer/vm_developer_common_widgets.dart';
 import 'cpu_profile_model.dart';
 
 const timeColumnWidthPx = 180.0;
@@ -95,7 +104,8 @@ class MethodNameColumn extends TreeColumnData<CpuStackFrame> {
 }
 
 // TODO(kenz): make these urls clickable once we can jump to source.
-class SourceColumn extends ColumnData<CpuStackFrame> {
+class SourceColumn extends ColumnData<CpuStackFrame>
+    implements ColumnRenderer<CpuStackFrame> {
   SourceColumn() : super.wide('Source', alignment: ColumnAlignment.right);
 
   @override
@@ -113,4 +123,32 @@ class SourceColumn extends ColumnData<CpuStackFrame> {
 
   @override
   bool get supportsSorting => true;
+
+  @override
+  Widget? build(
+    BuildContext context,
+    CpuStackFrame data, {
+    bool isRowSelected = false,
+    VoidCallback? onPressed,
+  }) {
+    final script = scriptManager.getScriptByUri(data.rawUrl);
+    if (script == null) {
+      return null;
+    }
+    final routerDelegate = DevToolsRouterDelegate.of(context);
+    return VmServiceObjectLink<Script>(
+      object: script,
+      textBuilder: (_) => getDisplayValue(data),
+      onTap: (e) {
+        routerDelegate.navigate(
+          DebuggerScreen.id,
+          const {},
+          CodeViewSourceLocationNavigationState(
+            script: script,
+            line: data.sourceLine!,
+          ),
+        );
+      },
+    );
+  }
 }

--- a/packages/devtools_app/lib/src/scripts/script_manager.dart
+++ b/packages/devtools_app/lib/src/scripts/script_manager.dart
@@ -66,18 +66,27 @@ class ScriptManager extends DisposableController
   Future<Script> getScript(ScriptRef scriptRef) {
     return _scriptCache.getScript(_service, _currentIsolate, scriptRef);
   }
+
+  Script? getScriptByUri(String uri) {
+    return _scriptCache.getScriptByUri(uri);
+  }
 }
 
 class _ScriptCache {
   _ScriptCache();
 
   final _scripts = <String, Script>{};
+  final _uriToScript = <String, Script>{};
   final _inProgress = <String, Future<Script>>{};
 
   /// Return a cached [Script] for the given [ScriptRef], returning null
   /// if there is no cached [Script].
   Script? getScriptCached(ScriptRef scriptRef) {
     return _scripts[scriptRef.id];
+  }
+
+  Script? getScriptByUri(String uri) {
+    return _uriToScript[uri];
   }
 
   /// Retrieve the [Script] for the given [ScriptRef].
@@ -109,6 +118,7 @@ class _ScriptCache {
     unawaited(
       scriptFuture.then((script) {
         scripts[scriptId] = script;
+        _uriToScript[script.uri!] = script;
       }),
     );
 

--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -7,6 +7,7 @@ import 'dart:collection';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
+import '../primitives/auto_dispose.dart';
 import '../primitives/utils.dart';
 import 'globals.dart';
 
@@ -21,10 +22,11 @@ const snapshotPageId = 'snapshot';
 
 /// Represents a Page/route for a DevTools screen.
 class DevToolsRouteConfiguration {
-  DevToolsRouteConfiguration(this.page, this.args);
+  DevToolsRouteConfiguration(this.page, this.args, this.state);
 
   final String page;
   final Map<String, String?> args;
+  final DevToolsNavigationState? state;
 }
 
 /// Converts between structured [DevToolsRouteConfiguration] (our internal data
@@ -66,7 +68,13 @@ class DevToolsRouteInformationParser
     // prefixed with a leading slash. Internally we use "page IDs" that do not
     // start with slashes but match the screenId for each screen.
     final path = uri.path.isNotEmpty ? uri.path.substring(1) : '';
-    final configuration = DevToolsRouteConfiguration(path, uri.queryParameters);
+    final configuration = DevToolsRouteConfiguration(
+      path,
+      uri.queryParameters,
+      DevToolsNavigationState._(
+        (routeInformation.state as Map).cast<String, String?>(),
+      ),
+    );
     return SynchronousFuture<DevToolsRouteConfiguration>(configuration);
   }
 
@@ -81,7 +89,11 @@ class DevToolsRouteInformationParser
     final params = {...configuration.args};
     params.removeWhere((key, value) => value == null);
     return RouteInformation(
-      location: Uri(path: path, queryParameters: params).toString(),
+      location: Uri(
+        path: path,
+        queryParameters: params,
+      ).toString(),
+      state: configuration.state,
     );
   }
 }
@@ -99,7 +111,12 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
   @override
   final GlobalKey<NavigatorState> navigatorKey;
 
-  final Page Function(BuildContext, String?, Map<String, String?>) _getPage;
+  final Page Function(
+    BuildContext,
+    String?,
+    Map<String, String?>,
+    DevToolsNavigationState?,
+  ) _getPage;
 
   /// A list of any routes/pages on the stack.
   ///
@@ -116,10 +133,11 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     final routeConfig = currentConfiguration;
     final page = routeConfig?.page;
     final args = routeConfig?.args ?? {};
+    final state = routeConfig?.state;
 
     return Navigator(
       key: navigatorKey,
-      pages: [_getPage(context, page, args)],
+      pages: [_getPage(context, page, args, state)],
       onPopPage: _handleOnPopPage,
     );
   }
@@ -139,21 +157,30 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
   /// If page and args would be the same, does nothing.
   /// Existing arguments (for example &uri=) will be preserved unless
   /// overwritten by [argUpdates].
-  void navigateIfNotCurrent(String page, [Map<String, String?>? argUpdates]) {
+  void navigateIfNotCurrent(
+    String page, [
+    Map<String, String?>? argUpdates,
+    DevToolsNavigationState? stateUpdates,
+  ]) {
     final pageChanged = page != currentConfiguration!.page;
     final argsChanged = _changesArgs(argUpdates);
-    if (!pageChanged && !argsChanged) {
+    final stateChanged = _changesState(stateUpdates);
+    if (!pageChanged && !argsChanged && !stateChanged) {
       return;
     }
 
-    navigate(page, argUpdates);
+    navigate(page, argUpdates, stateUpdates);
   }
 
   /// Navigates to a new page, optionally updating arguments.
   ///
   /// Existing arguments (for example &uri=) will be preserved unless
   /// overwritten by [argUpdates].
-  void navigate(String page, [Map<String, String?>? argUpdates]) {
+  void navigate(
+    String page, [
+    Map<String, String?>? argUpdates,
+    DevToolsNavigationState? state,
+  ]) {
     final newArgs = {...currentConfiguration!.args, ...?argUpdates};
 
     // Ensure we disconnect from any previously connected applications if we do
@@ -163,8 +190,9 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
       serviceManager.manuallyDisconnect();
     }
 
-    _replaceStack(DevToolsRouteConfiguration(page, newArgs));
-    notifyListeners();
+    _replaceStack(
+      DevToolsRouteConfiguration(page, newArgs, state),
+    );
   }
 
   void navigateHome({
@@ -185,6 +213,7 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     routes
       ..clear()
       ..add(configuration);
+    notifyListeners();
   }
 
   @override
@@ -205,8 +234,13 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
 
     final currentPage = currentConfiguration!.page;
     final newArgs = {...currentConfiguration!.args, ...argUpdates};
-    _replaceStack(DevToolsRouteConfiguration(currentPage, newArgs));
-    notifyListeners();
+    _replaceStack(
+      DevToolsRouteConfiguration(
+        currentPage,
+        newArgs,
+        currentConfiguration!.state,
+      ),
+    );
   }
 
   /// Checks whether applying [changes] over the current routes args will result
@@ -215,4 +249,67 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
         {...currentConfiguration!.args, ...?changes},
         {...currentConfiguration!.args},
       );
+
+  /// Checks whether applying [changes] over the current routes state will result
+  /// in any changes.
+  bool _changesState(DevToolsNavigationState? changes) {
+    return currentConfiguration!.state?.hasChanges(changes) ?? false;
+  }
+}
+
+class DevToolsNavigationState {
+  DevToolsNavigationState({
+    required this.kind,
+    required Map<String, String?> state,
+  }) : _state = {
+          '_kind': kind,
+          ...state,
+        };
+
+  DevToolsNavigationState._(this._state) : kind = _state['_kind']!;
+
+  final String kind;
+
+  UnmodifiableMapView<String, String?> get state => UnmodifiableMapView(_state);
+  final Map<String, String?> _state;
+
+  bool hasChanges(DevToolsNavigationState? other) {
+    return !mapEquals(
+      {...state, ...?other?.state},
+      state,
+    );
+  }
+}
+
+/// Mixin that gives controllers the ability to respond to changes in router
+/// navigation state.
+mixin RouteStateHandlerMixin on DisposableController {
+  DevToolsRouterDelegate? _delegate;
+
+  @override
+  void dispose() {
+    super.dispose();
+    _delegate?.removeListener(_onRouteStateUpdate);
+  }
+
+  void subscribeToRouterEvents(DevToolsRouterDelegate delegate) {
+    final oldDelegate = _delegate;
+    if (oldDelegate != null) {
+      oldDelegate.removeListener(_onRouteStateUpdate);
+    }
+    delegate.addListener(_onRouteStateUpdate);
+    _delegate = delegate;
+  }
+
+  void _onRouteStateUpdate() {
+    final state = _delegate?.currentConfiguration?.state;
+    if (state == null) return;
+    onRouteStateUpdate(state);
+  }
+
+  /// Perform operations based on changes in navigation state.
+  ///
+  /// This method is only invoked if [subscribeToRouterEvents] has been called on
+  /// this instance with a valid [DevToolsRouterDelegate].
+  void onRouteStateUpdate(DevToolsNavigationState state) {}
 }

--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -71,9 +71,11 @@ class DevToolsRouteInformationParser
     final configuration = DevToolsRouteConfiguration(
       path,
       uri.queryParameters,
-      DevToolsNavigationState._(
-        (routeInformation.state as Map).cast<String, String?>(),
-      ),
+      routeInformation.state == null
+          ? null
+          : DevToolsNavigationState._(
+              (routeInformation.state as Map).cast<String, String?>(),
+            ),
     );
     return SynchronousFuture<DevToolsRouteConfiguration>(configuration);
   }
@@ -266,6 +268,9 @@ class DevToolsNavigationState {
           ...state,
         };
 
+  factory DevToolsNavigationState.fromJson(Map<String, dynamic> json) =>
+      DevToolsNavigationState._(json.cast<String, String?>());
+
   DevToolsNavigationState._(this._state) : kind = _state['_kind']!;
 
   final String kind;
@@ -279,6 +284,11 @@ class DevToolsNavigationState {
       state,
     );
   }
+
+  @override
+  String toString() => _state.toString();
+
+  Map<String, dynamic> toJson() => _state;
 }
 
 /// Mixin that gives controllers the ability to respond to changes in router

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -1063,7 +1063,7 @@ abstract class ColumnRenderer<T> {
   ///
   /// This method can return `null` to indicate that the default rendering
   /// should be used instead.
-  Widget build(
+  Widget? build(
     BuildContext context,
     T data, {
     bool isRowSelected = false,
@@ -1419,7 +1419,7 @@ class _TableRowState<T> extends State<TableRow<T>>
   /// Presents the content of this row.
   Widget tableRowFor(BuildContext context, {VoidCallback? onPressed}) {
     Widget columnFor(ColumnData<T> column, double columnWidth) {
-      late Widget content;
+      Widget? content;
       final theme = Theme.of(context);
       final node = widget.node;
       if (widget.rowType == _TableRowType.columnHeader) {
@@ -1435,7 +1435,6 @@ class _TableRowState<T> extends State<TableRow<T>>
         // widget class.
         final padding = column.getNodeIndentPx(node);
         assert(padding >= 0);
-
         if (column is ColumnRenderer) {
           content = (column as ColumnRenderer).build(
             context,
@@ -1443,26 +1442,27 @@ class _TableRowState<T> extends State<TableRow<T>>
             isRowSelected: widget.isSelected,
             onPressed: onPressed,
           );
-        } else {
-          content = RichText(
-            text: TextSpan(
-              text: column.getDisplayValue(node),
-              children: [
-                if (column.getCaption(node) != null)
-                  TextSpan(
-                    text: ' ${column.getCaption(node)}',
-                    style: const TextStyle(
-                      fontStyle: FontStyle.italic,
-                    ),
-                  )
-              ],
-              style: contentTextStyle(column),
-            ),
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            textAlign: _textAlignmentFor(column),
-          );
         }
+        // If ColumnRenderer.build returns null, fall back to the default
+        // rendering.
+        content ??= RichText(
+          text: TextSpan(
+            text: column.getDisplayValue(node),
+            children: [
+              if (column.getCaption(node) != null)
+                TextSpan(
+                  text: ' ${column.getCaption(node)}',
+                  style: const TextStyle(
+                    fontStyle: FontStyle.italic,
+                  ),
+                )
+            ],
+            style: contentTextStyle(column),
+          ),
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          textAlign: _textAlignmentFor(column),
+        );
 
         final tooltip = column.getTooltip(node);
         if (tooltip.isNotEmpty) {

--- a/packages/devtools_app/test/shared/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/shared/syntax_highlighter_test.dart
@@ -179,7 +179,7 @@ void main() {
               ideTheme: getIdeTheme(),
             ),
             routerDelegate: DevToolsRouterDelegate(
-              (a, b, c) => const CupertinoPage(child: SizedBox.shrink()),
+              (a, b, c, d) => const CupertinoPage(child: SizedBox.shrink()),
             ),
             routeInformationParser: DevToolsRouteInformationParser(),
             builder: (context, _) {

--- a/packages/devtools_test/lib/src/wrappers.dart
+++ b/packages/devtools_test/lib/src/wrappers.dart
@@ -23,7 +23,7 @@ Widget wrap(Widget widget) {
   return MaterialApp.router(
     theme: themeFor(isDarkTheme: false, ideTheme: IdeTheme()),
     routerDelegate: DevToolsRouterDelegate(
-      (context, page, args) => MaterialPage(
+      (context, page, args, state) => MaterialPage(
         child: Material(
           child: Directionality(
             textDirection: TextDirection.ltr,


### PR DESCRIPTION
This change adds support for providing additional state when navigating through DevTools via `DevToolsRouterDelegate` without polluting the query parameters with extra entries. This state is included in the navigation history.

Controllers can mixin the new `RouteStateHandlerMixin` and override `onRouteStateUpdate(DevToolsNavigationState)` to handle changes in the current DevTools navigation state. To handle state changes, `subscribeToRouterEvents` must first be called on the controller.

This change also adds support for jumping to a source location in the debugger from URIs in the CPU profiler.