### PR TITLE
Add github workflow to close stale issues

### DIFF
--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
           only-issue-labels: "waiting for customer response"
-          days-before-issue-stale: 30
+          days-before-issue-stale: 14
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -16,11 +16,11 @@ jobs:
         with:
           debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
           only-issue-labels: "waiting for customer response"
-          days-before-issue-stale: 14
+          days-before-issue-stale: -1
           days-before-issue-close: 14
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
-          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          close-issue-message: "Without additional information we're unfortunately not sure how to resolve this issue. We're going to close this issue for now, but please don't hesitate to comment on the issue if you have any more information for us; we're happy to reopen. Thanks for your contribution!"
           days-before-pr-stale: -1
           days-before-pr-close: -1
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -2,6 +2,7 @@ name: Close inactive issues
 on:
   schedule:
     - cron: "30 1 * * *"
+  workflow_dispatch: # Allows for manual triggering if needed
 jobs:
   close-issues:
     runs-on: ubuntu-latest

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -1,7 +1,7 @@
 name: Close inactive issues
 on:
   schedule:
-    - cron: "30 1 * * *"
+    - cron: "30 18 * * *" # 10:30am PT
   workflow_dispatch: # Allows for manual triggering if needed
 jobs:
   close-issues:

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -15,11 +15,11 @@ jobs:
       - uses: actions/stale@v7
         with:
           debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
+          stale-issue-label: "waiting for customer response"
           only-issue-labels: "waiting for customer response"
+          labels-to-remove-when-unstale: "waiting for customer response"
           days-before-issue-stale: -1
           days-before-issue-close: 14
-          stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           close-issue-message: "Without additional information we're unfortunately not sure how to resolve this issue. We're going to close this issue for now, but please don't hesitate to comment on the issue if you have any more information for us; we're happy to reopen. Thanks for your contribution!"
           days-before-pr-stale: -1
           days-before-pr-close: -1

--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -1,0 +1,25 @@
+name: Close inactive issues
+on:
+  schedule:
+    - cron: "30 1 * * *"
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      # See https://github.com/actions/stale for
+      # details on the parameters for this action
+      - uses: actions/stale@v7
+        with:
+          debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
+          only-issue-labels: "waiting for customer response"
+          days-before-issue-stale: 30
+          days-before-issue-close: 14
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          close-issue-message: "This issue was closed because it has been inactive for 14 days since being marked as stale."
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
![](https://media.giphy.com/media/7vB7L4biHndU2Svj5G/giphy-downsized.gif)

This workflow will mark issues as stale if a "waiting for response" issue has not had any activity in 14 days.
14 days after an issue becomes stale, it will then be closed if there is no activity on it.

NOTE: this is being pushed up in debug mode so it can first be tested. It will then be fully rolled out in a follow up PR.

RELEASE_NOTE_EXCEPTION=Internal process only

