### PR TITLE
Disable experiments for debug and profile mode.

### DIFF
--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -15,7 +14,6 @@ import 'src/config_specific/url_strategy/url_strategy.dart';
 import 'src/extension_points/extensions_base.dart';
 import 'src/extension_points/extensions_external.dart';
 import 'src/framework/app_error_handling.dart';
-import 'src/primitives/feature_flags.dart';
 import 'src/primitives/url_utils.dart';
 import 'src/screens/debugger/syntax_highlighter.dart';
 import 'src/screens/provider/riverpod_error_logger_observer.dart';
@@ -47,11 +45,6 @@ void main() async {
   await SyntaxHighlighter.initialize();
 
   setupErrorHandling(() async {
-    // Experiments are enabled here,
-    // not at initialization, because
-    // [enableExperiments] should be false for tests.
-    if (!kReleaseMode) setExperimentsEnabled();
-
     // Run the app.
     runApp(
       ProviderScope(

--- a/packages/devtools_app/lib/src/primitives/feature_flags.dart
+++ b/packages/devtools_app/lib/src/primitives/feature_flags.dart
@@ -20,7 +20,6 @@ const bool _kEnableExperiments = bool.fromEnvironment('enable_experiments');
 
 @visibleForTesting
 bool enableExperiments = _kEnableExperiments;
-void setExperimentsEnabled() => enableExperiments = true;
 
 @visibleForTesting
 bool get enableBeta => enableExperiments || !isExternalBuild;


### PR DESCRIPTION
This implements the changes discussed [here](https://github.com/flutter/devtools/pull/4828#discussion_r1034154762) to have experiments off in debug / profile builds, unless the `--dart-define=enable_experiments=true` flag has been explicitly passed. Having experiments on by default could prevent us from catching issues that only show up when experiments are disabled, which is what our users will see.