### PR TITLE
Add DartDevtoolWorkflowBot back to dcm checks

### DIFF
--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -107,7 +107,7 @@ jobs:
           # Change github credentials back to the actions bot.
           GH_TOKEN="$ORIGINAL_GH_TOKEN"
 
-          gh pr edit $PR_URL $FLAGS --add-label "run-dcm-workflow,autosubmit"
+          gh pr edit $PR_URL $FLAGS --add-label "autosubmit"
 
         env:
           COMMIT_MESSAGE: ${{ steps.version-bump.outputs.COMMIT_MESSAGE }}

--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -12,7 +12,10 @@ on:
 
 jobs:
   dcm-label-reminder:
-    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }} && github.event.pull_request.user.login != 'DartDevtoolWorkflowBot'
+    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
+    paths:
+      - "**/*.dart"
+      - "!packages/devtools_app/lib/devtools.dart"
     name: Prevent submission
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   dcm-label-reminder:
-    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
+    if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }} && github.event.pull_request.user.login != 'DartDevtoolWorkflowBot'
     name: Prevent submission
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -33,7 +33,7 @@ jobs:
       needs-checkout-merge: true
 
   dcm:
-    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') 
+    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') || github.event.pull_request.user.login == 'DartDevtoolWorkflowBot'
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -23,6 +23,7 @@ on:
       - master
     paths:
       - "**/*.dart"
+      - "!packages/devtools_app/lib/devtools.dart"
 
 jobs:
   flutter-prep:
@@ -34,9 +35,6 @@ jobs:
 
   dcm:
     if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow')
-    paths:
-      - "**/*.dart"
-      - "!packages/devtools_app/lib/devtools.dart"
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -33,7 +33,7 @@ jobs:
       needs-checkout-merge: true
 
   dcm:
-    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow') || github.event.pull_request.user.login == 'DartDevtoolWorkflowBot'
+    if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow')
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -29,11 +29,14 @@ jobs:
     uses: ./.github/workflows/flutter-prep.yaml
     with:
       os-name: ubuntu
-      requires-label: ${{ github.event.pull_request.user.login == 'DartDevtoolWorkflowBot' && "" || "run-dcm-workflow" }}
+      requires-label: "run-dcm-workflow"
       needs-checkout-merge: true
 
   dcm:
     if: contains(github.event.pull_request.labels.*.name, 'run-dcm-workflow')
+    paths:
+      - "**/*.dart"
+      - "!packages/devtools_app/lib/devtools.dart"
     name: Dart Code Metrics
     needs: flutter-prep
     runs-on: ubuntu-latest

--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -29,7 +29,7 @@ jobs:
     uses: ./.github/workflows/flutter-prep.yaml
     with:
       os-name: ubuntu
-      requires-label: "run-dcm-workflow"
+      requires-label: ${{ github.event.pull_request.user.login == 'DartDevtoolWorkflowBot' && "" || "run-dcm-workflow" }}
       needs-checkout-merge: true
 
   dcm:


### PR DESCRIPTION
![](https://media.giphy.com/media/O1I2B29viaEhuWT01R/giphy-downsized.gif)

The way that labels resolve for our daily dev bump PRs make it difficult to use the `autosubmit` label. So they are failing to autosubmit now.

This PR adds back the DartDevtoolWorkflowBot exceptions so that the dcm workflows will run, and have a chance to pass on the Daily Dev Bumps.