### PR TITLE
A couple fixes to the extensions server apis

### DIFF
--- a/packages/devtools_shared/lib/src/devtools_api.dart
+++ b/packages/devtools_shared/lib/src/devtools_api.dart
@@ -77,17 +77,17 @@ abstract class ExtensionsApi {
   /// receiving a [apiServeAvailableExtensions] request.
   static const extensionsResultPropertyName = 'extensions';
 
-  /// Returns and optionally sets the activation state for a DevTools extension.
-  static const apiExtensionActivationState =
-      '${apiPrefix}extensionActivationState';
+  /// Returns and optionally sets the enabled state for a DevTools extension.
+  static const apiExtensionEnabledState =
+      '${apiPrefix}extensionEnabledState';
 
   /// The property name for the query parameter passed along with
-  /// [apiExtensionActivationState] requests to the server that describes the
+  /// [apiExtensionEnabledState] requests to the server that describes the
   /// name of the extension whose state is being queried.
   static const extensionNamePropertyName = 'name';
 
   /// The property name for the query parameter that is optionally passed along
-  /// with [apiExtensionActivationState] requests to the server to set the
-  /// activation state for the extension.
-  static const activationStatePropertyName = 'activate';
+  /// with [apiExtensionEnabledState] requests to the server to set the
+  /// enabled state for the extension.
+  static const enabledStatePropertyName = 'enable';
 }

--- a/packages/devtools_shared/lib/src/extensions/extension_enablement.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_enablement.dart
@@ -21,21 +21,21 @@ class DevToolsOptions {
 $_extensionsKey:
 ''';
 
-  /// Returns the current activation state for [extensionName] in the
+  /// Returns the current enabled state for [extensionName] in the
   /// 'devtools_options.yaml' file at [rootUri].
   ///
   /// If the 'devtools_options.yaml' file does not exist, it will be created
   /// with an empty set of extensions.
-  ExtensionActivationState lookupExtensionActivationState({
+  ExtensionEnabledState lookupExtensionEnabledState({
     required Uri rootUri,
     required String extensionName,
   }) {
     final options = _optionsAsMap(rootUri: rootUri);
-    if (options == null) return ExtensionActivationState.error;
+    if (options == null) return ExtensionEnabledState.error;
 
     final extensions =
         (options[_extensionsKey] as List?)?.cast<Map<String, Object?>>();
-    if (extensions == null) return ExtensionActivationState.none;
+    if (extensions == null) return ExtensionEnabledState.none;
 
     for (final e in extensions) {
       // Each entry should only have one key / value pair (e.g. '- foo: true').
@@ -45,20 +45,20 @@ $_extensionsKey:
         return _extensionStateForValue(e[extensionName]);
       }
     }
-    return ExtensionActivationState.none;
+    return ExtensionEnabledState.none;
   }
 
-  /// Sets the activation state for [extensionName] in the
+  /// Sets the enabled state for [extensionName] in the
   /// 'devtools_options.yaml' file at [rootUri].
   ///
   /// If the 'devtools_options.yaml' file does not exist, it will be created.
-  ExtensionActivationState setExtensionActivationState({
+  ExtensionEnabledState setExtensionEnabledState({
     required Uri rootUri,
     required String extensionName,
-    required bool activate,
+    required bool enable,
   }) {
     final options = _optionsAsMap(rootUri: rootUri);
-    if (options == null) return ExtensionActivationState.error;
+    if (options == null) return ExtensionEnabledState.error;
 
     var extensions =
         (options[_extensionsKey] as List?)?.cast<Map<String, Object?>>();
@@ -67,21 +67,21 @@ $_extensionsKey:
       extensions = options[_extensionsKey] as List<Map<String, Object?>>;
     }
 
-    // Write the new activation state to the map.
+    // Write the new enabled state to the map.
     final extension = extensions.firstWhereOrNull(
       (e) => e.keys.first == extensionName,
     );
     if (extension == null) {
-      extensions.add({extensionName: activate});
+      extensions.add({extensionName: enable});
     } else {
-      extension[extensionName] = activate;
+      extension[extensionName] = enable;
     }
 
     _writeToOptionsFile(rootUri: rootUri, options: options);
 
-    // Lookup the activation state from the file we just wrote to to ensure that
+    // Lookup the enabled state from the file we just wrote to to ensure that
     // are not returning an out of sync result.
-    return lookupExtensionActivationState(
+    return lookupExtensionEnabledState(
       rootUri: rootUri,
       extensionName: extensionName,
     );
@@ -130,14 +130,14 @@ $_extensionsKey:
     return optionsFile;
   }
 
-  ExtensionActivationState _extensionStateForValue(Object? value) {
+  ExtensionEnabledState _extensionStateForValue(Object? value) {
     switch (value) {
       case true:
-        return ExtensionActivationState.enabled;
+        return ExtensionEnabledState.enabled;
       case false:
-        return ExtensionActivationState.disabled;
+        return ExtensionEnabledState.disabled;
       default:
-        return ExtensionActivationState.none;
+        return ExtensionEnabledState.none;
     }
   }
 }

--- a/packages/devtools_shared/lib/src/extensions/extension_model.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_model.dart
@@ -112,7 +112,8 @@ class DevToolsExtensionConfig {
       };
 }
 
-enum ExtensionActivationState {
+/// Describes the enablement state of a DevTools extension.
+enum ExtensionEnabledState {
   /// The extension has been enabled manually by the user.
   enabled,
 
@@ -127,9 +128,10 @@ enum ExtensionActivationState {
   /// We should ignore extensions with this activation state.
   error;
 
-  static ExtensionActivationState from(String? value) {
-    return ExtensionActivationState.values
+  /// Parses [value] and returns the matching [ExtensionEnabledState] if found.
+  static ExtensionEnabledState from(String? value) {
+    return ExtensionEnabledState.values
             .firstWhereOrNull((e) => e.name == value) ??
-        ExtensionActivationState.none;
+        ExtensionEnabledState.none;
   }
 }

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -310,9 +310,9 @@ abstract class _ExtensionsApiHandler {
     await extensionsManager.serveAvailableExtensions(rootPath);
     final extensions =
         extensionsManager.devtoolsExtensions.map((p) => p.toJson()).toList();
-    final result = jsonEncode({
+    final result = {
       ExtensionsApi.extensionsResultPropertyName: extensions,
-    });
+    };
     return ServerApi._encodeResponse(result, api: api);
   }
 

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -237,13 +237,15 @@ class ServerApi {
     List<String> expectedParams, {
     required Map<String, String> queryParams,
     required ServerApi api,
+    required String requestName,
   }) {
     final missing = expectedParams.where(
       (param) => !queryParams.containsKey(param),
     );
     return missing.isNotEmpty
         ? api.badRequest(
-            'Missing required query parameters: ${missing.toList()}',
+            '[$requestName] missing required query parameters: '
+            '${missing.toList()}',
           )
         : null;
   }
@@ -302,6 +304,7 @@ abstract class _ExtensionsApiHandler {
       [ExtensionsApi.extensionRootPathPropertyName],
       queryParams: queryParams,
       api: api,
+      requestName: ExtensionsApi.apiServeAvailableExtensions,
     );
     if (missingRequiredParams != null) return missingRequiredParams;
 
@@ -327,6 +330,7 @@ abstract class _ExtensionsApiHandler {
       ],
       queryParams: queryParams,
       api: api,
+      requestName: ExtensionsApi.apiExtensionActivationState,
     );
     if (missingRequiredParams != null) return missingRequiredParams;
 

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -326,7 +326,7 @@ abstract class _ExtensionsApiHandler {
     final missingRequiredParams = ServerApi._checkRequiredParameters(
       [
         ExtensionsApi.extensionRootPathPropertyName,
-        ExtensionsApi.extensionsResultPropertyName,
+        ExtensionsApi.extensionNamePropertyName,
       ],
       queryParams: queryParams,
       api: api,

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -11,7 +11,7 @@ import 'dart:io';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../devtools_api.dart';
-import '../extensions/extension_activation.dart';
+import '../extensions/extension_enablement.dart';
 import '../extensions/extension_manager.dart';
 import 'file_system.dart';
 import 'usage.dart';
@@ -215,8 +215,8 @@ class ServerApi {
           extensionsManager,
         );
 
-      case ExtensionsApi.apiExtensionActivationState:
-        return _ExtensionsApiHandler.handleExtensionActivationState(
+      case ExtensionsApi.apiExtensionEnabledState:
+        return _ExtensionsApiHandler.handleExtensionEnabledState(
           api,
           queryParams,
         );
@@ -319,7 +319,7 @@ abstract class _ExtensionsApiHandler {
     return ServerApi._encodeResponse(result, api: api);
   }
 
-  static shelf.Response handleExtensionActivationState(
+  static shelf.Response handleExtensionEnabledState(
     ServerApi api,
     Map<String, String> queryParams,
   ) {
@@ -330,7 +330,7 @@ abstract class _ExtensionsApiHandler {
       ],
       queryParams: queryParams,
       api: api,
-      requestName: ExtensionsApi.apiExtensionActivationState,
+      requestName: ExtensionsApi.apiExtensionEnabledState,
     );
     if (missingRequiredParams != null) return missingRequiredParams;
 
@@ -338,17 +338,17 @@ abstract class _ExtensionsApiHandler {
     final rootUri = Uri.parse(rootPath);
     final extensionName = queryParams[ExtensionsApi.extensionNamePropertyName]!;
 
-    final activate = queryParams[ExtensionsApi.activationStatePropertyName];
+    final activate = queryParams[ExtensionsApi.enabledStatePropertyName];
     if (activate != null) {
-      final newState = ServerApi._devToolsOptions.setExtensionActivationState(
+      final newState = ServerApi._devToolsOptions.setExtensionEnabledState(
         rootUri: rootUri,
         extensionName: extensionName,
-        activate: bool.parse(activate),
+        enable: bool.parse(activate),
       );
       return ServerApi._encodeResponse(newState.name, api: api);
     }
     final activationState =
-        ServerApi._devToolsOptions.lookupExtensionActivationState(
+        ServerApi._devToolsOptions.lookupExtensionEnabledState(
       rootUri: rootUri,
       extensionName: extensionName,
     );

--- a/packages/devtools_shared/test/extensions/extension_enablement_test.dart
+++ b/packages/devtools_shared/test/extensions/extension_enablement_test.dart
@@ -5,7 +5,7 @@
 import 'dart:io';
 
 import 'package:devtools_shared/devtools_extensions.dart';
-import 'package:devtools_shared/src/extensions/extension_activation.dart';
+import 'package:devtools_shared/src/extensions/extension_enablement.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -34,9 +34,9 @@ void main() {
       return optionsFile;
     }
 
-    test('extensionActivatedState creates options file when none exists', () {
+    test('extensionEnabledState creates options file when none exists', () {
       expect(tmpDir.listSync(), isEmpty);
-      options.lookupExtensionActivationState(
+      options.lookupExtensionEnabledState(
         rootUri: tmpUri,
         extensionName: 'foo',
       );
@@ -50,10 +50,10 @@ extensions:
     });
 
     test('can write to options file', () {
-      options.setExtensionActivationState(
+      options.setExtensionEnabledState(
         rootUri: tmpUri,
         extensionName: 'foo',
-        activate: true,
+        enable: true,
       );
       final file = _optionsFileFromTmp();
       expect(
@@ -65,15 +65,15 @@ extensions:
     });
 
     test('can read from options file', () {
-      options.setExtensionActivationState(
+      options.setExtensionEnabledState(
         rootUri: tmpUri,
         extensionName: 'foo',
-        activate: true,
+        enable: true,
       );
-      options.setExtensionActivationState(
+      options.setExtensionEnabledState(
         rootUri: tmpUri,
         extensionName: 'bar',
-        activate: false,
+        enable: false,
       );
       final file = _optionsFileFromTmp();
       expect(
@@ -85,25 +85,25 @@ extensions:
       );
 
       expect(
-        options.lookupExtensionActivationState(
+        options.lookupExtensionEnabledState(
           rootUri: tmpUri,
           extensionName: 'foo',
         ),
-        ExtensionActivationState.enabled,
+        ExtensionEnabledState.enabled,
       );
       expect(
-        options.lookupExtensionActivationState(
+        options.lookupExtensionEnabledState(
           rootUri: tmpUri,
           extensionName: 'bar',
         ),
-        ExtensionActivationState.disabled,
+        ExtensionEnabledState.disabled,
       );
       expect(
-        options.lookupExtensionActivationState(
+        options.lookupExtensionEnabledState(
           rootUri: tmpUri,
           extensionName: 'baz',
         ),
-        ExtensionActivationState.none,
+        ExtensionEnabledState.none,
       );
     });
   });


### PR DESCRIPTION
- Fixed double encoding in `apiServeAvailableExtensions` handler
- added a more descriptive exception when required parameters are missing
- renamed `ExtensionActivationState` and related apis to `ExtensionEnabledState` to match the terminology used in the UI