### PR TITLE
Add navigation support to the object inspector

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -624,7 +624,9 @@ List<DevToolsScreen> get defaultScreens {
     ),
     DevToolsScreen<VMDeveloperToolsController>(
       VMDeveloperToolsScreen(),
-      createController: (_) => VMDeveloperToolsController(),
+      createController: (routerDelegate) => VMDeveloperToolsController(
+        routerDelegate: routerDelegate,
+      ),
     ),
     // Show the sample DevTools screen.
     if (debugEnableSampleScreen && (kDebugMode || kProfileMode))

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -35,7 +37,9 @@ class ClassHierarchyExplorer extends StatelessWidget {
           controller.classHierarchyController.selectedIsolateClassHierarchy,
       dataDisplayProvider: (node, onPressed) => VmServiceObjectLink<Class>(
         object: node.cls,
-        onTap: controller.findAndSelectNodeForObject,
+        onTap: (cls) => unawaited(
+          controller.findAndSelectNodeForObject(context, cls),
+        ),
       ),
       onItemSelected: (_) => null,
       emptyTreeViewBuilder: () => const CenteredCircularProgressIndicator(),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
@@ -8,6 +8,7 @@ import 'package:vm_service/vm_service.dart';
 import '../../../shared/common_widgets.dart';
 import '../../../shared/history_viewport.dart';
 import '../../../shared/primitives/history_manager.dart';
+import '../../../shared/routing.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_class_display.dart';
 import 'vm_code_display.dart';
@@ -36,6 +37,14 @@ class ObjectViewport extends StatelessWidget {
         ToolbarRefresh(onPressed: controller.refreshObject),
       ],
       generateTitle: viewportTitle,
+      // We disable history for the viewport as the browser history will
+      // correctly update the contents of the viewport and having separate
+      // history navigation controls will make it difficult to keep state
+      // properly synchronized.
+      //
+      // We should revisit this if we eventually decide to ship on desktop or
+      // some platform that doesn't have built-in router navigation history.
+      historyEnabled: false,
       contentBuilder: (context, _) {
         return ValueListenableBuilder<bool>(
           valueListenable: controller.refreshing,

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
@@ -208,7 +208,7 @@ class DisplayProvider extends StatelessWidget {
             },
             onTap: (object) async {
               if (object is ObjRef) {
-                await controller.findAndSelectNodeForObject(object);
+                await controller.findAndSelectNodeForObject(context, object);
               }
             },
           )

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -96,7 +96,7 @@ MapEntry<String, WidgetBuilder>
       textBuilder: textBuilder,
       preferUri: preferUri,
       onTap: (object) async {
-        await controller.findAndSelectNodeForObject(object);
+        await controller.findAndSelectNodeForObject(context, object);
       },
     ),
   );
@@ -424,7 +424,7 @@ class RetainingPathWidget extends StatelessWidget {
   ) {
     final onTap = (ObjRef? obj) async {
       if (obj == null) return;
-      await controller.findAndSelectNodeForObject(obj);
+      await controller.findAndSelectNodeForObject(context, obj);
     };
     final theme = Theme.of(context);
     final emptyList = SelectableText(

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_controller.dart
@@ -4,14 +4,22 @@
 
 import 'package:flutter/foundation.dart';
 
+import '../../shared/routing.dart';
 import 'object_inspector/object_inspector_view_controller.dart';
 import 'vm_developer_tools_screen.dart';
 
 class VMDeveloperToolsController {
   VMDeveloperToolsController({
+    DevToolsRouterDelegate? routerDelegate,
     ObjectInspectorViewController? objectInspectorViewController,
   }) : objectInspectorViewController =
-            objectInspectorViewController ?? ObjectInspectorViewController();
+            objectInspectorViewController ?? ObjectInspectorViewController() {
+    if (routerDelegate != null) {
+      this
+          .objectInspectorViewController
+          .subscribeToRouterEvents(routerDelegate);
+    }
+  }
 
   ValueListenable<int> get selectedIndex => _selectedIndex;
   final _selectedIndex = ValueNotifier<int>(0);

--- a/packages/devtools_app/lib/src/shared/primitives/history_manager.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/history_manager.dart
@@ -56,6 +56,11 @@ class HistoryManager<T> {
   /// Returns null if there is no next value.
   T? peekNext() => hasNext ? _history[_historyIndex + 1] : null;
 
+  /// Return the previous value.
+  ///
+  /// Returns null if there is no previous value.
+  T? peekPrevious() => hasPrevious ? _history[_historyIndex - 1] : null;
+
   /// Remove the most recent historical item on the stack.
   ///
   /// If [current] is the last item on the stack when this method is called,

--- a/packages/devtools_test/lib/src/mocks/fake_object_inspector_view_controller.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_object_inspector_view_controller.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vm_service/vm_service.dart';
 
@@ -12,5 +13,6 @@ class FakeObjectInspectorViewController extends Fake
   final classHierarchyController = ClassHierarchyExplorerController();
 
   @override
-  Future<void> findAndSelectNodeForObject(ObjRef obj) async {}
+  Future<void> findAndSelectNodeForObject(
+      BuildContext context, ObjRef obj) async {}
 }


### PR DESCRIPTION
Allows for navigating back/forward using the browser's back/forward buttons.

This change also updates DevToolsRouterDelegate to keep track of its own navigation history, allowing for history navigation for non-browser targets in the future.

RELEASE_NOTE_EXCEPTION=VM developer mode feature