### PR TITLE
Update case study on memory leaks.

### DIFF
--- a/case_study/memory_leaks/leaking_counter_1/lib/main.dart
+++ b/case_study/memory_leaks/leaking_counter_1/lib/main.dart
@@ -54,7 +54,6 @@ class _MyHomePageState extends State<MyHomePage> {
           oldIncrementer.increment();
         }
       },
-      //buildScreen(context),
     );
 
     _incrementer.increment();

--- a/case_study/memory_leaks/leaking_counter_1/lib/main.dart
+++ b/case_study/memory_leaks/leaking_counter_1/lib/main.dart
@@ -29,8 +29,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class MyIncrementer {
-  MyIncrementer(this.increment, {this.screen});
-  final Scaffold? screen;
+  MyIncrementer(this.increment);
   final VoidCallback increment;
 }
 

--- a/case_study/memory_leaks/leaking_counter_1/lib/main.dart
+++ b/case_study/memory_leaks/leaking_counter_1/lib/main.dart
@@ -29,7 +29,7 @@ class MyHomePage extends StatefulWidget {
 }
 
 class MyIncrementer {
-  MyIncrementer(this.increment, this.screen);
+  MyIncrementer(this.increment, {this.screen});
   final Scaffold? screen;
   final VoidCallback increment;
 }
@@ -41,27 +41,27 @@ class _MyHomePageState extends State<MyHomePage> {
     () => setState(() {
       _counter++;
     }),
-    null,
   );
 
   /// Increments counter if current screen contains floating action button.
   void _incrementCounter(BuildContext context) {
     final oldIncrementer = _incrementer;
+    final screen = buildScreen(context);
 
     _incrementer = MyIncrementer(
       () {
-        final screen = theScreen;
         if (screen.floatingActionButton != null) {
           oldIncrementer.increment();
         }
       },
-      theScreen,
+      //buildScreen(context),
     );
 
     _incrementer.increment();
   }
 
-  Scaffold get theScreen {
+  Scaffold buildScreen(BuildContext context) {
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(
         title: Text(widget.title),
@@ -80,13 +80,14 @@ class _MyHomePageState extends State<MyHomePage> {
       floatingActionButton: FloatingActionButton(
         onPressed: () => _incrementCounter(context),
         tooltip: 'Increment counter',
+        foregroundColor: theme.canvasColor,
         child: const Icon(Icons.add),
       ),
     );
   }
 
   @override
-  Widget build(BuildContext context) => theScreen;
+  Widget build(BuildContext context) => buildScreen(context);
 }
 
 class MyCounter extends StatelessWidget {


### PR DESCRIPTION
1. Move screen out of method to be included in closure
2. Remove stored field as not needed for leak