### PR TITLE
Tighten `vm_service` constraint in `devtools_app` to disallow major version 12

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -57,7 +57,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^6.1.0
   url_launcher_web: ^2.0.6
-  vm_service: ">=10.1.0 <12.0.0"
+  vm_service: ^10.1.0
   vm_snapshot_analysis: ^0.7.1
   web_socket_channel: ^2.1.0
   # widget_icons: ^0.0.1


### PR DESCRIPTION
`devtools_app` needs a tighter constraint than `devtools_shared` while https://github.com/flutter/devtools/pull/5127 is being worked on.

RELEASE_NOTE_EXCEPTION="No user-facing changes."