### PR TITLE
usePathUrlStrategy from flutter_web_plugins

### DIFF
--- a/packages/devtools_app/lib/initialization.dart
+++ b/packages/devtools_app/lib/initialization.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_web_plugins/url_strategy.dart';
 
 import 'src/app.dart';
 import 'src/framework/app_error_handling.dart';
@@ -14,7 +15,6 @@ import 'src/shared/config_specific/framework_initialize/framework_initialize.dar
 import 'src/shared/config_specific/ide_theme/ide_theme.dart';
 import 'src/shared/config_specific/logger/logger_helpers.dart';
 import 'src/shared/config_specific/url/url.dart';
-import 'src/shared/config_specific/url_strategy/url_strategy.dart';
 import 'src/shared/feature_flags.dart';
 import 'src/shared/globals.dart';
 import 'src/shared/preferences.dart';

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector.dart
@@ -115,7 +115,7 @@ class NetworkRequestInspector extends StatelessWidget {
           .map(
             (t) => (
               tab: t.tab,
-              tabView: OutlineDecoration.onlyTop(child: t.tabView)
+              tabView: OutlineDecoration.onlyTop(child: t.tabView),
             ),
           )
           .toList();

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -729,7 +729,6 @@ class VmServiceObjectLink extends StatelessWidget {
   @visibleForTesting
   static String? defaultTextBuilder(
     Object? object, {
-    // ignore: avoid-unused-parameters, false positive.
     bool preferUri = false,
   }) {
     if (object == null) return null;

--- a/packages/devtools_app/lib/src/shared/config_specific/url_strategy/noop.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/url_strategy/noop.dart
@@ -1,7 +1,0 @@
-// Copyright 2022 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
-
-void usePathUrlStrategy() {
-  // No-op. URL Strategies are only supported for web.
-}

--- a/packages/devtools_app/lib/src/shared/config_specific/url_strategy/url_strategy.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/url_strategy/url_strategy.dart
@@ -1,5 +1,0 @@
-// Copyright 2022 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
-
-export 'noop.dart' if (dart.library.html) 'web.dart';

--- a/packages/devtools_app/lib/src/shared/config_specific/url_strategy/web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/url_strategy/web.dart
@@ -1,9 +1,0 @@
-// Copyright 2022 The Chromium Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be found
-// in the LICENSE file.
-
-import 'package:flutter_web_plugins/flutter_web_plugins.dart';
-
-void usePathUrlStrategy() {
-  setUrlStrategy(PathUrlStrategy());
-}


### PR DESCRIPTION
The `usePathUrlStrategy` function can be imported from` flutter_web_plugins/url_strategy.dart`. No need to do a conditional import either.