### PR TITLE
Fix expression evaluation autocomplete bug 

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -76,7 +76,7 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
     });
     addAutoDisposeListener(
       _autoCompleteController.selectTheSearchNotifier,
-      _handleSearch,
+      _handleSearchTermSelected,
     );
     addAutoDisposeListener(
       _autoCompleteController.searchNotifier,
@@ -134,16 +134,17 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
     }
   }
 
-  void _handleSearch() async {
+  void _handleSearchTermSelected() {
+    _autoCompleteController.clearCurrentSuggestion();
+  }
+
+  Future<void> _handleSearch() async {
     final searchingValue = _autoCompleteController.search;
 
     _autoCompleteController.clearCurrentSuggestion();
 
     if (searchingValue.isNotEmpty) {
-      if (_autoCompleteController.selectTheSearch) {
-        _autoCompleteController.resetSearch();
-        return;
-      }
+      if (_autoCompleteController.selectTheSearch) return;
 
       // We avoid clearing the list of possible matches here even though the
       // current matches may be out of date as clearing results in flicker

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -22,6 +22,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
 * Improve support for inspecting `UserTag` and `MirrorReferent` instances - [#5490](https://github.com/flutter/devtools/pull/5490)
+* Fixes expression evaluation bug where selecting an autocomplete result for a field would clear the current input - [#5717](https://github.com/flutter/devtools/pull/5717)
 
 ## Network profiler updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/test/debugger/eval_field_test.dart
+++ b/packages/devtools_app/test/debugger/eval_field_test.dart
@@ -15,7 +15,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  group('ExpressionEvalField suggestions', () {
+  group('ExpressionEvalField', () {
     late ServiceConnectionManager manager;
 
     setUp(() {
@@ -28,205 +28,261 @@ void main() {
       setGlobal(BreakpointManager, BreakpointManager());
     });
 
-    testWidgets(
-      'shows no suggestion for empty text',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+    group('suggestions', () {
+      testWidgets(
+        'shows no suggestion for empty text',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, '');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, '');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, '');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, '');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'shows "bar" item as suggestion for string "b"',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'shows "bar" item as suggestion for string "b"',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'b');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'b');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'b');
-        expect(objects.searchTextEditingController.suggestionText, 'ar');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'b');
+          expect(objects.searchTextEditingController.suggestionText, 'ar');
+        },
+      );
 
-    testWidgets(
-      'shows "bazz" item as suggestion for string "baz"',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'shows "bazz" item as suggestion for string "baz"',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'baz');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'baz');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'baz');
-        expect(objects.searchTextEditingController.suggestionText, 'z');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'baz');
+          expect(objects.searchTextEditingController.suggestionText, 'z');
+        },
+      );
 
-    testWidgets(
-      'shows "foo" (first item) item as suggestion for field',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'shows "foo" (first item) item as suggestion for field',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.');
-        expect(objects.searchTextEditingController.suggestionText, 'foo');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.');
+          expect(objects.searchTextEditingController.suggestionText, 'foo');
+        },
+      );
 
-    testWidgets(
-      'pressing "arrowDown" shows the "bar" item as suggestion for field',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'pressing "arrowDown" shows the "bar" item as suggestion for field',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.');
-        await tester.pumpAndSettle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.enterText(objects.textField, 'someValue.');
+          await tester.pumpAndSettle();
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
 
-        expect(objects.searchTextEditingController.text, 'someValue.');
-        expect(objects.searchTextEditingController.suggestionText, 'bar');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.');
+          expect(objects.searchTextEditingController.suggestionText, 'bar');
+        },
+      );
 
-    testWidgets(
-      'pressing "arrowDown" and "arrowUp" shows the "foo" item as suggestion for field',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'pressing "arrowDown" and "arrowUp" shows the "foo" item as suggestion for field',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.');
-        await tester.pumpAndSettle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+          await tester.enterText(objects.textField, 'someValue.');
+          await tester.pumpAndSettle();
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
 
-        expect(objects.searchTextEditingController.text, 'someValue.');
-        expect(objects.searchTextEditingController.suggestionText, 'foo');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.');
+          expect(objects.searchTextEditingController.suggestionText, 'foo');
+        },
+      );
 
-    testWidgets(
-      'pressing "arrowDown" shows the "bazz" item as suggestion for string "ba"',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'pressing "arrowDown" shows the "bazz" item as suggestion for string "ba"',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.ba');
-        await tester.pumpAndSettle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.enterText(objects.textField, 'someValue.ba');
+          await tester.pumpAndSettle();
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
 
-        expect(objects.searchTextEditingController.text, 'someValue.ba');
-        expect(objects.searchTextEditingController.suggestionText, 'zz');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.ba');
+          expect(objects.searchTextEditingController.suggestionText, 'zz');
+        },
+      );
 
-    testWidgets(
-      'pressing "arrowDown" and "arrowUp" shows the "bar" item as suggestion for string "ba"',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'pressing "arrowDown" and "arrowUp" shows the "bar" item as suggestion for string "ba"',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.ba');
-        await tester.pumpAndSettle();
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
-        await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
+          await tester.enterText(objects.textField, 'someValue.ba');
+          await tester.pumpAndSettle();
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowDown);
+          await tester.sendKeyEvent(LogicalKeyboardKey.arrowUp);
 
-        expect(objects.searchTextEditingController.text, 'someValue.ba');
-        expect(objects.searchTextEditingController.suggestionText, 'r');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.ba');
+          expect(objects.searchTextEditingController.suggestionText, 'r');
+        },
+      );
 
-    testWidgets(
-      'removing the dot after a word removes the suggestion',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'removing the dot after a word removes the suggestion',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.');
-        await tester.enterText(objects.textField, 'someValue');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.');
+          await tester.enterText(objects.textField, 'someValue');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'when the cursor is not at the end of the text, don\'t show suggestion',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'when the cursor is not at the end of the text, don\'t show suggestion',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.');
-        objects.searchTextEditingController.selection =
-            const TextSelection.collapsed(offset: 0);
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.');
+          objects.searchTextEditingController.selection =
+              const TextSelection.collapsed(offset: 0);
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'when there is one exact match, don\'t show suggestion text',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'when there is one exact match, don\'t show suggestion text',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.bazz');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.bazz');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.bazz');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.bazz');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'when there is no match, don\'t show suggestion text',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'when there is no match, don\'t show suggestion text',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.bazzz');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.bazzz');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.bazzz');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.bazzz');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'when there is a exact match ("bar") and another match ("barz"), the exact won\'t show suggestion text',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'when there is a exact match ("bar") and another match ("barz"), the exact won\'t show suggestion text',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.bar');
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.bar');
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.bar');
-        expect(objects.searchTextEditingController.suggestionText, null);
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.bar');
+          expect(objects.searchTextEditingController.suggestionText, null);
+        },
+      );
 
-    testWidgets(
-      'when there is a exact match ("bar") and another match ("barz"), the other match will show suggestion text',
-      (tester) async {
-        final objects = await _setupEvalFieldObjects(tester);
+      testWidgets(
+        'when there is a exact match ("bar") and another match ("barz"), the other match will show suggestion text',
+        (tester) async {
+          final objects = await _setupEvalFieldObjects(tester);
 
-        await tester.enterText(objects.textField, 'someValue.bar');
-        await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
-        await tester.pumpAndSettle();
+          await tester.enterText(objects.textField, 'someValue.bar');
+          await tester.sendKeyDownEvent(LogicalKeyboardKey.arrowDown);
+          await tester.pumpAndSettle();
 
-        expect(objects.searchTextEditingController.text, 'someValue.bar');
-        expect(objects.searchTextEditingController.suggestionText, 'z');
-      },
-    );
+          expect(objects.searchTextEditingController.text, 'someValue.bar');
+          expect(objects.searchTextEditingController.suggestionText, 'z');
+        },
+      );
+    });
+
+    for (final key in [
+      LogicalKeyboardKey.enter,
+      LogicalKeyboardKey.tab,
+      LogicalKeyboardKey.arrowRight,
+    ]) {
+      group('selection with ${key.keyLabel} key', () {
+        testWidgets(
+          'selecting "bar" autocompletes "b" to "bar"',
+          (tester) async {
+            final objects = await _setupEvalFieldObjects(tester);
+
+            await tester.enterText(objects.textField, 'b');
+            await tester.pumpAndSettle();
+
+            expect(objects.searchTextEditingController.text, 'b');
+            expect(objects.searchTextEditingController.suggestionText, 'ar');
+
+            await tester.sendKeyEvent(key);
+            await tester.pumpAndSettle();
+
+            expect(objects.textFieldValue, equals('bar'));
+          },
+        );
+
+        testWidgets(
+          'selecting "foo" autocompletes "someValue." to "someValue.foo"',
+          (tester) async {
+            final objects = await _setupEvalFieldObjects(tester);
+
+            await tester.enterText(objects.textField, 'someValue.');
+            await tester.pumpAndSettle();
+
+            expect(objects.searchTextEditingController.text, 'someValue.');
+            expect(objects.searchTextEditingController.suggestionText, 'foo');
+
+            await tester.sendKeyEvent(key);
+            await tester.pumpAndSettle();
+
+            expect(objects.textFieldValue, equals('someValue.foo'));
+          },
+        );
+      });
+    }
   });
 }
 
 class _EvalFieldTestObjects {
-  _EvalFieldTestObjects(this.searchTextEditingController, this.textField);
+  _EvalFieldTestObjects(
+    this.searchTextEditingController,
+    this.textField,
+    this._tester,
+  );
 
   final SearchTextEditingController searchTextEditingController;
   final Finder textField;
+  final WidgetTester _tester;
+
+  String? get textFieldValue {
+    final textFieldWidget = _tester.firstWidget(textField) as TextField;
+    return textFieldWidget.controller?.value.text;
+  }
 }
 
 Future<_EvalFieldTestObjects> _setupEvalFieldObjects(
@@ -254,5 +310,9 @@ Future<_EvalFieldTestObjects> _setupEvalFieldObjects(
   final state =
       tester.state<ExpressionEvalFieldState>(find.byWidget(evalField));
 
-  return _EvalFieldTestObjects(state.searchTextFieldController, textField);
+  return _EvalFieldTestObjects(
+    state.searchTextFieldController,
+    textField,
+    tester,
+  );
 }

--- a/packages/devtools_app/test/debugger/eval_field_test.dart
+++ b/packages/devtools_app/test/debugger/eval_field_test.dart
@@ -222,14 +222,14 @@ void main() {
       );
     });
 
-    for (final key in [
+    for (final selectionKey in [
       LogicalKeyboardKey.enter,
       LogicalKeyboardKey.tab,
       LogicalKeyboardKey.arrowRight,
     ]) {
-      group('selection with ${key.keyLabel} key', () {
+      group('selection with ${selectionKey.keyLabel} key', () {
         testWidgets(
-          'selecting "bar" autocompletes "b" to "bar"',
+          'selecting "ar" autocompletes "b" to "bar"',
           (tester) async {
             final objects = await _setupEvalFieldObjects(tester);
 
@@ -239,7 +239,27 @@ void main() {
             expect(objects.searchTextEditingController.text, 'b');
             expect(objects.searchTextEditingController.suggestionText, 'ar');
 
-            await tester.sendKeyEvent(key);
+            // Select the suggestion.
+            await tester.sendKeyEvent(selectionKey);
+            await tester.pumpAndSettle();
+
+            expect(objects.textFieldValue, equals('bar'));
+          },
+        );
+
+        testWidgets(
+          'selecting "r" autocompletes "ba" to "bar"',
+          (tester) async {
+            final objects = await _setupEvalFieldObjects(tester);
+
+            await tester.enterText(objects.textField, 'ba');
+            await tester.pumpAndSettle();
+
+            expect(objects.searchTextEditingController.text, 'ba');
+            expect(objects.searchTextEditingController.suggestionText, 'r');
+
+            // Select the suggestion.
+            await tester.sendKeyEvent(selectionKey);
             await tester.pumpAndSettle();
 
             expect(objects.textFieldValue, equals('bar'));
@@ -257,7 +277,26 @@ void main() {
             expect(objects.searchTextEditingController.text, 'someValue.');
             expect(objects.searchTextEditingController.suggestionText, 'foo');
 
-            await tester.sendKeyEvent(key);
+            // Select the suggestion.
+            await tester.sendKeyEvent(selectionKey);
+            await tester.pumpAndSettle();
+
+            expect(objects.textFieldValue, equals('someValue.foo'));
+          },
+        );
+
+        testWidgets(
+          'selecting "oo" autocompletes "someValue.f" to "someValue.foo"',
+          (tester) async {
+            final objects = await _setupEvalFieldObjects(tester);
+
+            await tester.enterText(objects.textField, 'someValue.f');
+            await tester.pumpAndSettle();
+
+            expect(objects.searchTextEditingController.text, 'someValue.f');
+            expect(objects.searchTextEditingController.suggestionText, 'oo');
+
+            await tester.sendKeyEvent(selectionKey);
             await tester.pumpAndSettle();
 
             expect(objects.textFieldValue, equals('someValue.foo'));


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5710
Work towards https://github.com/flutter/devtools/issues/5703

Fixes the bug where selecting a field during expression evaluation would replace everything in the input, instead of everything up to the last dot (eg. `myClass.someMetho` -> enter to accept `someMethod` would replace all of `myClass.someMetho` with just `someMethod`).