### PR TITLE
Make FlatTable column sizing configurable

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/column_widths.dart
+++ b/packages/devtools_app/lib/src/shared/table/column_widths.dart
@@ -20,7 +20,7 @@ const columnGroupSpacingWithPadding = columnGroupSpacing + 2 * defaultSpacing;
 const columnSpacing = defaultSpacing;
 
 extension FlatColumnWidthExtension<T> on FlatTableController<T> {
-  List<double> computeColumnWidthsForSingleWideColumn(List<T> data) {
+  List<double> computeColumnWidthsSizeToContent(List<T> data) {
     final widths = <double>[];
     for (var column in columns) {
       double width;
@@ -53,7 +53,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
     return widths;
   }
 
-  List<double> computeColumnWidthsForManyWideColumns(double maxWidth) {
+  List<double> computeColumnWidthsSizeToFit(double maxWidth) {
     // Subtract width from outer padding around table.
     maxWidth -= 2 * defaultSpacing;
     final numColumnGroupSpacers = columnGroups?.numSpacers ?? 0;

--- a/packages/devtools_app/lib/src/shared/table/column_widths.dart
+++ b/packages/devtools_app/lib/src/shared/table/column_widths.dart
@@ -23,7 +23,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
   /// Calculates [FlatTable] column widths when the columns should be sized as
   /// either 1) the [fixedWidthPx] specified by the column, or 2) the size of
   /// the column's widest content.
-  /// 
+  ///
   /// If the sum of the column widths exceeds the available screen space, the
   /// table will scroll horizontally.
   List<double> computeColumnWidthsSizeToContent(List<T> data) {
@@ -59,7 +59,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
 
   /// Calculates [FlatTable] column widths such that they will take up the
   /// entire width available [maxWidth].
-  /// 
+  ///
   /// When this calculation method is used, the table will not scroll
   /// horizontally since there will not be any content outside of the viewport.
   List<double> computeColumnWidthsSizeToFit(double maxWidth) {

--- a/packages/devtools_app/lib/src/shared/table/column_widths.dart
+++ b/packages/devtools_app/lib/src/shared/table/column_widths.dart
@@ -20,13 +20,17 @@ const columnGroupSpacingWithPadding = columnGroupSpacing + 2 * defaultSpacing;
 const columnSpacing = defaultSpacing;
 
 extension FlatColumnWidthExtension<T> on FlatTableController<T> {
+  /// Calculates [FlatTable] column widths when the columns should be sized as
+  /// either 1) the [fixedWidthPx] specified by the column, or 2) the size of
+  /// the column's widest content.
+  /// 
+  /// If the sum of the column widths exceeds the available screen space, the
+  /// table will scroll horizontally.
   List<double> computeColumnWidthsSizeToContent(List<T> data) {
     final widths = <double>[];
     for (var column in columns) {
-      double width;
-      if (column.fixedWidthPx != null) {
-        width = column.fixedWidthPx!;
-      } else {
+      var width = column.fixedWidthPx;
+      if (width == null) {
         // Note: this is assuming that we're always using a monospace font in
         // our tree tables. This will almost certainly cause overflows if we
         // try to use non-monospace fonts.
@@ -53,6 +57,11 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
     return widths;
   }
 
+  /// Calculates [FlatTable] column widths such that they will take up the
+  /// entire width available [maxWidth].
+  /// 
+  /// When this calculation method is used, the table will not scroll
+  /// horizontally since there will not be any content outside of the viewport.
   List<double> computeColumnWidthsSizeToFit(double maxWidth) {
     // Subtract width from outer padding around table.
     maxWidth -= 2 * defaultSpacing;

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -76,6 +76,7 @@ class FlatTable<T> extends StatefulWidget {
     this.activeSearchMatchNotifier,
     this.preserveVerticalScrollPosition = false,
     this.includeColumnGroupHeaders = true,
+    this.sizeToFit = true,
     ValueNotifier<T?>? selectionNotifier,
   })  : selectionNotifier = selectionNotifier ?? ValueNotifier<T?>(null),
         super(key: key);
@@ -83,6 +84,10 @@ class FlatTable<T> extends StatefulWidget {
   final List<ColumnData<T>> columns;
 
   final List<ColumnGroup>? columnGroups;
+
+  /// Whether the columns for this table should be sized so that the entire
+  /// table fits in view (e.g. so that there is no horizontal scrolling).
+  final bool sizeToFit;
 
   /// Determines if the headers for column groups should be rendered.
   ///
@@ -248,7 +253,7 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
           rowItemExtent: defaultRowHeight,
           preserveVerticalScrollPosition: widget.preserveVerticalScrollPosition,
         );
-    if (tableController.columnWidths == null) {
+    if (widget.sizeToFit || tableController.columnWidths == null) {
       return LayoutBuilder(
         builder: (context, constraints) => _buildTable(
           tableController.computeColumnWidthsForManyWideColumns(

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -212,6 +212,7 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
         columnGroups: widget.columnGroups,
         includeColumnGroupHeaders: widget.includeColumnGroupHeaders,
         pinBehavior: widget.pinBehavior,
+        sizeToFit: widget.sizeToFit,
       );
     }
 
@@ -256,7 +257,7 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
     if (widget.sizeToFit || tableController.columnWidths == null) {
       return LayoutBuilder(
         builder: (context, constraints) => _buildTable(
-          tableController.computeColumnWidthsForManyWideColumns(
+          tableController.computeColumnWidthsSizeToFit(
             constraints.maxWidth,
           ),
         ),

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -239,11 +239,7 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
 
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final columnWidths =
-            tableController.computeColumnWidths(constraints.maxWidth);
-        return _Table<T>(
+    Widget _buildTable(List<double> columnWidths) => _Table<T>(
           tableController: tableController,
           columnWidths: columnWidths,
           autoScrollContent: widget.autoScrollContent,
@@ -252,8 +248,16 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
           rowItemExtent: defaultRowHeight,
           preserveVerticalScrollPosition: widget.preserveVerticalScrollPosition,
         );
-      },
-    );
+    if (tableController.columnWidths == null) {
+      return LayoutBuilder(
+        builder: (context, constraints) => _buildTable(
+          tableController.computeColumnWidthsForManyWideColumns(
+            constraints.maxWidth,
+          ),
+        ),
+      );
+    }
+    return _buildTable(tableController.columnWidths!);
   }
 
   Widget _buildRow({
@@ -598,7 +602,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
   Widget build(BuildContext context) {
     return _Table<T>(
       tableController: tableController,
-      columnWidths: tableController.columnWidths,
+      columnWidths: tableController.columnWidths!,
       rowBuilder: _buildRow,
       focusNode: _focusNode,
       handleKeyEvent: _handleKeyEvent,

--- a/packages/devtools_app/lib/src/shared/table/table_controller.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_controller.dart
@@ -32,12 +32,17 @@ class FlatTableController<T> extends TableControllerBase<T> {
     super.columnGroups,
     super.includeColumnGroupHeaders,
     this.pinBehavior = FlatTablePinBehavior.none,
+    this.sizeToFit = true,
   });
 
   /// Determines how elements that request to be pinned are displayed.
   ///
   /// Defaults to [FlatTablePinBehavior.none], which disables pinnning.
   FlatTablePinBehavior pinBehavior;
+
+  /// Whether the columns for this table should be sized so that the entire
+  /// table fits in view (e.g. so that there is no horizontal scrolling).
+  final bool sizeToFit;
 
   /// The unmodified, original data for the active data set [_tableData.value].
   ///
@@ -95,9 +100,8 @@ class FlatTableController<T> extends TableControllerBase<T> {
       data = dataCopy;
     }
 
-    final wideColumnCount = columns.where((c) => c.fixedWidthPx == null).length;
-    if (wideColumnCount <= 1) {
-      columnWidths = computeColumnWidthsForSingleWideColumn(data);
+    if (!sizeToFit) {
+      columnWidths = computeColumnWidthsSizeToContent(data);
     }
     _tableData.value = TableData<T>(
       data: data,

--- a/packages/devtools_app/lib/src/shared/table/table_controller.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_controller.dart
@@ -94,6 +94,11 @@ class FlatTableController<T> extends TableControllerBase<T> {
       }
       data = dataCopy;
     }
+
+    final wideColumnCount = columns.where((c) => c.fixedWidthPx == null).length;
+    if (wideColumnCount <= 1) {
+      columnWidths = computeColumnWidthsForSingleWideColumn(data);
+    }
     _tableData.value = TableData<T>(
       data: data,
       key: dataKey ?? _tableData.value.key,
@@ -120,8 +125,6 @@ class TreeTableController<T extends TreeNode<T>>
   final TreeColumnData<T> treeColumn;
 
   final bool autoExpandRoots;
-
-  late List<double> columnWidths;
 
   late List<T> dataRoots;
 
@@ -220,6 +223,8 @@ abstract class TableControllerBase<T> extends DisposableController {
   final List<ColumnData<T>> columns;
 
   final List<ColumnGroup>? columnGroups;
+
+  List<double>? columnWidths;
 
   /// Determines if the headers for column groups should be rendered.
   ///

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -71,9 +71,10 @@ void main() {
     });
 
     testWidgets('displays with simple content', (WidgetTester tester) async {
+      final simpleData = [TestData('empty', 0)];
       final table = FlatTable<TestData>(
         columns: [flatNameColumn],
-        data: [TestData('empty', 0)],
+        data: simpleData,
         dataKey: 'test-data',
         keyFactory: (d) => Key(d.name),
         defaultSortColumn: flatNameColumn,
@@ -81,11 +82,11 @@ void main() {
       );
       await tester.pumpWidget(wrap(table));
       expect(find.byWidget(table), findsOneWidget);
-      debugDumpApp();
       expect(find.text('FlatName'), findsOneWidget);
 
       final FlatTableState state = tester.state(find.byWidget(table));
-      final columnWidths = state.tableController.computeColumnWidths(1000);
+      expect(state.tableController.columnWidths, isNotNull);
+      final columnWidths = state.tableController.columnWidths!;
       expect(columnWidths.length, 1);
       expect(columnWidths.first, 300);
       expect(find.byKey(const Key('empty')), findsOneWidget);
@@ -467,11 +468,12 @@ void main() {
       {
         final FlatTableState<TestData> state =
             tester.state(find.byWidget(table));
-        final columnWidths = state.tableController.computeColumnWidths(800.0);
+        expect(state.tableController.columnWidths, isNotNull);
+        final columnWidths = state.tableController.columnWidths!;
         expect(columnWidths.length, equals(3));
         expect(columnWidths[0], equals(300.0));
         expect(columnWidths[1], equals(400.0));
-        expect(columnWidths[2], equals(36.0));
+        expect(columnWidths[2], equals(369.0));
       }
 
       // TODO(jacobr): add a golden image test.
@@ -489,11 +491,12 @@ void main() {
       {
         final FlatTableState<TestData> state =
             tester.state(find.byWidget(table));
-        final columnWidths = state.tableController.computeColumnWidths(200.0);
+        expect(state.tableController.columnWidths, isNotNull);
+        final columnWidths = state.tableController.columnWidths!;
         expect(columnWidths.length, equals(3));
         expect(columnWidths[0], equals(300.0)); // Fixed width column.
         expect(columnWidths[1], equals(400.0)); // Fixed width column.
-        expect(columnWidths[2], equals(0.0)); // Variable width column.
+        expect(columnWidths[2], equals(369.0)); // Variable width column.
       }
 
       // TODO(jacobr): add a golden image test.
@@ -528,8 +531,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths =
-              state.tableController.computeColumnWidths(1000.0);
+          final columnWidths = state.tableController
+              .computeColumnWidthsForManyWideColumns(1000.0);
           expect(columnWidths.length, equals(4));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(110.0)); // Min width wide column
@@ -549,7 +552,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController.computeColumnWidths(200.0);
+          final columnWidths = state.tableController
+              .computeColumnWidthsForManyWideColumns(200.0);
           expect(columnWidths.length, equals(4));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(100.0)); // Min width wide column
@@ -589,8 +593,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths =
-              state.tableController.computeColumnWidths(1501.0);
+          final columnWidths = state.tableController
+              .computeColumnWidthsForManyWideColumns(1501.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(235.0)); // Min width wide column
@@ -615,8 +619,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths =
-              state.tableController.computeColumnWidths(1200.0);
+          final columnWidths = state.tableController
+              .computeColumnWidthsForManyWideColumns(1200.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(122.0)); // Min width wide column
@@ -641,8 +645,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths =
-              state.tableController.computeColumnWidths(1000.0);
+          final columnWidths = state.tableController
+              .computeColumnWidthsForManyWideColumns(1000.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(100.0)); // Min width wide column
@@ -1141,8 +1145,8 @@ void main() {
       );
       await tester.pumpWidget(wrap(table));
       final TreeTableState state = tester.state(find.byWidget(table));
-      expect(state.tableController.columnWidths[0], equals(400));
-      expect(state.tableController.columnWidths[1], equals(81));
+      expect(state.tableController.columnWidths![0], equals(400));
+      expect(state.tableController.columnWidths![1], equals(81));
       final tree = state.tableController.dataRoots[0];
       expect(tree.children[0].name, equals('Bar'));
       expect(tree.children[0].children[0].name, equals('Baz'));

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -84,6 +84,29 @@ void main() {
       expect(find.text('FlatName'), findsOneWidget);
 
       final FlatTableState state = tester.state(find.byWidget(table));
+      final columnWidths =
+          state.tableController.computeColumnWidthsSizeToFit(1000);
+      expect(columnWidths.length, 1);
+      expect(columnWidths.first, 300);
+      expect(find.byKey(const Key('empty')), findsOneWidget);
+    });
+
+    testWidgets('displays with simple content size to content',
+        (WidgetTester tester) async {
+      final table = FlatTable<TestData>(
+        columns: [flatNameColumn],
+        data: [TestData('empty', 0)],
+        dataKey: 'test-data',
+        keyFactory: (d) => Key(d.name),
+        defaultSortColumn: flatNameColumn,
+        defaultSortDirection: SortDirection.ascending,
+        sizeToFit: false,
+      );
+      await tester.pumpWidget(wrap(table));
+      expect(find.byWidget(table), findsOneWidget);
+      expect(find.text('FlatName'), findsOneWidget);
+
+      final FlatTableState state = tester.state(find.byWidget(table));
       expect(state.tableController.columnWidths, isNotNull);
       final columnWidths = state.tableController.columnWidths!;
       expect(columnWidths.length, 1);
@@ -467,6 +490,67 @@ void main() {
       {
         final FlatTableState<TestData> state =
             tester.state(find.byWidget(table));
+        final columnWidths =
+            state.tableController.computeColumnWidthsSizeToFit(800.0);
+        expect(columnWidths.length, equals(3));
+        expect(columnWidths[0], equals(300.0));
+        expect(columnWidths[1], equals(400.0));
+        expect(columnWidths[2], equals(36.0));
+      }
+
+      // TODO(jacobr): add a golden image test.
+
+      await tester.pumpWidget(
+        wrap(
+          SizedBox(
+            width: 200.0,
+            height: 200.0,
+            child: table,
+          ),
+        ),
+      );
+
+      {
+        final FlatTableState<TestData> state =
+            tester.state(find.byWidget(table));
+        final columnWidths = state.tableController.computeColumnWidthsSizeToFit(200.0);
+        expect(columnWidths.length, equals(3));
+        expect(columnWidths[0], equals(300.0)); // Fixed width column.
+        expect(columnWidths[1], equals(400.0)); // Fixed width column.
+        expect(columnWidths[2], equals(0.0)); // Variable width column.
+      }
+
+      // TODO(jacobr): add a golden image test.
+    });
+
+    testWidgets('displays with wide column size to content',
+        (WidgetTester tester) async {
+      final table = FlatTable<TestData>(
+        columns: [
+          flatNameColumn,
+          _NumberColumn(),
+          _WideColumn(),
+        ],
+        data: flatData,
+        dataKey: 'test-data',
+        keyFactory: (data) => Key(data.name),
+        defaultSortColumn: flatNameColumn,
+        defaultSortDirection: SortDirection.ascending,
+        sizeToFit: false,
+      );
+      await tester.pumpWidget(
+        wrap(
+          SizedBox(
+            width: 800.0,
+            height: 200.0,
+            child: table,
+          ),
+        ),
+      );
+      expect(find.byWidget(table), findsOneWidget);
+      {
+        final FlatTableState<TestData> state =
+            tester.state(find.byWidget(table));
         expect(state.tableController.columnWidths, isNotNull);
         final columnWidths = state.tableController.columnWidths!;
         expect(columnWidths.length, equals(3));
@@ -530,8 +614,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController
-              .computeColumnWidthsForManyWideColumns(1000.0);
+          final columnWidths =
+              state.tableController.computeColumnWidthsSizeToFit(1000.0);
           expect(columnWidths.length, equals(4));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(110.0)); // Min width wide column
@@ -551,8 +635,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController
-              .computeColumnWidthsForManyWideColumns(200.0);
+          final columnWidths =
+              state.tableController.computeColumnWidthsSizeToFit(200.0);
           expect(columnWidths.length, equals(4));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(100.0)); // Min width wide column
@@ -592,8 +676,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController
-              .computeColumnWidthsForManyWideColumns(1501.0);
+          final columnWidths =
+              state.tableController.computeColumnWidthsSizeToFit(1501.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(235.0)); // Min width wide column
@@ -618,8 +702,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController
-              .computeColumnWidthsForManyWideColumns(1200.0);
+          final columnWidths =
+              state.tableController.computeColumnWidthsSizeToFit(1200.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(122.0)); // Min width wide column
@@ -644,8 +728,8 @@ void main() {
         {
           final FlatTableState<TestData> state =
               tester.state(find.byWidget(table));
-          final columnWidths = state.tableController
-              .computeColumnWidthsForManyWideColumns(1000.0);
+          final columnWidths =
+              state.tableController.computeColumnWidthsSizeToFit(1000.0);
           expect(columnWidths.length, equals(5));
           expect(columnWidths[0], equals(300.0)); // Fixed width column.
           expect(columnWidths[1], equals(100.0)); // Min width wide column

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -71,10 +71,9 @@ void main() {
     });
 
     testWidgets('displays with simple content', (WidgetTester tester) async {
-      final simpleData = [TestData('empty', 0)];
       final table = FlatTable<TestData>(
         columns: [flatNameColumn],
-        data: simpleData,
+        data: [TestData('empty', 0)],
         dataKey: 'test-data',
         keyFactory: (d) => Key(d.name),
         defaultSortColumn: flatNameColumn,

--- a/packages/devtools_app/test/shared/table_test.dart
+++ b/packages/devtools_app/test/shared/table_test.dart
@@ -513,7 +513,8 @@ void main() {
       {
         final FlatTableState<TestData> state =
             tester.state(find.byWidget(table));
-        final columnWidths = state.tableController.computeColumnWidthsSizeToFit(200.0);
+        final columnWidths =
+            state.tableController.computeColumnWidthsSizeToFit(200.0);
         expect(columnWidths.length, equals(3));
         expect(columnWidths[0], equals(300.0)); // Fixed width column.
         expect(columnWidths[1], equals(400.0)); // Fixed width column.


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=[too small to mention]

This adds a `sizeToFit` parameter for `FlatTable` that defaults to true (current implementation), but when false, will size the table according to its content.