### PR TITLE
Performance panel instructions for web apps

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -156,6 +156,12 @@ const timelineTaskLink =
     'https://api.flutter.dev/flutter/dart-developer/TimelineTask-class.html';
 const debugBuildsLink =
     'https://api.flutter.dev/flutter/widgets/debugProfileBuildsEnabled.html';
+const debugUserBuildsLink =
+    'https://api.flutter.dev/flutter/widgets/debugProfileBuildsEnabledUserWidgets.html';
+const debugLayoutsLink =
+    'https://api.flutter.dev/flutter/rendering/debugProfileLayoutsEnabled.html';
+const debugPaintsLink =
+    'https://api.flutter.dev/flutter/rendering/debugProfilePaintsEnabled.html';
 const profileModeLink = 'https://docs.flutter.dev/testing/build-modes#profile';
 const performancePanelLink =
     'https://developer.chrome.com/docs/devtools/performance';
@@ -163,18 +169,24 @@ const performancePanelLink =
 const flutterWebInstructionsMd = '''
 # How to use Chrome DevTools for performance profiling
 
-The timeline events emitted by the Flutter framework as it works to build
-frames, draw scenes, and track other activity such as HTTP request timings and
-garbage collection are exposed in the Chrome DevTools performance panel.
+The Flutter framework emits timeline events as it works to build frames, draw 
+scenes, and track other activity such as garbage collections. These events are 
+exposed in the Chrome DevTools performance panel for debugging.
 
 You can also emit your own timeline events using the `dart:developer` 
 [Timeline]($timelineLink) and [TimelineTask]($timelineTaskLink) APIs for further
 performance analysis.
 
-## Instructions:
+## Optional flags to enhance tracing
 
-1. *[Optional]* Set [debugProfileBuildsEnabled]($debugBuildsLink) to true to 
-track your app's widget builds.
+- [debugProfileBuildsEnabled]($debugBuildsLink): Adds Timeline events for every Widget built.
+- [debugProfileBuildsEnabledUserWidgets]($debugUserBuildsLink): Adds Timeline events for every user-created Widget built.
+- [debugProfileLayoutsEnabled]($debugLayoutsLink): Adds Timeline events for every RenderObject layout.
+- [debugProfilePaintsEnabled]($debugPaintsLink): Adds Timeline events for every RenderObject painted.
+
+## Instructions
+
+1. *[Optional]* Set any desired tracing flags to true from your app's main method.
 2. Run your Flutter web app in [profile mode]($profileModeLink).
 3. Open up the [Chrome DevTools' Performance panel]($performancePanelLink) for
 your application, and start recording to capture timeline events.

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -42,8 +42,7 @@ class PerformanceScreen extends Screen {
 
   @override
   Widget build(BuildContext context) {
-    if (FeatureFlags.performancePageForWeb &&
-        (serviceManager.connectedApp?.isDartWebAppNow ?? false)) {
+    if (serviceManager.connectedApp?.isDartWebAppNow ?? false) {
       return const WebPerformanceScreenBody();
     }
     return const PerformanceScreenBody();
@@ -135,6 +134,60 @@ class WebPerformanceScreenBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Markdown(data: 'This is some markdown');
+    final isFlutterWebApp =
+        serviceManager.connectedApp?.isFlutterWebAppNow ?? false;
+    return Markdown(
+      data: isFlutterWebApp ? flutterWebInstructionsMd : dartWebInstructionsMd,
+      onTapLink: (_, url, __) {
+        if (url != null) {
+          unawaited(
+            launchUrl(
+              Uri.parse(url),
+            ),
+          );
+        }
+      },
+    );
   }
 }
+
+const timelineLink =
+    'https://api.flutter.dev/flutter/dart-developer/Timeline-class.html';
+const timelineTaskLink =
+    'https://api.flutter.dev/flutter/dart-developer/TimelineTask-class.html';
+const debugBuildsLink =
+    'https://api.flutter.dev/flutter/widgets/debugProfileBuildsEnabled.html';
+const profileModeLink = 'https://docs.flutter.dev/testing/build-modes#profile';
+const performancePanelLink =
+    'https://developer.chrome.com/docs/devtools/performance';
+
+const flutterWebInstructionsMd = '''
+# How to use Chrome DevTools for performance profiling
+
+The timeline events emitted by the Flutter framework as it works to build
+frames, draw scenes, and track other activity such as HTTP request timings and
+garbage collection are exposed in the Chrome DevTools performance panel.
+
+You can also emit your own timeline events using the `dart:developer` 
+[Timeline]($timelineLink) and [TimelineTask]($timelineTaskLink) APIs for further
+performance analysis.
+
+## Instructions:
+
+1. *[Optional]* Set [debugProfileBuildsEnabled]($debugBuildsLink) to true to 
+track your app's widget builds.
+2. Run your Flutter web app in [profile mode]($profileModeLink).
+3. Open up the [Chrome DevTools' Performance panel]($performancePanelLink) for
+your application, and start recording to capture timeline events.
+''';
+
+const dartWebInstructionsMd = '''
+# How to use Chrome DevTools for performance profiling
+
+Any events emitted using the `dart:developer` [Timeline]($timelineLink) and 
+[TimelineTask]($timelineTaskLink) APIs are exposed in the Chrome DevTools 
+performance panel.
+
+Open up the [Chrome DevTools' Performance panel]($performancePanelLink) for
+your application, and start recording to capture timeline events.
+''';

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -12,7 +12,6 @@ import 'package:url_launcher/url_launcher.dart';
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/banner_messages.dart';
 import '../../shared/common_widgets.dart';
-import '../../shared/feature_flags.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/auto_dispose.dart';
 import '../../shared/screen.dart';

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -135,8 +135,6 @@ class WebPerformanceScreenBody extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Center(
-      child: Text('TODO: add instructions for using Chrome DevTools'),
-    );
+    return const Markdown(data: 'This is some markdown');
   }
 }

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -2,8 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:async';
+
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/banner_messages.dart';

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -74,13 +74,6 @@ abstract class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/1632
   static bool devToolsExtensions = enableExperiments;
 
-  // TODO(elliottbrooks): remove this flag once you add instructions to the
-  // web performance page body.
-  /// Flag to enable the Performance page for web.
-  ///
-  /// https://github.com/flutter/devtools/issues/6095
-  static bool get performancePageForWeb => enableExperiments;
-
   /// Stores a map of all the feature flags for debugging purposes.
   ///
   /// When adding a new flag, you are responsible for adding it to this map as

--- a/packages/devtools_app/test/performance/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance/performance_screen_test.dart
@@ -157,7 +157,7 @@ void main() {
         // Make sure NO Flutter-specific information is included:
         expect(
           markdownFinder(
-            'The timeline events emitted by the Flutter framework',
+            'The Flutter framework emits timeline events',
           ),
           findsNothing,
         );
@@ -193,7 +193,7 @@ void main() {
         // Make sure Flutter-specific information is included:
         expect(
           markdownFinder(
-            'The timeline events emitted by the Flutter framework',
+            'The Flutter framework emits timeline events',
           ),
           findsOneWidget,
         );


### PR DESCRIPTION
Adds instructions to the performance panel for web apps on how to use Chrome DevTools for performance profiling. 

For Flutter web users:

<img width="786" alt="Screenshot 2023-07-26 at 2 59 02 PM" src="https://github.com/flutter/devtools/assets/21270878/ffb5e4d6-1f68-4554-bcf0-7094af2dd7d3">

For Dart web users:

<img width="775" alt="Screenshot 2023-07-26 at 2 59 35 PM" src="https://github.com/flutter/devtools/assets/21270878/274aa332-10aa-4c3e-91ac-29477495da35">

Fixes https://github.com/flutter/devtools/issues/6095