### PR TITLE
Isolate runDevTools so that it can accessed internally and externally.

### DIFF
--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -21,7 +21,7 @@ import 'src/shared/primitives/utils.dart';
 /// Any initialization that needs to happen before running DevTools, regardless
 /// of context, should happen here.
 ///
-/// If the intialization is specific to running Devtools internally or
+/// If the intialization is specific to running Devtools in google3 or
 /// externally, then it should be added to that respective main.dart file.
 Future<void> runDevTools({
   bool shouldEnableExperiments = false,

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -21,9 +21,8 @@ import 'src/shared/primitives/utils.dart';
 /// Any initialization that needs to happen before running DevTools, regardless
 /// of context, should happen here.
 ///
-/// If the intialization is specific to running Devtools normally or
-/// running in DevTools in g3, then it should be added to that respective
-/// main.dart file.
+/// If the intialization is specific to running Devtools internally or
+/// externally, then it should be added to that respective main.dart file.
 Future<void> runDevTools({
   bool shouldEnableExperiments = false,
   List<DevToolsJsonFile> sampleData = const [],

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'src/app.dart';
+import 'src/framework/app_error_handling.dart';
+import 'src/screens/debugger/syntax_highlighter.dart';
+import 'src/screens/provider/riverpod_error_logger_observer.dart';
+import 'src/shared/analytics/analytics_controller.dart';
+import 'src/shared/config_specific/framework_initialize/framework_initialize.dart';
+import 'src/shared/config_specific/ide_theme/ide_theme.dart';
+import 'src/shared/config_specific/url/url.dart';
+import 'src/shared/config_specific/url_strategy/url_strategy.dart';
+import 'src/shared/feature_flags.dart';
+import 'src/shared/globals.dart';
+import 'src/shared/preferences.dart';
+import 'src/shared/primitives/url_utils.dart';
+import 'src/shared/primitives/utils.dart';
+
+/// Handles necessary initialization then runs DevTools.
+///
+/// Any initialization that needs to happen before running DevTools, regardless
+/// of context, should happen here.
+///
+/// If the intialization is specific to running Devtools normally or
+/// running in DevTools in g3, then it should be added to that respective
+/// main.dart file.
+Future<void> runDevTools({
+  bool shouldEnableExperiments = false,
+  List<DevToolsJsonFile> sampleData = const [],
+  List<DevToolsScreen>? screens,
+}) async {
+  screens ??= defaultScreens;
+
+  // Before switching to URL path strategy, check if this URL is in the legacy
+  // fragment format and redirect if necessary.
+  if (_handleLegacyUrl()) return;
+
+  usePathUrlStrategy();
+
+  // This may be set to true from our Flutter integration tests. Since we call
+  // [runDevTools] from Dart code, we cannot set the 'enable_experiments'
+  // environment variable before calling [runDevTools].
+  if (shouldEnableExperiments) {
+    setEnableExperiments();
+  }
+
+  // Initialize the framework before we do anything else, otherwise the
+  // StorageController won't be initialized and preferences won't be loaded.
+  await initializeFramework();
+
+  setGlobal(IdeTheme, getIdeTheme());
+
+  final preferences = PreferencesController();
+  // Wait for preferences to load before rendering the app to avoid a flash of
+  // content with the incorrect theme.
+  await preferences.init();
+
+  // Load the Dart syntax highlighting grammar.
+  await SyntaxHighlighter.initialize();
+
+  setupErrorHandling(() async {
+    // Run the app.
+    runApp(
+      ProviderScope(
+        observers: const [ErrorLoggerObserver()],
+        child: DevToolsApp(
+          screens!,
+          await analyticsController,
+          sampleData: sampleData,
+        ),
+      ),
+    );
+  });
+}
+
+/// Checks if the request is for a legacy URL and if so, redirects to the new
+/// equivalent.
+///
+/// Returns `true` if a redirect was performed, in which case normal app
+/// initialization should be skipped.
+bool _handleLegacyUrl() {
+  final url = getWebUrl();
+  if (url == null) return false;
+
+  final newUrl = mapLegacyUrl(url);
+  if (newUrl != null) {
+    webRedirect(newUrl);
+    return true;
+  }
+
+  return false;
+}

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -1,3 +1,7 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -21,7 +21,6 @@ void main() async {
 Future<void> externalRunDevTools({
   bool shouldEnableExperiments = false,
   List<DevToolsJsonFile> sampleData = const [],
-  List<DevToolsScreen>? screens,
 }) async {
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
@@ -29,6 +28,5 @@ Future<void> externalRunDevTools({
   await runDevTools(
     shouldEnableExperiments: shouldEnableExperiments,
     sampleData: sampleData,
-    screens: screens,
   );
 }

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -2,93 +2,20 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:flutter/material.dart';
-import 'package:flutter_riverpod/flutter_riverpod.dart';
-
-import 'src/app.dart';
+import 'initialization.dart';
 import 'src/extension_points/extensions_base.dart';
 import 'src/extension_points/extensions_external.dart';
-import 'src/framework/app_error_handling.dart';
-import 'src/screens/debugger/syntax_highlighter.dart';
-import 'src/screens/provider/riverpod_error_logger_observer.dart';
-import 'src/shared/analytics/analytics_controller.dart';
-import 'src/shared/config_specific/framework_initialize/framework_initialize.dart';
-import 'src/shared/config_specific/ide_theme/ide_theme.dart';
-import 'src/shared/config_specific/url/url.dart';
-import 'src/shared/config_specific/url_strategy/url_strategy.dart';
-import 'src/shared/feature_flags.dart';
 import 'src/shared/globals.dart';
-import 'src/shared/preferences.dart';
-import 'src/shared/primitives/url_utils.dart';
 import 'src/shared/primitives/utils.dart';
 
+/// This is the entrypoint for running DevTools normally.
+///
+/// WARNING: This entrypoint is not used when running DevTools in google3.
+/// Any intialization that needs to occur for all contexts should be added to
+/// [runDevTools].
 void main() async {
-  await runDevTools();
-}
-
-Future<void> runDevTools({
-  bool shouldEnableExperiments = false,
-  List<DevToolsJsonFile> sampleData = const [],
-}) async {
-  // Before switching to URL path strategy, check if this URL is in the legacy
-  // fragment format and redirect if necessary.
-  if (_handleLegacyUrl()) return;
-
-  usePathUrlStrategy();
-
-  // This may be set to true from our Flutter integration tests. Since we call
-  // [runDevTools] from Dart code, we cannot set the 'enable_experiments'
-  // environment variable before calling [runDevTools].
-  if (shouldEnableExperiments) {
-    setEnableExperiments();
-  }
-
-  // Initialize the framework before we do anything else, otherwise the
-  // StorageController won't be initialized and preferences won't be loaded.
-  await initializeFramework();
-
-  setGlobal(IdeTheme, getIdeTheme());
-
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
 
-  final preferences = PreferencesController();
-  // Wait for preferences to load before rendering the app to avoid a flash of
-  // content with the incorrect theme.
-  await preferences.init();
-
-  // Load the Dart syntax highlighting grammar.
-  await SyntaxHighlighter.initialize();
-
-  setupErrorHandling(() async {
-    // Run the app.
-    runApp(
-      ProviderScope(
-        observers: const [ErrorLoggerObserver()],
-        child: DevToolsApp(
-          defaultScreens,
-          await analyticsController,
-          sampleData: sampleData,
-        ),
-      ),
-    );
-  });
-}
-
-/// Checks if the request is for a legacy URL and if so, redirects to the new
-/// equivalent.
-///
-/// Returns `true` if a redirect was performed, in which case normal app
-/// initialization should be skipped.
-bool _handleLegacyUrl() {
-  final url = getWebUrl();
-  if (url == null) return false;
-
-  final newUrl = mapLegacyUrl(url);
-  if (newUrl != null) {
-    webRedirect(newUrl);
-    return true;
-  }
-
-  return false;
+  await runDevTools();
 }

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -17,6 +17,7 @@ import 'src/shared/primitives/utils.dart';
 void main() async {
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
+  await externalRunDevTools();
 }
 
 Future<void> externalRunDevTools({

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'initialization.dart';
-import 'src/app.dart';
 import 'src/extension_points/extensions_base.dart';
 import 'src/extension_points/extensions_external.dart';
 import 'src/shared/globals.dart';

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -3,9 +3,11 @@
 // found in the LICENSE file.
 
 import 'initialization.dart';
+import 'src/app.dart';
 import 'src/extension_points/extensions_base.dart';
 import 'src/extension_points/extensions_external.dart';
 import 'src/shared/globals.dart';
+import 'src/shared/primitives/utils.dart';
 
 /// This is the entrypoint for running DevTools normally.
 ///
@@ -15,6 +17,16 @@ import 'src/shared/globals.dart';
 void main() async {
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
+}
 
-  await runDevTools();
+Future<void> externalRunDevTools({
+  bool shouldEnableExperiments = false,
+  List<DevToolsJsonFile> sampleData = const [],
+  List<DevToolsScreen>? screens,
+}) async {
+  await runDevTools(
+    shouldEnableExperiments: shouldEnableExperiments,
+    sampleData: sampleData,
+    screens: screens,
+  );
 }

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -15,8 +15,6 @@ import 'src/shared/primitives/utils.dart';
 /// Any intialization that needs to occur, for both google3 and externally,
 /// should be added to [runDevTools].
 void main() async {
-  // Set the extension points global.
-  setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
   await externalRunDevTools();
 }
 
@@ -25,6 +23,9 @@ Future<void> externalRunDevTools({
   List<DevToolsJsonFile> sampleData = const [],
   List<DevToolsScreen>? screens,
 }) async {
+  // Set the extension points global.
+  setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
+
   await runDevTools(
     shouldEnableExperiments: shouldEnableExperiments,
     sampleData: sampleData,

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -9,7 +9,7 @@ import 'src/extension_points/extensions_external.dart';
 import 'src/shared/globals.dart';
 import 'src/shared/primitives/utils.dart';
 
-/// This is the entrypoint for running DevTools normally.
+/// This is the entrypoint for running DevTools externally.
 ///
 /// WARNING: This is the external entrypoint for running DevTools.
 /// Any intialization that needs to occur, for both google3 and externally,

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -6,12 +6,11 @@ import 'initialization.dart';
 import 'src/extension_points/extensions_base.dart';
 import 'src/extension_points/extensions_external.dart';
 import 'src/shared/globals.dart';
-import 'src/shared/primitives/utils.dart';
 
 /// This is the entrypoint for running DevTools normally.
 ///
 /// WARNING: This is the external entrypoint for running DevTools.
-/// Any intialization that needs to occur, both internally and externally,
+/// Any intialization that needs to occur, for both google3 and externally,
 /// should be added to [runDevTools].
 void main() async {
   // Set the extension points global.

--- a/packages/devtools_app/lib/main.dart
+++ b/packages/devtools_app/lib/main.dart
@@ -10,9 +10,9 @@ import 'src/shared/primitives/utils.dart';
 
 /// This is the entrypoint for running DevTools normally.
 ///
-/// WARNING: This entrypoint is not used when running DevTools in google3.
-/// Any intialization that needs to occur for all contexts should be added to
-/// [runDevTools].
+/// WARNING: This is the external entrypoint for running DevTools.
+/// Any intialization that needs to occur, both internally and externally,
+/// should be added to [runDevTools].
 void main() async {
   // Set the extension points global.
   setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/initialization.dart' as app;
+import 'package:devtools_app/main.dart' as app;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
@@ -20,7 +20,7 @@ Future<void> pumpDevTools(WidgetTester tester) async {
   // integration_test/test_infra? When trying to import, we get an error:
   // Error when reading 'org-dartlang-app:/test_infra/shared.dart': File not found
   const shouldEnableExperiments = bool.fromEnvironment('enable_experiments');
-  await app.runDevTools(
+  await app.externalRunDevTools(
     // ignore: avoid_redundant_argument_values
     shouldEnableExperiments: shouldEnableExperiments,
     sampleData: _sampleData,

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -5,7 +5,7 @@
 import 'dart:convert';
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/main.dart' as app;
+import 'package:devtools_app/initialization.dart' as app;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';


### PR DESCRIPTION
![](https://media.giphy.com/media/hoqvasPnqZS42Bvyvu/giphy.gif)

While trying to update main.dart I realized that the google3 entry point did not receive my changes.

This refactor isolates [runDevTools] so that each entry point can run it. This will avoid future confusion around keeping both main.dart files in sync.


RELEASE_NOTE_EXCEPTION=Internal refactor only
