### PR TITLE
Update Inspector tree controller ga ids to int.

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -123,7 +123,7 @@ class InspectorTreeController extends Object
 
   /// Identifier used when sending Google Analytics about events in this
   /// [InspectorTreeController].
-  final String? gaId;
+  final int? gaId;
 
   InspectorTreeNode createNode() => InspectorTreeNode();
 

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -106,7 +106,7 @@ class GtagEventDevTools extends GtagEvent {
     int? heap_objects_total, // metric9
     int? root_set_count, // metric10
     int? row_count, // metric11
-    String? inspector_tree_controller_id, // metric12
+    int? inspector_tree_controller_id, // metric12
   });
 
   @override

--- a/packages/devtools_app/lib/src/shared/analytics/metrics.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/metrics.dart
@@ -47,8 +47,8 @@ class InspectorScreenMetrics extends ScreenAnalyticsMetrics {
     required this.inspectorTreeControllerId,
   });
 
-  static const String summaryTreeGaId = 'summaryTree';
-  static const String detailsTreeGaId = 'detailsTree';
+  static const int summaryTreeGaId = 0;
+  static const int detailsTreeGaId = 1;
 
   /// The number of times the root has been set, since the
   /// [InspectorTreeController] with id [inspectorTreeControllerId], has been
@@ -60,5 +60,5 @@ class InspectorScreenMetrics extends ScreenAnalyticsMetrics {
   final int? rowCount;
 
   /// The id of the [InspectorTreeController], for which this event is tracking.
-  final String? inspectorTreeControllerId;
+  final int? inspectorTreeControllerId;
 }


### PR DESCRIPTION
![](https://media.giphy.com/media/PovpXQEF2gKnS/giphy.gif)
It looks like we need our metrics to be int unless we want to make them into dimensions.
https://github.com/flutter/devtools/pull/5322/files#r1129913017

So this PR turns the ids for the inspector tree controllers into ints.

RELEASE_NOTE_EXCEPTION=Analytics only
