### PR TITLE
Add skeleton for deep link validation tool

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -19,6 +19,8 @@ import 'screens/app_size/app_size_controller.dart';
 import 'screens/app_size/app_size_screen.dart';
 import 'screens/debugger/debugger_controller.dart';
 import 'screens/debugger/debugger_screen.dart';
+import 'screens/deep_link_validation/deep_links_controller.dart';
+import 'screens/deep_link_validation/deep_links_screen.dart';
 import 'screens/inspector/inspector_controller.dart';
 import 'screens/inspector/inspector_screen.dart';
 import 'screens/inspector/inspector_tree_controller.dart';
@@ -523,6 +525,11 @@ List<DevToolsScreen> defaultScreens({
       AppSizeScreen(),
       createController: (_) => AppSizeController(),
     ),
+    if (FeatureFlags.deepLinkValidation)
+      DevToolsScreen<DeepLinksController>(
+        DeepLinksScreen(),
+        createController: (_) => DeepLinksController(),
+      ),
     DevToolsScreen<VMDeveloperToolsController>(
       VMDeveloperToolsScreen(),
       createController: (_) => VMDeveloperToolsController(),

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -1,0 +1,5 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class DeepLinksController {}

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
@@ -1,0 +1,31 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '../../shared/screen.dart';
+
+class DeepLinksScreen extends Screen {
+  DeepLinksScreen()
+      : super.conditional(
+          id: id,
+          requiresConnection: false,
+          requiresDartVm: true,
+          title: ScreenMetaData.deepLinks.title,
+          icon: ScreenMetaData.deepLinks.icon,
+        );
+
+  static final id = ScreenMetaData.deepLinks.id;
+
+  // TODO(https://github.com/flutter/devtools/issues/6013): write documentation.
+  // @override
+  // String get docPageId => id;
+
+  @override
+  Widget build(BuildContext context) {
+    return const Center(
+      child: Text('TODO: build deep link validation tool'),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -63,6 +63,12 @@ abstract class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/5606
   static bool memoryAnalysis = enableExperiments;
 
+  /// Flag to enable the deep link validation tooling in DevTools, both for the
+  /// DevTools screen and the standalone tool for IDE embedding.
+  /// 
+  /// https://github.com/flutter/devtools/issues/6013
+  static bool deepLinkValidation = enableExperiments;
+
   /// Stores a map of all the feature flags for debugging purposes.
   ///
   /// When adding a new flag, you are responsible for adding it to this map as

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -65,7 +65,7 @@ abstract class FeatureFlags {
 
   /// Flag to enable the deep link validation tooling in DevTools, both for the
   /// DevTools screen and the standalone tool for IDE embedding.
-  /// 
+  ///
   /// https://github.com/flutter/devtools/issues/6013
   static bool deepLinkValidation = enableExperiments;
 

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -31,6 +31,7 @@ enum ScreenMetaData {
   logging('logging', title: 'Logging', icon: Octicons.clippy),
   provider('provider', title: 'Provider', icon: Icons.attach_file),
   appSize('app-size', title: 'App Size', icon: Octicons.fileZip),
+  deepLinks('deep-links', title: 'Deep Links', icon: Icons.link_rounded),
   vmTools('vm-tools', title: 'VM Tools', icon: Icons.settings_applications),
   simple('simple');
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6013. All work for the deep link validation tool should be hidden behind `FeatureFlags.deepLinkValidation` until the tool is ready to ship.

![Screenshot 2023-07-11 at 3 06 25 PM](https://github.com/flutter/devtools/assets/43759233/2219dcb6-edc7-45f9-aca4-5712be735f8f)
