### PR TITLE
[ VM Tools ] Fixed UI glitch in Object Inspector

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -1019,21 +1019,25 @@ class ObjectInspectorCodeView extends StatefulWidget {
 
 class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
   @override
-  void didChangeDependencies() async {
+  void didChangeDependencies() {
     super.didChangeDependencies();
     if (widget.script != widget.codeViewController.currentScriptRef.value) {
-      await widget.codeViewController.resetScriptLocation(
-        ScriptLocation(widget.script),
+      unawaited(
+        widget.codeViewController.resetScriptLocation(
+          ScriptLocation(widget.script),
+        ),
       );
     }
   }
 
   @override
-  Future<void> didUpdateWidget(ObjectInspectorCodeView oldWidget) async {
+  void didUpdateWidget(ObjectInspectorCodeView oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.script != widget.codeViewController.currentScriptRef.value) {
-      await widget.codeViewController.resetScriptLocation(
-        ScriptLocation(widget.script),
+      unawaited(
+        widget.codeViewController.resetScriptLocation(
+          ScriptLocation(widget.script),
+        ),
       );
     }
   }


### PR DESCRIPTION
`_ObjectInspectorCodeViewState`'s overridden `didChangeDependencies` and `didUpdateWidget` implementations were marked as async and returned `Future`s. This caused the framework to throw exceptions when these methods were called, resulting in stale UI elements being stacked rather than them being replaced with widgets rendering the new state.

**Example of bad behavior:**
![Screenshot 2023-07-20 at 11 29 47 AM](https://github.com/flutter/devtools/assets/24210656/dbda0aee-2e0e-4b03-a609-9f9d5086d6eb)
