### PR TITLE
Prevent console text from being cut-off

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/widgets/console_pane.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/console_pane.dart
@@ -7,7 +7,6 @@ import 'package:flutter/material.dart';
 
 import '../../common_widgets.dart';
 import '../../globals.dart';
-import '../../theme.dart';
 import '../console.dart';
 import '../console_service.dart';
 import 'evaluate.dart';

--- a/packages/devtools_app/lib/src/shared/console/widgets/console_pane.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/console_pane.dart
@@ -57,10 +57,7 @@ class ConsolePane extends StatelessWidget {
     if (serviceManager.connectedApp!.isProfileBuildNow!) {
       footer = null;
     } else {
-      footer = SizedBox(
-        height: consoleLineHeight,
-        child: const ExpressionEvalField(),
-      );
+      footer = const ExpressionEvalField();
     }
 
     return Column(

--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -249,9 +249,8 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
               },
               // Disable ligatures, so the suggestions of the auto complete work correcly.
               style: Theme.of(context)
-                  .textTheme
-                  .titleMedium
-                  ?.copyWith(fontFeatures: [const FontFeature.disable('liga')]),
+                  .fixedFontStyle
+                  .copyWith(fontFeatures: [const FontFeature.disable('liga')]),
             ),
           ),
         ),


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6080

We were wrapping the eval field in a sized box with the height constrained to match the height of the console rows above. The font in eval is larger than the font in the console rows, and the text field itself takes up space. Therefore the text was being cut-off. If we remove the `SizedBox`, the eval field now takes up all the space it needs. 

Also switches eval to use the same fixed font style of the other rows:


<img width="924" alt="Screenshot 2023-07-26 at 10 39 30 AM" src="https://github.com/flutter/devtools/assets/21270878/d3217568-4bfc-4dae-889c-d3b0c034c539">
