### PR TITLE
Disable `avoid-nested-conditional-expressions` DCM rule

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -160,7 +160,7 @@ dart_code_metrics:
 #    - avoid-ignoring-return-values
 #    - avoid-late-keyword
     - avoid-missing-enum-constant-in-map
-    - avoid-nested-conditional-expressions
+#    - avoid-nested-conditional-expressions Worth renabling but currently too many violators.
 #    - avoid-non-ascii-symbols  TODO(jacobr): probably worth enabling.
 #    - avoid-non-null-assertion
 #    - avoid-passing-async-when-sync-expected TODO(jacobr): consider re-enabliing.

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -110,7 +110,6 @@ class _CallStackState extends State<CallStack>
     return isAsyncBreak
         ? result
         : DevToolsTooltip(
-            // ignore: avoid-nested-conditional-expressions, false positive.
             message: locationDescription == null
                 ? frameDescription
                 : '$frameDescription $locationDescription',

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -127,7 +127,6 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
           );
         }
         final status = recording || profilerBusy
-            // ignore: avoid-nested-conditional-expressions, requires refactor.
             ? (recording
                 ? const RecordingStatus()
                 : ProfilerBusyStatus(status: profilerBusyStatus))

--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/instance_viewer.dart
@@ -286,8 +286,6 @@ class _InstanceViewerState extends ConsumerState<InstanceViewer> {
         yield child != null
             ? Padding(
                 padding: const EdgeInsets.only(left: defaultSpacing),
-                // Expression is easily understood.
-                // ignore: avoid-nested-conditional-expressions
                 child: isFirstItem
                     ? Row(
                         children: [

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -222,8 +222,6 @@ class RequestableSizeWidget extends StatelessWidget {
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: [
                     SelectableText(
-                      // Expression is easily understood.
-                      // ignore: avoid-nested-conditional-expressions
                       size.valueAsString == null
                           ? '--'
                           : prettyPrintBytes(


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/5479

Over half of the 60+ DCM violations are currently due to this rule. I think it makes more sense to re-enable with fixes after we get DCM working for the bots.