### PR TITLE
Consolidate dcm-label paths

### DIFF
--- a/.github/workflows/dcm-label.yaml
+++ b/.github/workflows/dcm-label.yaml
@@ -9,13 +9,11 @@ on:
       - master
     paths:
       - "**/*.dart"
+      - "!packages/devtools_app/lib/devtools.dart"
 
 jobs:
   dcm-label-reminder:
     if: ${{ !contains(github.event.*.labels.*.name, 'run-dcm-workflow') }}
-    paths:
-      - "**/*.dart"
-      - "!packages/devtools_app/lib/devtools.dart"
     name: Prevent submission
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
![](https://media.giphy.com/media/MFTygNX8Vy0R8xwwpu/giphy-downsized.gif)

The paths in dcm-label.yml can be consolidated up into the `on:` setting.