### PR TITLE
Remove top buttons from VS Code sidebar

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -72,25 +72,6 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const SizedBox(height: defaultSpacing),
-          if (widget.api.capabilities.executeCommand)
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                ElevatedButton(
-                  onPressed: () => unawaited(
-                    widget.api.executeCommand('flutter.createProject'),
-                  ),
-                  child: const Text('New Flutter Project'),
-                ),
-                ElevatedButton(
-                  onPressed: () => unawaited(
-                    widget.api.executeCommand('flutter.doctor'),
-                  ),
-                  child: const Text('Run Flutter Doctor'),
-                ),
-              ],
-            ),
-          const SizedBox(height: defaultSpacing),
           StreamBuilder(
             stream: widget.api.debugSessionsChanged,
             builder: (context, snapshot) {

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -126,10 +126,6 @@ class MockDartToolingApi extends DartToolingApiImpl {
     final params = parameters.asMap;
     final command = params['command'];
     switch (command) {
-      case 'flutter.createProject':
-        return null;
-      case 'flutter.doctor':
-        return null;
       default:
         throw 'Unknown command $command';
     }


### PR DESCRIPTION
These buttons are now in the sidebars title bar in VS Code instead.

![image](https://github.com/flutter/devtools/assets/1078012/b6380eaa-fc3f-401c-abd2-6c9c95a304b2)
