### PR TITLE
Prepare for release 2.28.0


### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -9,4 +9,4 @@
 // the constant declaration `const String version =`.
 // If you change the declaration you must also modify the regex in
 // tools/update_version.dart.
-const String version = '2.28.0-dev.4';
+const String version = '2.28.0';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.28.0-dev.4
+version: 2.28.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 
@@ -72,7 +72,7 @@ dependencies:
 dev_dependencies:
   args: ^2.4.2
   build_runner: ^2.3.3
-  devtools_test: 2.28.0-dev.4
+  devtools_test: 2.28.0
   fake_async: ^1.3.1
   flutter_driver:
     sdk: flutter

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: none
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
 # this package.
-version: 2.28.0-dev.4
+version: 2.28.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
@@ -19,7 +19,7 @@ dependencies:
   async: ^2.0.0
   collection: ^1.15.0
   devtools_shared: ^3.0.1
-  devtools_app: 2.28.0-dev.4
+  devtools_app: 2.28.0
   devtools_app_shared:
     path: ../devtools_app_shared
   flutter:


### PR DESCRIPTION
- Fix some DCM lints and replace stub openDevToolsPage with a generic no-op handler (#6338)
- Updating from 2.28.0-dev.1 to 2.28.0-dev.2 (#6348)
- Add back removed release notes image (#6343)
- Updating from 2.28.0-dev.2 to 2.28.0-dev.3 (#6350)
- Updating from 2.28.0-dev.3 to 2.28.0-dev.4 (#6351)
- Prepare for release 2.28.0
