### PR TITLE
Make sure app error handling falls through

### DIFF
--- a/packages/devtools_app/lib/src/framework/app_error_handling.dart
+++ b/packages/devtools_app/lib/src/framework/app_error_handling.dart
@@ -52,6 +52,7 @@ void setupErrorHandling(Future Function() appStartCallback) {
     },
     (Object error, StackTrace stack) {
       _reportError(error, stack, 'zoneGuarded');
+      throw error;
     },
   );
 }

--- a/packages/devtools_app/lib/src/framework/app_error_handling.dart
+++ b/packages/devtools_app/lib/src/framework/app_error_handling.dart
@@ -52,7 +52,6 @@ void setupErrorHandling(Future Function() appStartCallback) {
     },
     (Object error, StackTrace stack) {
       _reportError(error, stack, 'zoneGuarded');
-      throw error;
     },
   );
 }

--- a/packages/devtools_app/lib/src/framework/app_error_handling.dart
+++ b/packages/devtools_app/lib/src/framework/app_error_handling.dart
@@ -46,7 +46,7 @@ void setupErrorHandling(Future Function() appStartCallback) {
       PlatformDispatcher.instance.onError = (error, stack) {
         // Unhandled errors on the root isolate are caught here.
         _reportError(error, stack, 'PlatformDispatcher');
-        return true;
+        return false;
       };
       return appStartCallback();
     },


### PR DESCRIPTION
![](https://media.giphy.com/media/byGsNfk0bVRMA/giphy.gif)

Adding error fall throughs so all errors get reported to the console as well.

RELEASE_NOTE_EXCEPTION=Bug fix for logging