### PR TITLE
Fix release note workflow error persisting after fix.

### DIFF
--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -2,7 +2,7 @@ name: Release Notes
 
 on:
   pull_request:
-    types: [ assigned, opened, synchronize, reopened, edited ]
+    types: [assigned, opened, synchronize, reopened, edited]
 env:
   CURRENT_RELEASE_FILE_PATH: packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
 jobs:
@@ -68,6 +68,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] && [ "$IS_DEPENDABOT_PR" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error file=$CURRENT_RELEASE_FILE_PATH,line=0,col=0,endColumn=0,title='Release Notes were not Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
+            echo "::error title='Release Notes were not Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
             exit 1
           fi

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -68,6 +68,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] && [ "$IS_DEPENDABOT_PR" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error title='Release Notes were not Modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
+            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
             exit 1
           fi


### PR DESCRIPTION
![](https://media.giphy.com/media/3IFCiGqnbzFcPM6UCD/giphy.gif)
Previously, if the release note requirements were not met, an error would show up in the NEXT_RELEASE_NOTES.md file.

Even after the release note requirements were met, this error would stick around. I think it may be a bug since that file is not part of the PR, it doesn't get updated.

This PR resolves that by instead making that error message general. It will no longer show up in the "Files changed" section at all.

RELEASE_NOTE_EXCEPTION=Internal Process Only
