### PR TITLE
Fix analyzer regression introduced in latest flutter candidate

### DIFF
--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -44,8 +44,8 @@ class DevToolsAboutDialog extends StatelessWidget {
             ],
           ),
           const SizedBox(height: denseSpacing),
-          Wrap(
-            children: const [
+          const Wrap(
+            children: [
               Text('Encountered an issue? Let us know at '),
               _FeedbackLink(),
               Text('.'),
@@ -53,15 +53,15 @@ class DevToolsAboutDialog extends StatelessWidget {
           ),
           const SizedBox(height: defaultSpacing),
           ...dialogSubHeader(theme, 'Contributing'),
-          Wrap(
-            children: const [
+          const Wrap(
+            children: [
               Text('Want to contribute to DevTools? Please see our '),
               _ContributingLink(),
               Text(' guide, or '),
             ],
           ),
-          Wrap(
-            children: const [
+          const Wrap(
+            children: [
               Text('connect with us on '),
               _DiscordLink(),
               Text('.'),


### PR DESCRIPTION
![](https://media.giphy.com/media/3o7TKwZpRoFKTdb0Pe/giphy-downsized.gif)
new flutter candidate breaks this test. Fixing it here
RELEASE_NOTE_EXCEPTION=internal only