### PR TITLE
Fix pubRootDirectory errors on hot restart

### DIFF
--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -454,7 +454,7 @@ class InspectorService extends InspectorServiceBase {
       checkIfComplete();
     });
 
-    return futureListener.future;
+    return futureListener.future.timeout(const Duration(seconds: 15));
   }
 
   Future<void> addPubRootDirectories(List<String> rootDirectories) async {

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -421,7 +421,7 @@ class InspectorService extends InspectorServiceBase {
   /// Ensures that addPubRootDirectories, getPubRootDirectories, and
   /// removePubRootDirectories have all registered as services
   /// before completing.
-  Future<void> waitUntilPubRootDirectoriesInitialized() {
+  Future<void> waitUntilPubRootDirectoriesServicesAvailable() {
     final futureListener = Completer();
     bool addAvailable = false;
     bool getAvailable = false;
@@ -458,13 +458,13 @@ class InspectorService extends InspectorServiceBase {
   }
 
   Future<void> addPubRootDirectories(List<String> rootDirectories) async {
-    await waitUntilPubRootDirectoriesInitialized();
+    await waitUntilPubRootDirectoriesServicesAvailable();
     await _addPubRootDirectories(rootDirectories);
     await _onRootDirectoriesChanged(rootDirectories);
   }
 
   Future<void> removePubRootDirectories(List<String> rootDirectories) async {
-    await waitUntilPubRootDirectoriesInitialized();
+    await waitUntilPubRootDirectoriesServicesAvailable();
     await _removePubRootDirectories(rootDirectories);
     await _onRootDirectoriesChanged(rootDirectories);
   }
@@ -487,7 +487,7 @@ class InspectorService extends InspectorServiceBase {
 
   Future<List<String>?> getPubRootDirectories() async {
     assert(useDaemonApi);
-    await waitUntilPubRootDirectoriesInitialized();
+    await waitUntilPubRootDirectoriesServicesAvailable();
     final response = await invokeServiceMethodDaemonNoGroupArgs(
       WidgetInspectorServiceExtensions.getPubRootDirectories.name,
     );


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExbWdiaHdjYnpnN3ZiMWlha3g5OTJ5NWRieWlmMXJmZ2RqejRmMGVnMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/HTmDjoIA12TgM2uPrG/giphy-downsized.gif)

On hot restart it appears that the preferences are calling out before the services get registered.
I've added a helper that waits until the services are reported before allowing them to be called.

Fixes https://github.com/flutter/devtools/issues/6357
