### PR TITLE
Can inspect widgets in Debugger panel

### DIFF
--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -72,11 +72,7 @@ class DevToolsRouteInformationParser
     final configuration = DevToolsRouteConfiguration(
       path,
       uri.queryParameters,
-      routeInformation.state == null
-          ? null
-          : DevToolsNavigationState._(
-              (routeInformation.state as Map).cast<String, String?>(),
-            ),
+      _navigationStateFromRouteInformation(routeInformation),
     );
     return SynchronousFuture<DevToolsRouteConfiguration>(configuration);
   }
@@ -98,6 +94,20 @@ class DevToolsRouteInformationParser
       ).toString(),
       state: configuration.state,
     );
+  }
+
+  DevToolsNavigationState? _navigationStateFromRouteInformation(
+    RouteInformation routeInformation,
+  ) {
+    final routeState = routeInformation.state;
+    if (routeState == null) return null;
+    try {
+      return DevToolsNavigationState._(
+        (routeState as Map).cast<String, String?>(),
+      );
+    } catch (_) {
+      return null;
+    }
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5392

To be honest, I don't entirely understand what was happening. But if you use the widget inspector to inspect the debugger panel of your running DevTools (while doing local development work) your running DevTools will crash with the 
error seen in https://github.com/flutter/devtools/issues/5392

This fixes that by returning `null` if `RouteInformation.state` (in this case `CodeViewSourceLocationNavigationState`) can't be cast into a `Map`

RELEASE_NOTE_EXCEPTION="No user facing changes, just affects our ability to debug DevTools"