### PR TITLE
Tweak instructions for running with server, remove obsolete VS Code server debugging

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,11 +88,11 @@ To enable all experiments by default when you are running with VS Code, add the 
 ## Development (DevTools server + DevTools Flutter web app)
 
 To develop with a workflow that exercises the DevTools server <==> DevTools client connection,
-change to the `packages/devtools` directory, and run:
+from the main devtools/ directory run:
 
 ```
-flutter pub get
-dart bin/devtools.dart --debug
+export LOCAL_DART_SDK=/path/to/dart-sdk
+dart ./tool/build_e2e.dart
 ```
 
 That will:
@@ -157,21 +157,6 @@ using the VS Code tasks without having to run in a terminal window:
 This will serve the application in the background and launch Google Chrome. Subsequent
 launches will just re-launch the browser since the task remains running in the background
 and rebuilding as necessary.
-
-### DevTools Server
-
-Run and debug the local version of the server with a release build:
-- In VS Code on the Debug side bar, switch to the `Run Server with Release Build` config. Press F5.
-This will produce a release build of DevTools and then debug the server (`bin/devtools.dart`)
-to serve it.
-- From CLI, you can run the publish script to create a release build (`./devtools/tool/publish.sh`).
-Then `cd packages/devtools` and run `dart bin/devtools.dart`.
-
-If you need to make breaking changes to DevTools that require changes to the server
-(such that DevTools cannot run against the live Pub version of devtools_server) it's
-critical that the devtools_server is released first and the version numbers in
-`packages/devtools/pubspec.yaml` and `packages/devtools_app/pubspec.yaml` are updated.
- Please make sure this is clear on any PRs you open.
 
 ## Automated Testing
 


### PR DESCRIPTION
Some tweaks left over from https://github.com/flutter/devtools/pull/4356, and also remove the section about debugging the server code from VS Code, since that launch configuration is no longer available.

RELEASE_NOTE_EXCEPTION=documentation change

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
