### PR TITLE
Fix a performance regression in timeline event processing

### DIFF
--- a/packages/devtools_app/lib/src/shared/primitives/trace_event.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/trace_event.dart
@@ -183,3 +183,28 @@ enum TimelineEventType {
   async,
   other,
 }
+
+class ThreadNameEvent {
+  const ThreadNameEvent._(this.name, this.threadId);
+
+  factory ThreadNameEvent.from(TraceEvent event) {
+    final args = event.args!;
+    return ThreadNameEvent._(
+      args[TraceEvent.nameKey] as String?,
+      event.threadId,
+    );
+  }
+
+  final String? name;
+  final int? threadId;
+
+  @override
+  bool operator ==(other) {
+    return other is ThreadNameEvent &&
+        name == other.name &&
+        threadId == other.threadId;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, threadId);
+}

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,6 +18,7 @@ TODO: Remove this section if there are not any general updates.
 * Persist a user's preference for whether the Flutter Frames chart should be shown by default. - [#5339](https://github.com/flutter/devtools/pull/5339)
 * Point users to [Impeller](https://github.com/flutter/flutter/wiki/Impeller) when shader compilation
 jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools/pull/5455)
+* Fix a performance regression in timeline event processing. - [#5460](https://github.com/flutter/devtools/pull/5460)
 
 ## CPU profiler updates
 * Add a Method Table to the CPU profiler - [#5366](https://github.com/flutter/devtools/pull/5366)


### PR DESCRIPTION
We were previously doing a O(n) search to see if the thread name event is a duplicate. After this change, the duplicate check takes constant time O(1).

This was bringing the performance page to a crawl when N got large.

Work towards https://github.com/flutter/devtools/issues/5091