### PR TITLE
Add SDK constraint.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -9,7 +9,7 @@ version: 2.24.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: '>=3.0.0  <4.0.0'
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -9,7 +9,7 @@ version: 2.24.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
 environment:
-  sdk: '>=3.0.0  <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -6,7 +6,7 @@ version: 2.24.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
   path: ^1.8.0

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -12,7 +12,7 @@ version: 2.24.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: '>=3.0.0  <4.0.0'
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -12,7 +12,7 @@ version: 2.24.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
-  sdk: '>=3.0.0  <4.0.0'
+  sdk: '>=3.0.0 <4.0.0'
   flutter: '>=3.0.0'
 
 dependencies:


### PR DESCRIPTION
Fix failing `flutter pub publish` for `devtools_shared`:

```
Package validation found the following error:
* Published packages should have an upper bound constraint on the Dart SDK (typically this should restrict to less than the next major version to guard against breaking changes).
  See https://dart.dev/tools/pub/pubspec#sdk-constraints for instructions on setting an sdk version constraint.
```