### PR TITLE
Allow Dependabot PRs to skip release note validation

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -69,6 +69,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] && [ "$IS_DEPENDABOT_PR" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error file=$CURRENT_RELEASE_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes Weren\'t Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
+            echo "::error file=$CURRENT_RELEASE_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes were not Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
             exit 1
           fi

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -29,7 +29,7 @@ jobs:
           HAS_CHANGED_RELEASE_NOTES=$(echo $FILES_RESPONSE | jq '.[].filename' | jq -s '. | any(. == env.CURRENT_RELEASE_FILE_PATH)')
           echo "HAS_CHANGED_RELEASE_NOTES=$HAS_CHANGED_RELEASE_NOTES" >> $GITHUB_OUTPUT
 
-      - name: Get PR Description
+      - name: Get PR Info
         id: check-release-note-exceptions
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -37,25 +37,37 @@ jobs:
         run: |
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
+          AUTHOR_ID=$(echo $PULLS_RESPONSE | jq '.user.login')
 
           sudo apt-get install pandoc
 
           BODY_WITHOUT_COMMENTS=$(printf "$DESCRIPTION_BODY" | pandoc --strip-comments -f markdown -t plain)
           echo $DESCRIPTION_BODY
           echo $BODY_WITHOUT_COMMENTS
+          echo $AUTHOR_ID
+
           if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then
             HAS_RELEASE_NOTE_EXCEPTION_STRING=true
           else
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false
           fi
+
+          if [[ "$AUTHOR_ID" == "dependabot[bot]" ]] ; then
+            IS_DEPENDABOT_PR=true
+          else
+            IS_DEPENDABOT_PR=false
+          fi
+
           echo "HAS_RELEASE_NOTE_EXCEPTION_STRING=$HAS_RELEASE_NOTE_EXCEPTION_STRING" >> $GITHUB_OUTPUT
+          echo "IS_DEPENDABOT_PR=$IS_DEPENDABOT_PR" >> $GITHUB_OUTPUT
 
       - name: Check Release Preparedness requirements
         env:
           HAS_CHANGED_RELEASE_NOTES: ${{steps.get-modified-files.outputs.HAS_CHANGED_RELEASE_NOTES}}
           HAS_RELEASE_NOTE_EXCEPTION_STRING: ${{steps.check-release-note-exceptions.outputs.HAS_RELEASE_NOTE_EXCEPTION_STRING}}
+          IS_DEPENDABOT_PR: ${{steps.check-release-note-exceptions.outputs.IS_DEPENDABOT_PR}}
         run: |
-          if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] ; then
+          if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] && [ "$IS_DEPENDABOT_PR" != "true" ] ; then
             echo "Release Preparedness check failed"
             echo "::error file=$CURRENT_RELEASE_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes Weren\'t Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
             exit 1

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
           DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
-          AUTHOR_ID=$(echo $PULLS_RESPONSE | jq '.user.login')
+          AUTHOR_ID=$(echo $PULLS_RESPONSE | jq -r '.user.login')
 
           sudo apt-get install pandoc
 

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -52,7 +52,7 @@ jobs:
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false
           fi
 
-          if [[ "$AUTHOR_ID" == "dependabot[bot]" ]] ; then
+          if [[ "$AUTHOR_ID" == "CoderDake" ]] ; then
             IS_DEPENDABOT_PR=true
           else
             IS_DEPENDABOT_PR=false

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -52,7 +52,7 @@ jobs:
             HAS_RELEASE_NOTE_EXCEPTION_STRING=false
           fi
 
-          if [[ "$AUTHOR_ID" == "CoderDake" ]] ; then
+          if [[ "$AUTHOR_ID" == "dependabot[bot]" ]] ; then
             IS_DEPENDABOT_PR=true
           else
             IS_DEPENDABOT_PR=false


### PR DESCRIPTION
![](https://media.giphy.com/media/l4HnKUjXp2eHbVTxu/giphy.gif)

Dependabot auto merges are failing since they don't have the required exception in the description.
This PR makes it so that dependabot PR's are exempt from modifying the release notes
RELEASE_NOTE_EXCEPTION=Changes a dev process, not user facing