### PR TITLE
Stop passing a nullable value to Future<nn-type>.value or Completer<nn-type>.completer

### DIFF
--- a/packages/devtools_app/lib/src/shared/scripts/script_manager.dart
+++ b/packages/devtools_app/lib/src/shared/scripts/script_manager.dart
@@ -105,8 +105,9 @@ class _ScriptCache {
     ScriptRef scriptRef,
   ) {
     final scriptId = scriptRef.id!;
-    if (_scripts.containsKey(scriptId)) {
-      return Future.value(_scripts[scriptId]);
+    final script = _scripts[scriptId];
+    if (script != null) {
+      return Future.value(script);
     }
 
     if (_inProgress.containsKey(scriptId)) {

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -161,7 +161,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
         Response.parse({
           'layerBytes': 0,
           'pictureBytes': 0,
-        }),
+        })!,
       );
 
   @override
@@ -192,7 +192,7 @@ class FakeServiceManager extends Fake implements ServiceConnectionManager {
         'dartSdkVersion': '2.9.0 (build 2.9.0-8.0.dev d6fed1f624)',
         'frameworkRevisionShort': '74432fa91c',
         'engineRevisionShort': 'ae2222f47e',
-      }),
+      })!,
     );
   }
 

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -114,7 +114,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     int timeOriginMicros,
     int timeExtentMicros,
   ) {
-    return Future.value(cpuSamples);
+    return Future.value(cpuSamples!);
   }
 
   @override
@@ -249,7 +249,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
             },
           ),
         },
-      ),
+      )!,
     );
   }
 
@@ -338,7 +338,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
 
   @override
   Future<TimelineFlags> getVMTimelineFlags() =>
-      Future.value(TimelineFlags.parse(_vmTimelineFlags));
+      Future.value(TimelineFlags.parse(_vmTimelineFlags)!);
 
   @override
   Future<Timeline> getVMTimeline({
@@ -403,7 +403,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
   ) async {
     final httpProfile = await getHttpProfile(isolateId);
     return Future.value(
-      httpProfile.requests.firstWhereOrNull((request) => request.id == id),
+      httpProfile.requests.firstWhere((request) => request.id == id),
     );
   }
 

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -46,9 +46,9 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     'pid': 54321,
     'functions': [],
     'samples': [],
-  });
+  })!;
 
-  CpuSamples? cpuSamples;
+  CpuSamples cpuSamples;
 
   CpuSamples? allocationSamples;
 
@@ -114,7 +114,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     int timeOriginMicros,
     int timeExtentMicros,
   ) {
-    return Future.value(cpuSamples!);
+    return Future.value(cpuSamples);
   }
 
   @override


### PR DESCRIPTION
This is cleanup work required to start enforcing this with static analysis, as per https://github.com/dart-lang/sdk/issues/53253.

Real quick this issue is that this code is unsafe:

```dart
void f(Completer<int> c, int? i) {
  Future<int>.value(i); // Ouch!
  c.complete(i);        // Ouch!
}
```

The typical fix is to add a null-assert (`!`), but sometimes a more appropriate or safer fix can be made.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
