### PR TITLE
Add Hot Reload + Hot Restart functionality to sidebar

### DIFF
--- a/packages/devtools_app/lib/src/service/service_registrations.dart
+++ b/packages/devtools_app/lib/src/service/service_registrations.dart
@@ -8,6 +8,7 @@ import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 
 import '../shared/analytics/constants.dart' as gac;
+import '../shared/constants.dart';
 
 class RegisteredServiceDescription extends RegisteredService {
   const RegisteredServiceDescription._({
@@ -29,10 +30,7 @@ class RegisteredServiceDescription extends RegisteredService {
 final hotReload = RegisteredServiceDescription._(
   service: extensions.hotReloadServiceName,
   title: 'Hot Reload',
-  icon: Icon(
-    Icons.electric_bolt_outlined,
-    size: actionsIconSize,
-  ),
+  icon: Icon(hotReloadIcon, size: actionsIconSize),
   gaScreenName: gac.devToolsMain,
   gaItem: gac.hotReload,
 );
@@ -43,10 +41,7 @@ final hotReload = RegisteredServiceDescription._(
 final hotRestart = RegisteredServiceDescription._(
   service: extensions.hotRestartServiceName,
   title: 'Hot Restart',
-  icon: Icon(
-    Icons.settings_backup_restore_outlined,
-    size: actionsIconSize,
-  ),
+  icon: Icon(hotRestartIcon, size: actionsIconSize),
   gaScreenName: gac.devToolsMain,
   gaItem: gac.hotRestart,
 );

--- a/packages/devtools_app/lib/src/shared/constants.dart
+++ b/packages/devtools_app/lib/src/shared/constants.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:logging/logging.dart';
 
 const verboseLoggingLevel = Level.FINEST;
@@ -12,3 +13,9 @@ const verboseLoggingLevel = Level.FINEST;
 /// MORE LOGS THEN THERE MAY BE PERFORMANCE IMPLICATIONS, AS A RESULT OF LOTS OF
 /// LOGS ALWAYS BEING PRINTED AND SAVED.
 const basicLoggingLevel = Level.INFO;
+
+/// The icon used for Hot Reload.
+const hotReloadIcon = Icons.electric_bolt_outlined;
+
+/// The icon used for Hot Restart.
+const hotRestartIcon = Icons.settings_backup_restore_outlined;

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -45,8 +45,8 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
     return sendRequest(
       VsCodeApi.jsonExecuteCommandMethod,
       {
-        VsCodeApi.jsonExecuteCommandCommandParameter: command,
-        VsCodeApi.jsonExecuteCommandArgumentsParameter: arguments,
+        VsCodeApi.jsonCommandParameter: command,
+        VsCodeApi.jsonArgumentsParameter: arguments,
       },
     );
   }
@@ -55,17 +55,17 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
   Future<bool> selectDevice(String id) {
     return sendRequest(
       VsCodeApi.jsonSelectDeviceMethod,
-      {VsCodeApi.jsonSelectDeviceIdParameter: id},
+      {VsCodeApi.jsonIdParameter: id},
     );
   }
 
   @override
   Future<void> openDevToolsPage(String debugSessionId, String page) {
     return sendRequest(
-      VsCodeApi.openDevToolsPageMethod,
+      VsCodeApi.jsonOpenDevToolsPageMethod,
       {
-        VsCodeApi.openDevToolsPageDebugSessionIdParameter: debugSessionId,
-        VsCodeApi.openDevToolsPagePageParameter: page,
+        VsCodeApi.jsonDebugSessionIdParameter: debugSessionId,
+        VsCodeApi.openPageParameter: page,
       },
     );
   }
@@ -73,9 +73,9 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
   @override
   Future<void> hotReload(String debugSessionId) {
     return sendRequest(
-      VsCodeApi.hotReloadMethod,
+      VsCodeApi.jsonHotReloadMethod,
       {
-        VsCodeApi.hotReloadDebugSessionIdParameter: debugSessionId,
+        VsCodeApi.jsonDebugSessionIdParameter: debugSessionId,
       },
     );
   }
@@ -83,9 +83,9 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
   @override
   Future<void> hotRestart(String debugSessionId) {
     return sendRequest(
-      VsCodeApi.hotRestartMethod,
+      VsCodeApi.jsonHotRestartMethod,
       {
-        VsCodeApi.hotRestartDebugSessionIdParameter: debugSessionId,
+        VsCodeApi.jsonDebugSessionIdParameter: debugSessionId,
       },
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -65,7 +65,7 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
       VsCodeApi.jsonOpenDevToolsPageMethod,
       {
         VsCodeApi.jsonDebugSessionIdParameter: debugSessionId,
-        VsCodeApi.openPageParameter: page,
+        VsCodeApi.jsonOpenPageParameter: page,
       },
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -69,6 +69,26 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
       },
     );
   }
+
+  @override
+  Future<void> hotReload(String debugSessionId) {
+    return sendRequest(
+      VsCodeApi.hotReloadMethod,
+      {
+        VsCodeApi.hotReloadDebugSessionIdParameter: debugSessionId,
+      },
+    );
+  }
+
+  @override
+  Future<void> hotRestart(String debugSessionId) {
+    return sendRequest(
+      VsCodeApi.hotRestartMethod,
+      {
+        VsCodeApi.hotRestartDebugSessionIdParameter: debugSessionId,
+      },
+    );
+  }
 }
 
 class VsCodeDeviceImpl implements VsCodeDevice {
@@ -247,4 +267,10 @@ class VsCodeCapabilitiesImpl implements VsCodeCapabilities {
   @override
   bool get openDevToolsPage =>
       _raw?[VsCodeCapabilities.openDevToolsPageField] == true;
+
+  @override
+  bool get hotReload => _raw?[VsCodeCapabilities.hotReloadField] == true;
+
+  @override
+  bool get hotRestart => _raw?[VsCodeCapabilities.hotRestartField] == true;
 }

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -76,7 +76,7 @@ abstract interface class VsCodeApi {
   static const jsonCommandParameter = 'command';
   static const jsonArgumentsParameter = 'arguments';
   static const jsonIdParameter = 'id';
-  static const openPageParameter = 'page';
+  static const jsonOpenPageParameter = 'page';
   static const jsonDebugSessionIdParameter = 'debugSessionId';
 }
 

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -63,27 +63,21 @@ abstract interface class VsCodeApi {
   static const jsonApiName = 'vsCode';
 
   static const jsonInitializeMethod = 'initialize';
-
   static const jsonExecuteCommandMethod = 'executeCommand';
-  static const jsonExecuteCommandCommandParameter = 'command';
-  static const jsonExecuteCommandArgumentsParameter = 'arguments';
-
-  static const jsonDevicesChangedEvent = 'devicesChanged';
 
   static const jsonSelectDeviceMethod = 'selectDevice';
-  static const jsonSelectDeviceIdParameter = 'id';
+  static const jsonOpenDevToolsPageMethod = 'openDevToolsPage';
+  static const jsonHotReloadMethod = 'hotReload';
+  static const jsonHotRestartMethod = 'hotRestart';
 
-  static const openDevToolsPageMethod = 'openDevToolsPage';
-  static const openDevToolsPageDebugSessionIdParameter = 'debugSessionId';
-  static const openDevToolsPagePageParameter = 'page';
-
-  static const hotReloadMethod = 'hotReload';
-  static const hotReloadDebugSessionIdParameter = 'debugSessionId';
-
-  static const hotRestartMethod = 'hotRestart';
-  static const hotRestartDebugSessionIdParameter = 'debugSessionId';
-
+  static const jsonDevicesChangedEvent = 'devicesChanged';
   static const jsonDebugSessionsChangedEvent = 'debugSessionsChanged';
+
+  static const jsonCommandParameter = 'command';
+  static const jsonArgumentsParameter = 'arguments';
+  static const jsonIdParameter = 'id';
+  static const openPageParameter = 'page';
+  static const jsonDebugSessionIdParameter = 'debugSessionId';
 }
 
 /// This class defines a device exposed by the Dart/Flutter extensions in VS

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -54,6 +54,12 @@ abstract interface class VsCodeApi {
   /// external browser window.
   Future<void> openDevToolsPage(String debugSessionId, String page);
 
+  /// Sends a Hot Reload request to the debug session with ID [debugSessionId].
+  Future<void> hotReload(String debugSessionId);
+
+  /// Sends a Hot Restart request to the debug session with ID [debugSessionId].
+  Future<void> hotRestart(String debugSessionId);
+
   static const jsonApiName = 'vsCode';
 
   static const jsonInitializeMethod = 'initialize';
@@ -70,6 +76,12 @@ abstract interface class VsCodeApi {
   static const openDevToolsPageMethod = 'openDevToolsPage';
   static const openDevToolsPageDebugSessionIdParameter = 'debugSessionId';
   static const openDevToolsPagePageParameter = 'page';
+
+  static const hotReloadMethod = 'hotReload';
+  static const hotReloadDebugSessionIdParameter = 'debugSessionId';
+
+  static const hotRestartMethod = 'hotRestart';
+  static const hotRestartDebugSessionIdParameter = 'debugSessionId';
 
   static const jsonDebugSessionsChangedEvent = 'debugSessionsChanged';
 }
@@ -193,7 +205,17 @@ abstract interface class VsCodeCapabilities {
   /// DevTools page.
   bool get openDevToolsPage;
 
+  /// Whether the `hotReload` method is available call to hot reload a specific
+  /// debug session.
+  bool get hotReload;
+
+  /// Whether the `hotRestart` method is available call to restart a specific
+  /// debug session.
+  bool get hotRestart;
+
   static const jsonExecuteCommandField = 'executeCommand';
   static const jsonSelectDeviceField = 'selectDevice';
   static const openDevToolsPageField = 'openDevToolsPage';
+  static const hotReloadField = 'hotReload';
+  static const hotRestartField = 'hotRestart';
 }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
+import '../../shared/constants.dart';
 import '../../shared/screen.dart';
 import '../api/vs_code_api.dart';
 
@@ -29,88 +30,109 @@ class DebugSessions extends StatelessWidget {
           const Text('Begin a debug session to use DevTools.')
         else
           Table(
-            columnWidths: const {0: FlexColumnWidth()},
-            defaultColumnWidth:
-                FixedColumnWidth(defaultIconSize + defaultSpacing),
+            columnWidths: const {
+              0: FlexColumnWidth(2),
+              // TODO(dantup): Fixed width icons+menu?
+              1: FlexColumnWidth(),
+            },
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
             children: [
               for (final session in sessions)
-                _createSessionRow(context, session),
+                TableRow(
+                  children: [
+                    Text(
+                      '${session.name} (${session.flutterMode})',
+                      style: Theme.of(context).textTheme.titleSmall,
+                    ),
+                    if (api.capabilities.openDevToolsPage)
+                      _DevToolsMenu(api: api, session: session),
+                  ],
+                ),
             ],
           ),
       ],
     );
   }
+}
 
-  TableRow _createSessionRow(BuildContext context, VsCodeDebugSession session) {
+class _DevToolsMenu extends StatelessWidget {
+  const _DevToolsMenu({required this.api, required this.session});
+
+  final VsCodeApi api;
+  final VsCodeDebugSession session;
+
+  @override
+  Widget build(BuildContext context) {
     // TODO(dantup): What to show if mode is unknown (null)?
-    final name = session.name;
     final mode = session.flutterMode;
     final isDebug = mode == 'debug';
     final isProfile = mode == 'profile';
     // final isRelease = mode == 'release' || mode == 'jit_release';
     final isFlutter = session.debuggerType?.contains('Flutter') ?? false;
 
-    return TableRow(
+    return MenuBar(
       children: [
-        Text(
-          '$name ($mode)',
-          style: Theme.of(context).textTheme.titleSmall,
+        IconButton(
+          onPressed: api.capabilities.hotReload && (isDebug || !isFlutter)
+              ? () => unawaited(api.hotReload(session.id))
+              : null,
+          tooltip: 'Hot Reload',
+          icon: Icon(hotReloadIcon, size: actionsIconSize),
         ),
-        // TODO(dantup): Ensure the order matches the DevTools tab bar (if
-        //  possible, share this order).
-        if (api.capabilities.openDevToolsPage) ...[
-          // TODO(dantup): Make these conditions use the real screen
-          //  conditions and/or verify if these conditions are correct.
-          _devToolsButton(
-            session,
-            ScreenMetaData.inspector,
-            enabled: isFlutter && isDebug,
-          ),
-          _devToolsButton(
-            session,
-            ScreenMetaData.cpuProfiler,
-            enabled: isDebug || isProfile,
-          ),
-          _devToolsButton(
-            session,
-            ScreenMetaData.memory,
-            enabled: isDebug || isProfile,
-          ),
-          _devToolsButton(
-            session,
-            ScreenMetaData.performance,
-          ),
-          _devToolsButton(
-            session,
-            ScreenMetaData.network,
-            enabled: isDebug,
-          ),
-          _devToolsButton(
-            session,
-            ScreenMetaData.logging,
-          ),
-          // TODO(dantup): Check other screens (like appSize) work embedded and
-          //  add here.
-        ],
+        IconButton(
+          onPressed: api.capabilities.hotRestart && (isDebug || !isFlutter)
+              ? () => unawaited(api.hotRestart(session.id))
+              : null,
+          tooltip: 'Hot Restart',
+          icon: Icon(hotRestartIcon, size: actionsIconSize),
+        ),
+        SubmenuButton(
+          menuChildren: [
+            // TODO(dantup): Ensure the order matches the DevTools tab bar (if
+            //  possible, share this order).
+            // TODO(dantup): Make these conditions use the real screen
+            //  conditions and/or verify if these conditions are correct.
+            _devToolsButton(
+              ScreenMetaData.inspector,
+              enabled: isFlutter && isDebug,
+            ),
+            _devToolsButton(
+              ScreenMetaData.cpuProfiler,
+              enabled: isDebug || isProfile,
+            ),
+            _devToolsButton(
+              ScreenMetaData.memory,
+              enabled: isDebug || isProfile,
+            ),
+            _devToolsButton(
+              ScreenMetaData.performance,
+            ),
+            _devToolsButton(
+              ScreenMetaData.network,
+              enabled: isDebug,
+            ),
+            _devToolsButton(
+              ScreenMetaData.logging,
+            ),
+            // TODO(dantup): Check other screens (like appSize) work embedded and
+            //  add here.
+          ],
+          child: const Text('DevTools'),
+        ),
       ],
     );
   }
 
   Widget _devToolsButton(
-    VsCodeDebugSession session,
     ScreenMetaData screen, {
     bool enabled = true,
   }) {
-    return DevToolsTooltip(
-      message: screen.title ?? screen.id,
-      padding: const EdgeInsets.all(denseSpacing),
-      child: TextButton(
-        onPressed: enabled
-            ? () => unawaited(api.openDevToolsPage(session.id, screen.id))
-            : null,
-        child: Icon(screen.icon, size: actionsIconSize),
-      ),
+    return IconButton(
+      onPressed: enabled
+          ? () => unawaited(api.openDevToolsPage(session.id, screen.id))
+          : null,
+      tooltip: screen.title ?? screen.id,
+      icon: Icon(screen.icon, size: actionsIconSize),
     );
   }
 }

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -66,6 +66,8 @@ class MockDartToolingApi extends DartToolingApiImpl {
         'executeCommand': true,
         'selectDevice': true,
         'openDevToolsPage': true,
+        'hotReload': true,
+        'hotRestart': true,
       };
     });
     server.registerMethod('vsCode.initialize', initialize);


### PR DESCRIPTION
This adds capabilities and buttons for hot reload/hot restart, and moves the DevTools buttons into a menu.

The sidebar overall still requires work (both visual - this is just default menu styling - and for the set of DevTools pages + enable conditions), this is just trying to get the functionality done since the visuals don't require coordination with Dart-Code.


https://github.com/flutter/devtools/assets/1078012/af33a25b-74a2-4d7c-86b3-ce165f03c59f


