### PR TITLE
Moves shared integration test code to package:devtools_test

### DIFF
--- a/packages/devtools_app/integration_test/test/app_test.dart
+++ b/packages/devtools_app/integration_test/test/app_test.dart
@@ -7,11 +7,11 @@ import 'package:devtools_app/src/app.dart';
 import 'package:devtools_app/src/framework/landing_screen.dart';
 import 'package:devtools_app/src/framework/release_notes/release_notes.dart';
 import 'package:devtools_app/src/shared/primitives/simple_items.dart';
+import 'package:devtools_test/devtools_integration_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-import 'test_utils.dart';
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();

--- a/packages/devtools_app/integration_test/test/app_test.dart
+++ b/packages/devtools_app/integration_test/test/app_test.dart
@@ -12,7 +12,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 
-
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 

--- a/packages/devtools_app/integration_test/test/app_test.dart
+++ b/packages/devtools_app/integration_test/test/app_test.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/src/app.dart';
 import 'package:devtools_app/src/framework/landing_screen.dart';
 import 'package:devtools_app/src/framework/release_notes/release_notes.dart';
 import 'package:devtools_app/src/shared/primitives/simple_items.dart';

--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(polinach): consider reusing CheckboxSettings from shared/common_widgets
+// and then this hide can be removed.
+export 'src/app.dart' hide CheckboxSetting;
 export 'src/extension_points/extensions_base.dart';
 export 'src/extension_points/extensions_external.dart';
 export 'src/framework/notifications_view.dart';

--- a/packages/devtools_test/lib/devtools_integration_test.dart
+++ b/packages/devtools_test/lib/devtools_integration_test.dart
@@ -1,0 +1,5 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+export 'src/integration_test/integration_test_utils.dart';

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -4,8 +4,8 @@
 
 import 'dart:convert';
 
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/main.dart' as app;
-import 'package:devtools_app/src/app.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -42,3 +42,5 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.3.3
+  integration_test:
+    sdk: flutter


### PR DESCRIPTION
Test libraries under integration_test/test/ cannot import any libraries outside of their immediate directory or children directories (e.g. any import containing '../'. Move shared code to devtools_test allows for these libraries to be imported across the integration_test folder. 

There is only one lib right now, but there will be more in the future.

RELEASE_NOTE_EXCEPTION=testing change