### PR TITLE
Remove `devtools_shared` dependency on `package:io`

### DIFF
--- a/packages/devtools_shared/lib/src/devtools_api.dart
+++ b/packages/devtools_shared/lib/src/devtools_api.dart
@@ -78,8 +78,7 @@ abstract class ExtensionsApi {
   static const extensionsResultPropertyName = 'extensions';
 
   /// Returns and optionally sets the enabled state for a DevTools extension.
-  static const apiExtensionEnabledState =
-      '${apiPrefix}extensionEnabledState';
+  static const apiExtensionEnabledState = '${apiPrefix}extensionEnabledState';
 
   /// The property name for the query parameter passed along with
   /// [apiExtensionEnabledState] requests to the server that describes the

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -128,36 +128,36 @@ class ExtensionsManager {
     );
     await copyPath(extensionPath, newExtensionPath);
   }
+}
 
-  // NOTE: this code is copied from `package:io`:
-  // https://github.com/dart-lang/io/blob/master/lib/src/copy_path.dart.
-  /// Copies all of the files in the [from] directory to [to].
-  ///
-  /// This is similar to `cp -R <from> <to>`:
-  /// * Symlinks are supported.
-  /// * Existing files are over-written, if any.
-  /// * If [to] is within [from], throws [ArgumentError] (an infinite operation).
-  /// * If [from] and [to] are canonically the same, no operation occurs.
-  ///
-  /// Returns a future that completes when complete.
-  Future<void> copyPath(String from, String to) async {
-    if (path.canonicalize(from) == path.canonicalize(to)) {
-      return;
-    }
-    if (path.isWithin(from, to)) {
-      throw ArgumentError('Cannot copy from $from to $to');
-    }
+// NOTE: this code is copied from `package:io`:
+// https://github.com/dart-lang/io/blob/master/lib/src/copy_path.dart.
+/// Copies all of the files in the [from] directory to [to].
+///
+/// This is similar to `cp -R <from> <to>`:
+/// * Symlinks are supported.
+/// * Existing files are over-written, if any.
+/// * If [to] is within [from], throws [ArgumentError] (an infinite operation).
+/// * If [from] and [to] are canonically the same, no operation occurs.
+///
+/// Returns a future that completes when complete.
+Future<void> copyPath(String from, String to) async {
+  if (path.canonicalize(from) == path.canonicalize(to)) {
+    return;
+  }
+  if (path.isWithin(from, to)) {
+    throw ArgumentError('Cannot copy from $from to $to');
+  }
 
-    await Directory(to).create(recursive: true);
-    await for (final file in Directory(from).list(recursive: true)) {
-      final copyTo = path.join(to, path.relative(file.path, from: from));
-      if (file is Directory) {
-        await Directory(copyTo).create(recursive: true);
-      } else if (file is File) {
-        await File(file.path).copy(copyTo);
-      } else if (file is Link) {
-        await Link(copyTo).create(await file.target(), recursive: true);
-      }
+  await Directory(to).create(recursive: true);
+  await for (final file in Directory(from).list(recursive: true)) {
+    final copyTo = path.join(to, path.relative(file.path, from: from));
+    if (file is Directory) {
+      await Directory(copyTo).create(recursive: true);
+    } else if (file is File) {
+      await File(file.path).copy(copyTo);
+    } else if (file is Link) {
+      await Link(copyTo).create(await file.target(), recursive: true);
     }
   }
 }

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:io/io.dart';
 import 'package:path/path.dart' as path;
 
 import 'extension_model.dart';
@@ -128,6 +127,38 @@ class ExtensionsManager {
       extensionPackageName,
     );
     await copyPath(extensionPath, newExtensionPath);
+  }
+
+  // NOTE: this code is copied from `package:io`:
+  // https://github.com/dart-lang/io/blob/master/lib/src/copy_path.dart.
+  /// Copies all of the files in the [from] directory to [to].
+  ///
+  /// This is similar to `cp -R <from> <to>`:
+  /// * Symlinks are supported.
+  /// * Existing files are over-written, if any.
+  /// * If [to] is within [from], throws [ArgumentError] (an infinite operation).
+  /// * If [from] and [to] are canonically the same, no operation occurs.
+  ///
+  /// Returns a future that completes when complete.
+  Future<void> copyPath(String from, String to) async {
+    if (path.canonicalize(from) == path.canonicalize(to)) {
+      return;
+    }
+    if (path.isWithin(from, to)) {
+      throw ArgumentError('Cannot copy from $from to $to');
+    }
+
+    await Directory(to).create(recursive: true);
+    await for (final file in Directory(from).list(recursive: true)) {
+      final copyTo = path.join(to, path.relative(file.path, from: from));
+      if (file is Directory) {
+        await Directory(copyTo).create(recursive: true);
+      } else if (file is File) {
+        await File(file.path).copy(copyTo);
+      } else if (file is Link) {
+        await Link(copyTo).create(await file.target(), recursive: true);
+      }
+    }
   }
 }
 

--- a/packages/devtools_shared/test/extensions/extension_manager_test.dart
+++ b/packages/devtools_shared/test/extensions/extension_manager_test.dart
@@ -1,0 +1,63 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+@TestOn('vm')
+
+import 'dart:io';
+
+import 'package:devtools_shared/devtools_extensions.dart';
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+void main() {
+  late Directory from;
+  late Directory to;
+
+  tearDown(() {
+    // Delete [to] first so that we do not hit a file system exception when [to]
+    // is a subdirectory of [from].
+    to.deleteSync(recursive: true);
+    from.deleteSync(recursive: true);
+  });
+
+  test('copyPath', () async {
+    from = _createFromDir();
+    to = _createToDir();
+
+    await copyPath(from.path, to.path);
+    const expected =
+        "[File: 'tmp/foo.txt', Directory: 'tmp/bar', File: 'tmp/bar/baz.txt']";
+    final fromContents = from.listSync(recursive: true);
+    final toContents = to.listSync(recursive: true);
+    expect(fromContents.toString(), expected);
+    expect(toContents.toString(), expected.replaceAll('tmp', 'tmp2'));
+  });
+
+  test('copy path throws for infinite operation', () async {
+    from = _createFromDir();
+    to = Directory(p.join(from.path, 'bar'));
+    expect(to.existsSync(), isTrue);
+    await expectLater(copyPath(from.path, to.path), throwsArgumentError);
+  });
+}
+
+Directory _createFromDir() {
+  final from = Directory('tmp')..createSync();
+  File.fromUri(Uri.parse(p.join(from.path, 'foo.txt')))..createSync();
+  final dir = Directory(p.join(from.path, 'bar'))..createSync();
+  File.fromUri(Uri.parse(p.join(dir.path, 'baz.txt')))..createSync();
+  final contents = from.listSync(recursive: true);
+  expect(
+    contents.toString(),
+    "[File: 'tmp/foo.txt', Directory: 'tmp/bar', File: 'tmp/bar/baz.txt']",
+  );
+  return from;
+}
+
+Directory _createToDir() {
+  final to = Directory('tmp2')..createSync();
+  final contents = to.listSync(recursive: true);
+  expect(contents.toString(), '[]');
+  return to;
+}

--- a/packages/devtools_shared/test/extensions/extension_manager_test.dart
+++ b/packages/devtools_shared/test/extensions/extension_manager_test.dart
@@ -27,9 +27,9 @@ void main() {
 
     await copyPath(from.path, to.path);
     const expected =
-        "[File: 'tmp/foo.txt', Directory: 'tmp/bar', File: 'tmp/bar/baz.txt']";
-    final fromContents = from.listSync(recursive: true);
-    final toContents = to.listSync(recursive: true);
+        "[Directory: 'tmp/bar', File: 'tmp/bar/baz.txt', File: 'tmp/foo.txt']";
+    final fromContents = _contentAsOrderedString(from);
+    final toContents = _contentAsOrderedString(to);
     expect(fromContents.toString(), expected);
     expect(toContents.toString(), expected.replaceAll('tmp', 'tmp2'));
   });
@@ -47,17 +47,23 @@ Directory _createFromDir() {
   File.fromUri(Uri.parse(p.join(from.path, 'foo.txt')))..createSync();
   final dir = Directory(p.join(from.path, 'bar'))..createSync();
   File.fromUri(Uri.parse(p.join(dir.path, 'baz.txt')))..createSync();
-  final contents = from.listSync(recursive: true);
+  final contents = _contentAsOrderedString(from);
   expect(
-    contents.toString(),
-    "[File: 'tmp/foo.txt', Directory: 'tmp/bar', File: 'tmp/bar/baz.txt']",
+    contents,
+    "[Directory: 'tmp/bar', File: 'tmp/bar/baz.txt', File: 'tmp/foo.txt']",
   );
   return from;
 }
 
 Directory _createToDir() {
   final to = Directory('tmp2')..createSync();
-  final contents = to.listSync(recursive: true);
-  expect(contents.toString(), '[]');
+  final contents = _contentAsOrderedString(to);
+  expect(contents, '[]');
   return to;
+}
+
+String _contentAsOrderedString(Directory dir) {
+  final contents = dir.listSync(recursive: true)
+    ..sort((a, b) => a.path.compareTo(b.path));
+  return contents.toString();
 }


### PR DESCRIPTION
Copying this code prevents us from having to introduce an SDK dependency on `package:io`, which is likely overkill for use of this one method.