### PR TITLE
Pin bots to a version of Flutter before Dart 3

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,7 +31,10 @@ jobs:
       - name: Get Latest Flutter Candidate
         id: flutter-candidate
         run: |
-          LATEST_FLUTTER_CANDIDATE=$(./tool/latest_flutter_candidate.sh)
+          # TODO(https://github.com/flutter/devtools/issues/4943): unpin once we can version
+          # solve with Dart 3.0.0
+          # LATEST_FLUTTER_CANDIDATE=$(./tool/latest_flutter_candidate.sh)
+          LATEST_FLUTTER_CANDIDATE='flutter-3.7-candidate.3'
           echo "FLUTTER_CANDIDATE=$LATEST_FLUTTER_CANDIDATE" >> $GITHUB_OUTPUT
       
       - name: Load Cached Flutter SDK


### PR DESCRIPTION
This will unblock submit and make the bots go green.

Part of https://github.com/flutter/devtools/issues/4943.