### PR TITLE
Add support for specifying initial tab selection on AnalyticsTabbedView

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -71,6 +71,14 @@ class MemoryController extends DisposableController
   /// Controller for [AllocationProfileTableView].
   final allocationProfileController = AllocationProfileTableViewController();
 
+  /// Index of the selected feature tab.
+  /// 
+  /// This value is used to set the initial tab selection of the
+  /// [MemoryTabView]. This widget will be disposed and re-initialized on
+  /// DevTools screen changes, so we must store this value in the controller
+  /// instead of the widget state.
+  int selectedFeatureTabIndex = 0;
+
   static const logFilenamePrefix = 'memory_log_';
 
   final _shouldShowLeaksTab = ValueNotifier<bool>(false);

--- a/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_controller.dart
@@ -72,7 +72,7 @@ class MemoryController extends DisposableController
   final allocationProfileController = AllocationProfileTableViewController();
 
   /// Index of the selected feature tab.
-  /// 
+  ///
   /// This value is used to set the initial tab selection of the
   /// [MemoryTabView]. This widget will be disposed and re-initialized on
   /// DevTools screen changes, so we must store this value in the controller

--- a/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
@@ -46,7 +46,11 @@ class MemoryTabView extends StatelessWidget {
         return AnalyticsTabbedView(
           tabs: tabs,
           tabViews: tabViews,
+          initialSelectedIndex: controller.selectedFeatureTabIndex,
           gaScreen: gac.memory,
+          onTabChanged: (int index) {
+            controller.selectedFeatureTabIndex = index;
+          },
         );
       },
     );

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -55,7 +55,7 @@ class PerformanceController extends DisposableController
   final rebuildCountModel = RebuildCountModel();
 
   /// Index of the selected feature tab.
-  /// 
+  ///
   /// This value is used to set the initial tab selection of the
   /// [TabbedPerformanceView]. This widget will be disposed and re-initialized
   /// on DevTools screen changes, so we must store this value in the controller

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -54,6 +54,14 @@ class PerformanceController extends DisposableController
   //(https://github.com/flutter/devtools/pull/4566).
   final rebuildCountModel = RebuildCountModel();
 
+  /// Index of the selected feature tab.
+  /// 
+  /// This value is used to set the initial tab selection of the
+  /// [TabbedPerformanceView]. This widget will be disposed and re-initialized
+  /// on DevTools screen changes, so we must store this value in the controller
+  /// instead of the widget state.
+  int selectedFeatureTabIndex = 0;
+
   bool _fetchMissingLocationsStarted = false;
   IsolateRef? _currentRebuildWidgetsIsolate;
 

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -101,8 +101,10 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     return AnalyticsTabbedView(
       tabs: tabs,
       tabViews: tabViews,
+      initialSelectedIndex: controller.selectedFeatureTabIndex,
       gaScreen: gac.performance,
       onTabChanged: (int index) {
+        controller.selectedFeatureTabIndex = index;
         final featureController = featureControllers[index];
         unawaited(controller.setActiveFeature(featureController));
       },

--- a/packages/devtools_app/lib/src/shared/ui/tab.dart
+++ b/packages/devtools_app/lib/src/shared/ui/tab.dart
@@ -82,6 +82,7 @@ class AnalyticsTabbedView<T> extends StatefulWidget {
     this.outlined = true,
     this.sendAnalytics = true,
     this.onTabChanged,
+    this.initialSelectedIndex,
   })  : trailingWidgets = List.generate(
           tabs.length,
           (index) => tabs[index].trailing ?? const SizedBox(),
@@ -97,6 +98,8 @@ class AnalyticsTabbedView<T> extends StatefulWidget {
   final List<Widget> trailingWidgets;
 
   final bool outlined;
+
+  final int? initialSelectedIndex;
 
   /// Whether to send analytics events to GA.
   ///
@@ -124,6 +127,11 @@ class _AnalyticsTabbedViewState extends State<AnalyticsTabbedView>
       length: widget.tabs.length,
       vsync: this,
     );
+
+    final initialIndex = widget.initialSelectedIndex;
+    if (initialIndex != null) {
+      _currentTabControllerIndex = initialIndex;
+    }
     if (_currentTabControllerIndex >= _tabController!.length) {
       _currentTabControllerIndex = 0;
     }

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -20,8 +20,7 @@ MockPerformanceController createMockPerformanceControllerWithDefaults() {
   when(controller.enhanceTracingController)
       .thenReturn(EnhanceTracingController());
   when(controller.offlinePerformanceData).thenReturn(null);
-  var selectedIndex = 0;
-  when(controller.selectedFeatureTabIndex).thenReturn(selectedIndex);
+  when(controller.selectedFeatureTabIndex).thenReturn(0);
 
   // Stubs for Flutter Frames feature.
   when(controller.flutterFramesController).thenReturn(flutterFramesController);

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -20,6 +20,8 @@ MockPerformanceController createMockPerformanceControllerWithDefaults() {
   when(controller.enhanceTracingController)
       .thenReturn(EnhanceTracingController());
   when(controller.offlinePerformanceData).thenReturn(null);
+  var selectedIndex = 0;
+  when(controller.selectedFeatureTabIndex).thenReturn(selectedIndex);
 
   // Stubs for Flutter Frames feature.
   when(controller.flutterFramesController).thenReturn(flutterFramesController);


### PR DESCRIPTION
Fixes the Performance screen tabs and the Memory screen tabs so the tab selection persists after switching to another DevTools screen.
Fixes https://github.com/flutter/devtools/issues/4874