### PR TITLE
Repro for table behavior.

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
@@ -85,7 +85,9 @@ class _InstanceColumn extends ColumnData<SingleClassStats>
           titleTooltip: nonGcableInstancesColumnTooltip,
           fixedWidthPx: scaleByFontFactor(180.0),
           alignment: ColumnAlignment.right,
-        );
+        ) {
+    print('!!! in _InstanceColumn constructor: ${heap.snapshotName}');
+  }
 
   final AdaptedHeapData heap;
 
@@ -103,6 +105,8 @@ class _InstanceColumn extends ColumnData<SingleClassStats>
     VoidCallback? onPressed,
   }) {
     if (!FeatureFlags.evalAndBrowse) return null;
+
+    print('!!! in _InstanceColumn build: ${heap.snapshotName}');
 
     return InstanceTableCell(
       data.objects,
@@ -167,7 +171,10 @@ class _RetainedSizeColumn extends ColumnData<SingleClassStats> {
 }
 
 class _ClassesTableSingleColumns {
-  _ClassesTableSingleColumns(this.totalSize, this.classFilterButton, this.heap);
+  _ClassesTableSingleColumns(
+      this.totalSize, this.classFilterButton, this.heap) {
+    print('!!! in columns: ${heap.snapshotName}');
+  }
 
   /// Is needed to calculate percentage.
   final int totalSize;
@@ -187,7 +194,7 @@ class _ClassesTableSingleColumns {
 }
 
 class ClassesTableSingle extends StatelessWidget {
-  const ClassesTableSingle({
+  ClassesTableSingle({
     super.key,
     required this.classes,
     required this.selection,
@@ -206,16 +213,18 @@ class ClassesTableSingle extends StatelessWidget {
 
   final AdaptedHeapData heap;
 
+  late final columns = _ClassesTableSingleColumns(
+    totalSize,
+    classFilterButton,
+    heap,
+  );
+
   @override
   Widget build(BuildContext context) {
     // We want to preserve the sorting and sort directions for ClassesTableDiff
     // no matter what the data passed to it is.
     const dataKey = 'ClassesTableSingle';
-    final columns = _ClassesTableSingleColumns(
-      totalSize,
-      classFilterButton,
-      heap,
-    );
+
     return FlatTable<SingleClassStats>(
       columns: columns.columnList,
       data: classes,

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
@@ -86,7 +86,7 @@ class _InstanceColumn extends ColumnData<SingleClassStats>
           fixedWidthPx: scaleByFontFactor(180.0),
           alignment: ColumnAlignment.right,
         ) {
-    print('!!! in _InstanceColumn constructor: ${heap.snapshotName}');
+    print('!!! column ${identityHashCode(this)}, constructor');
   }
 
   final AdaptedHeapData heap;
@@ -106,7 +106,7 @@ class _InstanceColumn extends ColumnData<SingleClassStats>
   }) {
     if (!FeatureFlags.evalAndBrowse) return null;
 
-    print('!!! in _InstanceColumn build: ${heap.snapshotName}');
+    print('!!! column ${identityHashCode(this)}, build');
 
     return InstanceTableCell(
       data.objects,
@@ -172,9 +172,10 @@ class _RetainedSizeColumn extends ColumnData<SingleClassStats> {
 
 class _ClassesTableSingleColumns {
   _ClassesTableSingleColumns(
-      this.totalSize, this.classFilterButton, this.heap) {
-    print('!!! in columns: ${heap.snapshotName}');
-  }
+    this.totalSize,
+    this.classFilterButton,
+    this.heap,
+  );
 
   /// Is needed to calculate percentage.
   final int totalSize;
@@ -201,7 +202,9 @@ class ClassesTableSingle extends StatelessWidget {
     required this.totalSize,
     required this.classFilterButton,
     required this.heap,
-  });
+  }) {
+    print('!!! table ${identityHashCode(this)}, constructor');
+  }
 
   final int totalSize;
 
@@ -221,6 +224,11 @@ class ClassesTableSingle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final instanceColumn = columns.columnList[1];
+    print(
+      '!!! table ${identityHashCode(this)}, build, with instanceColumn ${identityHashCode(instanceColumn)}',
+    );
+
     // We want to preserve the sorting and sort directions for ClassesTableDiff
     // no matter what the data passed to it is.
     const dataKey = 'ClassesTableSingle';

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
@@ -54,15 +54,15 @@ class SnapshotView extends StatelessWidget {
         if (singleClasses != null) {
           final totalSize =
               (controller.core.selectedItem as SnapshotInstanceItem).totalSize;
+          final heap =
+              (controller.core.selectedItem as SnapshotInstanceItem).heap!;
+
           classTable = ClassesTableSingle(
             classes: singleClasses,
             selection: controller.derived.selectedSingleClassStats,
             totalSize: totalSize!,
             classFilterButton: classFilterButton,
-            heap:
-                (controller.derived.selectedItem.value as SnapshotInstanceItem)
-                    .heap!
-                    .data,
+            heap: heap.data,
           );
         } else if (diffClasses != null) {
           final diffHeapClasses =

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
@@ -54,15 +54,15 @@ class SnapshotView extends StatelessWidget {
         if (singleClasses != null) {
           final totalSize =
               (controller.core.selectedItem as SnapshotInstanceItem).totalSize;
-          final heap =
-              (controller.core.selectedItem as SnapshotInstanceItem).heap!;
-
           classTable = ClassesTableSingle(
             classes: singleClasses,
             selection: controller.derived.selectedSingleClassStats,
             totalSize: totalSize!,
             classFilterButton: classFilterButton,
-            heap: heap.data,
+            heap:
+                (controller.derived.selectedItem.value as SnapshotInstanceItem)
+                    .heap!
+                    .data,
           );
         } else if (diffClasses != null) {
           final diffHeapClasses =


### PR DESCRIPTION
RELEASE_NOTE_EXCEPTION=[not user facing]

To repro take three snapshots one by one. See:
1. Every time table constructs new instance of column
2. Build is invoked only for first instance of column.

Output:
flutter: !!! table 249649066, constructor
flutter: !!! column 923794089, constructor
flutter: !!! table 249649066, build, with instanceColumn 923794089
flutter: !!! column 923794089, build
flutter: !!! table 431409282, constructor
flutter: !!! column 923794089, build
flutter: !!! column 513140485, constructor
flutter: !!! table 431409282, build, with instanceColumn 513140485
flutter: !!! column 923794089, build
flutter: !!! table 1019687803, constructor
flutter: !!! column 923794089, build
flutter: !!! column 869989429, constructor
flutter: !!! table 1019687803, build, with instanceColumn 869989429
flutter: !!! column 923794089, build


