### PR TITLE
Cleanup release notes instructions and template

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -1,39 +1,53 @@
 This is draft for future release notes, that are going to land on
-[the Flutter website](https://docs.flutter.dev/development/tools/devtools/release-notes).
+[the Flutter website](https://docs.flutter.dev/tools/devtools/release-notes).
 
 # DevTools 2.27.0 release notes
 
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Inspector updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## CPU profiler updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
-* Improved responsiveness of the top bar in the Logging page - [#6281](https://github.com/flutter/devtools/pull/6281)
 
-* Add the ability to copy filtered logs - [#6260](https://github.com/flutter/devtools/pull/6260)
-![Logger tab copy](images/logger_copy.png "Logger tab copy")
+* Improved responsiveness of the top bar on the Logging page -
+  [#6281](https://github.com/flutter/devtools/pull/6281)
+
+* Add the ability to copy filtered logs -
+  [#6260](https://github.com/flutter/devtools/pull/6260)
+
+  ![The copy button on the Logger page to the right of the filter tool](images/logger_copy.png "The Logger page copy button")
+
 ## App size tool updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Full commit history
+
 More details about changes and fixes are available from the
-[DevTools git log.](https://github.com/flutter/devtools/commits/master).
+[DevTools git log](https://github.com/flutter/devtools/commits/master).

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -35,13 +35,13 @@ TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
 
-* Improved responsiveness of the top bar on the Logging page -
+* Improved responsiveness of the top bar on the Logging view -
   [#6281](https://github.com/flutter/devtools/pull/6281)
 
 * Add the ability to copy filtered logs -
   [#6260](https://github.com/flutter/devtools/pull/6260)
 
-  ![The copy button on the Logger page to the right of the filter tool](images/logger_copy.png "The Logger page copy button")
+  ![The copy button on the Logging view to the right of the filter tool](images/logger_copy.png "The Logging view copy button")
 
 ## App size tool updates
 

--- a/packages/devtools_app/release_notes/README.md
+++ b/packages/devtools_app/release_notes/README.md
@@ -1,35 +1,57 @@
 ## Updating NEXT_RELEASE_NOTES.md
-When you add a user-facing change to DevTools, please add a release note entry to document this improvement.
 
-If you want to add an image to the release note entry, add the image to the `release_notes/images` folder,
+When you add a user-facing change to DevTools,
+please add a release note entry to document this improvement.
+
+If you want to add an image to the release note entry,
+add the image to the `release_notes/images` folder,
 and then reference it in the markdown. For example:
 
-```
-![my feature](images/my_feature.png "my feature")
+```markdown
+![Accessible image description](images/my_feature.png "Image hover description")
 ```
 
-When adding these release notes to the Flutter website, you'll have to copy the image over and edit the path
+When adding these release notes to the Flutter website,
+you'll have to copy the image over and edit the path
 to match the structure of the Flutter website.
 
-## Generating Release notes for the Flutter website
-- Release notes for DevTools are hosted on the flutter website (see [archive](https://docs.flutter.dev/tools/devtools/release-notes)).
-- To add release notes for the latest release, create a PR with the appropriate changes for your release.
-    - The [NEXT_RELEASE_NOTES.md](NEXT_RELEASE_NOTES.md) file contains the running release notes for the current version.
-    - see example [PR](https://github.com/flutter/website/pull/6791) for an example of how to add those to the Flutter website.
-    - NOTE: when adding images, be cognizant that the images will be rendered in a relatively small window in DevTools, and they should be sized accordingly.
+## Generating release notes for the Flutter website
 
-- Once you are satisfied with the release notes, push up a PR to the `flutter/website` repo, and then 
-proceed to the testing steps below.
+- Release notes for DevTools are hosted on the Flutter website.
+  They are indexed at https://docs.flutter.dev/tools/devtools/release-notes.
+- To add release notes for the latest release,
+  create a PR with the appropriate changes for your release:
+
+  - The [NEXT_RELEASE_NOTES.md](NEXT_RELEASE_NOTES.md) file contains
+    the running release notes for the current version.
+  - See an example [PR](https://github.com/flutter/website/pull/6791) for
+    an example of how to add those to the Flutter website.
+  - NOTE: When adding images, be cognizant that the images will be
+    rendered in a relatively small window in DevTools,
+    and they should be sized accordingly.
+
+- Once you are satisfied with the release notes,
+  create a new branch directly on the `flutter/website` repo and open a PR,
+  and then proceed to the testing steps below.
 
 ### Testing the release notes in DevTools
-Once you push up your `flutter/website` PR, wait for the `github-actions` bot to stage your changes
-to firebase. Open the link and navigate to the release notes you want to test. Be sure to add `-src.md`
-to the url to get the raw json. The url should look something like:
+
+Once you push up your branch to `flutter/website` and open your PR,
+wait for the `github-actions` bot to stage your changes to Firebase.
+Open the link it comments and navigate to the release notes you want to test.
+Be sure to add `-src.md` to the url to get the raw json.
+The url should look something like:
+
 ```
 https://flutter-docs-prod--pr8928-dt-notes-links-b0b33er1.web.app/tools/devtools/release-notes/release-notes-2.24.0-src.md
 ```
-- Copy this url and set `_debugReleaseNotesUrl` in `release_notes.dart` to this value.
 
-- Run DevTools and the release notes viewer should open with the markdown at the url you provided.
+- Copy this url and set `_debugReleaseNotesUrl` in
+  `release_notes.dart` to this value.
 
-- Verify the release notes viewer displays the new release notes as expected. Some issues to watch out for are broken images or 'include_relative' lines in the markdown that don't load properly.
+- Run DevTools and the release notes viewer should open
+  with the markdown at the url you provided.
+
+- Verify the release notes viewer displays the new release notes as expected.
+  Some issues to watch out for are broken images or 'include_relative' lines in
+  the markdown that don't load properly.

--- a/packages/devtools_app/release_notes/helpers/release_notes_template.md
+++ b/packages/devtools_app/release_notes/helpers/release_notes_template.md
@@ -1,37 +1,47 @@
 This is draft for future release notes, that are going to land on
-[the Flutter website](https://docs.flutter.dev/development/tools/devtools/release-notes).
+[the Flutter website](https://docs.flutter.dev/tools/devtools/release-notes).
 
 # DevTools <number> release notes
 
 Dart & Flutter DevTools - A Suite of Performance Tools for Dart and Flutter
 
 ## General updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Inspector updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## CPU profiler updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## App size tool updates
+
 TODO: Remove this section if there are not any general updates.
 
 ## Full commit history
+
 More details about changes and fixes are available from the
-[DevTools git log.](https://github.com/flutter/devtools/commits/master).
+[DevTools git log](https://github.com/flutter/devtools/commits/master).


### PR DESCRIPTION
- Update release note instructional README:
  - Clarify the branch should be opened directly on `flutter/website` for automatic staging
  - Clarify the Firebase link is commented on the PR
  - Clarify/emphasize the alt text as an accessible image description
  - Use shorter lines and semantic breaks to make file easier to read, edit, and review
- Cleanup template
  - Remove duplicate periods in "Full commit history" section
  - Add extra line after headers to match `flutter/website` style
- Existing next release notes update
  - Apply changes from template
  - Add more complete alt text and title
  
Closes https://github.com/flutter/website/issues/9335
