### PR TITLE
Updating from 2.25.0 to 2.26.0-dev.0

### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -9,4 +9,4 @@
 // the constant declaration `const String version =`.
 // If you change the declaration you must also modify the regex in
 // tools/update_version.dart.
-const String version = '2.25.0';
+const String version = '2.26.0-dev.0';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.25.0
+version: 2.26.0-dev.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
@@ -24,7 +24,7 @@ dependencies:
   codicon: ^1.0.0
   collection: ^1.15.0
   dds_service_extensions: ^1.3.2
-  devtools_shared: 2.25.0
+  devtools_shared: 2.26.0-dev.0
   file: ^6.0.0
   file_selector: ^0.8.0
   file_selector_linux: ^0.0.2
@@ -64,7 +64,7 @@ dependencies:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  devtools_test: 2.25.0
+  devtools_test: 2.26.0-dev.0
   fake_async: ^1.3.1
   flutter_driver:
     sdk: flutter

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -1,49 +1,37 @@
 This is draft for future release notes, that are going to land on
 [the Flutter website](https://docs.flutter.dev/development/tools/devtools/release-notes).
 
-# DevTools 2.25.0 release notes
+# DevTools 2.26.0 release notes
 
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
-
-- Improve DevTools tab bar navigation when the list of tabs is long - [#5875](https://github.com/flutter/devtools/pull/5875)
-- Clear registered service methods between app connections - [#5960](https://github.com/flutter/devtools/pull/5960)
+TODO: Remove this section if there are not any general updates.
 
 ## Inspector updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## CPU profiler updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
-
-- Add legend for class types - [#5937](https://github.com/flutter/devtools/pull/5937)
-- Enable sampling for Memory > Profile - [#5947](https://github.com/flutter/devtools/pull/5947)
+TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## App size tool updates
-
 TODO: Remove this section if there are not any general updates.
 
 ## Full commit history
-
 More details about changes and fixes are available from the
 [DevTools git log.](https://github.com/flutter/devtools/commits/master).

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared structures between devtools_app, dds, and other tools.
 
-version: 2.25.0
+version: 2.26.0-dev.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 2.25.0
+version: 2.26.0-dev.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
@@ -18,8 +18,8 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: 2.25.0
-  devtools_app: 2.25.0
+  devtools_shared: 2.26.0-dev.0
+  devtools_app: 2.26.0-dev.0
   flutter:
     sdk: flutter
   flutter_test:


### PR DESCRIPTION
![](https://media.giphy.com/media/Pm08ZLlxa1mWttBOgt/giphy-downsized.gif)

The automatic version bumping workflow is currently broken, so I'm pushing up the dev bump manually for now.