### PR TITLE
Hide TODOs in VS Code when opening packages/devtools_app

### DIFF
--- a/packages/.vscode/settings.json
+++ b/packages/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
     // Set current working directory to devtools_app.
-    "terminal.integrated.cwd": "devtools_app"
+    "terminal.integrated.cwd": "devtools_app",
+    "dart.showTodos": false,
 }

--- a/packages/devtools_app/.vscode/settings.json
+++ b/packages/devtools_app/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "dart.showTodos": false,
+}


### PR DESCRIPTION
This hides TODOs by default when opening either of the folders that have .vscode folders (`packages`, `devtools_app` which I'm assuming are the folders usually opened for contributing).

Currently VS Code _shows_ TODOs by default in the Problems pane which is something we may wish to reconsider, but in the meantime it's probably better if we hide them here by default rather than rely on users knowing (or not) that they can hide them.

<!-- Uncomment and modify the following section if your PR does not require changes to the release notes -->
<!-- RELEASE_NOTE_EXCEPTION=[REASON GOES HERE] -->

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- N/A I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


RELEASE_NOTE_EXCEPTION=Only VS Code config change

![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
