### PR TITLE
Scaffolding cleanup

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -184,7 +184,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     return MaterialPage(
       child: DevToolsScaffold.withChild(
         key: const Key('not-found'),
-        ideTheme: ideTheme,
+        embed: isEmbedded(args),
         child: CenteredMessage("'$page' not found."),
       ),
     );
@@ -197,12 +197,13 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     DevToolsNavigationState? __,
   ) {
     final vmServiceUri = params['uri'];
+    final embed = isEmbedded(params);
 
     // Always return the landing screen if there's no VM service URI.
     if (vmServiceUri?.isEmpty ?? true) {
       return DevToolsScaffold.withChild(
         key: const Key('landing'),
-        ideTheme: ideTheme,
+        embed: embed,
         child: LandingScreenBody(sampleData: widget.sampleData),
       );
     }
@@ -213,7 +214,6 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     if (page?.isEmpty ?? true) {
       page = params['page'];
     }
-    final embed = params['embed'] == 'true';
     final hide = {...?params['hide']?.split(',')};
     return Initializer(
       url: vmServiceUri,
@@ -247,7 +247,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
             );
           },
           child: DevToolsScaffold.withChild(
-            ideTheme: ideTheme,
+            embed: embed,
             child: CenteredMessage(
               page != null
                   ? 'The "$page" screen is not available for this application.'
@@ -262,24 +262,26 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
   /// The pages that the app exposes.
   Map<String, UrlParametersBuilder> get pages {
     return _routes ??= {
-      homePageId: _buildTabbedPage,
+      homeScreenId: _buildTabbedPage,
       for (final screen in widget.screens)
         screen.screen.screenId: _buildTabbedPage,
-      snapshotPageId: (_, __, args, ___) {
+      snapshotScreenId: (_, __, args, ___) {
         final snapshotArgs = OfflineDataArguments.fromArgs(args);
+        final embed = isEmbedded(args);
         return DevToolsScaffold.withChild(
           key: UniqueKey(),
-          ideTheme: ideTheme,
+          embed: embed,
           child: MultiProvider(
             providers: _providedControllers(offline: true),
             child: OfflineScreenBody(snapshotArgs, _screens),
           ),
         );
       },
-      appSizePageId: (_, __, ___, ____) {
+      appSizeScreenId: (_, __, args, ____) {
+        final embed = isEmbedded(args);
         return DevToolsScaffold.withChild(
           key: const Key('appsize'),
-          ideTheme: ideTheme,
+          embed: embed,
           child: MultiProvider(
             providers: _providedControllers(),
             child: const AppSizeBody(),
@@ -288,6 +290,8 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
       },
     };
   }
+
+  bool isEmbedded(Map<String, String?> args) => args['embed'] == 'true';
 
   Map<String, UrlParametersBuilder>? _routes;
 

--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -199,7 +199,7 @@ class _InitializerState extends State<Initializer>
     final routerDelegate = DevToolsRouterDelegate.of(context);
     Router.neglect(
       context,
-      () => routerDelegate.navigate(snapshotPageId, args),
+      () => routerDelegate.navigate(snapshotScreenId, args),
     );
   }
 

--- a/packages/devtools_app/lib/src/framework/landing_screen.dart
+++ b/packages/devtools_app/lib/src/framework/landing_screen.dart
@@ -348,7 +348,7 @@ class AppSizeToolingInstructions extends StatelessWidget {
       gac.landingScreen,
       gac.openAppSizeTool,
     );
-    DevToolsRouterDelegate.of(context).navigate(appSizePageId);
+    DevToolsRouterDelegate.of(context).navigate(appSizeScreenId);
   }
 }
 

--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -16,10 +16,10 @@ import 'primitives/utils.dart';
 ///
 /// This must be different to the AppSizeScreen ID which is also used in routing when
 /// cnnected to a VM to ensure they have unique URLs.
-const appSizePageId = 'appsize';
+const appSizeScreenId = 'appsize';
 
-const homePageId = '';
-const snapshotPageId = 'snapshot';
+const homeScreenId = '';
+const snapshotScreenId = 'snapshot';
 
 /// Represents a Page/route for a DevTools screen.
 class DevToolsRouteConfiguration {
@@ -196,7 +196,7 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     // Ensure we disconnect from any previously connected applications if we do
     // not have a vm service uri as a query parameter, unless we are loading an
     // offline file.
-    if (page != snapshotPageId && newArgs['uri'] == null) {
+    if (page != snapshotScreenId && newArgs['uri'] == null) {
       serviceManager.manuallyDisconnect();
     }
 
@@ -211,7 +211,7 @@ class DevToolsRouterDelegate extends RouterDelegate<DevToolsRouteConfiguration>
     required bool clearScreenParam,
   }) {
     navigate(
-      homePageId,
+      homeScreenId,
       {
         if (clearUriParam) 'uri': null,
         if (clearScreenParam) 'screen': null,


### PR DESCRIPTION
Cleans up a TODO to move the app bar code in scaffold.dart over to app_bar.dart, and cleans up a bug where we weren't applying the `embed` parameter to all `DevToolsScaffold` constructors. 