### PR TITLE
Clean up duplicate connection available indicator in service manager

### DIFF
--- a/packages/devtools_app/lib/src/extensions/README.md
+++ b/packages/devtools_app/lib/src/extensions/README.md
@@ -3,4 +3,4 @@
 DevTools extensions are custom tooling screens provided by pub packages that
 can be loaded into DevTools at runtime.
 
-This feature is under construction - more documenation to come.
+This feature is under construction - more documentation to come.

--- a/packages/devtools_app/lib/src/framework/home_screen.dart
+++ b/packages/devtools_app/lib/src/framework/home_screen.dart
@@ -63,9 +63,7 @@ class _HomeScreenBodyState extends State<HomeScreenBody> with AutoDisposeMixin {
     super.initState();
     ga.screen(gac.home);
 
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable.listen((_) => setState(() {})),
-    );
+    addAutoDisposeListener(serviceManager.connectedState);
   }
 
   @override

--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -80,8 +80,7 @@ class _InitializerState extends State<Initializer>
       final connectionState = serviceManager.connectedState.value;
       if (connectionState.connected) {
         setState(() {});
-      } else if (!connectionState.connected &&
-          !connectionState.userInitiatedConnectionState) {
+      } else if (!connectionState.userInitiatedConnectionState) {
         // Try to reconnect (otherwise, will fall back to showing the
         // disconnected overlay).
         unawaited(

--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -78,7 +78,9 @@ class _InitializerState extends State<Initializer>
     // attempt to reconnect.
     addAutoDisposeListener(serviceManager.connectedState, () {
       final connectionState = serviceManager.connectedState.value;
-      if (!connectionState.connected &&
+      if (connectionState.connected) {
+        setState(() {});
+      } else if (!connectionState.connected &&
           !connectionState.userInitiatedConnectionState) {
         // Try to reconnect (otherwise, will fall back to showing the
         // disconnected overlay).
@@ -94,13 +96,6 @@ class _InitializerState extends State<Initializer>
         );
       }
     });
-
-    // Trigger a rebuild when the connection becomes available. This is done
-    // by onConnectionAvailable and not onStateChange because we also need
-    // to have queried what type of app this is before we load the UI.
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable.listen((_) => setState(() {})),
-    );
 
     unawaited(_attemptUrlConnection());
   }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -38,9 +38,11 @@ class DebuggerController extends DisposableController
     DevToolsRouterDelegate? routerDelegate,
     bool initialSwitchToIsolate = true,
   }) : _initialSwitchToIsolate = initialSwitchToIsolate {
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable.listen(_handleConnectionAvailable),
-    );
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (serviceManager.connectedState.value.connected) {
+        _handleConnectionAvailable(serviceManager.service!);
+      }
+    });
     if (routerDelegate != null) {
       codeViewController.subscribeToRouterEvents(routerDelegate);
     }

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -114,16 +114,17 @@ class InspectorController extends DisposableController
       });
     }
 
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable
-          .listen((_) => _handleConnectionStart()),
-    );
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (serviceManager.connectedState.value.connected) {
+        _handleConnectionStart();
+      } else {
+        _handleConnectionStop();
+      }
+    });
+
     if (serviceManager.connectedAppInitialized) {
       _handleConnectionStart();
     }
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionClosed.listen((_) => _handleConnectionStop()),
-    );
 
     serviceManager.consoleService.ensureServiceInitialized();
   }

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -163,15 +163,14 @@ class LoggingController extends DisposableController
         FilterControllerMixin<LogData>,
         AutoDisposeControllerMixin {
   LoggingController() {
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable.listen(_handleConnectionStart),
-    );
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (serviceManager.connectedState.value.connected) {
+        _handleConnectionStart(serviceManager.service!);
+      }
+    });
     if (serviceManager.connectedAppInitialized) {
       _handleConnectionStart(serviceManager.service!);
     }
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionClosed.listen(_handleConnectionStop),
-    );
     _handleBusEvents();
     subscribeToFilterChanges();
   }
@@ -499,8 +498,6 @@ class LoggingController extends DisposableController
       ),
     );
   }
-
-  void _handleConnectionStop(Object? _) {}
 
   void log(LogData log) {
     List<LogData> currentLogs = List.of(data);

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -125,12 +125,12 @@ class TimelineEventsController extends PerformanceFeatureController
   Future<void> _initForServiceConnection() async {
     await serviceManager.timelineStreamManager.setDefaultTimelineStreams();
 
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionClosed.listen((_) {
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (!serviceManager.connectedState.value.connected) {
         _pollingTimer?.cancel();
         _timelinePollingRateLimiter?.dispose();
-      }),
-    );
+      }
+    });
 
     // Load available timeline events.
     await _pullTraceEventsFromVmTimeline(isInitialPull: true);

--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/eval.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/eval.dart
@@ -16,7 +16,6 @@ import '../../../service/vm_service_wrapper.dart';
 import '../../../shared/eval_on_dart_library.dart';
 import '../../../shared/globals.dart';
 
-
 Stream<VmServiceWrapper> get _serviceConnectionStream =>
     _serviceConnectionStreamController.stream;
 final _serviceConnectionStreamController =

--- a/packages/devtools_app/lib/src/screens/provider/instance_viewer/eval.dart
+++ b/packages/devtools_app/lib/src/screens/provider/instance_viewer/eval.dart
@@ -6,6 +6,8 @@
 
 library eval;
 
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:vm_service/vm_service.dart';
@@ -14,13 +16,22 @@ import '../../../service/vm_service_wrapper.dart';
 import '../../../shared/eval_on_dart_library.dart';
 import '../../../shared/globals.dart';
 
+
+Stream<VmServiceWrapper> get _serviceConnectionStream =>
+    _serviceConnectionStreamController.stream;
+final _serviceConnectionStreamController =
+    StreamController<VmServiceWrapper>.broadcast();
+void setServiceConnectionForProviderScreen(VmServiceWrapper service) {
+  _serviceConnectionStreamController.add(service);
+}
+
 /// Exposes the current VmServiceWrapper.
 /// By listening to this provider instead of directly accessing `serviceManager.service`,
 /// this ensures that providers reload properly when the devtool is connected
 /// to a different application.
 final serviceProvider = StreamProvider<VmServiceWrapper>((ref) async* {
   yield serviceManager.service!;
-  yield* serviceManager.onConnectionAvailable;
+  yield* _serviceConnectionStream;
 });
 
 /// An [EvalOnDartLibrary] that has access to no specific library in particular

--- a/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
+++ b/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
@@ -13,8 +13,10 @@ import '../../shared/banner_messages.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/dialogs.dart';
 import '../../shared/globals.dart';
+import '../../shared/primitives/auto_dispose.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
+import 'instance_viewer/eval.dart';
 import 'instance_viewer/instance_details.dart';
 import 'instance_viewer/instance_providers.dart';
 import 'instance_viewer/instance_viewer.dart';
@@ -70,11 +72,19 @@ class ProviderScreenWrapper extends StatefulWidget {
   State<ProviderScreenWrapper> createState() => _ProviderScreenWrapperState();
 }
 
-class _ProviderScreenWrapperState extends State<ProviderScreenWrapper> {
+class _ProviderScreenWrapperState extends State<ProviderScreenWrapper>
+    with AutoDisposeMixin {
   @override
   void initState() {
     super.initState();
     ga.screen(ProviderScreen.id);
+
+    cancelListeners();
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (serviceManager.connectedState.value.connected) {
+        setServiceConnectionForProviderScreen(serviceManager.service!);
+      }
+    });
   }
 
   @override

--- a/packages/devtools_app/lib/src/service/service_manager.dart
+++ b/packages/devtools_app/lib/src/service/service_manager.dart
@@ -48,11 +48,9 @@ class ServiceConnectionManager {
     _serviceExtensionManager = ServiceExtensionManager(isolateManager);
   }
 
-  final StreamController<VmServiceWrapper> _connectionAvailableController =
-      StreamController<VmServiceWrapper>.broadcast();
-
   Completer<VmService> _serviceAvailable = Completer();
 
+  // TODO(kenz): try to replace uses of this with a listener on [connectedState]
   Future<VmService> get onServiceAvailable => _serviceAvailable.future;
 
   bool get isServiceAvailable => _serviceAvailable.isCompleted;
@@ -133,14 +131,6 @@ class ServiceConnectionManager {
 
   final ValueNotifier<ConnectedState> _connectedState =
       ValueNotifier(const ConnectedState(false));
-
-  // TODO(kenz): try to replace all uses of this stream with a listener to the
-  // [connectedState] ValueListenable.
-  Stream<VmServiceWrapper> get onConnectionAvailable =>
-      _connectionAvailableController.stream;
-
-  Stream<void> get onConnectionClosed => _connectionClosedController.stream;
-  final _connectionClosedController = StreamController<void>.broadcast();
 
   final ValueNotifier<bool> _deviceBusy = ValueNotifier<bool>(false);
 
@@ -331,7 +321,6 @@ class ServiceConnectionManager {
       return;
     }
 
-    _connectionAvailableController.add(service);
     _connectedState.value = const ConnectedState(true);
   }
 
@@ -374,7 +363,6 @@ class ServiceConnectionManager {
     setDeviceBusy(false);
 
     _connectedState.value = connectionState;
-    _connectionClosedController.add(null);
 
     _registeredMethodsForService.clear();
 

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -190,13 +190,13 @@ class InspectorPreferencesController extends DisposableController
   }
 
   void _initCustomPubRootDirectories() {
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable
-          .listen(_handleConnectionToNewService),
-    );
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionClosed.listen(_handleConnectionClosed),
-    );
+    addAutoDisposeListener(serviceManager.connectedState, () async {
+      if (serviceManager.connectedState.value.connected) {
+        await _handleConnectionToNewService();
+      } else {
+        _handleConnectionClosed();
+      }
+    });
     addAutoDisposeListener(_busyCounter, () {
       _customPubRootDirectoriesAreBusy.value = _busyCounter.value != 0;
     });
@@ -230,12 +230,12 @@ class InspectorPreferencesController extends DisposableController
     );
   }
 
-  void _handleConnectionClosed(Object? _) {
+  void _handleConnectionClosed() {
     _mainScriptDir = null;
     _customPubRootDirectories.clear();
   }
 
-  Future<void> _handleConnectionToNewService(VmServiceWrapper _) async {
+  Future<void> _handleConnectionToNewService() async {
     await _updateMainScriptRef();
     await _updateHoverEvalMode();
 

--- a/packages/devtools_app/lib/src/shared/scripts/script_manager.dart
+++ b/packages/devtools_app/lib/src/shared/scripts/script_manager.dart
@@ -15,13 +15,13 @@ import '../primitives/auto_dispose.dart';
 class ScriptManager extends DisposableController
     with AutoDisposeControllerMixin {
   ScriptManager() {
-    autoDisposeStreamSubscription(
-      serviceManager.onConnectionAvailable.listen((service) {
-        if (service == _lastService) return;
-        _lastService = service;
+    addAutoDisposeListener(serviceManager.connectedState, () {
+      if (serviceManager.connectedState.value.connected) {
+        if (serviceManager.service == _lastService) return;
+        _lastService = serviceManager.service;
         _scriptCache.clear();
-      }),
-    );
+      }
+    });
     addAutoDisposeListener(serviceManager.isolateManager.selectedIsolate, () {
       _scriptCache.clear();
     });

--- a/packages/devtools_app/test/shared/initializer_test.dart
+++ b/packages/devtools_app/test/shared/initializer_test.dart
@@ -33,7 +33,7 @@ void main() {
           ),
         ),
       );
-      await tester.pumpAndSettle();
+      await tester.pump();
     }
 
     testWidgets(

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -220,19 +220,21 @@ void main() {
     }
 
     testWidgetsWithWindowSize(
-        'displays CodeTable and InliningTable instructions in order of increasing address',
-        windowSize, (WidgetTester tester) async {
-      await tester.pumpWidget(
-        wrap(
-          VmCodeDisplay(
-            code: mockCodeObject,
-            controller: ObjectInspectorViewController(),
+      'displays CodeTable and InliningTable instructions in order of increasing address',
+      windowSize,
+      (WidgetTester tester) async {
+        await tester.pumpWidget(
+          wrap(
+            VmCodeDisplay(
+              code: mockCodeObject,
+              controller: ObjectInspectorViewController(),
+            ),
           ),
-        ),
-      );
+        );
 
-      await verifyCodeTable(tester);
-      await verifyInliningTable(tester);
-    });
+        await verifyCodeTable(tester);
+        await verifyInliningTable(tester);
+      },
+    );
   });
 }

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -118,12 +118,6 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
   final ConsoleService consoleService = ConsoleService();
 
   @override
-  Stream<VmServiceWrapper> get onConnectionClosed => const Stream.empty();
-
-  @override
-  Stream<VmServiceWrapper> get onConnectionAvailable => Stream.value(service!);
-
-  @override
   Future<double> get queryDisplayRefreshRate => Future.value(60.0);
 
   @override


### PR DESCRIPTION
This removes the streams `onConnectionAvailable` and `onConnectionClosed` and migrates existing uses to listen to the `serviceManager.connectedState` notifier.