### PR TITLE
Move trace category settings to timeline events tab bar

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/performance_screen_event_recording_test.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
+import 'package:devtools_app/src/screens/performance/panes/timeline_events/timeline_events_view.dart';
 import 'package:devtools_test/devtools_integration_test.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -90,8 +90,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
   static const summaryTreeKey = Key('Summary Tree');
   static const detailsTreeKey = Key('Details Tree');
   static const minScreenWidthForTextBeforeScaling = 900.0;
-  static const unscaledIncludeRefreshTreeWidth = 1255.0;
-  static const serviceExtensionButtonsIncludeTextWidth = 1160.0;
+  static const serviceExtensionButtonsIncludeTextWidth = 1200.0;
 
   @override
   void dispose() {

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_controls.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_controls.dart
@@ -25,7 +25,7 @@ class PerformanceControls extends StatelessWidget {
     required this.onClear,
   });
 
-  static const minScreenWidthForTextBeforeScaling = 920.0;
+  static const minScreenWidthForTextBeforeScaling = 1020.0;
 
   final PerformanceController controller;
 
@@ -97,9 +97,12 @@ class _PrimaryControls extends StatelessWidget {
         if (!offline)
           DevToolsButton(
             icon: Icons.block,
+            label: 'Clear all',
             gaScreen: gac.performance,
             gaSelection: gac.clear,
             tooltip: 'Clear all data on the Performance screen',
+            minScreenWidthForTextBeforeScaling:
+                PerformanceControls.minScreenWidthForTextBeforeScaling,
             onPressed: processing ? null : _clearPerformanceData,
           ),
       ],

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
@@ -2,16 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:flutter/material.dart';
 
 import '../../../../shared/common_widgets.dart';
 import '../../../../shared/dialogs.dart';
-import '../../../../shared/feature_flags.dart';
 import '../../../../shared/globals.dart';
 import '../../../../shared/theme.dart';
 import '../../performance_controller.dart';
+import '../flutter_frames/flutter_frames_controller.dart';
 
 class PerformanceSettingsDialog extends StatelessWidget {
   const PerformanceSettingsDialog(this.controller);
@@ -29,11 +27,19 @@ class PerformanceSettingsDialog extends StatelessWidget {
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            TimelineStreamSettings(controller: controller),
             if (serviceManager.connectedApp!.isFlutterAppNow!) ...[
+              FlutterSettings(
+                flutterFramesController: controller.flutterFramesController,
+              ),
               const SizedBox(height: denseSpacing),
-              FlutterSettings(controller: controller),
             ],
+            CheckboxSetting(
+              notifier:
+                  controller.timelineEventsController.useLegacyTraceViewer,
+              title: 'Use legacy trace viewer',
+              onChanged: controller
+                  .timelineEventsController.toggleUseLegacyTraceViewer,
+            ),
           ],
         ),
       ),
@@ -44,93 +50,10 @@ class PerformanceSettingsDialog extends StatelessWidget {
   }
 }
 
-class TimelineStreamSettings extends StatelessWidget {
-  const TimelineStreamSettings({
-    Key? key,
-    required this.controller,
-  }) : super(key: key);
-
-  final PerformanceController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        ...dialogSubHeader(theme, 'Recorded Timeline Streams'),
-        ..._defaultRecordedStreams(theme),
-        ..._advancedStreams(theme),
-      ],
-    );
-  }
-
-  List<Widget> _defaultRecordedStreams(ThemeData theme) {
-    return [
-      RichText(
-        text: TextSpan(
-          text: 'Default',
-          style: theme.subtleTextStyle,
-        ),
-      ),
-      ..._timelineStreams(advanced: false),
-      // Special case "Network Traffic" because it is not implemented as a
-      // Timeline recorded stream in the VM. The user does not need to be aware of
-      // the distinction, however.
-      CheckboxSetting(
-        title: 'Network',
-        description: 'Http traffic',
-        notifier: controller.timelineEventsController.httpTimelineLoggingEnabled
-            as ValueNotifier<bool?>,
-        onChanged: (value) => unawaited(
-          controller.timelineEventsController
-              .toggleHttpRequestLogging(value ?? false),
-        ),
-      ),
-    ];
-  }
-
-  List<Widget> _advancedStreams(ThemeData theme) {
-    return [
-      RichText(
-        text: TextSpan(
-          text: 'Advanced',
-          style: theme.subtleTextStyle,
-        ),
-      ),
-      ..._timelineStreams(advanced: true),
-    ];
-  }
-
-  List<Widget> _timelineStreams({
-    required bool advanced,
-  }) {
-    final streams = advanced
-        ? serviceManager.timelineStreamManager.advancedStreams
-        : serviceManager.timelineStreamManager.basicStreams;
-    final settings = streams
-        .map(
-          (stream) => CheckboxSetting(
-            title: stream.name,
-            description: stream.description,
-            notifier: stream.recorded as ValueNotifier<bool?>,
-            onChanged: (newValue) => unawaited(
-              serviceManager.timelineStreamManager.updateTimelineStream(
-                stream,
-                newValue ?? false,
-              ),
-            ),
-          ),
-        )
-        .toList();
-    return settings;
-  }
-}
-
 class FlutterSettings extends StatelessWidget {
-  const FlutterSettings({Key? key, required this.controller}) : super(key: key);
+  const FlutterSettings({required this.flutterFramesController, super.key});
 
-  final PerformanceController controller;
+  final FlutterFramesController flutterFramesController;
 
   @override
   Widget build(BuildContext context) {
@@ -139,17 +62,10 @@ class FlutterSettings extends StatelessWidget {
       children: [
         ...dialogSubHeader(Theme.of(context), 'Additional Settings'),
         CheckboxSetting(
-          notifier: controller.flutterFramesController.badgeTabForJankyFrames
+          notifier: flutterFramesController.badgeTabForJankyFrames
               as ValueNotifier<bool?>,
           title: 'Badge Performance tab when Flutter UI jank is detected',
         ),
-        if (FeatureFlags.embeddedPerfetto)
-          CheckboxSetting(
-            notifier: controller.timelineEventsController.useLegacyTraceViewer,
-            title: 'Use legacy trace viewer',
-            onChanged:
-                controller.timelineEventsController.toggleUseLegacyTraceViewer,
-          ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
@@ -60,7 +60,6 @@ class FlutterSettings extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        ...dialogSubHeader(Theme.of(context), 'Additional Settings'),
         CheckboxSetting(
           notifier: flutterFramesController.badgeTabForJankyFrames
               as ValueNotifier<bool?>,

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -1,0 +1,249 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+
+import '../../../../shared/analytics/constants.dart' as gac;
+import '../../../../shared/charts/flame_chart.dart';
+import '../../../../shared/common_widgets.dart';
+import '../../../../shared/dialogs.dart';
+import '../../../../shared/feature_flags.dart';
+import '../../../../shared/globals.dart';
+import '../../../../shared/theme.dart';
+import '../../../../shared/ui/search.dart';
+import 'legacy/legacy_events_controller.dart';
+import 'legacy/timeline_flame_chart.dart';
+import 'perfetto/perfetto.dart';
+import 'timeline_events_controller.dart';
+
+class TimelineEventsTabView extends StatelessWidget {
+  const TimelineEventsTabView({super.key, required this.controller});
+
+  final TimelineEventsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: controller.useLegacyTraceViewer,
+      builder: (context, useLegacy, _) {
+        return useLegacy
+            ? KeepAliveWrapper(
+                child:
+                    DualValueListenableBuilder<EventsControllerStatus, double>(
+                  firstListenable: controller.status,
+                  secondListenable:
+                      controller.legacyController.processor.progressNotifier,
+                  builder: (context, status, processingProgress, _) {
+                    return TimelineEventsView(
+                      controller: controller,
+                      processing: status == EventsControllerStatus.processing,
+                      processingProgress: processingProgress,
+                    );
+                  },
+                ),
+              )
+            : KeepAliveWrapper(
+                child: EmbeddedPerfetto(
+                  perfettoController: controller.perfettoController,
+                ),
+              );
+      },
+    );
+  }
+}
+
+class TimelineEventsTabControls extends StatelessWidget {
+  const TimelineEventsTabControls({super.key, required this.controller});
+
+  final TimelineEventsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: controller.useLegacyTraceViewer,
+      builder: (context, useLegacy, _) {
+        return Row(
+          mainAxisAlignment: MainAxisAlignment.end,
+          children: [
+            if (useLegacy || !FeatureFlags.embeddedPerfetto) ...[
+              ValueListenableBuilder<EventsControllerStatus>(
+                valueListenable: controller.status,
+                builder: (context, status, _) {
+                  final searchFieldEnabled =
+                      status == EventsControllerStatus.ready;
+                  return SearchField<LegacyTimelineEventsController>(
+                    searchController: controller.legacyController,
+                    searchFieldEnabled: searchFieldEnabled,
+                    searchFieldWidth: wideSearchFieldWidth,
+                  );
+                },
+              ),
+              const SizedBox(width: denseSpacing),
+              FlameChartHelpButton(
+                gaScreen: gac.performance,
+                gaSelection: gac.timelineFlameChartHelp,
+              ),
+            ],
+            if (!offlineController.offlineMode.value) ...[
+              const SizedBox(width: denseSpacing),
+              TraceCategoriesButton(controller: controller),
+              const SizedBox(width: denseSpacing),
+              RefreshTimelineEventsButton(controller: controller),
+            ],
+          ],
+        );
+      },
+    );
+  }
+}
+
+class TraceCategoriesButton extends StatelessWidget {
+  const TraceCategoriesButton({
+    required this.controller,
+    super.key,
+  });
+
+  final TimelineEventsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return DevToolsButton.iconOnly(
+      icon: Icons.checklist,
+      outlined: false,
+      tooltip: 'Trace categories',
+      gaScreen: gac.performance,
+      gaSelection: gac.traceCategories,
+      onPressed: () => _openTraceCategoriesDialog(context),
+    );
+  }
+
+  void _openTraceCategoriesDialog(BuildContext context) {
+    unawaited(
+      showDialog(
+        context: context,
+        builder: (context) => TraceCategoriesDialog(controller),
+      ),
+    );
+  }
+}
+
+class RefreshTimelineEventsButton extends StatelessWidget {
+  const RefreshTimelineEventsButton({
+    Key? key,
+    required this.controller,
+  }) : super(key: key);
+
+  final TimelineEventsController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<EventsControllerStatus>(
+      valueListenable: controller.status,
+      builder: (context, status, _) {
+        return RefreshButton(
+          iconOnly: true,
+          outlined: false,
+          onPressed: status == EventsControllerStatus.processing
+              ? null
+              : controller.processAllTraceEvents,
+          tooltip: 'Refresh timeline events',
+          gaScreen: gac.performance,
+          gaSelection: gac.refreshTimelineEvents,
+        );
+      },
+    );
+  }
+}
+
+class TraceCategoriesDialog extends StatelessWidget {
+  const TraceCategoriesDialog(this.timelineEventsController);
+
+  final TimelineEventsController timelineEventsController;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DevToolsDialog(
+      title: const DialogTitleText('Trace Categories'),
+      includeDivider: false,
+      content: Container(
+        width: defaultDialogWidth,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ..._defaultRecordedStreams(theme),
+            const SizedBox(height: denseSpacing),
+            ..._advancedStreams(theme),
+          ],
+        ),
+      ),
+      actions: const [
+        DialogCloseButton(),
+      ],
+    );
+  }
+
+  List<Widget> _defaultRecordedStreams(ThemeData theme) {
+    return [
+      RichText(
+        text: TextSpan(
+          text: 'Default',
+          style: theme.subtleTextStyle,
+        ),
+      ),
+      ..._timelineStreams(advanced: false),
+      // Special case "Network Traffic" because it is not implemented as a
+      // Timeline recorded stream in the VM. The user does not need to be aware of
+      // the distinction, however.
+      CheckboxSetting(
+        title: 'Network',
+        description: 'Http traffic',
+        notifier: timelineEventsController.httpTimelineLoggingEnabled
+            as ValueNotifier<bool?>,
+        onChanged: (value) => unawaited(
+          timelineEventsController.toggleHttpRequestLogging(value ?? false),
+        ),
+      ),
+    ];
+  }
+
+  List<Widget> _advancedStreams(ThemeData theme) {
+    return [
+      RichText(
+        text: TextSpan(
+          text: 'Advanced',
+          style: theme.subtleTextStyle,
+        ),
+      ),
+      ..._timelineStreams(advanced: true),
+    ];
+  }
+
+  List<Widget> _timelineStreams({
+    required bool advanced,
+  }) {
+    final streams = advanced
+        ? serviceManager.timelineStreamManager.advancedStreams
+        : serviceManager.timelineStreamManager.basicStreams;
+    final settings = streams
+        .map(
+          (stream) => CheckboxSetting(
+            title: stream.name,
+            description: stream.description,
+            notifier: stream.recorded as ValueNotifier<bool?>,
+            onChanged: (newValue) => unawaited(
+              serviceManager.timelineStreamManager.updateTimelineStream(
+                stream,
+                newValue ?? false,
+              ),
+            ),
+          ),
+        )
+        .toList();
+    return settings;
+  }
+}

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -8,13 +8,10 @@ import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 import '../../shared/analytics/constants.dart' as gac;
-import '../../shared/charts/flame_chart.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/feature_flags.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/auto_dispose.dart';
-import '../../shared/theme.dart';
-import '../../shared/ui/search.dart';
 import '../../shared/ui/tab.dart';
 import '../../shared/utils.dart';
 import 'panes/flutter_frames/flutter_frame_model.dart';
@@ -22,12 +19,8 @@ import 'panes/flutter_frames/flutter_frames_controller.dart';
 import 'panes/frame_analysis/frame_analysis.dart';
 import 'panes/raster_stats/raster_stats.dart';
 import 'panes/rebuild_stats/rebuild_stats.dart';
-import 'panes/timeline_events/legacy/legacy_events_controller.dart';
-import 'panes/timeline_events/legacy/timeline_flame_chart.dart';
-import 'panes/timeline_events/perfetto/perfetto.dart';
-import 'panes/timeline_events/timeline_events_controller.dart';
+import 'panes/timeline_events/timeline_events_view.dart';
 import 'performance_controller.dart';
-import 'performance_screen.dart';
 
 class TabbedPerformanceView extends StatefulWidget {
   const TabbedPerformanceView();
@@ -44,8 +37,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
 
   late FlutterFramesController _flutterFramesController;
 
-  late TimelineEventsController _timelineEventsController;
-
   FlutterFrame? _selectedFlutterFrame;
 
   @override
@@ -53,7 +44,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     super.didChangeDependencies();
     if (!initController()) return;
 
-    _timelineEventsController = controller.timelineEventsController;
     _flutterFramesController = controller.flutterFramesController;
 
     cancelListeners();
@@ -184,68 +174,12 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     return _PerformanceTabRecord(
       tab: _buildTab(
         tabName: 'Timeline Events',
-        trailing: ValueListenableBuilder<bool>(
-          valueListenable: _timelineEventsController.useLegacyTraceViewer,
-          builder: (context, useLegacy, _) {
-            return Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                if (useLegacy || !FeatureFlags.embeddedPerfetto) ...[
-                  ValueListenableBuilder<EventsControllerStatus>(
-                    valueListenable: _timelineEventsController.status,
-                    builder: (context, status, _) {
-                      final searchFieldEnabled =
-                          status == EventsControllerStatus.ready;
-                      return SearchField<LegacyTimelineEventsController>(
-                        searchController:
-                            _timelineEventsController.legacyController,
-                        searchFieldEnabled: searchFieldEnabled,
-                        searchFieldWidth: wideSearchFieldWidth,
-                      );
-                    },
-                  ),
-                  const SizedBox(width: denseSpacing),
-                  FlameChartHelpButton(
-                    gaScreen: PerformanceScreen.id,
-                    gaSelection: gac.timelineFlameChartHelp,
-                  ),
-                ],
-                if (!offlineController.offlineMode.value)
-                  const SizedBox(width: denseSpacing),
-                RefreshTimelineEventsButton(
-                  controller: _timelineEventsController,
-                ),
-              ],
-            );
-          },
+        trailing: TimelineEventsTabControls(
+          controller: controller.timelineEventsController,
         ),
       ),
-      tabView: ValueListenableBuilder<bool>(
-        valueListenable: _timelineEventsController.useLegacyTraceViewer,
-        builder: (context, useLegacy, _) {
-          return (useLegacy || !FeatureFlags.embeddedPerfetto)
-              ? KeepAliveWrapper(
-                  child: DualValueListenableBuilder<EventsControllerStatus,
-                      double>(
-                    firstListenable: _timelineEventsController.status,
-                    secondListenable: _timelineEventsController
-                        .legacyController.processor.progressNotifier,
-                    builder: (context, status, processingProgress, _) {
-                      return TimelineEventsView(
-                        controller: _timelineEventsController,
-                        processing: status == EventsControllerStatus.processing,
-                        processingProgress: processingProgress,
-                      );
-                    },
-                  ),
-                )
-              : KeepAliveWrapper(
-                  child: EmbeddedPerfetto(
-                    perfettoController:
-                        _timelineEventsController.perfettoController,
-                  ),
-                );
-        },
+      tabView: TimelineEventsTabView(
+        controller: controller.timelineEventsController,
       ),
       featureController: controller.timelineEventsController,
     );
@@ -256,35 +190,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
       tabName: tabName,
       gaPrefix: _gaPrefix,
       trailing: trailing,
-    );
-  }
-}
-
-@visibleForTesting
-class RefreshTimelineEventsButton extends StatelessWidget {
-  const RefreshTimelineEventsButton({
-    Key? key,
-    required this.controller,
-  }) : super(key: key);
-
-  final TimelineEventsController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return ValueListenableBuilder<EventsControllerStatus>(
-      valueListenable: controller.status,
-      builder: (context, status, _) {
-        return RefreshButton(
-          iconOnly: true,
-          outlined: false,
-          onPressed: status == EventsControllerStatus.processing
-              ? null
-              : controller.processAllTraceEvents,
-          tooltip: 'Refresh timeline events',
-          gaScreen: gac.performance,
-          gaSelection: gac.refreshTimelineEvents,
-        );
-      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -95,6 +95,7 @@ const perfettoModeTraceEventProcessingTime =
 const perfettoLoadTrace = 'perfettoLoadTrace';
 const perfettoScrollToTimeRange = 'perfettoScrollToTimeRange';
 const performanceSettings = 'performanceSettings';
+const traceCategories = 'traceCategories';
 
 // CPU profiler UX actions:
 const cpuSamplingRatePrefix = 'profileGranularity';

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -5,7 +5,6 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/performance/panes/frame_analysis/frame_analysis.dart';
 import 'package:devtools_app/src/screens/performance/panes/raster_stats/raster_stats.dart';
-import 'package:devtools_app/src/screens/performance/panes/timeline_events/legacy/timeline_flame_chart.dart';
 import 'package:devtools_app/src/screens/performance/panes/timeline_events/timeline_events_view.dart';
 import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
 import 'package:devtools_app/src/shared/charts/flame_chart.dart';
@@ -194,13 +193,14 @@ void main() {
         await tester.tap(find.text('Timeline Events'));
         await tester.pumpAndSettle();
 
+        expect(find.byType(TraceCategoriesButton), findsOneWidget);
         expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
         expect(find.byType(FlameChartHelpButton), findsOneWidget);
         expect(
           find.byType(SearchField<LegacyTimelineEventsController>),
           findsOneWidget,
         );
-        expect(find.byType(TimelineEventsView), findsOneWidget);
+        expect(find.byType(TimelineEventsTabView), findsOneWidget);
       });
     });
 

--- a/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/performance/tabbed_performance_view_test.dart
@@ -6,6 +6,7 @@ import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/performance/panes/frame_analysis/frame_analysis.dart';
 import 'package:devtools_app/src/screens/performance/panes/raster_stats/raster_stats.dart';
 import 'package:devtools_app/src/screens/performance/panes/timeline_events/legacy/timeline_flame_chart.dart';
+import 'package:devtools_app/src/screens/performance/panes/timeline_events/timeline_events_view.dart';
 import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
 import 'package:devtools_app/src/shared/charts/flame_chart.dart';
 import 'package:devtools_app/src/shared/config_specific/import_export/import_export.dart';

--- a/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
+++ b/packages/devtools_app/test/performance/timeline_events/legacy/timeline_flame_chart_test.dart
@@ -5,7 +5,7 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/performance/panes/timeline_events/legacy/event_details.dart';
 import 'package:devtools_app/src/screens/performance/panes/timeline_events/legacy/timeline_flame_chart.dart';
-import 'package:devtools_app/src/screens/performance/tabbed_performance_view.dart';
+import 'package:devtools_app/src/screens/performance/panes/timeline_events/timeline_events_view.dart';
 import 'package:devtools_app/src/shared/charts/flame_chart.dart';
 import 'package:devtools_app/src/shared/config_specific/import_export/import_export.dart';
 import 'package:devtools_test/devtools_test.dart';


### PR DESCRIPTION
This addresses some feedback from @zanderso regarding the trace category settings not being discoverable. Moving these settings closer to the feature they pertain to should help with this.

![Screenshot 2023-03-20 at 7 10 57 PM](https://user-images.githubusercontent.com/43759233/226503289-db240110-762d-433b-a38f-2315b8409530.png)
![Screenshot 2023-03-20 at 7 07 09 PM](https://user-images.githubusercontent.com/43759233/226503295-2b49b22a-e2aa-4925-9e86-906c1e682e51.png)
![Screenshot 2023-03-20 at 7 04 10 PM](https://user-images.githubusercontent.com/43759233/226503297-c07979e6-aa6b-49a8-b0b9-333e8eed6e3c.png)

The Performance Settings dialog now looks like this:
![Screenshot 2023-03-20 at 7 12 31 PM](https://user-images.githubusercontent.com/43759233/226503436-2490607a-a889-41de-bdad-d8d19220a98d.png)

This PR does some yak shaving to refactor code and group Timeline Events widgets together in timeline_events_view.dart, and also fixes a couple render flex overflow errors.

RELEASE_NOTE_EXCEPTION=[too small to mention]