### PR TITLE
Replace `DualValueListenableBuilder` with `MultiValueListenableBuilder`

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -250,10 +250,12 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     Widget scaffoldBuilder() {
       // Force regeneration of visible screens when VM developer mode is
       // enabled and when the list of available extensions change.
-      return DualValueListenableBuilder<bool, List<DevToolsExtensionConfig>>(
-        firstListenable: preferences.vmDeveloperModeEnabled,
-        secondListenable: extensionService.availableExtensions,
-        builder: (_, __, ___, child) {
+      return MultiValueListenableBuilder(
+        listenables: [
+          preferences.vmDeveloperModeEnabled,
+          extensionService.availableExtensions,
+        ],
+        builder: (_, __, child) {
           final screens = _visibleScreens()
               .where((p) => embed && page != null ? p.screenId == page : true)
               .where((p) => !hide.contains(p.screenId))

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 
-import 'package:devtools_shared/devtools_extensions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/packages/devtools_app/lib/src/framework/status_line.dart
+++ b/packages/devtools_app/lib/src/framework/status_line.dart
@@ -11,6 +11,7 @@ import '../service/service_manager.dart';
 import '../shared/analytics/constants.dart' as gac;
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
+import '../shared/primitives/utils.dart';
 import '../shared/screen.dart';
 import '../shared/theme.dart';
 import '../shared/ui/utils.dart';
@@ -219,20 +220,23 @@ class IsolateSelector extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final IsolateManager isolateManager = serviceManager.isolateManager;
-    return DualValueListenableBuilder<List<IsolateRef?>, IsolateRef?>(
-      firstListenable: isolateManager.isolates,
-      secondListenable: isolateManager.selectedIsolate,
-      builder: (context, isolates, selectedIsolateRef, _) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        isolateManager.isolates,
+        isolateManager.selectedIsolate,
+      ],
+      builder: (context, values, _) {
+        final isolates = values.first as List<IsolateRef>;
+        final selectedIsolateRef = values.second as IsolateRef?;
         return PopupMenuButton<IsolateRef?>(
           tooltip: 'Selected Isolate',
           initialValue: selectedIsolateRef,
           onSelected: isolateManager.selectIsolate,
-          itemBuilder: (BuildContext context) =>
-              isolates.where((ref) => ref != null).map(
+          itemBuilder: (BuildContext context) => isolates.map(
             (ref) {
               return PopupMenuItem<IsolateRef>(
                 value: ref,
-                child: IsolateOption(ref!),
+                child: IsolateOption(ref),
               );
             },
           ).toList(),

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
@@ -33,11 +33,15 @@ class _BreakpointsState extends State<Breakpoints>
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<List<BreakpointAndSourcePosition>,
-        BreakpointAndSourcePosition?>(
-      firstListenable: breakpointManager.breakpointsWithLocation,
-      secondListenable: controller.selectedBreakpoint,
-      builder: (context, breakpoints, selectedBreakpoint, _) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        breakpointManager.breakpointsWithLocation,
+        controller.selectedBreakpoint,
+      ],
+      builder: (context, values, _) {
+        final breakpoints = values.first as List<BreakpointAndSourcePosition>;
+        final selectedBreakpoint =
+            values.second as BreakpointAndSourcePosition?;
         return ListView.builder(
           itemCount: breakpoints.length,
           itemExtent: defaultListItemHeight,

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart' hide Stack;
 import 'package:vm_service/vm_service.dart';
 
 import '../../shared/common_widgets.dart';
+import '../../shared/primitives/utils.dart';
 import '../../shared/theme.dart';
 import '../../shared/utils.dart';
 import 'debugger_controller.dart';

--- a/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/call_stack.dart
@@ -32,11 +32,14 @@ class _CallStackState extends State<CallStack>
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<List<StackFrameAndSourcePosition>,
-        StackFrameAndSourcePosition?>(
-      firstListenable: controller.stackFramesWithLocation,
-      secondListenable: controller.selectedStackFrame,
-      builder: (context, stackFrames, selectedFrame, _) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.stackFramesWithLocation,
+        controller.selectedStackFrame,
+      ],
+      builder: (context, values, _) {
+        final stackFrames = values.first as List<StackFrameAndSourcePosition>;
+        final selectedFrame = values.second as StackFrameAndSourcePosition?;
         return ListView.builder(
           itemCount: stackFrames.length,
           itemExtent: defaultListItemHeight,

--- a/packages/devtools_app/lib/src/screens/debugger/codeview.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview.dart
@@ -788,10 +788,15 @@ class Gutters extends StatelessWidget {
 
     return Row(
       children: [
-        DualValueListenableBuilder<List<BreakpointAndSourcePosition>, bool>(
-          firstListenable: breakpointManager.breakpointsWithLocation,
-          secondListenable: codeViewController.showCodeCoverage,
-          builder: (context, breakpoints, showCodeCoverage, _) {
+        MultiValueListenableBuilder(
+          listenables: [
+            breakpointManager.breakpointsWithLocation,
+            codeViewController.showCodeCoverage,
+          ],
+          builder: (context, values, _) {
+            final breakpoints =
+                values.first as List<BreakpointAndSourcePosition>;
+            final showCodeCoverage = values.second as bool;
             return Gutter(
               gutterWidth: gutterWidth,
               scrollController: gutterController,

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -12,6 +12,7 @@ import '../../shared/analytics/constants.dart' as gac;
 import '../../shared/common_widgets.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/auto_dispose.dart';
+import '../../shared/primitives/utils.dart';
 import '../../shared/theme.dart';
 import '../../shared/ui/label.dart';
 import '../../shared/utils.dart';

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -167,10 +167,14 @@ class CodeStatisticsControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<bool, bool>(
-      firstListenable: controller.codeViewController.showCodeCoverage,
-      secondListenable: controller.codeViewController.showProfileInformation,
-      builder: (context, showCodeCoverage, showProfileInformation, _) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.codeViewController.showCodeCoverage,
+        controller.codeViewController.showProfileInformation,
+      ],
+      builder: (context, values, _) {
+        final showCodeCoverage = values.first as bool;
+        final showProfileInformation = values.second as bool;
         return Row(
           children: [
             // TODO(kenz): clean up this button group when records are

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -19,6 +19,7 @@ import '../../shared/flex_split_column.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/auto_dispose.dart';
 import '../../shared/primitives/listenable.dart';
+import '../../shared/primitives/utils.dart';
 import '../../shared/routing.dart';
 import '../../shared/screen.dart';
 import '../../shared/split.dart';
@@ -176,10 +177,14 @@ class DebuggerScreenBodyState extends State<DebuggerScreenBody>
                     return child!;
                   }
                 },
-                child: DualValueListenableBuilder<ScriptRef?, ParsedScript?>(
-                  firstListenable: codeViewController.currentScriptRef,
-                  secondListenable: codeViewController.currentParsedScript,
-                  builder: (context, scriptRef, parsedScript, _) {
+                child: MultiValueListenableBuilder(
+                  listenables: [
+                    codeViewController.currentScriptRef,
+                    codeViewController.currentParsedScript,
+                  ],
+                  builder: (context, values, _) {
+                    final scriptRef = values.first as ScriptRef?;
+                    final parsedScript = values.second as ParsedScript?;
                     if (scriptRef != null &&
                         parsedScript != null &&
                         !_shownFirstScript) {

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/chart_pane.dart
@@ -202,10 +202,14 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
                 ),
               ),
               // The legend.
-              DualValueListenableBuilder<bool, bool>(
-                firstListenable: widget.chartController.legendVisibleNotifier,
-                secondListenable: controller.isAndroidChartVisibleNotifier,
-                builder: (_, isLegendVisible, isAndroidChartVisible, __) {
+              MultiValueListenableBuilder(
+                listenables: [
+                  widget.chartController.legendVisibleNotifier,
+                  controller.isAndroidChartVisibleNotifier,
+                ],
+                builder: (_, values, __) {
+                  final isLegendVisible = values.first as bool;
+                  final isAndroidChartVisible = values.second as bool;
                   if (!isLegendVisible) return const SizedBox.shrink();
                   return Padding(
                     padding: const EdgeInsets.only(

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
@@ -123,18 +123,24 @@ class _PathView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<bool, bool>(
-      firstListenable: controller.hideStandard,
-      secondListenable: controller.invert,
-      builder: (_, hideStandard, invert, __) => SingleChildScrollView(
-        scrollDirection: Axis.horizontal,
-        child: SingleChildScrollView(
-          child: Text(
-            path.toLongString(inverted: invert, hideStandard: hideStandard),
-            overflow: TextOverflow.visible,
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.hideStandard,
+        controller.invert,
+      ],
+      builder: (_, values, __) {
+        final hideStandard = values.first as bool;
+        final invert = values.second as bool;
+        return SingleChildScrollView(
+          scrollDirection: Axis.horizontal,
+          child: SingleChildScrollView(
+            child: Text(
+              path.toLongString(inverted: invert, hideStandard: hideStandard),
+              overflow: TextOverflow.visible,
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/class_details/path.dart
@@ -7,6 +7,7 @@ import 'package:flutter/material.dart';
 import '../../../../../../shared/analytics/analytics.dart' as ga;
 import '../../../../../../shared/analytics/constants.dart' as gac;
 import '../../../../../../shared/common_widgets.dart';
+import '../../../../../../shared/primitives/utils.dart';
 import '../../../../../../shared/theme.dart';
 import '../../../../shared/heap/model.dart';
 import '../../controller/class_data.dart';

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_list.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_list.dart
@@ -360,10 +360,14 @@ class _SnapshotListItemsState extends State<_SnapshotListItems>
   Widget build(BuildContext context) {
     final core = widget.controller.core;
 
-    return DualValueListenableBuilder<List<SnapshotItem>, int>(
-      firstListenable: core.snapshots,
-      secondListenable: core.selectedSnapshotIndex,
-      builder: (_, snapshots, selectedIndex, __) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        core.snapshots,
+        core.selectedSnapshotIndex,
+      ],
+      builder: (_, values, __) {
+        final snapshots = values.first as List<SnapshotItem>;
+        final selectedIndex = values.second as int;
         return ListView.builder(
           controller: _scrollController,
           itemCount: snapshots.length,

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../../shared/common_widgets.dart';
+import '../../../../../shared/primitives/utils.dart';
 import '../../../../../shared/split.dart';
 import '../../../shared/heap/heap.dart';
 import '../controller/diff_pane_controller.dart';

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/snapshot_view.dart
@@ -20,11 +20,14 @@ class SnapshotView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<List<SingleClassStats>?,
-        List<DiffClassStats>?>(
-      firstListenable: controller.derived.singleClassesToShow,
-      secondListenable: controller.derived.diffClassesToShow,
-      builder: (_, singleClasses, diffClasses, __) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.derived.singleClassesToShow,
+        controller.derived.diffClassesToShow,
+      ],
+      builder: (_, values, __) {
+        final singleClasses = values.first as List<SingleClassStats>?;
+        final diffClasses = values.second as List<DiffClassStats>?;
         if (controller.derived.updatingValues) {
           return const Center(child: Text('Calculating...'));
         }

--- a/packages/devtools_app/lib/src/screens/memory/panes/leaks/primitives/analysis_status.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/leaks/primitives/analysis_status.dart
@@ -67,10 +67,14 @@ class AnalysisStatusView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<AnalysisStatus, String>(
-      firstListenable: controller.status,
-      secondListenable: controller.message,
-      builder: (_, status, message, __) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.status,
+        controller.message,
+      ],
+      builder: (_, values, __) {
+        final status = values.first as AnalysisStatus;
+        final message = values.second as String;
         if (status == AnalysisStatus.notStarted) {
           return analysisStarter;
         }

--- a/packages/devtools_app/lib/src/screens/memory/panes/leaks/primitives/analysis_status.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/leaks/primitives/analysis_status.dart
@@ -5,6 +5,7 @@
 import 'package:flutter/material.dart';
 
 import '../../../../../shared/common_widgets.dart';
+import '../../../../../shared/primitives/utils.dart';
 import '../../../../../shared/theme.dart';
 
 enum AnalysisStatus {

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/class_table.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/class_table.dart
@@ -172,10 +172,13 @@ class _AllocationTracingTableState extends State<AllocationTracingTable> {
           ),
         ),
         Expanded(
-          child: DualValueListenableBuilder<bool, TracingIsolateState>(
-            firstListenable: widget.controller.refreshing,
-            secondListenable: widget.controller.stateForIsolate,
-            builder: (context, _, state, __) {
+          child: MultiValueListenableBuilder(
+            listenables: [
+              widget.controller.refreshing,
+              widget.controller.stateForIsolate,
+            ],
+            builder: (context, values, __) {
+              final state = values.second as TracingIsolateState;
               return ValueListenableBuilder<List<TracedClass>>(
                 valueListenable: state.filteredClassList,
                 builder: (context, filteredClassList, _) {

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -50,10 +50,14 @@ class NetworkScreen extends Screen {
     final networkController = Provider.of<NetworkController>(context);
     final color = Theme.of(context).textTheme.bodyMedium!.color!;
 
-    return DualValueListenableBuilder<NetworkRequests, List<NetworkRequest>>(
-      firstListenable: networkController.requests,
-      secondListenable: networkController.filteredData,
-      builder: (context, networkRequests, filteredRequests, child) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        networkController.requests,
+        networkController.filteredData,
+      ],
+      builder: (context, values, child) {
+        final networkRequests = values.first as NetworkRequests;
+        final filteredRequests = values.second as List<NetworkRequest>;
         final filteredCount = filteredRequests.length;
         final totalCount = networkRequests.requests.length;
         return Row(

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
@@ -12,6 +12,7 @@ import '../../../../../service/service_extensions.dart' as extensions;
 import '../../../../../shared/common_widgets.dart';
 import '../../../../../shared/globals.dart';
 import '../../../../../shared/primitives/auto_dispose.dart';
+import '../../../../../shared/primitives/utils.dart';
 import '../../../../../shared/theme.dart';
 import '../performance_controls.dart';
 import 'enhance_tracing_controller.dart';

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing.dart
@@ -230,10 +230,14 @@ class _TrackWidgetBuildsSettingState extends State<TrackWidgetBuildsSetting>
             );
           },
         ),
-        DualValueListenableBuilder<bool, TrackWidgetBuildsScope?>(
-          firstListenable: _tracked,
-          secondListenable: _selectedScope,
-          builder: (context, tracked, selectedScope, _) {
+        MultiValueListenableBuilder(
+          listenables: [
+            _tracked,
+            _selectedScope,
+          ],
+          builder: (context, values, _) {
+            final tracked = values.first as bool;
+            final selectedScope = values.second as TrackWidgetBuildsScope?;
             return Padding(
               padding: const EdgeInsets.only(left: _scopeSelectorPadding),
               child: TrackWidgetBuildsScopeSelector(

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -42,21 +42,22 @@ class FlutterFramesChart extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<List<FlutterFrame>, double>(
-      firstListenable: framesController.flutterFrames,
-      secondListenable: framesController.displayRefreshRate,
-      builder: (context, frames, displayRefreshRate, child) {
-        return ValueListenableBuilder<bool>(
-          valueListenable: preferences.performance.showFlutterFramesChart,
-          builder: (context, show, _) {
-            return _FlutterFramesChart(
-              framesController: framesController,
-              frames: frames,
-              displayRefreshRate: displayRefreshRate,
-              isVisible: show,
-              offlineMode: offlineMode,
-            );
-          },
+    return MultiValueListenableBuilder(
+      listenables: [
+        framesController.flutterFrames,
+        framesController.displayRefreshRate,
+        preferences.performance.showFlutterFramesChart,
+      ],
+      builder: (context, values, child) {
+        final frames = values.first as List<FlutterFrame>;
+        final displayRefreshRate = values.second as double;
+        final showChart = values.third as bool;
+        return _FlutterFramesChart(
+          framesController: framesController,
+          frames: frames,
+          displayRefreshRate: displayRefreshRate,
+          isVisible: showChart,
+          offlineMode: offlineMode,
         );
       },
     );

--- a/packages/devtools_app/lib/src/screens/performance/panes/raster_stats/raster_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/raster_stats/raster_stats.dart
@@ -87,10 +87,14 @@ class _LayerVisualizer extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder<RasterStats?, bool>(
-      firstListenable: rasterStatsController.rasterStats,
-      secondListenable: rasterStatsController.loadingSnapshot,
-      builder: (context, rasterStats, loading, _) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        rasterStatsController.rasterStats,
+        rasterStatsController.loadingSnapshot,
+      ],
+      builder: (context, values, _) {
+        final rasterStats = values.first as RasterStats?;
+        final loading = values.second as bool;
         if (loading) {
           return const CenteredCircularProgressIndicator();
         }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -13,6 +13,7 @@ import '../../../../shared/dialogs.dart';
 import '../../../../shared/globals.dart';
 import '../../../../shared/http/http_service.dart' as http_service;
 import '../../../../shared/primitives/auto_dispose.dart';
+import '../../../../shared/primitives/utils.dart';
 import '../../../../shared/theme.dart';
 import '../../../../shared/ui/search.dart';
 import 'legacy/legacy_events_controller.dart';

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -32,12 +32,14 @@ class TimelineEventsTabView extends StatelessWidget {
       builder: (context, useLegacy, _) {
         return useLegacy
             ? KeepAliveWrapper(
-                child:
-                    DualValueListenableBuilder<EventsControllerStatus, double>(
-                  firstListenable: controller.status,
-                  secondListenable:
-                      controller.legacyController.processor.progressNotifier,
-                  builder: (context, status, processingProgress, _) {
+                child: MultiValueListenableBuilder(
+                  listenables: [
+                    controller.status,
+                    controller.legacyController.processor.progressNotifier,
+                  ],
+                  builder: (context, values, _) {
+                    final status = values.first as EventsControllerStatus;
+                    final processingProgress = values.second as double;
                     return TimelineEventsView(
                       controller: controller,
                       processing: status == EventsControllerStatus.processing,

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -2405,56 +2405,51 @@ class _BlinkingIconState extends State<BlinkingIcon> {
   }
 }
 
-// TODO(https://github.com/flutter/devtools/issues/2989): investigate if we can
-// modify this widget to be a 'MultiValueListenableBuilder' that can take an
-// arbitrary number of listenables.
-/// A widget that listens for changes to two different [ValueListenable]s and
-/// rebuilds for change notifications to either.
+/// A widget that listens for changes to multiple different [ValueListenable]s
+/// and rebuilds for change notifications from any of them.
 ///
-/// This widget is preferred over nesting two [ValueListenableBuilder]s in a
+/// The current value of each [ValueListenable] is provided by the [values]
+/// parameter in [builder], where the index of each value in the list is equal
+/// to the index of its parent [ValueListenable] in [listenables].
+///
+/// This widget is preferred over nesting many [ValueListenableBuilder]s in a
 /// single build method.
-class DualValueListenableBuilder<T, U> extends StatefulWidget {
-  const DualValueListenableBuilder({
-    Key? key,
-    required this.firstListenable,
-    required this.secondListenable,
+class MultiValueListenableBuilder<T, U> extends StatefulWidget {
+  const MultiValueListenableBuilder({
+    super.key,
+    required this.listenables,
     required this.builder,
     this.child,
-  }) : super(key: key);
+  });
 
-  final ValueListenable<T> firstListenable;
-
-  final ValueListenable<U> secondListenable;
+  final List<ValueListenable> listenables;
 
   final Widget Function(
     BuildContext context,
-    T firstValue,
-    U secondValue,
+    List<Object?> values,
     Widget? child,
   ) builder;
 
   final Widget? child;
 
   @override
-  State<DualValueListenableBuilder<T, U>> createState() =>
-      _DualValueListenableBuilderState<T, U>();
+  State<MultiValueListenableBuilder<T, U>> createState() =>
+      _MultiValueListenableBuilderState<T, U>();
 }
 
-class _DualValueListenableBuilderState<T, U>
-    extends State<DualValueListenableBuilder<T, U>> with AutoDisposeMixin {
+class _MultiValueListenableBuilderState<T, U>
+    extends State<MultiValueListenableBuilder<T, U>> with AutoDisposeMixin {
   @override
   void initState() {
     super.initState();
-    addAutoDisposeListener(widget.firstListenable);
-    addAutoDisposeListener(widget.secondListenable);
+    widget.listenables.forEach(addAutoDisposeListener);
   }
 
   @override
   Widget build(BuildContext context) {
     return widget.builder(
       context,
-      widget.firstListenable.value,
-      widget.secondListenable.value,
+      [for (final listenable in widget.listenables) listenable.value],
       widget.child,
     );
   }

--- a/packages/devtools_app/lib/src/shared/editable_list.dart
+++ b/packages/devtools_app/lib/src/shared/editable_list.dart
@@ -85,10 +85,12 @@ class _EditableListState extends State<EditableList> {
 
   @override
   Widget build(BuildContext context) {
-    return DualValueListenableBuilder(
-      firstListenable: widget.entries,
-      secondListenable: widget.isRefreshing ?? ValueNotifier<bool>(false),
-      builder: (_, __, ___, ____) {
+    return MultiValueListenableBuilder(
+      listenables: [
+        widget.entries,
+        widget.isRefreshing ?? ValueNotifier<bool>(false),
+      ],
+      builder: (_, __, ____) {
         return Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1214,6 +1214,10 @@ extension ListExtension<T> on List<T> {
     }
     return false;
   }
+
+  T get second => this[1];
+
+  T get third => this[2];
 }
 
 extension SetExtension<T> on Set<T> {


### PR DESCRIPTION
This allows us to listen and rebuild on an arbitrary number of listeners instead of being limited to 2.

Fixes https://github.com/flutter/devtools/issues/2989