### PR TITLE
Clean up search code

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -86,8 +86,7 @@ class CodeView extends StatefulWidget {
   _CodeViewState createState() => _CodeViewState();
 }
 
-class _CodeViewState extends State<CodeView>
-    with AutoDisposeMixin, SearchFieldMixin<CodeView> {
+class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
   static const searchFieldRightPadding = 75.0;
 
   late final LinkedScrollControllerGroup verticalController;
@@ -105,9 +104,6 @@ class _CodeViewState extends State<CodeView>
   // Used to ensure we don't update the scroll position when expanding or
   // collapsing the file explorer.
   ScriptRef? _lastScriptRef;
-
-  @override
-  SearchControllerMixin get searchController => widget.codeViewController;
 
   @override
   void initState() {
@@ -484,7 +480,7 @@ class _CodeViewState extends State<CodeView>
   Widget buildFileSearchField() {
     return ElevatedCard(
       key: debuggerCodeViewFileOpenerKey,
-      width: extraWideSearchTextWidth,
+      width: extraWideSearchFieldWidth,
       height: defaultTextFieldHeight,
       padding: EdgeInsets.zero,
       child: FileSearchField(
@@ -495,13 +491,13 @@ class _CodeViewState extends State<CodeView>
 
   Widget buildSearchInFileField() {
     return ElevatedCard(
-      width: wideSearchTextWidth,
+      width: wideSearchFieldWidth,
       height: defaultTextFieldHeight + 2 * denseSpacing,
-      child: SearchField<SourceToken>(
-        controller: widget.codeViewController,
+      child: SearchField<CodeViewController>(
+        searchController: widget.codeViewController,
         searchFieldEnabled: parsedScript != null,
         shouldRequestFocus: true,
-        supportsNavigation: true,
+        searchFieldWidth: wideSearchFieldWidth,
         onClose: () =>
             widget.codeViewController.toggleSearchInFileVisibility(false),
       ),

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -219,7 +219,8 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
                 constraints: constraints,
                 onRefreshInspectorPressed: _refreshInspector,
                 onSearchVisibleToggle: _onSearchVisibleToggle,
-                searchFieldBuilder: () => SearchField<InspectorTreeRow>(
+                searchFieldBuilder: () =>
+                    StatelessSearchField<InspectorTreeRow>(
                   controller: _summaryTreeController,
                   searchFieldEnabled: true,
                   shouldRequestFocus: searchVisible,

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -828,9 +828,8 @@ class LogData with SearchableDataMixin {
 
   @override
   bool matchesSearchToken(RegExp regExpSearch) {
-    return (summary != null &&
-            summary!.caseInsensitiveContains(regExpSearch)) ||
-        (details != null && details!.caseInsensitiveContains(regExpSearch));
+    return (summary?.caseInsensitiveContains(regExpSearch) == true) ||
+        (details?.caseInsensitiveContains(regExpSearch) == true);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -625,32 +625,7 @@ class LoggingController extends DisposableController
   }
 
   @override
-  List<LogData> matchesForSearch(
-    String search, {
-    bool searchPreviousMatches = false,
-  }) {
-    if (search.isEmpty) return [];
-    final matches = <LogData>[];
-    if (searchPreviousMatches) {
-      final previousMatches = searchMatches.value;
-      for (final previousMatch in previousMatches) {
-        if (previousMatch.summary!.caseInsensitiveContains(search)) {
-          matches.add(previousMatch);
-        }
-      }
-    } else {
-      final List<LogData> currentLogs = filteredData.value;
-      for (final log in currentLogs) {
-        if ((log.summary != null &&
-                log.summary!.caseInsensitiveContains(search)) ||
-            (log.details != null &&
-                log.details!.caseInsensitiveContains(search))) {
-          matches.add(log);
-        }
-      }
-    }
-    return matches;
-  }
+  Iterable<LogData> get currentDataToSearchThrough => filteredData.value;
 
   @override
   void filterData(Filter<LogData> filter) {
@@ -849,6 +824,13 @@ class LogData with SearchableDataMixin {
     }
 
     return false;
+  }
+
+  @override
+  bool matchesSearchToken(RegExp regExpSearch) {
+    return (summary != null &&
+            summary!.caseInsensitiveContains(regExpSearch)) ||
+        (details != null && details!.caseInsensitiveContains(regExpSearch));
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen.dart
@@ -79,12 +79,8 @@ Example queries:
 class _LoggingScreenState extends State<LoggingScreenBody>
     with
         AutoDisposeMixin,
-        ProvidedControllerMixin<LoggingController, LoggingScreenBody>,
-        SearchFieldMixin<LoggingScreenBody> {
+        ProvidedControllerMixin<LoggingController, LoggingScreenBody> {
   late List<LogData> filteredLogs;
-
-  @override
-  SearchControllerMixin get searchController => controller;
 
   @override
   void initState() {
@@ -134,15 +130,10 @@ class _LoggingScreenState extends State<LoggingScreenBody>
         StructuredErrorsToggle(),
         const SizedBox(width: denseSpacing),
         // TODO(kenz): fix focus issue when state is refreshed
-        Container(
-          width: wideSearchTextWidth,
-          height: defaultTextFieldHeight,
-          child: SearchField<LogData>(
-            controller: controller,
-            searchFieldEnabled: hasData,
-            shouldRequestFocus: false,
-            supportsNavigation: true,
-          ),
+        SearchField<LoggingController>(
+          searchFieldWidth: wideSearchFieldWidth,
+          searchController: controller,
+          searchFieldEnabled: hasData,
         ),
         const SizedBox(width: denseSpacing),
         FilterButton(

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -241,29 +241,7 @@ class NetworkController extends DisposableController
   }
 
   @override
-  List<NetworkRequest> matchesForSearch(
-    String search, {
-    bool searchPreviousMatches = false,
-  }) {
-    if (search.isEmpty) return [];
-    final matches = <NetworkRequest>[];
-    if (searchPreviousMatches) {
-      final previousMatches = searchMatches.value;
-      for (final previousMatch in previousMatches) {
-        if (previousMatch.uri.caseInsensitiveContains(search)) {
-          matches.add(previousMatch);
-        }
-      }
-    } else {
-      final currentRequests = filteredData.value;
-      for (final request in currentRequests) {
-        if (request.uri.caseInsensitiveContains(search)) {
-          matches.add(request);
-        }
-      }
-    }
-    return matches;
-  }
+  Iterable<NetworkRequest> get currentDataToSearchThrough => filteredData.value;
 
   @override
   void filterData(Filter<NetworkRequest> filter) {

--- a/packages/devtools_app/lib/src/screens/network/network_model.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_model.dart
@@ -48,6 +48,11 @@ abstract class NetworkRequest with SearchableDataMixin {
   }
 
   @override
+  bool matchesSearchToken(RegExp regExpSearch) {
+    return uri.caseInsensitiveContains(regExpSearch);
+  }
+
+  @override
   String toString() => '$method $uri';
 
   @override

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -177,15 +177,12 @@ class _NetworkProfilerControls extends StatefulWidget {
 }
 
 class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
-    with AutoDisposeMixin, SearchFieldMixin<_NetworkProfilerControls> {
+    with AutoDisposeMixin {
   late NetworkRequests _requests;
 
   late List<NetworkRequest> _filteredRequests;
 
   bool _recording = false;
-
-  @override
-  SearchControllerMixin get searchController => widget.controller;
 
   @override
   void initState() {
@@ -246,15 +243,10 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
         const SizedBox(width: defaultSpacing),
         const Expanded(child: SizedBox()),
         // TODO(kenz): fix focus issue when state is refreshed
-        Container(
-          width: wideSearchTextWidth,
-          height: defaultTextFieldHeight,
-          child: SearchField<NetworkRequest>(
-            controller: widget.controller,
-            searchFieldEnabled: hasRequests,
-            shouldRequestFocus: false,
-            supportsNavigation: true,
-          ),
+        SearchField<NetworkController>(
+          searchController: widget.controller,
+          searchFieldEnabled: hasRequests,
+          searchFieldWidth: wideSearchFieldWidth,
         ),
         const SizedBox(width: denseSpacing),
         FilterButton(

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/legacy_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/legacy_events_controller.dart
@@ -232,11 +232,12 @@ class LegacyTimelineEventsController extends DisposableController
     bool searchPreviousMatches = false,
   }) {
     if (search.isEmpty) return <TimelineEvent>[];
+    final regexSearch = RegExp(search, caseSensitive: false);
     final matches = <TimelineEvent>[];
     if (searchPreviousMatches) {
       final List<TimelineEvent> previousMatches = searchMatches.value;
       for (final previousMatch in previousMatches) {
-        if (previousMatch.name!.caseInsensitiveContains(search)) {
+        if (previousMatch.matchesSearchToken(regexSearch)) {
           matches.add(previousMatch);
         }
       }
@@ -246,7 +247,7 @@ class LegacyTimelineEventsController extends DisposableController
         breadthFirstTraversal<TimelineEvent>(
           event,
           action: (TimelineEvent e) {
-            if (e.name!.caseInsensitiveContains(search)) {
+            if (e.matchesSearchToken(regexSearch)) {
               matches.add(e);
             }
           },

--- a/packages/devtools_app/lib/src/screens/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_model.dart
@@ -757,6 +757,11 @@ abstract class TimelineEvent extends TreeNode<TimelineEvent>
     return copy;
   }
 
+  @override
+  bool matchesSearchToken(RegExp regExpSearch) {
+    return name!.caseInsensitiveContains(regExpSearch);
+  }
+
   // TODO(kenz): use DiagnosticableTreeMixin instead.
   @override
   String toString() {

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -200,6 +200,7 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
                         searchController:
                             _timelineEventsController.legacyController,
                         searchFieldEnabled: searchFieldEnabled,
+                        searchFieldWidth: wideSearchFieldWidth,
                       );
                     },
                   ),

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -22,11 +22,11 @@ import 'panes/flutter_frames/flutter_frames_controller.dart';
 import 'panes/frame_analysis/frame_analysis.dart';
 import 'panes/raster_stats/raster_stats.dart';
 import 'panes/rebuild_stats/rebuild_stats.dart';
+import 'panes/timeline_events/legacy/legacy_events_controller.dart';
 import 'panes/timeline_events/legacy/timeline_flame_chart.dart';
 import 'panes/timeline_events/perfetto/perfetto.dart';
 import 'panes/timeline_events/timeline_events_controller.dart';
 import 'performance_controller.dart';
-import 'performance_model.dart';
 import 'performance_screen.dart';
 
 class TabbedPerformanceView extends StatefulWidget {
@@ -39,7 +39,6 @@ class TabbedPerformanceView extends StatefulWidget {
 class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     with
         AutoDisposeMixin,
-        SearchFieldMixin<TabbedPerformanceView>,
         ProvidedControllerMixin<PerformanceController, TabbedPerformanceView> {
   static const _gaPrefix = 'performanceTab';
 
@@ -48,10 +47,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
   late TimelineEventsController _timelineEventsController;
 
   FlutterFrame? _selectedFlutterFrame;
-
-  @override
-  SearchControllerMixin get searchController =>
-      controller.timelineEventsController.legacyController;
 
   @override
   void didChangeDependencies() {
@@ -201,7 +196,11 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
                     builder: (context, status, _) {
                       final searchFieldEnabled =
                           status == EventsControllerStatus.ready;
-                      return _buildSearchField(searchFieldEnabled);
+                      return SearchField<LegacyTimelineEventsController>(
+                        searchController:
+                            _timelineEventsController.legacyController,
+                        searchFieldEnabled: searchFieldEnabled,
+                      );
                     },
                   ),
                   const SizedBox(width: denseSpacing),
@@ -248,19 +247,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
         },
       ),
       featureController: controller.timelineEventsController,
-    );
-  }
-
-  Widget _buildSearchField(bool searchFieldEnabled) {
-    return Container(
-      width: defaultSearchTextWidth,
-      height: defaultTextFieldHeight,
-      child: SearchField<TimelineEvent>(
-        controller: _timelineEventsController.legacyController,
-        searchFieldEnabled: searchFieldEnabled,
-        shouldRequestFocus: false,
-        supportsNavigation: true,
-      ),
     );
   }
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -197,13 +197,13 @@ class _CpuProfilerState extends State<CpuProfiler>
             // well. This will require implementing search for tree tables.
             if (CpuProfiler.searchableTabKeys.contains(currentTab.key)) ...[
               if (currentTab.key == ProfilerTab.methodTable.key)
-                CpuProfilerSearchField<MethodTableController>(
+                SearchField<MethodTableController>(
                   searchController: widget.controller.methodTableController,
                 )
               else
-                CpuProfilerSearchField<CpuProfilerController>(
+                SearchField<CpuProfilerController>(
                   searchController: widget.controller,
-                )
+                ),
             ],
             if (currentTab.key == ProfilerTab.cpuFlameChart.key) ...[
               Padding(
@@ -361,38 +361,6 @@ class _CpuProfilerState extends State<CpuProfiler>
     setState(() {
       roots.forEach(callback);
     });
-  }
-}
-
-// TODO(kenz): make other uses of [SearchFieldMixin] use a stateful search field
-// like this widget instead of having to mixin [SearchFieldMixin] everywhere.
-class CpuProfilerSearchField<T extends SearchControllerMixin>
-    extends StatefulWidget {
-  const CpuProfilerSearchField({required this.searchController, super.key});
-
-  final T searchController;
-
-  @override
-  State<CpuProfilerSearchField> createState() => _CpuProfilerSearchFieldState();
-}
-
-class _CpuProfilerSearchFieldState extends State<CpuProfilerSearchField>
-    with AutoDisposeMixin, SearchFieldMixin {
-  @override
-  SearchControllerMixin get searchController => widget.searchController;
-
-  @override
-  Widget build(BuildContext context) {
-    return Container(
-      width: wideSearchTextWidth,
-      height: defaultTextFieldHeight,
-      child: SearchField(
-        controller: searchController,
-        searchFieldEnabled: true,
-        shouldRequestFocus: false,
-        supportsNavigation: true,
-      ),
-    );
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -199,10 +199,12 @@ class _CpuProfilerState extends State<CpuProfiler>
               if (currentTab.key == ProfilerTab.methodTable.key)
                 SearchField<MethodTableController>(
                   searchController: widget.controller.methodTableController,
+                  containerPadding: const EdgeInsets.all(0.0),
                 )
               else
                 SearchField<CpuProfilerController>(
                   searchController: widget.controller,
+                  containerPadding: const EdgeInsets.all(0.0),
                 ),
             ],
             if (currentTab.key == ProfilerTab.cpuFlameChart.key) ...[

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -199,12 +199,12 @@ class _CpuProfilerState extends State<CpuProfiler>
               if (currentTab.key == ProfilerTab.methodTable.key)
                 SearchField<MethodTableController>(
                   searchController: widget.controller.methodTableController,
-                  containerPadding: const EdgeInsets.all(0.0),
+                  containerPadding: EdgeInsets.zero,
                 )
               else
                 SearchField<CpuProfilerController>(
                   searchController: widget.controller,
-                  containerPadding: const EdgeInsets.all(0.0),
+                  containerPadding: EdgeInsets.zero,
                 ),
             ],
             if (currentTab.key == ProfilerTab.cpuFlameChart.key) ...[

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1249,6 +1249,7 @@ Widget closeSearchDropdownButton(VoidCallback? onPressed) {
 Widget inputDecorationSuffixButton(IconData icon, VoidCallback? onPressed) {
   return Container(
     padding: const EdgeInsets.symmetric(horizontal: densePadding),
+    height: inputDecorationElementHeight,
     width: defaultIconSize + denseSpacing,
     child: IconButton(
       padding: const EdgeInsets.all(0.0),

--- a/packages/devtools_app/lib/src/shared/device_dialog.dart
+++ b/packages/devtools_app/lib/src/shared/device_dialog.dart
@@ -154,7 +154,7 @@ class _VMFlagsDialogState extends State<VMFlagsDialog> with AutoDisposeMixin {
           const DialogTitleText('VM Flags'),
           const Expanded(child: SizedBox(width: denseSpacing)),
           Container(
-            width: defaultSearchTextWidth,
+            width: defaultSearchFieldWidth,
             height: defaultTextFieldHeight,
             child: TextField(
               controller: filterController,

--- a/packages/devtools_app/lib/src/shared/theme.dart
+++ b/packages/devtools_app/lib/src/shared/theme.dart
@@ -522,9 +522,9 @@ extension ThemeDataExtension on ThemeData {
   }
 }
 
-const extraWideSearchTextWidth = 600.0;
-const wideSearchTextWidth = 400.0;
-const defaultSearchTextWidth = 200.0;
+const extraWideSearchFieldWidth = 600.0;
+const wideSearchFieldWidth = 400.0;
+const defaultSearchFieldWidth = 200.0;
 double get defaultTextFieldHeight => scaleByFontFactor(32.0);
 double get defaultTextFieldNumberWidth => scaleByFontFactor(100.0);
 

--- a/packages/devtools_app/lib/src/shared/theme.dart
+++ b/packages/devtools_app/lib/src/shared/theme.dart
@@ -271,6 +271,8 @@ double get actionWidgetSize => scaleByFontFactor(48.0);
 
 double get statusLineHeight => scaleByFontFactor(24.0);
 
+double get inputDecorationElementHeight => scaleByFontFactor(20.0);
+
 const chartTextFontSize = 10.0;
 
 const devtoolsGreen = Color(0xFF5BC43B);

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -26,8 +26,6 @@ import '../utils.dart';
 const defaultTopMatchesLimit = 10;
 int topMatchesLimit = defaultTopMatchesLimit;
 
-const double _searchControlDividerHeight = 24.0;
-
 mixin SearchControllerMixin<T extends SearchableDataMixin> {
   final _searchNotifier = ValueNotifier<String>('');
   final _searchInProgress = ValueNotifier<bool>(false);
@@ -902,19 +900,28 @@ mixin SearchFieldMixin<T extends StatefulWidget>
 /// field, consider using [StatelessSearchField] instead and manually mixing in
 /// [SearchFieldMixin] so that you can manage the lifecycle properly.
 class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
-  const SearchField({
+  SearchField({
     required this.searchController,
-    this.searchFieldWidth = defaultSearchFieldWidth,
     this.searchFieldEnabled = true,
     this.shouldRequestFocus = false,
     this.supportsNavigation = true,
     this.onClose,
+    this.searchFieldWidth = defaultSearchFieldWidth,
+    double? searchFieldHeight,
+    EdgeInsets? containerPadding,
     super.key,
-  });
+  })  : searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight,
+        containerPadding =
+            containerPadding ?? const EdgeInsets.only(top: _defaultTopPadding);
 
   final T searchController;
 
   final double searchFieldWidth;
+
+  final double searchFieldHeight;
+
+  /// The padding for the [Container] that contains the search text field.
+  final EdgeInsets containerPadding;
 
   /// Whether the search text field should be enabled.
   final bool searchFieldEnabled;
@@ -931,6 +938,10 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
   /// triggered.
   final VoidCallback? onClose;
 
+  /// Padding to ensure the 'Search' hint on the text field is not cut off for
+  /// the default text field height [defaultTextFieldHeight].
+  static const _defaultTopPadding = 3.0;
+
   @override
   State<SearchField> createState() => _SearchFieldState();
 }
@@ -944,7 +955,8 @@ class _SearchFieldState extends State<SearchField>
   Widget build(BuildContext context) {
     return Container(
       width: widget.searchFieldWidth,
-      height: defaultTextFieldHeight,
+      height: widget.searchFieldHeight,
+      padding: widget.containerPadding,
       child: StatelessSearchField(
         controller: searchController,
         searchFieldEnabled: widget.searchFieldEnabled,
@@ -1025,7 +1037,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
 
   @override
   Widget build(BuildContext context) {
-    final textStyle = style ?? Theme.of(context).textTheme.titleMedium;
+    final textStyle = style ?? Theme.of(context).textTheme.bodyMedium;
 
     final searchField = TextField(
       key: searchFieldKey,
@@ -1049,7 +1061,10 @@ class StatelessSearchField<T extends SearchableDataMixin>
       // snapshots will compare with the exact color.
       decoration: decoration ??
           InputDecoration(
-            contentPadding: const EdgeInsets.all(denseSpacing),
+            contentPadding: const EdgeInsets.symmetric(
+              horizontal: denseSpacing,
+              vertical: densePadding,
+            ),
             border: const OutlineInputBorder(),
             labelText: label,
             // TODO(kenz): add the search icon to the search field.
@@ -1060,7 +1075,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
                     children: <Widget>[
                       prefix!,
                       SizedBox(
-                        height: _searchControlDividerHeight,
+                        height: inputDecorationElementHeight,
                         width: defaultIconSize,
                         child: Transform.rotate(
                           angle: degToRad(90),
@@ -1401,7 +1416,7 @@ class SearchNavigationControls extends StatelessWidget {
                 ),
                 _matchesStatus(numMatches),
                 SizedBox(
-                  height: _searchControlDividerHeight,
+                  height: inputDecorationElementHeight,
                   width: defaultIconSize,
                   child: Transform.rotate(
                     angle: degToRad(90),

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -92,11 +92,11 @@ void main() {
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
         expect(find.byKey(ProfilerTab.bottomUp.key), findsOneWidget);
@@ -132,11 +132,11 @@ void main() {
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
         expect(find.byKey(ProfilerTab.bottomUp.key), findsOneWidget);
@@ -167,11 +167,11 @@ void main() {
         expect(find.byType(CollapseAllButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
         expect(find.byKey(ProfilerTab.bottomUp.key), findsOneWidget);
@@ -203,11 +203,11 @@ void main() {
         expect(find.byType(CollapseAllButton), findsNothing);
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
         expect(find.byKey(ProfilerTab.bottomUp.key), findsOneWidget);
@@ -373,11 +373,11 @@ void main() {
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
 
@@ -395,11 +395,11 @@ void main() {
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
 
@@ -417,11 +417,11 @@ void main() {
         expect(find.byType(FlameChartHelpButton), findsNothing);
         expect(find.byType(ModeDropdown), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsOneWidget,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsNothing,
         );
 
@@ -439,11 +439,11 @@ void main() {
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
         expect(find.byType(ModeDropdown), findsNothing);
         expect(
-          find.byType(CpuProfilerSearchField<MethodTableController>),
+          find.byType(SearchField<MethodTableController>),
           findsNothing,
         );
         expect(
-          find.byType(CpuProfilerSearchField<CpuProfilerController>),
+          find.byType(SearchField<CpuProfilerController>),
           findsOneWidget,
         );
       },

--- a/packages/devtools_app/test/debugger/debugger_codeview_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_codeview_test.dart
@@ -116,7 +116,7 @@ void main() {
           .thenReturn(SearchTextEditingController());
 
       await pumpDebuggerScreen(tester, debuggerController);
-      expect(find.byType(SearchField<SourceToken>), findsOneWidget);
+      expect(find.byType(SearchField<CodeViewController>), findsOneWidget);
     },
   );
 

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -195,7 +195,10 @@ void main() {
 
         expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
-        expect(find.byType(SearchField<TimelineEvent>), findsOneWidget);
+        expect(
+          find.byType(SearchField<LegacyTimelineEventsController>),
+          findsOneWidget,
+        );
         expect(find.byType(TimelineEventsView), findsOneWidget);
       });
     });

--- a/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
@@ -82,7 +82,10 @@ void main() {
         _setUpServiceManagerWithTimeline({});
         await pumpPerformanceScreenBody(tester);
         expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
-        expect(find.byType(SearchField<TimelineEvent>), findsOneWidget);
+        expect(
+          find.byType(SearchField<LegacyTimelineEventsController>),
+          findsOneWidget,
+        );
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
       });
     });


### PR DESCRIPTION
This further cleans up the search code to 
1. use the default `SearchController.matchesForSearch` behavior where possible
2. limit where the `SearchFieldMixin`(which is responsible for managing search field state) is used directly. The `SearchField` and `StatelessSearchField` widgets are now documented to describe where each should be used.
3. search field UI polish

Further cleanup is possible but not the highest priority.

RELEASE_NOTE_EXCEPTION=[not user facing]
