### PR TITLE
Prevent _gtagEvent from being called in a non-release builds

### DIFF
--- a/packages/devtools_app/lib/src/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/analytics/_analytics_web.dart
@@ -10,7 +10,6 @@ library gtags;
 import 'dart:async';
 import 'dart:html';
 
-import 'package:flutter/foundation.dart';
 import 'package:js/js.dart';
 
 import '../../devtools.dart' as devtools show version;
@@ -24,15 +23,6 @@ import '../ui/gtags.dart';
 import 'analytics_common.dart';
 import 'constants.dart' as analytics_constants;
 import 'metrics.dart';
-
-/// For gtags API see https://developers.google.com/gtagjs/reference/api
-/// For debugging install the Chrome Plugin "Google Analytics Debugger".
-
-/// Enable this flag to debug analytics when DevTools is run in debug or profile
-/// mode, otherwise analytics will only be sent in release builds.
-///
-/// `ga.isAnalyticsEnabled()` still must return true for analytics to be sent.
-bool _debugAnalytics = false;
 
 // Dimensions1 AppType values:
 const String appTypeFlutter = 'flutter';
@@ -393,16 +383,14 @@ void screen(
   String screenName, [
   int value = 0,
 ]) {
-  if (kReleaseMode || _debugAnalytics) {
-    GTag.event(
-      screenName,
-      _gtagEvent(
-        event_category: analytics_constants.screenViewEvent,
-        value: value,
-        send_to: gaDevToolsPropertyId(),
-      ),
-    );
-  }
+  GTag.event(
+    screenName,
+    gaEventProvider: () => _gtagEvent(
+      event_category: analytics_constants.screenViewEvent,
+      value: value,
+      send_to: gaDevToolsPropertyId(),
+    ),
+  );
 }
 
 String _operationKey(String screenName, String timedOperation) {
@@ -538,18 +526,16 @@ void _timing(
   required int durationMicros,
   ScreenAnalyticsMetrics? screenMetrics,
 }) {
-  if (kReleaseMode || _debugAnalytics) {
-    GTag.event(
-      screenName,
-      _gtagEvent(
-        event_category: analytics_constants.timingEvent,
-        event_label: timedOperation,
-        value: durationMicros,
-        send_to: gaDevToolsPropertyId(),
-        screenMetrics: screenMetrics,
-      ),
-    );
-  }
+  GTag.event(
+    screenName,
+    gaEventProvider: () => _gtagEvent(
+      event_category: analytics_constants.timingEvent,
+      event_label: timedOperation,
+      value: durationMicros,
+      send_to: gaDevToolsPropertyId(),
+      screenMetrics: screenMetrics,
+    ),
+  );
 }
 
 void select(
@@ -559,20 +545,18 @@ void select(
   bool nonInteraction = false,
   ScreenAnalyticsMetrics Function()? screenMetricsProvider,
 }) {
-  if (kReleaseMode || _debugAnalytics) {
-    GTag.event(
-      screenName,
-      _gtagEvent(
-        event_category: analytics_constants.selectEvent,
-        event_label: selectedItem,
-        value: value,
-        non_interaction: nonInteraction,
-        send_to: gaDevToolsPropertyId(),
-        screenMetrics:
-            screenMetricsProvider != null ? screenMetricsProvider() : null,
-      ),
-    );
-  }
+  GTag.event(
+    screenName,
+    gaEventProvider: () => _gtagEvent(
+      event_category: analytics_constants.selectEvent,
+      event_label: selectedItem,
+      value: value,
+      non_interaction: nonInteraction,
+      send_to: gaDevToolsPropertyId(),
+      screenMetrics:
+          screenMetricsProvider != null ? screenMetricsProvider() : null,
+    ),
+  );
 }
 
 String? _lastGaError;
@@ -587,7 +571,7 @@ void reportError(
   _lastGaError = errorMessage;
 
   GTag.exception(
-    _gtagException(
+    gaExceptionProvider: () => _gtagException(
       errorMessage,
       fatal: fatal,
       screenMetrics:

--- a/packages/devtools_app/lib/src/ui/gtags.dart
+++ b/packages/devtools_app/lib/src/ui/gtags.dart
@@ -14,6 +14,7 @@ import '../analytics/analytics.dart' as ga;
 
 /// For gtags API see https://developers.google.com/gtagjs/reference/api
 /// For debugging install the Chrome Plugin "Google Analytics Debugger".
+
 /// Enable this flag to debug analytics when DevTools is run in debug or profile
 /// mode, otherwise analytics will only be sent in release builds.
 ///

--- a/packages/devtools_app/lib/src/ui/gtags.dart
+++ b/packages/devtools_app/lib/src/ui/gtags.dart
@@ -7,19 +7,9 @@ library gtags;
 
 // ignore_for_file: non_constant_identifier_names
 
-import 'package:flutter/foundation.dart';
 import 'package:js/js.dart';
 
 import '../analytics/analytics.dart' as ga;
-
-/// For gtags API see https://developers.google.com/gtagjs/reference/api
-/// For debugging install the Chrome Plugin "Google Analytics Debugger".
-
-/// Enable this flag to debug analytics when DevTools is run in debug or profile
-/// mode, otherwise analytics will only be sent in release builds.
-///
-/// `ga.isAnalyticsEnabled()` still must return true for analytics to be sent.
-bool _debugAnalytics = false;
 
 @JS('gtag')
 external void _gTagCommandName(String command, String name, [dynamic params]);
@@ -31,10 +21,8 @@ class GTag {
 
   /// Collect the analytic's event and its parameters.
   static void event(String eventName, GtagEvent gaEvent) async {
-    if (kReleaseMode || _debugAnalytics) {
-      if (await ga.isAnalyticsEnabled()) {
-        _gTagCommandName(_event, eventName, gaEvent);
-      }
+    if (await ga.isAnalyticsEnabled()) {
+      _gTagCommandName(_event, eventName, gaEvent);
     }
   }
 


### PR DESCRIPTION
`_gtagEvent` cannot be called in a test environment, as it requires the index.html file to be present (where the js function `getDevToolsPropertyID` is registered). 