### PR TITLE
Remove mockito pins

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -73,8 +73,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  # TODO(https://github.com/flutter/devtools/issues/5843) Un-pin once fixed.
-  mockito: 5.4.1
+  mockito: ^5.4.1
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
   stager: ^1.0.1
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -24,8 +24,7 @@ dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  # TODO(https://github.com/flutter/devtools/issues/5843) Un-pin once fixed.
-  mockito: 5.4.1
+  mockito: ^5.4.1
   path: ^1.8.0
   provider: ^6.0.2
   vm_service: ">=10.1.0 <12.0.0"


### PR DESCRIPTION
Now that https://github.com/bryanoltman/stager/issues/45 is resolved (thanks @polina-c!) we should be able to remove the pin. 

Fixes https://github.com/flutter/devtools/issues/5843