### PR TITLE
Fetch dependencies for all DevTools packages in `tool/bots.sh`

### DIFF
--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -57,13 +57,21 @@ dart --disable-analytics
 flutter --version
 dart --version
 
-# Generate code.
+# Fetch dependencies
 pushd packages/devtools_app
+flutter pub get
+popd
+pushd packages/devtools_extensions
+flutter pub get
+popd
+pushd packages/devtools_shared
 flutter pub get
 popd
 pushd packages/devtools_test
 flutter pub get
 popd
+
+# Generate code.
 bash tool/generate_code.sh
 
 # Change the CI to the packages/devtools_app directory.


### PR DESCRIPTION
This should (hopefully) resolve the DCM false positive failure here: https://github.com/flutter/devtools/pull/6185
