### PR TITLE
Fix text selection issues in the codeview and console

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -210,6 +210,7 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
               } else if (line is VariableConsoleLine) {
                 return ExpandableVariable(
                   variable: line.variable,
+                  isSelectable: false,
                 );
               } else {
                 assert(

--- a/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
@@ -17,6 +17,7 @@ class ExpandableVariable extends StatelessWidget {
     Key? key,
     this.variable,
     this.dataDisplayProvider,
+    this.isSelectable = true,
   }) : super(key: key);
 
   @visibleForTesting
@@ -24,6 +25,8 @@ class ExpandableVariable extends StatelessWidget {
 
   final DartObjectNode? variable;
   final Widget Function(DartObjectNode, void Function())? dataDisplayProvider;
+
+  final bool isSelectable;
 
   @override
   Widget build(BuildContext context) {
@@ -33,7 +36,7 @@ class ExpandableVariable extends StatelessWidget {
     }
     // TODO(kenz): preserve expanded state of tree on switching frames and
     // on stepping.
-    return TreeView<DartObjectNode>(
+    final tree = TreeView<DartObjectNode>(
       dataRootsListenable:
           FixedValueListenable<List<DartObjectNode>>([variable]),
       dataDisplayProvider: dataDisplayProvider ??
@@ -42,7 +45,14 @@ class ExpandableVariable extends StatelessWidget {
                 onTap: onPressed,
               ),
       onItemSelected: onItemPressed,
+      isSelectable: isSelectable,
     );
+
+    if (isSelectable) {
+      return SelectionArea(child: tree);
+    }
+
+    return tree;
   }
 
   Future<void> onItemPressed(

--- a/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
@@ -36,7 +36,7 @@ class ExpandableVariable extends StatelessWidget {
     }
     // TODO(kenz): preserve expanded state of tree on switching frames and
     // on stepping.
-    final tree = TreeView<DartObjectNode>(
+    return TreeView<DartObjectNode>(
       dataRootsListenable:
           FixedValueListenable<List<DartObjectNode>>([variable]),
       dataDisplayProvider: dataDisplayProvider ??
@@ -47,12 +47,6 @@ class ExpandableVariable extends StatelessWidget {
       onItemSelected: onItemPressed,
       isSelectable: isSelectable,
     );
-
-    if (isSelectable) {
-      return SelectionArea(child: tree);
-    }
-
-    return tree;
   }
 
   Future<void> onItemPressed(

--- a/packages/devtools_app/lib/src/shared/tree.dart
+++ b/packages/devtools_app/lib/src/shared/tree.dart
@@ -26,6 +26,7 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
     this.emptyTreeViewBuilder,
     this.scrollController,
     this.includeScrollbar = false,
+    this.isSelectable = true,
   });
 
   final ValueListenable<List<T>> dataRootsListenable;
@@ -52,6 +53,8 @@ class TreeView<T extends TreeNode<T>> extends StatefulWidget {
 
   final bool includeScrollbar;
 
+  final bool isSelectable;
+
   @override
   State<TreeView<T>> createState() => _TreeViewState<T>();
 }
@@ -75,8 +78,8 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
     if (dataFlatList.isEmpty) return _emptyTreeViewBuilder();
     final content = SizedBox(
       height: dataFlatList.length * defaultTreeViewRowHeight,
-      child: SelectionArea(
-        child: ListView.builder(
+      child: _maybeWrapInSelectionArea(
+        ListView.builder(
           itemCount: dataFlatList.length,
           itemExtent: defaultTreeViewRowHeight,
           physics: const ClampingScrollPhysics(),
@@ -109,6 +112,13 @@ class _TreeViewState<T extends TreeNode<T>> extends State<TreeView<T>>
       return widget.emptyTreeViewBuilder!();
     }
     return const SizedBox();
+  }
+
+  Widget _maybeWrapInSelectionArea(Widget tree) {
+    if (widget.isSelectable) {
+      return SelectionArea(child: tree);
+    }
+    return tree;
   }
 
   // TODO(kenz): animate expansions and collapses.


### PR DESCRIPTION
Fixes issues reported in https://github.com/flutter/devtools/issues/6079

With this change:
1. highlighting in the console removes any selection areas in the codeview and visa versa
2. highlighting in the console and then right clicking maintains the current text selection 
3. cmd+c works in the console (and in codeview, but that was working for me before this change)

The reason this wasn't working before was because we had a `SelectionArea` (for the expandable variable `TreeView`) nested inside another `SelectionArea` (for the console). Now we only have the `SelectionArea` for the console.


See demo:

![selection fixes](https://github.com/flutter/devtools/assets/21270878/47952206-e84d-4856-b0ee-370dc90321e6)
