### PR TITLE
Updated `getListHelper` instance ref argument to be nullable

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1042,7 +1042,7 @@ abstract class ObjectGroupBase implements Disposable {
   }
 
   Future<List<RemoteDiagnosticsNode>> getListHelper(
-    InspectorInstanceRef instanceRef,
+    InspectorInstanceRef? instanceRef,
     String methodName,
     RemoteDiagnosticsNode? parent,
     bool isProperty,


### PR DESCRIPTION
Updated the `InspectorService`'s `getListHelper` instance ref argument to be nullable.

RELEASE_NOTE_EXCEPTION=Trivial no-op change