### PR TITLE
Use `package:args` to parse integration test arguments

### DIFF
--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -10,33 +10,19 @@ import 'test_infra/run/run_test.dart';
 // To run integration tests, run the following from `devtools_app/`:
 // `dart run integration_test/run_tests.dart`
 //
-// Arguments that may be passed to this command:
-// --target=<path/to/test.dart> - this will run a single test at the path
-//    provided.
-// --test-app-uri=<some vm service uri> - this will connect DevTools to the app
-//    you specify instead of spinning up a test app inside
-//    [runFlutterIntegrationTest].
-// --update-goldens - this will update the current golden images with the
-//   results from this test run
-// --headless - this will run the integration test on the 'web-server' device
-//    instead of the 'chrome' device, meaning you will not be able to see the
-//    integration test run in Chrome when running locally.
+// To see a list of arguments that you can pass to this test script, please run
+// the above command with the '-h' flag.
 
 const _testDirectory = 'integration_test/test';
 const _testSuffix = '_test.dart';
 const _offlineIndicator = 'integration_test/test/offline';
 
-void main(List<String> testRunnerArgs) async {
-  final testTargetProvided = testRunnerArgs
-      .where((arg) => arg.startsWith(TestRunnerArgs.testTargetArg))
-      .isNotEmpty;
-
-  if (testTargetProvided) {
-    final args = TestRunnerArgs(testRunnerArgs);
-
+void main(List<String> args) async {
+  final testRunnerArgs = TestRunnerArgs(args, verifyValidTarget: false);
+  if (testRunnerArgs.testTarget != null) {
     // TODO(kenz): add support for specifying a directory as the target instead
     // of a single file.
-    await _runTest(args);
+    await _runTest(testRunnerArgs);
   } else {
     // Run all tests since a target test was not provided.
     final testDirectory = Directory(_testDirectory);
@@ -46,11 +32,11 @@ void main(List<String> testRunnerArgs) async {
 
     for (final testFile in testFiles) {
       final testTarget = testFile.path;
-      final args = TestRunnerArgs([
-        ...testRunnerArgs,
-        '${TestRunnerArgs.testTargetArg}$testTarget',
+      final newArgsWithTarget = TestRunnerArgs([
+        ...args,
+        '--${TestRunnerArgs.testTargetArg}=$testTarget',
       ]);
-      await _runTest(args);
+      await _runTest(newArgsWithTarget);
     }
   }
 }
@@ -58,7 +44,7 @@ void main(List<String> testRunnerArgs) async {
 Future<void> _runTest(
   TestRunnerArgs testRunnerArgs,
 ) async {
-  final testTarget = testRunnerArgs.testTarget;
+  final testTarget = testRunnerArgs.testTarget!;
   if (!testRunnerArgs.testAppDevice.supportsTest(testTarget)) {
     // Skip test, since it is not supported for device.
     return;

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -63,6 +63,7 @@ dependencies:
   # widget_icons: ^0.0.1
 
 dev_dependencies:
+  args: ^2.4.2
   build_runner: ^2.3.3
   devtools_test: 2.25.0
   fake_async: ^1.3.1


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4970