### PR TITLE
Don't fail at startup if textmate grammar can't be parsed by browser

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 
+import '../../shared/config_specific/logger/logger.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/theme.dart';
 import 'span_parser.dart';
@@ -41,7 +42,19 @@ class SyntaxHighlighter {
       final grammarJson = json.decode(
         await rootBundle.loadString('assets/dart_syntax.json'),
       );
-      _grammar = Grammar.fromJson(grammarJson);
+      try {
+        _grammar = Grammar.fromJson(grammarJson);
+      } catch (error) {
+        // Safari does not support negative-lookbehind regex which are currently
+        // required by the syntax highlighting. An unhandled exception here will
+        // prevent DevTools initializing, so just print the error and leave
+        // syntax highlighting disabled if this happens.
+        log(
+          'Failed to load Dart Syntax Highlighting:\n'
+          '$error',
+          LogLevel.warning,
+        );
+      }
     }
   }
 
@@ -60,11 +73,15 @@ class SyntaxHighlighter {
           .sublist(lineRange.begin - 1, lineRange.end)
           .join('\n');
     }
+    final grammar = _grammar;
+    if (grammar == null) {
+      return TextSpan(text: _processedSource);
+    }
     return TextSpan(
       children: _highlightLoopHelper(
         currentScope: null,
         loopCondition: () => _currentPosition < _processedSource.length,
-        scopes: SpanParser.parse(_grammar!, _processedSource),
+        scopes: SpanParser.parse(grammar, _processedSource),
       ),
     );
   }


### PR DESCRIPTION
The textmate grammar uses negative lookbehinds which are not supported in Safari. I've had a go at changing the grammar, but I can't find a way to support what we need (without a significant change to how the textmate grammar works) so for now this change will just handle errors and leave syntax highlighting disabled for browsers that don't support this.

Before this change, DevTools fails to load in safari:

![image](https://user-images.githubusercontent.com/1078012/207321806-6d8dff81-6535-461b-9eec-db4edef36e51.png)

With the change, it loads and prints a warning about the failed syntax highlighting in the console:

<img width="951" alt="Screenshot 2022-12-13 at 12 40 16" src="https://user-images.githubusercontent.com/1078012/207321828-4411cc9b-2d43-4ace-b3d9-233511350231.png">

And using the app works as normal:

<img width="1314" alt="Screenshot 2022-12-13 at 12 43 35" src="https://user-images.githubusercontent.com/1078012/207321904-30b65e04-f77d-45c2-8c96-f2485775f051.png">

Fixes https://github.com/flutter/devtools/issues/2856.
