### PR TITLE
Fix slow scrolling performance in tree tables

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -654,6 +654,7 @@ class TreeTableState<T extends TreeNode<T>> extends State<TreeTable<T>>
       tableController: tableController,
       columnWidths: tableController.columnWidths!,
       rowBuilder: _buildRow,
+      rowItemExtent: defaultRowHeight,
       focusNode: _focusNode,
       handleKeyEvent: _handleKeyEvent,
       selectionNotifier: widget.selectionNotifier,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -6,7 +6,7 @@ This is draft for future release notes, that are going to land on
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
-* Improve the overal performance of DevTools tables - [#5664](https://github.com/flutter/devtools/pull/5664)
+* Improve the overal performance of DevTools tables - [#5664](https://github.com/flutter/devtools/pull/5664), [#5696](https://github.com/flutter/devtools/pull/5696)
 
 ## Inspector updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
It looked like `ListView.itemExtent` was being set on the table's vertical list widget, but we were actually setting the `ListView.itemExtent` to a null value. This PR fixes that. Behold, snappy scrolling in the CPU profiler 🎉 

![performant-scrolling](https://user-images.githubusercontent.com/43759233/233731037-df00fcec-b65f-43f5-ac05-a9fd4ffee68f.gif)

Fixes https://github.com/flutter/devtools/issues/3799, part of https://github.com/flutter/devtools/issues/5091