### PR TITLE
Fix daily dev bump for new labelled workflows

### DIFF
--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -102,12 +102,13 @@ jobs:
             CREATION_FLAGS="--draft"
           fi
 
-          PR_URL=$(gh pr create \
-            --title "$COMMIT_MESSAGE" \
-            --body "Automated Version Bump" $CREATION_FLAGS \
-            --label "autosubmit" \
-            --label "release-notes-not-required" \
-            --label "run-dcm-workflow")
+          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) 
+
+          # Change github credentials back to the actions bot.
+          GH_TOKEN="$ORIGINAL_GH_TOKEN"
+
+          gh pr edit $PR_URL $FLAGS --add-label "release-notes-not-required"
+          gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -106,6 +106,7 @@ jobs:
 
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
+
           gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -102,16 +102,18 @@ jobs:
             CREATION_FLAGS="--draft"
           fi
 
-          PR_URL=$(gh pr create \
-            --title "$COMMIT_MESSAGE" \
-            --body "Automated Version Bump" $CREATION_FLAGS \
-            --label "autosubmit" \
-            --label "release-notes-not-required" \
-            --label "run-dcm-workflow")
+          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) 
+
+          # Change github credentials back to the actions bot.
+          GH_TOKEN="$ORIGINAL_GH_TOKEN"
+          sleep 60
+          gh pr edit $PR_URL $FLAGS --add-label "release-notes-not-required"
+          sleep 60
+          gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}
-          # GH_TOKEN: ${{ secrets.DEVTOOLS_WORKFLOW_BOT_TOKEN }}
+          GH_TOKEN: ${{ secrets.DEVTOOLS_WORKFLOW_BOT_TOKEN }}
           ORIGINAL_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_DRAFT: ${{ inputs.draft == true }}
   clean-up-branches:

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -106,9 +106,6 @@ jobs:
 
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
-          sleep 60
-          gh pr edit $PR_URL $FLAGS --add-label "release-notes-not-required"
-          sleep 60
           gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -102,18 +102,16 @@ jobs:
             CREATION_FLAGS="--draft"
           fi
 
-          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) 
-
-          # Change github credentials back to the actions bot.
-          GH_TOKEN="$ORIGINAL_GH_TOKEN"
-          sleep 2
-          gh pr edit $PR_URL $FLAGS --add-label "release-notes-not-required"
-          sleep 2
-          gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
+          PR_URL=$(gh pr create \
+            --title "$COMMIT_MESSAGE" \
+            --body "Automated Version Bump" $CREATION_FLAGS \
+            --label "autosubmit" \
+            --label "release-notes-not-required" \
+            --label "run-dcm-workflow")
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}
-          GH_TOKEN: ${{ secrets.DEVTOOLS_WORKFLOW_BOT_TOKEN }}
+          # GH_TOKEN: ${{ secrets.DEVTOOLS_WORKFLOW_BOT_TOKEN }}
           ORIGINAL_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           IS_DRAFT: ${{ inputs.draft == true }}
   clean-up-branches:

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -104,10 +104,10 @@ jobs:
 
           PR_URL=$(gh pr create \
             --title "$COMMIT_MESSAGE" \
-            --body "Automated Version Bump" $CREATION_FLAGS) \
+            --body "Automated Version Bump" $CREATION_FLAGS \
             --label "autosubmit" \
             --label "release-notes-not-required" \
-            --label "run-dcm-workflow"
+            --label "run-dcm-workflow")
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: git clone devtools
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
-          ref: daily-bump-fix # TODO Restore this to master
+          ref: master
 
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
 

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: git clone devtools
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
-          ref: master
+          ref: daily-bump-fix # TODO Restore this to master
 
       - uses: dart-lang/setup-dart@d6a63dab3335f427404425de0fbfed4686d93c4f
 

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -102,12 +102,7 @@ jobs:
             CREATION_FLAGS="--draft"
           fi
 
-          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) 
-
-          # Change github credentials back to the actions bot.
-          GH_TOKEN="$ORIGINAL_GH_TOKEN"
-
-          gh pr edit $PR_URL $FLAGS --add-label "autosubmit,release-notes-not-required"
+          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) --label "autosubmit,release-notes-not-required,run-dcm-workflow"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -106,8 +106,9 @@ jobs:
 
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
-
+          sleep 2
           gh pr edit $PR_URL $FLAGS --add-label "release-notes-not-required"
+          sleep 2
           gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -102,7 +102,12 @@ jobs:
             CREATION_FLAGS="--draft"
           fi
 
-          PR_URL=$(gh pr create --title "$COMMIT_MESSAGE" --body "Automated Version Bump" $CREATION_FLAGS) --label "autosubmit,release-notes-not-required,run-dcm-workflow"
+          PR_URL=$(gh pr create \
+            --title "$COMMIT_MESSAGE" \
+            --body "Automated Version Bump" $CREATION_FLAGS) \
+            --label "autosubmit" \
+            --label "release-notes-not-required" \
+            --label "run-dcm-workflow"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -6,11 +6,11 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
     paths:
-      - '**/*.dart'
+      - "**/*.dart"
 
 jobs:
   changelog-reminder:
-    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') && github.event.pull_request.user.login != 'DartDevtoolWorkflowBot' }}
     name: Prevent submission
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -1,6 +1,6 @@
 # A CI workflow to run the Dart Code Metrics analyzer (https://dcm.dev).
 
-# NOTE: DCM usage in DevTools is currently experimental! 
+# NOTE: DCM usage in DevTools is currently experimental!
 
 # The DCM_CI_KEY and DCM_EMAIL secrets are set in the admin settings page
 # of the flutter/devtools repo. They can be found at: go/dash-devexp-dcm-keys
@@ -30,11 +30,11 @@ jobs:
     uses: ./.github/workflows/flutter-prep.yaml
     with:
       os-name: ubuntu
-      requires-label: 'run-dcm-workflow'
+      requires-label: "run-dcm-workflow"
       needs-checkout-merge: true
 
   dcm:
-    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow')
+    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') || github.event.pull_request.user.login == 'DartDevtoolWorkflowBot'
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -4,13 +4,13 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
     paths:
-      - '**/*.dart'
+      - "**/*.dart"
 
 env:
   CURRENT_RELEASE_FILE_PATH: packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
 jobs:
   release-preparedness:
-    if: ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'release-notes-not-required') && github.event.pull_request.user.login != 'DartDevtoolWorkflowBot' }}
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -14,9 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:
-      - name: Print PR USER
-        run: |
-          echo "PR USER: ${{ github.event.pull_request.user.login }}"
       - name: Get Pull Request Number
         id: get-pull-request-number
         run: |

--- a/.github/workflows/release-notes.yaml
+++ b/.github/workflows/release-notes.yaml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Verify PR Release Note Requirements
     steps:
+      - name: Print PR USER
+        run: |
+          echo "PR USER: ${{ github.event.pull_request.user.login }}"
       - name: Get Pull Request Number
         id: get-pull-request-number
         run: |


### PR DESCRIPTION
![](https://media.giphy.com/media/115PgUpRcgiTyU/giphy.gif)

The timing for label checking during the workflows is proving difficult. So this PR add's explicit exceptions for our workflow bot so that it:
- will always run DCM
- does not need release notes changes.

Fixes #5777
