### PR TITLE
Stop logging http to timeline by default and warn users about memory implications

### DIFF
--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -11,6 +11,7 @@ import '../screens/debugger/breakpoint_manager.dart';
 import '../service/service.dart';
 import '../service/service_manager.dart';
 import '../service/vm_service_wrapper.dart';
+import '../shared/banner_messages.dart';
 import '../shared/console/eval/eval_service.dart';
 import '../shared/framework_controller.dart';
 import '../shared/globals.dart';
@@ -36,6 +37,7 @@ class FrameworkCore {
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(ScriptManager, ScriptManager());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
     setGlobal(BreakpointManager, BreakpointManager());
     setGlobal(EvalService, EvalService());
   }

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -303,82 +303,79 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
     );
     final theme = Theme.of(context);
 
-    return Provider<BannerMessagesController>(
-      create: (_) => BannerMessagesController(),
-      child: Provider<ImportController>.value(
-        value: _importController,
-        builder: (context, _) {
-          final showConsole = serviceManager.connectedAppInitialized &&
-              !offlineController.offlineMode.value &&
-              _currentScreen.showConsole(widget.embed);
+    return Provider<ImportController>.value(
+      value: _importController,
+      builder: (context, _) {
+        final showConsole = serviceManager.connectedAppInitialized &&
+            !offlineController.offlineMode.value &&
+            _currentScreen.showConsole(widget.embed);
 
-          return DragAndDrop(
-            handleDrop: _importController.importData,
-            child: Title(
-              title: scaffoldTitle,
-              // Color is a required parameter but the color only appears to
-              // matter on Android and we do not care about Android.
-              // Using theme.primaryColor matches the default behavior of the
-              // title used by [WidgetsApp].
-              color: theme.primaryColor.withAlpha(255),
-              child: KeyboardShortcuts(
-                keyboardShortcuts: _currentScreen.buildKeyboardShortcuts(
-                  context,
-                ),
-                child: Scaffold(
-                  appBar: widget.embed
-                      ? null
-                      : PreferredSize(
-                          preferredSize: Size.fromHeight(defaultToolbarHeight),
-                          // Place the AppBar inside of a Hero widget to keep it the same across
-                          // route transitions.
-                          child: Hero(
-                            tag: _appBarTag,
-                            child: DevToolsAppBar(
-                              tabController: _tabController,
-                              title: scaffoldTitle,
-                              screens: widget.screens,
-                              actions: widget.actions,
-                            ),
+        return DragAndDrop(
+          handleDrop: _importController.importData,
+          child: Title(
+            title: scaffoldTitle,
+            // Color is a required parameter but the color only appears to
+            // matter on Android and we do not care about Android.
+            // Using theme.primaryColor matches the default behavior of the
+            // title used by [WidgetsApp].
+            color: theme.primaryColor.withAlpha(255),
+            child: KeyboardShortcuts(
+              keyboardShortcuts: _currentScreen.buildKeyboardShortcuts(
+                context,
+              ),
+              child: Scaffold(
+                appBar: widget.embed
+                    ? null
+                    : PreferredSize(
+                        preferredSize: Size.fromHeight(defaultToolbarHeight),
+                        // Place the AppBar inside of a Hero widget to keep it the same across
+                        // route transitions.
+                        child: Hero(
+                          tag: _appBarTag,
+                          child: DevToolsAppBar(
+                            tabController: _tabController,
+                            title: scaffoldTitle,
+                            screens: widget.screens,
+                            actions: widget.actions,
                           ),
                         ),
-                  body: OutlineDecoration.onlyTop(
-                    child: Padding(
-                      padding: widget.appPadding,
-                      child: showConsole
-                          ? Split(
-                              axis: Axis.vertical,
-                              splitters: [
-                                ConsolePaneHeader(
-                                  backgroundColor: theme.colorScheme.surface,
+                      ),
+                body: OutlineDecoration.onlyTop(
+                  child: Padding(
+                    padding: widget.appPadding,
+                    child: showConsole
+                        ? Split(
+                            axis: Axis.vertical,
+                            splitters: [
+                              ConsolePaneHeader(
+                                backgroundColor: theme.colorScheme.surface,
+                              ),
+                            ],
+                            initialFractions: const [0.8, 0.2],
+                            children: [
+                              Padding(
+                                padding: const EdgeInsets.only(
+                                  bottom: intermediateSpacing,
                                 ),
-                              ],
-                              initialFractions: const [0.8, 0.2],
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.only(
-                                    bottom: intermediateSpacing,
-                                  ),
-                                  child: content,
-                                ),
-                                RoundedOutlinedBorder.onlyBottom(
-                                  child: const ConsolePane(),
-                                ),
-                              ],
-                            )
-                          : content,
-                    ),
+                                child: content,
+                              ),
+                              RoundedOutlinedBorder.onlyBottom(
+                                child: const ConsolePane(),
+                              ),
+                            ],
+                          )
+                        : content,
                   ),
-                  bottomNavigationBar: StatusLine(
-                    currentScreen: _currentScreen,
-                    isEmbedded: widget.embed,
-                  ),
+                ),
+                bottomNavigationBar: StatusLine(
+                  currentScreen: _currentScreen,
+                  isEmbedded: widget.embed,
                 ),
               ),
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/framework/connected/connected_screen_body.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/connected/connected_screen_body.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../shared/banner_messages.dart';
+import '../../../../shared/http/http_service.dart' as http_service;
 import '../../../../shared/primitives/auto_dispose.dart';
 import '../../../../shared/primitives/simple_items.dart';
 import '../../../../shared/theme.dart';
@@ -46,7 +47,13 @@ class _ConnectedMemoryBodyState extends State<ConnectedMemoryBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     maybePushDebugModeMemoryMessage(context, ScreenMetaData.memory.id);
+    maybePushHttpLoggingMessage(context, ScreenMetaData.memory.id);
+
     if (!initController()) return;
+
+    addAutoDisposeListener(http_service.httpLoggingState, () {
+      maybePushHttpLoggingMessage(context, ScreenMetaData.memory.id);
+    });
 
     final vmChartController = VMChartController(controller);
     _chartController = MemoryChartPaneController(

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../../../../framework/scaffold.dart';
 import '../../../../shared/analytics/analytics.dart' as ga;
@@ -115,7 +114,7 @@ class _FlutterFramesChartState extends State<_FlutterFramesChart> {
         Duration.zero,
         (prev, frame) => prev + frame.shaderDuration,
       );
-      Provider.of<BannerMessagesController>(context).addMessage(
+      bannerMessages.addMessage(
         ShaderJankMessage(
           offlineController.offlineMode.value
               ? SimpleScreen.id

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -13,7 +13,6 @@ import '../../../../shared/analytics/constants.dart' as gac;
 import '../../../../shared/analytics/metrics.dart';
 import '../../../../shared/future_work_tracker.dart';
 import '../../../../shared/globals.dart';
-import '../../../../shared/http/http_service.dart' as http_service;
 import '../../../../shared/primitives/auto_dispose.dart';
 import '../../../../shared/primitives/trace_event.dart';
 import '../../../../shared/primitives/utils.dart';
@@ -83,16 +82,6 @@ class TimelineEventsController extends PerformanceFeatureController
       ValueNotifier<EventsControllerStatus>(EventsControllerStatus.empty);
 
   final _workTracker = FutureWorkTracker();
-
-  // TODO(jacobr): this isn't accurate. Another page of DevTools
-  // or a different instance of DevTools could change this value. We need to
-  // sync the value with the server like we do for other vm service extensions
-  // that we track with the vm service extension manager.
-  // See https://github.com/dart-lang/sdk/issues/41823.
-  /// Whether http timeline logging is enabled.
-  ValueListenable<bool> get httpTimelineLoggingEnabled =>
-      _httpTimelineLoggingEnabled;
-  final _httpTimelineLoggingEnabled = ValueNotifier<bool>(false);
 
   Timer? _pollingTimer;
 
@@ -481,11 +470,6 @@ class TimelineEventsController extends PerformanceFeatureController
     if (event != null) {
       frame.setEventFlow(event, type: type);
     }
-  }
-
-  Future<void> toggleHttpRequestLogging(bool state) async {
-    await http_service.toggleHttpRequestLogging(state);
-    _httpTimelineLoggingEnabled.value = state;
   }
 
   Future<void> toggleUseLegacyTraceViewer(bool? value) async {

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -135,7 +135,6 @@ class TimelineEventsController extends PerformanceFeatureController
 
   Future<void> _initForServiceConnection() async {
     await serviceManager.timelineStreamManager.setDefaultTimelineStreams();
-    await toggleHttpRequestLogging(true);
 
     autoDisposeStreamSubscription(
       serviceManager.onConnectionClosed.listen((_) {

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -183,7 +183,8 @@ class _TraceCategoriesDialogState extends State<TraceCategoriesDialog>
   void initState() {
     super.initState();
     // Mirror the value of [http_service.httpLoggingState] in the [_httpLogging]
-    // so that we can use [_httpLogging] for the [CheckboxSetting] widget below.
+    // notifier so that we can use [_httpLogging] for the [CheckboxSetting]
+    // widget below.
     _httpLogging = ValueNotifier<bool>(http_service.httpLoggingEnabled);
     addAutoDisposeListener(http_service.httpLoggingState, () {
       _httpLogging.value = http_service.httpLoggingState.value.enabled;

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -64,7 +64,6 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     maybePushUnsupportedFlutterVersionWarning(
-      context,
       PerformanceScreen.id,
       supportedFlutterVersion: SemanticVersion(
         major: 2,

--- a/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
+++ b/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
@@ -7,12 +7,12 @@ import 'dart:async';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:provider/provider.dart' as provider show Provider;
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/banner_messages.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/dialogs.dart';
+import '../../shared/globals.dart';
 import '../../shared/primitives/simple_items.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
@@ -98,7 +98,7 @@ class ProviderScreenBody extends ConsumerWidget {
         : '[No provider selected]';
 
     ref.listen<bool>(_hasErrorProvider, (_, hasError) {
-      if (hasError) showProviderErrorBanner(context);
+      if (hasError) showProviderErrorBanner();
     });
 
     return Split(
@@ -157,11 +157,8 @@ class ProviderScreenBody extends ConsumerWidget {
   }
 }
 
-void showProviderErrorBanner(BuildContext context) {
-  provider.Provider.of<BannerMessagesController>(
-    context,
-    listen: false,
-  ).addMessage(
+void showProviderErrorBanner() {
+  bannerMessages.addMessage(
     ProviderUnknownErrorBanner(screenId: ProviderScreen.id).build(),
   );
 }

--- a/packages/devtools_app/lib/src/shared/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/banner_messages.dart
@@ -391,7 +391,7 @@ class HttpLoggingEnabledMessage {
       textSpans: [
         const TextSpan(
           text: '''
-Http traffic is being logged for debugging purposes. This may result in increased memory usage for your app. If this is not intentional, consider ''',
+HTTP traffic is being logged for debugging purposes. This may result in increased memory usage for your app. If this is not intentional, consider ''',
         ),
         TextSpan(
           text: 'disabling http logging',

--- a/packages/devtools_app/lib/src/shared/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/banner_messages.dart
@@ -5,14 +5,15 @@
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 import '../screens/performance/performance_utils.dart';
 import 'analytics/constants.dart' as gac;
 import 'common_widgets.dart';
 import 'connected_app.dart';
 import 'globals.dart';
+import 'http/http_service.dart' as http_service;
 import 'primitives/utils.dart';
 import 'screen.dart';
 import 'theme.dart';
@@ -95,8 +96,7 @@ class BannerMessages extends StatelessWidget {
   // TODO(kenz): use an AnimatedList for message changes.
   @override
   Widget build(BuildContext context) {
-    final controller = Provider.of<BannerMessagesController>(context);
-    final messagesForScreen = controller.messagesForScreen(screen.screenId);
+    final messagesForScreen = bannerMessages.messagesForScreen(screen.screenId);
     return Column(
       children: [
         ValueListenableBuilder<List<BannerMessage>>(
@@ -181,10 +181,8 @@ class BannerMessage extends StatelessWidget {
                         ? colorScheme.onErrorContainer
                         : colorScheme.onWarningContainer,
                   ),
-                  onPressed: () => Provider.of<BannerMessagesController>(
-                    context,
-                    listen: false,
-                  ).removeMessage(this, dismiss: true),
+                  onPressed: () =>
+                      bannerMessages.removeMessage(this, dismiss: true),
                 ),
               ],
             ),
@@ -377,6 +375,47 @@ You are opting in to a high CPU sampling rate. This may affect the performance o
   }
 }
 
+class HttpLoggingEnabledMessage {
+  HttpLoggingEnabledMessage(this.screenId)
+      : key = Key('HttpLoggingEnabledMessage - $screenId');
+
+  final Key key;
+
+  final String screenId;
+
+  BannerMessage build(BuildContext context) {
+    final theme = Theme.of(context);
+    late final BannerWarning message;
+    message = BannerWarning(
+      key: key,
+      textSpans: [
+        const TextSpan(
+          text: '''
+Http traffic is being logged for debugging purposes. This may result in increased memory usage for your app. If this is not intentional, consider ''',
+        ),
+        TextSpan(
+          text: 'disabling http logging',
+          style: theme.warningMessageLinkStyle,
+          recognizer: TapGestureRecognizer()
+            ..onTap = () async {
+              await http_service.toggleHttpRequestLogging(false).then((_) {
+                if (!http_service.httpLoggingEnabled) {
+                  notificationService.push('Http logging disabled.');
+                  bannerMessages.removeMessage(message);
+                }
+              });
+            },
+        ),
+        const TextSpan(
+          text: ' before profiling the memory of your application.',
+        ),
+      ],
+      screenId: screenId,
+    );
+    return message;
+  }
+}
+
 class DebugModeMemoryMessage {
   const DebugModeMemoryMessage(this.screenId);
 
@@ -437,7 +476,6 @@ class UnsupportedFlutterVersionWarning {
 }
 
 void maybePushUnsupportedFlutterVersionWarning(
-  BuildContext context,
   String screenId, {
   required SemanticVersion supportedFlutterVersion,
 }) {
@@ -449,7 +487,7 @@ void maybePushUnsupportedFlutterVersionWarning(
   }
   final currentVersion = serviceManager.connectedApp!.flutterVersionNow!;
   if (currentVersion < supportedFlutterVersion) {
-    Provider.of<BannerMessagesController>(context).addMessage(
+    bannerMessages.addMessage(
       UnsupportedFlutterVersionWarning(
         screenId: screenId,
         currentFlutterVersion: currentVersion,
@@ -465,7 +503,7 @@ void maybePushDebugModePerformanceMessage(
 ) {
   if (offlineController.offlineMode.value) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
-    Provider.of<BannerMessagesController>(context).addMessage(
+    bannerMessages.addMessage(
       DebugModePerformanceMessage(screenId).build(context),
     );
   }
@@ -477,8 +515,18 @@ void maybePushDebugModeMemoryMessage(
 ) {
   if (offlineController.offlineMode.value) return;
   if (serviceManager.connectedApp?.isDebugFlutterAppNow ?? false) {
-    Provider.of<BannerMessagesController>(context)
-        .addMessage(DebugModeMemoryMessage(screenId).build(context));
+    bannerMessages.addMessage(DebugModeMemoryMessage(screenId).build(context));
+  }
+}
+
+void maybePushHttpLoggingMessage(
+  BuildContext context,
+  String screenId,
+) {
+  if (http_service.httpLoggingEnabled) {
+    bannerMessages.addMessage(
+      HttpLoggingEnabledMessage(screenId).build(context),
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/shared/globals.dart
+++ b/packages/devtools_app/lib/src/shared/globals.dart
@@ -5,6 +5,7 @@
 import '../extension_points/extensions_base.dart';
 import '../screens/debugger/breakpoint_manager.dart';
 import '../service/service_manager.dart';
+import '../shared/banner_messages.dart';
 import '../shared/notifications.dart';
 import 'config_specific/ide_theme/ide_theme.dart';
 import 'console/eval/eval_service.dart';
@@ -50,6 +51,9 @@ IdeTheme get ideTheme => globals[IdeTheme] as IdeTheme;
 
 NotificationService get notificationService =>
     globals[NotificationService] as NotificationService;
+
+BannerMessagesController get bannerMessages =>
+    globals[BannerMessagesController] as BannerMessagesController;
 
 BreakpointManager get breakpointManager =>
     globals[BreakpointManager] as BreakpointManager;

--- a/packages/devtools_app/lib/src/shared/http/http_service.dart
+++ b/packages/devtools_app/lib/src/shared/http/http_service.dart
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
+import '../../service/service_extension_manager.dart';
+import '../../service/service_extensions.dart' as extensions;
 import '../globals.dart';
 import '../primitives/utils.dart';
 
@@ -24,3 +30,10 @@ Future<void> toggleHttpRequestLogging(bool state) async {
     }
   });
 }
+
+bool get httpLoggingEnabled => httpLoggingState.value.enabled;
+
+ValueListenable<ServiceExtensionState> get httpLoggingState =>
+    serviceManager.serviceExtensionManager.getServiceExtensionState(
+      extensions.httpEnableTimelineLogging.extension,
+    );

--- a/packages/devtools_app/lib/src/shared/ui/vm_flag_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/ui/vm_flag_widgets.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
 import '../../screens/profiler/cpu_profile_service.dart';
@@ -52,14 +51,12 @@ class CpuSamplingRateDropdown extends StatelessWidget {
           unawaited(_onSamplingFrequencyChanged(safeValue));
         }
 
-        final bannerMessageController =
-            Provider.of<BannerMessagesController>(context);
         if (safeValue == highProfilePeriod) {
-          bannerMessageController.addMessage(
+          bannerMessages.addMessage(
             HighCpuSamplingRateMessage(screenId).build(context),
           );
         } else {
-          bannerMessageController.removeMessageByKey(
+          bannerMessages.removeMessageByKey(
             HighCpuSamplingRateMessage(screenId).key,
             screenId,
           );

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,7 +18,7 @@ TODO: Remove this section if there are not any general updates.
 TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
-TODO: Remove this section if there are not any general updates.
+* Warn users when Http logging may be affecting their app's memory consumption - [#5998](https://github.com/flutter/devtools/pull/5998)
 
 ## Debugger updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,7 +18,7 @@ TODO: Remove this section if there are not any general updates.
 TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
-* Warn users when Http logging may be affecting their app's memory consumption - [#5998](https://github.com/flutter/devtools/pull/5998)
+* Warn users when HTTP logging may be affecting their app's memory consumption - [#5998](https://github.com/flutter/devtools/pull/5998)
 
 ## Debugger updates
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -50,6 +50,7 @@ void main() {
     setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
     setGlobal(PreferencesController, PreferencesController());
     setGlobal(IdeTheme, IdeTheme());
     final mockScriptManager = MockScriptManager();

--- a/packages/devtools_app/test/memory/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory/memory_screen_test.dart
@@ -42,6 +42,10 @@ void main() {
     setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
     setGlobal(ServiceConnectionManager, fakeServiceManager);
     setGlobal(PreferencesController, PreferencesController());
+    setGlobal(OfflineModeController, OfflineModeController());
+    setGlobal(IdeTheme, IdeTheme());
+    setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
   }
 
   Future<void> pumpMemoryScreen(
@@ -64,19 +68,6 @@ void main() {
 
   group('MemoryScreen', () {
     setUp(() {
-      setGlobal(OfflineModeController, OfflineModeController());
-      fakeServiceManager = FakeServiceManager();
-      when(fakeServiceManager.connectedApp!.isDartWebAppNow).thenReturn(false);
-      when(fakeServiceManager.connectedApp!.isDebugFlutterAppNow)
-          .thenReturn(false);
-      when(fakeServiceManager.vm.operatingSystem).thenReturn('android');
-      when(fakeServiceManager.connectedApp!.isDartWebApp)
-          .thenAnswer((_) => Future.value(false));
-      when(fakeServiceManager.errorBadgeManager.errorCountNotifier('memory'))
-          .thenReturn(ValueNotifier<int>(0));
-      setGlobal(ServiceConnectionManager, fakeServiceManager);
-      setGlobal(IdeTheme, IdeTheme());
-      setGlobal(NotificationService, NotificationService());
       screen = MemoryScreen();
       controller = MemoryController();
       setUpServiceManagerForMemory();

--- a/packages/devtools_app/test/performance/flutter_frames/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/performance/flutter_frames/flutter_frames_chart_test.dart
@@ -20,9 +20,11 @@ void main() {
     bool offlineMode = false,
   }) async {
     await tester.pumpWidget(
-      wrapWithControllers(
-        FlutterFramesChart(framesController, offlineMode: offlineMode),
-        bannerMessages: BannerMessagesController(),
+      wrap(
+        FlutterFramesChart(
+          framesController,
+          offlineMode: offlineMode,
+        ),
       ),
     );
     await tester.pumpAndSettle();
@@ -42,6 +44,7 @@ void main() {
       setGlobal(OfflineModeController, OfflineModeController());
       setGlobal(IdeTheme, IdeTheme());
       setGlobal(NotificationService, NotificationService());
+      setGlobal(BannerMessagesController, BannerMessagesController());
       setGlobal(DevToolsExtensionPoints, ExternalDevToolsExtensionPoints());
       setGlobal(PreferencesController, PreferencesController());
 

--- a/packages/devtools_app/test/provider/provider_screen_test.dart
+++ b/packages/devtools_app/test/provider/provider_screen_test.dart
@@ -20,7 +20,6 @@ void main() {
   const windowSize = Size(2225.0, 1000.0);
 
   late Widget providerScreen;
-  late BannerMessagesController bannerMessagesController;
 
   setUpAll(() async => await loadFonts());
 
@@ -30,18 +29,18 @@ void main() {
     setGlobal(PreferencesController, PreferencesController());
     setGlobal(ServiceConnectionManager, FakeServiceManager());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
   });
 
   setUp(() {
-    bannerMessagesController = BannerMessagesController();
-
     providerScreen = Container(
       color: Colors.grey,
       child: Directionality(
         textDirection: TextDirection.ltr,
-        child: wrapWithControllers(
-          BannerMessages(screen: ProviderScreen()),
-          bannerMessages: bannerMessagesController,
+        child: wrap(
+          BannerMessages(
+            screen: ProviderScreen(),
+          ),
         ),
       ),
     );

--- a/packages/devtools_app/test/shared/scaffold_debugger_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_debugger_test.dart
@@ -34,6 +34,7 @@ void main() {
   setGlobal(OfflineModeController, OfflineModeController());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BannerMessagesController, BannerMessagesController());
 
   testWidgets(
     'does not display floating debugger controls when debugger screen is showing',

--- a/packages/devtools_app/test/shared/scaffold_debugging_controls_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_debugging_controls_test.dart
@@ -33,6 +33,7 @@ void main() {
   setGlobal(OfflineModeController, OfflineModeController());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BannerMessagesController, BannerMessagesController());
 
   testWidgets(
     'displays floating debugger controls',

--- a/packages/devtools_app/test/shared/scaffold_no_app_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_no_app_test.dart
@@ -30,6 +30,7 @@ void main() {
   setGlobal(OfflineModeController, OfflineModeController());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BannerMessagesController, BannerMessagesController());
 
   Widget wrapScaffold(Widget child) {
     return wrapWithControllers(

--- a/packages/devtools_app/test/shared/scaffold_profile_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_profile_test.dart
@@ -33,6 +33,7 @@ void main() {
   setGlobal(OfflineModeController, OfflineModeController());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BannerMessagesController, BannerMessagesController());
 
   testWidgets(
     'does not display floating debugger controls in profile mode',

--- a/packages/devtools_app/test/shared/scaffold_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_test.dart
@@ -30,6 +30,7 @@ void main() {
   setGlobal(OfflineModeController, OfflineModeController());
   setGlobal(IdeTheme, IdeTheme());
   setGlobal(NotificationService, NotificationService());
+  setGlobal(BannerMessagesController, BannerMessagesController());
 
   Widget wrapScaffold(Widget child) {
     return wrapWithControllers(

--- a/packages/devtools_app/test/shared/vm_flag_widgets_test.dart
+++ b/packages/devtools_app/test/shared/vm_flag_widgets_test.dart
@@ -16,7 +16,6 @@ void main() {
   group('Profile Granularity Dropdown', () {
     late FakeServiceManager fakeServiceManager;
     late CpuSamplingRateDropdown dropdown;
-    late BuildContext buildContext;
 
     setUp(() async {
       fakeServiceManager = FakeServiceManager();
@@ -24,6 +23,7 @@ void main() {
       setGlobal(ServiceConnectionManager, fakeServiceManager);
       setGlobal(IdeTheme, IdeTheme());
       setGlobal(NotificationService, NotificationService());
+      setGlobal(BannerMessagesController, BannerMessagesController());
       await fakeServiceManager.flagsInitialized.future;
       dropdown = CpuSamplingRateDropdown(
         screenId: ProfilerScreen.id,
@@ -33,29 +33,7 @@ void main() {
     });
 
     Future<void> pumpDropdown(WidgetTester tester) async {
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: themeFor(
-            isDarkTheme: false,
-            ideTheme: IdeTheme(),
-            theme: ThemeData(
-              useMaterial3: true,
-              colorScheme: lightColorScheme,
-            ),
-          ),
-          home: Material(
-            child: wrapWithControllers(
-              Builder(
-                builder: (context) {
-                  buildContext = context;
-                  return dropdown;
-                },
-              ),
-              bannerMessages: BannerMessagesController(),
-            ),
-          ),
-        ),
-      );
+      await tester.pumpWidget(wrap(dropdown));
     }
 
     testWidgets('displays with default content', (WidgetTester tester) async {
@@ -126,10 +104,7 @@ void main() {
       );
       // Verify we are showing the high profile granularity warning.
       expect(
-        bannerMessagesController(buildContext)
-            .messagesForScreen(ProfilerScreen.id)
-            .value
-            .length,
+        bannerMessages.messagesForScreen(ProfilerScreen.id).value.length,
         equals(1),
       );
 
@@ -151,9 +126,7 @@ void main() {
       );
       // Verify we are not showing the high profile granularity warning.
       expect(
-        bannerMessagesController(buildContext)
-            .messagesForScreen(ProfilerScreen.id)
-            .value,
+        bannerMessages.messagesForScreen(ProfilerScreen.id).value,
         isEmpty,
       );
     });

--- a/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/cpu_profiler/default.dart
@@ -35,6 +35,7 @@ class CpuProfilerDefaultScene extends Scene {
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(NotificationService, NotificationService());
     setGlobal(PreferencesController, PreferencesController());
+    setGlobal(BannerMessagesController, BannerMessagesController());
 
     fakeServiceManager = FakeServiceManager(
       service: FakeServiceManager.createFakeService(

--- a/packages/devtools_app/test/test_infra/scenes/memory/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/default.dart
@@ -42,6 +42,7 @@ class MemoryDefaultScene extends Scene {
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
     setGlobal(
       PreferencesController,
       PreferencesController()..memory.showChart.value = false,

--- a/packages/devtools_app/test/test_infra/scenes/performance/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/performance/default.dart
@@ -33,6 +33,7 @@ class PerformanceDefaultScene extends Scene {
     setGlobal(OfflineModeController, OfflineModeController());
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(NotificationService, NotificationService());
+    setGlobal(BannerMessagesController, BannerMessagesController());
     setGlobal(PreferencesController, PreferencesController());
     setGlobal(ServiceConnectionManager, ServiceConnectionManager());
     await _loadOfflineSnapshot(

--- a/packages/devtools_app/test/vm_developer/object_inspector/class_hierarchy_explorer_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/class_hierarchy_explorer_test.dart
@@ -101,7 +101,7 @@ void main() {
     (tester) async {
       final controller = objectInspectorViewController.classHierarchyController;
       await tester.pumpWidget(
-        wrapWithControllers(
+        wrap(
           ClassHierarchyExplorer(
             controller: objectInspectorViewController,
           ),

--- a/packages/devtools_test/lib/src/wrappers.dart
+++ b/packages/devtools_test/lib/src/wrappers.dart
@@ -8,8 +8,6 @@ import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:provider/provider.dart';
 
-import 'mocks/generated.mocks.dart';
-
 /// The RouterDelegate must use the same NavigatorKey when building in order
 /// for widget state to be preserved.
 final _testNavigatorKey = GlobalKey<NavigatorState>();
@@ -58,16 +56,12 @@ Widget wrapWithControllers(
   ProfilerScreenController? profiler,
   DebuggerController? debugger,
   NetworkController? network,
-  BannerMessagesController? bannerMessages,
   AppSizeController? appSize,
   AnalyticsController? analytics,
   ReleaseNotesController? releaseNotes,
   VMDeveloperToolsController? vmDeveloperTools,
 }) {
   final _providers = [
-    Provider<BannerMessagesController>.value(
-      value: bannerMessages ?? MockBannerMessagesController(),
-    ),
     if (inspector != null)
       Provider<InspectorController>.value(value: inspector),
     if (logging != null) Provider<LoggingController>.value(value: logging),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/4353. (please review with Hide Whitespace enabled)

This stops enabling http timeline logging by default on the performance page (this can still be enabled from the timeline stream settings dialog on the Timeline Events view). This setting will continue to be enabled by default when a user switches to the network page.

Additionally, this PR adds a warning on the memory screen when this setting is enabled. Users have made several reports being confused by the memory dart:io is holding onto for debugging. This warning allows the user to disable the http logging and automatically dismisses.

![http-logging-warning](https://github.com/flutter/devtools/assets/43759233/f5204201-1866-4ccc-bc6c-0d0a09c26797)
