### PR TITLE
Add Dart CLI test target to integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
       matrix:
         bot:
           # Consider running integration tests in ddc mode, too.
-          - integration_dart2js
+          - dart2js
         device:
           - flutter
           - flutter-web

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -103,7 +103,7 @@ jobs:
           path: packages/devtools_app/test/**/failures/*.png
 
   integration-test:
-    name: integration-test ${{ matrix.bot }}
+    name: integration-test ${{ matrix.bot }} - ${{ matrix.device }}
     needs: flutter-prep
     runs-on: macos-latest
     strategy:
@@ -112,6 +112,10 @@ jobs:
         bot:
           # Consider running integration tests in ddc mode, too.
           - integration_dart2js
+        device:
+          - flutter
+          - flutter-web
+          - dart-cli
     steps:
       - name: git clone
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
@@ -124,6 +128,7 @@ jobs:
       - name: tool/bots.sh
         env:
           BOT: ${{ matrix.bot }}
+          DEVICE: ${{ matrix.device }}
         run: ./tool/bots.sh
 
       - name: Upload Golden Failure Artifacts

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -19,6 +19,12 @@ const _testSuffix = '_test.dart';
 const _offlineIndicator = 'integration_test/test/offline';
 
 void main(List<String> args) async {
+  final testRunnerArgs = TestRunnerArgs(args, verifyValidTarget: false);
+  if (testRunnerArgs.help) {
+    testRunnerArgs.printHelp();
+    return;
+  }
+
   Exception? exception;
   final chromedriver = ChromeDriver();
 
@@ -26,7 +32,6 @@ void main(List<String> args) async {
     // Start chrome driver before running the flutter integration test.
     await chromedriver.start();
 
-    final testRunnerArgs = TestRunnerArgs(args, verifyValidTarget: false);
     if (testRunnerArgs.testTarget != null) {
       // TODO(kenz): add support for specifying a directory as the target instead
       // of a single file.
@@ -69,7 +74,7 @@ Future<void> _runTest(
 
   await runFlutterIntegrationTest(
     testRunnerArgs,
-    TestFileArgs(testTarget),
+    TestFileArgs(testTarget, testAppDevice: testRunnerArgs.testAppDevice),
     offline: testTarget.startsWith(_offlineIndicator),
   );
 }

--- a/packages/devtools_app/integration_test/test_infra/run/_chrome_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_chrome_driver.dart
@@ -32,6 +32,6 @@ class ChromeDriver with IOMixin {
   Future<void> stop() async {
     await cancelAllStreamSubscriptions();
     debugLog('killing the chromedriver process');
-    _process.kill();
+    await killGracefully(_process);
   }
 }

--- a/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_in_file_args.dart
@@ -7,32 +7,47 @@
 import 'dart:convert';
 import 'dart:io';
 
+import '_test_app_driver.dart';
+
 enum TestFileArgItems {
   experimentsOn,
   appPath,
 }
 
+const _defaultFlutterAppPath = 'test/test_infra/fixtures/flutter_app';
+const _defaultDartCliAppPath = 'test/test_infra/fixtures/empty_app.dart';
+
 /// Test arguments, defined inside the test file as a comment.
 class TestFileArgs {
-  factory TestFileArgs(String testFilePath) {
+  factory TestFileArgs(
+    String testFilePath, {
+    required TestAppDevice testAppDevice,
+  }) {
     final content = File(testFilePath).readAsStringSync();
-    return TestFileArgs.fromFileContent(content);
+    return TestFileArgs.fromFileContent(content, testAppDevice: testAppDevice);
   }
 
-  factory TestFileArgs.fromFileContent(String fileContent) {
+  factory TestFileArgs.fromFileContent(
+    String fileContent, {
+    required TestAppDevice testAppDevice,
+  }) {
     final testFileArgItems = _parseFileContent(fileContent);
 
     for (final arg in testFileArgItems.keys) {
       testFileArgItems.putIfAbsent(arg, () => null);
     }
 
-    return TestFileArgs.parse(testFileArgItems);
+    return TestFileArgs.parse(testFileArgItems, testAppDevice: testAppDevice);
   }
 
-  TestFileArgs.parse(Map<TestFileArgItems, dynamic> map)
-      : experimentsOn = map[TestFileArgItems.experimentsOn] ?? false,
+  TestFileArgs.parse(
+    Map<TestFileArgItems, dynamic> map, {
+    required TestAppDevice testAppDevice,
+  })  : experimentsOn = map[TestFileArgItems.experimentsOn] ?? false,
         appPath = map[TestFileArgItems.appPath] ??
-            'test/test_infra/fixtures/flutter_app';
+            (testAppDevice == TestAppDevice.cli
+                ? _defaultDartCliAppPath
+                : _defaultFlutterAppPath);
 
   /// If true, experiments will be enabled in the test.
   final bool experimentsOn;

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -8,17 +8,18 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
+
 import '_io_utils.dart';
-import 'run_test.dart';
+import '_utils.dart';
 
-// Set this to true for debugging to get JSON written to stdout.
-const bool _printDebugOutputToStdOut = false;
-
-class TestFlutterApp extends _TestApp {
+class TestFlutterApp extends IntegrationTestApp {
   TestFlutterApp({
     String appPath = 'test/test_infra/fixtures/flutter_app',
     TestAppDevice appDevice = TestAppDevice.flutterTester,
   }) : super(appPath, appDevice);
+
+  String? _currentRunningAppId;
 
   @override
   Future<void> startProcess() async {
@@ -33,79 +34,19 @@ class TestFlutterApp extends _TestApp {
       workingDirectory: testAppPath,
     );
   }
-}
 
-// TODO(kenz): implement for running integration tests against a Dart CLI app.
-class TestDartCliApp {}
-
-abstract class _TestApp with IOMixin {
-  _TestApp(this.testAppPath, this.testAppDevice);
-
-  static const _appStartTimeout = Duration(seconds: 120);
-
-  static const _defaultTimeout = Duration(seconds: 40);
-
-  static const _quitTimeout = Duration(seconds: 10);
-
-  /// The path relative to the 'devtools_app' directory where the test app
-  /// lives.
-  ///
-  /// This will either be a file path or a directory path depending on the type
-  /// of app.
-  final String testAppPath;
-
-  /// The device the test app should run on, e.g. flutter-tester, chrome.
-  final TestAppDevice testAppDevice;
-
-  late Process? runProcess;
-
-  late int runProcessId;
-
-  final _allMessages = StreamController<String>.broadcast();
-
-  Uri get vmServiceUri => _vmServiceWsUri;
-  late Uri _vmServiceWsUri;
-
-  String? _currentRunningAppId;
-
-  Future<void> startProcess();
-
-  Future<void> start() async {
-    await startProcess();
-    assert(
-      runProcess != null,
-      '\'runProcess\' cannot be null. Assign \'runProcess\' inside the '
-      '\'startProcess\' method.',
-    );
-
-    // This class doesn't use the result of the future. It's made available
-    // via a getter for external uses.
-    unawaited(
-      runProcess!.exitCode.then((int code) {
-        _debugPrint('Process exited ($code)');
-      }),
-    );
-
-    listenToProcessOutput(runProcess!, printCallback: _debugPrint);
-
-    // Stash the PID so that we can terminate the VM more reliably than using
-    // proc.kill() (because proc is a shell, because `flutter` is a shell
-    // script).
-    final connected =
-        await waitFor(event: FlutterDaemonConstants.daemonConnected.key);
-    runProcessId = (connected[FlutterDaemonConstants.params.key]!
-        as Map<String, Object?>)[FlutterDaemonConstants.pid.key] as int;
-
+  @override
+  Future<void> waitForAppStart() async {
     // Set this up now, but we don't await it yet. We want to make sure we don't
     // miss it while waiting for debugPort below.
     final started = waitFor(
       event: FlutterDaemonConstants.appStarted.key,
-      timeout: _appStartTimeout,
+      timeout: IntegrationTestApp._appStartTimeout,
     );
 
     final debugPort = await waitFor(
       event: FlutterDaemonConstants.appDebugPort.key,
-      timeout: _appStartTimeout,
+      timeout: IntegrationTestApp._appStartTimeout,
     );
     final wsUriString = (debugPort[FlutterDaemonConstants.params.key]!
         as Map<String, Object?>)[FlutterDaemonConstants.wsUri.key] as String;
@@ -123,34 +64,32 @@ abstract class _TestApp with IOMixin {
     _currentRunningAppId = params[FlutterDaemonConstants.appId.key] as String?;
   }
 
-  Future<int> stop() async {
+  @override
+  Future<void> manuallyStopApp() async {
     if (_currentRunningAppId != null) {
       _debugPrint('Stopping app');
       await Future.any<void>(<Future<void>>[
         runProcess!.exitCode,
-        _sendRequest(
+        _sendFlutterDaemonRequest(
           'app.stop',
           <String, dynamic>{'appId': _currentRunningAppId},
         ),
       ]).timeout(
-        _quitTimeout,
+        IOMixin.killTimeout,
         onTimeout: () {
-          _debugPrint('app.stop did not return within $_quitTimeout');
+          _debugPrint('app.stop did not return within ${IOMixin.killTimeout}');
         },
       );
       _currentRunningAppId = null;
     }
-
-    _debugPrint('Waiting for process to end');
-    return runProcess!.exitCode.timeout(
-      _quitTimeout,
-      onTimeout: _killGracefully,
-    );
   }
 
   int _requestId = 1;
   // ignore: avoid-dynamic, dynamic by design.
-  Future<dynamic> _sendRequest(String method, dynamic params) async {
+  Future<dynamic> _sendFlutterDaemonRequest(
+    String method,
+    Object? params,
+  ) async {
     final int requestId = _requestId++;
     final Map<String, dynamic> request = <String, dynamic>{
       'id': requestId,
@@ -175,22 +114,6 @@ abstract class _TestApp with IOMixin {
     }
 
     return response['result'];
-  }
-
-  Future<int> _killGracefully() async {
-    _debugPrint('Sending SIGTERM to $runProcessId..');
-    await cancelAllStreamSubscriptions();
-    Process.killPid(runProcessId);
-    return runProcess!.exitCode
-        .timeout(_quitTimeout, onTimeout: _killForcefully);
-  }
-
-  Future<int> _killForcefully() {
-    // Use sigint here instead of sigkill. See
-    // https://github.com/flutter/flutter/issues/117415.
-    _debugPrint('Sending SIGINT to $runProcessId..');
-    Process.killPid(runProcessId, ProcessSignal.sigint);
-    return runProcess!.exitCode;
   }
 
   Future<Map<String, Object?>> waitFor({
@@ -260,6 +183,83 @@ abstract class _TestApp with IOMixin {
     }
   }
 
+  Map<String, Object?>? _parseFlutterResponse(String line) {
+    if (line.startsWith('[') && line.endsWith(']')) {
+      try {
+        final Map<String, Object?>? resp = json.decode(line)[0];
+        return resp;
+      } catch (e) {
+        // Not valid JSON, so likely some other output that was surrounded by [brackets]
+        return null;
+      }
+    }
+    return null;
+  }
+}
+
+abstract class IntegrationTestApp with IOMixin {
+  IntegrationTestApp(this.testAppPath, this.testAppDevice);
+
+  static const _appStartTimeout = Duration(seconds: 120);
+
+  static const _defaultTimeout = Duration(seconds: 40);
+
+  /// The path relative to the 'devtools_app' directory where the test app
+  /// lives.
+  ///
+  /// This will either be a file path or a directory path depending on the type
+  /// of app.
+  final String testAppPath;
+
+  /// The device the test app should run on, e.g. flutter-tester, chrome.
+  final TestAppDevice testAppDevice;
+
+  late Process? runProcess;
+
+  int get runProcessId => runProcess!.pid;
+
+  final _allMessages = StreamController<String>.broadcast();
+
+  Uri get vmServiceUri => _vmServiceWsUri;
+  late Uri _vmServiceWsUri;
+
+  Future<void> startProcess();
+
+  Future<void> waitForAppStart();
+
+  Future<void> manuallyStopApp() async {}
+
+  Future<void> start() async {
+    await startProcess();
+    assert(
+      runProcess != null,
+      '\'runProcess\' cannot be null. Assign \'runProcess\' inside the '
+      '\'startProcess\' method.',
+    );
+    _debugPrint('process started (pid $runProcessId)');
+
+    // This class doesn't use the result of the future. It's made available
+    // via a getter for external uses.
+    unawaited(
+      runProcess!.exitCode.then((int code) {
+        _debugPrint('Process exited ($code)');
+      }),
+    );
+
+    listenToProcessOutput(runProcess!, printCallback: _debugPrint);
+
+    await waitForAppStart();
+  }
+
+  Future<int> stop({Future<int>? onTimeout}) async {
+    await manuallyStopApp();
+    _debugPrint('Waiting for process to end');
+    return runProcess!.exitCode.timeout(
+      IOMixin.killTimeout,
+      onTimeout: () => killGracefully(runProcess!),
+    );
+  }
+
   Future<T> _timeoutWithMessages<T>(
     Future<T> Function() f, {
     Duration? timeout,
@@ -287,25 +287,12 @@ abstract class _TestApp with IOMixin {
     }).whenComplete(() => sub.cancel());
   }
 
-  Map<String, Object?>? _parseFlutterResponse(String line) {
-    if (line.startsWith('[') && line.endsWith(']')) {
-      try {
-        final Map<String, Object?>? resp = json.decode(line)[0];
-        return resp;
-      } catch (e) {
-        // Not valid JSON, so likely some other output that was surrounded by [brackets]
-        return null;
-      }
-    }
-    return null;
-  }
-
   String _debugPrint(String msg) {
     const maxLength = 500;
     final truncatedMsg =
         msg.length > maxLength ? '${msg.substring(0, maxLength)}...' : msg;
     _allMessages.add(truncatedMsg);
-    if (_printDebugOutputToStdOut) {
+    if (debugTestScript) {
       print('_TestApp - $truncatedMsg');
     }
     return msg;
@@ -352,4 +339,116 @@ enum FlutterDaemonConstants {
   final String? _nameOverride;
 
   String get key => _nameOverride ?? name;
+}
+
+class TestDartCliApp extends IntegrationTestApp {
+  TestDartCliApp({
+    String appPath = 'test/test_infra/fixtures/empty_app.dart',
+  }) : super(appPath, TestAppDevice.cli);
+
+  static const vmServicePrefix = 'The Dart VM service is listening on ';
+
+  @override
+  Future<void> startProcess() async {
+    runProcess = await Process.start(
+      'dart',
+      [
+        '--observe',
+        'run',
+        testAppPath.split('/').last,
+      ],
+      workingDirectory: testAppPath,
+    );
+  }
+
+  @override
+  Future<void> waitForAppStart() async {
+    final vmServiceUri = await waitFor(
+      message: vmServicePrefix,
+      timeout: IntegrationTestApp._appStartTimeout,
+    );
+    final parsedVmServiceUri = Uri.parse(vmServiceUri);
+
+    // Map to WS URI.
+    _vmServiceWsUri =
+        convertToWebSocketUrl(serviceProtocolUrl: parsedVmServiceUri);
+  }
+
+  Future<String> waitFor({required String message, Duration? timeout}) {
+    final response = Completer<String>();
+    late StreamSubscription<String> sub;
+    sub = stdoutController.stream.listen(
+      (String line) => _handleStdout(
+        line,
+        subscription: sub,
+        response: response,
+        message: message,
+      ),
+    );
+
+    return _timeoutWithMessages<String>(
+      () => response.future,
+      timeout: timeout,
+      message: 'Did not receive expected message: $message.',
+    ).whenComplete(() => sub.cancel());
+  }
+
+  void _handleStdout(
+    String line, {
+    required StreamSubscription<String> subscription,
+    required Completer<String> response,
+    required String message,
+  }) async {
+    if (message == vmServicePrefix && line.startsWith(vmServicePrefix)) {
+      final vmServiceUri = line
+          .substring(line.indexOf(vmServicePrefix) + vmServicePrefix.length);
+      await subscription.cancel();
+      response.complete(vmServiceUri);
+    }
+  }
+}
+
+enum TestAppDevice {
+  flutterTester('flutter-tester'),
+  flutterChrome('chrome'),
+  cli('cli');
+
+  const TestAppDevice(this.argName);
+
+  final String argName;
+
+  /// A mapping of test app device to the unsupported tests for that device.
+  static final _unsupportedTestsForDevice = <TestAppDevice, List<String>>{
+    TestAppDevice.flutterTester: [],
+    TestAppDevice.flutterChrome: [
+      // TODO(https://github.com/flutter/devtools/issues/5874): Remove once supported on web.
+      'eval_and_browse_test.dart',
+      'perfetto_test.dart',
+      'performance_screen_event_recording_test.dart',
+      'service_connection_test.dart',
+    ],
+    TestAppDevice.cli: [
+      'debugger_panel_test.dart',
+      'eval_and_browse_test.dart',
+      'perfetto_test.dart',
+      'performance_screen_event_recording_test.dart',
+      'service_connection_test.dart',
+    ],
+  };
+
+  static final _argNameToDeviceMap =
+      TestAppDevice.values.fold(<String, TestAppDevice>{}, (map, device) {
+    map[device.argName] = device;
+    return map;
+  });
+
+  static TestAppDevice? fromArgName(String argName) {
+    return _argNameToDeviceMap[argName];
+  }
+
+  bool supportsTest(String testPath) {
+    final unsupportedTests = _unsupportedTestsForDevice[this] ?? [];
+    return unsupportedTests
+        .none((unsupportedTestPath) => testPath.endsWith(unsupportedTestPath));
+  }
 }

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -350,14 +350,18 @@ class TestDartCliApp extends IntegrationTestApp {
 
   @override
   Future<void> startProcess() async {
+    const separator = '/';
+    final parts = testAppPath.split(separator);
+    final scriptName = parts.removeLast();
+    final workingDir = parts.join(separator);
     runProcess = await Process.start(
       'dart',
       [
         '--observe',
         'run',
-        testAppPath.split('/').last,
+        scriptName,
       ],
-      workingDirectory: testAppPath,
+      workingDirectory: workingDir,
     );
   }
 

--- a/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
+++ b/packages/devtools_app/test/integration_test_infra/in_file_args_test.dart
@@ -5,19 +5,44 @@
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../integration_test/test_infra/run/_in_file_args.dart';
+import '../../integration_test/test_infra/run/_test_app_driver.dart';
 
 const _testAppPath = 'test/test_infra/fixtures/memory_app';
 
-final _defaultArgs = TestFileArgs.parse({});
+final _defaultArgs = TestFileArgs.parse(
+  {},
+  testAppDevice: TestAppDevice.flutterTester,
+);
+
+final _defaultArgsForCliDevice = TestFileArgs.parse(
+  {},
+  testAppDevice: TestAppDevice.cli,
+);
 
 final tests = [
   _InFileTestArgsTest(
     name: 'empty',
     input: '',
-    output: TestFileArgs.parse({
-      TestFileArgItems.experimentsOn: _defaultArgs.experimentsOn,
-      TestFileArgItems.appPath: _defaultArgs.appPath,
-    }),
+    testAppDevice: TestAppDevice.flutterTester,
+    output: TestFileArgs.parse(
+      {
+        TestFileArgItems.experimentsOn: _defaultArgs.experimentsOn,
+        TestFileArgItems.appPath: _defaultArgs.appPath,
+      },
+      testAppDevice: TestAppDevice.flutterTester,
+    ),
+  ),
+  _InFileTestArgsTest(
+    name: 'empty',
+    input: '',
+    testAppDevice: TestAppDevice.cli,
+    output: TestFileArgs.parse(
+      {
+        TestFileArgItems.experimentsOn: _defaultArgsForCliDevice.experimentsOn,
+        TestFileArgItems.appPath: _defaultArgsForCliDevice.appPath,
+      },
+      testAppDevice: TestAppDevice.cli,
+    ),
   ),
   _InFileTestArgsTest(
     name: 'non-empty',
@@ -33,17 +58,24 @@ final tests = [
 
 import 'dart:ui' as ui;
 ''',
-    output: TestFileArgs.parse({
-      TestFileArgItems.experimentsOn: true,
-      TestFileArgItems.appPath: _testAppPath,
-    }),
+    testAppDevice: TestAppDevice.flutterTester,
+    output: TestFileArgs.parse(
+      {
+        TestFileArgItems.experimentsOn: true,
+        TestFileArgItems.appPath: _testAppPath,
+      },
+      testAppDevice: TestAppDevice.flutterTester,
+    ),
   ),
 ];
 
 void main() {
   for (final t in tests) {
     test('$TestFileArgs, ${t.name}', () {
-      final args = TestFileArgs.fromFileContent(t.input);
+      final args = TestFileArgs.fromFileContent(
+        t.input,
+        testAppDevice: t.testAppDevice,
+      );
       expect(args.experimentsOn, t.output.experimentsOn);
       expect(args.appPath, t.output.appPath);
     });
@@ -54,10 +86,12 @@ class _InFileTestArgsTest {
   _InFileTestArgsTest({
     required this.name,
     required this.input,
+    required this.testAppDevice,
     required this.output,
   });
 
   final String name;
   final String input;
+  final TestAppDevice testAppDevice;
   final TestFileArgs output;
 }

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -138,7 +138,7 @@ elif [[ "$BOT" == "test_ddc" || "$BOT" == "test_dart2js" ]]; then
 # elif [ "$BOT" = "integration_ddc" ]; then
 
 # TODO(https://github.com/flutter/devtools/issues/1987): rewrite legacy integration tests.
-elif [ "$BOT" = "integration_dart2js" ]; then
+elif [ "$BOT" = "dart2js" ]; then
 
     flutter pub get
 

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -137,6 +137,7 @@ elif [[ "$BOT" == "test_ddc" || "$BOT" == "test_dart2js" ]]; then
 # for a DDC build of DevTools
 # elif [ "$BOT" = "integration_ddc" ]; then
 
+# TODO(https://github.com/flutter/devtools/issues/1987): rewrite legacy integration tests.
 elif [ "$BOT" = "integration_dart2js" ]; then
 
     flutter pub get
@@ -149,11 +150,19 @@ https://github.com/flutter/flutter/issues/118470). Run the test locally to see i
 images under a 'failures/' directory are created as a result of the test run:\n\
 $ dart run integration_test/run_tests.dart --headless"
 
-    # TODO(https://github.com/flutter/devtools/issues/1987): rewrite integration tests.
-    dart run integration_test/run_tests.dart --headless
+    if [ "$DEVICE" = "flutter" ]; then
 
-    # Run the supported integration tests connected to a web device.
-    dart run integration_test/run_tests.dart --test-app-device=chrome --headless
+        dart run integration_test/run_tests.dart --headless
+
+    elif [ "$DEVICE" = "flutter-web" ]; then
+
+        dart run integration_test/run_tests.dart --test-app-device=chrome --headless
+
+    elif [ "$DEVICE" = "dart-cli" ]; then
+
+        dart run integration_test/run_tests.dart --test-app-device=cli --headless
+
+    fi
 fi
 
 popd


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/5953. 

This PR also creates a separate job for integration tests of each type (flutter, flutter-web, and dart-cli). This will help with runtime some (reduces the longest run from 40 min to 27 - https://github.com/flutter/devtools/issues/5938), but the tests for each job will likely still need to be split into shards as the number grows.