### PR TITLE
Use records for AnalyticsTabbedView

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen_details_tab.dart
@@ -29,20 +29,21 @@ class InspectorDetails extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final tabs = [
-      _buildTab(tabName: 'Layout Explorer'),
-      _buildTab(
-        tabName: 'Widget Details Tree',
-        trailing: InspectorExpandCollapseButtons(controller: controller),
+      (
+        tab: _buildTab(tabName: 'Layout Explorer'),
+        tabView: LayoutExplorerTab(controller: controller),
       ),
-    ];
-    final tabViews = <Widget>[
-      LayoutExplorerTab(controller: controller),
-      detailsTree,
+      (
+        tab: _buildTab(
+          tabName: 'Widget Details Tree',
+          trailing: InspectorExpandCollapseButtons(controller: controller),
+        ),
+        tabView: detailsTree,
+      ),
     ];
 
     return AnalyticsTabbedView(
       tabs: tabs,
-      tabViews: tabViews,
       gaScreen: gac.inspector,
     );
   }

--- a/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
+++ b/packages/devtools_app/lib/src/screens/memory/memory_tabs.dart
@@ -36,16 +36,8 @@ class MemoryTabView extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: controller.shouldShowLeaksTab,
       builder: (context, showLeaksTab, _) {
-        final tabRecords = _generateTabRecords();
-        final tabs = <DevToolsTab>[];
-        final tabViews = <Widget>[];
-        for (final record in tabRecords) {
-          tabs.add(record.tab);
-          tabViews.add(record.tabView);
-        }
         return AnalyticsTabbedView(
-          tabs: tabs,
-          tabViews: tabViews,
+          tabs: _generateTabRecords(),
           initialSelectedIndex: controller.selectedFeatureTabIndex,
           gaScreen: gac.memory,
           onTabChanged: (int index) {
@@ -56,9 +48,9 @@ class MemoryTabView extends StatelessWidget {
     );
   }
 
-  List<TabRecord> _generateTabRecords() {
+  List<({DevToolsTab tab, Widget tabView})> _generateTabRecords() {
     return [
-      TabRecord(
+      (
         tab: DevToolsTab.create(
           key: MemoryScreenKeys.dartHeapTableProfileTab,
           tabName: 'Profile Memory',
@@ -70,7 +62,7 @@ class MemoryTabView extends StatelessWidget {
           ),
         ),
       ),
-      TabRecord(
+      (
         tab: DevToolsTab.create(
           key: MemoryScreenKeys.diffTab,
           gaPrefix: _gaPrefix,
@@ -82,7 +74,7 @@ class MemoryTabView extends StatelessWidget {
           ),
         ),
       ),
-      TabRecord(
+      (
         tab: DevToolsTab.create(
           key: MemoryScreenKeys.dartHeapAllocationTracingTab,
           tabName: 'Trace Instances',
@@ -93,7 +85,7 @@ class MemoryTabView extends StatelessWidget {
         ),
       ),
       if (controller.shouldShowLeaksTab.value)
-        TabRecord(
+        (
           tab: DevToolsTab.create(
             key: MemoryScreenKeys.leaksTab,
             gaPrefix: _gaPrefix,

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
@@ -50,42 +50,6 @@ class NetworkRequestInspector extends StatelessWidget {
     return ValueListenableBuilder<NetworkRequest?>(
       valueListenable: controller.selectedRequest,
       builder: (context, data, _) {
-        late final tabs = <DevToolsTab>[
-          _buildTab(tabName: NetworkRequestInspector._overviewTabTitle),
-          if (data is DartIOHttpRequestData) ...[
-            _buildTab(tabName: NetworkRequestInspector._headersTabTitle),
-            if (data.requestBody != null)
-              _buildTab(
-                tabName: NetworkRequestInspector._requestTabTitle,
-                trailing: HttpViewTrailingCopyButton(
-                  data,
-                  (data) => data.requestBody,
-                ),
-              ),
-            if (data.responseBody != null)
-              _buildTab(
-                tabName: NetworkRequestInspector._responseTabTitle,
-                trailing: HttpViewTrailingCopyButton(
-                  data,
-                  (data) => data.responseBody,
-                ),
-              ),
-            if (data.hasCookies)
-              _buildTab(tabName: NetworkRequestInspector._cookiesTabTitle),
-          ],
-        ];
-        late final tabViews = [
-          if (data != null) ...[
-            NetworkRequestOverviewView(data),
-            if (data is DartIOHttpRequestData) ...[
-              HttpRequestHeadersView(data),
-              if (data.requestBody != null) HttpRequestView(data),
-              if (data.responseBody != null) HttpResponseView(data),
-              if (data.hasCookies) HttpRequestCookiesView(data),
-            ],
-          ],
-        ].map((e) => OutlineDecoration.onlyTop(child: e)).toList();
-
         return RoundedOutlinedBorder(
           child: (data == null)
               ? Center(
@@ -96,12 +60,63 @@ class NetworkRequestInspector extends StatelessWidget {
                   ),
                 )
               : AnalyticsTabbedView(
-                  tabs: tabs,
-                  tabViews: tabViews,
+                  tabs: _generateTabs(data),
                   gaScreen: gac.network,
                 ),
         );
       },
     );
   }
+
+  List<({DevToolsTab tab, Widget tabView})> _generateTabs(
+    NetworkRequest data,
+  ) =>
+      [
+        (
+          tab: _buildTab(tabName: NetworkRequestInspector._overviewTabTitle),
+          tabView: NetworkRequestOverviewView(data),
+        ),
+        if (data is DartIOHttpRequestData) ...[
+          (
+            tab: _buildTab(tabName: NetworkRequestInspector._headersTabTitle),
+            tabView: HttpRequestHeadersView(data),
+          ),
+          if (data.requestBody != null)
+            (
+              tab: _buildTab(
+                tabName: NetworkRequestInspector._requestTabTitle,
+                trailing: HttpViewTrailingCopyButton(
+                  data,
+                  (data) => data.requestBody,
+                ),
+              ),
+              tabView: HttpRequestView(data),
+            ),
+          if (data.responseBody != null)
+            (
+              tab: _buildTab(
+                tabName: NetworkRequestInspector._responseTabTitle,
+                trailing: HttpViewTrailingCopyButton(
+                  data,
+                  (data) => data.responseBody,
+                ),
+              ),
+              tabView: HttpResponseView(data),
+            ),
+          if (data.hasCookies)
+            (
+              tab: _buildTab(
+                tabName: NetworkRequestInspector._cookiesTabTitle,
+              ),
+              tabView: HttpRequestCookiesView(data),
+            ),
+        ],
+      ]
+          .map(
+            (t) => (
+              tab: t.tab,
+              tabView: OutlineDecoration.onlyTop(child: t.tabView)
+            ),
+          )
+          .toList();
 }

--- a/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/tabbed_performance_view.dart
@@ -75,21 +75,17 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
           hasOfflineData &&
           offlineData.rebuildCountModel.isNotEmpty;
     }
-    final tabRecords = <_PerformanceTabRecord>[
-      if (showFrameAnalysis) _frameAnalysisRecord(),
-      if (showRasterStats) _rasterStatsRecord(),
-      if (showRebuildStats) _rebuildStatsRecord(),
-      _timelineEventsRecord(),
-    ];
 
-    final tabs = <DevToolsTab>[];
-    final tabViews = <Widget>[];
-    final featureControllers = <PerformanceFeatureController?>[];
-    for (final record in tabRecords) {
-      tabs.add(record.tab);
-      tabViews.add(record.tabView);
-      featureControllers.add(record.featureController);
-    }
+    final tabsAndControllers = _generateTabs(
+      showFrameAnalysis: showFrameAnalysis,
+      showRasterStats: showRasterStats,
+      showRebuildStats: showRebuildStats,
+    );
+    final tabs = tabsAndControllers
+        .map((t) => (tab: t.tab, tabView: t.tabView))
+        .toList();
+    final featureControllers =
+        tabsAndControllers.map((t) => t.featureController).toList();
 
     // If there is not an active feature, activate the first.
     if (featureControllers.firstWhereOrNull(
@@ -101,7 +97,6 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
 
     return AnalyticsTabbedView(
       tabs: tabs,
-      tabViews: tabViews,
       initialSelectedIndex: controller.selectedFeatureTabIndex,
       gaScreen: gac.performance,
       onTabChanged: (int index) {
@@ -118,71 +113,73 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
     unawaited(controller.setActiveFeature(featureController));
   }
 
-  _PerformanceTabRecord _frameAnalysisRecord() {
-    assert(serviceManager.connectedApp!.isFlutterAppNow!);
-    Widget frameAnalysisView;
-    final selectedFrame = _selectedFlutterFrame;
-    frameAnalysisView = selectedFrame != null
-        ? FlutterFrameAnalysisView(
-            frameAnalysis: selectedFrame.frameAnalysis,
-            enhanceTracingController: controller.enhanceTracingController,
-            rebuildCountModel: controller.data!.rebuildCountModel,
-          )
-        : const Center(
-            child: Text('Select a frame above to view analysis data.'),
-          );
-    return _PerformanceTabRecord(
-      tab: _buildTab(tabName: 'Frame Analysis'),
-      tabView: KeepAliveWrapper(
-        child: frameAnalysisView,
-      ),
-      featureController: null,
-    );
-  }
-
-  _PerformanceTabRecord _rebuildStatsRecord() {
-    final rebuildStatsView = RebuildStatsView(
-      model: controller.data!.rebuildCountModel,
-      selectedFrame: controller.flutterFramesController.selectedFrame,
-    );
-
-    return _PerformanceTabRecord(
-      tab: _buildTab(tabName: 'Rebuild Stats'),
-      tabView: KeepAliveWrapper(
-        child: rebuildStatsView,
-      ),
-      featureController: null,
-    );
-  }
-
-  _PerformanceTabRecord _rasterStatsRecord() {
-    assert(serviceManager.connectedApp!.isFlutterAppNow!);
-    return _PerformanceTabRecord(
-      tab: _buildTab(tabName: 'Raster Stats'),
-      tabView: KeepAliveWrapper(
-        child: Center(
-          child: RasterStatsView(
-            rasterStatsController: controller.rasterStatsController,
+  List<
+      ({
+        DevToolsTab tab,
+        Widget tabView,
+        PerformanceFeatureController? featureController,
+      })> _generateTabs({
+    required bool showFrameAnalysis,
+    required bool showRasterStats,
+    required bool showRebuildStats,
+  }) {
+    if (showFrameAnalysis || showRasterStats || showRebuildStats) {
+      assert(serviceManager.connectedApp!.isFlutterAppNow!);
+    }
+    return [
+      if (showFrameAnalysis)
+        (
+          tab: _buildTab(tabName: 'Frame Analysis'),
+          tabView: KeepAliveWrapper(
+            child: _selectedFlutterFrame != null
+                ? FlutterFrameAnalysisView(
+                    frameAnalysis: _selectedFlutterFrame!.frameAnalysis,
+                    enhanceTracingController:
+                        controller.enhanceTracingController,
+                    rebuildCountModel: controller.data!.rebuildCountModel,
+                  )
+                : const Center(
+                    child: Text('Select a frame above to view analysis data.'),
+                  ),
+          ),
+          featureController: null,
+        ),
+      if (showRasterStats)
+        (
+          tab: _buildTab(tabName: 'Raster Stats'),
+          tabView: KeepAliveWrapper(
+            child: Center(
+              child: RasterStatsView(
+                rasterStatsController: controller.rasterStatsController,
+              ),
+            ),
+          ),
+          featureController: controller.rasterStatsController,
+        ),
+      if (showRebuildStats)
+        (
+          tab: _buildTab(tabName: 'Rebuild Stats'),
+          tabView: KeepAliveWrapper(
+            child: RebuildStatsView(
+              model: controller.data!.rebuildCountModel,
+              selectedFrame: controller.flutterFramesController.selectedFrame,
+            ),
+          ),
+          featureController: null,
+        ),
+      (
+        tab: _buildTab(
+          tabName: 'Timeline Events',
+          trailing: TimelineEventsTabControls(
+            controller: controller.timelineEventsController,
           ),
         ),
-      ),
-      featureController: controller.rasterStatsController,
-    );
-  }
-
-  _PerformanceTabRecord _timelineEventsRecord() {
-    return _PerformanceTabRecord(
-      tab: _buildTab(
-        tabName: 'Timeline Events',
-        trailing: TimelineEventsTabControls(
+        tabView: TimelineEventsTabView(
           controller: controller.timelineEventsController,
         ),
+        featureController: controller.timelineEventsController,
       ),
-      tabView: TimelineEventsTabView(
-        controller: controller.timelineEventsController,
-      ),
-      featureController: controller.timelineEventsController,
-    );
+    ];
   }
 
   DevToolsTab _buildTab({required String tabName, Widget? trailing}) {
@@ -192,14 +189,4 @@ class _TabbedPerformanceViewState extends State<TabbedPerformanceView>
       trailing: trailing,
     );
   }
-}
-
-class _PerformanceTabRecord extends TabRecord {
-  _PerformanceTabRecord({
-    required super.tab,
-    required super.tabView,
-    required this.featureController,
-  });
-
-  final PerformanceFeatureController? featureController;
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view.dart
@@ -64,31 +64,35 @@ class _ObjectInspectorViewState extends State<_ObjectInspectorView>
         AnalyticsTabbedView(
           gaScreen: gac.objectInspectorScreen,
           tabs: [
-            DevToolsTab.create(
-              tabName: 'Program Explorer',
-              gaPrefix: gac.programExplorer,
+            (
+              tab: DevToolsTab.create(
+                tabName: 'Program Explorer',
+                gaPrefix: gac.programExplorer,
+              ),
+              tabView: ProgramExplorer(
+                controller: controller.programExplorerController,
+                onNodeSelected: _onNodeSelected,
+                displayHeader: false,
+              ),
             ),
-            DevToolsTab.create(
-              tabName: 'Object Store',
-              gaPrefix: gac.objectStore,
+            (
+              tab: DevToolsTab.create(
+                tabName: 'Object Store',
+                gaPrefix: gac.objectStore,
+              ),
+              tabView: ObjectStoreViewer(
+                controller: controller.objectStoreController,
+                onLinkTapped: controller.findAndSelectNodeForObject,
+              ),
             ),
-            DevToolsTab.create(
-              tabName: 'Class Hierarchy',
-              gaPrefix: gac.classHierarchy,
-            ),
-          ],
-          tabViews: [
-            ProgramExplorer(
-              controller: controller.programExplorerController,
-              onNodeSelected: _onNodeSelected,
-              displayHeader: false,
-            ),
-            ObjectStoreViewer(
-              controller: controller.objectStoreController,
-              onLinkTapped: controller.findAndSelectNodeForObject,
-            ),
-            ClassHierarchyExplorer(
-              controller: controller,
+            (
+              tab: DevToolsTab.create(
+                tabName: 'Class Hierarchy',
+                gaPrefix: gac.classHierarchy,
+              ),
+              tabView: ClassHierarchyExplorer(
+                controller: controller,
+              ),
             ),
           ],
         ),

--- a/packages/devtools_app/lib/src/shared/ui/tab.dart
+++ b/packages/devtools_app/lib/src/shared/ui/tab.dart
@@ -75,20 +75,17 @@ class AnalyticsTabbedView<T> extends StatefulWidget {
   AnalyticsTabbedView({
     Key? key,
     required this.tabs,
-    required this.tabViews,
     required this.gaScreen,
     this.sendAnalytics = true,
     this.onTabChanged,
     this.initialSelectedIndex,
   })  : trailingWidgets = List.generate(
           tabs.length,
-          (index) => tabs[index].trailing ?? const SizedBox(),
+          (index) => tabs[index].tab.trailing ?? const SizedBox(),
         ),
         super(key: key);
 
-  final List<DevToolsTab> tabs;
-
-  final List<Widget> tabViews;
+  final List<({DevToolsTab tab, Widget tabView})> tabs;
 
   final String gaScreen;
 
@@ -138,7 +135,7 @@ class _AnalyticsTabbedViewState extends State<AnalyticsTabbedView>
     if (widget.sendAnalytics) {
       ga.select(
         widget.gaScreen,
-        widget.tabs[_currentTabControllerIndex].gaId,
+        widget.tabs[_currentTabControllerIndex].tab.gaId,
         nonInteraction: true,
       );
     }
@@ -154,7 +151,7 @@ class _AnalyticsTabbedViewState extends State<AnalyticsTabbedView>
       if (widget.sendAnalytics) {
         ga.select(
           widget.gaScreen,
-          widget.tabs[_currentTabControllerIndex].gaId,
+          widget.tabs[_currentTabControllerIndex].tab.gaId,
         );
       }
     }
@@ -194,7 +191,7 @@ class _AnalyticsTabbedViewState extends State<AnalyticsTabbedView>
               child: TabBar(
                 labelColor: Theme.of(context).textTheme.bodyLarge?.color,
                 controller: _tabController,
-                tabs: widget.tabs,
+                tabs: widget.tabs.map((t) => t.tab).toList(),
                 isScrollable: true,
               ),
             ),
@@ -213,21 +210,11 @@ class _AnalyticsTabbedViewState extends State<AnalyticsTabbedView>
             child: TabBarView(
               physics: defaultTabBarViewPhysics,
               controller: _tabController,
-              children: widget.tabViews,
+              children: widget.tabs.map((t) => t.tabView).toList(),
             ),
           ),
         ],
       ),
     );
   }
-}
-
-class TabRecord {
-  TabRecord({
-    required this.tab,
-    required this.tabView,
-  });
-
-  final DevToolsTab tab;
-  final Widget tabView;
 }


### PR DESCRIPTION
Use the new records language feature to pair a tab and its respective tab view. Benefits:

1. Merges conditional checks that should be the same within the tabs list and tabViews list, preventing tab controller errors where the tabs and tabViews list lengths get out of sync.

Before:
```dart
final tabs = [
  if (foo) myFooTab,
  if (bar) myBarTab,
  if (baz) myBazTab,
];
final tabViews = [
  if (foo) myFooTabView,
  if (bar) myBarTabView,
  if (baz) myBazTabView,
];
```
After: 
```dart
final tabs = [
  if (foo) (tab: myFooTab, tabView: myFooTabView),
  if (bar) (tab: myBarTab, tabView: myBarTabView),
  if (baz) (tab: myBazTab, tabView: myBazTabView),
];
```

2. Eliminates record-like dart classes we were using to group tabs and tab views.