### PR TITLE
Fix scrolling to selected stack frame

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -44,7 +44,9 @@ class _CallStackState extends State<CallStack>
             final frame = stackFrames[index];
             return _buildStackFrame(
               frame,
-              frame == selectedFrame || frame == _clickedOnFrame,
+              _clickedOnFrame != null
+                  ? frame == _clickedOnFrame
+                  : frame == selectedFrame,
             );
           },
         );

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -38,10 +38,7 @@ class _CallStackState extends State<CallStack>
           itemExtent: defaultListItemHeight,
           itemBuilder: (_, index) {
             final frame = stackFrames[index];
-            return _buildStackFrame(
-              frame,
-              frame == selectedFrame,
-            );
+            return _buildStackFrame(frame, frame == selectedFrame);
           },
         );
       },

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -20,6 +20,8 @@ class CallStack extends StatefulWidget {
 
 class _CallStackState extends State<CallStack>
     with ProvidedControllerMixin<DebuggerController, CallStack> {
+  StackFrameAndSourcePosition? selectedFrame;
+
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
@@ -28,17 +30,18 @@ class _CallStackState extends State<CallStack>
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<List<StackFrameAndSourcePosition>,
-        StackFrameAndSourcePosition?>(
-      firstListenable: controller.stackFramesWithLocation,
-      secondListenable: controller.selectedStackFrame,
-      builder: (context, stackFrames, selectedFrame, _) {
+    return ValueListenableBuilder<List<StackFrameAndSourcePosition>>(
+      valueListenable: controller.stackFramesWithLocation,
+      builder: (context, stackFrames, _) {
         return ListView.builder(
           itemCount: stackFrames.length,
           itemExtent: defaultListItemHeight,
           itemBuilder: (_, index) {
             final frame = stackFrames[index];
-            return _buildStackFrame(frame, frame == selectedFrame);
+            return _buildStackFrame(
+              frame,
+              frame == selectedFrame,
+            );
           },
         );
       },
@@ -119,6 +122,9 @@ class _CallStackState extends State<CallStack>
   }
 
   Future<void> _onStackFrameSelected(StackFrameAndSourcePosition frame) async {
+    setState(() {
+      selectedFrame = frame;
+    });
     await controller.selectStackFrame(frame);
   }
 }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -531,12 +531,7 @@ class DebuggerController extends DisposableController
   }
 
   Future<void> selectStackFrame(StackFrameAndSourcePosition? frame) async {
-    _selectedStackFrame.value = frame;
-
-    serviceManager.appState.setVariables(
-      frame != null ? _createVariablesForFrame(frame.frame) : [],
-    );
-
+    // Load the new script location:
     final scriptRef = frame?.scriptRef;
     final position = frame?.position;
     if (scriptRef != null && position != null) {
@@ -544,6 +539,12 @@ class DebuggerController extends DisposableController
         ScriptLocation(scriptRef, location: position),
       );
     }
+    // Update the variables for the stack frame:
+    serviceManager.appState.setVariables(
+      frame != null ? _createVariablesForFrame(frame.frame) : [],
+    );
+    // Notify that the stack frame has been succesfully selected:
+    _selectedStackFrame.value = frame;
   }
 
   List<DartObjectNode> _createVariablesForFrame(Frame frame) {


### PR DESCRIPTION
The fix for https://github.com/flutter/devtools/issues/5707 was regressed by https://github.com/flutter/devtools/pull/5827

The good news is the debugger panel test I'm working on did catch the regression: https://github.com/flutter/devtools/pull/5854

The bad news is https://github.com/flutter/devtools/pull/5827 was already submitted!

In any case, this fixes the regression and now when you click on a stack frame we scroll to the correct location:


![scrolling to stack frame](https://github.com/flutter/devtools/assets/21270878/ed82f4b9-a390-4a72-9d6a-3aadc56603e6)
