### PR TITLE
Limit Network text view to 2^16 characters to prevent it from crashing

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -156,13 +156,10 @@ class HttpRequestView extends StatelessWidget {
             ? requestContentType.any((element) => element.contains('json'))
             : requestContentType.contains('json');
 
-        Widget child;
+        Widget child; 
         child = isJson
             ? JsonViewer(encodedJson: data.requestBody!)
-            : Text(
-                data.requestBody!,
-                style: theme.fixedFontStyle,
-              );
+            : TextViewer(text: data.requestBody!);
         return Padding(
           padding: const EdgeInsets.all(denseSpacing),
           child: SingleChildScrollView(
@@ -356,10 +353,7 @@ class HttpTextResponseViewer extends StatelessWidget {
 
         return switch (currentLocalResponseType) {
           NetworkResponseViewType.json => JsonViewer(encodedJson: responseBody),
-          NetworkResponseViewType.text => Text(
-              responseBody,
-              style: textStyle,
-            ),
+          NetworkResponseViewType.text => TextViewer(text: responseBody),
           _ => const SizedBox(),
         };
       },

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -142,6 +142,7 @@ class HttpRequestView extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: data.requestUpdatedNotifier,
       builder: (context, __, ___) {
+        final theme = Theme.of(context);
         final requestHeaders = data.requestHeaders;
         final requestContentType = requestHeaders?['content-type'] ?? '';
         final isLoading = data.isFetchingFullData;
@@ -158,7 +159,12 @@ class HttpRequestView extends StatelessWidget {
         Widget child;
         child = isJson
             ? JsonViewer(encodedJson: data.requestBody!)
-            : TextViewer(text: data.requestBody!);
+            // Using TextViewer fixes
+            // https://github.com/flutter/devtools/issues/5973
+            : TextViewer(
+                text: data.requestBody!,
+                style: theme.fixedFontStyle,
+              );
         return Padding(
           padding: const EdgeInsets.all(denseSpacing),
           child: SingleChildScrollView(
@@ -352,7 +358,12 @@ class HttpTextResponseViewer extends StatelessWidget {
 
         return switch (currentLocalResponseType) {
           NetworkResponseViewType.json => JsonViewer(encodedJson: responseBody),
-          NetworkResponseViewType.text => TextViewer(text: responseBody),
+          // Using TextViewer fixes
+          // https://github.com/flutter/devtools/issues/5973
+          NetworkResponseViewType.text => TextViewer(
+              text: responseBody,
+              style: textStyle,
+            ),
           _ => const SizedBox(),
         };
       },

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -142,7 +142,6 @@ class HttpRequestView extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: data.requestUpdatedNotifier,
       builder: (context, __, ___) {
-        final theme = Theme.of(context);
         final requestHeaders = data.requestHeaders;
         final requestContentType = requestHeaders?['content-type'] ?? '';
         final isLoading = data.isFetchingFullData;

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -159,8 +159,6 @@ class HttpRequestView extends StatelessWidget {
         Widget child;
         child = isJson
             ? JsonViewer(encodedJson: data.requestBody!)
-            // Using TextViewer fixes
-            // https://github.com/flutter/devtools/issues/5973
             : TextViewer(
                 text: data.requestBody!,
                 style: theme.fixedFontStyle,
@@ -358,8 +356,6 @@ class HttpTextResponseViewer extends StatelessWidget {
 
         return switch (currentLocalResponseType) {
           NetworkResponseViewType.json => JsonViewer(encodedJson: responseBody),
-          // Using TextViewer fixes
-          // https://github.com/flutter/devtools/issues/5973
           NetworkResponseViewType.text => TextViewer(
               text: responseBody,
               style: textStyle,

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -156,7 +156,7 @@ class HttpRequestView extends StatelessWidget {
             ? requestContentType.any((element) => element.contains('json'))
             : requestContentType.contains('json');
 
-        Widget child; 
+        Widget child;
         child = isJson
             ? JsonViewer(encodedJson: data.requestBody!)
             : TextViewer(text: data.requestBody!);

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1264,6 +1264,30 @@ class JsonViewer extends StatefulWidget {
   State<JsonViewer> createState() => _JsonViewerState();
 }
 
+class TextViewer extends StatelessWidget {
+  const TextViewer({
+    super.key,
+    required this.text,
+  });
+  final String text;
+  static const _maxLength = 65536; //2^16
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final String displayText;
+    // Limit the length of the displayed text to _MAX_LENGTH
+    if (text.length > _maxLength) {
+      displayText = '${text.substring(0, min(_maxLength, text.length))}...';
+    } else {
+      displayText = text;
+    }
+    return Text(
+      displayText,
+      style: theme.fixedFontStyle,
+    );
+  }
+}
+
 class _JsonViewerState extends State<JsonViewer>
     with ProvidedControllerMixin<DebuggerController, JsonViewer> {
   late Future<void> _initializeTree;

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1283,7 +1283,7 @@ class TextViewer extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final String displayText;
-    // Limit the length of the displayed text to _MAX_LENGTH
+    // Limit the length of the displayed text to maxLength
     if (text.length > maxLength) {
       displayText = '${text.substring(0, min(maxLength, text.length))}...';
     } else {

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1275,6 +1275,8 @@ class TextViewer extends StatelessWidget {
   });
 
   final String text;
+  // TODO: change the maxLength if we determine a more appropriate limit
+  // in https://github.com/flutter/devtools/issues/6263.
   final int maxLength;
   final TextStyle? style;
 

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -1264,26 +1264,32 @@ class JsonViewer extends StatefulWidget {
   State<JsonViewer> createState() => _JsonViewerState();
 }
 
+/// A wrapper for a Text widget, which allows for concatenating text if it
+/// becomes too long.
 class TextViewer extends StatelessWidget {
   const TextViewer({
     super.key,
     required this.text,
+    this.maxLength = 65536, //2^16
+    this.style,
   });
+
   final String text;
-  static const _maxLength = 65536; //2^16
+  final int maxLength;
+  final TextStyle? style;
+
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     final String displayText;
     // Limit the length of the displayed text to _MAX_LENGTH
-    if (text.length > _maxLength) {
-      displayText = '${text.substring(0, min(_maxLength, text.length))}...';
+    if (text.length > maxLength) {
+      displayText = '${text.substring(0, min(maxLength, text.length))}...';
     } else {
       displayText = text;
     }
     return Text(
       displayText,
-      style: theme.fixedFontStyle,
+      style: style,
     );
   }
 }

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -24,7 +24,7 @@ TODO: Remove this section if there are not any general updates.
 TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
-TODO: Remove this section if there are not any general updates.
+- Fixed a crash with large text in request or response - [#6254](https://github.com/flutter/devtools/pull/6254)
 
 ## Logging updates
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
![](https://media.giphy.com/media/3o7TKDTDN2DxqMkW52/giphy-downsized.gif)

For images, the request and response bodies can get large which cause the Text view to hang DevTools.

I've hardcoded the 2^16 character limit for now, but I could be persuaded to allow an override in case other textviews have different needs.

Fixes https://github.com/flutter/devtools/issues/5973 

## Examples
### Truncated
![Screenshot 2023-08-25 at 3 47 54 PM](https://github.com/flutter/devtools/assets/1386322/28b47a10-c745-400b-b758-3d109a8949d6)
### Under Character Limit

![Screenshot 2023-08-25 at 3 47 58 PM](https://github.com/flutter/devtools/assets/1386322/2192b158-1abe-4713-a2b2-1b54165c07f3)
