### PR TITLE
fix regex for release notes so it doesn't catch template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,9 +3,7 @@
 *List which issues are fixed by this PR. You must list at least one issue.*
 
 <!-- Uncomment and modify the following section if your PR does not require changes to the release notes -->
-<!-- 
-RELEASE_NOTE_EXCEPTION=[REASON GOES HERE]
- -->
+<!-- RELEASE_NOTE_EXCEPTION=[REASON GOES HERE] -->
 
 ## Pre-launch Checklist
 

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,7 +40,7 @@ jobs:
 
           sudo apt-get install pandoc
 
-          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t gfm)
+          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t html)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,8 +40,9 @@ jobs:
 
           sudo apt-get install pandoc
 
-          echo $DESCRIPTION_BODY
           BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t markdown)
+          echo $DESCRIPTION_BODY
+          echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -38,7 +38,7 @@ jobs:
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
           echo $DESCRIPTION_BODY
-          if $(echo $DESCRIPTION_BODY | grep -Eq "[[:space:]]*RELEASE_NOTE_EXCEPTION="); then
+          if $(echo $DESCRIPTION_BODY | grep -Eq "^[[:space:]]*RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -37,8 +37,12 @@ jobs:
         run: |
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
+
+          sudo apt-get install pandoc
+
           echo $DESCRIPTION_BODY
-          if $(echo $DESCRIPTION_BODY | grep -Eq "^[[:blank:]]*RELEASE_NOTE_EXCEPTION="); then
+          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t markdown)
+          if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -38,7 +38,7 @@ jobs:
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
           echo $DESCRIPTION_BODY
-          if $(echo $DESCRIPTION_BODY | grep -Eq "^[[:space:]]*RELEASE_NOTE_EXCEPTION="); then
+          if $(echo $DESCRIPTION_BODY | grep -Eq "^[[:blank:]]*RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -38,7 +38,7 @@ jobs:
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
           echo $DESCRIPTION_BODY
-          if $(echo $DESCRIPTION_BODY | grep -Eq "[:space:]*RELEASE_NOTE_EXCEPTION="); then
+          if $(echo $DESCRIPTION_BODY | grep -Eq "[[:space:]]*RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
     types: [ assigned, opened, synchronize, reopened, edited ]
 env:
-  CURRENT_RELEASE_JSON_FILE_PATH: tool/release_notes/NEXT_RELEASE_NOTES.md
+  CURRENT_RELEASE_FILE_PATH: tool/release_notes/NEXT_RELEASE_NOTES.md
 jobs:
   release-preparedness:
     runs-on: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
           FILES_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER/files)
           echo "FILES_RESPONSE: $FILES_RESPONSE"
           
-          HAS_CHANGED_RELEASE_NOTES=$(echo $FILES_RESPONSE | jq '.[].filename' | jq -s '. | any(. == env.CURRENT_RELEASE_JSON_FILE_PATH)')
+          HAS_CHANGED_RELEASE_NOTES=$(echo $FILES_RESPONSE | jq '.[].filename' | jq -s '. | any(. == env.CURRENT_RELEASE_FILE_PATH)')
           echo "HAS_CHANGED_RELEASE_NOTES=$HAS_CHANGED_RELEASE_NOTES" >> $GITHUB_OUTPUT
 
       - name: Get PR Description
@@ -57,6 +57,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error file=$CURRENT_RELEASE_JSON_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes Weren\'t Modified'::Please add a release note entry or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
+            echo "::error file=$CURRENT_RELEASE_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes Weren\'t Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
             exit 1
           fi

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,7 +40,7 @@ jobs:
 
           sudo apt-get install pandoc
 
-          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t markdown)
+          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t gfm)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,7 +40,7 @@ jobs:
 
           sudo apt-get install pandoc
 
-          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t plain)
+          BODY_WITHOUT_COMMENTS=$(printf $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t plain)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -38,7 +38,7 @@ jobs:
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
           echo $DESCRIPTION_BODY
-          if $(echo $DESCRIPTION_BODY | grep -Eq "RELEASE_NOTE_EXCEPTION="); then
+          if $(echo $DESCRIPTION_BODY | grep -Eq "[:space:]*RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,7 +40,7 @@ jobs:
 
           sudo apt-get install pandoc
 
-          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t html)
+          BODY_WITHOUT_COMMENTS=$(echo $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t plain)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,7 +40,7 @@ jobs:
 
           sudo apt-get install pandoc
 
-          BODY_WITHOUT_COMMENTS=$(printf $DESCRIPTION_BODY | pandoc --strip-comments -f markdown -t plain)
+          BODY_WITHOUT_COMMENTS=$(printf "$DESCRIPTION_BODY" | pandoc --strip-comments -f markdown -t plain)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then

--- a/tool/release_notes/NEXT_RELEASE_NOTES.md
+++ b/tool/release_notes/NEXT_RELEASE_NOTES.md
@@ -2,7 +2,7 @@ This is draft for future release notes, that are going to land on
 [the Flutter website](https://docs.flutter.dev/development/tools/devtools/release-notes).
 
 # DevTools 2.21.0 release notes
-
+ Test editing these
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates

--- a/tool/release_notes/NEXT_RELEASE_NOTES.md
+++ b/tool/release_notes/NEXT_RELEASE_NOTES.md
@@ -2,7 +2,7 @@ This is draft for future release notes, that are going to land on
 [the Flutter website](https://docs.flutter.dev/development/tools/devtools/release-notes).
 
 # DevTools 2.21.0 release notes
- Test editing these
+
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates


### PR DESCRIPTION
![](https://media.giphy.com/media/7R4uvPJCswCQg/giphy.gif)

The default template for PRs was passing the release note check. This changes the default and the regex and the template so that the users have to at least modify the original.

RELEASE_NOTE_EXCEPTION=Dev process change. Not user facing 

