### PR TITLE
Improve performance of CPU profile filtering

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'dart:collection';
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
@@ -240,11 +239,7 @@ class CpuProfileData {
         )
         .toList();
 
-    // Use a SplayTreeMap so that map iteration will be in sorted key order.
-    // This keeps the visualization of the profile as consistent as possible
-    // when applying filters.
-    final SplayTreeMap<String, CpuStackFrame> subStackFrames =
-        SplayTreeMap(stackFrameIdCompare);
+    final subStackFrames = <String, CpuStackFrame>{};
     for (final sample in subSamples) {
       final leafFrame = superProfile.stackFrames[sample.leafId]!;
       subStackFrames[sample.leafId] = leafFrame;
@@ -292,12 +287,7 @@ class CpuProfileData {
 
     final metaData = originalData.profileMetaData.copyWith();
 
-    // Use a SplayTreeMap so that map iteration will be in sorted key order.
-    // This keeps the visualization of the profile as consistent as possible
-    // when applying filters.
-    final SplayTreeMap<String, CpuStackFrame> stackFrames =
-        SplayTreeMap(stackFrameIdCompare);
-
+    final stackFrames = <String, CpuStackFrame>{};
     final samples = <CpuSampleEvent>[];
 
     int nextId = 1;
@@ -416,11 +406,7 @@ class CpuProfileData {
         ),
     );
 
-    // Use a SplayTreeMap so that map iteration will be in sorted key order.
-    // This keeps the visualization of the profile as consistent as possible
-    // when applying filters.
-    final SplayTreeMap<String, CpuStackFrame> stackFramesWithTag =
-        SplayTreeMap(stackFrameIdCompare);
+    final stackFramesWithTag = <String, CpuStackFrame>{};
 
     for (final sample in samplesWithTag) {
       String? currentId = sample.leafId;
@@ -484,11 +470,7 @@ class CpuProfileData {
       includeSampleOrWalkUp(sample, sampleJson, leafStackFrame);
     }
 
-    // Use a SplayTreeMap so that map iteration will be in sorted key order.
-    // This keeps the visualization of the profile as consistent as possible
-    // when applying filters.
-    final SplayTreeMap<String, CpuStackFrame> filteredStackFrames =
-        SplayTreeMap(stackFrameIdCompare);
+    final filteredStackFrames = <String, CpuStackFrame>{};
 
     String? filteredParentStackFrameId(CpuStackFrame? candidateParentFrame) {
       if (candidateParentFrame == null) return null;
@@ -1079,42 +1061,6 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
     buf.write(inclusiveSampleCount == 1 ? 'sample' : 'samples');
     buf.write(', ${percent(totalTimeRatio)})');
     return buf.toString();
-  }
-}
-
-@visibleForTesting
-int stackFrameIdCompare(String a, String b) {
-  if (a == b) {
-    return 0;
-  }
-  // Order the root first.
-  if (a == CpuProfileData.rootId) {
-    return -1;
-  }
-  if (b == CpuProfileData.rootId) {
-    return 1;
-  }
-
-  // Stack frame ids are structured as 140225212960768-24 (iOS) or -784070656-24
-  // (Android). We need to compare the number after the last dash to maintain
-  // the correct order.
-  const dash = '-';
-  final aDashIndex = a.lastIndexOf(dash);
-  final bDashIndex = b.lastIndexOf(dash);
-  try {
-    final int aId = int.parse(a.substring(aDashIndex + 1));
-    final int bId = int.parse(b.substring(bDashIndex + 1));
-    return aId.compareTo(bId);
-  } catch (e, stackTrace) {
-    String error = 'invalid stack frame ';
-    if (aDashIndex == -1 && bDashIndex != -1) {
-      error += 'id [$a]';
-    } else if (aDashIndex != -1 && bDashIndex == -1) {
-      error += 'id [$b]';
-    } else {
-      error += 'ids [$a, $b]';
-    }
-    Error.throwWithStackTrace(error, stackTrace);
   }
 }
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,7 +27,7 @@ jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools
 
 ## CPU profiler updates
 * Add a Method Table to the CPU profiler - [#5366](https://github.com/flutter/devtools/pull/5366)
-* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468)
+* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468), [#5535](https://github.com/flutter/devtools/pull/5535)
 * Polish and performance improvements for the CPU profile flame chart - [#5529](https://github.com/flutter/devtools/pull/5529)
 
 ![method table](images/image1.png "method_table")

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,10 +27,11 @@ jank is detected on an iOS device. - [#5455](https://github.com/flutter/devtools
 
 ## CPU profiler updates
 * Add a Method Table to the CPU profiler - [#5366](https://github.com/flutter/devtools/pull/5366)
-* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468), [#5533](https://github.com/flutter/devtools/pull/5533), [#5535](https://github.com/flutter/devtools/pull/5535)
-* Polish and performance improvements for the CPU profile flame chart - [#5529](https://github.com/flutter/devtools/pull/5529)
 
 ![method table](images/image1.png "method_table")
+
+* Improve the performance of data processing in the CPU profiler - [#5468](https://github.com/flutter/devtools/pull/5468), [#5533](https://github.com/flutter/devtools/pull/5533), [#5535](https://github.com/flutter/devtools/pull/5535)
+* Polish and performance improvements for the CPU profile flame chart - [#5529](https://github.com/flutter/devtools/pull/5529)
 
 * Add ability to inspect statistics for a CPU profile - [#5340](https://github.com/flutter/devtools/pull/5340)
 * Fix a bug where Native stack frames were missing their name - [#5344](https://github.com/flutter/devtools/pull/5344)

--- a/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
@@ -172,20 +172,6 @@ void main() {
         equals(packageUri),
       );
     });
-
-    test('stackFrameIdCompare', () {
-      // iOS
-      String idA = '140225212960768-2';
-      String idB = '140225212960768-10';
-      expect(idA.compareTo(idB), equals(1));
-      expect(stackFrameIdCompare(idA, idB), equals(-1));
-
-      // Android
-      idA = '-784070656-2';
-      idB = '-784070656-10';
-      expect(idA.compareTo(idB), equals(1));
-      expect(stackFrameIdCompare(idA, idB), equals(-1));
-    });
   });
 
   group('CpuStackFrame', () {


### PR DESCRIPTION
This improves the performance of filtering CPU profiles by ~66%. We do not need to use a SplayTreeMap here since the tables are all sorted by time. The CPU flame chart is the only view for which this might help, and this is the least used view, so we should prioritize performance.

Fixes https://github.com/flutter/devtools/issues/4807. Work towards https://github.com/flutter/devtools/issues/5091.