### PR TITLE
Refactored inspector-related classes to use more general inspector types

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -444,7 +444,7 @@ class InspectorController extends DisposableController
     int subtreeDepth = 2,
   }) async {
     assert(!_disposed);
-    final treeGroups = _treeGroups!;
+    final treeGroups = _treeGroups;
     if (_disposed || treeGroups == null) {
       return;
     }

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -444,11 +444,11 @@ class InspectorController extends DisposableController
     int subtreeDepth = 2,
   }) async {
     assert(!_disposed);
-    if (_disposed || _treeGroups == null) {
+    final treeGroups = _treeGroups!;
+    if (_disposed || treeGroups == null) {
       return;
     }
 
-    final treeGroups = _treeGroups!;
     treeGroups.cancelNext();
     try {
       final group = treeGroups.next;
@@ -635,13 +635,13 @@ class InspectorController extends DisposableController
       // our selection rather than updating it our self.
       return;
     }
-    if (_selectionGroups == null) {
+    final selectionGroups = _selectionGroups;
+    if (selectionGroups == null) {
       // Already disposed. Ignore this requested to update selection.
       return;
     }
     treeLoadStarted = true;
 
-    final selectionGroups = _selectionGroups!;
     selectionGroups.cancelNext();
 
     final group = selectionGroups.next;

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -573,7 +573,7 @@ class PubRootDirectorySection extends StatelessWidget {
           child: EditableList(
             gaScreen: gac.inspector,
             gaRefreshSelection: gac.refreshPubRoots,
-            entries:preferences.inspector.customPubRootDirectories,
+            entries: preferences.inspector.customPubRootDirectories,
             textFieldLabel: 'Enter a new package directory',
             isRefreshing:
                 preferences.inspector.isRefreshingCustomPubRootDirectories,

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -137,7 +137,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         searchPreventClose = false;
       }
     });
-    addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
+    addAutoDisposeListener(preferences.inspector!.customPubRootDirectories, () {
       if (serviceManager.hasConnection &&
           controller.firstInspectorTreeLoadCompleted) {
         _refreshInspector();
@@ -354,7 +354,7 @@ class FlutterInspectorSettingsDialog extends StatelessWidget {
               'General',
             ),
             CheckboxSetting(
-              notifier: preferences.inspector.hoverEvalModeEnabled
+              notifier: preferences.inspector!.hoverEvalModeEnabled
                   as ValueNotifier<bool?>,
               title: 'Enable hover inspection',
               description:
@@ -566,21 +566,22 @@ class PubRootDirectorySection extends StatelessWidget {
     return ValueListenableBuilder<IsolateRef?>(
       valueListenable: serviceManager.isolateManager.mainIsolate,
       builder: (_, __, ___) {
+        final inspectorPreferences = preferences.inspector!;
         return Container(
           height: 200.0,
           child: EditableList(
             gaScreen: gac.inspector,
             gaRefreshSelection: gac.refreshPubRoots,
-            entries: preferences.inspector.customPubRootDirectories,
+            entries:inspectorPreferences.customPubRootDirectories,
             textFieldLabel: 'Enter a new package directory',
             isRefreshing:
-                preferences.inspector.isRefreshingCustomPubRootDirectories,
+                inspectorPreferences.isRefreshingCustomPubRootDirectories,
             onEntryAdded: (p0) =>
-                unawaited(preferences.inspector.addPubRootDirectories([p0])),
+                unawaited(inspectorPreferences.addPubRootDirectories([p0])),
             onEntryRemoved: (p0) =>
-                unawaited(preferences.inspector.removePubRootDirectories([p0])),
+                unawaited(inspectorPreferences.removePubRootDirectories([p0])),
             onRefreshTriggered: () =>
-                unawaited(preferences.inspector.loadCustomPubRootDirectories()),
+                unawaited(inspectorPreferences.loadCustomPubRootDirectories()),
           ),
         );
       },

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -159,6 +159,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
       key: detailsTreeKey,
       treeController: _detailsTreeController,
       summaryTreeController: _summaryTreeController,
+      screenId: InspectorScreen.id,
     );
 
     final splitAxis = Split.axisFor(context, 0.85);
@@ -244,6 +245,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
                           treeController: _summaryTreeController,
                           isSummaryTree: true,
                           widgetErrors: inspectableErrors,
+                          screenId: InspectorScreen.id,
                         ),
                         if (errors.isNotEmpty)
                           ValueListenableBuilder<int?>(

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -137,7 +137,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         searchPreventClose = false;
       }
     });
-    addAutoDisposeListener(preferences.inspector!.customPubRootDirectories, () {
+    addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
       if (serviceManager.hasConnection &&
           controller.firstInspectorTreeLoadCompleted) {
         _refreshInspector();
@@ -356,7 +356,7 @@ class FlutterInspectorSettingsDialog extends StatelessWidget {
               'General',
             ),
             CheckboxSetting(
-              notifier: preferences.inspector!.hoverEvalModeEnabled
+              notifier: preferences.inspector.hoverEvalModeEnabled
                   as ValueNotifier<bool?>,
               title: 'Enable hover inspection',
               description:
@@ -568,22 +568,21 @@ class PubRootDirectorySection extends StatelessWidget {
     return ValueListenableBuilder<IsolateRef?>(
       valueListenable: serviceManager.isolateManager.mainIsolate,
       builder: (_, __, ___) {
-        final inspectorPreferences = preferences.inspector!;
         return Container(
           height: 200.0,
           child: EditableList(
             gaScreen: gac.inspector,
             gaRefreshSelection: gac.refreshPubRoots,
-            entries:inspectorPreferences.customPubRootDirectories,
+            entries:preferences.inspector.customPubRootDirectories,
             textFieldLabel: 'Enter a new package directory',
             isRefreshing:
-                inspectorPreferences.isRefreshingCustomPubRootDirectories,
+                preferences.inspector.isRefreshingCustomPubRootDirectories,
             onEntryAdded: (p0) =>
-                unawaited(inspectorPreferences.addPubRootDirectories([p0])),
+                unawaited(preferences.inspector.addPubRootDirectories([p0])),
             onEntryRemoved: (p0) =>
-                unawaited(inspectorPreferences.removePubRootDirectories([p0])),
+                unawaited(preferences.inspector.removePubRootDirectories([p0])),
             onRefreshTriggered: () =>
-                unawaited(inspectorPreferences.loadCustomPubRootDirectories()),
+                unawaited(preferences.inspector.loadCustomPubRootDirectories()),
           ),
         );
       },

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -33,7 +33,6 @@ import '../../shared/ui/utils.dart';
 import '../../shared/utils.dart';
 import 'inspector_breadcrumbs.dart';
 import 'inspector_controller.dart';
-import 'inspector_screen.dart';
 
 final _log = Logger('inspector_tree_controller');
 
@@ -749,6 +748,7 @@ class InspectorTree extends StatefulWidget {
     this.summaryTreeController,
     this.isSummaryTree = false,
     this.widgetErrors,
+    this.screenId,
   })  : assert(isSummaryTree == (summaryTreeController == null)),
         super(key: key);
 
@@ -763,6 +763,7 @@ class InspectorTree extends StatefulWidget {
 
   final bool isSummaryTree;
   final LinkedHashMap<String, InspectableWidgetError>? widgetErrors;
+  final String? screenId;
 
   @override
   State<InspectorTree> createState() => _InspectorTreeState();
@@ -1012,13 +1013,16 @@ class _InspectorTreeState extends State<InspectorTree>
     }
 
     if (!controller.firstInspectorTreeLoadCompleted && widget.isSummaryTree) {
-      ga.timeEnd(InspectorScreen.id, gac.pageReady);
-      unawaited(
-        serviceManager.sendDwdsEvent(
-          screen: InspectorScreen.id,
-          action: gac.pageReady,
-        ),
-      );
+      final screenId = widget.screenId;
+      if (screenId != null) {
+        ga.timeEnd(screenId, gac.pageReady);
+        unawaited(
+          serviceManager.sendDwdsEvent(
+            screen: screenId,
+            action: gac.pageReady,
+          ),
+        );
+      }
       controller.firstInspectorTreeLoadCompleted = true;
     }
     return LayoutBuilder(

--- a/packages/devtools_app/lib/src/shared/console/widgets/description.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/description.dart
@@ -184,7 +184,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
 
     return HoverCardTooltip.async(
       enabled: () =>
-          preferences.inspector.hoverEvalModeEnabled.value &&
+          preferences.inspector!.hoverEvalModeEnabled.value &&
           diagnosticLocal.inspectorService != null,
       asyncGenerateHoverCardData: ({
         required event,

--- a/packages/devtools_app/lib/src/shared/console/widgets/description.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/description.dart
@@ -184,7 +184,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
 
     return HoverCardTooltip.async(
       enabled: () =>
-          preferences.inspector!.hoverEvalModeEnabled.value &&
+          preferences.inspector.hoverEvalModeEnabled.value &&
           diagnosticLocal.inspectorService != null,
       asyncGenerateHoverCardData: ({
         required event,

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -108,6 +108,8 @@ abstract class InspectorServiceBase extends DisposableController
     super.dispose();
   }
 
+  bool get hoverEvalModeEnabledByDefault;
+
   Future<Object> forceRefresh() {
     final futures = <Future<void>>[];
     for (InspectorServiceClient client in clients) {
@@ -239,6 +241,10 @@ class InspectorService extends InspectorServiceBase {
     _cachedSelectionGroups = null;
     super.dispose();
   }
+
+  // When DevTools is embedded, default hover eval mode to off.
+  @override
+  bool get hoverEvalModeEnabledByDefault => !ideTheme.embed;
 
   void onExtensionVmServiceReceived(Event e) {
     if ('Flutter.Frame' == e.extensionKind) {

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -434,8 +434,8 @@ class CpuProfilerPreferencesController extends DisposableController
     with AutoDisposeControllerMixin {
   final displayTreeGuidelines = ValueNotifier<bool>(false);
 
-  static final _displayTreeGuidelinesId =
-      '${gac.cpuProfiler}.${gac.cpuProfileDisplayTreeGuidelines}';
+  static final _displayTreeGuidelinesId = '${gac.cpuProfiler}.'
+      '${gac.CpuProfilerEvents.cpuProfileDisplayTreeGuidelines.name}';
 
   Future<void> init() async {
     addAutoDisposeListener(
@@ -447,7 +447,7 @@ class CpuProfilerPreferencesController extends DisposableController
         );
         ga.select(
           gac.cpuProfiler,
-          gac.cpuProfileDisplayTreeGuidelines,
+          gac.CpuProfilerEvents.cpuProfileDisplayTreeGuidelines.name,
           value: displayTreeGuidelines.value ? 1 : 0,
         );
       },
@@ -462,7 +462,7 @@ class PerformancePreferencesController extends DisposableController
   final showFlutterFramesChart = ValueNotifier<bool>(true);
 
   static final _showFlutterFramesChartId =
-      '${gac.performance}.${gac.framesChartVisibility}';
+      '${gac.performance}.${gac.PerformanceEvents.framesChartVisibility.name}';
 
   Future<void> init() async {
     addAutoDisposeListener(
@@ -474,7 +474,7 @@ class PerformancePreferencesController extends DisposableController
         );
         ga.select(
           gac.performance,
-          gac.framesChartVisibility,
+          gac.PerformanceEvents.framesChartVisibility.name,
           value: showFlutterFramesChart.value ? 1 : 0,
         );
       },

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -31,8 +31,9 @@ class PreferencesController extends DisposableController
 
   final denseModeEnabled = ValueNotifier<bool>(false);
 
-  InspectorPreferencesController get inspector => _inspector;
-  final _inspector = InspectorPreferencesController();
+  InspectorPreferencesController? get inspector =>
+      serviceManager.inspectorService is InspectorService ? _inspector : null;
+  late final _inspector = InspectorPreferencesController();
 
   MemoryPreferencesController get memory => _memory;
   final _memory = MemoryPreferencesController();
@@ -66,7 +67,7 @@ class PreferencesController extends DisposableController
 
     await _initVerboseLogging();
 
-    await inspector.init();
+    await inspector?.init();
     await memory.init();
     await performance.init();
     await cpuProfiler.init();
@@ -96,7 +97,7 @@ class PreferencesController extends DisposableController
 
   @override
   void dispose() {
-    inspector.dispose();
+    inspector?.dispose();
     memory.dispose();
     performance.dispose();
     cpuProfiler.dispose();
@@ -134,6 +135,9 @@ class PreferencesController extends DisposableController
 
 class InspectorPreferencesController extends DisposableController
     with AutoDisposeControllerMixin {
+  InspectorPreferencesController()
+      : assert(serviceManager.inspectorService is InspectorService);
+
   ValueListenable<bool> get hoverEvalModeEnabled => _hoverEvalMode;
   ListValueNotifier<String> get customPubRootDirectories =>
       _customPubRootDirectories;
@@ -206,13 +210,13 @@ class InspectorPreferencesController extends DisposableController
           if (debuggerState?.isPaused.value == false) {
             // the isolate is already unpaused, we can try to load
             // the directories
-            unawaited(preferences.inspector.loadCustomPubRootDirectories());
+            unawaited(preferences.inspector!.loadCustomPubRootDirectories());
           } else {
             late Function() pausedListener;
 
             pausedListener = () {
               if (debuggerState?.isPaused.value == false) {
-                unawaited(preferences.inspector.loadCustomPubRootDirectories());
+                unawaited(preferences.inspector!.loadCustomPubRootDirectories());
 
                 debuggerState?.isPaused.removeListener(pausedListener);
               }

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -29,6 +29,7 @@ void main() {
 
   env.afterEverySetup = () async {
     assert(serviceManager.connectedAppInitialized);
+    setGlobal(IdeTheme, IdeTheme());
 
     inspectorService = InspectorService();
     if (env.runConfig.trackWidgetCreation) {
@@ -469,6 +470,15 @@ void main() {
         );
 
         await group.dispose();
+      });
+
+      test('enables hover eval mode by default', () async {
+        expect(inspectorService!.hoverEvalModeEnabledByDefault, isTrue);
+      });
+
+      test('disables hover eval mode by default when embedded', () async {
+        setGlobal(IdeTheme, IdeTheme(embed: true));
+        expect(inspectorService!.hoverEvalModeEnabledByDefault, isFalse);
       });
 
 // TODO(jacobr): uncomment this test once we have a more dependable golden

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -474,10 +474,12 @@ void main() {
       });
 
       test('enables hover eval mode by default', () async {
+        await env.setupEnvironment();
         expect(inspectorService!.hoverEvalModeEnabledByDefault, isTrue);
       });
 
       test('disables hover eval mode by default when embedded', () async {
+        await env.setupEnvironment();
         setGlobal(IdeTheme, IdeTheme(embed: true));
         expect(inspectorService!.hoverEvalModeEnabledByDefault, isFalse);
       });

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -7,6 +7,7 @@
 @TestOn('vm')
 import 'dart:async';
 
+import 'package:devtools_app/src/shared/config_specific/ide_theme/ide_theme.dart';
 import 'package:devtools_app/src/shared/console/primitives/simple_items.dart';
 import 'package:devtools_app/src/shared/diagnostics/diagnostics_node.dart';
 import 'package:devtools_app/src/shared/diagnostics/inspector_service.dart';

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -74,20 +74,18 @@ void main() {
   group('$InspectorPreferencesController', () {
     group('hoverEvalMode', () {
       late InspectorPreferencesController controller;
+      late FlutterTestStorage storage;
 
       setUp(() {
-        setGlobal(Storage, FlutterTestStorage());
-        storage.values.clear();
+        setGlobal(Storage, storage = FlutterTestStorage());
         controller = InspectorPreferencesController();
       });
 
-      test(
-        'default value equals inspector service default value',
-        () async {
+      test('default value equals inspector service default value', () async {
         await controller.init();
         expect(
           controller.hoverEvalModeEnabled.value,
-          serviceManager.inspectorService.hoverEvalModeEnabledByDefault,
+          serviceManager.inspectorService!.hoverEvalModeEnabledByDefault,
         );
       });
 

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -77,19 +77,12 @@ void main() {
 
       setUp(() {
         setGlobal(Storage, FlutterTestStorage());
-        setGlobal(IdeTheme, IdeTheme());
         controller = InspectorPreferencesController();
       });
 
-      group('init', () {
-        setUp(() {
-          controller.setHoverEvalMode(false);
-        });
-
-        test('enables hover eval mode by default', () async {
-          await controller.init();
-          expect(controller.hoverEvalModeEnabled.value, isTrue);
-        });
+      test('hover eval mode disabled by default with no inspector service', () async {
+        await controller.init();
+        expect(controller.hoverEvalModeEnabled.value, isFalse);
       });
 
       test('can be updated', () async {

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -77,14 +77,18 @@ void main() {
 
       setUp(() {
         setGlobal(Storage, FlutterTestStorage());
+        storage.values.clear();
         controller = InspectorPreferencesController();
       });
 
       test(
-        'hover eval mode disabled by default with no inspector service',
+        'default value equals inspector service default value',
         () async {
         await controller.init();
-        expect(controller.hoverEvalModeEnabled.value, isFalse);
+        expect(
+          controller.hoverEvalModeEnabled.value,
+          serviceManager.inspectorService.hoverEvalModeEnabledByDefault,
+        );
       });
 
       test('can be updated', () async {

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -86,15 +86,9 @@ void main() {
           controller.setHoverEvalMode(false);
         });
 
-        test('enables hover mode by default', () async {
+        test('enables hover eval mode by default', () async {
           await controller.init();
           expect(controller.hoverEvalModeEnabled.value, isTrue);
-        });
-
-        test('when embedded, disables hover mode by default', () async {
-          setGlobal(IdeTheme, IdeTheme(embed: true));
-          await controller.init();
-          expect(controller.hoverEvalModeEnabled.value, isFalse);
         });
       });
 

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -80,7 +80,9 @@ void main() {
         controller = InspectorPreferencesController();
       });
 
-      test('hover eval mode disabled by default with no inspector service', () async {
+      test(
+        'hover eval mode disabled by default with no inspector service',
+        () async {
         await controller.init();
         expect(controller.hoverEvalModeEnabled.value, isFalse);
       });

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -62,6 +62,9 @@ class FakeInspectorService extends Fake implements InspectorService {
   void removeClient(InspectorServiceClient client) {
     clients.remove(client);
   }
+
+  @override
+  bool get hoverEvalModeEnabledByDefault => true;
 }
 
 class TestInspectorController extends Fake implements InspectorController {


### PR DESCRIPTION
Refactored inspector-related classes to use general types (for internal use cases):
1) Updated `InspectorController` to hold a reference to `InspectorServiceBase` instead of the Flutter-specific `InspectorService`. Also, updated `InspectorController` to instantiate the selection-related `InspectorObjectGroupManager` only when an `InspectorService` is present.
2) Updated `InspectorPreferencesController`'s inspector service to be of type `InspectorServiceBase` instead of the Flutter-specific `InspectorService`. Also, added a new `hoverEvalModeEnabledByDefault` field to `InspectorServiceBase` to allow subclasses to specify whether hover evals should be enabled in DevTools by default.
3) Updated `InspectorTree` to take an optional `screenId` for analytics/profiling purpose. When non-null, the `InspectorTree` will report a `timeEnd()` profiling event AND send a DWDS service manager event with the given screen identifier.

RELEASE_NOTE_EXCEPTION="PR only contains inspector-related refactoring code (no user-visible change)"