### PR TITLE
Specify pull request in DCM workflow

### DIFF
--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -21,6 +21,8 @@ jobs:
     uses: ./.github/workflows/flutter-prep.yaml
     with:
       os-name: ubuntu
+      needs-checkout-merge: true
+
   dcm:
     name: Dart Code Metrics
     needs: flutter-prep

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Clone Flutter DevTools
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
       - name: Load Cached Flutter SDK
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -25,9 +25,6 @@ jobs:
         os: ${{ (inputs.os-name == 'macos' && fromJSON('[ "macos-latest"]')) || (inputs.os-name == 'ubuntu' && fromJSON('[ "ubuntu-latest"]')) || fromJSON('["ubuntu-latest", "macos-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: git clone devtools
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
-
       - name: Get Latest Flutter Candidate
         id: flutter-candidate
         run: |

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -28,7 +28,6 @@ jobs:
         os: ${{ (inputs.os-name == 'macos' && fromJSON('[ "macos-latest"]')) || (inputs.os-name == 'ubuntu' && fromJSON('[ "ubuntu-latest"]')) || fromJSON('["ubuntu-latest", "macos-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
-      steps:
       # TODO(https://github.com/flutter/devtools/issues/5729) Consider caching DevTools so that we
       # don't check it out again is subsequent workflows.
 

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -10,6 +10,9 @@ on:
       os-name:
         description: 'The OS to run against, either "macos" or "ubuntu". If neither is provided, will run against both.'
         type: string
+      needs-checkout-merge:
+        description: 'Whether the PR should be merged during the checkout step. Necessary for pull_request_target workflows.'
+        type: boolean
     outputs:
       latest_flutter_candidate:
         description: 'The latest Flutter candidate version.'
@@ -25,6 +28,24 @@ jobs:
         os: ${{ (inputs.os-name == 'macos' && fromJSON('[ "macos-latest"]')) || (inputs.os-name == 'ubuntu' && fromJSON('[ "ubuntu-latest"]')) || fromJSON('["ubuntu-latest", "macos-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
+      steps:
+      # TODO(https://github.com/flutter/devtools/issues/5729) Consider caching DevTools so that we
+      # don't check it out again is subsequent workflows.
+
+      # Merge in the PR branch during checkout. This is necessary for pull_request_target workflows.
+      # See: https://github.com/actions/checkout/issues/518
+      - name: Checkout PR branch for DevTools
+        if: ${{ inputs.needs-checkout-merge == true }}
+        id: checkout-pr-branch
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+        with:
+          ref: "refs/pull/${{ github.event.number }}/merge"
+  
+      # Otherwise use the default checkout action.
+      - name: Checkout DevTools (default)
+        if: steps.checkout-pr-branch.outcome == 'skipped'
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
       - name: Get Latest Flutter Candidate
         id: flutter-candidate
         run: |


### PR DESCRIPTION
Fixes the issue where DCM workflows are running against what is on `master` instead of the opened PR branch. See for example this CI run: https://github.com/flutter/devtools/actions/runs/4823063948/jobs/8591106697?pr=5722

See https://github.com/actions/checkout/issues/518 for details 

Unfortunately there is no way to trigger these changes until the PR has landed (due to using `pull_request_target`), so we will have to merge (with DCM failures) to confirm everything is working.