### PR TITLE
Catch circular import on presubmit.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/heap.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/heap.dart
@@ -2,9 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import '../../../../../devtools_app.dart';
 import '../../../../shared/memory/adapted_heap_data.dart';
 import '../../../../shared/memory/class_name.dart';
+import '../../../../shared/primitives/utils.dart';
 import 'class_filter.dart';
 import 'model.dart';
 import 'spanning_tree.dart';

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -102,8 +102,8 @@ if [ "$BOT" = "main" ]; then
     if [[ ! -z "$WRONG_IMPORTS" ]] ; then
         echo $WRONG_IMPORTS
         echo "Avoid importing the root devtools_app library from src/"
-        exit 2;
-    fi
+        exit 1;
+    fi;
 
 elif [ "$BOT" = "build_ddc" ]; then
 

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -98,6 +98,11 @@ if [ "$BOT" = "main" ]; then
     pushd packages/devtools_app
     echo `pwd`
 
+    if [! grep -nr "/devtools_app.dart';" lib/src]; then
+        echo "Avoid importing the root devtools_app library from src/"
+        exit 1;
+    fi
+
 elif [ "$BOT" = "build_ddc" ]; then
 
     # TODO(https://github.com/flutter/flutter/issues/43538): Remove workaround.

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -98,7 +98,9 @@ if [ "$BOT" = "main" ]; then
     pushd packages/devtools_app
     echo `pwd`
 
-    if [! grep -nr "/devtools_app.dart';" lib/src]; then
+    WRONG_IMPORTS=$(grep -nr "/devtools_app.dart';" lib/src)
+    if [[ ! -z "$WRONG_IMPORTS" ]] ; then
+        echo $WRONG_IMPORTS
         echo "Avoid importing the root devtools_app library from src/"
         exit 1;
     fi

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -102,7 +102,7 @@ if [ "$BOT" = "main" ]; then
     if [[ ! -z "$WRONG_IMPORTS" ]] ; then
         echo $WRONG_IMPORTS
         echo "Avoid importing the root devtools_app library from src/"
-        exit 1;
+        exit 2;
     fi
 
 elif [ "$BOT" = "build_ddc" ]; then

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -102,8 +102,8 @@ if [ "$BOT" = "main" ]; then
     if [[ ! -z "$WRONG_IMPORTS" ]] ; then
         echo $WRONG_IMPORTS
         echo "Avoid importing the root devtools_app library from src/"
-        exit 1;
-    fi;
+        exit 1
+    fi
 
 elif [ "$BOT" = "build_ddc" ]; then
 

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -98,6 +98,8 @@ if [ "$BOT" = "main" ]; then
     pushd packages/devtools_app
     echo `pwd`
 
+    grep -nr "/devtools_app.dart';" lib/src
+
     WRONG_IMPORTS=$(grep -nr "/devtools_app.dart';" lib/src)
     if [[ ! -z "$WRONG_IMPORTS" ]] ; then
         echo $WRONG_IMPORTS


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=[not customer facing]

Output will look like this:
```
lib/src/screens/memory/shared/heap/heap.dart:5:import '../../../../../devtools_app.dart';
Avoid importing the root devtools_app library from src/
```
