### PR TITLE
Fix tab bar alignment for latest flutter

### DIFF
--- a/packages/devtools_app/lib/src/shared/theme.dart
+++ b/packages/devtools_app/lib/src/shared/theme.dart
@@ -72,6 +72,7 @@ ThemeData _baseTheme({
   // as well as the background color?
   return theme.copyWith(
     tabBarTheme: theme.tabBarTheme.copyWith(
+      tabAlignment: TabAlignment.start,
       dividerColor: Colors.transparent,
       labelPadding:
           const EdgeInsets.symmetric(horizontal: defaultTabBarPadding),


### PR DESCRIPTION
The latest flutter broke DevTools tab bar UIs. This fixes the issue.

Related: https://github.com/flutter/flutter/issues/132259