### PR TITLE
Add warning message about breakpoints for Chrome version 115

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -13,6 +13,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
+import '../../shared/banner_messages.dart';
 import '../../shared/common_widgets.dart';
 import '../../shared/diagnostics/primitives/source_location.dart';
 import '../../shared/flex_split_column.dart';
@@ -125,6 +126,8 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         ),
       );
     });
+    // TODO(elliette): Remove once Chrome issue is resolved.
+    _maybeShowBreakpointsWarningBanner();
   }
 
   @override
@@ -214,6 +217,25 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
         ),
       ],
     );
+  }
+
+  void _maybeShowBreakpointsWarningBanner() {
+    final chrome115BreakpointBug =
+        devToolsExtensionPoints.chrome115BreakpointBug();
+    if (chrome115BreakpointBug != null) {
+      bannerMessages.addMessage(
+        BannerWarning(
+          key: const Key('Chrome115BreakpointsWarning'),
+          textSpans: [
+            TextSpan(
+              text:
+                  'Setting a breakpoint in Chrome version 115 will crash your app. See $chrome115BreakpointBug',
+            ),
+          ],
+          screenId: DebuggerScreen.id,
+        ),
+      );
+    }
   }
 
   void _onNodeSelected(VMServiceObjectNode? node) {

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -220,9 +220,10 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
   }
 
   void _maybeShowBreakpointsWarningBanner() {
+    final isWebApp = serviceManager.connectedApp?.isDartWebAppNow ?? false;
     final chrome115BreakpointBug =
         devToolsExtensionPoints.chrome115BreakpointBug();
-    if (chrome115BreakpointBug != null) {
+    if (isWebApp && chrome115BreakpointBug != null) {
       bannerMessages.addMessage(
         BannerWarning(
           key: const Key('Chrome115BreakpointsWarning'),

--- a/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_base.dart
+++ b/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_base.dart
@@ -20,4 +20,6 @@ abstract class DevToolsEnvironmentParameters {
   Link? enableSourceMapsLink();
 
   String get perfettoIndexLocation;
+  
+  String? chrome115BreakpointBug();
 }

--- a/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_base.dart
+++ b/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_base.dart
@@ -20,6 +20,6 @@ abstract class DevToolsEnvironmentParameters {
   Link? enableSourceMapsLink();
 
   String get perfettoIndexLocation;
-  
+
   String? chrome115BreakpointBug();
 }

--- a/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_external.dart
+++ b/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_external.dart
@@ -58,6 +58,13 @@ class ExternalDevToolsEnvironmentParameters
   @override
   String get perfettoIndexLocation =>
       'packages/perfetto_ui_compiled/dist/index.html';
+
+  @override
+  String? chrome115BreakpointBug() {
+    // This should always return a null value for 3p users.
+    return null;
+  }
+
 }
 
 const _newDevToolsIssueUriDisplay = 'github.com/flutter/devtools/issues/new';

--- a/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_external.dart
+++ b/packages/devtools_app/lib/src/shared/environment_parameters/environment_parameters_external.dart
@@ -64,7 +64,6 @@ class ExternalDevToolsEnvironmentParameters
     // This should always return a null value for 3p users.
     return null;
   }
-
 }
 
 const _newDevToolsIssueUriDisplay = 'github.com/flutter/devtools/issues/new';


### PR DESCRIPTION
See b/293487305

Hitting a breakpoint that's been set via theDart Debug Extension will crash the users application if they are on Chrome version 115 or later. This PR adds a big warning banner while we try to resolve the underlying issues. 

Will require updates to the internal DevToolsExtensionPoints once the change is rolled into g3.

![Screenshot 2023-07-31 at 11 59 07 AM](https://github.com/flutter/devtools/assets/21270878/2f19bc56-b4da-4c31-bf51-624928c1b3ea)
