### PR TITLE
Modify build script to build DevTools from release mode.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.20.1
+* Prepare a hotfix release that builds DevTools in release mode instead of profile mode.
+
 ## 2.20.0
 * Prepare for 2.20.0 release [#4843](https://github.com/flutter/devtools/pull/4843)
 * Turn off all rebuild related UI when the flag is off [#4840](https://github.com/flutter/devtools/pull/4840)

--- a/tool/README.md
+++ b/tool/README.md
@@ -130,7 +130,15 @@ to add release notes to Flutter website
    ```shell
    cd $LOCAL_DART_SDK && \
    git rebase-update && \
-   third_party/devtools/update.sh $TARGET_COMMIT_HASH;
+   third_party/devtools/update.sh $TARGET_COMMIT_HASH [optional --no-update-flutter];
+   ```
+For cherry pick releases that need to be built from a specific version of Flutter,
+checkout the Flutter version on your local flutter repo (the Flutter SDK that
+`which flutter` points to). Then when you run the `update.sh` command, include the
+`--no-update-flutter` flag:
+
+   ```shell
+   third_party/devtools/update.sh $TARGET_COMMIT_HASH --no-update-flutter
    ```
 
 ### Update the DevTools hash in the Dart SDK

--- a/tool/build_e2e.dart
+++ b/tool/build_e2e.dart
@@ -6,9 +6,15 @@ import 'dart:io';
 
 const argDevToolsBuild = 'devtools-build';
 const argUpdatePerfetto = '--update-perfetto';
+const argNoUpdateFlutter = '--no-update-flutter';
 
 void main(List<String> args) async {
   final shouldUpdatePerfetto = args.contains(argUpdatePerfetto);
+  final noUpdateFlutter = args.contains(argNoUpdateFlutter);
+
+  final argsCopy = List.of(args)
+    ..remove(argUpdatePerfetto)
+    ..remove(argNoUpdateFlutter);
 
   final mainDevToolsDirectory = Directory.current;
   if (!mainDevToolsDirectory.path.endsWith('/devtools')) {
@@ -28,6 +34,7 @@ void main(List<String> args) async {
     './tool/build_release.sh',
     [
       if (shouldUpdatePerfetto) argUpdatePerfetto,
+      if (noUpdateFlutter) argNoUpdateFlutter,
     ],
     workingDirectory: mainDevToolsDirectory.path,
   );
@@ -60,7 +67,7 @@ void main(List<String> args) async {
       // Pass any args that were provided to our script along. This allows IDEs
       // to pass `--machine` (etc.) so that this script can behave the same as
       // the "dart devtools" command for testing local DevTools/server changes.
-      ...args,
+      ...argsCopy,
     ],
     workingDirectory: localDartSdkLocation,
   );

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -15,17 +15,27 @@ DEVTOOLS_DIR="${TOOL_DIR}/.."
 
 pushd $TOOL_DIR
 
-# Use the Flutter SDK from flutter-sdk/.
-FLUTTER_DIR="`pwd`/flutter-sdk"
-PATH="$FLUTTER_DIR/bin":$PATH
+if [[ $1 = "--no-update-flutter" ]]
+then
+  # Use the Flutter SDK that is already on the user's PATH.
+  FLUTTER_EXE=`which flutter`
+  echo "Using the Flutter SDK that is already on PATH: $FLUTTER_EXE"
+else
+  # Use the Flutter SDK from flutter-sdk/.
+  FLUTTER_DIR="`pwd`/flutter-sdk"
+  PATH="$FLUTTER_DIR/bin":$PATH
 
-# Make sure the flutter sdk is on the correct branch.
-./update_flutter_sdk.sh
+  # Make sure the flutter sdk is on the correct branch.
+  ./update_flutter_sdk.sh
+fi
 
 popd
 
 # echo on
 set -ex
+
+which flutter
+flutter --version
 
 if [[ $1 = "--update-perfetto" ]]; then
   $TOOL_DIR/update_perfetto.sh
@@ -44,7 +54,7 @@ flutter pub get
 
 flutter build web \
   --pwa-strategy=none \
-  --profile \
+  --release \
   --dart-define=FLUTTER_WEB_USE_SKIA=true \
   --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ \
   --no-tree-shake-icons

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -34,8 +34,8 @@ popd
 # echo on
 set -ex
 
-which flutter
-flutter --version
+echo "Flutter Path: $(which flutter)"
+echo "Flutter Version: $(flutter --version)"
 
 if [[ $1 = "--update-perfetto" ]]; then
   $TOOL_DIR/update_perfetto.sh


### PR DESCRIPTION
This PR backfills the changes that were added to tag 2.20.1 for the hotfix release. Diff here: https://github.com/flutter/devtools/compare/v2.20.0...v2.20.1

We do not update the version here because the current version of DevTools is already beyond 2.20.1.

RELEASE_NOTE_EXCEPTION=[tool changes only]