### PR TITLE
Refresh available extensions when the main isolate changes.

### DIFF
--- a/packages/devtools_app/lib/src/extensions/extension_service.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service.dart
@@ -47,6 +47,16 @@ class ExtensionService extends DisposableController
       _maybeRefreshExtensions,
     );
 
+    // TODO(https://github.com/flutter/flutter/issues/134470): refresh on
+    // hot reload and hot restart events instead.
+    addAutoDisposeListener(
+        serviceConnection.serviceManager.isolateManager.mainIsolate, () async {
+      if (serviceConnection.serviceManager.isolateManager.mainIsolate.value !=
+          null) {
+        await _maybeRefreshExtensions();
+      }
+    });
+
     // TODO(kenz): we should also refresh the available extensions on some event
     // from the analysis server that is watching the
     // .dart_tool/package_config.json file for changes.


### PR DESCRIPTION
The main isolate is destroyed and recreated on hot restart. Until https://github.com/flutter/flutter/issues/134470 is resolved, we can use this as a signal that a hot restart has occurred. This makes sense to refresh here anyway since we detect available extensions based on the .package_config.json file for the main isolate's root lib.

Work towards https://github.com/flutter/devtools/issues/6272