### PR TITLE
Minor improvements.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/paths.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/paths.dart
@@ -30,7 +30,7 @@ class _RetainingPathColumn extends ColumnData<StatsByPathEntry> {
   bool get supportsSorting => true;
 
   @override
-  String getTooltip(StatsByPathEntry record) => record.key.toLongString();
+  String getTooltip(StatsByPathEntry record) => '';
 }
 
 class _InstanceColumn extends ColumnData<StatsByPathEntry> {

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
@@ -223,21 +223,21 @@ class ClassesTableDiff extends StatelessWidget {
   final ValueNotifier<DiffClassStats?> selection;
 
   static final _columnGroups = [
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: '',
       range: const Range(0, 1),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: 'Instances',
       range: const Range(1, 4),
       tooltip: nonGcableInstancesColumnTooltip,
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: 'Shallow Dart Size',
       range: const Range(4, 7),
       tooltip: shallowSizeColumnTooltip,
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: 'Retained Dart Size',
       range: const Range(7, 10),
       tooltip: retainedSizeColumnTooltip,

--- a/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
@@ -346,19 +346,19 @@ class _GCStatsTable extends StatelessWidget {
   }) : super(key: key);
 
   static final _columnGroup = [
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: '',
       range: const Range(0, 1),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.total.toString(),
       range: const Range(1, 5),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.newSpace.toString(),
       range: const Range(5, 9),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.oldSpace.toString(),
       range: const Range(9, 13),
     ),
@@ -478,19 +478,19 @@ class _AllocationProfileTable extends StatelessWidget {
 
   /// List of columns displayed in VM developer mode state.
   static final _vmModeColumnGroups = [
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: '',
       range: const Range(0, 1),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.total.toString(),
       range: const Range(1, 5),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.newSpace.toString(),
       range: const Range(5, 9),
     ),
-    ColumnGroup(
+    ColumnGroup.fromText(
       title: HeapGeneration.oldSpace.toString(),
       range: const Range(9, 13),
     ),

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
@@ -271,9 +271,12 @@ class CodeTable extends StatelessWidget {
       dataKey: 'vm-code-display',
       keyFactory: (instruction) => Key(instruction.address),
       columnGroups: [
-        ColumnGroup(title: 'Instructions', range: const Range(0, 3)),
+        ColumnGroup.fromText(title: 'Instructions', range: const Range(0, 3)),
         if (profilerTicksEnabled)
-          ColumnGroup(title: 'Profiler Ticks', range: const Range(4, 6)),
+          ColumnGroup.fromText(
+            title: 'Profiler Ticks',
+            range: const Range(4, 6),
+          ),
       ],
       columns: columns,
       defaultSortColumn: columns[0],

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -123,7 +123,7 @@ class ObjectPoolTable extends StatelessWidget {
       dataKey: 'vm-code-display',
       keyFactory: (entry) => Key(entry.offset.toString()),
       columnGroups: [
-        ColumnGroup(title: 'Entries', range: const Range(0, 2)),
+        ColumnGroup.fromText(title: 'Entries', range: const Range(0, 2)),
       ],
       columns: columns,
       defaultSortColumn: columns[0],

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -2002,7 +2002,7 @@ Widget maybeWrapWithTooltip({
   EdgeInsetsGeometry? tooltipPadding,
   required Widget child,
 }) {
-  if (tooltip != null) {
+  if (tooltip != null && tooltip.isNotEmpty) {
     return DevToolsTooltip(
       message: tooltip,
       padding: tooltipPadding,

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -1821,7 +1821,7 @@ class _ColumnGroupHeaderRow extends StatelessWidget {
           return Container(
             alignment: Alignment.center,
             width: groupWidth,
-            child: Text(group.title),
+            child: group.title,
           );
         },
       ),

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -131,12 +131,13 @@ mixin PinnableListEntry {
 class ColumnGroup {
   ColumnGroup({required this.title, required this.range, this.tooltip});
 
-  final String title;
+  ColumnGroup.fromText(
+      {required Sting title, required String? tooltip, required this.range});
+
+  final Widget title;
 
   /// The range of column indices for columns that make up this group.
   final Range range;
-
-  final String? tooltip;
 }
 
 extension ColumnDataExtension<T> on ColumnData<T> {

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 
+import '../common_widgets.dart';
 import '../primitives/trees.dart';
 import '../primitives/utils.dart';
 import '../theme.dart';
@@ -129,10 +130,16 @@ mixin PinnableListEntry {
 /// will be drawn between groups and an additional header row will be added to
 /// the table to display the column group titles.
 class ColumnGroup {
-  ColumnGroup({required this.title, required this.range, this.tooltip});
+  ColumnGroup({required this.title, required this.range});
 
-  ColumnGroup.fromText(
-      {required Sting title, required String? tooltip, required this.range});
+  ColumnGroup.fromText({
+    required String title,
+    required Range range,
+    String? tooltip,
+  }) : this(
+          title: maybeWrapWithTooltip(child: Text(title), tooltip: tooltip),
+          range: range,
+        );
 
   final Widget title;
 

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -136,11 +136,11 @@ void main() {
             _NumberColumn(),
           ],
           columnGroups: [
-            ColumnGroup(
+            ColumnGroup.fromText(
               title: 'Group 1',
               range: const Range(0, 1),
             ),
-            ColumnGroup(
+            ColumnGroup.fromText(
               title: 'Group 2',
               range: const Range(1, 2),
             ),


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=[too minor to mention]

1. Enable passing widget to column group
2. Remove tooltip for retaining path as it is too large and confusing.