### PR TITLE
Clean up and refactor search code.

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -38,9 +38,6 @@ import 'debugger_model.dart';
 import 'file_search.dart';
 import 'key_sets.dart';
 
-final debuggerCodeViewSearchKey =
-    GlobalKey(debugLabel: 'DebuggerCodeViewSearchKey');
-
 final debuggerCodeViewFileOpenerKey =
     GlobalKey(debugLabel: 'DebuggerCodeViewFileOpenerKey');
 
@@ -110,6 +107,9 @@ class _CodeViewState extends State<CodeView>
   ScriptRef? _lastScriptRef;
 
   @override
+  SearchControllerMixin get searchController => widget.codeViewController;
+
+  @override
   void initState() {
     super.initState();
 
@@ -169,7 +169,7 @@ class _CodeViewState extends State<CodeView>
 
     if (widget.codeViewController != oldWidget.codeViewController) {
       cancelListeners();
-
+      widget.codeViewController.initSearch();
       addAutoDisposeListener(
         widget.codeViewController.scriptLocation,
         _handleScriptLocationChanged,
@@ -495,9 +495,8 @@ class _CodeViewState extends State<CodeView>
     return ElevatedCard(
       width: wideSearchTextWidth,
       height: defaultTextFieldHeight + 2 * denseSpacing,
-      child: buildSearchField(
+      child: SearchField<SourceToken>(
         controller: widget.codeViewController,
-        searchFieldKey: debuggerCodeViewSearchKey,
         searchFieldEnabled: parsedScript != null,
         shouldRequestFocus: true,
         supportsNavigation: true,

--- a/packages/devtools_app/lib/src/screens/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/file_search.dart
@@ -33,20 +33,22 @@ class FileSearchField extends StatefulWidget {
 
 class FileSearchFieldState extends State<FileSearchField>
     with AutoDisposeMixin, SearchFieldMixin {
-  late AutoCompleteController autoCompleteController;
+  static final fileSearchFieldKey = GlobalKey(debugLabel: 'fileSearchFieldKey');
+
+  final autoCompleteController = AutoCompleteController(fileSearchFieldKey);
 
   final _scriptsCache = <String, ScriptRef>{};
-
-  final fileSearchFieldKey = GlobalKey(debugLabel: 'fileSearchFieldKey');
 
   late String _query;
   late FileSearchResults _searchResults;
 
   @override
+  SearchControllerMixin get searchController => autoCompleteController;
+
+  @override
   void initState() {
     super.initState();
 
-    autoCompleteController = AutoCompleteController();
     autoCompleteController.setCurrentHoveredIndexValue(0);
 
     addAutoDisposeListener(
@@ -70,12 +72,11 @@ class FileSearchFieldState extends State<FileSearchField>
 
   @override
   Widget build(BuildContext context) {
-    return buildAutoCompleteSearchField(
+    return AutoCompleteSearchField(
       controller: autoCompleteController,
-      searchFieldKey: fileSearchFieldKey,
       searchFieldEnabled: true,
       shouldRequestFocus: true,
-      keyEventsToPropagate: {LogicalKeyboardKey.escape},
+      keyEventsToIgnore: {LogicalKeyboardKey.escape},
       onSelection: _onSelection,
       onClose: _onClose,
       label: 'Open file',

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -124,7 +124,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       // Close the search once focus is lost and following conditions are met:
       //  1. Search string is empty.
       //  2. [searchPreventClose] == false (this is set true when searchTargetType Dropdown is opened).
-      if (!searchController.searchFieldFocusNode!.hasFocus &&
+      if (!searchController.searchFieldFocusNode.hasFocus &&
           searchController.search.isEmpty &&
           !searchPreventClose) {
         setState(() {
@@ -134,7 +134,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
 
       // Reset [searchPreventClose] state to false after the search field gains focus.
       // Focus is returned automatically once the Dropdown menu is closed.
-      if (searchController.searchFieldFocusNode!.hasFocus) {
+      if (searchController.searchFieldFocusNode.hasFocus) {
         searchPreventClose = false;
       }
     });

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -103,7 +103,7 @@ class _InspectorTreeRowState extends State<_InspectorTreeRowWidget>
   bool shouldShow() => widget.node.shouldShow;
 }
 
-class InspectorTreeController extends Object
+class InspectorTreeController extends DisposableController
     with SearchControllerMixin<InspectorTreeRow> {
   InspectorTreeController({this.gaId}) {
     ga.select(
@@ -647,10 +647,6 @@ class InspectorTreeController extends Object
 
   @override
   Duration get debounceDelay => const Duration(milliseconds: 300);
-
-  void dispose() {
-    disposeSearch();
-  }
 
   @override
   List<InspectorTreeRow> matchesForSearch(

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
@@ -23,8 +23,6 @@ import '_log_details.dart';
 import '_logs_table.dart';
 import 'logging_controller.dart';
 
-final loggingSearchFieldKey = GlobalKey(debugLabel: 'LoggingSearchFieldKey');
-
 /// Presents logs from the connected app.
 class LoggingScreen extends Screen {
   LoggingScreen()
@@ -85,6 +83,9 @@ class _LoggingScreenState extends State<LoggingScreenBody>
   late List<LogData> filteredLogs;
 
   @override
+  SearchControllerMixin get searchController => controller;
+
+  @override
   void initState() {
     super.initState();
     ga.screen(LoggingScreen.id);
@@ -130,9 +131,8 @@ class _LoggingScreenState extends State<LoggingScreenBody>
         Container(
           width: wideSearchTextWidth,
           height: defaultTextFieldHeight,
-          child: buildSearchField(
+          child: SearchField<LogData>(
             controller: controller,
-            searchFieldKey: loggingSearchFieldKey,
             searchFieldEnabled: hasData,
             shouldRequestFocus: false,
             supportsNavigation: true,

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -29,8 +29,6 @@ import 'network_controller.dart';
 import 'network_model.dart';
 import 'network_request_inspector.dart';
 
-final networkSearchFieldKey = GlobalKey(debugLabel: 'NetworkSearchFieldKey');
-
 class NetworkScreen extends Screen {
   NetworkScreen()
       : super.conditional(
@@ -187,6 +185,9 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
   bool _recording = false;
 
   @override
+  SearchControllerMixin get searchController => widget.controller;
+
+  @override
   void initState() {
     super.initState();
 
@@ -262,9 +263,8 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
         Container(
           width: wideSearchTextWidth,
           height: defaultTextFieldHeight,
-          child: buildSearchField(
+          child: SearchField<NetworkRequest>(
             controller: widget.controller,
-            searchFieldKey: networkSearchFieldKey,
             searchFieldEnabled: hasRequests,
             shouldRequestFocus: false,
             supportsNavigation: true,

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/legacy_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/legacy_events_controller.dart
@@ -12,6 +12,7 @@ import '../../../../../shared/analytics/metrics.dart';
 import '../../../../../shared/config_specific/logger/allowed_error.dart';
 import '../../../../../shared/config_specific/logger/logger.dart';
 import '../../../../../shared/globals.dart';
+import '../../../../../shared/primitives/auto_dispose.dart';
 import '../../../../../shared/primitives/trace_event.dart';
 import '../../../../../shared/primitives/trees.dart';
 import '../../../../../shared/primitives/utils.dart';
@@ -30,7 +31,8 @@ import 'legacy_event_processor.dart';
 /// Debugging flag to load sample trace events from [simple_trace_example.dart].
 bool debugSimpleTrace = false;
 
-class LegacyTimelineEventsController with SearchControllerMixin<TimelineEvent> {
+class LegacyTimelineEventsController extends DisposableController
+    with SearchControllerMixin<TimelineEvent> {
   LegacyTimelineEventsController(this.performanceController) {
     processor = LegacyEventProcessor(performanceController);
   }
@@ -297,5 +299,11 @@ class LegacyTimelineEventsController with SearchControllerMixin<TimelineEvent> {
     _nextTraceIndexToProcess = 0;
     _nextTimelineEventIndexToProcess = 0;
     _selectedTimelineEventNotifier.value = null;
+  }
+
+  @override
+  void dispose() {
+    cpuProfilerController.dispose();
+    super.dispose();
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -103,7 +103,8 @@ class TimelineEventsController extends PerformanceFeatureController
 
   static const _timelinePollingRateLimit = 5.0;
 
-  static const _timelinePollingInterval = Duration(seconds: 1);
+  Duration get _timelinePollingInterval =>
+      _perfettoMode ? const Duration(seconds: 1) : const Duration(seconds: 2);
 
   RateLimiter? _timelinePollingRateLimiter;
 
@@ -598,7 +599,7 @@ class TimelineEventsController extends PerformanceFeatureController
   void dispose() {
     _pollingTimer?.cancel();
     _timelinePollingRateLimiter?.dispose();
-    legacyController.cpuProfilerController.dispose();
+    legacyController.dispose();
     if (FeatureFlags.embeddedPerfetto) {
       perfettoController.dispose();
     }

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -26,9 +26,8 @@ import 'panes/timeline_events/legacy/timeline_flame_chart.dart';
 import 'panes/timeline_events/perfetto/perfetto.dart';
 import 'panes/timeline_events/timeline_events_controller.dart';
 import 'performance_controller.dart';
+import 'performance_model.dart';
 import 'performance_screen.dart';
-
-final timelineSearchFieldKey = GlobalKey(debugLabel: 'TimelineSearchFieldKey');
 
 class TabbedPerformanceView extends StatefulWidget {
   const TabbedPerformanceView();
@@ -49,6 +48,10 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
   late TimelineEventsController _timelineEventsController;
 
   FlutterFrame? _selectedFlutterFrame;
+
+  @override
+  SearchControllerMixin get searchController =>
+      controller.timelineEventsController.legacyController;
 
   @override
   void didChangeDependencies() {
@@ -250,9 +253,8 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     return Container(
       width: defaultSearchTextWidth,
       height: defaultTextFieldHeight,
-      child: buildSearchField(
+      child: SearchField<TimelineEvent>(
         controller: _timelineEventsController.legacyController,
-        searchFieldKey: timelineSearchFieldKey,
         searchFieldEnabled: searchFieldEnabled,
         shouldRequestFocus: false,
         supportsNavigation: true,

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -99,6 +99,9 @@ class _CpuProfilerState extends State<CpuProfiler>
   late CpuProfileData data;
 
   @override
+  SearchControllerMixin get searchController => widget.controller;
+
+  @override
   void initState() {
     super.initState();
     data = widget.data;
@@ -198,7 +201,7 @@ class _CpuProfilerState extends State<CpuProfiler>
             // TODO(kenz): support search for call tree and bottom up tabs as
             // well. This will require implementing search for tree tables.
             if (currentTab.key == CpuProfiler.flameChartTab) ...[
-              if (widget.searchFieldKey != null) _buildSearchField(),
+              _buildSearchField(),
               FlameChartHelpButton(
                 gaScreen: widget.standaloneProfiler
                     ? gac.cpuProfiler
@@ -288,9 +291,8 @@ class _CpuProfilerState extends State<CpuProfiler>
     return Container(
       width: wideSearchTextWidth,
       height: defaultTextFieldHeight,
-      child: buildSearchField(
+      child: SearchField<CpuStackFrame>(
         controller: widget.controller,
-        searchFieldKey: widget.searchFieldKey!,
         searchFieldEnabled: true,
         shouldRequestFocus: false,
         supportsNavigation: true,

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -27,9 +27,6 @@ import 'cpu_profiler.dart';
 import 'panes/controls/profiler_controls.dart';
 import 'profiler_screen_controller.dart';
 
-final profilerScreenSearchFieldKey =
-    GlobalKey(debugLabel: 'ProfilerScreenSearchFieldKey');
-
 class ProfilerScreen extends Screen {
   ProfilerScreen()
       : super.conditional(
@@ -199,7 +196,6 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
                 return CpuProfiler(
                   data: cpuProfileData,
                   controller: controller.cpuProfilerController,
-                  searchFieldKey: profilerScreenSearchFieldKey,
                 );
               },
             ),

--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -39,22 +39,28 @@ class ExpressionEvalField extends StatefulWidget {
 }
 
 class ExpressionEvalFieldState extends State<ExpressionEvalField>
-    with AutoDisposeMixin, SearchFieldMixin {
-  late AutoCompleteController _autoCompleteController;
+    with AutoDisposeMixin, SearchFieldMixin<ExpressionEvalField> {
+  static final evalTextFieldKey = GlobalKey(debugLabel: 'evalTextFieldKey');
+
+  final _autoCompleteController = AutoCompleteController(evalTextFieldKey);
+
   int historyPosition = -1;
 
   String _activeWord = '';
+
   List<String> _matches = [];
 
-  final evalTextFieldKey = GlobalKey(debugLabel: 'evalTextFieldKey');
+  SearchTextEditingController get searchTextFieldController =>
+      _autoCompleteController.searchTextFieldController!;
+
+  @override
+  SearchControllerMixin get searchController => _autoCompleteController;
 
   @override
   void initState() {
     super.initState();
 
     serviceManager.consoleService.ensureServiceInitialized();
-
-    _autoCompleteController = AutoCompleteController();
 
     addAutoDisposeListener(_autoCompleteController.searchNotifier, () {
       _autoCompleteController.handleAutoCompleteOverlay(
@@ -164,8 +170,9 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
       if (matches.length == 1 && matches.first == parts.activeWord) {
         // It is not useful to show a single autocomplete that is exactly what
         // the already typed.
-        _autoCompleteController.clearSearchAutoComplete();
-        _autoCompleteController.clearCurrentSuggestion();
+        _autoCompleteController
+          ..clearSearchAutoComplete()
+          ..clearCurrentSuggestion();
       } else {
         final results = matches
             .sublist(
@@ -175,9 +182,10 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
             .map((match) => AutoCompleteMatch(match))
             .toList();
 
-        _autoCompleteController.searchAutoComplete.value = results;
-        _autoCompleteController.setCurrentHoveredIndexValue(0);
-        _autoCompleteController.updateCurrentSuggestion(parts.activeWord);
+        _autoCompleteController
+          ..searchAutoComplete.value = results
+          ..setCurrentHoveredIndexValue(0)
+          ..updateCurrentSuggestion(parts.activeWord);
       }
     } else {
       _autoCompleteController.closeAutoCompleteOverlay();
@@ -206,12 +214,11 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
 
               return KeyEventResult.ignored;
             },
-            child: buildAutoCompleteSearchField(
+            child: AutoCompleteSearchField(
               controller: _autoCompleteController,
-              searchFieldKey: evalTextFieldKey,
               searchFieldEnabled: true,
               shouldRequestFocus: false,
-              supportClearField: true,
+              clearFieldOnEscapeWhenOverlayHidden: true,
               onSelection: _onSelection,
               decoration: const InputDecoration(
                 contentPadding: EdgeInsets.all(denseSpacing),
@@ -250,9 +257,10 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
   void _onSelection(String word) {
     setState(() {
       _replaceActiveWord(word);
-      _autoCompleteController.selectTheSearch = false;
-      _autoCompleteController.closeAutoCompleteOverlay();
-      _autoCompleteController.clearCurrentSuggestion();
+      _autoCompleteController
+        ..selectTheSearch = false
+        ..closeAutoCompleteOverlay()
+        ..clearCurrentSuggestion();
     });
   }
 
@@ -294,8 +302,9 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
 
   void _handleExpressionEval() async {
     final expressionText = searchTextFieldController.value.text.trim();
-    updateSearchField(newValue: '', caretPosition: 0);
-    clearSearchField(_autoCompleteController, force: true);
+    _autoCompleteController
+      ..updateSearchField(newValue: '', caretPosition: 0)
+      ..clearSearchField(force: true);
 
     if (expressionText.isEmpty) return;
 

--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -51,7 +51,7 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
   List<String> _matches = [];
 
   SearchTextEditingController get searchTextFieldController =>
-      _autoCompleteController.searchTextFieldController!;
+      _autoCompleteController.searchTextFieldController;
 
   @override
   SearchControllerMixin get searchController => _autoCompleteController;

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -828,12 +828,12 @@ mixin SearchFieldMixin<T extends StatefulWidget>
   SearchControllerMixin get searchController;
 
   @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    // We call this in [didChangeDependencies] in case the [searchController] is
-    // only available when [BuildContext] is available. This happens whenever a
-    // controller is provided through package:provider.
+  void initState() {
+    super.initState();
     if (this is ProvidedControllerMixin) {
+      // Controllers provided through package:provider will not be ready until
+      // [didChangeDependencies] is called, so ensure [searchController] is
+      // ready before calling [searchController.initSearch].
       (this as ProvidedControllerMixin).callWhenControllerReady((_) {
         searchController.initSearch();
       });

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -19,7 +19,8 @@ import '../theme.dart';
 import '../ui/utils.dart';
 import '../utils.dart';
 
-// TODO(kenz): break this file up into managable pieces.
+// TODO(https://github.com/flutter/devtools/issues/5416): break this file up
+// into managable pieces.
 
 /// Top 10 matches to display in auto-complete overlay.
 const defaultTopMatchesLimit = 10;
@@ -63,11 +64,14 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
 
   /// Text field controller for the [SearchField] that this instance of
   /// [SearchControllerMixin] controls.
-  SearchTextEditingController? searchTextFieldController;
+  SearchTextEditingController get searchTextFieldController =>
+      _searchTextFieldController!;
+  SearchTextEditingController? _searchTextFieldController;
 
   /// Focus node for the [SearchField] that this instance of
   /// [SearchControllerMixin] controls.
-  FocusNode? searchFieldFocusNode;
+  FocusNode get searchFieldFocusNode => _searchFieldFocusNode!;
+  FocusNode? _searchFieldFocusNode;
 
   void refreshSearchMatches({bool searchPreviousMatches = false}) {
     if (_searchNotifier.value.isNotEmpty) {
@@ -200,17 +204,17 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
 
   void resetSearch() {
     _searchNotifier.value = '';
-    searchTextFieldController?.clear();
+    _searchTextFieldController?.clear();
     refreshSearchMatches();
   }
 
   @mustCallSuper
   void initSearch() {
-    searchTextFieldController?.dispose();
-    searchFieldFocusNode?.dispose();
-    searchTextFieldController = SearchTextEditingController()
+    _searchTextFieldController?.dispose();
+    _searchFieldFocusNode?.dispose();
+    _searchTextFieldController = SearchTextEditingController()
       ..text = _searchNotifier.value;
-    searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
+    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
   }
 
   @mustCallSuper
@@ -219,10 +223,10 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
     if (_searchDebounce?.isActive ?? false) {
       _searchDebounce!.cancel();
     }
-    searchTextFieldController?.dispose();
-    searchFieldFocusNode?.dispose();
-    searchTextFieldController = null;
-    searchFieldFocusNode = null;
+    _searchTextFieldController?.dispose();
+    _searchFieldFocusNode?.dispose();
+    _searchTextFieldController = null;
+    _searchFieldFocusNode = null;
   }
 }
 
@@ -539,19 +543,20 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
 
   /// [FocusNode] for the keyboard listener responsible for handling auto
   /// complete search.
-  FocusNode? rawKeyboardFocusNode;
+  FocusNode get rawKeyboardFocusNode => _rawKeyboardFocusNode!;
+  FocusNode? _rawKeyboardFocusNode;
 
   @override
   void initSearch() {
     super.initSearch();
-    rawKeyboardFocusNode?.dispose();
-    rawKeyboardFocusNode = FocusNode(debugLabel: 'search-raw-keyboard');
+    _rawKeyboardFocusNode?.dispose();
+    _rawKeyboardFocusNode = FocusNode(debugLabel: 'search-raw-keyboard');
   }
 
   @override
   void disposeSearch() {
-    rawKeyboardFocusNode?.dispose();
-    rawKeyboardFocusNode = null;
+    _rawKeyboardFocusNode?.dispose();
+    _rawKeyboardFocusNode = null;
     super.disposeSearch();
   }
 
@@ -722,14 +727,14 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
   }
 
   void selectFromSearchField(String selection) {
-    searchTextFieldController!.clear();
+    searchTextFieldController.clear();
     search = selection;
     clearSearchField(force: true);
     selectTheSearch = true;
     closeAutoCompleteOverlay();
   }
 
-  void clearSearchField({force = false}) {
+  void clearSearchField({bool force = false}) {
     if (force || search.isNotEmpty) {
       resetSearch();
       closeAutoCompleteOverlay();
@@ -740,7 +745,7 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
     required String newValue,
     required int caretPosition,
   }) {
-    searchTextFieldController!
+    searchTextFieldController
       ..text = newValue
       ..selection = TextSelection.collapsed(offset: caretPosition);
   }
@@ -924,7 +929,7 @@ class SearchField<T extends DataSearchStateMixin> extends StatelessWidget {
         controller.search = value;
       },
       onEditingComplete: () {
-        controller.searchFieldFocusNode!.requestFocus();
+        controller.searchFieldFocusNode.requestFocus();
       },
       // Guarantee that the TextField on all platforms renders in the same
       // color for border, label text, and cursor. Primarly, so golden screen
@@ -973,7 +978,7 @@ class SearchField<T extends DataSearchStateMixin> extends StatelessWidget {
     );
 
     if (shouldRequestFocus) {
-      controller.searchFieldFocusNode!.requestFocus();
+      controller.searchFieldFocusNode.requestFocus();
     }
 
     return searchField;
@@ -1089,13 +1094,13 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
       widget.controller.rawKeyboardFocusNode,
       _handleLostFocus,
     );
-    widget.controller.rawKeyboardFocusNode!.onKey = _handleKeyStrokes;
+    widget.controller.rawKeyboardFocusNode.onKey = _handleKeyStrokes;
   }
 
   @override
   Widget build(BuildContext context) {
     return RawKeyboardListener(
-      focusNode: widget.controller.rawKeyboardFocusNode!,
+      focusNode: widget.controller.rawKeyboardFocusNode,
       child: CompositedTransformTarget(
         link: widget.controller.autoCompleteLayerLink,
         child: SearchField(
@@ -1121,8 +1126,8 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
   }
 
   void _handleLostFocus() {
-    if (widget.controller.searchFieldFocusNode!.hasPrimaryFocus ||
-        widget.controller.rawKeyboardFocusNode!.hasPrimaryFocus) {
+    if (widget.controller.searchFieldFocusNode.hasPrimaryFocus ||
+        widget.controller.rawKeyboardFocusNode.hasPrimaryFocus) {
       return;
     }
 
@@ -1152,7 +1157,7 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
         if (key == enter ||
             key == tab ||
             (key == arrowRight &&
-                widget.controller.searchTextFieldController!.isAtEnd)) {
+                widget.controller.searchTextFieldController.isAtEnd)) {
           // Enter / Tab pressed OR right arrow pressed while text field is at the end
           String? foundExact;
 

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -19,6 +19,8 @@ import '../theme.dart';
 import '../ui/utils.dart';
 import '../utils.dart';
 
+// TODO(kenz): break this file up into managable pieces.
+
 /// Top 10 matches to display in auto-complete overlay.
 const defaultTopMatchesLimit = 10;
 int topMatchesLimit = defaultTopMatchesLimit;
@@ -32,9 +34,6 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
   /// Notify that the search has changed.
   ValueListenable<String> get searchNotifier => _searchNotifier;
   ValueListenable<bool> get searchInProgressNotifier => _searchInProgress;
-
-  /// Last X position of caret in search field, used for pop-up position.
-  double xPosition = 0.0;
 
   CancelableOperation<void>? _searchOperation;
   Timer? _searchDebounce;
@@ -61,6 +60,14 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
   /// Delay to reduce the amount of search queries
   /// Duration.zero (default) disables debounce
   Duration? get debounceDelay => null;
+
+  /// Text field controller for the [SearchField] that this instance of
+  /// [SearchControllerMixin] controls.
+  SearchTextEditingController? searchTextFieldController;
+
+  /// Focus node for the [SearchField] that this instance of
+  /// [SearchControllerMixin] controls.
+  FocusNode? searchFieldFocusNode;
 
   void refreshSearchMatches({bool searchPreviousMatches = false}) {
     if (_searchNotifier.value.isNotEmpty) {
@@ -193,14 +200,29 @@ mixin SearchControllerMixin<T extends DataSearchStateMixin> {
 
   void resetSearch() {
     _searchNotifier.value = '';
+    searchTextFieldController?.clear();
     refreshSearchMatches();
   }
 
+  @mustCallSuper
+  void initSearch() {
+    searchTextFieldController?.dispose();
+    searchFieldFocusNode?.dispose();
+    searchTextFieldController = SearchTextEditingController()
+      ..text = _searchNotifier.value;
+    searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
+  }
+
+  @mustCallSuper
   void disposeSearch() {
     unawaited(_searchOperation?.cancel());
     if (_searchDebounce?.isActive ?? false) {
       _searchDebounce!.cancel();
     }
+    searchTextFieldController?.dispose();
+    searchFieldFocusNode?.dispose();
+    searchTextFieldController = null;
+    searchFieldFocusNode = null;
   }
 }
 
@@ -502,11 +524,36 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       ? searchAutoComplete.value[currentHoveredIndex.value].text
       : null;
 
+  /// Last X position of caret in search field, used for pop-up position.
+  double xPosition = 0.0;
+
   ValueListenable<String?> get currentSuggestion => _currentSuggestionNotifier;
 
   final _currentSuggestionNotifier = ValueNotifier<String?>(null);
 
   static const minPopupWidth = 300.0;
+
+  /// Key used to find the search text field for positioning the auto complete
+  /// overlay.
+  GlobalKey get searchFieldKey;
+
+  /// [FocusNode] for the keyboard listener responsible for handling auto
+  /// complete search.
+  FocusNode? rawKeyboardFocusNode;
+
+  @override
+  void initSearch() {
+    super.initSearch();
+    rawKeyboardFocusNode?.dispose();
+    rawKeyboardFocusNode = FocusNode(debugLabel: 'search-raw-keyboard');
+  }
+
+  @override
+  void disposeSearch() {
+    rawKeyboardFocusNode?.dispose();
+    rawKeyboardFocusNode = null;
+    super.disposeSearch();
+  }
 
   void setCurrentHoveredIndexValue(int index) {
     _currentHoveredIndex.value = index;
@@ -673,6 +720,30 @@ mixin AutoCompleteSearchControllerMixin on SearchControllerMixin {
       rightSide: rightSide,
     );
   }
+
+  void selectFromSearchField(String selection) {
+    searchTextFieldController!.clear();
+    search = selection;
+    clearSearchField(force: true);
+    selectTheSearch = true;
+    closeAutoCompleteOverlay();
+  }
+
+  void clearSearchField({force = false}) {
+    if (force || search.isNotEmpty) {
+      resetSearch();
+      closeAutoCompleteOverlay();
+    }
+  }
+
+  void updateSearchField({
+    required String newValue,
+    required int caretPosition,
+  }) {
+    searchTextFieldController!
+      ..text = newValue
+      ..selection = TextSelection.collapsed(offset: caretPosition);
+  }
 }
 
 mixin SearchableMixin<T> {
@@ -692,7 +763,7 @@ typedef HighlightAutoComplete = Function(
 
 /// Callback for clearing the search field.
 typedef ClearSearchField = Function(
-  SearchControllerMixin controller, {
+  AutoCompleteSearchControllerMixin controller, {
   bool force,
 });
 
@@ -748,189 +819,94 @@ class SearchTextEditingController extends TextEditingController {
   }
 }
 
-// TODO(elliette) Consider refactoring this mixin to be a widget. See discussion
-// at https://github.com/flutter/devtools/pull/3532#discussion_r767015567.
+/// Mixin for managing search field lifecycle.
+///
+/// This should be mixed into any [State] class that builds [SearchField] or
+/// [AutoCompleteSearchField].
 mixin SearchFieldMixin<T extends StatefulWidget>
     on AutoDisposeMixin<T>, State<T> {
-  late final SearchTextEditingController searchTextFieldController;
-  late FocusNode _searchFieldFocusNode;
-  late FocusNode _rawKeyboardFocusNode;
-  late SelectAutoComplete _onSelection;
-
-  FocusNode get searchFieldFocusNode => _searchFieldFocusNode;
+  SearchControllerMixin get searchController;
 
   @override
-  void initState() {
-    super.initState();
-    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
-    _rawKeyboardFocusNode = FocusNode(debugLabel: 'search-raw-keyboard');
-    autoDisposeFocusNode(_searchFieldFocusNode);
-    autoDisposeFocusNode(_rawKeyboardFocusNode);
-
-    searchTextFieldController = SearchTextEditingController();
-  }
-
-  void callOnSelection(String foundMatch) {
-    _onSelection(foundMatch);
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    // We call this in [didChangeDependencies] in case the [searchController] is
+    // only available when [BuildContext] is available. This happens whenever a
+    // controller is provided through package:provider.
+    if (this is ProvidedControllerMixin) {
+      (this as ProvidedControllerMixin).callWhenControllerReady((_) {
+        searchController.initSearch();
+      });
+    } else {
+      searchController.initSearch();
+    }
   }
 
   @override
   void dispose() {
+    searchController.disposeSearch();
     super.dispose();
-    searchTextFieldController.dispose();
-  }
-
-  /// Hookup up TextField (search field) to the auto-complete overlay
-  /// pop-up.
-  ///
-  /// [controller]
-  /// [searchFieldKey]
-  /// [searchFieldEnabled]
-  /// [onSelection]
-  /// [onHighlightDropdown] use to override default highlghter.
-  /// [decoration]
-  /// [overlayXPositionBuilder] callback function to determine where the
-  /// autocomplete overlay should be positioned relative to the input text.
-  /// [supportClearField] if true clear TextField content if pop-up not visible. If
-  /// pop-up is visible close the pop-up on first ESCAPE.
-  /// [keyEventsToPropagate] a set of key events that should be propagated to
-  /// other handlers
-  Widget buildAutoCompleteSearchField({
-    required AutoCompleteSearchControllerMixin controller,
-    required GlobalKey searchFieldKey,
-    required bool searchFieldEnabled,
-    required bool shouldRequestFocus,
-    required SelectAutoComplete onSelection,
-    HighlightAutoComplete? onHighlightDropdown,
-    InputDecoration? decoration,
-    String label = 'Search',
-    OverlayXPositionBuilder? overlayXPositionBuilder,
-    bool supportClearField = false,
-    Set<LogicalKeyboardKey> keyEventsToPropagate = const {},
-    VoidCallback? onClose,
-    VoidCallback? onFocusLost,
-    TextStyle? style,
-  }) {
-    _onSelection = onSelection;
-
-    final searchField = _SearchField(
-      controller: controller,
-      searchFieldKey: searchFieldKey,
-      searchFieldEnabled: searchFieldEnabled,
-      shouldRequestFocus: shouldRequestFocus,
-      searchFieldFocusNode: _searchFieldFocusNode,
-      searchTextFieldController: searchTextFieldController,
-      decoration: decoration,
-      label: label,
-      overlayXPositionBuilder: overlayXPositionBuilder,
-      onClose: onClose,
-      style: style,
-    );
-
-    return _AutoCompleteSearchField(
-      controller: controller,
-      searchField: searchField,
-      searchFieldFocusNode: _searchFieldFocusNode,
-      rawKeyboardFocusNode: _rawKeyboardFocusNode,
-      autoCompleteLayerLink: controller.autoCompleteLayerLink,
-      onSelection: onSelection,
-      onHighlightDropdown: onHighlightDropdown,
-      clearSearchField: clearSearchField,
-      keyEventsToPropagate: keyEventsToPropagate,
-      supportClearField: supportClearField,
-      onFocusLost: onFocusLost,
-    );
-  }
-
-  Widget buildSearchField({
-    required SearchControllerMixin controller,
-    required GlobalKey searchFieldKey,
-    required bool searchFieldEnabled,
-    required bool shouldRequestFocus,
-    bool supportsNavigation = false,
-    VoidCallback? onClose,
-    Widget? prefix,
-    Widget? suffix,
-  }) {
-    return _SearchField(
-      controller: controller,
-      searchFieldKey: searchFieldKey,
-      searchFieldEnabled: searchFieldEnabled,
-      shouldRequestFocus: shouldRequestFocus,
-      searchFieldFocusNode: _searchFieldFocusNode,
-      searchTextFieldController: searchTextFieldController,
-      supportsNavigation: supportsNavigation,
-      onClose: onClose,
-      prefix: prefix,
-      suffix: suffix,
-    );
-  }
-
-  void selectFromSearchField(
-    SearchControllerMixin controller,
-    String selection,
-  ) {
-    searchTextFieldController.clear();
-    controller.search = selection;
-    clearSearchField(controller, force: true);
-    if (controller is AutoCompleteSearchControllerMixin) {
-      controller.selectTheSearch = true;
-      controller.closeAutoCompleteOverlay();
-    }
-  }
-
-  void clearSearchField(SearchControllerMixin controller, {force = false}) {
-    if (force || controller.search.isNotEmpty) {
-      searchTextFieldController.clear();
-      controller.resetSearch();
-      if (controller is AutoCompleteSearchControllerMixin) {
-        controller.closeAutoCompleteOverlay();
-      }
-    }
-  }
-
-  void updateSearchField({
-    required String newValue,
-    required int caretPosition,
-  }) {
-    searchTextFieldController.text = newValue;
-    searchTextFieldController.selection =
-        TextSelection.collapsed(offset: caretPosition);
   }
 }
 
-class _SearchField extends StatelessWidget {
-  const _SearchField({
+/// A text field with search capability.
+///
+/// The widget that builds [SearchField] is responsible for mixing in
+/// [SearchFieldMixin], which manages the search field lifecycle.
+class SearchField<T extends DataSearchStateMixin> extends StatelessWidget {
+  const SearchField({
     required this.controller,
-    required this.searchFieldKey,
     required this.searchFieldEnabled,
     required this.shouldRequestFocus,
-    required this.searchFieldFocusNode,
-    required this.searchTextFieldController,
+    this.searchFieldKey,
     this.label = 'Search',
-    this.supportsNavigation = false,
     this.decoration,
+    this.supportsNavigation = false,
     this.onClose,
-    this.overlayXPositionBuilder,
+    this.onChanged,
     this.prefix,
     this.suffix,
     this.style,
   });
 
-  final SearchControllerMixin controller;
-  final GlobalKey searchFieldKey;
+  final SearchControllerMixin<T> controller;
+
+  /// Whether the search text field should be enabled.
   final bool searchFieldEnabled;
+
+  /// Whether the search text field should automatically request focus once it
+  /// is built.
   final bool shouldRequestFocus;
-  final FocusNode searchFieldFocusNode;
-  final SearchTextEditingController searchTextFieldController;
-  final String label;
+
+  /// Whether this search field includes navigation controls for traversing
+  /// search results.
   final bool supportsNavigation;
-  final InputDecoration? decoration;
+
+  /// Label for the search field's input text decoration.
+  final String label;
+
+  /// Callback called when the search field suffix close action is triggered.
   final VoidCallback? onClose;
-  final OverlayXPositionBuilder? overlayXPositionBuilder;
+
+  /// Optional prefix to be used for the [TextField]'s decoration.
   final Widget? prefix;
+
+  /// Optional suffix to be used for the [TextField]'s decoration.
   final Widget? suffix;
+
+  /// Style for the search text field.
   final TextStyle? style;
+
+  /// Optional decoration for the search text field.
+  ///
+  /// When null, a default [InputDecoration] will be used.
+  final InputDecoration? decoration;
+
+  /// Optional callback called in the [TextField]'s onChanged handler.
+  final void Function(String)? onChanged;
+
+  /// Optional key for the search text field.
+  final GlobalKey? searchFieldKey;
 
   @override
   Widget build(BuildContext context) {
@@ -940,17 +916,15 @@ class _SearchField extends StatelessWidget {
       key: searchFieldKey,
       autofocus: true,
       enabled: searchFieldEnabled,
-      focusNode: searchFieldFocusNode,
-      controller: searchTextFieldController,
+      focusNode: controller.searchFieldFocusNode,
+      controller: controller.searchTextFieldController,
       style: textStyle,
       onChanged: (value) {
-        if (overlayXPositionBuilder != null) {
-          controller.xPosition = overlayXPositionBuilder!(value, textStyle);
-        }
+        onChanged?.call(value);
         controller.search = value;
       },
       onEditingComplete: () {
-        searchFieldFocusNode.requestFocus();
+        controller.searchFieldFocusNode!.requestFocus();
       },
       // Guarantee that the TextField on all platforms renders in the same
       // color for border, label text, and cursor. Primarly, so golden screen
@@ -999,46 +973,86 @@ class _SearchField extends StatelessWidget {
     );
 
     if (shouldRequestFocus) {
-      searchFieldFocusNode.requestFocus();
+      controller.searchFieldFocusNode!.requestFocus();
     }
 
     return searchField;
   }
 }
 
-class _AutoCompleteSearchField extends StatefulWidget {
-  const _AutoCompleteSearchField({
-    required this.searchField,
+/// A text field with autocomplete search capability.
+///
+/// The widget that builds [AutoCompleteSearchField] is responsible for mixing
+/// in [SearchFieldMixin], which manages the search field lifecycle.
+class AutoCompleteSearchField extends StatefulWidget {
+  const AutoCompleteSearchField({
     required this.controller,
-    required this.searchFieldFocusNode,
-    required this.rawKeyboardFocusNode,
-    required this.autoCompleteLayerLink,
+    required this.searchFieldEnabled,
+    required this.shouldRequestFocus,
     required this.onSelection,
-    required this.onHighlightDropdown,
-    required this.clearSearchField,
-    this.keyEventsToPropagate = const {},
-    this.supportClearField = false,
+    this.onHighlightDropdown,
+    this.label = 'Search',
+    this.decoration,
+    this.overlayXPositionBuilder,
+    this.clearFieldOnEscapeWhenOverlayHidden = false,
+    this.onClose,
     this.onFocusLost,
+    this.style,
+    this.keyEventsToIgnore = const {},
   });
 
   final AutoCompleteSearchControllerMixin controller;
-  final _SearchField searchField;
-  final FocusNode searchFieldFocusNode;
-  final FocusNode rawKeyboardFocusNode;
-  final LayerLink autoCompleteLayerLink;
+
+  /// Whether the search text field should be enabled.
+  final bool searchFieldEnabled;
+
+  /// Whether the search text field should automatically request focus once it
+  /// is built.
+  final bool shouldRequestFocus;
+
+  /// Label for the search field's input text decoration.
+  final String label;
+
+  /// Callback called when the search field suffix close action is triggered.
+  final VoidCallback? onClose;
+
+  /// Callback to determine where the autocomplete overlay should be positioned
+  /// relative to the input text.
+  final OverlayXPositionBuilder? overlayXPositionBuilder;
+
+  /// Style for the search text field.
+  final TextStyle? style;
+
+  /// Optional decoration for the search text field.
+  ///
+  /// When null, a default [InputDecoration] will be used.
+  final InputDecoration? decoration;
+
+  /// Handler called when an item is selected from the autocomplete dropdown.
   final SelectAutoComplete onSelection;
+
+  /// Handler to manage how an item in the autocomplete dropdown should be
+  /// highlighted.
   final HighlightAutoComplete? onHighlightDropdown;
-  final ClearSearchField clearSearchField;
-  final Set<LogicalKeyboardKey> keyEventsToPropagate;
-  final bool supportClearField;
+
+  /// A set of key events that should be ignored, as they will be propagated to
+  /// other handlers.
+  final Set<LogicalKeyboardKey> keyEventsToIgnore;
+
+  /// Whether to clear [TextField] content when the escape key is pressed and
+  /// autocomplete overlay is not showing.
+  final bool clearFieldOnEscapeWhenOverlayHidden;
+
+  /// Handler called when either [controller.searchFieldFocusNode] or
+  /// [controller.rawKeyboardFocusNode] has lost focus.
   final VoidCallback? onFocusLost;
 
   @override
-  State<_AutoCompleteSearchField> createState() =>
+  State<AutoCompleteSearchField> createState() =>
       _AutoCompleteSearchFieldState();
 }
 
-class _AutoCompleteSearchFieldState extends State<_AutoCompleteSearchField>
+class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
     with AutoDisposeMixin {
   /// Platform independent (Mac or Linux).
   int get arrowDown =>
@@ -1061,31 +1075,54 @@ class _AutoCompleteSearchFieldState extends State<_AutoCompleteSearchField>
   HighlightAutoComplete get _highlightDropdown =>
       widget.onHighlightDropdown != null
           ? widget.onHighlightDropdown as HighlightAutoComplete
-          : _highlightDropdownDefault;
+          : _highlightDropdownItem;
 
   @override
   void initState() {
     super.initState();
 
-    addAutoDisposeListener(widget.searchFieldFocusNode, _handleLostFocus);
-    addAutoDisposeListener(widget.rawKeyboardFocusNode, _handleLostFocus);
-    widget.rawKeyboardFocusNode.onKey = _handleKeyStrokes;
+    addAutoDisposeListener(
+      widget.controller.searchFieldFocusNode,
+      _handleLostFocus,
+    );
+    addAutoDisposeListener(
+      widget.controller.rawKeyboardFocusNode,
+      _handleLostFocus,
+    );
+    widget.controller.rawKeyboardFocusNode!.onKey = _handleKeyStrokes;
   }
 
   @override
   Widget build(BuildContext context) {
     return RawKeyboardListener(
-      focusNode: widget.rawKeyboardFocusNode,
+      focusNode: widget.controller.rawKeyboardFocusNode!,
       child: CompositedTransformTarget(
-        link: widget.autoCompleteLayerLink,
-        child: widget.searchField,
+        link: widget.controller.autoCompleteLayerLink,
+        child: SearchField(
+          controller: widget.controller,
+          searchFieldKey: widget.controller.searchFieldKey,
+          searchFieldEnabled: widget.searchFieldEnabled,
+          shouldRequestFocus: widget.shouldRequestFocus,
+          label: widget.label,
+          decoration: widget.decoration,
+          onChanged: (value) {
+            if (widget.overlayXPositionBuilder != null) {
+              widget.controller.xPosition = widget.overlayXPositionBuilder!(
+                value,
+                widget.style ?? Theme.of(context).textTheme.titleMedium,
+              );
+            }
+          },
+          onClose: widget.onClose,
+          style: widget.style,
+        ),
       ),
     );
   }
 
   void _handleLostFocus() {
-    if (widget.searchFieldFocusNode.hasPrimaryFocus ||
-        widget.rawKeyboardFocusNode.hasPrimaryFocus) {
+    if (widget.controller.searchFieldFocusNode!.hasPrimaryFocus ||
+        widget.controller.rawKeyboardFocusNode!.hasPrimaryFocus) {
       return;
     }
 
@@ -1106,19 +1143,16 @@ class _AutoCompleteSearchFieldState extends State<_AutoCompleteSearchField>
         // ESCAPE key pressed clear search TextField.c
         if (widget.controller.autoCompleteOverlay != null) {
           widget.controller.closeAutoCompleteOverlay();
-        } else if (widget.supportClearField) {
+        } else if (widget.clearFieldOnEscapeWhenOverlayHidden) {
           // If pop-up closed ESCAPE will clean the TextField.
-          widget.clearSearchField(widget.controller, force: true);
+          widget.controller.clearSearchField(force: true);
         }
-        return _determineKeyEventResult(
-          key,
-          widget.keyEventsToPropagate,
-        );
+        return _determineKeyEventResult(key);
       } else if (widget.controller.autoCompleteOverlay != null) {
         if (key == enter ||
             key == tab ||
             (key == arrowRight &&
-                widget.searchField.searchTextFieldController.isAtEnd)) {
+                widget.controller.searchTextFieldController!.isAtEnd)) {
           // Enter / Tab pressed OR right arrow pressed while text field is at the end
           String? foundExact;
 
@@ -1145,39 +1179,37 @@ class _AutoCompleteSearchFieldState extends State<_AutoCompleteSearchField>
           }
 
           if (foundExact != null) {
-            widget.controller.selectTheSearch = true;
-            widget.controller.search = foundExact;
+            widget.controller
+              ..selectTheSearch = true
+              ..search = foundExact;
             widget.onSelection(foundExact);
-            return _determineKeyEventResult(key, widget.keyEventsToPropagate);
+            return _determineKeyEventResult(key);
           }
         } else if (key == arrowDown || key == arrowUp) {
           _highlightDropdown(widget.controller, key == arrowDown);
-          return _determineKeyEventResult(key, widget.keyEventsToPropagate);
+          return _determineKeyEventResult(key);
         }
       }
 
       // We don't support tabs in the search input. Swallow to prevent a
       // change of focus.
       if (key == tab) {
-        _determineKeyEventResult(key, widget.keyEventsToPropagate);
+        _determineKeyEventResult(key);
       }
     }
 
     return KeyEventResult.ignored;
   }
 
-  KeyEventResult _determineKeyEventResult(
-    int keyEventId,
-    Set<LogicalKeyboardKey> keyEventsToPropagate,
-  ) {
-    final shouldPropagateKeyEvent = keyEventsToPropagate
+  KeyEventResult _determineKeyEventResult(int keyEventId) {
+    final shouldIgnoreKeyEvent = widget.keyEventsToIgnore
         .any((key) => key.keyId & LogicalKeyboardKey.valueMask == keyEventId);
-    return shouldPropagateKeyEvent
+    return shouldIgnoreKeyEvent
         ? KeyEventResult.ignored
         : KeyEventResult.handled;
   }
 
-  void _highlightDropdownDefault(
+  void _highlightDropdownItem(
     AutoCompleteSearchControllerMixin controller,
     bool directionDown,
   ) {
@@ -1311,6 +1343,12 @@ mixin TreeDataSearchStateMixin<T extends TreeNode<T>>
 
 class AutoCompleteController extends DisposableController
     with SearchControllerMixin, AutoCompleteSearchControllerMixin {
+  AutoCompleteController(this._searchFieldKey);
+
+  @override
+  GlobalKey get searchFieldKey => _searchFieldKey;
+  final GlobalKey _searchFieldKey;
+
   // TODO(jacobr): seems a little surprising that returning an empty list of
   // matches for the search is the intended behavior for the auto-complete
   // controller.

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -148,6 +148,8 @@ List<String> issueLinkDetails() {
   return issueDescriptionItems;
 }
 
+typedef _ProvidedControllerCallback<T> = void Function(T);
+
 /// Mixin that provides a [controller] from package:provider for a State class.
 ///
 /// [initController] must be called from [State.didChangeDependencies]. If
@@ -158,6 +160,20 @@ mixin ProvidedControllerMixin<T, V extends StatefulWidget> on State<V> {
   T get controller => _controller!;
 
   T? _controller;
+
+  final _callWhenReady = <_ProvidedControllerCallback>[];
+
+  /// Calls the provided [callback] once [_controller] has been initialized.
+  /// 
+  /// The [callback] will be called immediately if [_controller] has already
+  /// been initialized.
+  void callWhenControllerReady(_ProvidedControllerCallback callback) {
+    if (_controller != null) {
+      callback(_controller!);
+    } else {
+      _callWhenReady.add(callback);
+    }
+  }
 
   /// Initializes [_controller] from package:provider.
   ///
@@ -173,7 +189,14 @@ mixin ProvidedControllerMixin<T, V extends StatefulWidget> on State<V> {
   bool initController() {
     final newController = Provider.of<T>(context);
     if (newController == _controller) return false;
+    final firstInitialization = _controller == null;
     _controller = newController;
+    if (firstInitialization) {
+      for (final callback in _callWhenReady) {
+        callback(_controller!);
+      }
+      _callWhenReady.clear();
+    }
     return true;
   }
 }

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -164,7 +164,7 @@ mixin ProvidedControllerMixin<T, V extends StatefulWidget> on State<V> {
   final _callWhenReady = <_ProvidedControllerCallback>[];
 
   /// Calls the provided [callback] once [_controller] has been initialized.
-  /// 
+  ///
   /// The [callback] will be called immediately if [_controller] has already
   /// been initialized.
   void callWhenControllerReady(_ProvidedControllerCallback callback) {

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -66,7 +66,6 @@ void main() {
 
   group('CpuProfiler', () {
     const windowSize = Size(2000.0, 1000.0);
-    final searchFieldKey = GlobalKey(debugLabel: 'test search field key');
 
     testWidgetsWithWindowSize(
       'builds for empty cpuProfileData',
@@ -76,7 +75,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
         );
         await tester.pumpWidget(wrap(cpuProfiler));
         expect(find.byType(TabBar), findsOneWidget);
@@ -91,7 +89,7 @@ void main() {
         expect(find.byType(ExpandAllButton), findsOneWidget);
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
         expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.methodTableTab), findsOneWidget);
@@ -109,7 +107,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
           summaryView: const SizedBox(key: summaryViewKey),
         );
         await tester.pumpWidget(wrap(cpuProfiler));
@@ -125,7 +122,7 @@ void main() {
         expect(find.byType(ExpandAllButton), findsNothing);
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
         expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.methodTableTab), findsOneWidget);
@@ -142,7 +139,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
         );
         await tester.pumpWidget(wrap(cpuProfiler));
         expect(find.byType(TabBar), findsOneWidget);
@@ -154,7 +150,7 @@ void main() {
         expect(find.byType(ExpandAllButton), findsOneWidget);
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
         expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.methodTableTab), findsOneWidget);
@@ -171,7 +167,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
           summaryView: const SizedBox(key: summaryViewKey),
         );
         await tester.pumpWidget(wrap(cpuProfiler));
@@ -184,7 +179,7 @@ void main() {
         expect(find.byType(ExpandAllButton), findsNothing);
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
         expect(find.byKey(CpuProfiler.bottomUpTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.callTreeTab), findsOneWidget);
         expect(find.byKey(CpuProfiler.methodTableTab), findsOneWidget);
@@ -332,7 +327,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
         );
         await tester.pumpWidget(wrap(cpuProfiler));
         expect(find.byType(TabBar), findsOneWidget);
@@ -348,7 +342,7 @@ void main() {
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
 
         await tester.tap(find.text('Call Tree'));
         await tester.pumpAndSettle();
@@ -363,7 +357,7 @@ void main() {
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
 
         await tester.tap(find.text('Method Table'));
         await tester.pumpAndSettle();
@@ -378,7 +372,7 @@ void main() {
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsNothing);
 
         await tester.tap(find.text('CPU Flame Chart'));
         await tester.pumpAndSettle();
@@ -393,32 +387,7 @@ void main() {
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
         expect(find.byType(ModeDropdown), findsNothing);
-        expect(find.byKey(searchFieldKey), findsOneWidget);
-      },
-    );
-
-    testWidgetsWithWindowSize(
-      'does not include search field without search field key',
-      windowSize,
-      (WidgetTester tester) async {
-        cpuProfiler = CpuProfiler(
-          data: cpuProfileData,
-          controller: controller,
-          // No search field key.
-          // searchFieldKey: searchFieldKey,
-        );
-        await tester.pumpWidget(wrap(cpuProfiler));
-        await tester.pumpAndSettle();
-        await tester.tap(find.text('CPU Flame Chart'));
-        await tester.pumpAndSettle();
-        expect(find.byType(CpuProfileFlameChart), findsOneWidget);
-        expect(find.byType(CpuCallTreeTable), findsNothing);
-        expect(find.byType(CpuBottomUpTable), findsNothing);
-        expect(find.byType(UserTagDropdown), findsOneWidget);
-        expect(find.byType(ExpandAllButton), findsNothing);
-        expect(find.byType(CollapseAllButton), findsNothing);
-        expect(find.byType(FlameChartHelpButton), findsOneWidget);
-        expect(find.byKey(searchFieldKey), findsNothing);
+        expect(find.byType(SearchField<CpuStackFrame>), findsOneWidget);
       },
     );
 
@@ -429,7 +398,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
         );
         await tester.pumpWidget(wrap(cpuProfiler));
         await tester.tap(find.text('Call Tree'));
@@ -464,7 +432,6 @@ void main() {
         cpuProfiler = CpuProfiler(
           data: cpuProfileData,
           controller: controller,
-          searchFieldKey: searchFieldKey,
         );
         await tester.pumpWidget(wrap(cpuProfiler));
         await tester.tap(find.text('Call Tree'));

--- a/packages/devtools_app/test/debugger/debugger_codeview_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_codeview_test.dart
@@ -2,18 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/screens/debugger/breakpoint_manager.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/debugger/codeview.dart';
-import 'package:devtools_app/src/screens/debugger/codeview_controller.dart';
-import 'package:devtools_app/src/screens/debugger/debugger_controller.dart';
 import 'package:devtools_app/src/screens/debugger/debugger_model.dart';
-import 'package:devtools_app/src/screens/debugger/debugger_screen.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/shared/diagnostics/primitives/source_location.dart';
-import 'package:devtools_app/src/shared/globals.dart';
-import 'package:devtools_app/src/shared/notifications.dart';
-import 'package:devtools_app/src/shared/scripts/script_manager.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -117,11 +109,12 @@ void main() {
     (WidgetTester tester) async {
       when(codeViewController.showSearchInFileField)
           .thenReturn(ValueNotifier(true));
+      when(codeViewController.searchFieldFocusNode).thenReturn(FocusNode());
+      when(codeViewController.searchTextFieldController)
+          .thenReturn(SearchTextEditingController());
+
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(
-        find.byKey(debuggerCodeViewSearchKey),
-        findsOneWidget,
-      );
+      expect(find.byType(SearchField<SourceToken>), findsOneWidget);
     },
   );
 

--- a/packages/devtools_app/test/logging/logging_screen_data_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_data_test.dart
@@ -97,7 +97,7 @@ void main() async {
       await pumpLoggingScreen(tester);
       verifyNever(mockLoggingController.clear());
 
-      final textFieldFinder = find.byKey(loggingSearchFieldKey);
+      final textFieldFinder = find.byType(TextField);
       expect(textFieldFinder, findsOneWidget);
       final TextField textField = tester.widget(textFieldFinder) as TextField;
       expect(textField.enabled, isTrue);

--- a/packages/devtools_app/test/logging/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_test.dart
@@ -84,7 +84,7 @@ void main() async {
         await pumpLoggingScreen(tester);
         verifyNever(mockLoggingController.clear());
 
-        final textFieldFinder = find.byKey(loggingSearchFieldKey);
+        final textFieldFinder = find.byType(TextField);
         expect(textFieldFinder, findsOneWidget);
         final TextField textField = tester.widget(textFieldFinder) as TextField;
         expect(textField.enabled, isFalse);

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -195,7 +195,7 @@ void main() {
 
         expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
-        expect(find.byKey(timelineSearchFieldKey), findsOneWidget);
+        expect(find.byType(SearchField<TimelineEvent>), findsOneWidget);
         expect(find.byType(TimelineEventsView), findsOneWidget);
       });
     });

--- a/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
@@ -82,7 +82,7 @@ void main() {
         _setUpServiceManagerWithTimeline({});
         await pumpPerformanceScreenBody(tester);
         expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
-        expect(find.byKey(timelineSearchFieldKey), findsOneWidget);
+        expect(find.byType(SearchField<TimelineEvent>), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
       });
     });

--- a/packages/devtools_app/test/shared/search_test.dart
+++ b/packages/devtools_app/test/shared/search_test.dart
@@ -2,8 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:devtools_app/src/shared/primitives/utils.dart';
-import 'package:devtools_app/src/shared/ui/search.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 // TODO(https://github.com/flutter/devtools/issues/3514): increase test coverage
@@ -70,7 +69,8 @@ void main() {
   });
 }
 
-class TestSearchController with SearchControllerMixin<TestSearchData> {
+class TestSearchController extends DisposableController
+    with SearchControllerMixin<TestSearchData> {
   final data = <TestSearchData>[];
 
   @override

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart' hide TimelineEvent;

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -6,6 +6,7 @@ import 'dart:async';
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart' hide TimelineEvent;
 
@@ -162,6 +163,9 @@ MockLoggingController createMockLoggingControllerWithDefaults({
       .thenReturn(ListValueNotifier<LogData>(data));
   when(mockLoggingController.selectedLog)
       .thenReturn(ValueNotifier<LogData?>(null));
+  when(mockLoggingController.searchFieldFocusNode).thenReturn(FocusNode());
+  when(mockLoggingController.searchTextFieldController)
+      .thenReturn(SearchTextEditingController());
   when(mockLoggingController.searchMatches)
       .thenReturn(const FixedValueListenable(<LogData>[]));
   when(mockLoggingController.activeSearchMatch)


### PR DESCRIPTION
This PR reduces the formerly large `SearchFieldMixin` to include only what needs to be in a mixin (the state management for initializing and disposing search components). I moved controller functionality to the controller mixins `SearchControllerMixin` and `AutoCompleteSearchControllerMixin` and moved widget helper methods into formal Widgets `SearchField` and `AutoCompleteSearchField`.

RELEASE_NOTE_EXCEPTION=[not user facing]