### PR TITLE
Refactor `display_provider` to include an abstract `NodeDisplayProvider`

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/variables.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/variables.dart
@@ -36,8 +36,8 @@ class Variables extends StatelessWidget {
     } else {
       return TreeView<DartObjectNode>(
         dataRootsListenable: serviceManager.appState.variables,
-        dataDisplayProvider: (variable, onPressed) => DisplayProvider(
-          variable: variable,
+        dataDisplayProvider: (variable, onPressed) => VmDisplayProvider(
+          node: variable,
           onTap: onPressed,
         ),
         onItemSelected: onItemPressed,

--- a/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/expandable_variable.dart
@@ -40,8 +40,8 @@ class ExpandableVariable extends StatelessWidget {
       dataRootsListenable:
           FixedValueListenable<List<DartObjectNode>>([variable]),
       dataDisplayProvider: dataDisplayProvider ??
-          (variable, onPressed) => DisplayProvider(
-                variable: variable,
+          (variable, onPressed) => VmDisplayProvider(
+                node: variable,
                 onTap: onPressed,
               ),
       onItemSelected: onItemPressed,


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6056

Both `VmDisplayProvider` and `DapDisplayProvider` implement the abstract `NodeDisplayProvider`. This will make it easier to use the two interchangeably during the DAP migration process.