### PR TITLE
[VM Tools] Fix open port inspector and UI inconsistencies

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics/isolate_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics/isolate_statistics_view.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:vm_service/vm_service.dart';
@@ -154,6 +155,7 @@ class GeneralIsolateStatisticsWidget extends StatelessWidget {
       showBottom: false,
       child: VMInfoCard(
         title: 'General',
+        roundedTopBorder: false,
         rowKeyValues: [
           selectableTextBuilderMapEntry('Name', isolate?.name),
           selectableTextBuilderMapEntry('Started at', _startTime(isolate)),
@@ -190,6 +192,7 @@ class IsolateMemoryStatisticsWidget extends StatelessWidget {
       showBottom: false,
       child: VMInfoCard(
         title: 'Memory',
+        roundedTopBorder: false,
         rowKeyValues: [
           selectableTextBuilderMapEntry(
             'Dart Heap',
@@ -235,6 +238,7 @@ class TagStatisticsWidget extends StatelessWidget {
       showBottom: false,
       child: VMInfoCard(
         title: 'Execution Time',
+        roundedTopBorder: false,
         table: Flexible(
           child: controller.cpuProfilerController.profilerEnabled
               ? FlatTable<VMTag>(
@@ -308,36 +312,46 @@ class _StackTraceViewerFrameColumn extends ColumnData<String> {
 // TODO(bkonyi): merge with debugger stack trace viewer.
 /// A simple table to display a stack trace, sorted by frame number.
 class StackTraceViewerWidget extends StatelessWidget {
-  const StackTraceViewerWidget({super.key, required this.stackTrace});
+  const StackTraceViewerWidget({
+    super.key,
+    required this.stackTrace,
+  });
 
   static final frame = _StackTraceViewerFrameColumn();
 
-  final InstanceRef? stackTrace;
+  final ValueListenable<InstanceRef?> stackTrace;
 
   @override
   Widget build(BuildContext context) {
-    final List<String>? lines = stackTrace?.allocationLocation?.valueAsString
-        ?.split('\n')
-        .where((e) => e.isNotEmpty)
-        .toList();
-    return VMInfoList(
-      title: 'Allocation Location',
-      table: lines == null
-          ? const Expanded(
-              child: Center(
-                child: Text('No port selected'),
-              ),
-            )
-          : Flexible(
-              child: FlatTable<String>(
-                keyFactory: (String s) => ValueKey<String>(s),
-                data: lines,
-                dataKey: 'stack-trace-viewer',
-                columns: [frame],
-                defaultSortColumn: frame,
-                defaultSortDirection: SortDirection.ascending,
-              ),
-            ),
+    return ValueListenableBuilder<InstanceRef?>(
+      valueListenable: stackTrace,
+      builder: (context, stackTrace, _) {
+        final List<String>? lines = stackTrace
+            ?.allocationLocation?.valueAsString
+            ?.split('\n')
+            .where((e) => e.isNotEmpty)
+            .toList();
+        return VMInfoList(
+          title: 'Allocation Location',
+          roundedTopBorder: false,
+          table: lines == null
+              ? const Expanded(
+                  child: Center(
+                    child: Text('No port selected'),
+                  ),
+                )
+              : Flexible(
+                  child: FlatTable<String>(
+                    keyFactory: (String s) => ValueKey<String>(s),
+                    data: lines,
+                    dataKey: 'stack-trace-viewer',
+                    columns: [frame],
+                    defaultSortColumn: frame,
+                    defaultSortDirection: SortDirection.ascending,
+                  ),
+                ),
+        );
+      },
     );
   }
 }
@@ -379,6 +393,7 @@ class _IsolatePortsWidgetState extends State<IsolatePortsWidget> {
               children: [
                 AreaPaneHeader(
                   includeTopBorder: false,
+                  roundedTopBorder: false,
                   title: Text(
                     'Open Ports (${ports.length})',
                   ),
@@ -400,7 +415,7 @@ class _IsolatePortsWidgetState extends State<IsolatePortsWidget> {
           ),
           OutlineDecoration.onlyLeft(
             child: StackTraceViewerWidget(
-              stackTrace: selectedPort.value,
+              stackTrace: selectedPort,
             ),
           ),
         ],
@@ -434,6 +449,7 @@ class ServiceExtensionsWidget extends StatelessWidget {
       showLeft: false,
       child: VMInfoCard(
         title: 'Service Extensions (${extensions.length})',
+        roundedTopBorder: false,
         table: Flexible(
           child: FlatTable<String>(
             keyFactory: (String extension) => ValueKey<String>(extension),

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics/vm_statistics_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_statistics/vm_statistics_view.dart
@@ -127,6 +127,7 @@ class GeneralVMStatisticsWidget extends StatelessWidget {
     return OutlineDecoration(
       child: VMInfoCard(
         title: 'VM',
+        roundedTopBorder: false,
         rowKeyValues: [
           selectableTextBuilderMapEntry('Name', vm?.name),
           selectableTextBuilderMapEntry('Version', vm?.version),
@@ -172,6 +173,7 @@ class ProcessStatisticsWidget extends StatelessWidget {
       showTop: false,
       child: VMInfoCard(
         title: 'Process',
+        roundedTopBorder: false,
         rowKeyValues: [
           selectableTextBuilderMapEntry('PID', vm?.pid?.toString()),
           selectableTextBuilderMapEntry(
@@ -306,6 +308,7 @@ class IsolatesPreviewWidget extends StatelessWidget {
       showTop: !systemIsolates,
       child: VMInfoCard(
         title: '$title (${isolates.length})',
+        roundedTopBorder: false,
         table: Flexible(
           child: FlatTable<Isolate>(
             keyFactory: (Isolate i) => ValueKey<String>(i.id!),


### PR DESCRIPTION
The stacktrace viewer for the open port inspector required a page refresh when switching between selected ports. Updated the stracktrace viewer to use a `ValueListenableBuilder` to properly rebuild when the selected port has changed.

Also removed some rounded borders that were introduced when DevTools was migrated to Material 3.