### PR TITLE
[VM Tools] Add support for inspecting inbound references and internal VM types

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
@@ -1,0 +1,117 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:vm_service/vm_service.dart';
+
+import '../../../shared/primitives/trees.dart';
+import '../../../shared/primitives/utils.dart';
+import '../vm_developer_common_widgets.dart';
+import '../vm_service_private_extensions.dart';
+
+class InboundReferencesTreeNode extends TreeNode<InboundReferencesTreeNode> {
+  InboundReferencesTreeNode._({required this.ref});
+
+  static List<InboundReferencesTreeNode> buildTreeRoots(
+    InboundReferences inboundReferences,
+  ) {
+    return [
+      for (final ref in inboundReferences.references!)
+        InboundReferencesTreeNode._(ref: ref),
+    ];
+  }
+
+  final InboundReference ref;
+
+  @override
+  bool get isExpandable => ref.source != null;
+
+  // TODO(bkonyi):
+  late final String description = _inboundRefDescription(ref, null);
+
+  /// Wrapper to get the name of an ObjRef depending on its type.
+  String? _objectName(ObjRef? objectRef) {
+    if (objectRef == null) {
+      return null;
+    }
+
+    return switch (objectRef) {
+      ClassRef(:final name) ||
+      FuncRef(:final name) ||
+      FieldRef(:final name) =>
+        name,
+      LibraryRef(:final name, :final uri) => name.isNullOrEmpty ? uri : name,
+      ScriptRef(:final uri) => fileNameFromUri(uri),
+      InstanceRef(:final name, :final classRef) =>
+        name ?? 'Instance of ${classRef?.name ?? '<Class>'}',
+      _ => (objectRef.vmType ?? objectRef.type)..replaceFirst('@', ''),
+    };
+  }
+
+  String? _instanceClassName(ObjRef? object) {
+    if (object == null) {
+      return null;
+    }
+
+    return object is InstanceRef ? object.classRef?.name : _objectName(object);
+  }
+
+  String _parentListElementDescription(int listIndex, ObjRef? obj) {
+    final parentListName = _instanceClassName(obj) ?? '<parentListName>';
+    return 'element [$listIndex] of $parentListName';
+  }
+
+  /// Describes the given InboundReference [inboundRef] and its parentListIndex,
+  /// [offset], and parentField where applicable.
+  String _inboundRefDescription(InboundReference inboundRef, int? offset) {
+    final parentListIndex = inboundRef.parentListIndex;
+    if (parentListIndex != null) {
+      return 'Referenced by ${_parentListElementDescription(
+        parentListIndex,
+        inboundRef.source,
+      )}';
+    }
+
+    final description = StringBuffer('Referenced by ');
+
+    if (offset != null) {
+      description.write(
+        'offset $offset of ',
+      );
+    }
+
+    if (inboundRef.parentField is int) {
+      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
+      description.write('\$${inboundRef.parentField} of ');
+    } else if (inboundRef.parentField is String) {
+      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
+      description.write('${inboundRef.parentField} of ');
+    } else if (inboundRef.parentField is FieldRef) {
+      description.write(
+        '${_objectName(inboundRef.parentField)} of ',
+      );
+    }
+
+    description.write(
+      _objectDescription(inboundRef.source) ?? '<object>',
+    );
+
+    return description.toString();
+  }
+
+  // Returns a description of the object containing its name and owner.
+  String? _objectDescription(ObjRef? object) {
+    if (object == null) return null;
+    return switch (object) {
+      FieldRef(:final declaredType, :final name, :final owner) =>
+        '${declaredType?.name ?? 'Field'} $name of ${_objectName(owner) ?? '<Owner>'}',
+      FuncRef() => qualifiedName(object) ?? '<Function Name>',
+      _ => _objectName(object),
+    };
+  }
+
+  @override
+  TreeNode<InboundReferencesTreeNode> shallowCopy() {
+    throw UnimplementedError();
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
@@ -26,7 +26,6 @@ class InboundReferencesTreeNode extends TreeNode<InboundReferencesTreeNode> {
   @override
   bool get isExpandable => ref.source != null;
 
-  // TODO(bkonyi):
   late final String description = _inboundRefDescription(ref, null);
 
   /// Wrapper to get the name of an ObjRef depending on its type.

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/inbound_references_tree.dart
@@ -28,7 +28,7 @@ class InboundReferencesTreeNode extends TreeNode<InboundReferencesTreeNode> {
 
   late final String description = _inboundRefDescription(ref, null);
 
-  /// Wrapper to get the name of an ObjRef depending on its type.
+  /// Wrapper to get the name of an [ObjRef] depending on its type.
   String? _objectName(ObjRef? objectRef) {
     if (objectRef == null) {
       return null;
@@ -56,7 +56,7 @@ class InboundReferencesTreeNode extends TreeNode<InboundReferencesTreeNode> {
   }
 
   String _parentListElementDescription(int listIndex, ObjRef? obj) {
-    final parentListName = _instanceClassName(obj) ?? '<parentListName>';
+    final parentListName = _instanceClassName(obj) ?? '<parentList>';
     return 'element [$listIndex] of $parentListName';
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
@@ -133,7 +133,7 @@ class ObjectInspectorViewController extends DisposableController
     ObjRef objRef, {
     ScriptRef? scriptRef,
   }) async {
-    VmObject? object;
+    VmObject object;
     if (objRef is ClassRef) {
       object = ClassObject(
         ref: objRef,
@@ -183,9 +183,13 @@ class ObjectInspectorViewController extends DisposableController
       object = WeakArrayObject(
         ref: objRef,
       );
+    } else {
+      object = UnknownObject(
+        ref: objRef,
+      );
     }
 
-    await object?.initialize();
+    await object.initialize();
 
     return object;
   }

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_viewport.dart
@@ -20,6 +20,7 @@ import 'vm_object_model.dart';
 import 'vm_object_pool_display.dart';
 import 'vm_script_display.dart';
 import 'vm_simple_list_display.dart';
+import 'vm_unknown_object_display.dart';
 
 /// Displays the VM information for the currently selected object in the
 /// program explorer.
@@ -70,6 +71,10 @@ class ObjectViewport extends StatelessWidget {
     if (object.obj is Instance) {
       final instance = object.obj as Instance;
       return 'Instance of ${instance.classRef!.name}';
+    }
+
+    if (object is UnknownObject) {
+      return 'Instance of VM type ${object.name}';
     }
 
     return '${object.obj.type} ${object.name ?? ''}'.trim();
@@ -136,6 +141,12 @@ class ObjectViewport extends StatelessWidget {
       return VmSimpleListDisplay(
         controller: controller,
         vmObject: obj,
+      );
+    }
+    if (obj is UnknownObject) {
+      return VmUnknownObjectDisplay(
+        controller: controller,
+        object: obj,
       );
     }
     return const SizedBox.shrink();

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_class_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_class_display.dart
@@ -28,28 +28,32 @@ class VmClassDisplay extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ObjectInspectorCodeView(
-      codeViewController: controller.codeViewController,
-      script: clazz.scriptRef!,
-      object: clazz.ref,
-      child: Row(
-        children: [
+    final child = Row(
+      children: [
+        Flexible(
+          child: VmObjectDisplayBasicLayout(
+            controller: controller,
+            object: clazz,
+            generalDataRows: _classDataRows(clazz),
+          ),
+        ),
+        if (displayClassInstances)
           Flexible(
-            child: VmObjectDisplayBasicLayout(
-              controller: controller,
-              object: clazz,
-              generalDataRows: _classDataRows(clazz),
+            child: ClassInstancesWidget(
+              instances: clazz.instances,
             ),
           ),
-          if (displayClassInstances)
-            Flexible(
-              child: ClassInstancesWidget(
-                instances: clazz.instances,
-              ),
-            ),
-        ],
-      ),
+      ],
     );
+    if (clazz.scriptRef != null) {
+      return ObjectInspectorCodeView(
+        codeViewController: controller.codeViewController,
+        script: clazz.scriptRef!,
+        object: clazz.ref,
+        child: child,
+      );
+    }
+    return child;
   }
 
   // TODO(mtaylee): Delete 'Currently allocated instances' row when

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_unknown_object_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_unknown_object_display.dart
@@ -1,0 +1,59 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import '../../../shared/common_widgets.dart';
+import '../vm_developer_common_widgets.dart';
+import 'object_inspector_view_controller.dart';
+import 'vm_object_model.dart';
+
+class VmUnknownObjectDisplay extends StatelessWidget {
+  const VmUnknownObjectDisplay({
+    super.key,
+    required this.controller,
+    required this.object,
+  });
+
+  final ObjectInspectorViewController controller;
+  final UnknownObject object;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlineDecoration.onlyBottom(
+      child: _UnknownObjectViewer(
+        controller: controller,
+        object: object,
+      ),
+    );
+  }
+}
+
+class _UnknownObjectViewer extends StatelessWidget {
+  const _UnknownObjectViewer({
+    required this.controller,
+    required this.object,
+  });
+
+  final ObjectInspectorViewController controller;
+  final UnknownObject object;
+
+  @override
+  Widget build(BuildContext context) {
+    return VmObjectDisplayBasicLayout(
+      controller: controller,
+      object: object,
+      generalDataRows: [
+        serviceObjectLinkBuilderMapEntry(
+          controller: controller,
+          key: 'Object Class',
+          object: object.obj.classRef!,
+        ),
+        shallowSizeRowBuilder(object),
+        reachableSizeRowBuilder(object),
+        retainedSizeRowBuilder(object),
+      ],
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_unknown_object_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_unknown_object_display.dart
@@ -9,6 +9,7 @@ import '../vm_developer_common_widgets.dart';
 import 'object_inspector_view_controller.dart';
 import 'vm_object_model.dart';
 
+/// Displays basic properties about an VM service object of an unknown type.
 class VmUnknownObjectDisplay extends StatelessWidget {
   const VmUnknownObjectDisplay({
     super.key,
@@ -22,38 +23,20 @@ class VmUnknownObjectDisplay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return OutlineDecoration.onlyBottom(
-      child: _UnknownObjectViewer(
+      child: VmObjectDisplayBasicLayout(
         controller: controller,
         object: object,
+        generalDataRows: [
+          serviceObjectLinkBuilderMapEntry(
+            controller: controller,
+            key: 'Object Class',
+            object: object.obj.classRef!,
+          ),
+          shallowSizeRowBuilder(object),
+          reachableSizeRowBuilder(object),
+          retainedSizeRowBuilder(object),
+        ],
       ),
-    );
-  }
-}
-
-class _UnknownObjectViewer extends StatelessWidget {
-  const _UnknownObjectViewer({
-    required this.controller,
-    required this.object,
-  });
-
-  final ObjectInspectorViewController controller;
-  final UnknownObject object;
-
-  @override
-  Widget build(BuildContext context) {
-    return VmObjectDisplayBasicLayout(
-      controller: controller,
-      object: object,
-      generalDataRows: [
-        serviceObjectLinkBuilderMapEntry(
-          controller: controller,
-          key: 'Object Class',
-          object: object.obj.classRef!,
-        ),
-        shallowSizeRowBuilder(object),
-        reachableSizeRowBuilder(object),
-        retainedSizeRowBuilder(object),
-      ],
     );
   }
 }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -592,7 +592,10 @@ class InboundReferencesTree extends StatelessWidget {
             builder: (context, references, _) {
               return TreeView<InboundReferencesTreeNode>(
                 dataRootsListenable: object.inboundReferencesTree,
-                dataDisplayProvider: (node, _) => _displayProvider(theme, node),
+                dataDisplayProvider: (node, _) => InboundReferenceWidget(
+                  controller: controller,
+                  node: node,
+                ),
                 emptyTreeViewBuilder: () {
                   return Padding(
                     padding: EdgeInsets.all(defaultRowHeight / 2),
@@ -610,11 +613,22 @@ class InboundReferencesTree extends StatelessWidget {
       ],
     );
   }
+}
 
-  Widget _displayProvider(
-    ThemeData theme,
-    InboundReferencesTreeNode node,
-  ) {
+/// An entry in a [InboundReferencesTree].
+class InboundReferenceWidget extends StatelessWidget {
+  const InboundReferenceWidget({
+    super.key,
+    required this.controller,
+    required this.node,
+  });
+
+  final ObjectInspectorViewController controller;
+  final InboundReferencesTreeNode node;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final rowContent = <Widget>[
       const Text('Referenced by '),
     ];

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -17,9 +17,11 @@ import '../../shared/primitives/utils.dart';
 import '../../shared/split.dart';
 import '../../shared/table/table.dart';
 import '../../shared/theme.dart';
+import '../../shared/tree.dart';
 import '../debugger/codeview.dart';
 import '../debugger/codeview_controller.dart';
 import '../debugger/debugger_model.dart';
+import 'object_inspector/inbound_references_tree.dart';
 import 'object_inspector/object_inspector_view_controller.dart';
 import 'object_inspector/vm_object_model.dart';
 import 'vm_service_private_extensions.dart';
@@ -249,25 +251,6 @@ class RequestableSizeWidget extends StatelessWidget {
   }
 }
 
-/// Wrapper to get the name of an ObjRef depending on its type.
-String? _objectName(ObjRef? objectRef) {
-  if (objectRef == null) {
-    return null;
-  }
-
-  return switch (objectRef) {
-    ClassRef(:final name) ||
-    FuncRef(:final name) ||
-    FieldRef(:final name) =>
-      name,
-    LibraryRef(:final name, :final uri) => name.isNullOrEmpty ? uri : name,
-    ScriptRef(:final uri) => fileNameFromUri(uri),
-    InstanceRef(:final name, :final classRef) =>
-      name ?? 'Instance of ${classRef?.name ?? '<Class>'}',
-    _ => (objectRef.vmType ?? objectRef.type)..replaceFirst('@', ''),
-  };
-}
-
 /// Returns the name of a function, qualified with the name of
 /// its owner added as a prefix, separated by a period.
 ///
@@ -289,17 +272,6 @@ String? qualifiedName(ObjRef? ref) {
   }
 
   throw Exception('Unexpected owner type: ${ref.type}');
-}
-
-// Returns a description of the object containing its name and owner.
-String? _objectDescription(ObjRef? object) {
-  if (object == null) return null;
-  return switch (object) {
-    FieldRef(:final declaredType, :final name, :final owner) =>
-      '${declaredType?.name ?? 'Field'} $name of ${_objectName(owner) ?? '<Owner>'}',
-    FuncRef() => qualifiedName(object) ?? '<Function Name>',
-    _ => _objectName(object),
-  };
 }
 
 /// An ExpansionTile with an AreaPaneHeader as header and custom style
@@ -593,126 +565,82 @@ class _RetainingObjectDescription extends StatelessWidget {
   }
 }
 
-String? _instanceClassName(ObjRef? object) {
-  if (object == null) {
-    return null;
-  }
-
-  return object is InstanceRef ? object.classRef?.name : _objectName(object);
-}
-
-String _parentListElementDescription(int listIndex, ObjRef? obj) {
-  final parentListName = _instanceClassName(obj) ?? '<parentListName>';
-  return 'element [$listIndex] of $parentListName';
-}
-
-/// An expandable list to display the inbound references for a given
-/// instance of InboundReferences.
-class InboundReferencesWidget extends StatelessWidget {
-  const InboundReferencesWidget({
+class InboundReferencesTree extends StatelessWidget {
+  const InboundReferencesTree({
     super.key,
-    required this.inboundReferences,
+    required this.controller,
+    required this.object,
     this.onExpanded,
   });
 
-  final ValueListenable<InboundReferences?> inboundReferences;
+  final ObjectInspectorViewController controller;
+  final VmObject object;
   final void Function(bool)? onExpanded;
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<InboundReferences?>(
-      valueListenable: inboundReferences,
-      builder: (context, inboundReferences, _) {
-        final references = inboundReferences == null
-            ? const <Widget>[]
-            : _inboundReferencesList(context, inboundReferences);
-
-        return VmExpansionTile(
-          title: 'Inbound References',
-          onExpanded: onExpanded,
-          children: [
-            inboundReferences == null
-                ? const SizedCircularProgressIndicator()
-                : SizedBox.fromSize(
-                    size: Size.fromHeight(
-                      references.length * defaultRowHeight + densePadding,
+    final theme = Theme.of(context);
+    return VmExpansionTile(
+      title: 'Inbound References',
+      onExpanded: onExpanded,
+      children: [
+        const Divider(height: 1),
+        Container(
+          color: theme.expansionTileTheme.backgroundColor,
+          child: ValueListenableBuilder(
+            valueListenable: object.inboundReferencesTree,
+            builder: (context, references, _) {
+              return TreeView<InboundReferencesTreeNode>(
+                dataRootsListenable: object.inboundReferencesTree,
+                dataDisplayProvider: (node, _) => _displayProvider(theme, node),
+                emptyTreeViewBuilder: () {
+                  return Padding(
+                    padding: EdgeInsets.all(defaultRowHeight / 2),
+                    child: const Text(
+                      'There are no inbound references for this object',
                     ),
-                    child: Column(children: references),
-                  ),
-          ],
-        );
-      },
-    );
-  }
-
-  /// Returns a list of Widgets that will be the rows in the VmExpansionTile
-  /// for InboundReferencesWidget.
-  List<Widget> _inboundReferencesList(
-    BuildContext context,
-    InboundReferences inboundRefs,
-  ) {
-    int index = 0;
-
-    final references = <Row>[];
-
-    for (final inboundRef in inboundRefs.references!) {
-      final int? parentWordOffset = inboundRefs.parentWordOffset(index);
-
-      references.add(
-        Row(
-          children: [
-            Flexible(
-              child: Text(
-                _inboundRefDescription(inboundRef, parentWordOffset),
-                style: Theme.of(context).fixedFontStyle,
-              ),
-            ),
-          ],
+                  );
+                },
+                onItemExpanded: object.expandInboundRef,
+                onItemSelected: (_) => null,
+              );
+            },
+          ),
         ),
-      );
-
-      index++;
-    }
-
-    return prettyRows(context, references);
+      ],
+    );
   }
 
-  /// Describes the given InboundReference [inboundRef] and its parentListIndex,
-  /// [offset], and parentField where applicable.
-  String _inboundRefDescription(InboundReference inboundRef, int? offset) {
-    final parentListIndex = inboundRef.parentListIndex;
-    if (parentListIndex != null) {
-      return 'Referenced by ${_parentListElementDescription(
-        parentListIndex,
-        inboundRef.source,
-      )}';
+  Widget _displayProvider(
+    ThemeData theme,
+    InboundReferencesTreeNode node,
+  ) {
+    final rowContent = <Widget>[
+      const Text('Referenced by '),
+    ];
+
+    final parentField = node.ref.parentField;
+    if (parentField != null) {
+      if (parentField is int) {
+        // The parent field is an entry in a list
+        rowContent.add(Text('element $parentField of '));
+      } else if (parentField is String) {
+        rowContent.add(Text('$parentField in '));
+      }
     }
 
-    final description = StringBuffer('Referenced by ');
-
-    if (offset != null) {
-      description.write(
-        'offset $offset of ',
-      );
-    }
-
-    if (inboundRef.parentField is int) {
-      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
-      description.write('\$${inboundRef.parentField} of ');
-    } else if (inboundRef.parentField is String) {
-      assert((inboundRef.source as InstanceRef).kind == InstanceKind.kRecord);
-      description.write('${inboundRef.parentField} of ');
-    } else if (inboundRef.parentField is FieldRef) {
-      description.write(
-        '${_objectName(inboundRef.parentField)} of ',
-      );
-    }
-
-    description.write(
-      _objectDescription(inboundRef.source) ?? '<object>',
+    rowContent.add(
+      VmServiceObjectLink(
+        object: node.ref.source,
+        onTap: controller.findAndSelectNodeForObject,
+      ),
     );
-
-    return description.toString();
+    return DefaultTextStyle(
+      style: theme.fixedFontStyle,
+      child: Row(
+        children: rowContent,
+      ),
+    );
   }
 }
 
@@ -739,10 +667,11 @@ class VmServiceObjectLink extends StatelessWidget {
     return switch (object) {
       FieldRef(:final name) ||
       FuncRef(:final name) ||
-      ClassRef(:final name) ||
       CodeRef(:final name) ||
       TypeArgumentsRef(:final name) =>
         name,
+      // If a class has an empty name, it's a special "top level" class.
+      ClassRef(:final name) => name!.isEmpty ? 'top-level-class' : name,
       LibraryRef(:final uri, :final name) =>
         uri!.startsWith('dart') || preferUri
             ? uri
@@ -757,8 +686,7 @@ class VmServiceObjectLink extends StatelessWidget {
         'Object Pool(length: ${object.asObjectPool.length})',
       ObjRef(:final isWeakArray) when isWeakArray =>
         'WeakArray(length: ${object.asWeakArray.length})',
-      ObjRef(:final isSubtypeTestCache) when isSubtypeTestCache =>
-        'SubtypeTestCache',
+      ObjRef(:final vmType) => vmType,
       _ => null,
     };
   }
@@ -890,8 +818,9 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
           retainingPath: object.retainingPath,
           onExpanded: _onExpandRetainingPath,
         ),
-        InboundReferencesWidget(
-          inboundReferences: object.inboundReferences,
+        InboundReferencesTree(
+          controller: controller,
+          object: object,
           onExpanded: _onExpandInboundRefs,
         ),
         ...?expandableWidgets,
@@ -906,7 +835,7 @@ class VmObjectDisplayBasicLayout extends StatelessWidget {
   }
 
   void _onExpandInboundRefs(bool _) {
-    if (object.inboundReferences.value == null) {
+    if (object.inboundReferencesTree.value.isEmpty) {
       unawaited(object.requestInboundsRefs());
     }
   }
@@ -955,7 +884,7 @@ List<MapEntry<String, WidgetBuilder>> vmObjectGeneralDataRows(
     shallowSizeRowBuilder(object),
     reachableSizeRowBuilder(object),
     retainedSizeRowBuilder(object),
-    if (object is ClassObject)
+    if (object is ClassObject && object.obj.library != null)
       serviceObjectLinkBuilderMapEntry(
         controller: controller,
         key: 'Library',

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_class_display_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       expect(find.byType(RetainingPathWidget), findsOneWidget);
 
-      expect(find.byType(InboundReferencesWidget), findsOneWidget);
+      expect(find.byType(InboundReferencesTree), findsOneWidget);
 
       // TODO(mtaylee): test ClassInstancesWidget when implemented
     },

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_code_display_test.dart
@@ -5,6 +5,7 @@
 import 'dart:math';
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector/inbound_references_tree.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/vm_code_display.dart';
 import 'package:devtools_app/src/shared/table/table.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -87,8 +88,8 @@ void main() {
       when(mockCodeObject.retainingPath).thenReturn(
         const FixedValueListenable<RetainingPath?>(null),
       );
-      when(mockCodeObject.inboundReferences).thenReturn(
-        const FixedValueListenable<InboundReferences?>(null),
+      when(mockCodeObject.inboundReferencesTree).thenReturn(
+        const FixedValueListenable<List<InboundReferencesTreeNode>>([]),
       );
       when(mockCodeObject.fetchingReachableSize).thenReturn(
         const FixedValueListenable<bool>(false),

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_developer_common_widgets_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector/inbound_references_tree.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
@@ -27,7 +28,7 @@ void main() {
 
   final retainingPathNotifier = ValueNotifier<RetainingPath?>(null);
 
-  final inboundRefsNotifier = ValueNotifier<InboundReferences?>(null);
+  final inboundRefsNotifier = ListValueNotifier<InboundReferencesTreeNode>([]);
 
   setUp(() {
     fakeServiceManager = FakeServiceManager();
@@ -75,12 +76,32 @@ void main() {
       retainingPathNotifier.value = testRetainingPath;
     });
 
-    when(mockClassObject.inboundReferences).thenReturn(inboundRefsNotifier);
+    when(mockClassObject.inboundReferencesTree).thenReturn(inboundRefsNotifier);
 
     // Intentionally unawaited.
     // ignore: discarded_futures
     when(mockClassObject.requestInboundsRefs()).thenAnswer((_) async {
-      inboundRefsNotifier.value = testInboundRefs;
+      inboundRefsNotifier.clear();
+      inboundRefsNotifier.addAll(
+        InboundReferencesTreeNode.buildTreeRoots(testInboundRefs),
+      );
+    });
+
+    // Intentionally unawaited.
+    // ignore: discarded_futures
+    when(mockClassObject.expandInboundRef(any)).thenAnswer((_) async {
+      for (final entry in inboundRefsNotifier.value) {
+        entry.addAllChildren(
+          InboundReferencesTreeNode.buildTreeRoots(
+            TestInboundReferences(
+              references: [
+                InboundReference(source: testFunction),
+              ],
+            ),
+          ),
+        );
+      }
+      inboundRefsNotifier.notifyListeners();
     });
   });
 
@@ -223,15 +244,16 @@ void main() {
   );
 
   testWidgetsWithWindowSize(
-    'test InboundReferencesWidget with null data',
+    'test $InboundReferencesTree with null data',
     windowSize,
     (WidgetTester tester) async {
-      inboundRefsNotifier.value = null;
+      inboundRefsNotifier.clear();
 
       await tester.pumpWidget(
         wrap(
-          InboundReferencesWidget(
-            inboundReferences: mockClassObject.inboundReferences,
+          InboundReferencesTree(
+            controller: testObjectInspectorViewController,
+            object: mockClassObject,
             onExpanded: (bool _) {},
           ),
         ),
@@ -243,45 +265,74 @@ void main() {
 
       await tester.pump();
 
-      expect(find.byType(CenteredCircularProgressIndicator), findsOneWidget);
+      expect(
+        find.text('There are no inbound references for this object'),
+        findsOneWidget,
+      );
     },
   );
 
   testWidgetsWithWindowSize(
-    'test InboundReferencesWidget with data',
+    'test $InboundReferencesTree with data',
     windowSize,
     (WidgetTester tester) async {
       await tester.pumpWidget(
         wrap(
-          InboundReferencesWidget(
-            inboundReferences: mockClassObject.inboundReferences,
+          InboundReferencesTree(
+            controller: testObjectInspectorViewController,
+            object: mockClassObject,
             onExpanded: (bool _) => mockClassObject.requestInboundsRefs(),
           ),
         ),
       );
 
       await tester.tap(find.text('Inbound References'));
+      await tester.pumpAndSettle();
 
+      expect(
+        find.text('Referenced by '),
+        findsNWidgets(5),
+      );
+
+      // Covers:
+      //   - Referenced by fooParentField in Record
+      //   - Referenced by element 1 of Record
+      expect(
+        find.text('fooParentField in ', findRichText: true),
+        findsOneWidget,
+      );
+      expect(find.text('element 1 of '), findsOneWidget);
+      expect(
+        find.text('Record', findRichText: true),
+        findsNWidgets(2),
+      );
+
+      // Covers:
+      //   - Referenced by fooField
+      //   - Referenced by fooSuperClass
+      //   - Referenced by fooFunction
+      expect(
+        find.text('fooField', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('fooSuperClass', findRichText: true),
+        findsOneWidget,
+      );
+      expect(
+        find.text('fooFunction', findRichText: true),
+        findsOneWidget,
+      );
+
+      await tester.tap(find.byIcon(Icons.keyboard_arrow_down).first);
       await tester.pumpAndSettle();
       expect(
-        find.text('Referenced by fooFunction'),
-        findsOneWidget,
+        find.text('Referenced by '),
+        findsNWidgets(6),
       );
       expect(
-        find.text('Referenced by fooParentField of fooType fooField of fooLib'),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Referenced by fooParentField of fooRecord'),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Referenced by \$1 of fooRecord'),
-        findsOneWidget,
-      );
-      expect(
-        find.text('Referenced by element [1] of fooSuperClass'),
-        findsOneWidget,
+        find.text('fooFunction', findRichText: true),
+        findsNWidgets(2),
       );
     },
   );

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_field_display_test.dart
@@ -86,7 +86,7 @@ void main() {
 
         expect(find.byType(RetainingPathWidget), findsOneWidget);
 
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
       },
     );
 

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_function_display_test.dart
@@ -107,7 +107,7 @@ void main() {
 
         expect(find.byType(RequestableSizeWidget), findsNWidgets(2));
         expect(find.byType(RetainingPathWidget), findsOneWidget);
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
         expect(find.byType(CallSiteDataArrayWidget), findsOneWidget);
       },
     );

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_ic_data_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_ic_data_display_test.dart
@@ -81,7 +81,7 @@ void main() {
 
         expect(find.byType(RequestableSizeWidget), findsNWidgets(2));
         expect(find.byType(RetainingPathWidget), findsOneWidget);
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
         expect(find.byType(ExpansionTileInstanceList), findsNWidgets(2));
       },
     );

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_library_display_test.dart
@@ -73,7 +73,7 @@ void main() {
 
         expect(find.byType(RetainingPathWidget), findsOneWidget);
 
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
 
         expect(find.byType(LibraryDependencies), findsOneWidget);
       },

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_object_pool_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_object_pool_display_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector/inbound_references_tree.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart';
 import 'package:devtools_app/src/screens/vm_developer/vm_developer_common_widgets.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -65,8 +66,8 @@ void main() {
       when(mockObjectPool.retainingPath).thenReturn(
         const FixedValueListenable<RetainingPath?>(null),
       );
-      when(mockObjectPool.inboundReferences).thenReturn(
-        const FixedValueListenable<InboundReferences?>(null),
+      when(mockObjectPool.inboundReferencesTree).thenReturn(
+        const FixedValueListenable<List<InboundReferencesTreeNode>>([]),
       );
       when(mockObjectPool.fetchingReachableSize).thenReturn(
         const FixedValueListenable<bool>(false),
@@ -101,7 +102,7 @@ void main() {
         expect(find.text('Retained Size:'), findsOneWidget);
 
         expect(find.byType(RetainingPathWidget), findsOneWidget);
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
 
         expect(find.byType(ObjectPoolTable), findsOneWidget);
 

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_script_display_test.dart
@@ -72,7 +72,7 @@ void main() {
 
       expect(find.byType(RetainingPathWidget), findsOneWidget);
 
-      expect(find.byType(InboundReferencesWidget), findsOneWidget);
+      expect(find.byType(InboundReferencesTree), findsOneWidget);
     },
   );
 }

--- a/packages/devtools_app/test/vm_developer/object_inspector/vm_simple_list_display_test.dart
+++ b/packages/devtools_app/test/vm_developer/object_inspector/vm_simple_list_display_test.dart
@@ -73,7 +73,7 @@ void main() {
 
         expect(find.byType(RequestableSizeWidget), findsNWidgets(2));
         expect(find.byType(RetainingPathWidget), findsOneWidget);
-        expect(find.byType(InboundReferencesWidget), findsOneWidget);
+        expect(find.byType(InboundReferencesTree), findsOneWidget);
         expect(find.byType(ExpansionTileInstanceList), findsOneWidget);
       },
     );

--- a/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
+++ b/packages/devtools_app/test/vm_developer/vm_developer_test_utils.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/src/screens/debugger/program_explorer_controller.dart';
+import 'package:devtools_app/src/screens/vm_developer/object_inspector/inbound_references_tree.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/object_viewport.dart';
 import 'package:devtools_app/src/screens/vm_developer/object_inspector/vm_object_model.dart';
@@ -221,8 +222,10 @@ void mockVmObject(VmObject object) {
   when(object.retainingPath).thenReturn(
     ValueNotifier<RetainingPath?>(testRetainingPath),
   );
-  when(object.inboundReferences).thenReturn(
-    ValueNotifier<InboundReferences?>(testInboundRefs),
+  when(object.inboundReferencesTree).thenReturn(
+    ListValueNotifier<InboundReferencesTreeNode>(
+      InboundReferencesTreeNode.buildTreeRoots(testInboundRefs),
+    ),
   );
 
   if (object is ClassObject) {


### PR DESCRIPTION
This change replaces the existing "Inbound References" expandable tile on each object inspector view with a lazily-loaded tree of inbound references.

`UnknownObject` and `VmUnknownObjectDisplay` were also added to support displaying VM internal types that don't require explicit rendering support in the object inspector (e.g., types like `Namespace` or `KernelProgramInfo` which don't provide any useful properties to inspect).

<img width="1373" alt="image" src="https://github.com/flutter/devtools/assets/24210656/1532c801-8cea-4a42-b2dd-b8225dd2d0dd">
