### PR TITLE
Add theme support for devtools extensions

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -103,6 +103,19 @@ class _ExtensionIFrameController extends DisposableController
         }
       }),
     );
+
+    addAutoDisposeListener(preferences.darkModeTheme, () {
+      _postMessage(
+        DevToolsExtensionEvent(
+          DevToolsExtensionEventType.themeUpdate,
+          data: {
+            ExtensionEventParameters.theme: preferences.darkModeTheme.value
+                ? ExtensionEventParameters.themeValueDark
+                : ExtensionEventParameters.themeValueLight,
+          },
+        ),
+      );
+    });
   }
 
   void _postMessage(DevToolsExtensionEvent event) async {
@@ -174,11 +187,25 @@ class _ExtensionIFrameController extends DisposableController
   }
 
   @override
-  void vmServiceConnectionChanged({required String? uri}) {
+  void updateVmServiceConnection({required String? uri}) {
     _postMessage(
       DevToolsExtensionEvent(
         DevToolsExtensionEventType.vmServiceConnection,
-        data: {'uri': uri},
+        data: {ExtensionEventParameters.vmServiceConnectionUri: uri},
+      ),
+    );
+  }
+
+  @override
+  void updateTheme({required String theme}) {
+    assert(
+      theme == ExtensionEventParameters.themeValueLight ||
+          theme == ExtensionEventParameters.themeValueDark,
+    );
+    _postMessage(
+      DevToolsExtensionEvent(
+        DevToolsExtensionEventType.themeUpdate,
+        data: {ExtensionEventParameters.theme: theme},
       ),
     );
   }
@@ -198,7 +225,7 @@ class _ExtensionIFrameController extends DisposableController
         break;
       case DevToolsExtensionEventType.vmServiceConnection:
         final service = serviceConnection.serviceManager.service;
-        vmServiceConnectionChanged(uri: service?.connectedUri.toString());
+        updateVmServiceConnection(uri: service?.connectedUri.toString());
         break;
       case DevToolsExtensionEventType.showNotification:
         _handleShowNotification(event);

--- a/packages/devtools_app/lib/src/extensions/embedded/controller.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/controller.dart
@@ -21,5 +21,8 @@ abstract class EmbeddedExtensionController extends DisposableController {
 
   void init() {}
 
-  void postMessage(DevToolsExtensionEventType type, String message) {}
+  void postMessage(
+    DevToolsExtensionEventType type, {
+    Map<String, String> data = const <String, String>{},
+  }) {}
 }

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -147,7 +147,6 @@ class MockDartToolingApi extends DartToolingApiImpl {
   /// Simulates opening a DevTools feature.
   // TODO(dantup): does this method need to be async and is the [parameters]
   // parameter actually unnecessary?
-  // ignore: avoid-unused-parameters, todo investigate
   // ignore: avoid-redundant-async, avoid-unused-parameters, todo investigate
   Future<void> openDevToolsPage(json_rpc_2.Parameters parameters) async {}
 

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -148,7 +148,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
   // TODO(dantup): does this method need to be async and is the [parameters]
   // paraeter actually unnecessary?
   // ignore: avoid-unused-parameters, todo investigate
-  // ignore: avoid-redundant-async, todo investigate
+  // ignore: avoid-redundant-async, avoid-unused-parameters, todo investigate
   Future<void> openDevToolsPage(json_rpc_2.Parameters parameters) async {}
 
   /// Simulates devices being connected in the IDE by notifying the embedded

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -146,7 +146,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
 
   /// Simulates opening a DevTools feature.
   // TODO(dantup): does this method need to be async and is the [parameters]
-  // paraeter actually unnecessary?
+  // parameter actually unnecessary?
   // ignore: avoid-unused-parameters, todo investigate
   // ignore: avoid-redundant-async, avoid-unused-parameters, todo investigate
   Future<void> openDevToolsPage(json_rpc_2.Parameters parameters) async {}

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -19,6 +19,10 @@ enum DevToolsExtensionEventType {
   /// connected vm service uri.
   vmServiceConnection,
 
+  /// An event that DevTools will send to an extension to notify of changes to
+  /// the active DevTools theme (light or dark).
+  themeUpdate(ExtensionEventDirection.toExtension),
+
   /// An event that an extension will send to DevTools asking DevTools to post
   /// a notification to the DevTools global [notificationService].
   showNotification,
@@ -41,6 +45,29 @@ enum DevToolsExtensionEventType {
   }
 }
 
+/// Parameter names and expected values for DevTools extension events.
+abstract class ExtensionEventParameters {
+  /// The parameter name for the theme value 'light' or 'dark' sent with the
+  /// [DevToolsExtensionEventType.themeUpdate] event.
+  static const theme = 'theme';
+
+  /// The value for the [theme] parameter that indicates use of a light theme.
+  ///
+  /// This value is sent with a [DevToolsExtensionEventType.themeUpdate] event
+  /// from DevTools when the theme is changed to use light mode.
+  static const themeValueLight = 'light';
+
+  /// The value for the [theme] parameter that indicates use of a dark theme.
+  ///
+  /// This value is sent with a [DevToolsExtensionEventType.themeUpdate] event
+  /// from DevTools when the theme is changed to use dark mode.
+  static const themeValueDark = 'dark';
+
+  /// The parameter name for the vm service uri value that is optionally sent
+  /// with the [DevToolsExtensionEventType.vmServiceConnection] event.
+  static const vmServiceConnectionUri = 'uri';
+}
+
 /// Interface that a DevTools extension host should implement.
 ///
 /// This interface is implemented by DevTools itself as well as by a simulated
@@ -53,7 +80,14 @@ abstract interface class DevToolsExtensionHostInterface {
   /// This method should send a [DevToolsExtensionEventType.vmServiceConnection]
   /// event to the extension to notify it of the vm service uri it should
   /// establish a connection to.
-  void vmServiceConnectionChanged({required String? uri});
+  void updateVmServiceConnection({required String? uri});
+
+  /// This method should send a [DevToolsExtensionEventType.themeUpdate] event
+  /// to the extension to notify if of a theme change in DevTools.
+  ///
+  /// [theme] should be one of [ExtensionEventParameters.themeValueLight] or
+  /// [ExtensionEventParameters.themeValueDark].
+  void updateTheme({required String theme});
 
   /// Handles events sent by the extension.
   ///

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -123,7 +123,7 @@ class _DisconnectedVmServiceDisplayState
               hintStyle: theme.regularTextStyle,
             ),
             onSubmitted: (value) =>
-                widget.simController.vmServiceConnectionChanged(uri: value),
+                widget.simController.updateVmServiceConnection(uri: value),
             controller: _connectTextFieldController,
           ),
         ),
@@ -133,7 +133,7 @@ class _DisconnectedVmServiceDisplayState
           label: 'Connect',
           onPressed: () {
             _connectedUri = _connectTextFieldController.text;
-            widget.simController.vmServiceConnectionChanged(
+            widget.simController.updateVmServiceConnection(
               uri: _connectTextFieldController.text,
             );
           },

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -150,11 +150,15 @@ class _SimulatedApi extends StatelessWidget {
     return Column(
       children: [
         Row(
-          mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             DevToolsButton(
               label: 'PING',
               onPressed: simController.ping,
+            ),
+            const SizedBox(width: denseSpacing),
+            DevToolsButton(
+              label: 'TOGGLE THEME',
+              onPressed: simController.toggleTheme,
             ),
             // TODO(kenz): add buttons for other simulated events as the extension
             // API expands.

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -77,7 +77,8 @@ class DevToolsExtension extends StatefulWidget {
   State<DevToolsExtension> createState() => _DevToolsExtensionState();
 }
 
-class _DevToolsExtensionState extends State<DevToolsExtension> {
+class _DevToolsExtensionState extends State<DevToolsExtension>
+    with AutoDisposeMixin {
   @override
   void initState() {
     super.initState();
@@ -88,6 +89,8 @@ class _DevToolsExtensionState extends State<DevToolsExtension> {
     for (final handler in widget.eventHandlers.entries) {
       extensionManager.registerEventHandler(handler.key, handler.value);
     }
+
+    addAutoDisposeListener(extensionManager.darkThemeEnabled);
   }
 
   void _initGlobals() {
@@ -119,6 +122,9 @@ class _DevToolsExtensionState extends State<DevToolsExtension> {
       child: widget.child,
     );
     return MaterialApp(
+      themeMode: extensionManager.darkThemeEnabled.value
+          ? ThemeMode.dark
+          : ThemeMode.light,
       theme: themeFor(
         isDarkTheme: false,
         ideTheme: ideTheme,

--- a/packages/devtools_extensions/test/api_test.dart
+++ b/packages/devtools_extensions/test/api_test.dart
@@ -95,6 +95,11 @@ void main() {
         DevToolsExtensionEventType.from('vmServiceConnection'),
         DevToolsExtensionEventType.vmServiceConnection,
       );
+
+      expect(
+        DevToolsExtensionEventType.from('themeUpdate'),
+        DevToolsExtensionEventType.themeUpdate,
+      );
     });
 
     test('parses for unexpected values', () {
@@ -105,6 +110,37 @@ void main() {
       expect(
         DevToolsExtensionEventType.from('pongg'),
         DevToolsExtensionEventType.unknown,
+      );
+    });
+
+    test('supportedForDirection', () {
+      verifyEventDirection(
+        DevToolsExtensionEventType.ping,
+        (bidirectional: false, toDevTools: false, toExtension: true),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.pong,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.vmServiceConnection,
+        (bidirectional: true, toDevTools: true, toExtension: true),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.vmServiceConnection,
+        (bidirectional: false, toDevTools: false, toExtension: true),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.showNotification,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.showBannerMessage,
+        (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.unknown,
+        (bidirectional: true, toDevTools: true, toExtension: true),
       );
     });
   });


### PR DESCRIPTION
The DevTools extensions now update for theme changes from DevTools:
![extension-theme-update](https://github.com/flutter/devtools/assets/43759233/02656278-b02e-467f-b75a-705eda12d238)

The simulated DevTools environment also exposes an action to toggle the theme:
<img width="441" alt="Screenshot 2023-09-07 at 10 47 55 AM" src="https://github.com/flutter/devtools/assets/43759233/1c890837-3b68-4472-b068-d4b311bc5c40">

Work towards https://github.com/flutter/devtools/issues/6272