### PR TITLE
Make device info text flexible so it doesn't overflow

### DIFF
--- a/packages/devtools_app/lib/src/shared/device_dialog.dart
+++ b/packages/devtools_app/lib/src/shared/device_dialog.dart
@@ -50,9 +50,11 @@ class DeviceDialog extends StatelessWidget {
               child: Row(
                 children: [
                   Text('${entry.title}: ', style: boldText),
-                  SelectableText(
-                    entry.description,
-                    style: theme.subtleTextStyle,
+                  Flexible(
+                    child: SelectableText(
+                      entry.description,
+                      style: theme.subtleTextStyle,
+                    ),
                   ),
                   if (entry.actions.isNotEmpty) ...entry.actions,
                 ],


### PR DESCRIPTION
![](https://media.giphy.com/media/Iv6evVLjNXmve/giphy-downsized.gif)

New flutter candidate seems to have broken these tests. So I've made the text on the device info dialog wrap to avoid overflow.

 
![Screenshot 2023-05-12 at 11 54 57 AM](https://github.com/flutter/devtools/assets/1386322/3c917730-924d-45cb-ba95-238ac1107e6b)
