### PR TITLE
Reduce version bump codeowner spam

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -27,9 +27,9 @@ vm_developer/       @bkonyi
 # Tooling files
 /tool/              @CoderDake
 
-# DartDevtoolWorkflowBot added here to prevent other CODEOWNERS
-# from being added to auto generated dev bumps
-packages/devtools_app/lib/devtools.dart @DartDevtoolWorkflowBot
-packages/devtools_app/pubspec.yaml @DartDevtoolWorkflowBot
-packages/devtools_shared/pubspec.yaml @DartDevtoolWorkflowBot
-packages/devtools_test/pubspec.yaml @DartDevtoolWorkflowBot
+# Version bump files.
+# No owners to prevent auto update spam
+packages/devtools_app/lib/devtools.dart
+packages/devtools_app/pubspec.yaml
+packages/devtools_shared/pubspec.yaml
+packages/devtools_test/pubspec.yaml

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -26,3 +26,10 @@ vm_developer/       @bkonyi
 
 # Tooling files
 /tool/              @CoderDake
+
+# DartDevtoolWorkflowBot added here to prevent other CODEOWNERS
+# from being added to auto generated dev bumps
+packages/devtools_app/lib/devtools.dart @DartDevtoolWorkflowBot
+packages/devtools_app/pubspec.yaml @DartDevtoolWorkflowBot
+packages/devtools_shared/pubspec.yaml @DartDevtoolWorkflowBot
+packages/devtools_test/pubspec.yaml @DartDevtoolWorkflowBot

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -28,7 +28,7 @@ vm_developer/       @bkonyi
 /tool/              @CoderDake
 
 # Version bump files.
-# No owners to prevent auto update spam
+# No owners to prevent version update spam
 packages/devtools_app/lib/devtools.dart
 packages/devtools_app/pubspec.yaml
 packages/devtools_shared/pubspec.yaml


### PR DESCRIPTION
To avoid top level code-owners from being spammed, the CODEOWNERS are being removed for files involved in the version bumps. For example see[this auto bump PR](https://github.com/flutter/devtools/pull/5890/files)
After doing some research, it looks like it is possible to set files/directories so they have no owners. 

See[about-code-owners](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) which describes the situation as:
```
# In this example, @octocat owns any file in the `/apps`
# directory in the root of your repository except for the `/apps/github`
# subdirectory, as its owners are left empty.
/apps/ @octocat
/apps/github
```