### PR TITLE
Ensure clipboard text is non-null

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -1481,7 +1481,7 @@ final copyPackagePathOption = ScriptPopupMenuOption(
   label: 'Copy package path',
   icon: Icons.content_copy,
   onSelected: (_, controller) => Clipboard.setData(
-    ClipboardData(text: controller.scriptLocation.value?.scriptRef.uri),
+    ClipboardData(text: controller.scriptLocation.value?.scriptRef.uri ?? ''),
   ),
 );
 
@@ -1490,8 +1490,9 @@ final copyFilePathOption = ScriptPopupMenuOption(
   icon: Icons.content_copy,
   onSelected: (_, controller) {
     unawaited(() async {
+      final filePath = await fetchScriptLocationFullFilePath(controller);
       await Clipboard.setData(
-        ClipboardData(text: await fetchScriptLocationFullFilePath(controller)),
+        ClipboardData(text: filePath ?? ''),
       );
     }());
   },


### PR DESCRIPTION
Flutter behaves unexpectedly if you set your clipboard text to null:

1. Android and iOS will set your clipboard content to the text "null".
2. Linux and web throws
3. Windows crashes

Flutter will be updated to disallow setting the clipboard text to null: https://github.com/flutter/flutter/pull/122446

Part of https://github.com/flutter/flutter/issues/121976

RELEASE_NOTE_EXCEPTION=Null safety change that shouldn't affect functionality.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
