### PR TITLE
Positional fields names for `Records` should begin at `$1` not `$0`

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
@@ -518,13 +518,16 @@ List<DartObjectNode> createVariablesForRecords(
   }
   // Sort positional fields in ascending order:
   _sortPositionalFields(positionalFields);
+  // Determine whether the VM service is indexing positional fields at 0 or 1,
+  // see https://github.com/dart-lang/sdk/issues/51451 for details:
+  final startsAtZero = _positionalFieldsStartAtZero(positionalFields);
   return [
     // Always show positional fields before named fields:
     for (final field in positionalFields)
       DartObjectNode.fromValue(
-        // Positional fields are designated by their getter syntax, eg $0, $1,
-        // $2, etc:
-        name: '\$${field.name}',
+        // Positional fields are designated by their getter syntax, eg $1, $2,
+        // $3, etc:
+        name: _positionalFieldName(field, startsAtZero: startsAtZero),
         value: field.value,
         isolateRef: isolateRef,
       ),
@@ -546,6 +549,18 @@ void _sortPositionalFields(List<BoundField> fields) {
     final name2 = field2.name as int;
     return name1.compareTo(name2);
   });
+}
+
+bool _positionalFieldsStartAtZero(List<BoundField> fields) {
+  if (fields.isEmpty) return false;
+  final firstFieldName = fields.first.name as int;
+  return firstFieldName == 0;
+}
+
+String _positionalFieldName(BoundField field, {required bool startsAtZero}) {
+  final name = field.name as int;
+  final fieldNum = startsAtZero ? name + 1 : name;
+  return '\$$fieldNum';
 }
 
 List<DartObjectNode> createVariablesForFields(

--- a/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
@@ -518,17 +518,14 @@ List<DartObjectNode> createVariablesForRecords(
   }
   // Sort positional fields in ascending order:
   _sortPositionalFields(positionalFields);
-  // Determine whether the VM service is indexing positional fields at 0 or 1,
-  // see https://github.com/dart-lang/sdk/issues/51451 for details:
-  final startsAtZero = _positionalFieldsStartAtZero(positionalFields);
   return [
     // Always show positional fields before named fields:
-    for (final field in positionalFields)
+    for (var i = 0; i < positionalFields.length; i++)
       DartObjectNode.fromValue(
         // Positional fields are designated by their getter syntax, eg $1, $2,
         // $3, etc:
-        name: _positionalFieldName(field, startsAtZero: startsAtZero),
-        value: field.value,
+        name: '\$${i + 1}',
+        value: positionalFields[i].value,
         isolateRef: isolateRef,
       ),
     for (final field in namedFields)
@@ -549,18 +546,6 @@ void _sortPositionalFields(List<BoundField> fields) {
     final name2 = field2.name as int;
     return name1.compareTo(name2);
   });
-}
-
-bool _positionalFieldsStartAtZero(List<BoundField> fields) {
-  if (fields.isEmpty) return false;
-  final firstFieldName = fields.first.name as int;
-  return firstFieldName == 0;
-}
-
-String _positionalFieldName(BoundField field, {required bool startsAtZero}) {
-  final name = field.name as int;
-  final fieldNum = startsAtZero ? name + 1 : name;
-  return '\$$fieldNum';
 }
 
 List<DartObjectNode> createVariablesForFields(

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -26,6 +26,7 @@ in deeply nested trees - [#5181](https://github.com/flutter/devtools/pull/5181)
 
 ## Debugger updates
 * Add support for browser navigation history when navigating using the `File Explorer` [#4906](https://github.com/flutter/devtools/pull/4906).
+* Designate positional fields for `Record` types with the getter syntax beginning at `$1` [#5272](https://github.com/flutter/devtools/pull/5272)
 
 ## Network profiler updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/test/debugger/records_variable_test.dart
+++ b/packages/devtools_app/test/debugger/records_variable_test.dart
@@ -92,8 +92,8 @@ void main() {
       await buildVariablesTree(recordVar);
 
       expect(recordVar.children, [
-        matchesVariable(name: '\$0', value: '12.34'),
-        matchesVariable(name: '\$1', value: 'true'),
+        matchesVariable(name: '\$1', value: '12.34'),
+        matchesVariable(name: '\$2', value: 'true'),
         matchesVariable(name: 'myNamedField', value: "'hello world'"),
       ]);
     },


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5264
