### PR TITLE
Change lee-dowhm/no-response to working hash

### DIFF
--- a/.github/workflows/close-inactive-issues.yaml
+++ b/.github/workflows/close-inactive-issues.yaml
@@ -12,7 +12,7 @@ jobs:
   noResponse:
     runs-on: ubuntu-latest
     steps:
-      - uses: lee-dohm/no-response@caff5e7de24d19659c31dda1ff2520a3f6a88370
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb
         with:
           token: ${{ github.token }}
           # Comment to post when closing an Issue for lack of response. Set to `false` to disable


### PR DESCRIPTION
![](https://media.giphy.com/media/CLQGQYjxPtV0Q/giphy.gif)
It looks like the other approved hash for this action points to something  that doesn't work for the action. So I'm changing this to the exact same hash that intellij uses.