### PR TITLE
Fix App.started timeout in integration tests

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     // Tap on the gutter for the line to set a breakpoint:
     await tester.tap(gutter30Finder);
-    await tester.pumpAndSettle(safePumpDuration);
+    await tester.pumpAndSettle(longPumpDuration);
 
     logStatus('pausing at breakpoint');
 

--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     // Tap on the gutter for the line to set a breakpoint:
     await tester.tap(gutter30Finder);
-    await tester.pumpAndSettle(longPumpDuration);
+    await tester.pumpAndSettle(const Duration(milliseconds: 1));
 
     logStatus('pausing at breakpoint');
 

--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -101,7 +101,7 @@ void main() {
 
     // Tap on the gutter for the line to set a breakpoint:
     await tester.tap(gutter30Finder);
-    await tester.pumpAndSettle(const Duration(milliseconds: 1));
+    await tester.pumpAndSettle(safePumpDuration);
 
     logStatus('pausing at breakpoint');
 

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -430,6 +430,9 @@ enum TestAppDevice {
       'perfetto_test.dart',
       'performance_screen_event_recording_test.dart',
       'service_connection_test.dart',
+      // TODO(https://github.com/flutter/devtools/issues/6289): re-enable this
+      // test once the flake is fixed.
+      'debugger_panel_test.dart',
     ],
     TestAppDevice.cli: [
       'debugger_panel_test.dart',

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -285,7 +285,8 @@ class TestDartCliApp extends IntegrationTestApp {
 abstract class IntegrationTestApp with IOMixin {
   IntegrationTestApp(this.testAppPath, this.testAppDevice);
 
-  static const _appStartTimeout = Duration(seconds: 120);
+  static const _appStartTimeout =
+      Duration(seconds: 300); // TODO change this to 200
 
   static const _defaultTimeout = Duration(seconds: 40);
 

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -430,9 +430,6 @@ enum TestAppDevice {
       'perfetto_test.dart',
       'performance_screen_event_recording_test.dart',
       'service_connection_test.dart',
-      // TODO(https://github.com/flutter/devtools/issues/6289): re-enable this
-      // test once the flake is fixed.
-      'debugger_panel_test.dart',
     ],
     TestAppDevice.cli: [
       'debugger_panel_test.dart',

--- a/packages/devtools_app/test/test_infra/flutter_test_driver.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_driver.dart
@@ -315,10 +315,9 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     // to stdout. This avoids race conditions and deadlocks.
     final Future<Map<String, dynamic>> startedFuture =
         waitFor(event: 'app.started', timeout: appStartTimeout);
-    final connectedFuture =
-        waitFor(event: 'daemon.connected');
+    final connectedFuture = waitFor(event: 'daemon.connected');
     final debugPortFuture =
-          waitFor(event: 'app.debugPort', timeout: appStartTimeout);
+        waitFor(event: 'app.debugPort', timeout: appStartTimeout);
 
     await super.setupProcess(
       args,
@@ -333,14 +332,11 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     // Stash the PID so that we can terminate the VM more reliably than using
     // proc.kill() (because proc is a shell, because `flutter` is a shell
     // script).
-    final Map<String, dynamic> connected =
-        await connectedFuture;
+    final Map<String, dynamic> connected = await connectedFuture;
     procPid = connected['params']['pid'];
 
-
     if (runConfig.withDebugger) {
-      final Map<String, dynamic> debugPort =
-          await debugPortFuture;
+      final Map<String, dynamic> debugPort = await debugPortFuture;
       final String wsUriString = debugPort['params']['wsUri'];
       _vmServiceWsUri = Uri.parse(wsUriString);
 
@@ -383,7 +379,6 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       }
       await resume(wait: false);
     }
-
   }
 
   Future<void> hotRestart({bool pause = false}) =>

--- a/packages/devtools_app/test/test_infra/flutter_test_driver.dart
+++ b/packages/devtools_app/test/test_infra/flutter_test_driver.dart
@@ -26,7 +26,7 @@ import 'package:vm_service/vm_service_io.dart';
 // Set this to true for debugging to get JSON written to stdout.
 const bool _printDebugOutputToStdOut = false;
 const Duration defaultTimeout = Duration(seconds: 40);
-const Duration appStartTimeout = Duration(seconds: 120);
+const Duration appStartTimeout = Duration(seconds: 240);
 const Duration quitTimeout = Duration(seconds: 10);
 
 abstract class FlutterTestDriver {
@@ -311,14 +311,6 @@ class FlutterRunTestDriver extends FlutterTestDriver {
     FlutterRunConfiguration runConfig = const FlutterRunConfiguration(),
     File? pidFile,
   }) async {
-    // Start listening for all events before we start printing
-    // to stdout. This avoids race conditions and deadlocks.
-    final Future<Map<String, dynamic>> startedFuture =
-        waitFor(event: 'app.started', timeout: appStartTimeout);
-    final connectedFuture = waitFor(event: 'daemon.connected');
-    final debugPortFuture =
-        waitFor(event: 'app.debugPort', timeout: appStartTimeout);
-
     await super.setupProcess(
       args,
       flutterExecutable: flutterExecutable,
@@ -326,17 +318,21 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       pidFile: pidFile,
     );
 
-    // Await the startedFuture, which signals that the app has started.
-    _currentRunningAppId = (await startedFuture)['params']['appId'];
-
     // Stash the PID so that we can terminate the VM more reliably than using
     // proc.kill() (because proc is a shell, because `flutter` is a shell
     // script).
-    final Map<String, dynamic> connected = await connectedFuture;
+    final Map<String, dynamic> connected =
+        await waitFor(event: 'daemon.connected');
     procPid = connected['params']['pid'];
 
+    // Set this up now, but we don't wait it yet. We want to make sure we don't
+    // miss it while waiting for debugPort below.
+    final Future<Map<String, dynamic>> started =
+        waitFor(event: 'app.started', timeout: appStartTimeout);
+
     if (runConfig.withDebugger) {
-      final Map<String, dynamic> debugPort = await debugPortFuture;
+      final Map<String, dynamic> debugPort =
+          await waitFor(event: 'app.debugPort', timeout: appStartTimeout);
       final String wsUriString = debugPort['params']['wsUri'];
       _vmServiceWsUri = Uri.parse(wsUriString);
 
@@ -379,6 +375,10 @@ class FlutterRunTestDriver extends FlutterTestDriver {
       }
       await resume(wait: false);
     }
+
+    // Now await the started event; if it had already happened the future will
+    // have already completed.
+    _currentRunningAppId = (await started)['params']['appId'];
   }
 
   Future<void> hotRestart({bool pause = false}) =>


### PR DESCRIPTION
![](https://media.giphy.com/media/3o7budjt2L4nx185qM/giphy-downsized.gif)


Fixes https://github.com/flutter/devtools/issues/6294

The app is likely timing out too early in some instances. I've doubled the timeout values for app start to `4 minutes`.

If we still have timeouts then we may need to do more investigation into why the app start is increasing so much.