### PR TITLE
Don't run DCM workflow when merging to master

### DIFF
--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -107,8 +107,7 @@ jobs:
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
 
-          gh pr edit $PR_URL $FLAGS --add-label "run-dcm-workflow"
-          gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
+          gh pr edit $PR_URL $FLAGS --add-label "run-dcm-workflow,autosubmit"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -107,6 +107,7 @@ jobs:
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
 
+          gh pr edit $PR_URL $FLAGS --add-label "run-dcm-workflow"
           gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:

--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -5,12 +5,14 @@ name: DCM Label Reminder
 on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
+    branches:
+      - master
     paths:
       - "**/*.dart"
 
 jobs:
   changelog-reminder:
-    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') && github.event.pull_request.user.login != 'DartDevtoolWorkflowBot' }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
     name: Prevent submission
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -11,7 +11,7 @@ on:
       - "**/*.dart"
 
 jobs:
-  changelog-reminder:
+  dcm-label-reminder:
     if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
     name: Prevent submission
     runs-on: ubuntu-latest

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -14,9 +14,6 @@
 name: Dart Code Metrics
 
 on:
-  push:
-    branches:
-      - master
   pull_request_target:
     # synchronize, opened, and reopened are the default pull_request_target
     # types. labeled and unlabeled are also required to re-run workflow when
@@ -24,6 +21,8 @@ on:
     types: [synchronize, opened, reopened, labeled, unlabeled]
     branches:
       - master
+    paths:
+      - "**/*.dart"
 
 jobs:
   flutter-prep:
@@ -34,19 +33,15 @@ jobs:
       needs-checkout-merge: true
 
   dcm:
-    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') || github.event.pull_request.user.login == 'DartDevtoolWorkflowBot'
+    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') 
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest
     steps:
-      - name: Clone Flutter DevTools for PR
-        if: ${{ github.event_name != 'push' }}
+      - name: Clone Flutter DevTools
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
-      - name: Clone Flutter DevTools
-        if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Load Cached Flutter SDK
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -39,10 +39,14 @@ jobs:
     needs: flutter-prep
     runs-on: ubuntu-latest
     steps:
-      - name: Clone Flutter DevTools
+      - name: Clone Flutter DevTools for PR
+        if: ${{ github.event_name != 'push' }}
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
         with:
           ref: "refs/pull/${{ github.event.number }}/merge"
+      - name: Clone Flutter DevTools
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
       - name: Load Cached Flutter SDK
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   reusable-flutter-prep:
+    # Note: Do not delete the following check. This is needed for the DCM workflow.
+    if: inputs.requires-label == '' || contains(github.event.pull_request.labels.*.name, inputs.requires-label)
     name: ${{ matrix.os }} Flutter Prep
     outputs:
       latest_flutter_candidate: ${{ steps.flutter-candidate.outputs.FLUTTER_CANDIDATE }}


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5797

Changes introduced:
- only runs DCM workflow on PRs, not when merging to master
- adds the run-dcm-workflow label for daily bump PRs