### PR TITLE
Handle a null value for `mainIsolateState` 

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -33,9 +33,10 @@ class _DebuggingControlsState extends State<DebuggingControls>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!initController()) return;
-    addAutoDisposeListener(
-      serviceManager.isolateManager.mainIsolateState!.isPaused,
-    );
+    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
+    if (mainIsolateState != null) {
+      addAutoDisposeListener(mainIsolateState.isPaused);
+    }
     addAutoDisposeListener(controller.resuming);
     addAutoDisposeListener(controller.stackFramesWithLocation);
   }

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -33,10 +33,9 @@ class _DebuggingControlsState extends State<DebuggingControls>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!initController()) return;
-    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
-    if (mainIsolateState != null) {
-      addAutoDisposeListener(mainIsolateState.isPaused);
-    }
+    addAutoDisposeListener(
+      serviceManager.isolateManager.mainIsolateState?.isPaused,
+    );
     addAutoDisposeListener(controller.resuming);
     addAutoDisposeListener(controller.stackFramesWithLocation);
   }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -399,15 +399,12 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
   }
 
   void _updateStatusOnPause() {
-    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
-    if (mainIsolateState != null) {
-      addAutoDisposeListener(
-        mainIsolateState.isPaused,
-        () => unawaited(
-          _updateStatus(),
-        ),
-      );
-    }
+    addAutoDisposeListener(
+      serviceManager.isolateManager.mainIsolateState?.isPaused,
+      () => unawaited(
+        _updateStatus(),
+      ),
+    );
   }
 
   @override
@@ -479,16 +476,14 @@ class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
     cancelListeners();
 
     controlHeight = _isPaused ? defaultButtonHeight : 0.0;
-    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
-    if (mainIsolateState != null) {
-      addAutoDisposeListener(mainIsolateState.isPaused, () {
-        setState(() {
-          if (_isPaused) {
-            controlHeight = defaultButtonHeight;
-          }
-        });
+    addAutoDisposeListener(
+        serviceManager.isolateManager.mainIsolateState?.isPaused, () {
+      setState(() {
+        if (_isPaused) {
+          controlHeight = defaultButtonHeight;
+        }
       });
-    }
+    });
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -479,14 +479,16 @@ class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
     cancelListeners();
 
     controlHeight = _isPaused ? defaultButtonHeight : 0.0;
-    addAutoDisposeListener(
-        serviceManager.isolateManager.mainIsolateState?.isPaused ?? false, () {
-      setState(() {
-        if (_isPaused) {
-          controlHeight = defaultButtonHeight;
-        }
+    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
+    if (mainIsolateState != null) {
+      addAutoDisposeListener(mainIsolateState.isPaused, () {
+        setState(() {
+          if (_isPaused) {
+            controlHeight = defaultButtonHeight;
+          }
+        });
       });
-    });
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -399,12 +399,15 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
   }
 
   void _updateStatusOnPause() {
-    addAutoDisposeListener(
-      serviceManager.isolateManager.mainIsolateState!.isPaused,
-      () => unawaited(
-        _updateStatus(),
-      ),
-    );
+    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
+    if (mainIsolateState != null) {
+      addAutoDisposeListener(
+        mainIsolateState.isPaused,
+        () => unawaited(
+          _updateStatus(),
+        ),
+      );
+    }
   }
 
   @override
@@ -477,7 +480,7 @@ class _FloatingDebuggerControlsState extends State<FloatingDebuggerControls>
 
     controlHeight = _isPaused ? defaultButtonHeight : 0.0;
     addAutoDisposeListener(
-        serviceManager.isolateManager.mainIsolateState!.isPaused, () {
+        serviceManager.isolateManager.mainIsolateState?.isPaused ?? false, () {
       setState(() {
         if (_isPaused) {
           controlHeight = defaultButtonHeight;

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -773,12 +773,14 @@ class _InspectorTreeState extends State<InspectorTree>
     }
     _focusNode = FocusNode(debugLabel: 'inspector-tree');
     autoDisposeFocusNode(_focusNode);
-
-    callOnceWhenReady(
-      trigger: serviceManager.isolateManager.mainIsolateState!.isPaused,
-      callback: _bindToController,
-      readyWhen: (triggerValue) => triggerValue == false,
-    );
+    final mainIsolateState = serviceManager.isolateManager.mainIsolateState;
+    if (mainIsolateState != null) {
+      callOnceWhenReady(
+        trigger: mainIsolateState.isPaused,
+        callback: _bindToController,
+        readyWhen: (triggerValue) => triggerValue == false,
+      );
+    }
   }
 
   @override

--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -540,7 +540,7 @@ class ServiceConnectionManager {
     if (uri == null) return false;
     assert(_serviceAvailable.isCompleted);
     assert(serviceManager.isolateManager.mainIsolate.value != null);
-    final isolate = isolateManager.mainIsolateState!.isolateNow;
+    final isolate = isolateManager.mainIsolateState?.isolateNow;
     return (isolate?.libraries ?? [])
         .map((ref) => ref.uri)
         .toList()

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -6,7 +6,7 @@ This is draft for future release notes, that are going to land on
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
-TODO: Remove this section if there are not any general updates.
+* Prevent crashes if there is no main isolate - [#5232](https://github.com/flutter/devtools/pull/5232)
 
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -16,7 +16,7 @@ final _pubspecs = [
   'packages/devtools_test/pubspec.yaml',
   'packages/devtools_shared/pubspec.yaml',
 ].map((path) => File(path)).toList();
-  
+
 const _releaseNoteDirPath = './packages/devtools_app/release_notes';
 
 void main(List<String> args) async {

--- a/tool/update_version.dart
+++ b/tool/update_version.dart
@@ -16,7 +16,6 @@ final _pubspecs = [
   'packages/devtools_test/pubspec.yaml',
   'packages/devtools_shared/pubspec.yaml',
 ].map((path) => File(path)).toList();
-
 const _releaseNoteDirPath = './packages/devtools_app/release_notes';
 
 void main(List<String> args) async {


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/5231 (doesn't fix underlying issue of `mainIsolateState` being `null`, but prevents a crash).
