### PR TITLE
Release for 2.22.1

### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -7,4 +7,4 @@
 // that updates all versions for DevTools.
 // Note: a regexp in tools/update_version.dart matches the following line so
 // if you change it you must also modify tools/update_version.dart.
-const String version = '2.22.1-dev.0';
+const String version = '2.22.1';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.22.1-dev.0
+version: 2.22.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
@@ -25,7 +25,7 @@ dependencies:
   collection: ^1.15.0
   dds: ^2.7.2
   dds_service_extensions: ^1.3.2
-  devtools_shared: 2.22.1-dev.0
+  devtools_shared: 2.22.1
   file: ^6.0.0
   file_selector: ^0.8.0
   file_selector_linux: ^0.0.2
@@ -64,7 +64,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  devtools_test: 2.22.1-dev.0
+  devtools_test: 2.22.1
   fake_async: ^1.3.1
   flutter_test:
     sdk: flutter

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -51,7 +51,7 @@
        application. For more information, see:
        https://developers.google.com/web/fundamentals/primers/service-workers -->
   <script>
-    var version = '2.22.1-dev.0';
+    var version = '2.22.1';
     var scriptLoaded = false;
     function loadMainDartJs() {
       if (scriptLoaded) {

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app, dds, and other tools.
 
-version: 2.22.1-dev.0
+version: 2.22.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 2.22.1-dev.0
+version: 2.22.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
@@ -18,8 +18,8 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: 2.22.1-dev.0
-  devtools_app: 2.22.1-dev.0
+  devtools_shared: 2.22.1
+  devtools_app: 2.22.1
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
![](https://media.giphy.com/media/jri2Nz7VcnOKXMmeqb/giphy.gif)
For the 2.22.0 release I forgot to push a clean version  without the -dev suffix. So I'm doing this clean release, and will fast follow with another patch bump afterwards.

RELEASE_NOTE_EXCEPTION=Internal only
