### PR TITLE
Stop duplicating events in Performance exports

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
@@ -1,0 +1,84 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/framework/release_notes/release_notes.dart';
+import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
+import 'package:devtools_app/src/shared/primitives/simple_items.dart';
+import 'package:devtools_test/devtools_integration_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late TestApp testApp;
+
+  setUpAll(() {
+    testApp = TestApp.fromEnvironment();
+    expect(testApp.vmServiceUri, isNotNull);
+  });
+
+  testWidgets('refreshing the timeline does not duplicate recorded events',
+      (tester) async {
+    await pumpDevTools(tester);
+    await connectToTestApp(tester, testApp);
+
+    // If the release notes viewer is open, close it.
+    final releaseNotesView =
+        tester.widget<ReleaseNotes>(find.byType(ReleaseNotes));
+    if (releaseNotesView.releaseNotesController.releaseNotesVisible.value) {
+      final closeReleaseNotesButton = find.descendant(
+        of: find.byType(ReleaseNotes),
+        matching: find.byType(IconButton),
+      );
+      expect(closeReleaseNotesButton, findsOneWidget);
+      await tester.tap(closeReleaseNotesButton);
+    }
+
+    logStatus(
+      'Open the Performance screen and switch to the Timeline Events tab',
+    );
+    await tester.tap(
+      find.widgetWithText(Tab, ScreenMetaData.performance.title),
+    );
+    await tester.pump(longPumpDuration);
+    await tester.tap(find.widgetWithText(InkWell, 'Timeline Events'));
+    await tester.pumpAndSettle(longPumpDuration);
+
+    // Find the [PerformanceController] to access its data.
+    final performanceScreenFinder = find.byType(PerformanceScreenBody);
+    expect(performanceScreenFinder, findsOneWidget);
+    final screenState =
+        tester.state<PerformanceScreenBodyState>(performanceScreenFinder);
+    final performanceController = screenState.controller;
+    final initialEventsRecorded =
+        List.of(performanceController.data!.traceEvents, growable: false);
+
+    logStatus('toggling the Performance Overlay to trigger new Flutter frames');
+    final performanceOverlayFinder = find.text('Performance Overlay');
+    expect(performanceOverlayFinder, findsOneWidget);
+    await tester.tap(performanceOverlayFinder);
+    await tester.pump(safePumpDuration);
+
+    logStatus('Refreshing the timeline to load new events');
+    await tester.tap(find.byType(RefreshTimelineEventsButton));
+    await tester.pump(longPumpDuration);
+
+    logStatus('Verifying that we have not recorded duplicate events');
+    final newEventsRecorded = performanceController.data!.traceEvents
+        .sublist(initialEventsRecorded.length);
+    for (final newEvent in newEventsRecorded) {
+      final eventDuplicated = initialEventsRecorded.containsWhere(
+        (event) => collectionEquals(event, newEvent),
+      );
+      expect(
+        eventDuplicated,
+        isFalse,
+        reason: 'Duplicate event recorded: $newEvent',
+      );
+    }
+  });
+}

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_event_processor.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_event_processor.dart
@@ -145,7 +145,9 @@ abstract class BaseTraceEventProcessor {
         //
         debugTraceEventCallback(
           () => log(
-            'Duplicate duration end event - skipping processing: $eventJson',
+            'Duplicate duration end event - skipping processing.\n'
+            'Current event: $eventJson\n'
+            'Previous event: ${_previousDurationEndEvents[eventThreadId]?.json}',
           ),
         );
         return;
@@ -233,7 +235,10 @@ abstract class BaseTraceEventProcessor {
 
           // Do not return early. Now that the tree is rebalanced, we can
           // continue processing [event].
-          assert(current != null && event.name != current.name);
+          assert(
+            current != null && event.name != current.name,
+            'Current: ${current?.name}, Event: ${event.name}',
+          );
         }
       } else {
         // The current event node has fallen into an unrecoverable state. Reset

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -7,6 +7,9 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../../../shared/analytics/analytics.dart' as ga;
+import '../../../../shared/analytics/constants.dart' as gac;
+import '../../../../shared/analytics/metrics.dart';
 import '../../../../shared/config_specific/logger/logger.dart';
 import '../../../../shared/feature_flags.dart';
 import '../../../../shared/future_work_tracker.dart';
@@ -100,6 +103,9 @@ class TimelineEventsController extends PerformanceFeatureController
   static const _timelinePollingInterval = Duration(seconds: 1);
 
   RateLimiter? _timelinePollingRateLimiter;
+
+  /// The tracking index for the first unprocessed trace event collected.
+  int _nextTraceIndexToProcess = 0;
 
   /// The collection of [TimelineEvent]s that should be linked to
   /// [FlutterFrame]s but have not yet been assigned.
@@ -264,7 +270,38 @@ class TimelineEventsController extends PerformanceFeatureController
 
   Future<void> _processAllTraceEvents() async {
     if (_perfettoMode) {
-      await perfettoController.processor.processData(allTraceEvents);
+      final traceEventCount = allTraceEvents.length;
+      debugTraceEventCallback(
+        () => log(
+          'processing traceEvents at startIndex '
+          '$_nextTraceIndexToProcess',
+        ),
+      );
+      final processingTraceCount = traceEventCount - _nextTraceIndexToProcess;
+      Future<void> processTraceEventsHelper() async {
+        await perfettoController.processor.processData(
+          allTraceEvents,
+          startIndex: _nextTraceIndexToProcess,
+        );
+        debugTraceEventCallback(
+          () => log(
+            'after processing traceEvents at startIndex $_nextTraceIndexToProcess, '
+            'and now _nextTraceIndexToProcess = $traceEventCount',
+          ),
+        );
+        _nextTraceIndexToProcess = traceEventCount;
+      }
+
+      // Process trace events [processTraceEventsHelper] and time the operation
+      // for analytics.
+      await ga.timeAsync(
+        gac.performance,
+        gac.perfettoModeTraceEventProcessingTime,
+        asyncOperation: processTraceEventsHelper,
+        screenMetricsProvider: () => PerformanceScreenMetrics(
+          traceEventCount: processingTraceCount,
+        ),
+      );
       await perfettoController.loadTrace(allTraceEvents);
     } else {
       await legacyController.processTraceEvents(
@@ -527,6 +564,7 @@ class TimelineEventsController extends PerformanceFeatureController
   @override
   Future<void> clearData() async {
     allTraceEvents.clear();
+    _nextTraceIndexToProcess = 0;
     _unassignedFlutterFrameEvents.clear();
 
     threadNamesById.clear();

--- a/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../../shared/primitives/trace_event.dart';
 import '../../shared/primitives/utils.dart';
 import 'performance_model.dart';
 
@@ -85,3 +86,9 @@ void debugTraceEventCallback(VoidCallback callback) {
 }
 
 const preCompileShadersDocsUrl = 'https://docs.flutter.dev/perf/shader';
+
+extension TraceEventExtension on TraceEvent {
+  bool get isThreadNameEvent =>
+      phase == TraceEvent.metadataEventPhase &&
+      name == TraceEvent.threadNameEvent;
+}

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -60,7 +60,8 @@ const performanceOverlay = 'performanceOverlay';
 const performanceOverlayDocs = 'performanceOverlayDocs';
 const timelineFlameChartHelp = 'timelineFlameChartHelp';
 const selectFlutterFrame = 'selectFlutterFrame';
-const perfettoModeTraceEventProcessingTime = 'traceEventProcessingTime-perfettoMode';
+const perfettoModeTraceEventProcessingTime =
+    'traceEventProcessingTime-perfettoMode';
 const traceEventProcessingTime = 'traceEventProcessingTime';
 const trackRebuilds = 'trackRebuilds';
 const trackWidgetBuildsDocs = 'trackWidgetBuildsDocs';

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -60,6 +60,7 @@ const performanceOverlay = 'performanceOverlay';
 const performanceOverlayDocs = 'performanceOverlayDocs';
 const timelineFlameChartHelp = 'timelineFlameChartHelp';
 const selectFlutterFrame = 'selectFlutterFrame';
+const perfettoModeTraceEventProcessingTime = 'traceEventProcessingTime-perfettoMode';
 const traceEventProcessingTime = 'traceEventProcessingTime';
 const trackRebuilds = 'trackRebuilds';
 const trackWidgetBuildsDocs = 'trackWidgetBuildsDocs';

--- a/packages/devtools_app/lib/src/shared/primitives/trace_event.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/trace_event.dart
@@ -43,6 +43,9 @@ class TraceEvent {
 
   static const frameNumberArg = 'frame_number';
 
+  /// Event name for thread name metadata events.
+  static const threadNameEvent = 'thread_name';
+
   /// The original event JSON.
   final Map<String, Object?> json;
 

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1138,6 +1138,17 @@ extension ListExtension<T> on List<T> {
   }
 }
 
+extension SetExtension<T> on Set<T> {
+  bool containsWhere(bool test(T element)) {
+    for (var e in this) {
+      if (test(e)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
 extension UiListExtension<T> on List<T> {
   int get numSpacers => max(0, length - 1);
 }

--- a/packages/devtools_app/test/primitives/utils_test.dart
+++ b/packages/devtools_app/test/primitives/utils_test.dart
@@ -1149,6 +1149,29 @@ void main() {
       });
     });
 
+    group('SetExtension', () {
+      test('containsWhere', () {
+        final set = {1, 2, 3, 4};
+        expect(set.containsWhere((element) => element == 1), isTrue);
+        expect(set.containsWhere((element) => element == 5), isFalse);
+        expect(set.containsWhere((element) => element + 2 == 3), isTrue);
+
+        final otherSet = {'hi', 'hey', 'foo', 'bar'};
+        expect(
+          otherSet.containsWhere((element) => element.contains('h')),
+          isTrue,
+        );
+        expect(
+          otherSet.containsWhere((element) => element.startsWith('ba')),
+          isTrue,
+        );
+        expect(
+          otherSet.containsWhere((element) => element.endsWith('ba')),
+          isFalse,
+        );
+      });
+    });
+
     group('ListValueNotifier', () {
       late ListValueNotifier<int> notifier;
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5122

RELEASE_NOTE_EXCEPTION=feature behind a flag

We were processing all events each time the refresh button was selected. Upon refresh, we do not need to re-process everything we've already processed, but instead we just need to process the new events since the last time we processed the timeline. This fixes the issue and records analytics for how long the processing operation took