### PR TITLE
Make file search and search in file snappier

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -261,34 +261,24 @@ class _CodeViewState extends State<CodeView> with AutoDisposeMixin {
       return const CenteredCircularProgressIndicator();
     }
 
-    return DualValueListenableBuilder<bool, bool>(
-      firstListenable: widget.enableFileExplorer
-          ? widget.codeViewController.showFileOpener
-          : const FixedValueListenable<bool>(false),
-      secondListenable: widget.enableSearch
-          ? widget.codeViewController.showSearchInFileField
-          : const FixedValueListenable<bool>(false),
-      builder: (context, showFileOpener, showSearch, _) {
-        return Stack(
-          children: [
-            scriptRef == null
-                ? CodeViewEmptyState(widget: widget)
-                : buildCodeArea(context),
-            if (showFileOpener)
-              Positioned(
-                left: noPadding,
-                right: noPadding,
-                child: buildFileSearchField(),
-              ),
-            if (showSearch && scriptRef != null)
-              Positioned(
-                top: denseSpacing,
-                right: searchFieldRightPadding,
-                child: buildSearchInFileField(),
-              ),
-          ],
-        );
-      },
+    return Stack(
+      children: [
+        scriptRef == null
+            ? CodeViewEmptyState(widget: widget)
+            : buildCodeArea(context),
+        PositionedPopup(
+          isVisibleListenable: widget.codeViewController.showFileOpener,
+          left: noPadding,
+          right: noPadding,
+          child: buildFileSearchField(),
+        ),
+        PositionedPopup(
+          isVisibleListenable: widget.codeViewController.showSearchInFileField,
+          top: denseSpacing,
+          right: searchFieldRightPadding,
+          child: buildSearchInFileField(),
+        ),
+      ],
     );
   }
 
@@ -1585,6 +1575,40 @@ class GoToLineDialog extends StatelessWidget {
       actions: const [
         DialogCancelButton(),
       ],
+    );
+  }
+}
+
+class PositionedPopup extends StatelessWidget {
+  const PositionedPopup({
+    super.key,
+    required this.isVisibleListenable,
+    required this.child,
+    this.top,
+    this.left,
+    this.right,
+  });
+
+  final ValueListenable<bool> isVisibleListenable;
+  final double? top;
+  final double? left;
+  final double? right;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<bool>(
+      valueListenable: isVisibleListenable,
+      builder: (context, isVisible, _) {
+        return isVisible
+            ? Positioned(
+                top: top,
+                left: left,
+                right: right,
+                child: child,
+              )
+            : const SizedBox.shrink();
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -336,7 +336,8 @@ class CodeViewController extends DisposableController
   }
 
   void toggleSearchInFileVisibility(bool visible) {
-    _showSearchInFileField.value = visible;
+    final fileExists = _currentScriptRef.value != null;
+    _showSearchInFileField.value = visible && fileExists;
     if (!visible) {
       resetSearch();
     }

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -23,6 +23,7 @@ TODO: Remove this section if there are not any general updates.
 ## Debugger updates
 * Improve support for inspecting `UserTag` and `MirrorReferent` instances - [#5490](https://github.com/flutter/devtools/pull/5490)
 * Fixes expression evaluation bug where selecting an autocomplete result for a field would clear the current input - [#5717](https://github.com/flutter/devtools/pull/5717)
+* Performance improvements when searching in a file, or searching for a file - [#5733](https://github.com/flutter/devtools/pull/5733)
 
 ## Network profiler updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/5706, https://github.com/flutter/devtools/issues/5703

We were rebuilding the entire "code area" whenever the file search / search in file popups were opened or closed. This is quite slow for large files! (More work to be done for that, see https://github.com/flutter/devtools/issues/5706).

Now we only build the popups themselves. 


## Before (~ 5 seconds to open / close):
![slower bigger](https://user-images.githubusercontent.com/21270878/235206128-674f5ccf-2710-45f8-a331-89c1940e1b8e.gif)

## After (< 1 second to open/close):

![faster bigger](https://user-images.githubusercontent.com/21270878/235205986-7ab476f6-b879-451c-bdf5-5b55656ba0ed.gif)
