### PR TITLE
Fix issues at head to unblock PRs

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -75,9 +75,7 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.1.0
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
-  stager: ^0.1.0
-  # See https://github.com/dart-lang/test/issues/1977
-  test_api: 0.4.18
+  stager: ^1.0.0
 
 flutter:
   uses-material-design: true

--- a/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/profiler_screen_test.dart
@@ -47,7 +47,7 @@ void main() {
 
     Future<void> pumpProfilerScreen(WidgetTester tester) async {
       await tester.runAsync(() async {
-        await tester.pumpWidget(scene.build());
+        await tester.pumpWidget(scene.build(MockBuildContext()));
         // Delay to ensure the memory profiler has collected data.
         await tester.pump(const Duration(seconds: 1));
         expect(find.byType(ProfilerScreenBody), findsOneWidget);

--- a/packages/devtools_app/test/memory/control/settings_dialog_test.dart
+++ b/packages/devtools_app/test/memory/control/settings_dialog_test.dart
@@ -18,7 +18,7 @@ void main() {
   late MemoryDefaultScene scene;
 
   Future<void> pumpMemoryScreen(WidgetTester tester) async {
-    await tester.pumpWidget(scene.build());
+    await tester.pumpWidget(scene.build(MockBuildContext()));
     // Delay to ensure the memory profiler has collected data.
     await tester.pumpAndSettle(const Duration(seconds: 1));
     expect(find.byType(MemoryBody), findsOneWidget);

--- a/packages/devtools_app/test/memory/diff/widgets/class_filter_test.dart
+++ b/packages/devtools_app/test/memory/diff/widgets/class_filter_test.dart
@@ -69,7 +69,7 @@ void main() {
       diffWith,
     );
 
-    await tester.pumpWidget(scene.build());
+    await tester.pumpWidget(scene.build(MockBuildContext()));
     await tester.pumpAndSettle();
     expect(
       scene.diffController.core.classFilter.value.filterType,

--- a/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
+++ b/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
@@ -17,7 +17,7 @@ void main() {
     late MemoryDefaultScene scene;
 
     Future<void> pumpScene(WidgetTester tester) async {
-      await tester.pumpWidget(scene.build());
+      await tester.pumpWidget(scene.build(MockBuildContext()));
       // Delay to ensure the memory profiler has collected data.
       await tester.pumpAndSettle(const Duration(seconds: 1));
       expect(find.byType(MemoryBody), findsOneWidget);

--- a/packages/devtools_app/test/memory/profile/allocation_profile_table_view_test.dart
+++ b/packages/devtools_app/test/memory/profile/allocation_profile_table_view_test.dart
@@ -25,7 +25,7 @@ void main() {
   });
 
   Future<void> pumpMemoryScreen(WidgetTester tester) async {
-    await tester.pumpWidget(scene.build());
+    await tester.pumpWidget(scene.build(MockBuildContext()));
     // Delay to ensure the memory profiler has collected data.
     await tester.pumpAndSettle(const Duration(seconds: 1));
     expect(find.byType(MemoryBody), findsOneWidget);

--- a/packages/devtools_app/test/memory/tracing/tracing_view_test.dart
+++ b/packages/devtools_app/test/memory/tracing/tracing_view_test.dart
@@ -56,7 +56,7 @@ void main() {
     late final CpuSamples allocationTracingProfile;
 
     Future<void> pumpScene(WidgetTester tester) async {
-      await tester.pumpWidget(scene.build());
+      await tester.pumpWidget(scene.build(MockBuildContext()));
       // Delay to ensure the memory profiler has collected data.
       await tester.pumpAndSettle(const Duration(seconds: 1));
       expect(find.byType(MemoryBody), findsOneWidget);

--- a/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.dart
@@ -21,7 +21,7 @@ class CpuProfilerDefaultScene extends Scene {
   late ProfilerScreen screen;
 
   @override
-  Widget build() {
+  Widget build(BuildContext _) {
     return wrapWithControllers(
       const ProfilerScreenBody(),
       profiler: controller,

--- a/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.stager_app.g.dart
+++ b/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.stager_app.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StagerAppGenerator
+// **************************************************************************
+
+import 'package:stager/stager.dart';
+
+import 'default.dart';
+
+void main() {
+  final List<Scene> scenes = <Scene>[
+    CpuProfilerDefaultScene(),
+  ];
+
+  if (const String.fromEnvironment('Scene').isNotEmpty) {
+    const String sceneName = String.fromEnvironment('Scene');
+    final Scene scene =
+        scenes.firstWhere((Scene scene) => scene.title == sceneName);
+    runStagerApp(scenes: <Scene>[scene]);
+  } else {
+    runStagerApp(scenes: scenes);
+  }
+}

--- a/packages/devtools_app/test/test_infra/scenes/hello.dart
+++ b/packages/devtools_app/test/test_infra/scenes/hello.dart
@@ -9,7 +9,7 @@ import 'package:stager/stager.dart';
 /// flutter run -t test/scenes/hello.stager_app.dart -d macos
 class HelloScene extends Scene {
   @override
-  Widget build() {
+  Widget build(BuildContext _) {
     return MaterialApp(
       home: Card(
         child: Text('Hello, I am $title.'),

--- a/packages/devtools_app/test/test_infra/scenes/hello.stager_app.g.dart
+++ b/packages/devtools_app/test/test_infra/scenes/hello.stager_app.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StagerAppGenerator
+// **************************************************************************
+
+import 'package:stager/stager.dart';
+
+import 'hello.dart';
+
+void main() {
+  final List<Scene> scenes = <Scene>[
+    HelloScene(),
+  ];
+
+  if (const String.fromEnvironment('Scene').isNotEmpty) {
+    const String sceneName = String.fromEnvironment('Scene');
+    final Scene scene =
+        scenes.firstWhere((Scene scene) => scene.title == sceneName);
+    runStagerApp(scenes: <Scene>[scene]);
+  } else {
+    runStagerApp(scenes: scenes);
+  }
+}

--- a/packages/devtools_app/test/test_infra/scenes/memory/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/default.dart
@@ -27,7 +27,7 @@ class MemoryDefaultScene extends Scene {
   late FakeServiceManager fakeServiceManager;
 
   @override
-  Widget build() {
+  Widget build(BuildContext _) {
     return wrapWithControllers(
       const MemoryBody(),
       memory: controller,

--- a/packages/devtools_app/test/test_infra/scenes/memory/default.stager_app.g.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/default.stager_app.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StagerAppGenerator
+// **************************************************************************
+
+import 'package:stager/stager.dart';
+
+import 'default.dart';
+
+void main() {
+  final List<Scene> scenes = <Scene>[
+    MemoryDefaultScene(),
+  ];
+
+  if (const String.fromEnvironment('Scene').isNotEmpty) {
+    const String sceneName = String.fromEnvironment('Scene');
+    final Scene scene =
+        scenes.firstWhere((Scene scene) => scene.title == sceneName);
+    runStagerApp(scenes: <Scene>[scene]);
+  } else {
+    runStagerApp(scenes: scenes);
+  }
+}

--- a/packages/devtools_app/test/test_infra/scenes/memory/diff_snapshot.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/diff_snapshot.dart
@@ -22,7 +22,7 @@ class DiffSnapshotScene extends Scene {
   late FakeServiceManager fakeServiceManager;
 
   @override
-  Widget build() {
+  Widget build(BuildContext _) {
     return wrap(
       SnapshotInstanceItemPane(controller: diffController),
     );

--- a/packages/devtools_app/test/test_infra/scenes/memory/diff_snapshot.stager_app.g.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/diff_snapshot.stager_app.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StagerAppGenerator
+// **************************************************************************
+
+import 'package:stager/stager.dart';
+
+import 'diff_snapshot.dart';
+
+void main() {
+  final List<Scene> scenes = <Scene>[
+    DiffSnapshotScene(),
+  ];
+
+  if (const String.fromEnvironment('Scene').isNotEmpty) {
+    const String sceneName = String.fromEnvironment('Scene');
+    final Scene scene =
+        scenes.firstWhere((Scene scene) => scene.title == sceneName);
+    runStagerApp(scenes: <Scene>[scene]);
+  } else {
+    runStagerApp(scenes: scenes);
+  }
+}

--- a/packages/devtools_app/test/test_infra/scenes/performance/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/performance/default.dart
@@ -19,7 +19,7 @@ class PerformanceDefaultScene extends Scene {
   late PerformanceController controller;
 
   @override
-  Widget build() {
+  Widget build(BuildContext _) {
     return wrapWithControllers(
       const PerformanceScreenBody(),
       performance: controller,

--- a/packages/devtools_app/test/test_infra/scenes/performance/default.stager_app.g.dart
+++ b/packages/devtools_app/test/test_infra/scenes/performance/default.stager_app.g.dart
@@ -1,0 +1,24 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// StagerAppGenerator
+// **************************************************************************
+
+import 'package:stager/stager.dart';
+
+import 'default.dart';
+
+void main() {
+  final List<Scene> scenes = <Scene>[
+    PerformanceDefaultScene(),
+  ];
+
+  if (const String.fromEnvironment('Scene').isNotEmpty) {
+    const String sceneName = String.fromEnvironment('Scene');
+    final Scene scene =
+        scenes.firstWhere((Scene scene) => scene.title == sceneName);
+    runStagerApp(scenes: <Scene>[scene]);
+  } else {
+    runStagerApp(scenes: scenes);
+  }
+}

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -8,10 +8,13 @@ import 'dart:convert';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:mockito/mockito.dart';
 import 'package:vm_service/vm_service.dart';
 
 import 'generated_mocks_factories.dart';
+
+class MockBuildContext extends Mock implements BuildContext {}
 
 class FakeInspectorService extends Fake implements InspectorService {
   final pubRootDirectories = <String>{};

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -44,5 +44,4 @@ dev_dependencies:
   build_runner: ^2.3.3
   integration_test:
     sdk: flutter
-  # See https://github.com/dart-lang/test/issues/1977
-  test_api: 0.4.18
+


### PR DESCRIPTION
- Removes `test_api` pin now that https://github.com/dart-lang/test/issues/1977 is resolved (`test_api` 0.5.1 now comes from `integration_test`)
- Updates stager to  ^1.0.0  for dependency resolution with `test_api 0.5.1`
- Fixes the `invalid_override` analyzer errors for `Scene.build` (they were missing `BuildContext` parameter, breaking change in stager 1.0.0)
- Create a `MockBuildContext` to pass to `Scene.build` in tests


`RELEASE_NOTE_EXCEPTION="No user facing changes"`