### PR TITLE
Add event direction to `DevToolsExtensionEventType` values

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -188,9 +188,13 @@ class _ExtensionIFrameController extends DisposableController
     DevToolsExtensionEvent event, {
     void Function()? onUnknownEvent,
   }) {
+    // Ignore events that are not supported for the DevTools => Extension
+    // direction.
+    if (!event.type.supportedForDirection(ExtensionEventDirection.toDevTools)) {
+      return;
+    }
+
     switch (event.type) {
-      case DevToolsExtensionEventType.ping:
-      // Ignore. DevTools should not receive/handle ping events.
       case DevToolsExtensionEventType.pong:
         if (!_extensionHandlerReady.isCompleted) {
           _extensionHandlerReady.complete();

--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -188,7 +188,7 @@ class _ExtensionIFrameController extends DisposableController
     DevToolsExtensionEvent event, {
     void Function()? onUnknownEvent,
   }) {
-    // Ignore events that are not supported for the DevTools => Extension
+    // Ignore events that are not supported for the Extension => DevTools
     // direction.
     if (!event.type.supportedForDirection(ExtensionEventDirection.toDevTools)) {
       return;

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -41,7 +41,6 @@ class Devices extends StatelessWidget {
             children: [
               for (final device in devices)
                 _createDeviceRow(
-                  context,
                   device,
                   isSelected: device.id == selectedDeviceId,
                 ),
@@ -51,11 +50,7 @@ class Devices extends StatelessWidget {
     );
   }
 
-  TableRow _createDeviceRow(
-    BuildContext context,
-    VsCodeDevice device, {
-    required bool isSelected,
-  }) {
+  TableRow _createDeviceRow(VsCodeDevice device, {required bool isSelected}) {
     return TableRow(
       children: [
         Align(

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -145,6 +145,10 @@ class MockDartToolingApi extends DartToolingApiImpl {
   }
 
   /// Simulates opening a DevTools feature.
+  // TODO(dantup): does this method need to be async and is the [parameters]
+  // paraeter actually unnecessary?
+  // ignore: avoid-unused-parameters, todo investigate
+  // ignore: avoid-redundant-async, todo investigate
   Future<void> openDevToolsPage(json_rpc_2.Parameters parameters) async {}
 
   /// Simulates devices being connected in the IDE by notifying the embedded

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -31,9 +31,9 @@ enum DevToolsExtensionEventType {
   /// Any unrecognized event that is not one of the above supported event types.
   unknown(ExtensionEventDirection.bidirectional);
 
-  const DevToolsExtensionEventType(this.direction);
+  const DevToolsExtensionEventType(this._direction);
 
-  final ExtensionEventDirection direction;
+  final ExtensionEventDirection _direction;
 
   static DevToolsExtensionEventType from(String name) {
     for (final event in DevToolsExtensionEventType.values) {
@@ -44,8 +44,9 @@ enum DevToolsExtensionEventType {
     return unknown;
   }
 
-  bool supportedForDirection(ExtensionEventDirection d) {
-    return direction == d || direction == ExtensionEventDirection.bidirectional;
+  bool supportedForDirection(ExtensionEventDirection direction) {
+    return _direction == direction ||
+        _direction == ExtensionEventDirection.bidirectional;
   }
 }
 

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -7,8 +7,8 @@ import 'model.dart';
 /// Supported events that can be sent and received over 'postMessage' between
 /// DevTools and a DevTools extension running in an embedded iFrame.
 enum DevToolsExtensionEventType {
-  /// An DevTools will send to an extension to verify that the extension is
-  /// ready for use.
+  /// An event DevTools will send to an extension to verify that the extension
+  /// is ready for use.
   ping(ExtensionEventDirection.toExtension),
 
   /// An event that a DevTools extension will send back to DevTools after

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -7,29 +7,33 @@ import 'model.dart';
 /// Supported events that can be sent and received over 'postMessage' between
 /// DevTools and a DevTools extension running in an embedded iFrame.
 enum DevToolsExtensionEventType {
-  /// An event that a DevTools extension expects from DevTools to verify that
-  /// the extension is ready for use.
-  ping,
+  /// An DevTools will send to an extension to verify that the extension is
+  /// ready for use.
+  ping(ExtensionEventDirection.toExtension),
 
   /// An event that a DevTools extension will send back to DevTools after
   /// receiving a [ping] event.
-  pong,
+  pong(ExtensionEventDirection.toDevTools),
 
   /// An event that DevTools will send to an extension to notify of the
   /// connected vm service uri.
-  vmServiceConnection,
+  vmServiceConnection(ExtensionEventDirection.bidirectional),
 
   /// An event that an extension will send to DevTools asking DevTools to post
   /// a notification to the DevTools global [notificationService].
-  showNotification,
+  showNotification(ExtensionEventDirection.toDevTools),
 
   /// An event that an extension will send to DevTools asking DevTools to post
   /// a banner message to the extension's screen using the global
   /// [bannerMessages].
-  showBannerMessage,
+  showBannerMessage(ExtensionEventDirection.toDevTools),
 
   /// Any unrecognized event that is not one of the above supported event types.
-  unknown;
+  unknown(ExtensionEventDirection.bidirectional);
+
+  const DevToolsExtensionEventType(this.direction);
+
+  final ExtensionEventDirection direction;
 
   static DevToolsExtensionEventType from(String name) {
     for (final event in DevToolsExtensionEventType.values) {
@@ -39,6 +43,27 @@ enum DevToolsExtensionEventType {
     }
     return unknown;
   }
+
+  bool supportedForDirection(ExtensionEventDirection d) {
+    return direction == d || direction == ExtensionEventDirection.bidirectional;
+  }
+}
+
+/// Describes the flow direction for a [DevToolsExtensionEventType].
+///
+/// Some events are unidirecitonal and some are bidirectional.
+enum ExtensionEventDirection {
+  /// Describes events that can be sent both from DevTools to extensions and
+  /// from extensions to DevTools.
+  bidirectional,
+
+  /// Describes events that can be sent from extensions to DevTools, but not
+  /// from DevTools to extensions.
+  toDevTools,
+
+  /// Describes events that can be sent from DevTools to extensions, but not
+  /// from extensions to DevTools.
+  toExtension,
 }
 
 /// Interface that a DevTools extension host should implement.

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -11,8 +11,8 @@ enum DevToolsExtensionEventType {
   /// is ready for use.
   ping(ExtensionEventDirection.toExtension),
 
-  /// An event that a DevTools extension will send back to DevTools after
-  /// receiving a [ping] event.
+  /// An event that an extension will send back to DevTools after receiving a
+  /// [ping] event.
   pong(ExtensionEventDirection.toDevTools),
 
   /// An event that DevTools will send to an extension to notify of the

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -75,8 +75,7 @@ class ExtensionManager {
         );
         break;
       case DevToolsExtensionEventType.vmServiceConnection:
-        final vmServiceUri = extensionEvent
-            .data?[ExtensionEventParameters.vmServiceConnectionUri] as String?;
+        final vmServiceUri = extensionEvent.data?['uri'] as String?;
         unawaited(_connectToVmService(vmServiceUri));
         break;
       case DevToolsExtensionEventType.unknown:

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -10,11 +10,16 @@ class ExtensionManager {
   final _registeredEventHandlers =
       <DevToolsExtensionEventType, ExtensionEventHandler>{};
 
+  /// Registers an event handler for [DevToolsExtensionEvent]s of type [type].
+  ///
+  /// When an event of type [type] is received by the extension, [handler] will
+  /// be called after any default event handling takes place for event [type].
+  /// See [_handleExtensionEvent].
   void registerEventHandler(
-    DevToolsExtensionEventType event,
+    DevToolsExtensionEventType type,
     ExtensionEventHandler handler,
   ) {
-    _registeredEventHandlers[event] = handler;
+    _registeredEventHandlers[type] = handler;
   }
 
   // ignore: unused_element, false positive due to part files
@@ -43,35 +48,45 @@ class ExtensionManager {
     if (e is html.MessageEvent) {
       final extensionEvent = DevToolsExtensionEvent.tryParse(e.data);
       if (extensionEvent != null) {
-        // Do not handle messages that come from the [ExtensionManager] itself.
-        if (extensionEvent.source == '$ExtensionManager') return;
-
-        switch (extensionEvent.type) {
-          case DevToolsExtensionEventType.ping:
-            postMessageToDevTools(
-              DevToolsExtensionEvent(DevToolsExtensionEventType.pong),
-              targetOrigin: e.origin,
-            );
-            break;
-          case DevToolsExtensionEventType.vmServiceConnection:
-            final vmServiceUri = extensionEvent.data?['uri'] as String?;
-            unawaited(_connectToVmService(vmServiceUri));
-            break;
-          case DevToolsExtensionEventType.pong:
-          case DevToolsExtensionEventType.showNotification:
-          case DevToolsExtensionEventType.showBannerMessage:
-            // Ignore. These events are sent from extensions to DevTools only.
-            break;
-          case DevToolsExtensionEventType.unknown:
-          default:
-            _log.warning(
-              'Unrecognized event received by extension: '
-              '(${extensionEvent.type} - ${e.data}',
-            );
-        }
-        _registeredEventHandlers[extensionEvent.type]?.call(extensionEvent);
+        _handleExtensionEvent(extensionEvent, e);
       }
     }
+  }
+
+  void _handleExtensionEvent(
+    DevToolsExtensionEvent extensionEvent,
+    html.MessageEvent e,
+  ) {
+    // Ignore events that come from the [ExtensionManager] itself.
+    if (extensionEvent.source == '$ExtensionManager') return;
+
+    // Ignore events that are not supported for the DevTools => Extension
+    // direction.
+    if (!extensionEvent.type
+        .supportedForDirection(ExtensionEventDirection.toExtension)) {
+      return;
+    }
+
+    switch (extensionEvent.type) {
+      case DevToolsExtensionEventType.ping:
+        postMessageToDevTools(
+          DevToolsExtensionEvent(DevToolsExtensionEventType.pong),
+          targetOrigin: e.origin,
+        );
+        break;
+      case DevToolsExtensionEventType.vmServiceConnection:
+        final vmServiceUri = extensionEvent
+            .data?[ExtensionEventParameters.vmServiceConnectionUri] as String?;
+        unawaited(_connectToVmService(vmServiceUri));
+        break;
+      case DevToolsExtensionEventType.unknown:
+      default:
+        _log.warning(
+          'Unrecognized event received by extension: '
+          '(${extensionEvent.type} - ${e.data}',
+        );
+    }
+    _registeredEventHandlers[extensionEvent.type]?.call(extensionEvent);
   }
 
   /// Posts a [DevToolsExtensionEvent] to the DevTools extension host.

--- a/packages/devtools_extensions/test/api_test.dart
+++ b/packages/devtools_extensions/test/api_test.dart
@@ -107,6 +107,33 @@ void main() {
         DevToolsExtensionEventType.unknown,
       );
     });
+
+    test('supportedForDirection', () {
+      verifyEventDirection(
+        DevToolsExtensionEventType.ping,
+        (bidirectional: false, toDevTools: false, toExtension: true),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.pong,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.vmServiceConnection,
+        (bidirectional: true, toDevTools: true, toExtension: true),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.showNotification,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.showBannerMessage,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.unknown,
+        (bidirectional: true, toDevTools: true, toExtension: true),
+      );
+    });
   });
 
   group('$ShowNotificationExtensionEvent', () {
@@ -264,4 +291,22 @@ void main() {
       );
     });
   });
+}
+
+void verifyEventDirection(
+  DevToolsExtensionEventType type,
+  ({bool bidirectional, bool toDevTools, bool toExtension}) expected,
+) {
+  expect(
+    type.supportedForDirection(ExtensionEventDirection.bidirectional),
+    expected.bidirectional,
+  );
+  expect(
+    type.supportedForDirection(ExtensionEventDirection.toDevTools),
+    expected.toDevTools,
+  );
+  expect(
+    type.supportedForDirection(ExtensionEventDirection.toExtension),
+    expected.toExtension,
+  );
 }

--- a/packages/devtools_shared/test/deeplink/deeplink_manager_test.dart
+++ b/packages/devtools_shared/test/deeplink/deeplink_manager_test.dart
@@ -56,31 +56,36 @@ Running Gradle task 'printBuildVariants'...                        10.4s
       );
     });
 
-    test('getBuildVariants return internal server error if command failed',
-        () async {
-      const String projectRoot = '/abc';
-      manager.expectedCommands.add(
-        TestCommand(
-          executable: 'flutter',
-          arguments: <String>[
-            'analyze',
-            '--android',
-            '--list-build-variants',
-            projectRoot,
-          ],
-          result: ProcessResult(
-            0,
-            1,
-            '',
-            'unknown error',
+    test(
+      'getBuildVariants return internal server error if command failed',
+      () async {
+        const String projectRoot = '/abc';
+        manager.expectedCommands.add(
+          TestCommand(
+            executable: 'flutter',
+            arguments: <String>[
+              'analyze',
+              '--android',
+              '--list-build-variants',
+              projectRoot,
+            ],
+            result: ProcessResult(
+              0,
+              1,
+              '',
+              'unknown error',
+            ),
           ),
-        ),
-      );
-      final response = await manager.getBuildVariants(
-        rootPath: projectRoot,
-      );
-      expect(response[DeeplinkManager.kErrorField], contains('unknown error'));
-    });
+        );
+        final response = await manager.getBuildVariants(
+          rootPath: projectRoot,
+        );
+        expect(
+          response[DeeplinkManager.kErrorField],
+          contains('unknown error'),
+        );
+      },
+    );
   });
 }
 


### PR DESCRIPTION
This clarifies which direction the events from the extension api should flow in.