### PR TITLE
Add support for inspecting `ObjectPool`s in the Object Inspector

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/material.dart';
-import 'package:vm_service/vm_service.dart';
 
 import '../../../shared/common_widgets.dart';
 import '../../../shared/tree.dart';

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/class_hierarchy_explorer.dart
@@ -33,7 +33,7 @@ class ClassHierarchyExplorer extends StatelessWidget {
     return TreeView<ClassHierarchyNode>(
       dataRootsListenable:
           controller.classHierarchyController.selectedIsolateClassHierarchy,
-      dataDisplayProvider: (node, onPressed) => VmServiceObjectLink<Class>(
+      dataDisplayProvider: (node, onPressed) => VmServiceObjectLink(
         object: node.cls,
         onTap: controller.findAndSelectNodeForObject,
       ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
@@ -10,6 +10,7 @@ import '../../../shared/globals.dart';
 import '../../../shared/primitives/auto_dispose.dart';
 import '../../debugger/codeview_controller.dart';
 import '../../debugger/program_explorer_controller.dart';
+import '../vm_service_private_extensions.dart';
 import 'class_hierarchy_explorer_controller.dart';
 import 'object_store_controller.dart';
 import 'object_viewport.dart';
@@ -163,6 +164,10 @@ class ObjectInspectorViewController extends DisposableController
       );
     } else if (objRef is CodeRef) {
       object = CodeObject(
+        ref: objRef,
+      );
+    } else if (objRef.isObjectPool) {
+      object = ObjectPoolObject(
         ref: objRef,
       );
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
@@ -16,6 +16,7 @@ import 'vm_function_display.dart';
 import 'vm_instance_display.dart';
 import 'vm_library_display.dart';
 import 'vm_object_model.dart';
+import 'vm_object_pool_display.dart';
 import 'vm_script_display.dart';
 
 /// Displays the VM information for the currently selected object in the
@@ -69,7 +70,7 @@ class ObjectViewport extends StatelessWidget {
       return 'Instance of ${instance.classRef!.name}';
     }
 
-    return '${object.obj.type} ${object.name ?? '<name>'}';
+    return '${object.obj.type} ${object.name ?? ''}';
   }
 
   /// Calls the object VM statistics card builder according to the VM Object type.
@@ -117,6 +118,12 @@ class ObjectViewport extends StatelessWidget {
         code: obj,
       );
     }
+    if (obj is ObjectPoolObject) {
+      return VmObjectPoolDisplay(
+        controller: controller,
+        objectPool: obj,
+      );
+    }
     return const SizedBox.shrink();
   }
 }
@@ -127,7 +134,7 @@ String viewportTitle(VmObject? object) {
     return 'No object selected.';
   }
 
-  return '${object.obj.type} ${object.name ?? '<name>'}';
+  return '${object.obj.type} ${object.name ?? ''}';
 }
 
 /// Manages the history of selected ObjRefs to make them accessible on a

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
@@ -71,7 +71,7 @@ class ObjectViewport extends StatelessWidget {
       return 'Instance of ${instance.classRef!.name}';
     }
 
-    return '${object.obj.type} ${object.name ?? ''}';
+    return '${object.obj.type} ${object.name ?? ''}'.trim();
   }
 
   /// Calls the object VM statistics card builder according to the VM Object type.
@@ -141,7 +141,7 @@ String viewportTitle(VmObject? object) {
     return 'No object selected.';
   }
 
-  return '${object.obj.type} ${object.name ?? ''}';
+  return '${object.obj.type} ${object.name ?? ''}'.trim();
 }
 
 /// Manages the history of selected ObjRefs to make them accessible on a

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
@@ -10,6 +10,7 @@ import '../../../shared/primitives/utils.dart';
 import '../../../shared/table/table.dart';
 import '../../../shared/table/table_data.dart';
 import '../../../shared/theme.dart';
+import '../vm_developer_common_widgets.dart';
 import '../vm_service_private_extensions.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
@@ -157,67 +158,27 @@ class _InstructionColumn extends _CodeColumnData
   }
 }
 
-class _DartObjectColumn extends _CodeColumnData {
-  _DartObjectColumn() : super.wide('Object');
+class _DartObjectColumn extends _CodeColumnData
+    implements ColumnRenderer<Instruction> {
+  _DartObjectColumn({required this.controller}) : super.wide('Object');
+
+  final ObjectInspectorViewController controller;
 
   @override
-  String getValue(Instruction dataObject) =>
-      _objectToDisplayValue(dataObject.object);
+  ObjRef? getValue(Instruction inst) => inst.object;
 
-  // TODO(bkonyi): verify this covers all cases.
-  String _objectToDisplayValue(Object? object) {
-    if (object is InstanceRef) {
-      final instance = object;
-      switch (instance.kind!) {
-        case InstanceKind.kNull:
-          return 'null';
-        case InstanceKind.kBool:
-          return instance.valueAsString!;
-        case InstanceKind.kList:
-          return 'List(${instance.length})';
-        case InstanceKind.kString:
-          return '"${instance.valueAsString}"';
-        case InstanceKind.kPlainInstance:
-          return 'TODO(PlainInstance)';
-        case InstanceKind.kClosure:
-          return instance.closureFunction!.name!;
-      }
-    }
-
-    if (object is FuncRef) {
-      final func = object;
-      return '${func.owner.name}.${func.name!}';
-    }
-
-    if (object is CodeRef) {
-      final code = object;
-      return code.name!;
-    }
-
-    if (object is FieldRef) {
-      final field = object;
-      return '${field.declaredType!.name} ${field.name}';
-    }
-
-    if (object is TypeArgumentsRef) {
-      final typeArgsRef = object;
-      return 'TypeArguments(${typeArgsRef.name!})';
-    }
-
-    // Note: this check should be last as [ObjRef] is a super type to most
-    // other types in package:vm_service.
-    if (object is ObjRef) {
-      final objRef = object;
-      if (objRef.isICData) {
-        final icData = objRef.asICData;
-        return 'ICData (${icData.selector})';
-      }
-      if (objRef.vmType != null) {
-        return objRef.vmType!;
-      }
-    }
-
-    return object?.toString() ?? '';
+  @override
+  Widget? build(
+    BuildContext context,
+    Instruction data, {
+    bool isRowSelected = false,
+    VoidCallback? onPressed,
+  }) {
+    if (data.object == null) return Container();
+    return VmServiceObjectLink<ObjRef>(
+      object: data.object!,
+      onTap: controller.findAndSelectNodeForObject,
+    );
   }
 }
 
@@ -234,7 +195,10 @@ class VmCodeDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CodeTable(code: code);
+    return CodeTable(
+      code: code,
+      controller: controller,
+    );
   }
 }
 
@@ -242,18 +206,20 @@ class CodeTable extends StatelessWidget {
   CodeTable({
     Key? key,
     required this.code,
+    required this.controller,
   }) : super(key: key);
 
-  final columns = <ColumnData<Instruction>>[
+  late final columns = <ColumnData<Instruction>>[
     _AddressColumn(),
     _InstructionColumn(),
-    _DartObjectColumn(),
+    _DartObjectColumn(controller: controller),
     if (profilerTicksEnabled) ...[
       _ProfileTicksColumn('Inclusive'),
       _ProfileTicksColumn('Exclusive'),
     ],
   ];
 
+  final ObjectInspectorViewController controller;
   final CodeObject code;
 
   @override

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
@@ -197,7 +197,6 @@ class VmCodeDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    print(code.obj.json!.keys.toList());
     return Split(
       initialFractions: const [0.4, 0.6],
       axis: Axis.vertical,

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
@@ -6,7 +6,9 @@ import 'package:flutter/material.dart';
 import 'package:string_scanner/string_scanner.dart';
 import 'package:vm_service/vm_service.dart';
 
+import '../../../shared/common_widgets.dart';
 import '../../../shared/primitives/utils.dart';
+import '../../../shared/split.dart';
 import '../../../shared/table/table.dart';
 import '../../../shared/table/table_data.dart';
 import '../../../shared/theme.dart';
@@ -195,10 +197,51 @@ class VmCodeDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return CodeTable(
-      code: code,
-      controller: controller,
+    print(code.obj.json!.keys.toList());
+    return Split(
+      initialFractions: const [0.4, 0.6],
+      axis: Axis.vertical,
+      children: [
+        OutlineDecoration.onlyBottom(
+          child: VmObjectDisplayBasicLayout(
+            controller: controller,
+            object: code,
+            generalDataRows: vmObjectGeneralDataRows(controller, code),
+            sideCardTitle: 'Code Details',
+            sideCardDataRows: _codeDetailRows(code),
+          ),
+        ),
+        OutlineDecoration.onlyTop(
+          child: CodeTable(
+            code: code,
+            controller: controller,
+          ),
+        ),
+      ],
     );
+  }
+
+  /// Returns a list of key-value pairs (map entries)
+  /// containing detailed information of a VM Func object [function].
+  List<MapEntry<String, Widget Function(BuildContext)>> _codeDetailRows(
+    CodeObject code,
+  ) {
+    return [
+      selectableTextBuilderMapEntry(
+        'Kind',
+        code.obj.kind,
+      ),
+      serviceObjectLinkBuilderMapEntry(
+        controller: controller,
+        key: 'Function',
+        object: code.obj.function!,
+      ),
+      serviceObjectLinkBuilderMapEntry(
+        controller: controller,
+        key: 'Object Pool',
+        object: code.obj.objectPool,
+      ),
+    ];
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_instance_display.dart
@@ -198,7 +198,7 @@ class DisplayProvider extends StatelessWidget {
         ),
         if (variable.ref!.value is! Sentinel)
           VmServiceObjectLink(
-            object: variable.ref!.value,
+            object: variable.ref!.value as ObjRef,
             textBuilder: (object) {
               if (object is InstanceRef &&
                   object.kind == InstanceKind.kString) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_model.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_model.dart
@@ -266,3 +266,16 @@ class CodeObject extends VmObject {
   @override
   String? get name => obj.name;
 }
+
+class ObjectPoolObject extends VmObject {
+  ObjectPoolObject({required super.ref, super.scriptRef});
+
+  @override
+  ObjectPool get obj => _obj.asObjectPool;
+
+  @override
+  SourceLocation? get _sourceLocation => null;
+
+  @override
+  String? get name => null;
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_model.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_model.dart
@@ -277,7 +277,7 @@ class ObjectPoolObject extends VmObject {
 
   @override
   String? get name => null;
-  
+
   @override
   SourceLocation? get _sourceLocation => null;
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -67,12 +67,11 @@ class _DartObjectColumn extends _ObjectPoolColumnData
   }) {
     if (data.value is int) return Text(data.value.toString());
     return VmServiceObjectLink<Response>(
-      object: data.value as Response,
-      onTap: (e) {
-        if (e is! ObjRef) return;
-        unawaited(controller.findAndSelectNodeForObject(e));
-      }
-    );
+        object: data.value as Response,
+        onTap: (e) {
+          if (e is! ObjRef) return;
+          unawaited(controller.findAndSelectNodeForObject(e));
+        });
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -1,4 +1,4 @@
-// Copyright 2022 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
@@ -64,6 +64,8 @@ class _DartObjectColumn extends _ObjectPoolColumnData
     return VmServiceObjectLink<Response>(
       object: data.value as Response,
       onTap: (e) {
+        // TODO(bkonyi): add support for non-object responses (e.g., Sentinels)
+        // See https://github.com/flutter/devtools/issues/5241
         if (e is! ObjRef) return;
         unawaited(controller.findAndSelectNodeForObject(e));
       },
@@ -72,7 +74,7 @@ class _DartObjectColumn extends _ObjectPoolColumnData
 }
 
 /// A widget for the object inspector historyViewport displaying information
-/// related to [Code] objects in the Dart VM.
+/// related to [ObjectPool] objects in the Dart VM.
 class VmObjectPoolDisplay extends StatelessWidget {
   const VmObjectPoolDisplay({
     required this.controller,

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -1,0 +1,143 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:string_scanner/string_scanner.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../../shared/common_widgets.dart';
+import '../../../shared/primitives/utils.dart';
+import '../../../shared/split.dart';
+import '../../../shared/table/table.dart';
+import '../../../shared/table/table_data.dart';
+import '../../../shared/theme.dart';
+import '../vm_developer_common_widgets.dart';
+import '../vm_service_private_extensions.dart';
+import 'object_inspector_view_controller.dart';
+import 'vm_object_model.dart';
+
+// TODO(bkonyi): remove once profile ticks are populated for instructions.
+const profilerTicksEnabled = false;
+
+abstract class _ObjectPoolColumnData extends ColumnData<ObjectPoolEntry> {
+  _ObjectPoolColumnData(super.title, {required super.fixedWidthPx});
+  _ObjectPoolColumnData.wide(super.title) : super.wide();
+
+  @override
+  bool get supportsSorting => false;
+}
+
+class _AddressColumn extends _ObjectPoolColumnData {
+  _AddressColumn()
+      : super(
+          'Offset',
+          fixedWidthPx: 160,
+        );
+
+  @override
+  int getValue(ObjectPoolEntry dataObject) {
+    return dataObject.offset;
+  }
+
+  @override
+  String getDisplayValue(ObjectPoolEntry dataObject) {
+    final value = getValue(dataObject);
+    return '[PP + 0x${value.toRadixString(16).toUpperCase()}]';
+  }
+}
+
+class _DartObjectColumn extends _ObjectPoolColumnData
+    implements ColumnRenderer<ObjectPoolEntry> {
+  _DartObjectColumn({required this.controller}) : super.wide('Object');
+
+  final ObjectInspectorViewController controller;
+
+  @override
+  Object getValue(ObjectPoolEntry entry) => entry.value;
+
+  @override
+  Widget? build(
+    BuildContext context,
+    ObjectPoolEntry data, {
+    bool isRowSelected = false,
+    VoidCallback? onPressed,
+  }) {
+    if (data.value is int) return Text(data.value.toString());
+    return VmServiceObjectLink<Response>(
+      object: data.value as Response,
+      onTap: (e) {
+        if (e is! ObjRef) return;
+        unawaited(controller.findAndSelectNodeForObject(e));
+      }
+    );
+  }
+}
+
+/// A widget for the object inspector historyViewport displaying information
+/// related to [Code] objects in the Dart VM.
+class VmObjectPoolDisplay extends StatelessWidget {
+  const VmObjectPoolDisplay({
+    required this.controller,
+    required this.objectPool,
+  });
+
+  final ObjectInspectorViewController controller;
+  final ObjectPoolObject objectPool;
+
+  @override
+  Widget build(BuildContext context) {
+    return Split(
+      initialFractions: const [0.4, 0.6],
+      axis: Axis.vertical,
+      children: [
+        OutlineDecoration.onlyBottom(
+          child: VmObjectDisplayBasicLayout(
+            controller: controller,
+            object: objectPool,
+            generalDataRows: vmObjectGeneralDataRows(controller, objectPool),
+          ),
+        ),
+        OutlineDecoration.onlyTop(
+          child: ObjectPoolTable(
+            objectPool: objectPool,
+            controller: controller,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class ObjectPoolTable extends StatelessWidget {
+  ObjectPoolTable({
+    Key? key,
+    required this.objectPool,
+    required this.controller,
+  }) : super(key: key);
+
+  late final columns = <ColumnData<ObjectPoolEntry>>[
+    _AddressColumn(),
+    _DartObjectColumn(controller: controller),
+  ];
+
+  final ObjectInspectorViewController controller;
+  final ObjectPoolObject objectPool;
+
+  @override
+  Widget build(BuildContext context) {
+    return FlatTable<ObjectPoolEntry>(
+      data: objectPool.obj.entries,
+      dataKey: 'vm-code-display',
+      keyFactory: (entry) => Key(entry.offset.toString()),
+      columnGroups: [
+        ColumnGroup(title: 'Entries', range: const Range(0, 2)),
+      ],
+      columns: columns,
+      defaultSortColumn: columns[0],
+      defaultSortDirection: SortDirection.ascending,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:string_scanner/string_scanner.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../../shared/common_widgets.dart';
@@ -13,14 +12,10 @@ import '../../../shared/primitives/utils.dart';
 import '../../../shared/split.dart';
 import '../../../shared/table/table.dart';
 import '../../../shared/table/table_data.dart';
-import '../../../shared/theme.dart';
 import '../vm_developer_common_widgets.dart';
 import '../vm_service_private_extensions.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
-
-// TODO(bkonyi): remove once profile ticks are populated for instructions.
-const profilerTicksEnabled = false;
 
 abstract class _ObjectPoolColumnData extends ColumnData<ObjectPoolEntry> {
   _ObjectPoolColumnData(super.title, {required super.fixedWidthPx});
@@ -67,11 +62,12 @@ class _DartObjectColumn extends _ObjectPoolColumnData
   }) {
     if (data.value is int) return Text(data.value.toString());
     return VmServiceObjectLink<Response>(
-        object: data.value as Response,
-        onTap: (e) {
-          if (e is! ObjRef) return;
-          unawaited(controller.findAndSelectNodeForObject(e));
-        });
+      object: data.value as Response,
+      onTap: (e) {
+        if (e is! ObjRef) return;
+        unawaited(controller.findAndSelectNodeForObject(e));
+      },
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -805,7 +805,7 @@ class VmServiceObjectLink<T extends Response?> extends StatelessWidget {
     } else if (object is Sentinel) {
       final sentinel = object;
       text = 'Sentinel ${sentinel.valueAsString!}';
-    } else if (object != null && object is Obj && object.isICData) {
+    } else if (object != null && object is ObjRef && object.isICData) {
       final icData = object.asICData;
       text = 'ICData(${icData.selector})';
     } else if (object != null && object is ObjRef && object.isObjectPool) {

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -691,7 +691,7 @@ class InboundReferencesWidget extends StatelessWidget {
   }
 }
 
-class VmServiceObjectLink<T extends ObjRef?> extends StatelessWidget {
+class VmServiceObjectLink<T extends Response?> extends StatelessWidget {
   const VmServiceObjectLink({
     required this.object,
     required this.onTap,
@@ -765,10 +765,13 @@ class VmServiceObjectLink<T extends ObjRef?> extends StatelessWidget {
         text = typeArgs.name!;
       } else if (object is Sentinel) {
         final sentinel = object as Sentinel;
-        text = sentinel.valueAsString!;
-      } else if (object?.isICData ?? false) {
-        final icData = object!.asICData;
+        text = 'Sentinel ${sentinel.valueAsString!}';
+      } else if (object is Obj? && ((object as Obj?)?.isICData ?? false)) {
+        final icData = (object as Obj).asICData;
         text = 'ICData(${icData.selector})';
+      } else if (object is ObjRef? && ((object as ObjRef?)?.isObjectPool ?? false)) {
+        final objectPool = (object as ObjRef).asObjectPool;
+        text = 'Object Pool(length: ${objectPool.length})';
       } else {
         isServiceObject = false;
         text = object.toString();
@@ -795,15 +798,20 @@ class VmServiceObjectLink<T extends ObjRef?> extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return SelectableText.rich(
-      style: theme.linkTextStyle.apply(
-        fontFamily: theme.fixedFontStyle.fontFamily,
-        overflow: TextOverflow.ellipsis,
-      ),
-      maxLines: 1,
-      buildTextSpan(context),
-    );
+    try {
+      final theme = Theme.of(context);
+      return SelectableText.rich(
+        style: theme.linkTextStyle.apply(
+          fontFamily: theme.fixedFontStyle.fontFamily,
+          overflow: TextOverflow.ellipsis,
+        ),
+        maxLines: 1,
+        buildTextSpan(context),
+      );
+    } catch (e, st) {
+      print("ERROR: $e\n$st");
+    }
+    return Container();
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -808,9 +808,7 @@ class VmServiceObjectLink<T extends Response?> extends StatelessWidget {
     } else if (object != null && object is Obj && object.isICData) {
       final icData = object.asICData;
       text = 'ICData(${icData.selector})';
-    } else if (object != null &&
-        object is ObjRef &&
-        object.isObjectPool) {
+    } else if (object != null && object is ObjRef && object.isObjectPool) {
       final objectPool = object.asObjectPool;
       text = 'Object Pool(length: ${objectPool.length})';
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -821,7 +821,7 @@ class VmServiceObjectLink<T extends Response?> extends StatelessWidget {
     String? text = textBuilder?.call(object);
     bool isServiceObject = true;
     if (text == null) {
-      text = defaultTextBuilder(object);
+      text = defaultTextBuilder(object, preferUri: preferUri);
       if (text == null) {
         isServiceObject = false;
         text = object.toString();

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -691,7 +691,7 @@ class InboundReferencesWidget extends StatelessWidget {
   }
 }
 
-class VmServiceObjectLink<T> extends StatelessWidget {
+class VmServiceObjectLink<T extends ObjRef?> extends StatelessWidget {
   const VmServiceObjectLink({
     required this.object,
     required this.onTap,
@@ -766,6 +766,9 @@ class VmServiceObjectLink<T> extends StatelessWidget {
       } else if (object is Sentinel) {
         final sentinel = object as Sentinel;
         text = sentinel.valueAsString!;
+      } else if (object?.isICData ?? false) {
+        final icData = object!.asICData;
+        text = 'ICData(${icData.selector})';
       } else {
         isServiceObject = false;
         text = object.toString();

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -818,14 +818,12 @@ class VmServiceObjectLink<T extends Response?> extends StatelessWidget {
   TextSpan buildTextSpan(BuildContext context) {
     final theme = Theme.of(context);
 
-    String? text = textBuilder?.call(object);
+    String? text = textBuilder?.call(object) ??
+        defaultTextBuilder(object, preferUri: preferUri);
     bool isServiceObject = true;
     if (text == null) {
-      text = defaultTextBuilder(object, preferUri: preferUri);
-      if (text == null) {
-        isServiceObject = false;
-        text = object.toString();
-      }
+      isServiceObject = false;
+      text = object.toString();
     }
 
     final TextStyle style;

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -411,7 +411,7 @@ extension CodeRefPrivateViewExtension on CodeRef {
 
   /// Returns the function from which this code object was generated.
   FuncRef? get function {
-    final functionJson = json![_functionKey] as Map<String, dynamic>;
+    final functionJson = json![_functionKey] as Map<String, dynamic>?;
     return FuncRef.parse(functionJson);
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -167,7 +167,6 @@ extension ObjRefPrivateViewExtension on ObjRef {
   /// `true` if this object is an instance of [ICDataRef].
   bool get isICData => vmType == _icDataType;
 
-
   /// Casts the current [ObjRef] into an instance of [ICDataRef].
   ICDataRef get asICData => ICDataRef.parse(json!)!;
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -465,12 +465,11 @@ class ObjectPool extends ObjectPoolRef implements Obj {
     required super.id,
     required this.entries,
     required super.length,
-  }) : super();
+  });
 
   static const _entriesKey = '_entries';
 
   static ObjectPool parse(Map<String, dynamic> json) {
-    print(json.keys.toList());
     return ObjectPool(
       json: json,
       id: json[ObjectPoolRef._idKey],

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -4,11 +4,8 @@
 
 import 'dart:math';
 
-import 'package:devtools_app/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/vm_code_display.dart';
-import 'package:devtools_app/src/screens/vm_developer/vm_service_private_extensions.dart';
-import 'package:devtools_app/src/shared/config_specific/ide_theme/ide_theme.dart';
-import 'package:devtools_app/src/shared/globals.dart';
 import 'package:devtools_app/src/shared/table/table.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -34,7 +31,13 @@ void main() {
         kind: 'Dart',
         name: 'testFuncCode',
       );
-      testCode.json = {};
+      testCode.json = {
+        'function': testFunction.toJson(),
+        '_objectPool': {
+          'id': 'pool-id',
+          'length': 0,
+        }
+      };
       final offset = pow(2, 20) as int;
       testCode.disassembly = Disassembly.parse(<Object?>[
         for (int i = 0; i < 1000; ++i) ...[
@@ -47,6 +50,20 @@ void main() {
 
       when(mockCodeObject.obj).thenReturn(testCode);
       when(mockCodeObject.script).thenReturn(null);
+      when(mockCodeObject.retainingPath).thenReturn(
+        const FixedValueListenable<RetainingPath?>(null),
+      );
+      when(mockCodeObject.inboundReferences).thenReturn(
+        const FixedValueListenable<InboundReferences?>(null),
+      );
+      when(mockCodeObject.fetchingReachableSize).thenReturn(
+        const FixedValueListenable<bool>(false),
+      );
+      when(mockCodeObject.fetchingRetainedSize).thenReturn(
+        const FixedValueListenable<bool>(false),
+      );
+      when(mockCodeObject.retainedSize).thenReturn(null);
+      when(mockCodeObject.reachableSize).thenReturn(null);
     });
 
     void verifyAddressOrder(List<Instruction> data) {

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -46,6 +46,7 @@ void main() {
       ]);
 
       when(mockCodeObject.obj).thenReturn(testCode);
+      when(mockCodeObject.script).thenReturn(null);
     });
 
     void verifyAddressOrder(List<Instruction> data) {

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_object_pool_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_object_pool_display_test.dart
@@ -1,0 +1,120 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart';
+import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
+import 'package:devtools_test/devtools_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../vm_developer_test_utils.dart';
+
+void main() {
+  late MockObjectPoolObject mockObjectPool;
+
+  const windowSize = Size(4000.0, 4000.0);
+
+  group('VmObjectPoolDisplay', () {
+    setUp(() {
+      setUpMockScriptManager();
+      setGlobal(IdeTheme, IdeTheme());
+
+      mockObjectPool = MockObjectPoolObject();
+
+      final objectPoolEntries = <ObjectPoolEntry>[
+        ObjectPoolEntry(
+          offset: 0,
+          kind: ObjectPoolEntryKind.object,
+          value: InstanceRef(
+            id: 'fake-inst',
+            kind: InstanceKind.kList,
+            length: 0,
+          ),
+        ),
+        const ObjectPoolEntry(
+          offset: 10,
+          kind: ObjectPoolEntryKind.immediate,
+          value: 42,
+        ),
+        ObjectPoolEntry(
+          offset: 20,
+          kind: ObjectPoolEntryKind.nativeFunction,
+          value: FuncRef(id: 'func-id', name: 'Foo'),
+        ),
+      ];
+
+      final testPool = ObjectPool(
+        json: {
+          'size': 0,
+        },
+        id: 'object-pool-id',
+        entries: objectPoolEntries,
+        length: objectPoolEntries.length,
+      );
+      when(mockObjectPool.obj).thenReturn(testPool);
+      when(mockObjectPool.script).thenReturn(null);
+      when(mockObjectPool.retainingPath).thenReturn(
+        const FixedValueListenable<RetainingPath?>(null),
+      );
+      when(mockObjectPool.inboundReferences).thenReturn(
+        const FixedValueListenable<InboundReferences?>(null),
+      );
+      when(mockObjectPool.fetchingReachableSize).thenReturn(
+        const FixedValueListenable<bool>(false),
+      );
+      when(mockObjectPool.fetchingRetainedSize).thenReturn(
+        const FixedValueListenable<bool>(false),
+      );
+      when(mockObjectPool.retainedSize).thenReturn(null);
+      when(mockObjectPool.reachableSize).thenReturn(null);
+    });
+
+    testWidgetsWithWindowSize('displays object pool entries', windowSize,
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrap(
+          VmObjectPoolDisplay(
+            objectPool: mockObjectPool,
+            controller: ObjectInspectorViewController(),
+          ),
+        ),
+      );
+
+      expect(find.byType(VmObjectDisplayBasicLayout), findsOneWidget);
+      expect(find.byType(VMInfoCard), findsOneWidget);
+      expect(find.text('General Information'), findsOneWidget);
+      expect(find.text('ObjectPool'), findsOneWidget);
+      expect(find.text('Shallow Size:'), findsOneWidget);
+      expect(find.text('0 B'), findsOneWidget);
+      expect(find.text('Reachable Size:'), findsOneWidget);
+      expect(find.text('Retained Size:'), findsOneWidget);
+
+      expect(find.byType(RetainingPathWidget), findsOneWidget);
+      expect(find.byType(InboundReferencesWidget), findsOneWidget);
+
+      expect(find.byType(ObjectPoolTable), findsOneWidget);
+
+      for (final entry in mockObjectPool.obj.entries) {
+        // Includes the offset within the pool.
+        expect(
+          find.text(
+            '[PP + 0x${entry.offset.toRadixString(16).toUpperCase()}]',
+            findRichText: true,
+          ),
+          findsOneWidget,
+        );
+        expect(
+          find.text(
+            VmServiceObjectLink.defaultTextBuilder(entry.value) ??
+                entry.value.toString(),
+          ),
+          findsOneWidget,
+        );
+      }
+    });
+  });
+}

--- a/packages/devtools_test/lib/src/mocks/generated.dart
+++ b/packages/devtools_test/lib/src/mocks/generated.dart
@@ -36,6 +36,7 @@ import 'package:vm_service/vm_service.dart';
   FuncObject,
   ScriptObject,
   LibraryObject,
+  ObjectPoolObject,
   CodeViewController,
   BreakpointManager,
   EvalService,


### PR DESCRIPTION
Allows for VM developers to inspect the object pool associated with a code object. The object pool is a set of all Dart objects referenced by a Dart code object.

![image](https://user-images.githubusercontent.com/24210656/218508781-4ddd701c-ef76-45f2-89a6-df03aa89f692.png)

RELEASE_NOTE_EXCEPTION=VM developer mode functionality.