### PR TITLE
Fix integration test timeout and retry logic

### DIFF
--- a/packages/devtools_app/integration_test/test_infra/_run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/_run_test.dart
@@ -106,7 +106,7 @@ class TestRunner with IOMixin {
   static const _endExceptionMarker = '===========================';
   static const _errorMarker = ': Error: ';
   static const _unhandledExceptionMarker = 'Unhandled exception:';
-  static const _retriesOnTimeout = 1;
+  static const _maxRetriesOnTimeout = 1;
 
   Future<void> run(
     String testTarget, {
@@ -181,7 +181,7 @@ class TestRunner with IOMixin {
       );
 
       bool testTimedOut = false;
-      final timeout = Future.delayed(const Duration(minutes: 6)).then((_) {
+      final timeout = Future.delayed(const Duration(minutes: 8)).then((_) {
         testTimedOut = true;
       });
 
@@ -194,7 +194,7 @@ class TestRunner with IOMixin {
       _debugLog('flutter drive process has exited');
 
       if (testTimedOut) {
-        if (attemptNumber < _retriesOnTimeout) {
+        if (attemptNumber >= _maxRetriesOnTimeout) {
           throw Exception(
             'Integration test timed out on try #$attemptNumber: $testTarget',
           );


### PR DESCRIPTION
fixes a logic error and increases the timeout by 2 minutes to reduce flakiness.

RELEASE_NOTE_EXCEPTION=testing change