### PR TITLE
Fix network copy bug

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
@@ -57,22 +57,12 @@ class NetworkRequestInspector extends StatelessWidget {
             if (data.requestBody != null)
               _buildTab(
                 tabName: NetworkRequestInspector._requestTabTitle,
-                trailing: Align(
-                  alignment: Alignment.centerRight,
-                  child: CopyToClipboardControl(
-                    dataProvider: () => data.requestBody,
-                  ),
-                ),
+                trailing: HttpViewCopyButton(data,(data) => data.requestBody),
               ),
             if (data.responseBody != null)
-              _buildTab(
+              _buildTab( // These need a value listenable builder!!!!!!!!!! yuck
                 tabName: NetworkRequestInspector._responseTabTitle,
-                trailing: Align(
-                  alignment: Alignment.centerRight,
-                  child: CopyToClipboardControl(
-                    dataProvider: () => data.responseBody,
-                  ),
-                ),
+                trailing: HttpViewCopyButton(data,(data) => data.responseBody),
               ),
             if (data.hasCookies)
               _buildTab(tabName: NetworkRequestInspector._cookiesTabTitle),

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
@@ -57,12 +57,18 @@ class NetworkRequestInspector extends StatelessWidget {
             if (data.requestBody != null)
               _buildTab(
                 tabName: NetworkRequestInspector._requestTabTitle,
-                trailing: HttpViewCopyButton(data,(data) => data.requestBody),
+                trailing: HttpViewTrailingCopyButton(
+                  data,
+                  (data) => data.requestBody,
+                ),
               ),
             if (data.responseBody != null)
-              _buildTab( // These need a value listenable builder!!!!!!!!!! yuck
+              _buildTab(
                 tabName: NetworkRequestInspector._responseTabTitle,
-                trailing: HttpViewCopyButton(data,(data) => data.responseBody),
+                trailing: HttpViewTrailingCopyButton(
+                  data,
+                  (data) => data.responseBody,
+                ),
               ),
             if (data.hasCookies)
               _buildTab(tabName: NetworkRequestInspector._cookiesTabTitle),

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -178,6 +178,7 @@ class HttpViewTrailingCopyButton extends StatelessWidget {
   const HttpViewTrailingCopyButton(this.data, this.dataSelector);
   final DartIOHttpRequestData data;
   final String? Function(DartIOHttpRequestData) dataSelector;
+
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
@@ -185,8 +186,9 @@ class HttpViewTrailingCopyButton extends StatelessWidget {
       builder: (context, __, ___) {
         final dataToCopy = dataSelector(data);
         final isLoading = data.isFetchingFullData;
-        if (dataToCopy == null || dataToCopy == '' || isLoading)
+        if (dataToCopy == null || dataToCopy.isEmpty || isLoading){
           return Container();
+        }
 
         return Align(
           alignment: Alignment.centerRight,

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -169,7 +169,27 @@ class HttpRequestView extends StatelessWidget {
     );
   }
 }
-
+class HttpViewCopyButton extends StatelessWidget {
+  HttpViewCopyButton(this.data, this.dataSelector);
+  final DartIOHttpRequestData data;
+  final String? Function(DartIOHttpRequestData) dataSelector; 
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: data.requestUpdatedNotifier,
+      builder: (context, __, ___) {
+        final dataToCopy = dataSelector(data);
+        if(dataToCopy == null || dataToCopy == '') return Container();
+        return Align(
+                  alignment: Alignment.centerRight,
+                  child: CopyToClipboardControl(
+                    dataProvider: () => dataToCopy,
+                  ),
+                );
+      },
+    );
+  }
+}
 class HttpResponseView extends StatelessWidget {
   const HttpResponseView(this.data);
 

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -169,27 +169,36 @@ class HttpRequestView extends StatelessWidget {
     );
   }
 }
-class HttpViewCopyButton extends StatelessWidget {
-  HttpViewCopyButton(this.data, this.dataSelector);
+
+/// A button for copying [DartIOHttpRequestData] contents.
+///
+/// If there is no content to copy, the button will not show. The copy contents
+/// will update as the request's data is updated.
+class HttpViewTrailingCopyButton extends StatelessWidget {
+  const HttpViewTrailingCopyButton(this.data, this.dataSelector);
   final DartIOHttpRequestData data;
-  final String? Function(DartIOHttpRequestData) dataSelector; 
+  final String? Function(DartIOHttpRequestData) dataSelector;
   @override
   Widget build(BuildContext context) {
     return ValueListenableBuilder(
       valueListenable: data.requestUpdatedNotifier,
       builder: (context, __, ___) {
         final dataToCopy = dataSelector(data);
-        if(dataToCopy == null || dataToCopy == '') return Container();
+        final isLoading = data.isFetchingFullData;
+        if (dataToCopy == null || dataToCopy == '' || isLoading)
+          return Container();
+
         return Align(
-                  alignment: Alignment.centerRight,
-                  child: CopyToClipboardControl(
-                    dataProvider: () => dataToCopy,
-                  ),
-                );
+          alignment: Alignment.centerRight,
+          child: CopyToClipboardControl(
+            dataProvider: () => dataToCopy,
+          ),
+        );
       },
     );
   }
 }
+
 class HttpResponseView extends StatelessWidget {
   const HttpResponseView(this.data);
 

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -186,7 +186,7 @@ class HttpViewTrailingCopyButton extends StatelessWidget {
       builder: (context, __, ___) {
         final dataToCopy = dataSelector(data);
         final isLoading = data.isFetchingFullData;
-        if (dataToCopy == null || dataToCopy.isEmpty || isLoading){
+        if (dataToCopy == null || dataToCopy.isEmpty || isLoading) {
           return Container();
         }
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -43,6 +43,7 @@ jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools
 ## Network profiler updates
 * Fix a bug viewing JSON responses with null values - [#5424](https://github.com/flutter/devtools/pull/5424)
 * Fix a bug where JSON requests were shown in plain text, instead of the formatted JSON viewer - [#5463](https://github.com/flutter/devtools/pull/5463)
+* Fix a UI issue where the copy button on the response or request tab would let you copy while still loading the data - [#5476](https://github.com/flutter/devtools/pull/5476)
 
 ## Logging updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
![](https://media.giphy.com/media/i7Mtc0aWPTZyo/giphy.gif)

Fixes https://github.com/flutter/devtools/issues/5192

I noticed while testing the network response and requests tabs that one could click copy while the data was still loading.
this could result in empty copies. 

Another issue I seemed to intermittently see was that the data would still be empty even after data was loaded. This only happened intermittently thought.


This PR changes the copy buttons so that they won't show until there is data for them to copy, and also makes sure that they are more tightly coupled with the state of data being fetched. 