### PR TITLE
Add Safari fix to release notes

### DIFF
--- a/packages/devtools_app/lib/src/framework/release_notes/release-notes-next.md
+++ b/packages/devtools_app/lib/src/framework/release_notes/release-notes-next.md
@@ -6,7 +6,8 @@ This is draft for future release notes, that are going to land on
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
-TODO: Remove this section if there are not any general updates.
+
+- Fix an issue in Safari (browsers that do not support RegExp negative lookbehind) that prevented DevTools from loading.
 
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/lib/src/framework/release_notes/release-notes-next.md
+++ b/packages/devtools_app/lib/src/framework/release_notes/release-notes-next.md
@@ -7,7 +7,8 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
 
-- Fix an issue in Safari (browsers that do not support RegExp negative lookbehind) that prevented DevTools from loading.
+- Fix several issues in syntax highlighting that would color variable names that contain reserved words incorrectly and leave `extends`/`implements` clauses uncolored for some classes [#4948](https://github.com/flutter/devtools/pull/4948)
+- Fix an issue in Safari (browsers that do not support RegExp negative lookbehind) that prevented DevTools from loading [#4938](https://github.com/flutter/devtools/pull/4938)
 
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
Just adds https://github.com/flutter/devtools/pull/4938 to release notes.

(feel free to suggest wording changes.. I wasn't sure what the official line is on Safari and whether to recommend Chrome or add any disclaimer)