### PR TITLE
Add documentation comments for `DapDisplayProvider` and `DisplayProvider` 

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
@@ -16,7 +16,7 @@ import '../../screen.dart';
 import '../../theme.dart';
 import 'description.dart';
 
-/// The display provider for variables fetching via the VM service protocol.
+/// The display provider for variables fetched via the VM service protocol.
 class DisplayProvider extends StatelessWidget {
   const DisplayProvider({
     super.key,
@@ -177,7 +177,7 @@ class DisplayProvider extends StatelessWidget {
   }
 }
 
-/// The display provider for variables fetching via the Debug Adapter Protocol.
+/// The display provider for variables fetched via the Debug Adapter Protocol.
 class DapDisplayProvider extends StatelessWidget {
   const DapDisplayProvider({
     super.key,

--- a/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/display_provider.dart
@@ -16,6 +16,7 @@ import '../../screen.dart';
 import '../../theme.dart';
 import 'description.dart';
 
+/// The display provider for variables fetching via the VM service protocol.
 class DisplayProvider extends StatelessWidget {
   const DisplayProvider({
     super.key,
@@ -176,6 +177,7 @@ class DisplayProvider extends StatelessWidget {
   }
 }
 
+/// The display provider for variables fetching via the Debug Adapter Protocol.
 class DapDisplayProvider extends StatelessWidget {
   const DapDisplayProvider({
     super.key,


### PR DESCRIPTION
I accidentally merged  https://github.com/flutter/devtools/pull/6070 before addressing https://github.com/flutter/devtools/pull/6070#discussion_r1275333348 😬 

This PR adds documentation comments for `DapDisplayProvider` and `DisplayProvider`