### PR TITLE
disable flaky flutter web integration test

### DIFF
--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -430,6 +430,9 @@ enum TestAppDevice {
       'perfetto_test.dart',
       'performance_screen_event_recording_test.dart',
       'service_connection_test.dart',
+      // TODO(https://github.com/flutter/devtools/issues/6289): re-enable this
+      // test once the flake is fixed.
+      'debugger_panel_test.dart',
     ],
     TestAppDevice.cli: [
       'debugger_panel_test.dart',


### PR DESCRIPTION
This is blocking submit, sometimes having to re-run the job 3-4 times to get it to pass. We should fix the flake and then re-enable: https://github.com/flutter/devtools/issues/6289