### PR TITLE
Disable Daily Dev Bumps until new bot is created

### DIFF
--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -1,8 +1,5 @@
 name: Daily Dev Bump
 on:
-  schedule:
-    # * is a special character in YAML so you have to quote this string
-    - cron: '0 0 * * *' # Run every day at midnight
   workflow_dispatch: # Allows for manual triggering if needed
 
 permissions:


### PR DESCRIPTION
![](https://media.giphy.com/media/xT0BKKVhBdhMCciCmA/giphy-downsized.gif)

In the new year I will be able to finish the process that allows the auto merging.
For now, removing the cron line will disable the nightly attempts

Future progress tracked in: https://github.com/flutter/devtools/issues/4986

RELEASE_NOTE_EXCEPTION=Internal process. Not user facing.
