### PR TITLE
Provide the `entrypointUrl` to the Flutter bootstrap script (1P-only)

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -107,6 +107,7 @@
       window.addEventListener('load', function(ev) {
         // Download main.dart.js
         _flutter.loader.loadEntrypoint({
+          entrypointUrl: 'main.dart.js',
           onEntrypointLoaded: function(engineInitializer) {
             engineInitializer.initializeEngine({
               renderer: 'canvaskit',


### PR DESCRIPTION
Will fix b/277980966 once rolled into google3
