### PR TITLE
Remove Inspector use of `getRootRenderObject` and `getSelectedRenderObject`

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -921,15 +921,6 @@ class InspectorController extends DisposableController
     super.dispose();
   }
 
-  static String treeTypeDisplayName(FlutterTreeType treeType) {
-    switch (treeType) {
-      case FlutterTreeType.widget:
-        return 'Widget';
-      case FlutterTreeType.renderObject:
-        return 'Render Objects';
-    }
-  }
-
   void _onNodeAdded(
     InspectorTreeNode node,
     RemoteDiagnosticsNode diagnosticsNode,

--- a/packages/devtools_app/lib/src/shared/console/primitives/simple_items.dart
+++ b/packages/devtools_app/lib/src/shared/console/primitives/simple_items.dart
@@ -2,8 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// TODO(jacobr): add render, semantics, and layer trees.
 enum FlutterTreeType {
-  widget, // ('Widget'),
-  renderObject // ('Render');
-// TODO(jacobr): add semantics, and layer trees.
+  widget('Widget');
+
+  const FlutterTreeType(this.title);
+
+  final String title;
 }

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1151,8 +1151,6 @@ class ObjectGroup extends ObjectGroupBase {
     switch (type) {
       case FlutterTreeType.widget:
         return getRootWidget();
-      case FlutterTreeType.renderObject:
-        return getRootRenderObject();
     }
   }
 
@@ -1177,13 +1175,6 @@ class ObjectGroup extends ObjectGroupBase {
       invokeServiceMethodDaemon(
         WidgetInspectorServiceExtensions.getRootWidgetSummaryTree.name,
       ),
-    );
-  }
-
-  Future<RemoteDiagnosticsNode?> getRootRenderObject() {
-    assert(!disposed);
-    return invokeServiceMethodReturningNode(
-      WidgetInspectorServiceExtensions.getRootRenderObject.name,
     );
   }
 
@@ -1242,12 +1233,6 @@ class ObjectGroup extends ObjectGroupBase {
           isSummaryTree
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
-          previousSelectionRef,
-        );
-        break;
-      case FlutterTreeType.renderObject:
-        newSelection = await invokeServiceMethodReturningNodeInspectorRef(
-          WidgetInspectorServiceExtensions.getSelectedRenderObject.name,
           previousSelectionRef,
         );
         break;

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -451,7 +451,7 @@ void main() async {
         expect(nodeInDetailsTree.valueRef, equals(nodeInSummaryTree.valueRef));
 
         await group.setSelectionInspector(nodeInDetailsTree.valueRef, true);
-        var selection = (await group.getSelection(
+        final selection = (await group.getSelection(
           null,
           FlutterTreeType.widget,
           isSummaryTree: false,
@@ -463,20 +463,6 @@ void main() async {
           equalsIgnoringHashCodes(
             'Text\n'
             ' └─RichText\n',
-          ),
-        );
-
-        // Get selection in the render tree.
-        selection = (await group.getSelection(
-          null,
-          FlutterTreeType.renderObject,
-          isSummaryTree: false,
-        ))!;
-        expect(
-          treeToDebugString(selection),
-          equalsIgnoringHashCodes(
-            'RenderParagraph#00000 relayoutBoundary=up2\n'
-            ' └─text: TextSpan\n',
           ),
         );
 


### PR DESCRIPTION
this will simplify multi-window support.
RELEASE_NOTE_EXCEPTION=[not user facing]
CC @goderbauer 