### PR TITLE
Disable allocation tracing in profile mode

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import '../../ui/search.dart';
@@ -49,6 +50,7 @@ class _MemoryTabsState extends State<MemoryTabs>
   final ValueNotifier<int> _currentTab = ValueNotifier(0);
 
   void _initTabs() {
+    final isProfile = serviceManager.connectedApp?.isProfileBuildNow ?? false;
     _tabs = [
       DevToolsTab.create(
         key: MemoryScreenKeys.dartHeapTableProfileTab,
@@ -60,11 +62,12 @@ class _MemoryTabsState extends State<MemoryTabs>
         gaPrefix: _gaPrefix,
         tabName: 'Diff',
       ),
-      DevToolsTab.create(
-        key: MemoryScreenKeys.dartHeapAllocationTracingTab,
-        tabName: 'Trace',
-        gaPrefix: _gaPrefix,
-      ),
+      if (!isProfile)
+        DevToolsTab.create(
+          key: MemoryScreenKeys.dartHeapAllocationTracingTab,
+          tabName: 'Trace',
+          gaPrefix: _gaPrefix,
+        ),
       if (widget.controller.shouldShowLeaksTab.value)
         DevToolsTab.create(
           key: MemoryScreenKeys.leaksTab,
@@ -107,7 +110,7 @@ class _MemoryTabsState extends State<MemoryTabs>
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-
+    final isProfile = serviceManager.connectedApp?.isProfileBuildNow ?? false;
     return Column(
       children: [
         const SizedBox(height: defaultSpacing),
@@ -144,9 +147,10 @@ class _MemoryTabsState extends State<MemoryTabs>
                 ),
               ),
               // Trace tab.
-              const KeepAliveWrapper(
-                child: AllocationProfileTracingView(),
-              ),
+              if (!isProfile)
+                const KeepAliveWrapper(
+                  child: AllocationProfileTracingView(),
+                ),
               // Leaks tab.
               if (controller.shouldShowLeaksTab.value)
                 const KeepAliveWrapper(child: LeaksPane()),

--- a/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 import '../../primitives/auto_dispose_mixin.dart';
 import '../../shared/common_widgets.dart';
-import '../../shared/globals.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import '../../ui/search.dart';
@@ -50,7 +49,6 @@ class _MemoryTabsState extends State<MemoryTabs>
   final ValueNotifier<int> _currentTab = ValueNotifier(0);
 
   void _initTabs() {
-    final isProfile = serviceManager.connectedApp?.isProfileBuildNow ?? false;
     _tabs = [
       DevToolsTab.create(
         key: MemoryScreenKeys.dartHeapTableProfileTab,
@@ -62,12 +60,11 @@ class _MemoryTabsState extends State<MemoryTabs>
         gaPrefix: _gaPrefix,
         tabName: 'Diff',
       ),
-      if (!isProfile)
-        DevToolsTab.create(
-          key: MemoryScreenKeys.dartHeapAllocationTracingTab,
-          tabName: 'Trace',
-          gaPrefix: _gaPrefix,
-        ),
+      DevToolsTab.create(
+        key: MemoryScreenKeys.dartHeapAllocationTracingTab,
+        tabName: 'Trace',
+        gaPrefix: _gaPrefix,
+      ),
       if (widget.controller.shouldShowLeaksTab.value)
         DevToolsTab.create(
           key: MemoryScreenKeys.leaksTab,
@@ -110,7 +107,7 @@ class _MemoryTabsState extends State<MemoryTabs>
   @override
   Widget build(BuildContext context) {
     final themeData = Theme.of(context);
-    final isProfile = serviceManager.connectedApp?.isProfileBuildNow ?? false;
+
     return Column(
       children: [
         const SizedBox(height: defaultSpacing),
@@ -147,10 +144,9 @@ class _MemoryTabsState extends State<MemoryTabs>
                 ),
               ),
               // Trace tab.
-              if (!isProfile)
-                const KeepAliveWrapper(
-                  child: AllocationProfileTracingView(),
-                ),
+              const KeepAliveWrapper(
+                child: AllocationProfileTracingView(),
+              ),
               // Leaks tab.
               if (controller.shouldShowLeaksTab.value)
                 const KeepAliveWrapper(child: LeaksPane()),

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
@@ -82,7 +82,8 @@ class AllocationProfileTracingViewState
               ? const OutlineDecoration(
                   child: Center(
                     child: Text(
-                      'Allocation tracing is temporarily disabled in profile mode',
+                      'Allocation tracing is temporary disabled in profile mode.\n'
+                      'Run the application in debug mode to trace allocations.',
                     ),
                   ),
                 )

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
@@ -82,7 +82,7 @@ class AllocationProfileTracingViewState
               ? const OutlineDecoration(
                   child: Center(
                     child: Text(
-                      'Allocation tracing is currently disabled in profile mode',
+                      'Allocation tracing is temporarily disabled in profile mode',
                     ),
                   ),
                 )

--- a/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/allocation_tracing/allocation_profile_tracing_view.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import '../../../../analytics/analytics.dart' as ga;
 import '../../../../analytics/constants.dart' as analytics_constants;
 import '../../../../shared/common_widgets.dart';
+import '../../../../shared/globals.dart';
 import '../../../../shared/split.dart';
 import '../../../../shared/theme.dart';
 import 'allocation_profile_class_table.dart';
@@ -38,6 +39,8 @@ class AllocationProfileTracingViewState
 
   @override
   Widget build(BuildContext context) {
+    final isProfileMode =
+        serviceManager.connectedApp?.isProfileBuildNow ?? false;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -45,46 +48,58 @@ class AllocationProfileTracingViewState
           children: [
             RefreshButton(
               tooltip: 'Request the set of updated allocation traces',
-              onPressed: () async {
-                ga.select(
-                  analytics_constants.memory,
-                  analytics_constants.MemoryEvent.tracingRefresh,
-                );
-                await controller.refresh();
-              },
+              onPressed: isProfileMode
+                  ? null
+                  : () async {
+                      ga.select(
+                        analytics_constants.memory,
+                        analytics_constants.MemoryEvent.tracingRefresh,
+                      );
+                      await controller.refresh();
+                    },
             ),
             const SizedBox(
               width: denseSpacing,
             ),
             ClearButton(
               tooltip: 'Clear the set of previously collected traces',
-              onPressed: () async {
-                ga.select(
-                  analytics_constants.memory,
-                  analytics_constants.MemoryEvent.tracingClear,
-                );
-                await controller.clear();
-              },
+              onPressed: isProfileMode
+                  ? null
+                  : () async {
+                      ga.select(
+                        analytics_constants.memory,
+                        analytics_constants.MemoryEvent.tracingClear,
+                      );
+                      await controller.clear();
+                    },
             ),
             const _ProfileHelpLink(),
           ],
         ),
         const SizedBox(height: denseRowSpacing),
         Expanded(
-          child: Split(
-            axis: Axis.horizontal,
-            initialFractions: const [0.25, 0.75],
-            children: [
-              AllocationTracingTable(
-                controller: controller,
-              ),
-              OutlineDecoration(
-                child: AllocationTracingTree(
-                  controller: controller,
+          child: isProfileMode
+              ? const OutlineDecoration(
+                  child: Center(
+                    child: Text(
+                      'Allocation tracing is currently disabled in profile mode',
+                    ),
+                  ),
+                )
+              : Split(
+                  axis: Axis.horizontal,
+                  initialFractions: const [0.25, 0.75],
+                  children: [
+                    AllocationTracingTable(
+                      controller: controller,
+                    ),
+                    OutlineDecoration(
+                      child: AllocationTracingTree(
+                        controller: controller,
+                      ),
+                    ),
+                  ],
                 ),
-              ),
-            ],
-          ),
         ),
       ],
     );


### PR DESCRIPTION
Dart AOT applications don't currently support allocation tracing. This changes hides the "Trace" tab in the memory screen when connected to a profile mode Flutter application or an AOT Dart application.

Temporary fix for https://github.com/flutter/devtools/issues/4597