### PR TITLE
Potential fix for DevTools going a bit blurry when window is expanded 

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -53,6 +53,9 @@
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script> 
 
+  <!-- TODO(elliette): Remove once https://github.com/flutter/flutter/issues/122541 is fixed. -->
+  <link rel="stylesheet" href="styles.css" type="text/css" />
+
 </head>
 
 <body>

--- a/packages/devtools_app/web/styles.css
+++ b/packages/devtools_app/web/styles.css
@@ -1,0 +1,5 @@
+@media (-webkit-max-device-pixel-ratio: 1) {
+  * {
+    image-rendering: pixelated;
+  }
+}


### PR DESCRIPTION
Note: Need to confirm this fixes the issue when I'm at home (I can only reproduce this on my monitor at home, not in the office)

Details here: https://github.com/flutter/flutter/issues/122541

When expanded:

![Screenshot 2023-03-13 at 2 56 19 PM](https://user-images.githubusercontent.com/21270878/225479048-9c791830-a7f4-4a35-8793-dfc42eb961bf.png)

When not expanded:
![Screenshot 2023-03-13 at 2 56 03 PM](https://user-images.githubusercontent.com/21270878/225479084-40fbd16b-28f1-4b9c-9e3c-2644d2e6303f.png)


`RELEASE_NOTE_EXCEPTION="No new feature / not a fix for a feature"`

