### PR TITLE
Improve the performance of generating a bottom up profile

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -472,7 +472,11 @@ class CpuProfileData {
             traceJson: sampleJson,
           ),
         );
-      } else if (stackFrame.parentId != CpuProfileData.rootId) {
+      }
+      // TODO(kenz): investigate why [stackFrame.parentId] is sometimes
+      // missing.
+      else if (stackFrame.parentId != CpuProfileData.rootId &&
+          originalData.stackFrames.containsKey(stackFrame.parentId)) {
         final parent = originalData.stackFrames[stackFrame.parentId]!;
         includeSampleOrWalkUp(sample, sampleJson, parent);
       }
@@ -495,7 +499,11 @@ class CpuProfileData {
 
       if (includeFilter(candidateParentFrame)) {
         return candidateParentFrame.id;
-      } else if (candidateParentFrame.parentId != CpuProfileData.rootId) {
+      }
+      // TODO(kenz): investigate why [stackFrame.parentId] is sometimes
+      // missing.
+      else if (candidateParentFrame.parentId != CpuProfileData.rootId &&
+          originalData.stackFrames.containsKey(candidateParentFrame.parentId)) {
         final parent = originalData.stackFrames[candidateParentFrame.parentId]!;
         return filteredParentStackFrameId(parent);
       }

--- a/packages/devtools_app/lib/src/shared/profiler_utils.dart
+++ b/packages/devtools_app/lib/src/shared/profiler_utils.dart
@@ -4,8 +4,14 @@
 
 import 'package:flutter/material.dart';
 
-import '../../devtools_app.dart';
+import '../screens/debugger/codeview_controller.dart';
+import '../screens/debugger/debugger_screen.dart';
 import '../screens/vm_developer/vm_developer_common_widgets.dart';
+import 'globals.dart';
+import 'primitives/trees.dart';
+import 'primitives/utils.dart';
+import 'routing.dart';
+import 'theme.dart';
 
 mixin ProfilableDataMixin<T extends TreeNode<T>> on TreeNode<T> {
   ProfileMetaData get profileMetaData;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,7 +27,7 @@ jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools
 
 ## CPU profiler updates
 * Add a Method Table to the CPU profiler - [#5366](https://github.com/flutter/devtools/pull/5366)
-* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468)
+* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468), [#5533](https://github.com/flutter/devtools/pull/5533)
 * Polish and performance improvements for the CPU profile flame chart - [#5529](https://github.com/flutter/devtools/pull/5529)
 
 ![method table](images/image1.png "method_table")


### PR DESCRIPTION
This improves the performance of generating a bottom up profile by ~60%.

We were using `List.remove`, which triggered a call to `List.copy`. This was quite expensive. Now we build up a new list of `mergedRoots` instead of  calling `remove` on the original list, and call `clear` + `addAll` after we are done merging roots. 

We also limit the list traversal using a `traverseIndex` and limit the calls to `CpuStackFrame.matches`, which can also be expensive for a large N.

Work towards https://github.com/flutter/devtools/issues/5091