### PR TITLE
Specify release notes not required with label, not description in PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,4 @@ updates:
       interval: "daily"
     labels:
       - "autosubmit"
+      - "dependabot"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,4 +9,4 @@ updates:
       interval: "daily"
     labels:
       - "autosubmit"
-      - "dependabot"
+      - "release-notes-not-required"

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -11,8 +11,7 @@ env:
 jobs:
   release-preparedness:
     if: |
-      ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') 
-      && !contains(github.event.*.labels.*.name, 'dependabot') }}
+      ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') }}
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:
-
       - name: Get Pull Request Number
         id: get-pull-request-number
         run: |

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -10,8 +10,7 @@ env:
   CURRENT_RELEASE_FILE_PATH: packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
 jobs:
   release-preparedness:
-    if: |
-      ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') }}
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -40,6 +40,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or add the `release-notes-not-required` label."
+            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or add the release-notes-not-required label."
             exit 1
           fi

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -2,14 +2,21 @@ name: Release Notes
 
 on:
   pull_request:
-    types: [assigned, opened, synchronize, reopened, edited]
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+    paths:
+      - '**/*.dart'
+
 env:
   CURRENT_RELEASE_FILE_PATH: packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
 jobs:
   release-preparedness:
+    if: |
+      ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') 
+      && !contains(github.event.*.labels.*.name, 'dependabot') }}
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:
+
       - name: Get Pull Request Number
         id: get-pull-request-number
         run: |
@@ -28,46 +35,12 @@ jobs:
           HAS_CHANGED_RELEASE_NOTES=$(echo $FILES_RESPONSE | jq '.[].filename' | jq -s '. | any(. == env.CURRENT_RELEASE_FILE_PATH)')
           echo "HAS_CHANGED_RELEASE_NOTES=$HAS_CHANGED_RELEASE_NOTES" >> $GITHUB_OUTPUT
 
-      - name: Get PR Info
-        id: check-release-note-exceptions
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PULL_NUMBER: ${{steps.get-pull-request-number.outputs.PULL_REQUEST_NUMBER}}
-        run: |
-          PULLS_RESPONSE=$(gh api /repos/$GITHUB_REPOSITORY/pulls/$PULL_NUMBER)
-          DESCRIPTION_BODY=$(echo $PULLS_RESPONSE | jq '.body')
-          AUTHOR_ID=$(echo $PULLS_RESPONSE | jq -r '.user.login')
-
-          sudo apt-get install pandoc
-
-          BODY_WITHOUT_COMMENTS=$(printf "$DESCRIPTION_BODY" | pandoc --strip-comments -f markdown -t plain)
-          echo $DESCRIPTION_BODY
-          echo $BODY_WITHOUT_COMMENTS
-          echo $AUTHOR_ID
-
-          if $(echo $BODY_WITHOUT_COMMENTS | grep -Eq "RELEASE_NOTE_EXCEPTION="); then
-            HAS_RELEASE_NOTE_EXCEPTION_STRING=true
-          else
-            HAS_RELEASE_NOTE_EXCEPTION_STRING=false
-          fi
-
-          if [[ "$AUTHOR_ID" == "dependabot[bot]" ]] ; then
-            IS_DEPENDABOT_PR=true
-          else
-            IS_DEPENDABOT_PR=false
-          fi
-
-          echo "HAS_RELEASE_NOTE_EXCEPTION_STRING=$HAS_RELEASE_NOTE_EXCEPTION_STRING" >> $GITHUB_OUTPUT
-          echo "IS_DEPENDABOT_PR=$IS_DEPENDABOT_PR" >> $GITHUB_OUTPUT
-
       - name: Check Release Preparedness requirements
         env:
           HAS_CHANGED_RELEASE_NOTES: ${{steps.get-modified-files.outputs.HAS_CHANGED_RELEASE_NOTES}}
-          HAS_RELEASE_NOTE_EXCEPTION_STRING: ${{steps.check-release-note-exceptions.outputs.HAS_RELEASE_NOTE_EXCEPTION_STRING}}
-          IS_DEPENDABOT_PR: ${{steps.check-release-note-exceptions.outputs.IS_DEPENDABOT_PR}}
         run: |
-          if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] && [ "$HAS_RELEASE_NOTE_EXCEPTION_STRING" != "true" ] && [ "$IS_DEPENDABOT_PR" != "true" ] ; then
+          if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or an exception reason to your description using: \`RELEASE_NOTE_EXCEPTION=[reason goes here]\`"
+            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or add the `release-notes-not-required` label."
             exit 1
           fi

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -38,6 +38,6 @@ jobs:
         run: |
           if [ "$HAS_CHANGED_RELEASE_NOTES" != "true" ] ; then
             echo "Release Preparedness check failed"
-            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or add the release-notes-not-required label."
+            echo "::error title='Release Notes were not modified'::Please add a release note entry to $CURRENT_RELEASE_FILE_PATH or add the 'release-notes-not-required' label."
             exit 1
           fi

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -34,6 +34,7 @@ void runDevTools({
   List<DevToolsScreen>? screens,
 }) {
   setupErrorHandling(() async {
+    // edit.
     screens ??= defaultScreens;
 
     initDevToolsLogging();

--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -34,7 +34,6 @@ void runDevTools({
   List<DevToolsScreen>? screens,
 }) {
   setupErrorHandling(() async {
-    // edit.
     screens ??= defaultScreens;
 
     initDevToolsLogging();


### PR DESCRIPTION
- Only checks for release notes requirement for PRs with `.dart` files edited
- If the PR has the label `release-notes-not-required`, the check is skipped
- This PR also adds the `release-notes-not-required` label to dependabot PRs
