### PR TITLE
Start chromedriver once for running all integration tests

### DIFF
--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'test_infra/run/_chrome_driver.dart';
 import 'test_infra/run/_in_file_args.dart';
 import 'test_infra/run/run_test.dart';
 
@@ -18,26 +19,42 @@ const _testSuffix = '_test.dart';
 const _offlineIndicator = 'integration_test/test/offline';
 
 void main(List<String> args) async {
-  final testRunnerArgs = TestRunnerArgs(args, verifyValidTarget: false);
-  if (testRunnerArgs.testTarget != null) {
-    // TODO(kenz): add support for specifying a directory as the target instead
-    // of a single file.
-    await _runTest(testRunnerArgs);
-  } else {
-    // Run all tests since a target test was not provided.
-    final testDirectory = Directory(_testDirectory);
-    final testFiles = testDirectory
-        .listSync(recursive: true)
-        .where((testFile) => testFile.path.endsWith(_testSuffix));
+  Exception? exception;
+  final chromedriver = ChromeDriver();
 
-    for (final testFile in testFiles) {
-      final testTarget = testFile.path;
-      final newArgsWithTarget = TestRunnerArgs([
-        ...args,
-        '--${TestRunnerArgs.testTargetArg}=$testTarget',
-      ]);
-      await _runTest(newArgsWithTarget);
+  try {
+    // Start chrome driver before running the flutter integration test.
+    await chromedriver.start();
+
+    final testRunnerArgs = TestRunnerArgs(args, verifyValidTarget: false);
+    if (testRunnerArgs.testTarget != null) {
+      // TODO(kenz): add support for specifying a directory as the target instead
+      // of a single file.
+      await _runTest(testRunnerArgs);
+    } else {
+      // Run all tests since a target test was not provided.
+      final testDirectory = Directory(_testDirectory);
+      final testFiles = testDirectory
+          .listSync(recursive: true)
+          .where((testFile) => testFile.path.endsWith(_testSuffix));
+
+      for (final testFile in testFiles) {
+        final testTarget = testFile.path;
+        final newArgsWithTarget = TestRunnerArgs([
+          ...args,
+          '--${TestRunnerArgs.testTargetArg}=$testTarget',
+        ]);
+        await _runTest(newArgsWithTarget);
+      }
     }
+  } on Exception catch (e) {
+    exception = e;
+  } finally {
+    await chromedriver.stop();
+  }
+
+  if (exception != null) {
+    throw exception;
   }
 }
 

--- a/packages/devtools_app/integration_test/test_infra/run/_chrome_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_chrome_driver.dart
@@ -1,0 +1,37 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import '_io_utils.dart';
+import '_utils.dart';
+
+class ChromeDriver with IOMixin {
+  late final Process _process;
+
+  // TODO(kenz): add error messaging if the chromedriver executable is not
+  // found. We can also consider using web installers directly in this script:
+  // https://github.com/flutter/flutter/wiki/Running-Flutter-Driver-tests-with-Web#web-installers-repo.
+  Future<void> start() async {
+    try {
+      debugLog('starting the chromedriver process');
+      _process = await Process.start(
+        'chromedriver',
+        [
+          '--port=4444',
+        ],
+      );
+      listenToProcessOutput(_process, printTag: 'ChromeDriver');
+    } catch (e) {
+      // ignore: avoid-throw-in-catch-block, by design
+      throw Exception('Error starting chromedriver: $e');
+    }
+  }
+
+  Future<void> stop() async {
+    await cancelAllStreamSubscriptions();
+    debugLog('killing the chromedriver process');
+    _process.kill();
+  }
+}

--- a/packages/devtools_app/integration_test/test_infra/run/_utils.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_utils.dart
@@ -1,0 +1,13 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// ignore_for_file: avoid_print
+
+bool debugTestScript = false;
+
+void debugLog(String log) {
+  if (debugTestScript) {
+    print(log);
+  }
+}


### PR DESCRIPTION
This appears to have shaved a few minutes off the total integration test run time. We will still need to investigate how we can shard them.

Work towards https://github.com/flutter/devtools/issues/5938