### PR TITLE
Add support for new timeline event names `LAYOUT (root)` and `PAINT (root)`

### DIFF
--- a/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
+++ b/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
@@ -27,16 +27,16 @@ void main() {
       mockEnhanceTracingController = MockEnhanceTracingController();
       mockFrameAnalysis = MockFrameAnalysis();
       mockBuildPhase = MockFramePhase();
-      when(mockBuildPhase.title).thenReturn(FramePhaseType.build.eventName);
+      when(mockBuildPhase.title).thenReturn(FramePhaseType.build.display);
       when(mockBuildPhase.type).thenReturn(FramePhaseType.build);
       mockLayoutPhase = MockFramePhase();
-      when(mockLayoutPhase.title).thenReturn(FramePhaseType.layout.eventName);
+      when(mockLayoutPhase.title).thenReturn(FramePhaseType.layout.display);
       when(mockLayoutPhase.type).thenReturn(FramePhaseType.layout);
       mockPaintPhase = MockFramePhase();
-      when(mockPaintPhase.title).thenReturn(FramePhaseType.paint.eventName);
+      when(mockPaintPhase.title).thenReturn(FramePhaseType.paint.display);
       when(mockPaintPhase.type).thenReturn(FramePhaseType.paint);
       mockRasterPhase = MockFramePhase();
-      when(mockRasterPhase.title).thenReturn(FramePhaseType.raster.eventName);
+      when(mockRasterPhase.title).thenReturn(FramePhaseType.raster.display);
       when(mockRasterPhase.type).thenReturn(FramePhaseType.raster);
 
       setGlobal(IdeTheme, IdeTheme());


### PR DESCRIPTION
These event names are changing with multi-view support and we need to support frame phase detection for the new names (and old ones for a while).

@goderbauer 