### PR TITLE
Fix build release script

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -52,10 +52,14 @@ flutter pub get
 # as code size doesn't matter very much for us as minification makes some
 # crashes harder to debug. For example, https://github.com/flutter/devtools/issues/2125
 
+# TODO(https://github.com/flutter/devtools/issues/5148): remove the FLUTTER_WEB_CANVASKIT_URL
+# flag and set `canvasKitBaseUrl` in `initializeEngine` instead.
+# See https://docs.flutter.dev/development/platform-integration/web/initialization.
+
 flutter build web \
+  --web-renderer canvaskit \
   --pwa-strategy=none \
   --release \
-  --dart-define=FLUTTER_WEB_USE_SKIA=true \
   --dart-define=FLUTTER_WEB_CANVASKIT_URL=canvaskit/ \
   --no-tree-shake-icons
 
@@ -66,6 +70,5 @@ mv build/web/devtools_service_worker.js build/web/service_worker.js
 
 # Ensure permissions are set correctly on canvaskit binaries.
 chmod 0755 build/web/canvaskit/canvaskit.*
-chmod 0755 build/web/canvaskit/profiling/canvaskit.*
 
 popd


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=tool change only

Addresses part of https://github.com/flutter/devtools/issues/5148. The todo to remove the FLUTTER_WEB_CANVASKIT_URL flag will be addressed in a later PR. The profiling copy of canvas kit was removed a few days ago, so the chmod line fails.