### PR TITLE
Notifications can be dismissed

### DIFF
--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -135,7 +135,10 @@ class _InitializerState extends State<Initializer>
     }
 
     errorReporter ??= (String message, Object error) {
-      notificationService.push('$message, $error');
+      notificationService.pushError(
+        '$message, $error',
+        isReportable: false,
+      );
     };
 
     final uri = normalizeVmServiceUri(widget.url!);

--- a/packages/devtools_app/lib/src/framework/landing_screen.dart
+++ b/packages/devtools_app/lib/src/framework/landing_screen.dart
@@ -234,7 +234,10 @@ class _ConnectDialogState extends State<ConnectDialog>
       '',
       explicitUri: uri,
       errorReporter: (message, error) {
-        notificationService.push('$message $error');
+        notificationService.pushError(
+          '$message $error',
+          isReportable: false,
+        );
       },
     );
     if (connected) {

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -255,7 +255,7 @@ class _NotificationState extends State<_Notification>
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   if (widget.message.isDismissable)
-                    _DismissAction(widget: widget, context: context),
+                    _DismissAction(widget: widget),
                   _NotificationMessage(widget: widget, context: context),
                   const SizedBox(height: defaultSpacing),
                   _NotificationActions(widget: widget),
@@ -272,11 +272,9 @@ class _NotificationState extends State<_Notification>
 class _DismissAction extends StatelessWidget {
   const _DismissAction({
     required this.widget,
-    required this.context,
   });
 
   final _Notification widget;
-  final BuildContext context;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -254,7 +254,7 @@ class _NotificationState extends State<_Notification>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (widget.message.isDismissable)
+                  if (widget.message.isDismissible)
                     _DismissAction(widget: widget),
                   _NotificationMessage(widget: widget, context: context),
                   const SizedBox(height: defaultSpacing),

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -168,6 +168,7 @@ class _NotificationOverlay extends StatelessWidget {
           child: SingleChildScrollView(
             reverse: true,
             child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
               mainAxisSize: MainAxisSize.min,
               children: _notifications,
             ),
@@ -265,7 +266,11 @@ class _NotificationState extends State<_Notification>
                                 context: context,
                               ),
                             ),
-                            _DismissAction(widget: widget),
+                            _DismissAction(
+                              onPressed: () {
+                                widget.remove(widget);
+                              },
+                            ),
                           ],
                         )
                       : _NotificationMessage(
@@ -286,10 +291,10 @@ class _NotificationState extends State<_Notification>
 
 class _DismissAction extends StatelessWidget {
   const _DismissAction({
-    required this.widget,
+    required this.onPressed,
   });
 
-  final _Notification widget;
+  final void Function() onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -299,9 +304,7 @@ class _DismissAction extends StatelessWidget {
         icon: const Icon(
           Icons.close,
         ),
-        onPressed: () {
-          widget.remove(widget);
-        },
+        onPressed: onPressed,
       ),
     );
   }
@@ -320,13 +323,21 @@ class _NotificationMessage extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final textStyle = theme.textTheme.bodyMedium;
-    return Text(
-      widget.message.text,
-      style: widget.message.isError
-          ? textStyle?.copyWith(color: theme.colorScheme.error)
-          : textStyle,
-      overflow: TextOverflow.visible,
-      maxLines: 10,
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        denseSpacing,
+        denseSpacing,
+        denseSpacing,
+        0,
+      ),
+      child: Text(
+        widget.message.text,
+        style: widget.message.isError
+            ? textStyle?.copyWith(color: theme.colorScheme.error)
+            : textStyle,
+        overflow: TextOverflow.visible,
+        maxLines: 10,
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -254,6 +254,8 @@ class _NotificationState extends State<_Notification>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
+                  if (widget.message.isDismissable)
+                    _DismissAction(widget: widget, context: context),
                   _NotificationMessage(widget: widget, context: context),
                   const SizedBox(height: defaultSpacing),
                   _NotificationActions(widget: widget),
@@ -262,6 +264,31 @@ class _NotificationState extends State<_Notification>
             ),
           ),
         ),
+      ),
+    );
+  }
+}
+
+class _DismissAction extends StatelessWidget {
+  const _DismissAction({
+    required this.widget,
+    required this.context,
+  });
+
+  final _Notification widget;
+  final BuildContext context;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topRight,
+      child: IconButton(
+        icon: const Icon(
+          Icons.close,
+        ),
+        onPressed: () {
+          widget.remove(widget);
+        },
       ),
     );
   }

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -254,9 +254,24 @@ class _NotificationState extends State<_Notification>
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  if (widget.message.isDismissible)
-                    _DismissAction(widget: widget),
-                  _NotificationMessage(widget: widget, context: context),
+                  widget.message.isDismissible
+                      ? Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Flexible(
+                              child: _NotificationMessage(
+                                widget: widget,
+                                context: context,
+                              ),
+                            ),
+                            _DismissAction(widget: widget),
+                          ],
+                        )
+                      : _NotificationMessage(
+                          widget: widget,
+                          context: context,
+                        ),
                   const SizedBox(height: defaultSpacing),
                   _NotificationActions(widget: widget),
                 ],

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -17,7 +17,7 @@ class NotificationMessage {
     this.actions = const [],
     this.duration = defaultDuration,
     this.isError = false,
-    this.isDismissable = false,
+    this.isDismissible = false,
   });
 
   /// The default duration for notifications to show.
@@ -27,7 +27,7 @@ class NotificationMessage {
   final List<Widget> actions;
   final Duration duration;
   final bool isError;
-  final bool isDismissable;
+  final bool isDismissible;
 }
 
 /// Collects tasks to show or dismiss notifications in UI.
@@ -45,15 +45,15 @@ class NotificationService {
 
   /// Pushes a notification [message].
   ///
-  /// Includes a button to close the notification if [isDismissable] is true.
+  /// Includes a button to close the notification if [isDismissible] is true.
   bool push(
     String message, {
-    isDismissable = false,
+    isDismissible = false,
   }) =>
       pushNotification(
         NotificationMessage(
           message,
-          isDismissable: isDismissable,
+          isDismissible: isDismissible,
         ),
       );
 
@@ -61,10 +61,10 @@ class NotificationService {
   ///
   /// Includes an action to report the error by opening the link to our issue
   /// tracker if [isReportable] is true. Includes a button to close the error if
-  /// [isDismissable] is true.
+  /// [isDismissible] is true.
   bool pushError(
     String errorMessage, {
-    isDismissable = true,
+    isDismissible = true,
     isReportable = true,
   }) {
     final reportErrorAction = NotificationAction(
@@ -85,7 +85,7 @@ class NotificationService {
       NotificationMessage(
         errorMessage,
         isError: true,
-        isDismissable: isDismissable,
+        isDismissible: isDismissible,
         actions: [if (isReportable) reportErrorAction],
         // Double the duration so that the user has time to report the error:
         duration: isReportable

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -17,6 +17,7 @@ class NotificationMessage {
     this.actions = const [],
     this.duration = defaultDuration,
     this.isError = false,
+    this.isDismissable = false,
   });
 
   /// The default duration for notifications to show.
@@ -26,6 +27,7 @@ class NotificationMessage {
   final List<Widget> actions;
   final Duration duration;
   final bool isError;
+  final bool isDismissable;
 }
 
 /// Collects tasks to show or dismiss notifications in UI.
@@ -42,13 +44,29 @@ class NotificationService {
   final activeMessages = <NotificationMessage>[];
 
   /// Pushes a notification [message].
-  bool push(String message) => pushNotification(NotificationMessage(message));
+  ///
+  /// Includes a button to close the notification if [isDismissable] is true.
+  bool push(
+    String message, {
+    isDismissable = false,
+  }) =>
+      pushNotification(
+        NotificationMessage(
+          message,
+          isDismissable: isDismissable,
+        ),
+      );
 
   /// Pushes an error notification with [errorMessage] as the text.
   ///
   /// Includes an action to report the error by opening the link to our issue
-  /// tracker.
-  bool pushError(String errorMessage) {
+  /// tracker if [isReportable] is true. Includes a button to close the error if
+  /// [isDismissable] is true.
+  bool pushError(
+    String errorMessage, {
+    isDismissable = true,
+    isReportable = true,
+  }) {
     final reportErrorAction = NotificationAction(
       'Report error',
       () {
@@ -67,9 +85,12 @@ class NotificationService {
       NotificationMessage(
         errorMessage,
         isError: true,
-        actions: [reportErrorAction],
+        isDismissable: isDismissable,
+        actions: [if (isReportable) reportErrorAction],
         // Double the duration so that the user has time to report the error:
-        duration: NotificationMessage.defaultDuration * 2,
+        duration: isReportable
+            ? NotificationMessage.defaultDuration * 2
+            : NotificationMessage.defaultDuration,
       ),
       allowDuplicates: false,
     );

--- a/packages/devtools_app/test/shared/notifications_test.dart
+++ b/packages/devtools_app/test/shared/notifications_test.dart
@@ -59,7 +59,7 @@ void main() {
     testWidgets('notifications can be dismissed', (WidgetTester tester) async {
       const notification = 'This is a notification!';
       await showNotification(
-        () => notificationService.push(notification, isDismissable: true),
+        () => notificationService.push(notification, isDismissible: true),
         tester: tester,
       );
 

--- a/packages/devtools_app/test/shared/notifications_test.dart
+++ b/packages/devtools_app/test/shared/notifications_test.dart
@@ -13,22 +13,28 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   group('Notifications', () {
-    Widget buildNotificationsWithButtonToPush(String text, {isError = false}) {
-      return Directionality(
+    Future<void> showNotification(
+      void Function() triggerNotification, {
+      required WidgetTester tester,
+    }) async {
+      final notificationsWidget = Directionality(
         textDirection: TextDirection.ltr,
         child: NotificationsView(
           child: Builder(
             builder: (context) {
               return ElevatedButton(
-                onPressed: () => isError
-                    ? notificationService.pushError(text)
-                    : notificationService.push(text),
+                onPressed: triggerNotification,
                 child: const SizedBox(),
               );
             },
           ),
         ),
       );
+
+      await tester.pumpWidget(notificationsWidget);
+      await tester.pumpAndSettle();
+      await tester.tap(find.byType(ElevatedButton));
+      await tester.pumpAndSettle();
     }
 
     setUp(() {
@@ -38,10 +44,11 @@ void main() {
 
     testWidgets('displays notifications', (WidgetTester tester) async {
       const notification = 'This is a notification!';
-      await tester.pumpWidget(buildNotificationsWithButtonToPush(notification));
-      await tester.pumpAndSettle();
-      await tester.tap(find.byType(ElevatedButton));
-      await tester.pumpAndSettle();
+      await showNotification(
+        () => notificationService.push(notification),
+        tester: tester,
+      );
+
       expect(find.text(notification), findsOneWidget);
 
       await tester.tap(find.byType(ElevatedButton));
@@ -49,31 +56,34 @@ void main() {
       expect(find.text(notification), findsNWidgets(2));
     });
 
+    testWidgets('notifications can be dismissed', (WidgetTester tester) async {
+      const notification = 'This is a notification!';
+      await showNotification(
+        () => notificationService.push(notification, isDismissable: true),
+        tester: tester,
+      );
+
+      final closeButton = find.byType(IconButton);
+      expect(closeButton, findsOneWidget);
+      await tester.tap(closeButton);
+
+      // Verify the notification has been dismissed:
+      await tester.pumpAndSettle();
+      expect(find.text(notification), findsNothing);
+    });
+
     testWidgets('notifications expire', (WidgetTester tester) async {
       const notification = 'This is a notification!';
-      await tester.pumpWidget(buildNotificationsWithButtonToPush(notification));
-      await tester.tap(find.byType(ElevatedButton));
-      await tester.pumpAndSettle();
+      await showNotification(
+        () => notificationService.push(notification),
+        tester: tester,
+      );
+
       expect(find.text(notification), findsOneWidget);
 
       // Wait for the notification to disappear.
       await tester.pumpAndSettle(NotificationMessage.defaultDuration);
       expect(find.text(notification), findsNothing);
-    });
-
-    testWidgets('displays error notifications', (WidgetTester tester) async {
-      const errorMessage = 'This is an error!';
-      await tester.pumpWidget(
-        buildNotificationsWithButtonToPush(errorMessage, isError: true),
-      );
-      await tester.pumpAndSettle();
-      await tester.tap(find.byType(ElevatedButton));
-      await tester.pumpAndSettle();
-      expect(find.text(errorMessage), findsOneWidget);
-      expect(
-        find.widgetWithText(OutlinedButton, 'Report error'),
-        findsOneWidget,
-      );
     });
 
     testWidgets('persist across routes', (WidgetTester tester) async {
@@ -118,6 +128,47 @@ void main() {
       await tester.pumpAndSettle();
       expect(find.text(notification), findsOneWidget);
       expect(find.byKey(detailsKey), findsOneWidget);
+    });
+
+    group('Error notifications', () {
+      testWidgets('displays errors', (WidgetTester tester) async {
+        const errorMessage = 'This is an error!';
+        await showNotification(
+          () => notificationService.push(errorMessage),
+          tester: tester,
+        );
+
+        expect(find.text(errorMessage), findsOneWidget);
+      });
+
+      testWidgets('are reportable by default', (WidgetTester tester) async {
+        const errorMessage = 'This is an error!';
+        await showNotification(
+          () => notificationService.pushError(errorMessage),
+          tester: tester,
+        );
+
+        expect(
+          find.widgetWithText(OutlinedButton, 'Report error'),
+          findsOneWidget,
+        );
+      });
+
+      testWidgets('are dismissable by default', (WidgetTester tester) async {
+        const errorMessage = 'This is an error!';
+        await showNotification(
+          () => notificationService.pushError(errorMessage),
+          tester: tester,
+        );
+
+        final closeButton = find.byType(IconButton);
+        expect(closeButton, findsOneWidget);
+        await tester.tap(closeButton);
+
+        // Verify the error has been dismissed:
+        await tester.pumpAndSettle();
+        expect(find.text(errorMessage), findsNothing);
+      });
     });
   });
 }


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/5814
Work towards https://github.com/flutter/devtools/issues/5703, https://github.com/flutter/devtools/issues/5709 (if we are unable to parse a file, we would like to notify the user of what has happened).

1. Allow notifications to be dismissed by the user by closing the "X" at the top right:

<img width="454" alt="Screenshot 2023-05-18 at 4 11 42 PM" src="https://github.com/flutter/devtools/assets/21270878/06b981fa-31de-4444-a70b-14a6bab6612b">

2. Fixes the positioning of short notifications:

After:
<img width="1230" alt="Screenshot 2023-05-18 at 4 22 16 PM" src="https://github.com/flutter/devtools/assets/21270878/217b6974-66fd-4ad6-a7e6-79b7a253f018">

Before:
<img width="1007" alt="Screenshot 2023-05-18 at 4 04 23 PM" src="https://github.com/flutter/devtools/assets/21270878/ac521a0f-4bc5-4a48-a394-57b3558a4b1f">


3. Makes the VM service connection failure notification an error notification.