### PR TITLE
Add a default error notification

### DIFF
--- a/packages/devtools_app/lib/src/extension_points/extensions_base.dart
+++ b/packages/devtools_app/lib/src/extension_points/extensions_base.dart
@@ -9,7 +9,7 @@ import '../shared/diagnostics/inspector_service.dart';
 abstract class DevToolsExtensionPoints {
   List<ScriptPopupMenuOption> buildExtraDebuggerScriptPopupMenuOptions();
 
-  Link issueTrackerLink({String? additionalInfo});
+  Link issueTrackerLink({String? additionalInfo, String? issueTitle});
 
   String? username();
 

--- a/packages/devtools_app/lib/src/extension_points/extensions_external.dart
+++ b/packages/devtools_app/lib/src/extension_points/extensions_external.dart
@@ -18,11 +18,12 @@ class ExternalDevToolsExtensionPoints implements DevToolsExtensionPoints {
       <ScriptPopupMenuOption>[];
 
   @override
-  Link issueTrackerLink({String? additionalInfo}) {
+  Link issueTrackerLink({String? additionalInfo, String? issueTitle}) {
     return Link(
       display: _newDevToolsIssueUriDisplay,
       url: newDevToolsGitHubIssueUriLengthSafe(
         additionalInfo: additionalInfo,
+        issueTitle: issueTitle,
         environment: issueLinkDetails(),
       ).toString(),
       gaScreenName: gac.devToolsMain,
@@ -61,9 +62,11 @@ const maxGitHubUriLength = 8190;
 Uri newDevToolsGitHubIssueUriLengthSafe({
   required List<String> environment,
   String? additionalInfo,
+  String? issueTitle,
 }) {
   final fullUri = _newDevToolsGitHubIssueUri(
     additionalInfo: additionalInfo,
+    issueTitle: issueTitle,
     environment: environment,
   );
 
@@ -74,11 +77,13 @@ Uri newDevToolsGitHubIssueUriLengthSafe({
     return Uri.parse(fullUri.toString().substring(0, maxGitHubUriLength));
   }
 
+  // Truncate the additional info if the URL is too long:
   final truncatedInfo =
       additionalInfo.substring(0, additionalInfo.length - lengthToCut);
 
   final truncatedUri = _newDevToolsGitHubIssueUri(
     additionalInfo: truncatedInfo,
+    issueTitle: issueTitle,
     environment: environment,
   );
   assert(truncatedUri.toString().length <= maxGitHubUriLength);
@@ -88,6 +93,7 @@ Uri newDevToolsGitHubIssueUriLengthSafe({
 Uri _newDevToolsGitHubIssueUri({
   required List<String> environment,
   String? additionalInfo,
+  String? issueTitle,
 }) {
   final issueBody = [
     if (additionalInfo != null) additionalInfo,
@@ -96,6 +102,7 @@ Uri _newDevToolsGitHubIssueUri({
 
   return Uri.parse('https://$_newDevToolsIssueUriDisplay').replace(
     queryParameters: {
+      'title': issueTitle,
       'body': issueBody,
     },
   );

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -278,9 +278,13 @@ class _NotificationMessage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textStyle = theme.textTheme.bodyMedium;
     return Text(
       widget.message.text,
-      style: Theme.of(context).textTheme.bodyMedium,
+      style: widget.message.isError
+          ? textStyle?.copyWith(color: theme.colorScheme.error)
+          : textStyle,
       overflow: TextOverflow.visible,
       maxLines: 10,
     );

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -55,7 +55,9 @@ class NotificationService {
         unawaited(
           launchUrl(
             devToolsExtensionPoints
-                .issueTrackerLink(additionalInfo: errorMessage)
+                .issueTrackerLink(
+                  issueTitle: 'Reporting error: $errorMessage',
+                )
                 .url,
           ),
         );
@@ -66,6 +68,8 @@ class NotificationService {
         errorMessage,
         isError: true,
         actions: [reportErrorAction],
+        // Double the duration so that the user has time to report the error:
+        duration: NotificationMessage.defaultDuration * 2,
       ),
       allowDuplicates: false,
     );

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
 import 'dart:collection';
 
 import 'package:flutter/material.dart';
 
+import 'config_specific/launch_url/launch_url.dart';
+import 'globals.dart';
 import 'primitives/utils.dart';
 
 class NotificationMessage {
@@ -13,6 +16,7 @@ class NotificationMessage {
     this.text, {
     this.actions = const [],
     this.duration = defaultDuration,
+    this.isError = false,
   });
 
   /// The default duration for notifications to show.
@@ -21,6 +25,7 @@ class NotificationMessage {
   final String text;
   final List<Widget> actions;
   final Duration duration;
+  final bool isError;
 }
 
 /// Collects tasks to show or dismiss notifications in UI.
@@ -38,6 +43,33 @@ class NotificationService {
 
   /// Pushes a notification [message].
   bool push(String message) => pushNotification(NotificationMessage(message));
+
+  /// Pushes an error notification with [errorMessage] as the text.
+  ///
+  /// Includes an action to report the error by opening the link to our issue
+  /// tracker.
+  bool pushError(String errorMessage) {
+    final reportErrorAction = NotificationAction(
+      'Report error',
+      () {
+        unawaited(
+          launchUrl(
+            devToolsExtensionPoints
+                .issueTrackerLink(additionalInfo: errorMessage)
+                .url,
+          ),
+        );
+      },
+    );
+    return pushNotification(
+      NotificationMessage(
+        errorMessage,
+        isError: true,
+        actions: [reportErrorAction],
+      ),
+      allowDuplicates: false,
+    );
+  }
 
   /// Pushes a notification [message].
   ///

--- a/packages/devtools_app/test/extentsion_points/extensions_external_test.dart
+++ b/packages/devtools_app/test/extentsion_points/extensions_external_test.dart
@@ -17,4 +17,17 @@ void main() {
     expect(uri.toString().contains(tail), false);
     expect(uri.toString().length, maxGitHubUriLength);
   });
+
+  test(
+    'newDevToolsGitHubIssueUriLengthSafe includes title and additional info',
+    () {
+      final uri = newDevToolsGitHubIssueUriLengthSafe(
+        issueTitle: 'Issue title',
+        additionalInfo: 'Some additional info',
+        environment: [],
+      );
+      expect(uri.toString(), contains('title=Issue+title'));
+      expect(uri.toString(), contains('body=Some+additional+info'));
+    },
+  );
 }

--- a/packages/devtools_app/test/shared/notifications_test.dart
+++ b/packages/devtools_app/test/shared/notifications_test.dart
@@ -13,14 +13,16 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Notifications', () {
-    Widget buildNotificationsWithButtonToPush(String text) {
+    Widget buildNotificationsWithButtonToPush(String text, {isError = false}) {
       return Directionality(
         textDirection: TextDirection.ltr,
         child: NotificationsView(
           child: Builder(
             builder: (context) {
               return ElevatedButton(
-                onPressed: () => notificationService.push(text),
+                onPressed: () => isError
+                    ? notificationService.pushError(text)
+                    : notificationService.push(text),
                 child: const SizedBox(),
               );
             },
@@ -57,6 +59,21 @@ void main() {
       // Wait for the notification to disappear.
       await tester.pumpAndSettle(NotificationMessage.defaultDuration);
       expect(find.text(notification), findsNothing);
+    });
+
+    testWidgets('displays error notifications', (WidgetTester tester) async {
+      const errorMessage = 'This is an error!';
+      await tester.pumpWidget(
+        buildNotificationsWithButtonToPush(errorMessage, isError: true),
+      );
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
+      expect(find.text(errorMessage), findsOneWidget);
+      expect(
+        find.widgetWithText(OutlinedButton, 'Report error'),
+        findsOneWidget,
+      );
     });
 
     testWidgets('persist across routes', (WidgetTester tester) async {


### PR DESCRIPTION
Adds a default error notification that can be triggered with `NotificationService.pushError(errorMessage)`.

The notification will display the error, and include a button to report it to our issue tracker. The opened bug will be pre-filled with "Reporting error: {{error message}}" as the title. 
 
![Screenshot 2023-05-16 at 9 48 14 AM](https://github.com/flutter/devtools/assets/21270878/5e70cf1d-3368-46d1-84e7-0923a214f9d7)

Work towards https://github.com/flutter/devtools/issues/5709 (if we are unable to parse a file, we would like to notify the user of what has happened). 