### PR TITLE
Handle breaking changes in package:vm_service v10

### DIFF
--- a/packages/devtools_app/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/NEXT_RELEASE_NOTES.md
@@ -12,6 +12,7 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 * Fix an issue that would prevent DevTools connecting to the backend server that would disable some functionality - [#5016](https://github.com/flutter/devtools/pull/5016)
 * Add a link to the DevTools [CONTRIBUTING](https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md) guide to the About menu, and fixed the Discord link - [#4926](https://github.com/flutter/devtools/pull/4926)
 * Fix conflicting colors in light theme - [5067](https://github.com/flutter/devtools/pull/5067)
+* Update `package:vm_service` constraint to `^10.1.0`.
 
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -520,7 +520,10 @@ class _RetainingObjectDescription extends StatelessWidget {
       const TextSpan(text: 'Retained by '),
     ];
 
-    if (object.parentField != null) {
+    if (object.parentField is int) {
+      assert((object.value as InstanceRef).kind == InstanceKind.kRecord);
+      entries.add(TextSpan(text: '\$${object.parentField} of '));
+    } else if (object.parentField != null) {
       entries.add(TextSpan(text: '${object.parentField} of '));
     }
 
@@ -553,13 +556,12 @@ class _RetainingObjectDescription extends StatelessWidget {
         ).buildTextSpan(context),
       );
     } else {
-      entries.addAll([
-        const TextSpan(text: 'of '),
+      entries.add(
         VmServiceObjectLink(
           object: object.value,
           onTap: onTap,
         ).buildTextSpan(context),
-      ]);
+      );
     }
     return SelectableText.rich(
       TextSpan(children: entries),
@@ -669,7 +671,13 @@ class InboundReferencesWidget extends StatelessWidget {
       );
     }
 
-    if (inboundRef.parentField != null) {
+    if (inboundRef.parentField is int) {
+      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
+      description.write('\$${inboundRef.parentField} of ');
+    } else if (inboundRef.parentField is String) {
+      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
+      description.write('${inboundRef.parentField} of ');
+    } else if (inboundRef.parentField is FieldRef) {
       description.write(
         '${_objectName(inboundRef.parentField)} of ',
       );
@@ -733,6 +741,8 @@ class VmServiceObjectLink<T> extends StatelessWidget {
           text = 'List(length: ${instance.length})';
         } else if (instance.kind == InstanceKind.kMap) {
           text = 'Map(length: ${instance.length})';
+        } else if (instance.kind == InstanceKind.kRecord) {
+          text = 'Record';
         } else if (instance.kind == InstanceKind.kType) {
           text = instance.name!;
         } else if (instance.kind == InstanceKind.kStackTrace) {

--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -275,7 +275,8 @@ class VmServiceWrapper implements VmService {
     String isolateId,
     String objectId,
     int limit, {
-    String? classId,
+    bool? includeSubclasses,
+    bool? includeImplementers,
   }) async {
     return trackFuture(
       'getInstances',

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   image: ^3.0.2
   intl: '>=0.16.1 <0.18.0'
   js: ^0.6.1+1
-  leak_tracker: ^1.0.0-dev.1.2
+  leak_tracker: 2.0.1
   mime: ^1.0.0
   path: ^1.8.0
   perfetto_compiled:
@@ -57,7 +57,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^6.1.0
   url_launcher_web: ^2.0.6
-  vm_service: ^9.0.0
+  vm_service: ^10.1.0
   vm_snapshot_analysis: ^0.7.1
   web_socket_channel: ^2.1.0
   # widget_icons: ^0.0.1

--- a/packages/devtools_app/test/test_infra/test_data/cpu_profile.dart
+++ b/packages/devtools_app/test/test_infra/test_data/cpu_profile.dart
@@ -198,7 +198,6 @@ final Map<String, dynamic> goldenCpuSamplesJson = {
   'samplePeriod': 50,
   'maxStackDepth': 128,
   'sampleCount': 8,
-  'timeSpan': -1,
   'timeOriginMicros': 47377796685,
   'timeExtentMicros': 3000,
   'pid': 77616,

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
@@ -179,10 +179,18 @@ void main() {
     await tester.tap(find.byType(AreaPaneHeader));
 
     await tester.pumpAndSettle();
-    expect(find.byType(SelectableText), findsNWidgets(5));
+    expect(find.byType(SelectableText), findsNWidgets(7));
     expect(find.text('FooClass'), findsOneWidget);
     expect(
       find.text('Retained by element [1] of fooSuperClass'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Retained by \$1 of Record'),
+      findsOneWidget,
+    );
+    expect(
+      find.text('Retained by fooParentField of Record'),
       findsOneWidget,
     );
     expect(
@@ -240,13 +248,21 @@ void main() {
       await tester.tap(find.byType(AreaPaneHeader));
 
       await tester.pumpAndSettle();
-      expect(find.byType(SelectableText), findsNWidgets(3));
+      expect(find.byType(SelectableText), findsNWidgets(5));
       expect(
         find.text('Referenced by fooFunction'),
         findsOneWidget,
       );
       expect(
         find.text('Referenced by fooParentField of fooType fooField of fooLib'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Referenced by fooParentField of fooRecord'),
+        findsOneWidget,
+      );
+      expect(
+        find.text('Referenced by \$1 of fooRecord'),
         findsOneWidget,
       );
       expect(

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -58,6 +58,12 @@ final testInstance = Instance(
   classRef: testSuperClass,
 );
 
+final testRecordInstance = Instance(
+  id: '1234',
+  kind: InstanceKind.kRecord,
+  name: 'fooRecord',
+);
+
 final testSuperClass =
     ClassRef(name: 'fooSuperClass', library: testLib, id: '1234');
 
@@ -104,12 +110,18 @@ final testRetainingObjects = [
   RetainingObject(
     value: testInstance,
     parentListIndex: 1,
+  ),
+  RetainingObject(
+    value: testRecordInstance,
+    parentField: 1,
+  ),
+  RetainingObject(
+    value: testRecordInstance,
     parentField: 'fooParentField',
   ),
   RetainingObject(
     value: testInstance,
     parentMapKey: testField,
-    parentField: 'fooParentField',
   ),
   RetainingObject(
     value: testField,
@@ -130,9 +142,16 @@ final testInboundRefList = [
     parentField: testParentField,
   ),
   InboundReference(
+    source: testRecordInstance,
+    parentField: 'fooParentField',
+  ),
+  InboundReference(
+    source: testRecordInstance,
+    parentField: 1,
+  ),
+  InboundReference(
     source: testInstance,
     parentListIndex: 1,
-    parentField: testParentField,
   ),
 ];
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   mockito: ^5.0.9
   path: ^1.8.0
   provider: ^6.0.2
-  vm_service: ^9.0.0
+  vm_service: ^10.1.0
   vm_snapshot_analysis: ^0.7.1
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 


### PR DESCRIPTION
The `InboundReference` and `RetainingObject` types will be changed in `package:vm_service` version 10.0.0 (see [this CL](https://dart-review.googlesource.com/c/sdk/+/268521/14/runtime/vm/service/service.md)). This handles those changes. The also handles the optional parameters added to `getInstances` in `package:vm_service` version 10.1.0.