### PR TITLE
Change Latest Flutter Candidate to tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,7 +55,7 @@ jobs:
         run: |
           cd flutter-sdk
           HEAD_SHA=$(git rev-parse HEAD)
-          LATEST_FLUTTER_CANDIDATE_SHA=$(git rev-parse "tags/$LATEST_FLUTTER_CANDIDATE")
+          LATEST_FLUTTER_CANDIDATE_SHA=$(git rev-list -1 "$LATEST_FLUTTER_CANDIDATE")
           if [ "$HEAD_SHA" != "$LATEST_FLUTTER_CANDIDATE_SHA" ]; then
             echo "::error ,title=Error checking out Latest Flutter Candidate::{expected HEAD to be at $LATEST_FLUTTER_CANDIDATE_SHA but got $HEAD_SHA}"
             exit 1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
           LATEST_FLUTTER_CANDIDATE=$(./tool/latest_flutter_candidate.sh)
           echo "FLUTTER_CANDIDATE=$LATEST_FLUTTER_CANDIDATE" >> $GITHUB_OUTPUT
-      
+
       - name: Load Cached Flutter SDK
         id: cache-flutter
         uses: actions/cache@69d9d449aced6a2ede0bc19182fadc3a0a42d2b0
@@ -53,13 +53,13 @@ jobs:
 
       - name: Assert that the Latest Flutter Candidate is checked out
         run: |
-            cd flutter-sdk
-            HEAD_SHA=$(git rev-parse HEAD)
-            LATEST_FLUTTER_CANDIDATE_SHA=$(git rev-parse "origin/$LATEST_FLUTTER_CANDIDATE")
-            if [ "$HEAD_SHA" != "$LATEST_FLUTTER_CANDIDATE_SHA" ]; then
-              echo "::error ,title=Error checking out Latest Flutter Candidate::{expected HEAD to be at $LATEST_FLUTTER_CANDIDATE_SHA but got $HEAD_SHA}"
-              exit 1
-            fi
+          cd flutter-sdk
+          HEAD_SHA=$(git rev-parse HEAD)
+          LATEST_FLUTTER_CANDIDATE_SHA=$(git rev-parse "tags/$LATEST_FLUTTER_CANDIDATE")
+          if [ "$HEAD_SHA" != "$LATEST_FLUTTER_CANDIDATE_SHA" ]; then
+            echo "::error ,title=Error checking out Latest Flutter Candidate::{expected HEAD to be at $LATEST_FLUTTER_CANDIDATE_SHA but got $HEAD_SHA}"
+            exit 1
+          fi
         env:
           LATEST_FLUTTER_CANDIDATE: ${{ steps.flutter-candidate.outputs.FLUTTER_CANDIDATE }}
 
@@ -83,7 +83,7 @@ jobs:
         with:
           path: |
             ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }} 
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
 
       - name: tool/bots.sh
         env:
@@ -110,13 +110,13 @@ jobs:
         with:
           path: |
             ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }} 
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
       - name: tool/bots.sh
         env:
           BOT: ${{ matrix.bot }}
           PLATFORM: vm
         run: ./tool/bots.sh
-                
+
   macos-test:
     needs: flutter-prep
     name: macos goldens ${{ matrix.bot }}
@@ -128,7 +128,7 @@ jobs:
           - test_dart2js
         only_golden:
           - true
-        
+
     steps:
       - name: git clone
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
@@ -137,18 +137,18 @@ jobs:
         with:
           path: |
             ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }} 
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
       - name: tool/bots.sh
         env:
           BOT: ${{ matrix.bot }}
           PLATFORM: vm
           ONLY_GOLDEN: ${{ matrix.only_golden }}
         run: ./tool/bots.sh
-  
+
       - name: Upload Golden Failure Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         if: failure()
-        with: 
+        with:
           name: golden_image_failures.${{ matrix.bot }}
           path: packages/devtools_app/test/**/failures/*.png
 
@@ -170,7 +170,7 @@ jobs:
         with:
           path: |
             ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }} 
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
       - name: tool/bots.sh
         env:
           BOT: ${{ matrix.bot }}
@@ -179,10 +179,9 @@ jobs:
       - name: Upload Golden Failure Artifacts
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         if: failure()
-        with: 
+        with:
           name: golden_image_failures.${{ matrix.bot }}
           path: packages/devtools_app/integration_test/**/failures/*.png
-
 # TODO(https://github.com/flutter/devtools/issues/1715): add a windows compatible version of tool/bots.sh
 # and run it from this job.
 #  windows-test:

--- a/tool/latest_flutter_candidate.sh
+++ b/tool/latest_flutter_candidate.sh
@@ -7,8 +7,8 @@
 # Any subsequent commands failure will cause this script to exit immediately
 set -e
 
-LATEST_FLUTTER_CANDIDATE=$(git ls-remote --heads --sort='-v:refname' https://flutter.googlesource.com/mirrors/flutter/ \
-  | grep "refs/heads/flutter-.*-candidate" \
+LATEST_FLUTTER_CANDIDATE=$(git ls-remote --tags --sort='-v:refname' https://flutter.googlesource.com/mirrors/flutter/ \
+  | grep "refs/tags/flutter-.*-candidate" \
   | cut -f2 \
   | sort --version-sort \
   | tail -n1 \

--- a/tool/latest_flutter_candidate.sh
+++ b/tool/latest_flutter_candidate.sh
@@ -7,8 +7,10 @@
 # Any subsequent commands failure will cause this script to exit immediately
 set -e
 
+# To determine the most recent candidate available on g3 find the largest
+# tag that matches the version X.Y.Z-M.N.pre, where Z=0 and N=0.(i.e. X.Y.0-M.0.pre)
 LATEST_FLUTTER_CANDIDATE=$(git ls-remote --tags --sort='-v:refname' https://flutter.googlesource.com/mirrors/flutter/ \
-  | grep "refs/tags/flutter-.*-candidate" \
+  | grep -E "refs/tags/[0-9]+.[0-9]+.0-[0-9]+.0.pre" \
   | cut -f2 \
   | sort --version-sort \
   | tail -n1 \

--- a/tool/update_flutter_sdk.sh
+++ b/tool/update_flutter_sdk.sh
@@ -17,12 +17,12 @@ TOOL_DIR=`dirname "${RELATIVE_PATH_TO_SCRIPT}"`
 
 pushd "$TOOL_DIR"
 dart pub get
-REQUIRED_FLUTTER_BRANCH=`./latest_flutter_candidate.sh`
+REQUIRED_FLUTTER_TAG="tags/$(./latest_flutter_candidate.sh)"
 
-echo "REQUIRED_FLUTTER_BRANCH: $REQUIRED_FLUTTER_BRANCH"
+echo "REQUIRED_FLUTTER_TAG: $REQUIRED_FLUTTER_TAG"
 
 if [[ $UPDATE_LOCALLY = "--local" ]]; then
-  echo "STATUS: Updating local Flutter checkout to branch '$REQUIRED_FLUTTER_BRANCH'."
+  echo "STATUS: Updating local Flutter checkout to branch '$REQUIRED_FLUTTER_TAG'."
 
   FLUTTER_EXE=`which flutter`
   FLUTTER_BIN=`dirname "${FLUTTER_EXE}"`
@@ -35,7 +35,7 @@ if [[ $UPDATE_LOCALLY = "--local" ]]; then
   git checkout upstream/master
   git reset --hard upstream/master
   git fetch upstream
-  git checkout $REQUIRED_FLUTTER_BRANCH -f
+  git checkout $REQUIRED_FLUTTER_TAG -f
   flutter --version
   popd
 
@@ -45,7 +45,7 @@ fi
 FLUTTER_DIR="flutter-sdk"
 PATH="$FLUTTER_DIR/bin":$PATH
 
-echo "STATUS: Updating 'tool/flutter-sdk' to branch '$REQUIRED_FLUTTER_BRANCH'."
+echo "STATUS: Updating 'tool/flutter-sdk' to branch '$REQUIRED_FLUTTER_TAG'."
 
 if [ -d "$FLUTTER_DIR" ]; then
   echo "STATUS: 'tool/$FLUTTER_DIR' directory already exists"
@@ -53,7 +53,7 @@ if [ -d "$FLUTTER_DIR" ]; then
   # switch to the specified version
   pushd $FLUTTER_DIR
   git fetch
-  git checkout $REQUIRED_FLUTTER_BRANCH -f
+  git checkout $REQUIRED_FLUTTER_TAG -f
   ./bin/flutter --version
   popd
 else
@@ -62,7 +62,7 @@ else
   # clone the flutter repo and switch to the specified version
   git clone https://github.com/flutter/flutter "$FLUTTER_DIR"
   pushd "$FLUTTER_DIR"
-  git checkout $REQUIRED_FLUTTER_BRANCH
+  git checkout $REQUIRED_FLUTTER_TAG
   ./bin/flutter --version
   popd
 fi


### PR DESCRIPTION
![](https://media.giphy.com/media/l3mZdFsWbPECBydby/giphy.gif)

**BLOCKED**: this is blocked until the tags start being added to the branches. 

The flutter rolling process is being changed so that it will tag candidate branches that have made it into g3.

This PR updates our process to treat that tag as the latest flutter candidate.
This should ensure that our code is always tested against a version of flutter that has been rolled to g3.

RELEASE_NOTE_EXCEPTION=Internal process

Fixes https://github.com/flutter/devtools/issues/5173