### PR TITLE
Add hot reload and hot restart buttons to the simulated devtools environment

### DIFF
--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.3-wip
+* Add hot reload and hot restart actions to the simulated DevTools environment.
+
 ## 0.0.2
 * Add a simulated DevTools environment that for easier development.
 * Add a `build_and_copy` command to build a devtools extension and copy the output to the

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -175,7 +175,7 @@ class _SimulatedApi extends StatelessWidget {
               onPressed: simController.hotRestartConnectedApp,
             ),
           ],
-        )
+        ),
       ],
     );
   }

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -147,15 +147,35 @@ class _SimulatedApi extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Row(
-      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+    return Column(
       children: [
-        DevToolsButton(
-          label: 'PING',
-          onPressed: simController.ping,
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            DevToolsButton(
+              label: 'PING',
+              onPressed: simController.ping,
+            ),
+            // TODO(kenz): add buttons for other simulated events as the extension
+            // API expands.
+          ],
         ),
-        // TODO(kenz): add buttons for other simulated events as the extension
-        // API expands.
+        const SizedBox(height: defaultSpacing),
+        Row(
+          children: [
+            DevToolsButton(
+              icon: Icons.bolt,
+              tooltip: 'Hot reload connected app',
+              onPressed: simController.hotReloadConnectedApp,
+            ),
+            const SizedBox(width: denseSpacing),
+            DevToolsButton(
+              icon: Icons.replay,
+              tooltip: 'Hot restart connected app',
+              onPressed: simController.hotRestartConnectedApp,
+            ),
+          ],
+        )
       ],
     );
   }
@@ -205,9 +225,11 @@ class _LogMessagesState extends State<_LogMessages> {
                       '[${log.timestamp.toString()}] from ${log.source.display}',
                       style: theme.fixedFontStyle,
                     ),
-                    FormattedJson(
-                      json: log.data,
-                    ),
+                    if (log.message != null) Text(log.message!),
+                    if (log.data != null)
+                      FormattedJson(
+                        json: log.data,
+                      ),
                   ],
                 ),
               );

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.0.2
+version: 0.0.3-wip
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:


### PR DESCRIPTION
This will allow extension developers to easily hot reload or hot restart the connected app:
![Screenshot 2023-08-28 at 4 10 30 PM](https://github.com/flutter/devtools/assets/43759233/f5fe0ca2-9fa5-4f7a-8860-f73823d86828)
