### PR TITLE
Ensure release notes show most recent notes for pre-release version

### DIFF
--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -39,7 +39,7 @@ class DevToolsAboutDialog extends StatelessWidget {
                   style: theme.linkTextStyle,
                 ),
                 onTap: () =>
-                    releaseNotesController.toggleReleaseNotesVisible(true),
+                    unawaited(releaseNotesController.openLatestReleaseNotes()),
               ),
             ],
           ),

--- a/packages/devtools_app/test/shared/release_notes_test.dart
+++ b/packages/devtools_app/test/shared/release_notes_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_shared/devtools_shared.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('$ReleaseNotesController', () {
+    late ReleaseNotesController controller;
+    setUp(() {
+      debugTestReleaseNotes = true;
+      controller = ReleaseNotesController();
+    });
+
+    test('latestVersionToCheckForReleaseNotes', () {
+      var version = controller.latestVersionToCheckForReleaseNotes(
+        SemanticVersion.parse('2.24.5-dev.1'),
+      );
+      expect(version.toString(), '2.23.10');
+
+      version = controller.latestVersionToCheckForReleaseNotes(
+        SemanticVersion.parse('2.24.1'),
+      );
+      expect(version.toString(), '2.24.1');
+    });
+  });
+}


### PR DESCRIPTION
This will ensure that for a dev version like 2.24.0-dev.1, we will still show release notes for the most recent release (2.23.1 in this case). g3 users very rarely have a non-dev version of DevTools.