### PR TITLE
Add actions to DevToolsScaffold by default.

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -9,15 +9,12 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'example/conditional_screen.dart';
-import 'framework/about_dialog.dart';
 import 'framework/framework_core.dart';
 import 'framework/initializer.dart';
 import 'framework/landing_screen.dart';
 import 'framework/notifications_view.dart';
 import 'framework/release_notes/release_notes.dart';
-import 'framework/report_feedback_button.dart';
 import 'framework/scaffold.dart';
-import 'framework/settings_dialog.dart';
 import 'screens/app_size/app_size_controller.dart';
 import 'screens/app_size/app_size_screen.dart';
 import 'screens/debugger/debugger_controller.dart';
@@ -205,11 +202,6 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
       return DevToolsScaffold.withChild(
         key: const Key('landing'),
         ideTheme: ideTheme,
-        actions: [
-          OpenSettingsAction(),
-          ReportFeedbackButton(),
-          OpenAboutAction(),
-        ],
         child: LandingScreenBody(sampleData: widget.sampleData),
       );
     }
@@ -248,9 +240,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
                     HotReloadButton(),
                     HotRestartButton(),
                   ],
-                  OpenSettingsAction(),
-                  ReportFeedbackButton(),
-                  OpenAboutAction(),
+                  ...DevToolsScaffold.defaultActions(),
                 ],
               ),
             );
@@ -289,11 +279,6 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
         return DevToolsScaffold.withChild(
           key: const Key('appsize'),
           ideTheme: ideTheme,
-          actions: [
-            OpenSettingsAction(),
-            ReportFeedbackButton(),
-            OpenAboutAction(),
-          ],
           child: MultiProvider(
             providers: _providedControllers(),
             child: const AppSizeBody(),

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -135,7 +135,7 @@ class _DiscordLink extends StatelessWidget {
 
 class OpenAboutAction extends StatelessWidget {
   const OpenAboutAction();
-  
+
   @override
   Widget build(BuildContext context) {
     final releaseNotesController = Provider.of<ReleaseNotesController>(context);

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -134,6 +134,8 @@ class _DiscordLink extends StatelessWidget {
 }
 
 class OpenAboutAction extends StatelessWidget {
+  const OpenAboutAction();
+  
   @override
   Widget build(BuildContext context) {
     final releaseNotesController = Provider.of<ReleaseNotesController>(context);

--- a/packages/devtools_app/lib/src/framework/report_feedback_button.dart
+++ b/packages/devtools_app/lib/src/framework/report_feedback_button.dart
@@ -15,7 +15,7 @@ import '../shared/theme.dart';
 
 class ReportFeedbackButton extends StatelessWidget {
   const ReportFeedbackButton();
-  
+
   @override
   Widget build(BuildContext context) {
     return DevToolsTooltip(

--- a/packages/devtools_app/lib/src/framework/report_feedback_button.dart
+++ b/packages/devtools_app/lib/src/framework/report_feedback_button.dart
@@ -14,6 +14,8 @@ import '../shared/globals.dart';
 import '../shared/theme.dart';
 
 class ReportFeedbackButton extends StatelessWidget {
+  const ReportFeedbackButton();
+  
   @override
   Widget build(BuildContext context) {
     return DevToolsTooltip(

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -27,6 +27,9 @@ import '../shared/split.dart';
 import '../shared/theme.dart';
 import '../shared/title.dart';
 import '../shared/utils.dart';
+import 'about_dialog.dart';
+import 'report_feedback_button.dart';
+import 'settings_dialog.dart';
 import 'status_line.dart';
 
 /// Scaffolding for a screen and navigation in the DevTools App.
@@ -36,13 +39,14 @@ import 'status_line.dart';
 /// [DevToolsApp] defines the collections of [Screen]s to show in a scaffold
 /// for different routes.
 class DevToolsScaffold extends StatefulWidget {
-  const DevToolsScaffold({
+  DevToolsScaffold({
     Key? key,
     required this.screens,
     this.page,
-    this.actions,
+    List<Widget>? actions,
     this.embed = false,
-  }) : super(key: key);
+  })  : actions = actions ?? defaultActions(),
+        super(key: key);
 
   DevToolsScaffold.withChild({
     Key? key,
@@ -60,6 +64,12 @@ class DevToolsScaffold extends StatefulWidget {
 
   /// A [Key] that indicates the scaffold is showing in full-width mode.
   static const Key fullWidthKey = Key('Full-width Scaffold');
+
+  static List<Widget> defaultActions() => const [
+        OpenSettingsAction(),
+        ReportFeedbackButton(),
+        OpenAboutAction(),
+      ];
 
   /// The padding around the content in the DevTools UI.
   EdgeInsets get appPadding => EdgeInsets.fromLTRB(

--- a/packages/devtools_app/lib/src/framework/settings_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/settings_dialog.dart
@@ -18,6 +18,8 @@ import '../shared/theme.dart';
 import '../shared/utils.dart';
 
 class OpenSettingsAction extends StatelessWidget {
+  const OpenSettingsAction();
+  
   @override
   Widget build(BuildContext context) {
     return DevToolsTooltip(

--- a/packages/devtools_app/lib/src/framework/settings_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/settings_dialog.dart
@@ -19,7 +19,7 @@ import '../shared/utils.dart';
 
 class OpenSettingsAction extends StatelessWidget {
   const OpenSettingsAction();
-  
+
   @override
   Widget build(BuildContext context) {
     return DevToolsTooltip(

--- a/packages/devtools_app/lib/src/framework/status_line.dart
+++ b/packages/devtools_app/lib/src/framework/status_line.dart
@@ -18,9 +18,7 @@ import '../shared/screen.dart';
 import '../shared/theme.dart';
 import '../shared/ui/utils.dart';
 import '../shared/utils.dart';
-import 'about_dialog.dart';
-import 'report_feedback_button.dart';
-import 'settings_dialog.dart';
+import 'scaffold.dart';
 
 /// The status line widget displayed at the bottom of DevTools.
 ///
@@ -84,11 +82,7 @@ class StatusLine extends StatelessWidget {
         const BulletSpacer(),
         Row(
           crossAxisAlignment: CrossAxisAlignment.end,
-          children: [
-            OpenSettingsAction(),
-            ReportFeedbackButton(),
-            OpenAboutAction(),
-          ],
+          children: DevToolsScaffold.defaultActions(),
         ),
       ],
     ];

--- a/packages/devtools_app/test/shared/scaffold_debugging_controls_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_debugging_controls_test.dart
@@ -58,7 +58,7 @@ void main() {
 
       await tester.pumpWidget(
         wrapWithControllers(
-          const DevToolsScaffold(screens: [_screen1, _screen2]),
+          DevToolsScaffold(screens: const [_screen1, _screen2]),
           debugger: mockDebuggerController,
           analytics: AnalyticsController(enabled: false, firstRun: false),
         ),

--- a/packages/devtools_app/test/shared/scaffold_no_app_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_no_app_test.dart
@@ -42,7 +42,7 @@ void main() {
       await tester.pumpWidget(
         wrapScaffold(
           wrapWithNotifications(
-            const DevToolsScaffold(screens: [_screen1, _screen2]),
+            DevToolsScaffold(screens: const [_screen1, _screen2]),
           ),
         ),
       );

--- a/packages/devtools_app/test/shared/scaffold_profile_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_profile_test.dart
@@ -54,7 +54,7 @@ void main() {
 
       await tester.pumpWidget(
         wrapWithControllers(
-          const DevToolsScaffold(screens: [_screen1, _screen2]),
+          DevToolsScaffold(screens: const [_screen1, _screen2]),
           debugger: mockDebuggerController,
           analytics: AnalyticsController(enabled: false, firstRun: false),
         ),

--- a/packages/devtools_app/test/shared/scaffold_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_test.dart
@@ -42,8 +42,8 @@ void main() {
       await tester.pumpWidget(
         wrapScaffold(
           wrapWithNotifications(
-            const DevToolsScaffold(
-              screens: [_screen1, _screen2, _screen3, _screen4, _screen5],
+            DevToolsScaffold(
+              screens: const [_screen1, _screen2, _screen3, _screen4, _screen5],
             ),
           ),
         ),
@@ -61,8 +61,8 @@ void main() {
       await tester.pumpWidget(
         wrapScaffold(
           wrapWithNotifications(
-            const DevToolsScaffold(
-              screens: [_screen1, _screen2, _screen3, _screen4, _screen5],
+            DevToolsScaffold(
+              screens: const [_screen1, _screen2, _screen3, _screen4, _screen5],
             ),
           ),
         ),
@@ -79,7 +79,7 @@ void main() {
       await tester.pumpWidget(
         wrapScaffold(
           wrapWithNotifications(
-            const DevToolsScaffold(screens: [_screen1]),
+            DevToolsScaffold(screens: const [_screen1]),
           ),
         ),
       );
@@ -92,7 +92,7 @@ void main() {
     await tester.pumpWidget(
       wrapScaffold(
         wrapWithNotifications(
-          const DevToolsScaffold(screens: [_screen1, _screen2]),
+          DevToolsScaffold(screens: const [_screen1, _screen2]),
         ),
       ),
     );


### PR DESCRIPTION
This ensures the default actions (settings, report feedback, and about) show up on every instance of DevToolsScaffold, including the scaffold for viewing offline data.

RELEASE_NOTE_EXCEPTION=[too small to mention]