### PR TITLE
Fix request bug with json view for request data

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -147,8 +147,13 @@ class HttpRequestView extends StatelessWidget {
             size: mediumProgressSize,
           );
         }
+
+        final isJson = requestContentType is List
+            ? requestContentType.any((element) => element.contains('json'))
+            : requestContentType.contains('json');
+
         Widget child;
-        child = (requestContentType.contains('json'))
+        child = isJson
             ? JsonViewer(encodedJson: data.requestBody!)
             : Text(
                 data.requestBody!,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -40,6 +40,7 @@ jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools
 
 ## Network profiler updates
 * Fix a bug viewing JSON responses with null values - [#5424](https://github.com/flutter/devtools/pull/5424)
+* Fix a bug where JSON requests were shown in plain text, instead of the formatted JSON viewer - [#5463](https://github.com/flutter/devtools/pull/5463)
 
 ## Logging updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
![](https://media.giphy.com/media/wYeeSlDqyhY1W/giphy.gif)
Fixes https://github.com/flutter/devtools/issues/5413

It looks like the request content type may be stored as an array of headers. So I've updated the request view to check the header type before checking whether it contains 'json'.

This resolves an issue where json was showing up in the plain text view instead of the json view.

