### PR TITLE
Fix variable inspection for `List` and `Map` instances

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
@@ -319,9 +319,13 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
       if (kind != null && kind == InstanceKind.kList ||
           kind == InstanceKind.kMap ||
           kind!.endsWith('List')) {
+        // TODO(elliette): After https://github.com/dart-lang/sdk/issues/51550
+        // is fixed, to only use `classRef.name`. Currently we use `kind` for VM
+        // apps, because that provides us with a more readable name.
+        final name = _isPrivateName(valueStr) ? kind : valueStr;
         final itemLength = value.length;
         if (itemLength == null) return valueStr;
-        return '$valueStr (${_itemCount(itemLength)})';
+        return '$name (${_itemCount(itemLength)})';
       }
     } else if (value is Sentinel) {
       valueStr = value.valueAsString;
@@ -335,6 +339,8 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
 
     return valueStr;
   }
+
+  bool _isPrivateName(String name) => name.startsWith('_');
 
   static String _itemCount(int count) {
     return '${nf.format(count)} ${pluralize('item', count)}';

--- a/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
@@ -319,9 +319,11 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
       if (kind != null && kind == InstanceKind.kList ||
           kind == InstanceKind.kMap ||
           kind!.endsWith('List')) {
-        // TODO(elliette): After https://github.com/dart-lang/sdk/issues/51550
-        // is fixed, to only use `classRef.name`. Currently we use `kind` for VM
-        // apps, because that provides us with a more readable name.
+        // TODO(elliette): Determine the type signature from type parameters.
+        // https://api.flutter.dev/flutter/vm_service/ClassRef/typeParameters.html
+        // DWDS provides us with a readable format including type parameters in
+        // the classRef name, for the vm_service we fall back to just using the
+        // kind:
         final name = _isPrivateName(valueStr) ? kind : valueStr;
         final itemLength = value.length;
         if (itemLength == null) return valueStr;

--- a/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
@@ -319,7 +319,7 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
       if (kind != null && kind == InstanceKind.kList ||
           kind == InstanceKind.kMap ||
           kind!.endsWith('List')) {
-        // TODO(elliette): Determine the type signature from type parameters.
+        // TODO(elliette): Determine the signature from type parameters, see:
         // https://api.flutter.dev/flutter/vm_service/ClassRef/typeParameters.html
         // DWDS provides us with a readable format including type parameters in
         // the classRef name, for the vm_service we fall back to just using the

--- a/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
@@ -469,7 +469,7 @@ List<DartObjectNode> createVariablesForList(
   final elements = instance.elements ?? [];
   for (int i = 0; i < elements.length; i++) {
     final index = instance.offset == null ? i : i + instance.offset!;
-    final name = '[$index]${instance.classRef!.name}';
+    final name = '[$index]';
 
     variables.add(
       DartObjectNode.fromValue(

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -28,6 +28,7 @@ in deeply nested trees - [#5181](https://github.com/flutter/devtools/pull/5181)
 ## Debugger updates
 * Add support for browser navigation history when navigating using the `File Explorer` [#4906](https://github.com/flutter/devtools/pull/4906).
 * Designate positional fields for `Record` types with the getter syntax beginning at `$1` [#5272](https://github.com/flutter/devtools/pull/5272)
+* Fix variable inspection for `Map` and `List` instances: [#5320](https://github.com/flutter/devtools/pull/5320)
 
 ## Network profiler updates
 * Improve reliability and performance of the Network tab - [#5056](https://github.com/flutter/devtools/pull/5056)

--- a/packages/devtools_app/test/debugger/debugger_screen_variables_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_screen_variables_test.dart
@@ -76,16 +76,16 @@ void main() {
       await pumpDebuggerScreen(tester, debuggerController);
       expect(find.text('Variables'), findsOneWidget);
 
-      final listFinder = find.selectableText('Root 1: _GrowableList (2 items)');
+      final listFinder = find.selectableText('Root 1: List (2 items)');
 
       // expect a tooltip for the list value
       expect(
-        find.byTooltip('_GrowableList (2 items)'),
+        find.byTooltip('List (2 items)'),
         findsOneWidget,
       );
 
       final mapFinder = find.selectableTextContaining(
-        'Root 2: _InternalLinkedHashmap (2 items)',
+        'Root 2: Map (2 items)',
       );
       final mapElement1Finder = find.selectableTextContaining("['key1']: 1.0");
       final mapElement2Finder = find.selectableTextContaining("['key2']: 2.0");
@@ -135,8 +135,7 @@ void main() {
 
       await pumpDebuggerScreen(tester, debuggerController);
 
-      final listFinder =
-          find.selectableText('Root 1: _GrowableList (380,250 items)');
+      final listFinder = find.selectableText('Root 1: List (380,250 items)');
       final group0To9999Finder = find.selectableTextContaining('[0 - 9999]');
       final group10000To19999Finder =
           find.selectableTextContaining('[10000 - 19999]');
@@ -193,8 +192,7 @@ void main() {
 
       await pumpDebuggerScreen(tester, debuggerController);
 
-      final listFinder =
-          find.selectableText('Root 1: _InternalLinkedHashmap (243,621 items)');
+      final listFinder = find.selectableText('Root 1: Map (243,621 items)');
       final group0To9999Finder = find.selectableTextContaining('[0 - 9999]');
       final group10000To19999Finder =
           find.selectableTextContaining('[10000 - 19999]');


### PR DESCRIPTION
* Fixes https://github.com/flutter/devtools/issues/5271
* Work towards https://github.com/flutter/devtools/issues/5092

Previously, when inspecting `Map` and `List` instances we would display:

![219795954-f9de828d-c961-4352-85b5-d9f671545f97](https://user-images.githubusercontent.com/21270878/221687412-b7149e36-d045-457c-834d-b99e6ba0ecc9.png)

Now, for apps using the VM service we show:

![Screenshot 2023-02-27 at 1 17 34 PM](https://user-images.githubusercontent.com/21270878/221687705-8b65d352-fb6f-4abf-893d-a5d272d9a0af.png)

And for apps using DWDS:

![Screenshot 2023-02-27 at 12 34 19 PM](https://user-images.githubusercontent.com/21270878/221687496-e91f6178-e782-4429-91a9-0d9cdb88b959.png)

Will follow up with tests and adding the type signatures for VM service connected apps (that will probably not make it into the release cut-off).