### PR TITLE
Prepare `devtools_extensions`, `devtools_app_shared` releases and fix bug

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -25,10 +25,9 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
-  devtools_extensions: ^0.0.2-dev.0
-  devtools_shared: 3.0.0
-  devtools_app_shared:
-    path: ../devtools_app_shared
+  devtools_extensions: ^0.0.3
+  devtools_shared: ^3.0.1
+  devtools_app_shared: ^0.0.1
   file: ^6.0.0
   file_selector: ^0.8.0
   file_selector_linux: ^0.0.2

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
-  devtools_extensions: ^0.0.3
+  devtools_extensions: ^0.0.2
   devtools_shared: ^3.0.1
   devtools_app_shared: ^0.0.1
   file: ^6.0.0

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  devtools_shared: ^3.0.0
+  devtools_shared: ^3.0.1
   flutter:
     sdk: flutter
   logging: ^1.1.1

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   devtools_shared: ^3.0.0
   flutter:
     sdk: flutter
+  logging: ^1.1.1
   meta: ^1.9.1
   pointer_interceptor: ^0.9.3+3
   vm_service: ^11.3.0

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -8,6 +8,7 @@ environment:
   flutter: '>=3.0.0'
 
 dependencies:
+  collection: ^1.15.0
   devtools_shared: ^3.0.0
   flutter:
     sdk: flutter

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.0.3
+## 0.0.2
 * Add a simulated DevTools environment that for easier development.
 * Add a `build_and_copy` command to build a devtools extension and copy the output to the
 parent package's extension/devtools directory.

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -132,7 +132,7 @@ class _DisconnectedVmServiceDisplayState
           elevated: true,
           label: 'Connect',
           onPressed: () {
-            _connectedUri = _connectTextFieldController.text,
+            _connectedUri = _connectTextFieldController.text;
             widget.simController.vmServiceConnectionChanged(
               uri: _connectTextFieldController.text,
             );

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -4,6 +4,9 @@
 
 part of '_simulated_devtools_environment.dart';
 
+// TODO(kenz): delete this once we can bump to vm_service ^11.10.0
+String? _connectedUri;
+
 class _VmServiceConnection extends StatelessWidget {
   const _VmServiceConnection({
     required this.simController,
@@ -45,7 +48,7 @@ class _ConnectedVmServiceDisplay extends StatelessWidget {
               'Debugging:',
               style: theme.regularTextStyle,
             ),
-            const Text('<connected uri>'),
+            Text(_connectedUri ?? '--'),
             // TODO(kenz): uncomment once we can bump to vm_service ^11.10.0
             // Text(
             //   serviceManager.service!.wsUri ?? '--',
@@ -59,7 +62,10 @@ class _ConnectedVmServiceDisplay extends StatelessWidget {
         DevToolsButton(
           elevated: true,
           label: 'Disconnect',
-          onPressed: serviceManager.manuallyDisconnect,
+          onPressed: () {
+            _connectedUri = null;
+            unawaited(serviceManager.manuallyDisconnect());
+          },
         ),
       ],
     );
@@ -106,7 +112,6 @@ class _DisconnectedVmServiceDisplayState
             autofocus: true,
             style: theme.regularTextStyle,
             decoration: InputDecoration(
-              // contentPadding: const EdgeInsets.all(denseSpacing),
               isDense: true,
               border: const OutlineInputBorder(),
               enabledBorder: OutlineInputBorder(
@@ -126,9 +131,12 @@ class _DisconnectedVmServiceDisplayState
         DevToolsButton(
           elevated: true,
           label: 'Connect',
-          onPressed: () => widget.simController.vmServiceConnectionChanged(
-            uri: _connectTextFieldController.text,
-          ),
+          onPressed: () {
+            _connectedUri = _connectTextFieldController.text,
+            widget.simController.vmServiceConnectionChanged(
+              uri: _connectTextFieldController.text,
+            );
+          },
         ),
       ],
     );

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -12,8 +12,8 @@ executables:
 
 dependencies:
   args: ^2.4.2
-  devtools_shared: ^3.0.0
-  devtools_app_shared: ^0.0.1-dev.0
+  devtools_shared: ^3.0.1
+  devtools_app_shared: ^0.0.1
   flutter:
     sdk: flutter
   io: ^1.0.4

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.0.3
+version: 0.0.2
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: 3.0.0
+  devtools_shared: ^3.0.1
   devtools_app: 2.27.0-dev.16
   devtools_app_shared:
     path: ../devtools_app_shared


### PR DESCRIPTION
Display connected uri in devtools simulated environment. We will remove this once we can bump to vm_service ^11.10.0. 

This PR also bumps dependency versions to make pub solve happy and adds some missing dependencies for `package:devtools_app_shared`