### PR TITLE
Fix hover background shape for `DebuggerButton`s

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -86,6 +86,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
             title: 'Pause',
             icon: Codicons.debugPause,
             autofocus: true,
+            roundedLeftBorder: true,
             // Disable when paused or selected isolate is a system isolate.
             onPressed: (isPaused || isSystemIsolate)
                 ? null
@@ -95,6 +96,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
             child: DebuggerButton(
               title: 'Resume',
               icon: Codicons.debugContinue,
+              roundedRightBorder: true,
               // Enable while paused + not resuming and selected isolate is not
               // a system isolate.
               onPressed: ((isPaused && !resuming) && !isSystemIsolate)
@@ -114,6 +116,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
           DebuggerButton(
             title: 'Step Over',
             icon: Codicons.debugStepOver,
+            roundedLeftBorder: true,
             onPressed: canStep ? () => unawaited(controller.stepOver()) : null,
           ),
           LeftBorder(
@@ -127,6 +130,7 @@ class _DebuggingControlsState extends State<DebuggingControls>
             child: DebuggerButton(
               title: 'Step Out',
               icon: Codicons.debugStepOut,
+              roundedRightBorder: true,
               onPressed: canStep ? () => unawaited(controller.stepOut()) : null,
             ),
           ),
@@ -314,12 +318,16 @@ class DebuggerButton extends StatelessWidget {
     required this.icon,
     required this.onPressed,
     this.autofocus = false,
+    this.roundedLeftBorder = false,
+    this.roundedRightBorder = false,
   });
 
   final String title;
   final IconData icon;
   final VoidCallback? onPressed;
   final bool autofocus;
+  final bool roundedLeftBorder;
+  final bool roundedRightBorder;
 
   @override
   Widget build(BuildContext context) {
@@ -329,7 +337,16 @@ class DebuggerButton extends StatelessWidget {
         autofocus: autofocus,
         style: OutlinedButton.styleFrom(
           side: BorderSide.none,
-          shape: const ContinuousRectangleBorder(),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.horizontal(
+              left: roundedLeftBorder
+                  ? const Radius.circular(defaultBorderRadius)
+                  : Radius.zero,
+              right: roundedRightBorder
+                  ? const Radius.circular(defaultBorderRadius)
+                  : Radius.zero,
+            ),
+          ),
         ),
         onPressed: onPressed,
         child: MaterialIconLabel(


### PR DESCRIPTION
The `DebuggerButton`s in the debugger screen's controls have rounded buttons but, when hovered over, had rectangular selection overlays.

This change adds support for rounded selection overlays for `DebuggerButton`.

**Before:**
![Screenshot 2023-07-20 at 1 28 35 PM](https://github.com/flutter/devtools/assets/24210656/9422c0c2-5e7f-4463-a9a3-552af868cdb2)
![Screenshot 2023-07-20 at 1 28 21 PM](https://github.com/flutter/devtools/assets/24210656/6f5f1071-5515-43e7-b74e-2c861f1b9c3a)
![Screenshot 2023-07-20 at 1 29 06 PM](https://github.com/flutter/devtools/assets/24210656/68c33ffc-8adc-45a5-8a4f-ddd030f2cd04)
![Screenshot 2023-07-20 at 1 29 14 PM](https://github.com/flutter/devtools/assets/24210656/0f9e934e-5680-42a5-a201-3b06e1794104)

**After:**
![Screenshot 2023-07-20 at 1 30 19 PM](https://github.com/flutter/devtools/assets/24210656/1e26476e-e783-422e-afec-ba8da9d02ded)
![Screenshot 2023-07-20 at 1 30 05 PM](https://github.com/flutter/devtools/assets/24210656/84fd114b-f1b4-41e3-ab12-8a4668fde3cf)
![Screenshot 2023-07-20 at 1 29 56 PM](https://github.com/flutter/devtools/assets/24210656/c6b7e1ee-f8e8-4c82-a4ad-ddc310215ec4)
![Screenshot 2023-07-20 at 1 29 49 PM](https://github.com/flutter/devtools/assets/24210656/884d9700-e569-41e8-886a-ce77fb805b0c)
