### PR TITLE
Separate method _addChildrenToInstanceVariable.

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
@@ -264,92 +264,106 @@ Future<void> _addInstanceRefItems(
         index: 0,
       );
     }
-    switch (result.kind) {
-      case InstanceKind.kMap:
-        variable.addAllChildren(
-          createVariablesForAssociations(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kList:
-        variable.addAllChildren(
-          createVariablesForElements(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kRecord:
-        variable.addAllChildren(
-          createVariablesForRecords(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kUint8ClampedList:
-      case InstanceKind.kUint8List:
-      case InstanceKind.kUint16List:
-      case InstanceKind.kUint32List:
-      case InstanceKind.kUint64List:
-      case InstanceKind.kInt8List:
-      case InstanceKind.kInt16List:
-      case InstanceKind.kInt32List:
-      case InstanceKind.kInt64List:
-      case InstanceKind.kFloat32List:
-      case InstanceKind.kFloat64List:
-      case InstanceKind.kInt32x4List:
-      case InstanceKind.kFloat32x4List:
-      case InstanceKind.kFloat64x2List:
-        variable.addAllChildren(
-          createVariablesForBytes(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kRegExp:
-        variable.addAllChildren(
-          createVariablesForRegExp(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kClosure:
-        variable.addAllChildren(
-          createVariablesForClosure(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kReceivePort:
-        variable.addAllChildren(
-          createVariablesForReceivePort(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kType:
-        variable.addAllChildren(
-          createVariablesForType(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kTypeParameter:
-        variable.addAllChildren(
-          createVariablesForTypeParameters(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kFunctionType:
-        variable.addAllChildren(
-          createVariablesForFunctionType(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kWeakProperty:
-        variable.addAllChildren(
-          createVariablesForWeakProperty(result, isolateRef),
-        );
-        break;
-      case InstanceKind.kStackTrace:
-        variable.addAllChildren(
-          createVariablesForStackTrace(result, isolateRef),
-        );
-        break;
-      default:
-        break;
-    }
-    if (result.fields != null && result.kind != InstanceKind.kRecord) {
+    await _addChildrenToInstanceVariable(
+      variable,
+      result,
+      isolateRef,
+      existingNames,
+    );
+  }
+}
+
+Future<void> _addChildrenToInstanceVariable(
+  DartObjectNode variable,
+  Instance value,
+  IsolateRef? isolateRef,
+  Set<String>? existingNames,
+) async {
+  switch (value.kind) {
+    case InstanceKind.kMap:
       variable.addAllChildren(
-        createVariablesForFields(
-          result,
-          isolateRef,
-          existingNames: existingNames,
-        ),
+        createVariablesForAssociations(value, isolateRef),
       );
-    }
+      break;
+    case InstanceKind.kList:
+      variable.addAllChildren(
+        createVariablesForElements(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kRecord:
+      variable.addAllChildren(
+        createVariablesForRecords(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kUint8ClampedList:
+    case InstanceKind.kUint8List:
+    case InstanceKind.kUint16List:
+    case InstanceKind.kUint32List:
+    case InstanceKind.kUint64List:
+    case InstanceKind.kInt8List:
+    case InstanceKind.kInt16List:
+    case InstanceKind.kInt32List:
+    case InstanceKind.kInt64List:
+    case InstanceKind.kFloat32List:
+    case InstanceKind.kFloat64List:
+    case InstanceKind.kInt32x4List:
+    case InstanceKind.kFloat32x4List:
+    case InstanceKind.kFloat64x2List:
+      variable.addAllChildren(
+        createVariablesForBytes(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kRegExp:
+      variable.addAllChildren(
+        createVariablesForRegExp(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kClosure:
+      variable.addAllChildren(
+        createVariablesForClosure(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kReceivePort:
+      variable.addAllChildren(
+        createVariablesForReceivePort(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kType:
+      variable.addAllChildren(
+        createVariablesForType(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kTypeParameter:
+      variable.addAllChildren(
+        createVariablesForTypeParameters(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kFunctionType:
+      variable.addAllChildren(
+        createVariablesForFunctionType(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kWeakProperty:
+      variable.addAllChildren(
+        createVariablesForWeakProperty(value, isolateRef),
+      );
+      break;
+    case InstanceKind.kStackTrace:
+      variable.addAllChildren(
+        createVariablesForStackTrace(value, isolateRef),
+      );
+      break;
+    default:
+      break;
+  }
+  if (value.fields != null && value.kind != InstanceKind.kRecord) {
+    variable.addAllChildren(
+      createVariablesForFields(
+        value,
+        isolateRef,
+        existingNames: existingNames,
+      ),
+    );
   }
 }
 


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=[refactoring]

We need this separation to reuse method for outbound live references.
No functional changes.