### PR TITLE
Improve the VS Code sidebar UI

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -53,11 +53,15 @@ class DebugSessions extends StatelessWidget {
     // final isRelease = mode == 'release' || mode == 'jit_release';
     final isFlutter = session.debuggerType?.contains('Flutter') ?? false;
 
+    final label = session.flutterMode != null
+        ? '${session.name} (${session.flutterMode})'
+        : session.name;
+
     return TableRow(
       children: [
         Text(
-          '${session.name} (${session.flutterMode})',
-          style: Theme.of(context).textTheme.titleSmall,
+          label,
+          style: Theme.of(context).regularTextStyle,
         ),
         IconButton(
           onPressed: api.capabilities.hotReload && (isDebug || !isFlutter)
@@ -132,14 +136,13 @@ class _DevToolsMenu extends StatelessWidget {
     }
 
     return Directionality(
-      textDirection: reversedDirection,
+      // Reverse the direction so the menu is anchored on the far side and
+      // expands in the opposite direction with the icons on the right.
+      textDirection: normalDirection,
       child: MenuAnchor(
-        // TODO(dantup): How to flip the menu to be anchored from the right
-        //  and expand to the left?
         style: const MenuStyle(
           alignment: AlignmentDirectional.bottomStart,
         ),
-        alignmentOffset: const Offset(2, 0),
         menuChildren: [
           // TODO(dantup): Ensure the order matches the DevTools tab bar (if
           //  possible, share this order).

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -138,7 +138,7 @@ class _DevToolsMenu extends StatelessWidget {
     return Directionality(
       // Reverse the direction so the menu is anchored on the far side and
       // expands in the opposite direction with the icons on the right.
-      textDirection: normalDirection,
+      textDirection: reversedDirection,
       child: MenuAnchor(
         style: const MenuStyle(
           alignment: AlignmentDirectional.bottomStart,

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -184,7 +184,7 @@ class _DevToolsMenu extends StatelessWidget {
           tooltip: 'DevTools',
           // TODO(dantup): Icon for DevTools menu?
           icon: Icon(
-            Icons.developer_mode,
+            Icons.construction,
             size: actionsIconSize,
           ),
         ),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -24,45 +24,28 @@ class DebugSessions extends StatelessWidget {
       children: [
         Text(
           'Debug Sessions',
-          style: Theme.of(context).textTheme.titleSmall,
+          style: Theme.of(context).textTheme.titleMedium,
         ),
         if (sessions.isEmpty)
           const Text('Begin a debug session to use DevTools.')
         else
           Table(
             columnWidths: const {
-              0: FlexColumnWidth(2),
-              // TODO(dantup): Fixed width icons+menu?
-              1: FlexColumnWidth(),
+              0: FlexColumnWidth(),
             },
+            defaultColumnWidth:
+                FixedColumnWidth(actionsIconSize + denseSpacing),
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
             children: [
               for (final session in sessions)
-                TableRow(
-                  children: [
-                    Text(
-                      '${session.name} (${session.flutterMode})',
-                      style: Theme.of(context).textTheme.titleSmall,
-                    ),
-                    if (api.capabilities.openDevToolsPage)
-                      _DevToolsMenu(api: api, session: session),
-                  ],
-                ),
+                _debugSessionRow(session, context),
             ],
           ),
       ],
     );
   }
-}
 
-class _DevToolsMenu extends StatelessWidget {
-  const _DevToolsMenu({required this.api, required this.session});
-
-  final VsCodeApi api;
-  final VsCodeDebugSession session;
-
-  @override
-  Widget build(BuildContext context) {
+  TableRow _debugSessionRow(VsCodeDebugSession session, BuildContext context) {
     // TODO(dantup): What to show if mode is unknown (null)?
     final mode = session.flutterMode;
     final isDebug = mode == 'debug';
@@ -70,8 +53,12 @@ class _DevToolsMenu extends StatelessWidget {
     // final isRelease = mode == 'release' || mode == 'jit_release';
     final isFlutter = session.debuggerType?.contains('Flutter') ?? false;
 
-    return MenuBar(
+    return TableRow(
       children: [
+        Text(
+          '${session.name} (${session.flutterMode})',
+          style: Theme.of(context).textTheme.titleSmall,
+        ),
         IconButton(
           onPressed: api.capabilities.hotReload && (isDebug || !isFlutter)
               ? () => unawaited(api.hotReload(session.id))
@@ -86,53 +73,119 @@ class _DevToolsMenu extends StatelessWidget {
           tooltip: 'Hot Restart',
           icon: Icon(hotRestartIcon, size: actionsIconSize),
         ),
-        SubmenuButton(
-          menuChildren: [
-            // TODO(dantup): Ensure the order matches the DevTools tab bar (if
-            //  possible, share this order).
-            // TODO(dantup): Make these conditions use the real screen
-            //  conditions and/or verify if these conditions are correct.
-            _devToolsButton(
-              ScreenMetaData.inspector,
-              enabled: isFlutter && isDebug,
-            ),
-            _devToolsButton(
-              ScreenMetaData.cpuProfiler,
-              enabled: isDebug || isProfile,
-            ),
-            _devToolsButton(
-              ScreenMetaData.memory,
-              enabled: isDebug || isProfile,
-            ),
-            _devToolsButton(
-              ScreenMetaData.performance,
-            ),
-            _devToolsButton(
-              ScreenMetaData.network,
-              enabled: isDebug,
-            ),
-            _devToolsButton(
-              ScreenMetaData.logging,
-            ),
-            // TODO(dantup): Check other screens (like appSize) work embedded and
-            //  add here.
-          ],
-          child: const Text('DevTools'),
-        ),
+        if (api.capabilities.openDevToolsPage)
+          _DevToolsMenu(
+            api: api,
+            session: session,
+            isFlutter: isFlutter,
+            isDebug: isDebug,
+            isProfile: isProfile,
+          ),
       ],
     );
   }
+}
 
-  Widget _devToolsButton(
-    ScreenMetaData screen, {
-    bool enabled = true,
-  }) {
-    return IconButton(
-      onPressed: enabled
-          ? () => unawaited(api.openDevToolsPage(session.id, screen.id))
-          : null,
-      tooltip: screen.title ?? screen.id,
-      icon: Icon(screen.icon, size: actionsIconSize),
+class _DevToolsMenu extends StatelessWidget {
+  const _DevToolsMenu({
+    required this.api,
+    required this.session,
+    required this.isFlutter,
+    required this.isDebug,
+    required this.isProfile,
+  });
+
+  final VsCodeApi api;
+  final VsCodeDebugSession session;
+  final bool isFlutter;
+  final bool isDebug;
+  final bool isProfile;
+
+  @override
+  Widget build(BuildContext context) {
+    final normalDirection = Directionality.of(context);
+    final reversedDirection = normalDirection == TextDirection.ltr
+        ? TextDirection.rtl
+        : TextDirection.ltr;
+
+    Widget devToolsButton(
+      ScreenMetaData screen, {
+      bool enabled = true,
+    }) {
+      return SizedBox(
+        width: double.infinity,
+        child: TextButton.icon(
+          style: TextButton.styleFrom(
+            alignment: Alignment.centerRight,
+            shape: const ContinuousRectangleBorder(),
+          ),
+          onPressed: enabled
+              ? () => unawaited(api.openDevToolsPage(session.id, screen.id))
+              : null,
+          label: Directionality(
+            textDirection: normalDirection,
+            child: Text(screen.title ?? screen.id),
+          ),
+          icon: Icon(screen.icon, size: actionsIconSize),
+        ),
+      );
+    }
+
+    return Directionality(
+      textDirection: reversedDirection,
+      child: MenuAnchor(
+        // TODO(dantup): How to flip the menu to be anchored from the right
+        //  and expand to the left?
+        style: const MenuStyle(
+          alignment: AlignmentDirectional.bottomStart,
+        ),
+        alignmentOffset: const Offset(2, 0),
+        menuChildren: [
+          // TODO(dantup): Ensure the order matches the DevTools tab bar (if
+          //  possible, share this order).
+          // TODO(dantup): Make these conditions use the real screen
+          //  conditions and/or verify if these conditions are correct.
+          devToolsButton(
+            ScreenMetaData.inspector,
+            enabled: isFlutter && isDebug,
+          ),
+          devToolsButton(
+            ScreenMetaData.cpuProfiler,
+            enabled: isDebug || isProfile,
+          ),
+          devToolsButton(
+            ScreenMetaData.memory,
+            enabled: isDebug || isProfile,
+          ),
+          devToolsButton(
+            ScreenMetaData.performance,
+          ),
+          devToolsButton(
+            ScreenMetaData.network,
+            enabled: isDebug,
+          ),
+          devToolsButton(
+            ScreenMetaData.logging,
+          ),
+          // TODO(dantup): Check other screens (like appSize) work embedded and
+          //  add here.
+        ],
+        builder: (context, controller, child) => IconButton(
+          onPressed: () {
+            if (controller.isOpen) {
+              controller.close();
+            } else {
+              controller.open();
+            }
+          },
+          tooltip: 'DevTools',
+          // TODO(dantup): Icon for DevTools menu?
+          icon: Icon(
+            Icons.developer_mode,
+            size: actionsIconSize,
+          ),
+        ),
+      ),
     );
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -4,6 +4,7 @@
 
 import 'dart:async';
 
+import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import '../api/vs_code_api.dart';
@@ -22,7 +23,6 @@ class Devices extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -38,7 +38,7 @@ class Devices extends StatelessWidget {
             children: [
               for (final device in devices)
                 _createDeviceRow(
-                  colorScheme,
+                  Theme.of(context),
                   device,
                   isSelected: device.id == selectedDeviceId,
                 ),
@@ -49,12 +49,15 @@ class Devices extends StatelessWidget {
   }
 
   TableRow _createDeviceRow(
-    ColorScheme colorScheme,
+    ThemeData theme,
     VsCodeDevice device, {
     required bool isSelected,
   }) {
+    final backgroundColor = isSelected ? theme.colorScheme.primary : null;
+    final foregroundColor = isSelected ? theme.colorScheme.onPrimary : null;
+
     return TableRow(
-      decoration: BoxDecoration(color: isSelected ? colorScheme.primary : null),
+      decoration: BoxDecoration(color: backgroundColor),
       children: [
         SizedBox(
           width: double.infinity,
@@ -62,11 +65,11 @@ class Devices extends StatelessWidget {
             style: TextButton.styleFrom(
               alignment: Alignment.centerLeft,
               shape: const ContinuousRectangleBorder(),
+              textStyle: theme.regularTextStyle,
             ),
             child: Text(
               device.name,
-              style:
-                  TextStyle(color: isSelected ? colorScheme.onPrimary : null),
+              style: theme.regularTextStyle.copyWith(color: foregroundColor),
             ),
             onPressed: () => unawaited(api.selectDevice(device.id)),
           ),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -22,25 +22,23 @@ class Devices extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           'Devices',
-          style: Theme.of(context).textTheme.titleSmall,
+          style: Theme.of(context).textTheme.titleMedium,
         ),
         if (devices.isEmpty)
           const Text('Connect a device or enable web/desktop platforms.')
         else
           Table(
-            columnWidths: const {
-              0: FlexColumnWidth(3),
-              1: FlexColumnWidth(),
-            },
             defaultVerticalAlignment: TableCellVerticalAlignment.middle,
             children: [
               for (final device in devices)
                 _createDeviceRow(
+                  colorScheme,
                   device,
                   isSelected: device.id == selectedDeviceId,
                 ),
@@ -50,18 +48,29 @@ class Devices extends StatelessWidget {
     );
   }
 
-  TableRow _createDeviceRow(VsCodeDevice device, {required bool isSelected}) {
+  TableRow _createDeviceRow(
+    ColorScheme colorScheme,
+    VsCodeDevice device, {
+    required bool isSelected,
+  }) {
     return TableRow(
+      decoration: BoxDecoration(color: isSelected ? colorScheme.primary : null),
       children: [
-        Align(
-          alignment: Alignment.centerLeft,
+        SizedBox(
+          width: double.infinity,
           child: TextButton(
-            child: Text(device.name),
+            style: TextButton.styleFrom(
+              alignment: Alignment.centerLeft,
+              shape: const ContinuousRectangleBorder(),
+            ),
+            child: Text(
+              device.name,
+              style:
+                  TextStyle(color: isSelected ? colorScheme.onPrimary : null),
+            ),
             onPressed: () => unawaited(api.selectDevice(device.id)),
           ),
         ),
-        // TODO(dantup): Use a highlighted/select row for this instead of text.
-        Text(isSelected ? 'current device' : ''),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -23,12 +23,13 @@ class Devices extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           'Devices',
-          style: Theme.of(context).textTheme.titleMedium,
+          style: theme.textTheme.titleMedium,
         ),
         if (devices.isEmpty)
           const Text('Connect a device or enable web/desktop platforms.')
@@ -38,7 +39,7 @@ class Devices extends StatelessWidget {
             children: [
               for (final device in devices)
                 _createDeviceRow(
-                  Theme.of(context),
+                  theme,
                   device,
                   isSelected: device.id == selectedDeviceId,
                 ),

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -74,6 +74,8 @@ class MockDartToolingApi extends DartToolingApiImpl {
     server.registerMethod('vsCode.executeCommand', executeCommand);
     server.registerMethod('vsCode.selectDevice', selectDevice);
     server.registerMethod('vsCode.openDevToolsPage', noOpHandler);
+    server.registerMethod('vsCode.hotReload', noOpHandler);
+    server.registerMethod('vsCode.hotRestart', noOpHandler);
   }
 
   final json_rpc_2.Peer client;


### PR DESCRIPTION
Some tweaks to the sidebar UI. Currently looks like this:

https://github.com/flutter/devtools/assets/1078012/267c9006-8683-4433-950a-38178abc6544

Things that still need doing:

- [ ] background color is from the editor, not the sidebar
- [ ] test light theme
- [ ] need an icon for DevTools dropdown
- [ ] debug session names show literal `(null)` for mode while starting
- [ ] some items missing from DevTools menu
- [ ] DevTools page conditions need verifying/sharing
- [ ] ...

@kenzieschmoll @anderdobo 