### PR TITLE
Aggressively seal classes in `package:devtools_app_shared`

### DIFF
--- a/packages/devtools_app/test/shared/instance_viewer_test.dart
+++ b/packages/devtools_app/test/shared/instance_viewer_test.dart
@@ -1539,4 +1539,5 @@ void main() {
   });
 }
 
+// ignore: subtype_of_sealed_class, fake for testing.
 class FakeEvalOnDartLibrary extends Fake implements EvalOnDartLibrary {}

--- a/packages/devtools_app_shared/lib/src/service/connected_app.dart
+++ b/packages/devtools_app_shared/lib/src/service/connected_app.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 
 import 'eval_on_dart_library.dart';
 import 'flutter_version.dart';
@@ -15,6 +16,7 @@ final _log = Logger('connected_app');
 const flutterLibraryUri = 'package:flutter/src/widgets/binding.dart';
 const dartHtmlLibraryUri = 'dart:html';
 
+@sealed
 class ConnectedApp {
   ConnectedApp(this.serviceManager);
 

--- a/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
+++ b/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
@@ -11,6 +11,7 @@ import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 import 'package:vm_service/vm_service.dart' as vm_service;
 
@@ -29,6 +30,7 @@ class Disposable {
   }
 }
 
+@sealed
 class EvalOnDartLibrary extends DisposableController
     with AutoDisposeControllerMixin {
   EvalOnDartLibrary(
@@ -636,7 +638,7 @@ class EvalOnDartLibrary extends DisposableController
   }
 }
 
-class LibraryNotFound implements Exception {
+final class LibraryNotFound implements Exception {
   LibraryNotFound(this.name);
 
   final String name;
@@ -644,7 +646,7 @@ class LibraryNotFound implements Exception {
   String get message => 'Library matchining $name not found';
 }
 
-class FutureFailedException implements Exception {
+final class FutureFailedException implements Exception {
   FutureFailedException(this.expression, this.errorRef, this.stacktraceRef);
 
   final String expression;
@@ -657,9 +659,9 @@ class FutureFailedException implements Exception {
   }
 }
 
-class CancelledException implements Exception {}
+final class CancelledException implements Exception {}
 
-class UnknownEvalException implements Exception {
+final class UnknownEvalException implements Exception {
   UnknownEvalException({
     required this.expression,
     required this.scope,
@@ -676,7 +678,7 @@ class UnknownEvalException implements Exception {
   }
 }
 
-class SentinelException implements Exception {
+final class SentinelException implements Exception {
   SentinelException(this.sentinel);
 
   final Sentinel sentinel;
@@ -687,7 +689,7 @@ class SentinelException implements Exception {
   }
 }
 
-class EvalSentinelException extends SentinelException {
+final class EvalSentinelException extends SentinelException {
   EvalSentinelException({
     required this.expression,
     required this.scope,
@@ -703,7 +705,7 @@ class EvalSentinelException extends SentinelException {
   }
 }
 
-class EvalErrorException implements Exception {
+final class EvalErrorException implements Exception {
   EvalErrorException({
     required this.expression,
     required this.scope,

--- a/packages/devtools_app_shared/lib/src/service/flutter_version.dart
+++ b/packages/devtools_app_shared/lib/src/service/flutter_version.dart
@@ -13,7 +13,7 @@ const flutterVersionService = RegisteredService(
   title: 'Flutter Version',
 );
 
-class FlutterVersion extends SemanticVersion {
+final class FlutterVersion extends SemanticVersion {
   FlutterVersion._({
     required this.version,
     required this.channel,

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -7,12 +7,14 @@ import 'dart:core';
 
 import 'package:collection/collection.dart' show IterableExtension;
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
 import '../../utils.dart';
 import 'isolate_state.dart';
 import 'service_extensions.dart' as extensions;
 
+@sealed
 class IsolateManager extends Disposer {
   final _isolateStates = <IsolateRef, IsolateState>{};
   VmService? _service;

--- a/packages/devtools_app_shared/lib/src/service/isolate_state.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_state.dart
@@ -6,8 +6,10 @@ import 'dart:async';
 import 'dart:core';
 
 import 'package:flutter/foundation.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
+@sealed
 class IsolateState {
   IsolateState(this.isolateRef);
 

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -7,6 +7,7 @@ import 'dart:core';
 
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
 import '../../service.dart';
@@ -16,6 +17,7 @@ import 'service_extensions.dart' as extensions;
 final _log = Logger('service_extension_manager');
 
 /// Manager that handles tracking the service extension for the main isolate.
+@sealed
 class ServiceExtensionManager extends Disposer {
   ServiceExtensionManager(this._isolateManager);
 

--- a/packages/devtools_app_shared/lib/src/service/service_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_manager.dart
@@ -7,6 +7,7 @@ import 'dart:core';
 
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
 import 'package:vm_service/vm_service.dart' hide Error;
 
 import '../../service.dart';
@@ -18,6 +19,7 @@ final _log = Logger('service_manager');
 // TODO(kenz): add an offline service manager implementation.
 // TODO(jacobr): refactor all of these apis to be in terms of ValueListenable
 // instead of Streams.
+@sealed
 class ServiceManager<T extends VmService> {
   ServiceManager() {
     _serviceExtensionManager = ServiceExtensionManager(isolateManager);

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   devtools_shared: ^3.0.0
   flutter:
     sdk: flutter
+  meta: ^1.9.1
   pointer_interceptor: ^0.9.3+3
   vm_service: ^11.3.0
 

--- a/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
@@ -9,6 +9,7 @@ import 'package:vm_service/vm_service.dart';
 
 import 'generated.mocks.dart';
 
+// ignore: subtype_of_sealed_class, fake for testing.
 class FakeIsolateManager extends Fake implements IsolateManager {
   @override
   ValueListenable<IsolateRef?> get selectedIsolate => _selectedIsolate;

--- a/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
@@ -9,6 +9,7 @@ import 'package:devtools_app_shared/service_extensions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:mockito/mockito.dart';
 
+// ignore: subtype_of_sealed_class, fake for testing.
 /// Fake that simplifies writing UI tests that depend on the
 /// ServiceExtensionManager.
 // TODO(jacobr): refactor ServiceExtensionManager so this fake can reuse more


### PR DESCRIPTION
`devtools_app_shared` will be published on pub and will be used by DevTools extension authors to build extensions. In order to limit breaking changes to DevTools extensions, we would like to "seal" critical classes related to interacting with a connected app's vm service.

This PR aggressively marks service-related classes in `devtools_app_shared` as `final`, where possible. In cases where marking classes `final` would prohibit us from being able to effectively write tests, we use the `@sealed` annotation from `package:meta`.

Looking for:
- early feedback on these changes before I add a large commit full of refactors to support this change.
- feedback on whether we should seal other classes such as utilities (e.g. auto dispose functionality) and common ui components?

@bkonyi @jacob314 