### PR TITLE
Add `DevToolsExtensionHostInterface` and clean up some service management for extensions

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -176,7 +176,7 @@ class _ExtensionIFrameController extends DisposableController
     _postMessage(
       DevToolsExtensionEvent(
         DevToolsExtensionEventType.vmServiceConnection,
-        data: {'uri': uri!},
+        data: {'uri': uri},
       ),
     );
   }

--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -196,8 +196,7 @@ class _ExtensionIFrameController extends DisposableController
         break;
       case DevToolsExtensionEventType.vmServiceConnection:
         final service = serviceConnection.serviceManager.service;
-        if (service == null) break;
-        vmServiceConnectionChanged(uri: service.connectedUri.toString());
+        vmServiceConnectionChanged(uri: service?.connectedUri.toString());
         break;
       default:
         onUnknownEvent?.call();

--- a/packages/devtools_app_shared/lib/src/service/connected_app.dart
+++ b/packages/devtools_app_shared/lib/src/service/connected_app.dart
@@ -147,6 +147,8 @@ class ConnectedApp {
     // Return early if already initialized.
     if (initialized.isCompleted) return;
 
+    assert(serviceManager!.isServiceAvailable);
+
     await Future.wait([isFlutterApp, isProfileBuild, isDartWebApp]);
 
     _operatingSystem = serviceManager!.vm!.operatingSystem ?? unknownOS;

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'model.dart';
+
 /// Supported events that can be sent and received over 'postMessage' between
 /// DevTools and a DevTools extension running in an embedded iFrame.
 enum DevToolsExtensionEventType {
@@ -28,4 +30,28 @@ enum DevToolsExtensionEventType {
     }
     return unknown;
   }
+}
+
+/// Interface that a DevTools extension host should implement.
+/// 
+/// This interface is implemented by DevTools itself as well as by a simulated
+/// DevTools environment for simplifying extension development.
+abstract interface class DevToolsExtensionHostInterface {
+  /// This method should send a [DevToolsExtensionEventType.ping] event to the
+  /// DevTools extension to check that it is ready.
+  void ping();
+
+  /// This method should send a [DevToolsExtensionEventType.vmServiceConnection]
+  /// event to the extension to notify it of the vm service uri it should
+  /// establish a connection to.
+  void vmServiceConnectionChanged({String? uri});
+
+  /// Handles events sent by the extension.
+  /// 
+  /// If an unknown event is recevied, this handler should call [onUnknownEvent]
+  /// if non-null.
+  void onEventReceived(
+    DevToolsExtensionEvent event, {
+    void Function()? onUnknownEvent,
+  });
 }

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -56,13 +56,7 @@ class ExtensionManager {
             break;
           case DevToolsExtensionEventType.vmServiceConnection:
             final vmServiceUri = extensionEvent.data?['uri'] as String?;
-            unawaited(
-              connectToVmService(vmServiceUri).catchError((e) {
-                // TODO(kenz): post a notification to DevTools for errors
-                // or create an error panel for the extensions screens.
-                print('Error connecting to VM service: $e');
-              }),
-            );
+            unawaited(_connectToVmService(vmServiceUri));
             break;
           case DevToolsExtensionEventType.unknown:
           default:
@@ -80,25 +74,34 @@ class ExtensionManager {
     html.window.parent?.postMessage(event.toJson(), html.window.origin!);
   }
 
-  Future<void> connectToVmService(String? vmServiceUri) async {
+  Future<void> _connectToVmService(String? vmServiceUri) async {
     if (vmServiceUri == null) return;
 
-    final finishedCompleter = Completer<void>();
-    final vmService = await connect<VmService>(
-      uri: Uri.parse(vmServiceUri),
-      finishedCompleter: finishedCompleter,
-      createService: ({
-        // ignore: avoid-dynamic, code needs to match API from VmService.
-        required Stream<dynamic> /*String|List<int>*/ inStream,
-        required void Function(String message) writeMessage,
-        required Uri connectedUri,
-      }) {
-        return VmService(inStream, writeMessage);
-      },
-    );
-    await serviceManager.vmServiceOpened(
-      vmService,
-      onClosed: finishedCompleter.future,
-    );
+    try {
+      final finishedCompleter = Completer<void>();
+      final vmService = await connect<VmService>(
+        uri: Uri.parse(vmServiceUri),
+        finishedCompleter: finishedCompleter,
+        createService: ({
+          // ignore: avoid-dynamic, code needs to match API from VmService.
+          required Stream<dynamic> /*String|List<int>*/ inStream,
+          required void Function(String message) writeMessage,
+          required Uri connectedUri,
+        }) {
+          return VmService(
+            inStream,
+            writeMessage,
+          );
+        },
+      );
+      await serviceManager.vmServiceOpened(
+        vmService,
+        onClosed: finishedCompleter.future,
+      );
+    } catch (e) {
+      // TODO(kenz): post a notification to DevTools for errors
+      // or create an error panel for the extensions screens.
+      print('Unable to connect to VM service at $vmServiceUri: $e');
+    }
   }
 }

--- a/packages/devtools_shared/lib/src/service/service.dart
+++ b/packages/devtools_shared/lib/src/service/service.dart
@@ -102,8 +102,8 @@ Future<T> connect<T extends VmService>({
   // Connects to a VM Service but does not verify the connection was fully
   // successful.
   Future<T> connectHelper() async {
-    T service;
-    service = uri.scheme == 'sse' || uri.scheme == 'sses'
+    final useSse = uri.scheme == 'sse' || uri.scheme == 'sses';
+    final T service = useSse
         ? await _connectWithSse<T>(
             uri: uri,
             onError: onError,


### PR DESCRIPTION
I will follow up with a PR to create a `_SimulatedDevToolsController` that implements the host interface (which will allow for a simulated environment for extension development)

Work towards https://github.com/flutter/devtools/issues/1632