### PR TITLE
Use `onItemExpanded` instead of `onItemSelected` for `ExpandableVariable`

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
@@ -44,17 +44,15 @@ class ExpandableVariable extends StatelessWidget {
                 variable: variable,
                 onTap: onPressed,
               ),
-      onItemSelected: onItemPressed,
+      onItemExpanded: onItemExpanded,
       isSelectable: isSelectable,
     );
   }
 
-  Future<void> onItemPressed(
+  Future<void> onItemExpanded(
     DartObjectNode v,
   ) async {
-    // On expansion, lazily build the variables tree for performance reasons.
-    if (v.isExpanded) {
-      await Future.wait(v.children.map(buildVariablesTree));
-    }
+    // Lazily build the variables tree for performance reasons.
+    await Future.wait(v.children.map(buildVariablesTree));
   }
 }


### PR DESCRIPTION
Just a small thing I noticed during DAP migration - we are using `onItemSelected` when really what we care about is whether the variable has been expanded. Therefore `onItemExpanded` is more appropriate (and allows us to remove the check for `isExpanded`)
