### PR TITLE
Use `github.event.pull_request.head.sha` as PR reference in DCM workflow

### DIFF
--- a/.github/workflows/dcm.yaml
+++ b/.github/workflows/dcm.yaml
@@ -42,7 +42,7 @@ jobs:
       - name: Clone Flutter DevTools
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          ref: "${{ github.event.pull_request.sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
       - name: Load Cached Flutter SDK
         uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
         with:

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -44,7 +44,7 @@ jobs:
         id: checkout-pr-branch
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:
-          ref: "${{ github.event.pull_request.sha }}"
+          ref: "${{ github.event.pull_request.head.sha }}"
 
       # Otherwise use the default checkout action.
       - name: Checkout DevTools (default)


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/5886

Currently the DCM workflow is running against the last commit on the master branch, not on the PR branch

From reading https://github.com/orgs/community/discussions/25191#discussioncomment-3246770, I believe `github.event.pull_request.head.sha` is what we want.