### PR TITLE
Update internal issue workflow to ignore our comments

### DIFF
--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -15,6 +15,7 @@ jobs:
       - uses: actions/stale@v7
         with:
           debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
+          exempt-issue-assignees: "jacob314,kenzieschmoll,CoderDake,polina-c"
           stale-issue-label: "waiting for customer response"
           only-issue-labels: "waiting for customer response"
           labels-to-remove-when-unstale: "waiting for customer response"

--- a/.github/workflows/handle-inactive-issues.yaml
+++ b/.github/workflows/handle-inactive-issues.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/stale@v7
         with:
           debug-only: true # TODO: Delete this line when we are ready to implement this for our process.
-          exempt-issue-assignees: "jacob314,kenzieschmoll,CoderDake,polina-c"
+          exempt-issue-assignees: "jacob314,kenzieschmoll,CoderDake,polina-c,helin24,elliette"
           stale-issue-label: "waiting for customer response"
           only-issue-labels: "waiting for customer response"
           labels-to-remove-when-unstale: "waiting for customer response"

--- a/.github/workflows/handle-inactive-issues.yaml
+++ b/.github/workflows/handle-inactive-issues.yaml
@@ -1,4 +1,4 @@
-name: Close inactive issues
+name: Handle Inactive Issues
 on:
   schedule:
     - cron: "30 18 * * *" # 10:30am PT


### PR DESCRIPTION
![](https://media.giphy.com/media/xUPGcHBHN1PIYh7E2c/giphy.gif)

To ensure that our own comments don't remove the "waiting for customer response" label, I'm adding us to the exempt list.

RELEASE_NOTE_EXCEPTION=Internal process only
