### PR TITLE
Fix the perfetto asset path when DevTools is served via --observe

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -11,6 +11,7 @@ import 'package:flutter/foundation.dart';
 import '../../../../../shared/globals.dart';
 import '../../../../../shared/primitives/trace_event.dart';
 import '../../../../../shared/primitives/utils.dart';
+import '../../../performance_utils.dart';
 import 'perfetto_controller.dart';
 
 /// Flag to enable embedding an instance of the Perfetto UI running on
@@ -64,8 +65,12 @@ class PerfettoControllerImpl extends PerfettoController {
     if (_debugUseLocalPerfetto) {
       return _debugPerfettoUrl;
     }
+    final assetsPath = assetUrlHelper(
+      origin: html.window.location.origin,
+      path: html.window.location.pathname ?? '',
+    );
     final baseUrl = isExternalBuild
-        ? '${html.window.location.origin}/assets/packages/perfetto_compiled/dist/index.html'
+        ? '$assetsPath/assets/packages/perfetto_compiled/dist/index.html'
         : 'https://ui.perfetto.dev';
     return '$baseUrl$_embeddedModeQuery';
   }

--- a/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
@@ -94,12 +94,12 @@ extension TraceEventExtension on TraceEvent {
 }
 
 /// Returns the url (as a string) where the DevTools assets are served.
-/// 
+///
 /// For Flutter apps and when DevTools is served via the `dart devtools`
 /// command, this url should be equivalent to [html.window.location.origin].
 /// However, when DevTools is served directly from DDS via the --observe flag,
 /// the authentication token and 'devtools/' path part are also required.
-/// 
+///
 /// Examples:
 /// * 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools/performance'
 ///     ==> 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'

--- a/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
@@ -92,3 +92,23 @@ extension TraceEventExtension on TraceEvent {
       phase == TraceEvent.metadataEventPhase &&
       name == TraceEvent.threadNameEvent;
 }
+
+/// Returns the url (as a string) where the DevTools assets are served.
+/// 
+/// For Flutter apps and when DevTools is served via the `dart devtools`
+/// command, this url should be equivalent to [html.window.location.origin].
+/// However, when DevTools is served directly from DDS via the --observe flag,
+/// the authentication token and 'devtools/' path part are also required.
+/// 
+/// Examples:
+/// * 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools/performance'
+///     ==> 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'
+/// * 'http://127.0.0.1:61962/performance' ==> 'http://127.0.0.1:61962'
+String assetUrlHelper({required String origin, required String path}) {
+  const separator = '/';
+  final pathParts = path.split(separator);
+  // The last path part is the DevTools page (e.g. 'performance' or 'snapshot'),
+  // which is not part of the hosted asset path.
+  pathParts.removeLast();
+  return '$origin${pathParts.join(separator)}';
+}

--- a/packages/devtools_app/test/performance/performance_utils_test.dart
+++ b/packages/devtools_app/test/performance/performance_utils_test.dart
@@ -108,5 +108,23 @@ void main() {
         equals(-1),
       );
     });
+
+    test('assetUrlHelper', () {
+      // This is how a DevTools url will be structured when DevTools is served
+      // directly from DDS using the `--observe` flag.
+      expect(
+        assetUrlHelper(
+          origin: 'http://127.0.0.1:61962',
+          path: '/mb9Sw4gCYvU=/devtools/performance',
+        ),
+        equals('http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'),
+      );
+      // This is how a DevTools url will be structured when served from DevTools
+      // server (e.g. from Flutter tools and from the `dart devtools` command).
+      expect(
+        assetUrlHelper(origin: 'http://127.0.0.1:61962', path: '/performance'),
+        equals('http://127.0.0.1:61962'),
+      );
+    });
   });
 }


### PR DESCRIPTION
 RELEASE_NOTE_EXCEPTION=fixes an unreleased bug