### PR TITLE
Add an action to force a reload of a DevTools extension

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -98,8 +98,7 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   @override
   void forceReload() {
     if (_extensionIFrame.contentWindow != null) {
-      // ignore: unsafe_html, forcing reload by resetting the pre-existing
-      // IFrame src.
+      // ignore: unsafe_html, forcing reload by resetting the pre-existing IFrame src.
       _extensionIFrame.src = _extensionIFrame.src;
     }
   }

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -98,7 +98,8 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   @override
   void forceReload() {
     if (_extensionIFrame.contentWindow != null) {
-      // ignore: unsafe_html, forcing reload.
+      // ignore: unsafe_html, forcing reload by resetting the pre-existing
+      // IFrame src.
       _extensionIFrame.src = _extensionIFrame.src;
     }
   }

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -96,6 +96,14 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   }
 
   @override
+  void forceReload() {
+    if (_extensionIFrame.contentWindow != null) {
+      // ignore: unsafe_html, forcing reload.
+      _extensionIFrame.src = _extensionIFrame.src;
+    }
+  }
+
+  @override
   void dispose() async {
     await extensionPostEventStream.close();
     super.dispose();

--- a/packages/devtools_app/lib/src/extensions/embedded/controller.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/controller.dart
@@ -25,4 +25,6 @@ abstract class EmbeddedExtensionController extends DisposableController {
     DevToolsExtensionEventType type, {
     Map<String, String> data = const <String, String>{},
   }) {}
+
+  void forceReload() {}
 }

--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -97,7 +97,10 @@ class ExtensionView extends StatelessWidget {
   Widget build(BuildContext context) {
     return Column(
       children: [
-        EmbeddedExtensionHeader(extension: extension),
+        EmbeddedExtensionHeader(
+          extension: extension,
+          onForceReload: controller.forceReload,
+        ),
         const SizedBox(height: intermediateSpacing),
         Expanded(
           child: ValueListenableBuilder<ExtensionEnabledState>(

--- a/packages/devtools_app/lib/src/extensions/extension_screen_controls.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen_controls.dart
@@ -61,11 +61,11 @@ class EmbeddedExtensionHeader extends StatelessWidget {
           valueListenable:
               extensionService.enabledStateListenable(extension.displayName),
           builder: (context, activationState, _) {
-            return ContextMenuButton(
-              iconSize: defaultIconSize,
-              buttonWidth: buttonMinWidth,
-              menuChildren: <Widget>[
-                if (activationState == ExtensionEnabledState.enabled)
+            if (activationState == ExtensionEnabledState.enabled) {
+              return ContextMenuButton(
+                iconSize: defaultIconSize,
+                buttonWidth: buttonMinWidth,
+                menuChildren: <Widget>[
                   PointerInterceptor(
                     child: MenuItemButton(
                       onPressed: () {
@@ -87,23 +87,25 @@ class EmbeddedExtensionHeader extends StatelessWidget {
                       ),
                     ),
                   ),
-                PointerInterceptor(
-                  child: MenuItemButton(
-                    onPressed: () {
-                      ga.select(
-                        gac.extensionScreenId,
-                        gac.extensionForceReload(extension.displayName),
-                      );
-                      onForceReload();
-                    },
-                    child: const MaterialIconLabel(
-                      label: 'Force reload extension',
-                      iconData: Icons.refresh,
+                  PointerInterceptor(
+                    child: MenuItemButton(
+                      onPressed: () {
+                        ga.select(
+                          gac.extensionScreenId,
+                          gac.extensionForceReload(extension.displayName),
+                        );
+                        onForceReload();
+                      },
+                      child: const MaterialIconLabel(
+                        label: 'Force reload extension',
+                        iconData: Icons.refresh,
+                      ),
                     ),
                   ),
-                ),
-              ],
-            );
+                ],
+              );
+            }
+            return const SizedBox.shrink();
           },
         ),
       ],

--- a/packages/devtools_app/lib/src/extensions/extension_screen_controls.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen_controls.dart
@@ -7,16 +7,24 @@ import 'dart:async';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
 import 'package:flutter/material.dart';
+import 'package:pointer_interceptor/pointer_interceptor.dart';
 
+import '../shared/analytics/analytics.dart' as ga;
 import '../shared/analytics/constants.dart' as gac;
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
 import '../shared/routing.dart';
 
 class EmbeddedExtensionHeader extends StatelessWidget {
-  const EmbeddedExtensionHeader({super.key, required this.extension});
+  const EmbeddedExtensionHeader({
+    super.key,
+    required this.extension,
+    required this.onForceReload,
+  });
 
   final DevToolsExtensionConfig extension;
+
+  final VoidCallback onForceReload;
 
   @override
   Widget build(BuildContext context) {
@@ -48,44 +56,57 @@ class EmbeddedExtensionHeader extends StatelessWidget {
             context: context,
           ),
         ),
+        const SizedBox(width: denseSpacing),
         ValueListenableBuilder<ExtensionEnabledState>(
           valueListenable:
               extensionService.enabledStateListenable(extension.displayName),
           builder: (context, activationState, _) {
-            if (activationState == ExtensionEnabledState.enabled) {
-              return Padding(
-                padding: const EdgeInsets.only(left: denseSpacing),
-                child: DisableExtensionButton(extension: extension),
-              );
-            }
-            return const SizedBox.shrink();
+            return ContextMenuButton(
+              iconSize: defaultIconSize,
+              buttonWidth: buttonMinWidth,
+              menuChildren: <Widget>[
+                if (activationState == ExtensionEnabledState.enabled)
+                  PointerInterceptor(
+                    child: MenuItemButton(
+                      onPressed: () {
+                        ga.select(
+                          gac.extensionScreenId,
+                          gac.extensionDisable(extension.displayName),
+                        );
+                        unawaited(
+                          showDialog(
+                            context: context,
+                            builder: (_) =>
+                                DisableExtensionDialog(extension: extension),
+                          ),
+                        );
+                      },
+                      child: const MaterialIconLabel(
+                        label: 'Disable extension',
+                        iconData: Icons.extension_off_outlined,
+                      ),
+                    ),
+                  ),
+                PointerInterceptor(
+                  child: MenuItemButton(
+                    onPressed: () {
+                      ga.select(
+                        gac.extensionScreenId,
+                        gac.extensionForceReload(extension.displayName),
+                      );
+                      onForceReload();
+                    },
+                    child: const MaterialIconLabel(
+                      label: 'Force reload extension',
+                      iconData: Icons.refresh,
+                    ),
+                  ),
+                ),
+              ],
+            );
           },
         ),
-        const SizedBox(width: defaultSpacing),
       ],
-    );
-  }
-}
-
-@visibleForTesting
-class DisableExtensionButton extends StatelessWidget {
-  const DisableExtensionButton({super.key, required this.extension});
-
-  final DevToolsExtensionConfig extension;
-
-  @override
-  Widget build(BuildContext context) {
-    return GaDevToolsButton.iconOnly(
-      icon: Icons.extension_off_outlined,
-      tooltip: 'Disable extension',
-      gaScreen: gac.extensionScreenId,
-      gaSelection: gac.extensionDisable(extension.displayName),
-      onPressed: () => unawaited(
-        showDialog(
-          context: context,
-          builder: (_) => DisableExtensionDialog(extension: extension),
-        ),
-      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -206,8 +206,10 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
         serviceConnection.errorBadgeManager.clearErrors(screen.screenId);
 
         // Update routing with the change.
-        final routerDelegate = DevToolsRouterDelegate.of(context);
-        routerDelegate.navigateIfNotCurrent(screen.screenId);
+        WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+          final routerDelegate = DevToolsRouterDelegate.of(context);
+          routerDelegate.navigateIfNotCurrent(screen.screenId);
+        });
       }
     });
 

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -47,6 +47,7 @@ const extensionSettingsId = 'devtoolsExtensionSettings';
 String extensionFeedback(String name) => 'extensionFeedback-$name';
 String extensionEnable(String name) => 'extensionEnable-$name';
 String extensionDisable(String name) => 'extensionDisable-$name';
+String extensionForceReload(String name) => 'extensionForceReload-$name';
 
 // Inspector UX actions:
 const refresh = 'refresh';

--- a/packages/devtools_app/test/extensions/extension_screen_test.dart
+++ b/packages/devtools_app/test/extensions/extension_screen_test.dart
@@ -63,10 +63,7 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
 
@@ -79,10 +76,7 @@ void main() {
         );
         expect(find.richTextContaining('(v2.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
 
@@ -95,10 +89,7 @@ void main() {
         );
         expect(find.richTextContaining('(v3.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
       },
@@ -122,10 +113,7 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: true,
-        );
+        await verifyContextMenuContents(tester);
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
       },
@@ -149,10 +137,7 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
       },
@@ -170,10 +155,7 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
 
         await tester.tap(
           find.descendant(
@@ -191,7 +173,6 @@ void main() {
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
         await verifyContextMenuContents(
           tester,
-          disableActionVisible: true,
           autoDismiss: false,
         );
 
@@ -209,10 +190,7 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
-        await verifyContextMenuContents(
-          tester,
-          disableActionVisible: false,
-        );
+        expect(_extensionContextMenuFinder, findsNothing);
       },
     );
   });
@@ -220,24 +198,21 @@ void main() {
 
 Future<void> verifyContextMenuContents(
   WidgetTester tester, {
-  required bool disableActionVisible,
   bool autoDismiss = true,
 }) async {
-  final contextMenuFinder = find.descendant(
-    of: find.byType(EmbeddedExtensionHeader),
-    matching: find.byType(ContextMenuButton),
-  );
-  expect(contextMenuFinder, findsOneWidget);
-  await tester.tap(contextMenuFinder);
+  expect(_extensionContextMenuFinder, findsOneWidget);
+  await tester.tap(_extensionContextMenuFinder);
   await tester.pumpAndSettle();
-  expect(
-    find.text('Disable extension'),
-    disableActionVisible ? findsOneWidget : findsNothing,
-  );
+  expect(find.text('Disable extension'), findsOneWidget);
   expect(find.text('Force reload extension'), findsOneWidget);
   if (autoDismiss) {
     // Tap the context menu again to dismiss it.
-    await tester.tap(contextMenuFinder);
+    await tester.tap(_extensionContextMenuFinder);
     await tester.pumpAndSettle();
   }
 }
+
+Finder get _extensionContextMenuFinder => find.descendant(
+      of: find.byType(EmbeddedExtensionHeader),
+      matching: find.byType(ContextMenuButton),
+    );

--- a/packages/devtools_app/test/extensions/extension_screen_test.dart
+++ b/packages/devtools_app/test/extensions/extension_screen_test.dart
@@ -113,7 +113,7 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        await verifyContextMenuContents(tester);
+        await _verifyContextMenuContents(tester);
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
       },
@@ -171,7 +171,7 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
-        await verifyContextMenuContents(
+        await _verifyContextMenuContents(
           tester,
           autoDismiss: false,
         );
@@ -196,7 +196,7 @@ void main() {
   });
 }
 
-Future<void> verifyContextMenuContents(
+Future<void> _verifyContextMenuContents(
   WidgetTester tester, {
   bool autoDismiss = true,
 }) async {

--- a/packages/devtools_app/test/extensions/extension_screen_test.dart
+++ b/packages/devtools_app/test/extensions/extension_screen_test.dart
@@ -63,7 +63,10 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
 
@@ -76,7 +79,10 @@ void main() {
         );
         expect(find.richTextContaining('(v2.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
 
@@ -89,7 +95,10 @@ void main() {
         );
         expect(find.richTextContaining('(v3.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
       },
@@ -113,7 +122,10 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsOneWidget);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: true,
+        );
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
       },
@@ -137,7 +149,10 @@ void main() {
         );
         expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
         expect(find.richTextContaining('Report an issue'), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
       },
@@ -155,7 +170,10 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
 
         await tester.tap(
           find.descendant(
@@ -171,9 +189,13 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
-        expect(find.byType(DisableExtensionButton), findsOneWidget);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: true,
+          autoDismiss: false,
+        );
 
-        await tester.tap(find.byType(DisableExtensionButton));
+        await tester.tap(find.text('Disable extension'));
         await tester.pumpAndSettle();
 
         expect(find.byType(DisableExtensionDialog), findsOneWidget);
@@ -187,8 +209,35 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
-        expect(find.byType(DisableExtensionButton), findsNothing);
+        await verifyContextMenuContents(
+          tester,
+          disableActionVisible: false,
+        );
       },
     );
   });
+}
+
+Future<void> verifyContextMenuContents(
+  WidgetTester tester, {
+  required bool disableActionVisible,
+  bool autoDismiss = true,
+}) async {
+  final contextMenuFinder = find.descendant(
+    of: find.byType(EmbeddedExtensionHeader),
+    matching: find.byType(ContextMenuButton),
+  );
+  expect(contextMenuFinder, findsOneWidget);
+  await tester.tap(contextMenuFinder);
+  await tester.pumpAndSettle();
+  expect(
+    find.text('Disable extension'),
+    disableActionVisible ? findsOneWidget : findsNothing,
+  );
+  expect(find.text('Force reload extension'), findsOneWidget);
+  if (autoDismiss) {
+    // Tap the context menu again to dismiss it.
+    await tester.tap(contextMenuFinder);
+    await tester.pumpAndSettle();
+  }
 }


### PR DESCRIPTION
This PR adds the "Force reload extension" action and moves the existing "Disable extension" action into the shared context menu.

![Screenshot 2023-09-12 at 1 02 00 PM](https://github.com/flutter/devtools/assets/43759233/5deb98f5-5322-4482-bf92-474a64903593)

![force-reload](https://github.com/flutter/devtools/assets/43759233/a65d735c-943b-47d3-8ca8-2ffe8b45f8f1)

This forces a reload of the iFrame, which is a safety feature to protect against edge cases and the user getting into a bad state with an Extension iFrame. We will monitor usage of this action as we roll DevTools extensions out to users to see how often users are having to use this escape hatch.

Work towards https://github.com/flutter/devtools/issues/6272