### PR TITLE
Set a debug key for the DevTools server and service SSE clients

### DIFF
--- a/packages/devtools_app/lib/src/service/service.dart
+++ b/packages/devtools_app/lib/src/service/service.dart
@@ -20,7 +20,7 @@ Future<VmServiceWrapper> _connectWithSse(
   uri = uri.scheme == 'sse'
       ? uri.replace(scheme: 'http')
       : uri.replace(scheme: 'https');
-  final client = SseClient('$uri');
+  final client = SseClient('$uri', debugKey: 'DevToolsService');
   final Stream<String> stream =
       client.stream!.asBroadcastStream() as Stream<String>;
   final service = VmServiceWrapper.fromNewVmService(

--- a/packages/devtools_app/lib/src/shared/config_specific/sse/_fake_sse.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/sse/_fake_sse.dart
@@ -10,7 +10,7 @@ import 'dart:async';
 /// available, like the Flutter desktop embedder.
 // TODO(https://github.com/flutter/devtools/issues/1122): Make SSE work without dart:html.
 class SseClient {
-  SseClient(String endpoint);
+  SseClient(String endpoint, {String? debugKey});
 
   Stream? get stream => null;
 

--- a/packages/devtools_app/lib/src/shared/server_api_client.dart
+++ b/packages/devtools_app/lib/src/shared/server_api_client.dart
@@ -67,7 +67,7 @@ class DevToolsServerConnection {
         'sse',
       ],
     );
-    final client = SseClient(sseUri.toString());
+    final client = SseClient(sseUri.toString(), debugKey: 'DevToolsServer');
     return DevToolsServerConnection._(client);
   }
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -52,7 +52,7 @@ dependencies:
   provider: ^6.0.2
   # Only used for debug mode logic.
   shared_preferences: ^2.0.15
-  sse: ^4.0.0
+  sse: ^4.1.2
   stack_trace: ^1.10.0
   string_scanner: ^1.1.0
   url_launcher: ^6.1.0


### PR DESCRIPTION
The ability to provide an optional debug key was added in https://github.com/dart-lang/sse/pull/67

This debug key identifies the SSE connection and can be used to debug SSE connection issues.

RELEASE_NOTE_EXCEPTION="No new feature"