### PR TITLE
Preliminary support for record types when vm_service <10.0.0

### DIFF
--- a/packages/devtools_app/lib/src/shared/object_tree.dart
+++ b/packages/devtools_app/lib/src/shared/object_tree.dart
@@ -783,15 +783,24 @@ List<DartObjectNode> _createVariablesForFields(
 }) {
   final variables = <DartObjectNode>[];
   for (var field in instance.fields!) {
-    final name = field.decl!.name;
-    if (existingNames != null && existingNames.contains(name)) continue;
-    variables.add(
-      DartObjectNode.fromValue(
-        name: name,
-        value: field.value,
-        isolateRef: isolateRef,
-      ),
-    );
+    final name = field.decl?.name;
+    if (name == null) {
+      variables.add(
+        DartObjectNode.fromValue(
+          value: field.value,
+          isolateRef: isolateRef,
+        ),
+      );
+    } else {
+      if (existingNames != null && existingNames.contains(name)) continue;
+      variables.add(
+        DartObjectNode.fromValue(
+          name: name,
+          value: field.value,
+          isolateRef: isolateRef,
+        ),
+      );
+    }
   }
   return variables;
 }
@@ -1026,6 +1035,9 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
       if (kind == InstanceKind.kStackTrace) {
         final depth = children.length;
         valueStr = 'StackTrace ($depth ${pluralize('frame', depth)})';
+      } else if (kind == 'Record') {
+        // TODO(elliette): Compare against InstanceKind.kRecord when vm_service >= 10.0.0.
+        valueStr = 'Record';
       } else if (value.valueAsString == null) {
         valueStr = value.classRef?.name ?? '';
       } else {


### PR DESCRIPTION
From what I can tell, we don't yet have access to the field names for records when `vm_service` is <10.0.0. This adds preliminary support for records by simply displaying the values without names. 

Inspecting the following shows:

`var record = (1, a: "Hello there", 3, b: 4, true);`

![Screenshot 2023-01-10 at 4 24 43 PM](https://user-images.githubusercontent.com/21270878/211690060-c5828522-395e-48a8-a2ee-bc0af3558fd8.png)

RELEASE_NOTE_EXCEPTION='Record types not fully supported yet, will update release notes once they are'
