### PR TITLE
Do not send count and offset params when requesting the entire object

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
@@ -241,7 +241,9 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
 
     final value = this.value;
     if (value is InstanceRef) {
-      return value.length ?? 0;
+      final instanceLength = value.length;
+      if (instanceLength == null) return 0;
+      return instanceLength - offset;
     }
 
     return 0;
@@ -251,13 +253,13 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
 
   bool get isPartialObject {
     final value = this.value;
-    // Only instances kinds can be partial:
+    // Only instance kinds can be partial:
     if (value is InstanceRef) {
       // Only instance kinds with a length property can be partial. See:
       // https://api.flutter.dev/flutter/vm_service/Instance/length.html
       final instanceLength = value.length;
       if (instanceLength == null) return false;
-      return childCount < instanceLength;
+      return offset != 0 || childCount < instanceLength;
     }
 
     return false;

--- a/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/dart_object_node.dart
@@ -241,19 +241,27 @@ class DartObjectNode extends TreeNode<DartObjectNode> {
 
     final value = this.value;
     if (value is InstanceRef) {
-      if (value.kind != null &&
-          (isList(value) ||
-              value.kind == InstanceKind.kMap ||
-              value.kind == InstanceKind.kRecord ||
-              isSet)) {
-        return value.length ?? 0;
-      }
+      return value.length ?? 0;
     }
 
     return 0;
   }
 
   int? _childCount;
+
+  bool get isPartialObject {
+    final value = this.value;
+    // Only instances kinds can be partial:
+    if (value is InstanceRef) {
+      // Only instance kinds with a length property can be partial. See:
+      // https://api.flutter.dev/flutter/vm_service/Instance/length.html
+      final instanceLength = value.length;
+      if (instanceLength == null) return false;
+      return childCount < instanceLength;
+    }
+
+    return false;
+  }
 
   // TODO(elliette): Can remove this workaround once DWDS correctly returns
   // InstanceKind.kSet for the kind of `Sets`. See:

--- a/packages/devtools_app/lib/src/shared/diagnostics/helpers.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/helpers.dart
@@ -16,11 +16,22 @@ Future<Object?> getObject({
   required ObjRef value,
   DartObjectNode? variable,
 }) async {
+  // Don't include the offset and count parameters if we are not fetching a
+  // partial object. Offset and count parameters are only necessary to request
+  // subranges of the following instance kinds:
+  // https://api.flutter.dev/flutter/vm_service/VmServiceInterface/getObject.html
+  if (variable == null || !variable.isPartialObject) {
+    return await serviceManager.service!.getObject(
+      isolateRef!.id!,
+      value.id!,
+    );
+  }
+
   return await serviceManager.service!.getObject(
     isolateRef!.id!,
     value.id!,
-    offset: variable?.offset,
-    count: variable?.childCount,
+    offset: variable.offset,
+    count: variable.childCount,
   );
 }
 

--- a/packages/devtools_app/test/shared/dart_object_node_test.dart
+++ b/packages/devtools_app/test/shared/dart_object_node_test.dart
@@ -1,0 +1,130 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+
+import '../test_infra/utils/variable_utils.dart';
+
+void main() {
+  setUp(() {
+    resetRef();
+    resetRoot();
+  });
+
+  group('childCount', () {
+    group('for map instances', () {
+      test('entire map', () {
+        final map = buildMapVariable(length: 3);
+        expect(map.childCount, equals(3));
+      });
+      test('map grouping with offset', () {
+        final mapGrouping = buildMapGroupingVariable(
+          length: 10,
+          offset: 2,
+          count: 4,
+        );
+        expect(mapGrouping.childCount, equals(4));
+      });
+      test('map grouping no offset', () {
+        final mapGrouping = buildMapGroupingVariable(
+          length: 10,
+          offset: 0,
+          count: 4,
+        );
+        expect(mapGrouping.childCount, equals(4));
+      });
+    });
+
+    group('for list instances', () {
+      test('entire list', () {
+        final list = buildListVariable(length: 3);
+        expect(list.childCount, equals(3));
+      });
+      test('list grouping with offset', () {
+        final listGrouping = buildListGroupingVariable(
+          length: 10,
+          offset: 2,
+          count: 4,
+        );
+        expect(listGrouping.childCount, equals(4));
+      });
+      test('list grouping no offset', () {
+        final listGrouping = buildListGroupingVariable(
+          length: 10,
+          offset: 0,
+          count: 4,
+        );
+        expect(listGrouping.childCount, equals(4));
+      });
+    });
+
+    test('for booleans', () {
+      final boolean = buildBooleanVariable(true);
+      expect(boolean.childCount, equals(0));
+    });
+
+    test('for strings', () {
+      final str = buildStringVariable('Hello there!');
+      expect(str.childCount, equals(0));
+    });
+  });
+
+  group('isPartialObject', () {
+    group('for map instances', () {
+      test('entire map', () {
+        final map = buildMapVariable(length: 3);
+        expect(map.isPartialObject, isFalse);
+      });
+      test('map grouping with offset', () {
+        final mapGrouping = buildMapGroupingVariable(
+          length: 10,
+          offset: 2,
+          count: 4,
+        );
+        expect(mapGrouping.isPartialObject, isTrue);
+      });
+      test('map grouping no offset', () {
+        final mapGrouping = buildMapGroupingVariable(
+          length: 10,
+          offset: 0,
+          count: 4,
+        );
+        expect(mapGrouping.isPartialObject, isTrue);
+      });
+    });
+
+    group('for list instances', () {
+      test('entire list', () {
+        final list = buildListVariable(length: 3);
+        expect(list.isPartialObject, isFalse);
+      });
+      test('list grouping with offset', () {
+        final listGrouping = buildListGroupingVariable(
+          length: 10,
+          offset: 2,
+          count: 4,
+        );
+        expect(listGrouping.isPartialObject, isTrue);
+      });
+      test('list grouping no offset', () {
+        final listGrouping = buildListGroupingVariable(
+          length: 10,
+          offset: 0,
+          count: 4,
+        );
+        expect(listGrouping.isPartialObject, isTrue);
+      });
+    });
+
+    test('for booleans', () {
+      final boolean = buildBooleanVariable(true);
+      expect(boolean.isPartialObject, isFalse);
+    });
+
+    test('for strings', () {
+      final str = buildStringVariable('Hello there!');
+      expect(str.isPartialObject, isFalse);
+    });
+  });
+}

--- a/packages/devtools_app/test/test_infra/utils/variable_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/variable_utils.dart
@@ -1,0 +1,213 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/src/shared/diagnostics/dart_object_node.dart';
+import 'package:devtools_app/src/shared/diagnostics/generic_instance_reference.dart';
+
+import 'package:vm_service/vm_service.dart';
+
+import '../../debugger/typed_data_variable_test.dart';
+
+void resetRef() {
+  _refNumber = 0;
+}
+
+void resetRoot() {
+  _rootNumber = 0;
+}
+
+DartObjectNode buildParentListVariable({int length = 2}) {
+  return DartObjectNode.create(
+    BoundVariable(
+      name: _incrementRoot(),
+      value: _buildInstanceRefForList(length: length),
+    ),
+    _isolateRef,
+  );
+}
+
+DartObjectNode buildListVariable({int length = 2}) {
+  final listVariable = buildParentListVariable(length: length);
+
+  for (int i = 0; i < length; i++) {
+    listVariable.addChild(
+      DartObjectNode.create(
+        BoundVariable(
+          name: '$i',
+          value: InstanceRef(
+            id: _incrementRef(),
+            kind: InstanceKind.kInt,
+            classRef: ClassRef(
+              name: 'Integer',
+              id: _incrementRef(),
+              library: _libraryRef,
+            ),
+            valueAsString: '$i',
+            valueAsStringIsTruncated: false,
+          ),
+        ),
+        _isolateRef,
+      ),
+    );
+  }
+
+  return listVariable;
+}
+
+DartObjectNode buildListGroupingVariable({
+  required int length,
+  required int offset,
+  required int count,
+}) {
+  return DartObjectNode.grouping(
+    GenericInstanceRef(
+      isolateRef: isolateRef,
+      value: _buildInstanceRefForList(length: length),
+    ),
+    offset: offset,
+    count: count,
+  );
+}
+
+DartObjectNode buildParentMapVariable({int length = 2}) {
+  return DartObjectNode.create(
+    BoundVariable(
+      name: _incrementRoot(),
+      value: _buildInstanceRefForMap(length: length),
+    ),
+    _isolateRef,
+  );
+}
+
+DartObjectNode buildMapVariable({int length = 2}) {
+  final mapVariable = buildParentMapVariable(length: length);
+
+  for (int i = 0; i < length; i++) {
+    mapVariable.addChild(
+      DartObjectNode.create(
+        BoundVariable(
+          name: "['key${i + 1}']",
+          value: InstanceRef(
+            id: _incrementRef(),
+            kind: InstanceKind.kDouble,
+            classRef: ClassRef(
+              name: 'Double',
+              id: _incrementRef(),
+              library: _libraryRef,
+            ),
+            valueAsString: '${i + 1}.0',
+            valueAsStringIsTruncated: false,
+          ),
+        ),
+        _isolateRef,
+      ),
+    );
+  }
+
+  return mapVariable;
+}
+
+DartObjectNode buildMapGroupingVariable({
+  required int length,
+  required int offset,
+  required int count,
+}) {
+  return DartObjectNode.grouping(
+    GenericInstanceRef(
+      isolateRef: isolateRef,
+      value: _buildInstanceRefForMap(length: length),
+    ),
+    offset: offset,
+    count: count,
+  );
+}
+
+DartObjectNode buildStringVariable(String value) {
+  return DartObjectNode.create(
+    BoundVariable(
+      name: _incrementRoot(),
+      value: InstanceRef(
+        id: _incrementRef(),
+        kind: InstanceKind.kString,
+        classRef: ClassRef(
+          name: 'String',
+          id: _incrementRef(),
+          library: _libraryRef,
+        ),
+        valueAsString: value,
+        valueAsStringIsTruncated: true,
+      ),
+    ),
+    _isolateRef,
+  );
+}
+
+DartObjectNode buildBooleanVariable(bool value) {
+  return DartObjectNode.create(
+    BoundVariable(
+      name: _incrementRoot(),
+      value: InstanceRef(
+        id: _incrementRef(),
+        kind: InstanceKind.kBool,
+        classRef: ClassRef(
+          name: 'Boolean',
+          id: _incrementRef(),
+          library: _libraryRef,
+        ),
+        valueAsString: '$value',
+        valueAsStringIsTruncated: false,
+      ),
+    ),
+    _isolateRef,
+  );
+}
+
+InstanceRef _buildInstanceRefForMap({required int length}) => InstanceRef(
+      id: _incrementRef(),
+      kind: InstanceKind.kMap,
+      classRef: ClassRef(
+        name: '_InternalLinkedHashmap',
+        id: _incrementRef(),
+        library: _libraryRef,
+      ),
+      length: length,
+    );
+
+InstanceRef _buildInstanceRefForList({required int length}) => InstanceRef(
+      id: _incrementRef(),
+      kind: InstanceKind.kList,
+      classRef: ClassRef(
+        name: '_GrowableList',
+        id: _incrementRef(),
+        library: _libraryRef,
+      ),
+      length: length,
+    );
+
+final _libraryRef = LibraryRef(
+  name: 'some library',
+  uri: 'package:foo/foo.dart',
+  id: 'lib-id-1',
+);
+
+final _isolateRef = IsolateRef(
+  id: '433',
+  number: '1',
+  name: 'my-isolate',
+  isSystemIsolate: false,
+);
+
+int _refNumber = 0;
+
+String _incrementRef() {
+  _refNumber++;
+  return 'ref$_refNumber';
+}
+
+int _rootNumber = 0;
+
+String _incrementRoot() {
+  _rootNumber++;
+  return 'Root $_rootNumber';
+}


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5329

Previously, for objects where there was no explicitly set offset and childCount, we were sending `getObject` requests with `offset` set to 0 and `count` set to the length of the object (if it was a `List`, `Map`, `Record` or `Set` instance) or 0 if it wasn't. 

This was causing a few problems. If we missed any of the instance kinds that had a `length` (for example, we were missing [`Set` instances](https://github.com/flutter/devtools/pull/5323)), then we would send a `getObject` request with `count` equal to 0.  The VM service would then correctly respond with an empty object. 

This PR ignores sending `offset` and `count` params in `getObject` requests, unless we are explicitly requesting a partial object.