### PR TITLE
Update cupertino_icons constraint to one supporting sound null safety

### DIFF
--- a/case_study/code_size/optimized/code_size_images/pubspec.yaml
+++ b/case_study/code_size/optimized/code_size_images/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/code_size/optimized/code_size_package/pubspec.yaml
+++ b/case_study/code_size/optimized/code_size_package/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   steel_crypt: ^3.0.0
 
-  cupertino_icons: ^1.0.0
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   encrypt: ^5.0.0
 
-  cupertino_icons: ^1.0.0
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/memory_leaks/images_1/pubspec.yaml
+++ b/case_study/memory_leaks/images_1/pubspec.yaml
@@ -33,7 +33,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/memory_leaks/leaking_counter_1/pubspec.yaml
+++ b/case_study/memory_leaks/leaking_counter_1/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/case_study/platform_channel/pubspec.yaml
+++ b/case_study/platform_channel/pubspec.yaml
@@ -22,7 +22,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   flutter_test:

--- a/third_party/packages/widget_icons/example/pubspec.yaml
+++ b/third_party/packages/widget_icons/example/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.2
+  cupertino_icons: ^1.0.3
   widget_icons:
     path: ../
 


### PR DESCRIPTION
Versions of cupertino_icons before 1.0.3 didn't have a lower bound of `>= 2.12`, breaking usage of Dart 3, which requires sound null safety. This caused package resolution to fail when using a Dart 3 SDK (https://github.com/flutter/devtools/actions/runs/3688647196/jobs/6243745534).

Contributes to #4943

