### PR TITLE
Fixing flakey debug panel test

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     // Tap on the gutter for the line to set a breakpoint:
     await tester.tap(gutter30Finder);
-    await tester.pumpAndSettle(safePumpDuration);
+    await tester.pumpAndSettle(longPumpDuration);
 
     logStatus('pausing at breakpoint');
 

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -430,9 +430,6 @@ enum TestAppDevice {
       'perfetto_test.dart',
       'performance_screen_event_recording_test.dart',
       'service_connection_test.dart',
-      // TODO(https://github.com/flutter/devtools/issues/6289): re-enable this
-      // test once the flake is fixed.
-      'debugger_panel_test.dart',
     ],
     TestAppDevice.cli: [
       'debugger_panel_test.dart',


### PR DESCRIPTION
![](https://media.giphy.com/media/27bJAxEwVDigvrTCjR/giphy.gif)

Fixes https://github.com/flutter/devtools/issues/6289

I was able to reproduce locally by reducing the pump duration, after setting a breakpoint, to 1 millisecond.

Therefore I think it would be reasonable to use the 6 second pump, rather than 3s, to give the callstack a bit more time to load.

If we are still having a consistent amount of flake, then we can rediscuss.
