### PR TITLE
Display class and function names for anonymous closures in the profiler

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
@@ -5,6 +5,7 @@
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/diagnostics/primitives/source_location.dart';
+import '../../shared/primitives/simple_items.dart';
 import '../../shared/primitives/trees.dart';
 import '../../shared/ui/search.dart';
 
@@ -212,8 +213,6 @@ class StackFrameAndSourcePosition {
   String get description {
     const unoptimized = '[Unoptimized] ';
     const none = '<none>';
-    const anonymousClosure = '<anonymous closure>';
-    const closure = '<closure>';
     const asyncBreak = '<async break>';
 
     if (frame.kind == FrameKind.kAsyncSuspensionMarker) {
@@ -224,7 +223,7 @@ class StackFrameAndSourcePosition {
     if (name.startsWith(unoptimized)) {
       name = name.substring(unoptimized.length);
     }
-    name = name.replaceAll(anonymousClosure, closure);
+    name = name.replaceAll(anonymousClosureName, closureName);
     name = name == none ? name : '$name';
     return name;
   }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -1335,6 +1335,32 @@ extension CpuSamplesExtension on vm_service.CpuSamples {
       if (className != null) {
         return '$className.${current.name}';
       }
+      if (current.name == anonymousClosureName &&
+          current._function is vm_service.FuncRef) {
+        final nameParts = <String?>[current.name];
+
+        final function = current._function as vm_service.FuncRef;
+        var owner = function.owner;
+        switch (owner.runtimeType) {
+          case vm_service.FuncRef:
+            owner = owner as vm_service.FuncRef;
+            final functionName = owner.name;
+
+            String? className;
+            if (owner.owner is vm_service.ClassRef) {
+              className = (owner.owner as vm_service.ClassRef).name;
+            }
+
+            nameParts.insertAll(0, [className, functionName]);
+            break;
+          case vm_service.ClassRef:
+            final className = (owner as vm_service.ClassRef).name;
+            nameParts.insert(0, className);
+        }
+
+        nameParts.removeWhere((element) => element == null);
+        return nameParts.join('.');
+      }
       return current.name;
     }
 

--- a/packages/devtools_app/lib/src/shared/primitives/simple_items.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/simple_items.dart
@@ -46,3 +46,7 @@ enum ScreenMetaData {
 }
 
 const String traceEventsFieldName = 'traceEvents';
+
+const closureName = '<closure>';
+
+const anonymousClosureName = '<anonymous closure>';

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -18,6 +18,8 @@ import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:intl/intl.dart';
 
+import 'simple_items.dart';
+
 bool isPrivate(String member) => member.startsWith('_');
 
 /// Public properties first, then sort alphabetically
@@ -292,7 +294,7 @@ String pluralize(String word, int count, {String? plural}) =>
 /// See (https://github.com/dart-lang/sdk/issues/36999).
 String getSimpleStackFrameName(String? name) {
   name ??= '';
-  final newName = name.replaceAll('<anonymous closure>', '<closure>');
+  final newName = name.replaceAll(anonymousClosureName, closureName);
 
   // If the class name contains a space, then it is not a valid Dart name. We
   // throw out simplified names with spaces to prevent simplifying C++ class


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5354

Before:
![image](https://user-images.githubusercontent.com/43759233/222863996-287ba003-ccd4-45b4-849c-2def06ff965f.png)

After:
![Screenshot 2023-03-03 at 4 58 06 PM](https://user-images.githubusercontent.com/43759233/222864006-3a996b1e-53d8-4ad7-8ee2-cc0bda8505da.png)

This matches what Observatory does (with the exception that we shorten `<anonymous closure>` to `<closure>`):
![image](https://user-images.githubusercontent.com/43759233/222864045-796578bc-741a-478e-8b1e-d7ca4c924b1a.png)

RELEASE_NOTE_EXCEPTION=[too small to mention]