### PR TITLE
Point users to Impeller from shader compilation warnings on iOS

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
@@ -59,13 +59,13 @@ class FrameHints extends StatelessWidget {
               IntrinsicOperationsHint(intrinsicOperationsCount),
           ]
         : [];
-    final rasterHints = (true || showRasterJankHints)
+    final rasterHints = showRasterJankHints
         ? [
             const Text('Raster Jank Detected'),
             const SizedBox(height: denseSpacing),
             if (saveLayerCount > 0) CanvasSaveLayerHint(saveLayerCount),
             const SizedBox(height: denseSpacing),
-            if (true || frame.hasShaderTime)
+            if (frame.hasShaderTime)
               ShaderCompilationHint(shaderTime: frame.shaderDuration),
             const SizedBox(height: denseSpacing),
             const RasterStatsHint(),

--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
@@ -57,13 +57,13 @@ class FrameHints extends StatelessWidget {
               IntrinsicOperationsHint(intrinsicOperationsCount),
           ]
         : [];
-    final rasterHints = showRasterJankHints
+    final rasterHints = (true || showRasterJankHints)
         ? [
             const Text('Raster Jank Detected'),
             const SizedBox(height: denseSpacing),
             if (saveLayerCount > 0) CanvasSaveLayerHint(saveLayerCount),
             const SizedBox(height: denseSpacing),
-            if (frame.hasShaderTime)
+            if (true || frame.hasShaderTime)
               ShaderCompilationHint(shaderTime: frame.shaderDuration),
             const SizedBox(height: denseSpacing),
             const RasterStatsHint(),
@@ -351,6 +351,29 @@ class ShaderCompilationHint extends StatelessWidget {
             ),
           ],
         ),
+        childrenSpans: serviceManager.connectedApp!.isIosApp
+            ? [
+                TextSpan(
+                  text:
+                      ' Note: pre-compiling shaders is a legacy solution with many '
+                      'pitfalls. Try ',
+                  style: theme.regularTextStyle,
+                ),
+                LinkTextSpan(
+                  link: Link(
+                    display: 'Impeller',
+                    url: impellerWikiUrl,
+                    gaScreenName: gac.performance,
+                    gaSelectedItemDescription: gac.impellerWiki,
+                  ),
+                  context: context,
+                ),
+                TextSpan(
+                  text: ' instead!',
+                  style: theme.regularTextStyle,
+                ),
+              ]
+            : [],
       ),
     );
   }
@@ -394,12 +417,14 @@ class _ExpensiveOperationHint extends StatelessWidget {
     required this.docsUrl,
     required this.gaScreenName,
     required this.gaSelectedItemDescription,
+    this.childrenSpans = const <TextSpan>[],
   }) : super(key: key);
 
   final TextSpan message;
   final String docsUrl;
   final String gaScreenName;
   final String gaSelectedItemDescription;
+  final List<TextSpan> childrenSpans;
 
   @override
   Widget build(BuildContext context) {
@@ -426,6 +451,7 @@ class _ExpensiveOperationHint extends StatelessWidget {
             text: '.',
             style: theme.regularTextStyle,
           ),
+          ...childrenSpans,
         ],
       ),
     );

--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_hints.dart
@@ -8,6 +8,8 @@ import 'package:provider/provider.dart';
 import '../../../../service/service_extensions.dart' as extensions;
 import '../../../../shared/analytics/constants.dart' as gac;
 import '../../../../shared/common_widgets.dart';
+import '../../../../shared/connected_app.dart';
+import '../../../../shared/globals.dart';
 import '../../../../shared/primitives/utils.dart';
 import '../../../../shared/theme.dart';
 import '../../performance_controller.dart';

--- a/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
@@ -87,6 +87,8 @@ void debugTraceEventCallback(VoidCallback callback) {
 
 const preCompileShadersDocsUrl = 'https://docs.flutter.dev/perf/shader';
 
+const impellerWikiUrl = 'https://github.com/flutter/flutter/wiki/Impeller';
+
 extension TraceEventExtension on TraceEvent {
   bool get isThreadNameEvent =>
       phase == TraceEvent.metadataEventPhase &&

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -86,6 +86,7 @@ const canvasSaveLayerDocs = 'canvasSaveLayerDocs';
 const intrinsicOperationsDocs = 'intrinsicOperationsDocs';
 const shaderCompilationDocs = 'shaderCompilationDocs';
 const shaderCompilationDocsTooltipLink = 'shaderCompilationDocsTooltipLink';
+const impellerWiki = 'impellerWikiLink';
 const collectRasterStats = 'collectRasterStats';
 const clearRasterStats = 'clearRasterStats';
 const clearRebuildStats = 'clearRebuildStats';

--- a/packages/devtools_app/lib/src/shared/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/banner_messages.dart
@@ -8,10 +8,10 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../devtools_app.dart';
 import '../screens/performance/performance_utils.dart';
 import 'analytics/constants.dart' as gac;
 import 'common_widgets.dart';
+import 'connected_app.dart';
 import 'globals.dart';
 import 'primitives/utils.dart';
 import 'screen.dart';

--- a/packages/devtools_app/lib/src/shared/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/banner_messages.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
+import '../../devtools_app.dart';
 import '../screens/performance/performance_utils.dart';
 import 'analytics/constants.dart' as gac;
 import 'common_widgets.dart';
@@ -205,8 +206,6 @@ class _BannerError extends BannerMessage {
           screenId: screenId,
           messageType: BannerMessageType.error,
         );
-
-  static const linkColor = Color(0xFF54C1EF);
 }
 
 // TODO(kenz): add "Do not show this again" option to warnings.
@@ -216,8 +215,6 @@ class _BannerWarning extends BannerMessage {
     required super.textSpans,
     required super.screenId,
   }) : super(messageType: BannerMessageType.warning);
-
-  static const linkColor = Color(0xFF54C1EF);
 }
 
 class DebugModePerformanceMessage {
@@ -242,7 +239,7 @@ class DebugModePerformanceMessage {
         _runInProfileModeTextSpan(
           context,
           screenId: screenId,
-          style: theme.errorMessageLinkStyle,
+          style: theme.warningMessageLinkStyle,
         ),
         const TextSpan(
           text: '.',
@@ -296,10 +293,10 @@ class ShaderJankMessage {
       key: Key('ShaderJankMessage - $screenId'),
       textSpans: [
         TextSpan(
-          text: '''
-Shader compilation jank detected. $jankyFramesCount ${pluralize('frame', jankyFramesCount)} janked with a total of ${msText(jankDuration)} spent in shader compilation.
-
-To pre-compile shaders, see the instructions at ''',
+          text: 'Shader compilation jank detected. $jankyFramesCount '
+              '${pluralize('frame', jankyFramesCount)} janked with a total of '
+              '${msText(jankDuration)} spent in shader compilation. To pre-compile '
+              'shaders, see the instructions at ',
         ),
         LinkTextSpan(
           link: Link(
@@ -311,9 +308,26 @@ To pre-compile shaders, see the instructions at ''',
           context: context,
           style: theme.errorMessageLinkStyle,
         ),
-        const TextSpan(
-          text: '.',
-        ),
+        const TextSpan(text: '.'),
+        if (serviceManager.connectedApp!.isIosApp) ...[
+          const TextSpan(
+            text: '\n\nNote: this is a legacy solution with many pitfalls. '
+                'Try ',
+          ),
+          LinkTextSpan(
+            link: Link(
+              display: 'Impeller',
+              url: impellerWikiUrl,
+              gaScreenName: screenId,
+              gaSelectedItemDescription: gac.impellerWiki,
+            ),
+            context: context,
+            style: theme.errorMessageLinkStyle,
+          ),
+          const TextSpan(
+            text: ' instead!',
+          ),
+        ]
       ],
       screenId: screenId,
     );
@@ -462,14 +476,14 @@ void maybePushDebugModeMemoryMessage(
 }
 
 extension BannerMessageThemeExtension on ThemeData {
-  TextStyle get warningMessageLinkStyle => const TextStyle(
+  TextStyle get warningMessageLinkStyle => regularTextStyle.copyWith(
         decoration: TextDecoration.underline,
-        color: _BannerWarning.linkColor,
+        color: colorScheme.tertiary,
       );
 
-  TextStyle get errorMessageLinkStyle => const TextStyle(
+  TextStyle get errorMessageLinkStyle => regularTextStyle.copyWith(
         decoration: TextDecoration.underline,
-        color: _BannerError.linkColor,
+        color: colorScheme.error,
       );
 }
 

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
@@ -20,11 +20,6 @@ const devToolsSnapshotKey = 'devToolsSnapshot';
 const activeScreenIdKey = 'activeScreenId';
 const devToolsVersionKey = 'devtoolsVersion';
 const connectedAppKey = 'connectedApp';
-const isFlutterAppKey = 'isFlutterApp';
-const isProfileBuildKey = 'isProfileBuild';
-const isDartWebAppKey = 'isDartWebApp';
-const isRunningOnDartVMKey = 'isRunningOnDartVM';
-const flutterVersionKey = 'flutterVersion';
 const nonDevToolsFileMessage = 'The imported file is not a Dart DevTools file.'
     ' At this time, DevTools only supports importing files that were originally'
     ' exported from DevTools.';
@@ -153,15 +148,7 @@ abstract class ExportController {
       devToolsSnapshotKey: true,
       activeScreenIdKey: activeScreenId,
       devToolsVersionKey: version,
-      connectedAppKey: {
-        isFlutterAppKey: serviceManager.connectedApp!.isFlutterAppNow,
-        isProfileBuildKey: serviceManager.connectedApp!.isProfileBuildNow,
-        isDartWebAppKey: serviceManager.connectedApp!.isDartWebAppNow,
-        isRunningOnDartVMKey: serviceManager.connectedApp!.isRunningOnDartVM,
-      },
-      if (serviceManager.connectedApp!.flutterVersionNow != null)
-        flutterVersionKey:
-            serviceManager.connectedApp!.flutterVersionNow!.version,
+      connectedAppKey: serviceManager.connectedApp!.toJson(),
     };
     // This is a workaround to guarantee that DevTools exports are compatible
     // with other trace viewers (catapult, perfetto, chrome://tracing), which

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -14,8 +14,10 @@ Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.
 
-##**** Performance updates
+## Performance updates
 * Persist a user's preference for whether the Flutter Frames chart should be shown by default. - [#5339](https://github.com/flutter/devtools/pull/5339)
+* Point users to [Impeller](https://github.com/flutter/flutter/wiki/Impeller) when shader compilation
+jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools/pull/5455)
 
 ## CPU profiler updates
 * Add a Method Table to the CPU profiler - [#5366](https://github.com/flutter/devtools/pull/5366)

--- a/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
+++ b/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
@@ -317,6 +317,46 @@ void main() {
         ),
         findsOneWidget,
       );
+      expect(
+        find.richTextContaining(
+          ' Note: pre-compiling shaders is a legacy solution with many '
+          'pitfalls. Try',
+        ),
+        findsOneWidget,
+      );
+    });
+
+    testWidgetsWithWindowSize(
+        'does not show impeller link on android', windowSize,
+        (WidgetTester tester) async {
+      _mockFrameAnalysis(
+        frameAnalysis: mockFrameAnalysis,
+        frame: testFrameWithShaderJank,
+      );
+      mockConnectedApp(
+        serviceManager.connectedApp!,
+        isFlutterApp: true,
+        isProfileBuild: true,
+        isWebApp: false,
+        os: 'android',
+      );
+      await pumpHints(tester, mockFrameAnalysis);
+
+      expect(find.byType(ShaderCompilationHint), findsOneWidget);
+      expect(
+        find.richTextContaining(
+          ' of shader compilation occurred during this frame. This may '
+          'negatively affect your app\'s performance',
+        ),
+        findsOneWidget,
+      );
+      expect(
+        find.richTextContaining(
+          ' Note: pre-compiling shaders is a legacy solution with many '
+          'pitfalls. Try',
+        ),
+        findsNothing,
+      );
     });
   });
 }

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -108,6 +108,7 @@ void mockConnectedApp(
   required bool isFlutterApp,
   required isProfileBuild,
   required isWebApp,
+  String os = 'ios',
 }) {
   assert(!(!isFlutterApp && isProfileBuild));
 
@@ -156,6 +157,9 @@ void mockConnectedApp(
   when(connectedApp.isProfileBuildNow).thenReturn(isProfileBuild);
   when(connectedApp.isDebugFlutterAppNow)
       .thenReturn(isFlutterApp && !isProfileBuild);
+
+  // Operating system.
+  when(connectedApp.operatingSystem).thenReturn(os);
 
   // Initialized.
   when(connectedApp.connectedAppInitialized).thenReturn(true);


### PR DESCRIPTION
![Screenshot 2023-03-20 at 1 29 23 PM](https://user-images.githubusercontent.com/43759233/226460448-bbc81657-1a4f-41e7-8fd5-deb125bfa086.png)

The note suggesting that users try Impeller will only show up when the connected app is running on iOS. The Impeller link takes users to the [wiki](https://github.com/flutter/flutter/wiki/Impeller).

Fixes https://github.com/flutter/devtools/issues/5349

CC @chinmaygarde @dnfield @jonahwilliams 
