### PR TITLE
Update RetainingPathWidget to use VmServiceObjectLinks for VM service objects

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_class_display.dart
@@ -35,6 +35,7 @@ class VmClassDisplay extends StatelessWidget {
         children: [
           Flexible(
             child: VmObjectDisplayBasicLayout(
+              controller: controller,
               object: clazz,
               generalDataRows: _classDataRows(clazz),
             ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_field_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_field_display.dart
@@ -28,6 +28,7 @@ class VmFieldDisplay extends StatelessWidget {
       script: field.scriptRef!,
       object: field.obj,
       child: VmObjectDisplayBasicLayout(
+        controller: controller,
         object: field,
         generalDataRows: _fieldDataRows(field),
       ),
@@ -50,10 +51,10 @@ class VmFieldDisplay extends StatelessWidget {
         _fieldObservedTypes(field),
       ),
       if (staticValue is InstanceRef)
-        selectableTextBuilderMapEntry(
-          'Static Value',
-          '${staticValue.name ?? staticValue.classRef?.name}: '
-              '${staticValue.valueAsString ?? 'Unknown value'}',
+        serviceObjectLinkBuilderMapEntry<InstanceRef>(
+          controller: controller,
+          key: 'Static Value',
+          object: staticValue,
         ),
     ];
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_function_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_function_display.dart
@@ -31,6 +31,7 @@ class VmFuncDisplay extends StatelessWidget {
       script: function.scriptRef!,
       object: function.obj,
       child: VmObjectDisplayBasicLayout(
+        controller: controller,
         object: function,
         generalDataRows: vmObjectGeneralDataRows(controller, function),
         sideCardDataRows: _functionDetailRows(function),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_library_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_library_display.dart
@@ -29,6 +29,7 @@ class VmLibraryDisplay extends StatelessWidget {
       script: library.scriptRef!,
       object: library.obj,
       child: VmObjectDisplayBasicLayout(
+        controller: controller,
         object: library,
         generalDataRows: _libraryDataRows(library),
         expandableWidgets: [

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_script_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_script_display.dart
@@ -28,6 +28,7 @@ class VmScriptDisplay extends StatelessWidget {
       script: scriptRef,
       object: scriptRef,
       child: VmObjectDisplayBasicLayout(
+        controller: controller,
         object: script,
         generalDataRows: _scriptDataRows(script),
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -452,7 +452,10 @@ class RetainingPathWidget extends StatelessWidget {
               Flexible(
                 child: DefaultTextStyle(
                   style: theme.fixedFontStyle,
-                  child: _retainingObjectDescription(context, object, onTap),
+                  child: _RetainingObjectDescription(
+                    object: object,
+                    onTap: onTap,
+                  ),
                 ),
               ),
             ],
@@ -469,14 +472,19 @@ class RetainingPathWidget extends StatelessWidget {
 
     return prettyRows(context, retainingObjects);
   }
+}
 
-  /// Describes the given RetainingObject [object] and its parentListIndex,
-  /// parentMapKey, and parentField where applicable.
-  Widget _retainingObjectDescription(
-    BuildContext context,
-    RetainingObject object,
-    Function(ObjRef?) onTap,
-  ) {
+class _RetainingObjectDescription extends StatelessWidget {
+  const _RetainingObjectDescription({
+    required this.object,
+    required this.onTap,
+  });
+
+  final RetainingObject object;
+  final Function(ObjRef? obj) onTap;
+
+  @override
+  Widget build(BuildContext context) {
     final parentListIndex = object.parentListIndex;
     if (parentListIndex != null) {
       return SelectableText.rich(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -377,10 +377,12 @@ class SizedCircularProgressIndicator extends StatelessWidget {
 /// An expandable list to display the retaining objects for a given RetainingPath.
 class RetainingPathWidget extends StatelessWidget {
   const RetainingPathWidget({
+    required this.controller,
     required this.retainingPath,
     this.onExpanded,
   });
 
+  final ObjectInspectorViewController controller;
   final ValueListenable<RetainingPath?> retainingPath;
   final void Function(bool)? onExpanded;
 
@@ -419,6 +421,10 @@ class RetainingPathWidget extends StatelessWidget {
     BuildContext context,
     RetainingPath retainingPath,
   ) {
+    final onTap = (ObjRef? obj) async {
+      if (obj == null) return;
+      await controller.findAndSelectNodeForObject(obj);
+    };
     final theme = Theme.of(context);
     final emptyList = SelectableText(
       'No retaining objects',
@@ -427,10 +433,9 @@ class RetainingPathWidget extends StatelessWidget {
     if (retainingPath.elements == null) return [emptyList];
 
     final firstRetainingObject = retainingPath.elements!.isNotEmpty
-        ? SelectableText(
-            _objectName(retainingPath.elements!.first.value) ??
-                '<RetainingObject>',
-            style: theme.fixedFontStyle,
+        ? VmServiceObjectLink(
+            object: retainingPath.elements!.first.value,
+            onTap: onTap,
           )
         : emptyList;
 
@@ -445,9 +450,9 @@ class RetainingPathWidget extends StatelessWidget {
           Row(
             children: [
               Flexible(
-                child: SelectableText(
-                  _retainingObjectDescription(object),
+                child: DefaultTextStyle(
                   style: theme.fixedFontStyle,
+                  child: _retainingObjectDescription(context, object, onTap),
                 ),
               ),
             ],
@@ -455,7 +460,7 @@ class RetainingPathWidget extends StatelessWidget {
       Row(
         children: [
           SelectableText(
-            'Retained by a GC root of type ${retainingPath.gcRootType ?? '<unknown>'}',
+            'Retained by a GC root of type: ${retainingPath.gcRootType ?? '<unknown>'}',
             style: theme.fixedFontStyle,
           ),
         ],
@@ -467,35 +472,89 @@ class RetainingPathWidget extends StatelessWidget {
 
   /// Describes the given RetainingObject [object] and its parentListIndex,
   /// parentMapKey, and parentField where applicable.
-  String _retainingObjectDescription(RetainingObject object) {
+  Widget _retainingObjectDescription(
+    BuildContext context,
+    RetainingObject object,
+    Function(ObjRef?) onTap,
+  ) {
     final parentListIndex = object.parentListIndex;
     if (parentListIndex != null) {
-      return 'Retained by ${_parentListElementDescription(
-        parentListIndex,
-        object.value,
-      )}';
+      return SelectableText.rich(
+        TextSpan(
+          children: [
+            TextSpan(text: 'Retained by element [$parentListIndex] of '),
+            VmServiceObjectLink(
+              object: object.value,
+              onTap: onTap,
+            ).buildTextSpan(context),
+          ],
+        ),
+      );
     }
 
     if (object.parentMapKey != null) {
-      final ref = object.value;
-      final parentMapKey = _objectName(object.parentMapKey);
-
-      final parentMapName = _instanceClassName(ref) ?? '<parentMapName>';
-
-      return 'Retained by element at [$parentMapKey] of $parentMapName';
+      return SelectableText.rich(
+        TextSpan(
+          children: [
+            const TextSpan(text: 'Retained by element at ['),
+            VmServiceObjectLink(object: object.parentMapKey, onTap: onTap)
+                .buildTextSpan(context),
+            const TextSpan(text: '] of '),
+            VmServiceObjectLink(object: object.value, onTap: onTap)
+                .buildTextSpan(context),
+          ],
+        ),
+      );
     }
 
-    final description = StringBuffer('Retained by ');
+    final entries = <TextSpan>[
+      const TextSpan(text: 'Retained by '),
+    ];
 
     if (object.parentField != null) {
-      description.write('${object.parentField} of ');
+      entries.add(TextSpan(text: '${object.parentField} of '));
     }
 
-    description.write(
-      _objectDescription(object.value) ?? '<object>',
+    if (object.value is FieldRef) {
+      final field = object.value as FieldRef;
+      entries.addAll(
+        [
+          VmServiceObjectLink(
+            object: field.declaredType,
+            onTap: onTap,
+          ).buildTextSpan(context),
+          const TextSpan(text: ' '),
+          VmServiceObjectLink(
+            object: field,
+            onTap: onTap,
+          ).buildTextSpan(context),
+          const TextSpan(text: ' of '),
+          VmServiceObjectLink(
+            object: field.owner,
+            onTap: onTap,
+          ).buildTextSpan(context),
+        ],
+      );
+    } else if (object.value is FuncRef) {
+      final func = object.value as FuncRef;
+      entries.add(
+        VmServiceObjectLink(
+          object: func,
+          onTap: onTap,
+        ).buildTextSpan(context),
+      );
+    } else {
+      entries.addAll([
+        const TextSpan(text: 'of '),
+        VmServiceObjectLink(
+          object: object.value,
+          onTap: onTap,
+        ).buildTextSpan(context),
+      ]);
+    }
+    return SelectableText.rich(
+      TextSpan(children: entries),
     );
-
-    return description.toString();
   }
 }
 
@@ -625,13 +684,14 @@ class VmServiceObjectLink<T> extends StatelessWidget {
 
   final T object;
   final bool preferUri;
-  final String Function(T)? textBuilder;
+  final String? Function(T)? textBuilder;
   final FutureOr<void> Function(T) onTap;
 
-  @override
-  Widget build(BuildContext context) {
-    String text = '';
-    if (textBuilder == null) {
+  TextSpan buildTextSpan(BuildContext context) {
+    final theme = Theme.of(context);
+
+    String? text = textBuilder?.call(object);
+    if (text == null) {
       if (object is LibraryRef) {
         final lib = object as LibraryRef;
         if (lib.uri!.startsWith('dart') || preferUri) {
@@ -671,6 +731,8 @@ class VmServiceObjectLink<T> extends StatelessWidget {
           text = buf.toString();
         } else if (instance.kind == InstanceKind.kList) {
           text = 'List(length: ${instance.length})';
+        } else if (instance.kind == InstanceKind.kMap) {
+          text = 'Map(length: ${instance.length})';
         } else if (instance.kind == InstanceKind.kType) {
           text = instance.name!;
         } else {
@@ -678,34 +740,43 @@ class VmServiceObjectLink<T> extends StatelessWidget {
             text = instance.valueAsString!;
           } else {
             final cls = instance.classRef!;
-            text = 'Instance of ${cls.name}';
+            text = '${cls.name}';
           }
         }
+      } else if (object is ContextRef) {
+        final context = object as ContextRef;
+        text = 'Context(length: ${context.length})';
       } else if (object is TypeArgumentsRef) {
         final typeArgs = object as TypeArgumentsRef;
         text = typeArgs.name!;
+      } else if (object is Sentinel) {
+        final sentinel = object as Sentinel;
+        text = sentinel.valueAsString!;
       }
-    } else {
-      text = textBuilder!(object);
     }
+    return TextSpan(
+      text: text,
+      style: theme.linkTextStyle.apply(
+        fontFamily: theme.fixedFontStyle.fontFamily,
+        overflow: TextOverflow.ellipsis,
+      ),
+      recognizer: TapGestureRecognizer()
+        ..onTap = () async {
+          await onTap(object);
+        },
+    );
+  }
 
+  @override
+  Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return SelectableText.rich(
       style: theme.linkTextStyle.apply(
+        fontFamily: theme.fixedFontStyle.fontFamily,
         overflow: TextOverflow.ellipsis,
       ),
       maxLines: 1,
-      TextSpan(
-        text: text,
-        style: theme.linkTextStyle.apply(
-          fontFamily: theme.fixedFontStyle.fontFamily,
-          overflow: TextOverflow.ellipsis,
-        ),
-        recognizer: TapGestureRecognizer()
-          ..onTap = () async {
-            await onTap(object);
-          },
-      ),
+      buildTextSpan(context),
     );
   }
 }
@@ -714,6 +785,7 @@ class VmServiceObjectLink<T> extends StatelessWidget {
 /// layout of information widgets related to VM object types.
 class VmObjectDisplayBasicLayout extends StatelessWidget {
   const VmObjectDisplayBasicLayout({
+    required this.controller,
     required this.object,
     required this.generalDataRows,
     this.sideCardDataRows,
@@ -722,6 +794,7 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
     this.expandableWidgets,
   });
 
+  final ObjectInspectorViewController controller;
   final VmObject object;
   final List<MapEntry<String, WidgetBuilder>> generalDataRows;
   final List<MapEntry<String, WidgetBuilder>>? sideCardDataRows;
@@ -764,6 +837,7 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
           child: ListView(
             children: [
               RetainingPathWidget(
+                controller: controller,
                 retainingPath: object.retainingPath,
                 onExpanded: _onExpandRetainingPath,
               ),

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
+import 'package:devtools_app/src/service/service_manager.dart';
 import 'package:devtools_app/src/shared/common_widgets.dart';
 import 'package:devtools_app/src/shared/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/shared/globals.dart';
@@ -19,6 +20,10 @@ void main() {
 
   late MockClassObject mockClassObject;
 
+  late TestObjectInspectorViewController testObjectInspectorViewController;
+
+  late FakeServiceManager fakeServiceManager;
+
   late InstanceRef requestedSize;
 
   final fetchingSizeNotifier = ValueNotifier<bool>(false);
@@ -28,9 +33,15 @@ void main() {
   final inboundRefsNotifier = ValueNotifier<InboundReferences?>(null);
 
   setUp(() {
+    fakeServiceManager = FakeServiceManager();
+
+    setUpMockScriptManager();
+    setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(IdeTheme, IdeTheme());
 
     mockClassObject = MockClassObject();
+
+    testObjectInspectorViewController = TestObjectInspectorViewController();
 
     final json = testInstance.toJson();
     requestedSize = Instance.parse(json)!;
@@ -130,6 +141,7 @@ void main() {
     await tester.pumpWidget(
       wrap(
         RetainingPathWidget(
+          controller: testObjectInspectorViewController,
           retainingPath: mockClassObject.retainingPath,
           onExpanded: (bool) => null,
         ),
@@ -155,6 +167,7 @@ void main() {
     await tester.pumpWidget(
       wrap(
         RetainingPathWidget(
+          controller: testObjectInspectorViewController,
           retainingPath: mockClassObject.retainingPath,
           onExpanded: (bool) {
             mockClassObject.requestRetainingPath();
@@ -166,23 +179,22 @@ void main() {
     await tester.tap(find.byType(AreaPaneHeader));
 
     await tester.pumpAndSettle();
-
     expect(find.byType(SelectableText), findsNWidgets(5));
     expect(find.text('FooClass'), findsOneWidget);
     expect(
-      find.text('Retained by element [1] of <parentListName>'),
+      find.text('Retained by element [1] of fooSuperClass'),
       findsOneWidget,
     );
     expect(
-      find.text('Retained by element at [fooField] of <parentMapName>'),
+      find.text('Retained by element at [fooField] of fooSuperClass'),
       findsOneWidget,
     );
     expect(
-      find.text('Retained by fooParentField of Field fooField of fooLib'),
+      find.text('Retained by fooParentField of FooClass fooField of fooLib'),
       findsOneWidget,
     );
     expect(
-      find.text('Retained by a GC root of type class table'),
+      find.text('Retained by a GC root of type: class table'),
       findsOneWidget,
     );
   });
@@ -228,18 +240,17 @@ void main() {
       await tester.tap(find.byType(AreaPaneHeader));
 
       await tester.pumpAndSettle();
-
       expect(find.byType(SelectableText), findsNWidgets(3));
       expect(
         find.text('Referenced by fooFunction'),
         findsOneWidget,
       );
       expect(
-        find.text('Referenced by fooParentField of Field fooField of fooLib'),
+        find.text('Referenced by fooParentField of fooType fooField of fooLib'),
         findsOneWidget,
       );
       expect(
-        find.text('Referenced by element [1] of <parentListName>'),
+        find.text('Referenced by element [1] of fooSuperClass'),
         findsOneWidget,
       );
     },

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -74,7 +74,7 @@ void main() {
       expect(find.text('fooScript.dart:10:4'), findsOneWidget);
       expect(find.text('Observed types not found'), findsOneWidget);
       expect(find.text('Static Value:'), findsOneWidget);
-      expect(find.text('FooNumberType: 100'), findsOneWidget);
+      expect(find.text('100'), findsOneWidget);
 
       expect(find.byType(RequestableSizeWidget), findsNWidgets(2));
 

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -48,21 +48,31 @@ final testFunction = Func(
 final testField = Field(
   name: 'fooField',
   owner: testLib,
+  declaredType: testType,
   id: '1234',
 );
 
 final testInstance = Instance(
   id: '1234',
   name: 'fooInstance',
+  classRef: testSuperClass,
 );
 
 final testSuperClass =
     ClassRef(name: 'fooSuperClass', library: testLib, id: '1234');
 
+final testType = InstanceRef(
+  kind: '',
+  id: '1234',
+  name: 'fooType',
+  classRef: testClass,
+);
+
 final testSuperType = InstanceRef(
   kind: '',
   id: '1234',
   name: 'fooSuperType',
+  classRef: testSuperClass,
 );
 
 const testPos = SourcePosition(line: 10, column: 4);


### PR DESCRIPTION
These links can be used to jump to other VM service objects in the VM Tools Objects tab.

<img width="859" alt="image" src="https://user-images.githubusercontent.com/24210656/211054263-45a286b0-1e98-4525-b598-8fbfeed8dd16.png">

RELEASE_NOTE_EXCEPTION=VM Developer Tooling