### PR TITLE
Fix issue with viewing network request and response data

### DIFF
--- a/packages/devtools_app/lib/src/service/json_to_service_cache.dart
+++ b/packages/devtools_app/lib/src/service/json_to_service_cache.dart
@@ -151,7 +151,7 @@ class JsonToServiceCache {
       for (final entry in json.entries)
         MapAssociation(
           key: insertJsonObject(entry.key),
-          value: insertJsonObject(entry.value ?? 'null'),
+          value: insertJsonObject(entry.value),
         ),
     ];
     map.length = json.length;

--- a/packages/devtools_app/lib/src/service/json_to_service_cache.dart
+++ b/packages/devtools_app/lib/src/service/json_to_service_cache.dart
@@ -151,7 +151,7 @@ class JsonToServiceCache {
       for (final entry in json.entries)
         MapAssociation(
           key: insertJsonObject(entry.key),
-          value: insertJsonObject(entry.value!),
+          value: insertJsonObject(entry.value ?? 'null'),
         ),
     ];
     map.length = json.length;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -33,7 +33,7 @@ TODO: Remove this section if there are not any general updates.
 * Add search icon in file bar to make file search more discoverable - [#5351](https://github.com/flutter/devtools/issues/5351)
 
 ## Network profiler updates
-TODO: Remove this section if there are not any general updates.
+* Fix a bug viewing JSON responses with null values - [#5424](https://github.com/flutter/devtools/pull/5424)
 
 ## Logging updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/test/shared/json_to_service_cache_test.dart
+++ b/packages/devtools_app/test/shared/json_to_service_cache_test.dart
@@ -20,6 +20,7 @@ void main() {
           true,
           null,
         ],
+        'aNullValue': null
       };
 
       final cache = JsonToServiceCache();
@@ -33,11 +34,11 @@ void main() {
 
       final instance = cache.insertJsonObject(data);
       ensureIsInCache(instance);
-      expect(cache.length, 11);
+      expect(cache.length, 12);
 
       expect(instance.kind, InstanceKind.kMap);
       final associations = instance.associations!;
-      expect(associations.length, 3);
+      expect(associations.length, 4);
 
       // 'id': 1
       expect(associations[0].key.kind, InstanceKind.kString);


### PR DESCRIPTION
![](https://media.giphy.com/media/xT4AplQ21okJsnUc1y/giphy.gif)

Fixes https://github.com/flutter/devtools/issues/5327

With the help of the new experimental logging code, we were able to get enough indication to see what was going wrong. The logs led me to find that the json view has a hard time viewing null values. with some quick testing i found out that having a json object  that contains a null value, causes the same crash.

This PR fixes and tests for that problem.
