### PR TITLE
Shard flutter integration tests

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,7 +109,7 @@ jobs:
   #         echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
 
   integration-test:
-    name: integration-test ${{ matrix.bot }} - ${{ matrix.device }}
+    name: integration-test ${{ matrix.bot }} - ${{ matrix.device }} ${{ matrix.shard }}
     needs: flutter-prep
     runs-on: macos-latest
     strategy:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -115,13 +115,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bot:
           # Consider running integration tests in ddc mode, too.
-          - dart2js
-        device:
-          - flutter
-          - flutter-web
-          - dart-cli
+        bot: [dart2js]
+        device: [flutter, flutter-web, dart-cli]
         include:
           - device: flutter
             shard: "1/2"
@@ -140,6 +136,7 @@ jobs:
         env:
           BOT: ${{ matrix.bot }}
           DEVICE: ${{ matrix.device }}
+          SHARD: ${{ matrix.shard }}
         run: ./tool/bots.sh
 
       - name: Upload Golden Failure Artifacts

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -124,9 +124,9 @@ jobs:
           - dart-cli
         include:
           - device: flutter
-            shard: 1/2
+            shard: "1/2"
           - device: flutter
-            shard: 2/2
+            shard: "2/2"
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,98 +19,98 @@ jobs:
   flutter-prep:
     uses: ./.github/workflows/flutter-prep.yaml
 
-  # main:
-  #   name: main
-  #   needs: flutter-prep
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #   steps:
-  #     - name: git clone
-  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-  #     - name: Load Cached Flutter SDK
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-  #       with:
-  #         path: |
-  #           ./flutter-sdk
-  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+  main:
+    name: main
+    needs: flutter-prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: git clone
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Load Cached Flutter SDK
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ./flutter-sdk
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
 
-  #     - name: tool/bots.sh
-  #       env:
-  #         BOT: main
-  #       run: ./tool/bots.sh
+      - name: tool/bots.sh
+        env:
+          BOT: main
+        run: ./tool/bots.sh
 
-  # test:
-  #   name: ${{ matrix.bot }}
-  #   needs: flutter-prep
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       bot:
-  #         - build_ddc
-  #         - build_dart2js
-  #         - test_ddc
-  #         - test_dart2js
-  #   steps:
-  #     - name: git clone
-  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-  #     - name: Load Cached Flutter SDK
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-  #       with:
-  #         path: |
-  #           ./flutter-sdk
-  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-  #     - name: tool/bots.sh
-  #       env:
-  #         BOT: ${{ matrix.bot }}
-  #         PLATFORM: vm
-  #       run: ./tool/bots.sh
+  test:
+    name: ${{ matrix.bot }}
+    needs: flutter-prep
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bot:
+          - build_ddc
+          - build_dart2js
+          - test_ddc
+          - test_dart2js
+    steps:
+      - name: git clone
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Load Cached Flutter SDK
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ./flutter-sdk
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+      - name: tool/bots.sh
+        env:
+          BOT: ${{ matrix.bot }}
+          PLATFORM: vm
+        run: ./tool/bots.sh
 
-  # macos-test:
-  #   needs: flutter-prep
-  #   name: macos goldens ${{ matrix.bot }}
-  #   runs-on: macos-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       bot:
-  #         - test_dart2js
-  #       only_golden:
-  #         - true
+  macos-test:
+    needs: flutter-prep
+    name: macos goldens ${{ matrix.bot }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bot:
+          - test_dart2js
+        only_golden:
+          - true
 
-  #   steps:
-  #     - name: git clone
-  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-  #     - name: Load Cached Flutter SDK
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-  #       with:
-  #         path: |
-  #           ./flutter-sdk
-  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-  #     - name: tool/bots.sh
-  #       env:
-  #         BOT: ${{ matrix.bot }}
-  #         PLATFORM: vm
-  #         ONLY_GOLDEN: ${{ matrix.only_golden }}
-  #       run: ./tool/bots.sh
+    steps:
+      - name: git clone
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Load Cached Flutter SDK
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ./flutter-sdk
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+      - name: tool/bots.sh
+        env:
+          BOT: ${{ matrix.bot }}
+          PLATFORM: vm
+          ONLY_GOLDEN: ${{ matrix.only_golden }}
+        run: ./tool/bots.sh
 
-  #     - name: Upload Golden Failure Artifacts
-  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-  #       if: failure()
-  #       with:
-  #         name: golden_image_failures.${{ matrix.bot }}
-  #         path: packages/devtools_app/test/**/failures/*.png
-  #     - name: Notify of Quick Fix
-  #       if: failure()
-  #       env:
-  #         WORKFLOW_ID: ${{ github.run_id }}
-  #       run: |
-  #         echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
+      - name: Upload Golden Failure Artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        if: failure()
+        with:
+          name: golden_image_failures.${{ matrix.bot }}
+          path: packages/devtools_app/test/**/failures/*.png
+      - name: Notify of Quick Fix
+        if: failure()
+        env:
+          WORKFLOW_ID: ${{ github.run_id }}
+        run: |
+          echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
 
   integration-test:
     name: integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}
-    # needs: flutter-prep
+    needs: flutter-prep
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -110,7 +110,7 @@ jobs:
 
   integration-test:
     name: integration-test ${{ matrix.bot }} - ${{ matrix.device }} ${{ matrix.shard }}
-    needs: flutter-prep
+    # needs: flutter-prep
     runs-on: macos-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -109,17 +109,21 @@ jobs:
   #         echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
 
   integration-test:
-    name: integration-test ${{ matrix.bot }} - ${{ matrix.device }} ${{ matrix.shard }}
+    name: integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}
     # needs: flutter-prep
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-          # Consider running integration tests in ddc mode, too.
+        # Consider running integration tests in ddc mode, too.
         bot: [dart2js]
         device: [flutter, flutter-web, dart-cli]
-        shard: [1/2, 2/2]
+        # Option 1/1 will run all tests for a device in a single shard.
+        # Option 1/2 and 2/2 should be enabled to run tests for a device in 2 shards.
+        shard: [1/1, 1/2, 2/2]
         exclude:
+          - device: flutter
+            shard: 1/1
           - device: flutter-web
             shard: 1/2
           - device: flutter-web

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -118,9 +118,16 @@ jobs:
           # Consider running integration tests in ddc mode, too.
         bot: [dart2js]
         device: [flutter, flutter-web, dart-cli]
-        include:
-          - device: flutter
-            shard: [1/2, 2/2]
+        shard: [1/2, 2/2]
+        exclude:
+          - device: flutter-web
+            shard: 1/2
+          - device: flutter-web
+            shard: 2/2
+          - device: dart-cli
+            shard: 1/2
+          - device: dart-cli
+            shard: 2/2
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,94 +19,94 @@ jobs:
   flutter-prep:
     uses: ./.github/workflows/flutter-prep.yaml
 
-  main:
-    name: main
-    needs: flutter-prep
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-      - name: git clone
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-      - name: Load Cached Flutter SDK
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-        with:
-          path: |
-            ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+  # main:
+  #   name: main
+  #   needs: flutter-prep
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #   steps:
+  #     - name: git clone
+  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+  #     - name: Load Cached Flutter SDK
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+  #       with:
+  #         path: |
+  #           ./flutter-sdk
+  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
 
-      - name: tool/bots.sh
-        env:
-          BOT: main
-        run: ./tool/bots.sh
+  #     - name: tool/bots.sh
+  #       env:
+  #         BOT: main
+  #       run: ./tool/bots.sh
 
-  test:
-    name: ${{ matrix.bot }}
-    needs: flutter-prep
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bot:
-          - build_ddc
-          - build_dart2js
-          - test_ddc
-          - test_dart2js
-    steps:
-      - name: git clone
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-      - name: Load Cached Flutter SDK
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-        with:
-          path: |
-            ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-      - name: tool/bots.sh
-        env:
-          BOT: ${{ matrix.bot }}
-          PLATFORM: vm
-        run: ./tool/bots.sh
+  # test:
+  #   name: ${{ matrix.bot }}
+  #   needs: flutter-prep
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       bot:
+  #         - build_ddc
+  #         - build_dart2js
+  #         - test_ddc
+  #         - test_dart2js
+  #   steps:
+  #     - name: git clone
+  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+  #     - name: Load Cached Flutter SDK
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+  #       with:
+  #         path: |
+  #           ./flutter-sdk
+  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+  #     - name: tool/bots.sh
+  #       env:
+  #         BOT: ${{ matrix.bot }}
+  #         PLATFORM: vm
+  #       run: ./tool/bots.sh
 
-  macos-test:
-    needs: flutter-prep
-    name: macos goldens ${{ matrix.bot }}
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bot:
-          - test_dart2js
-        only_golden:
-          - true
+  # macos-test:
+  #   needs: flutter-prep
+  #   name: macos goldens ${{ matrix.bot }}
+  #   runs-on: macos-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       bot:
+  #         - test_dart2js
+  #       only_golden:
+  #         - true
 
-    steps:
-      - name: git clone
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-      - name: Load Cached Flutter SDK
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-        with:
-          path: |
-            ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-      - name: tool/bots.sh
-        env:
-          BOT: ${{ matrix.bot }}
-          PLATFORM: vm
-          ONLY_GOLDEN: ${{ matrix.only_golden }}
-        run: ./tool/bots.sh
+  #   steps:
+  #     - name: git clone
+  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+  #     - name: Load Cached Flutter SDK
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+  #       with:
+  #         path: |
+  #           ./flutter-sdk
+  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+  #     - name: tool/bots.sh
+  #       env:
+  #         BOT: ${{ matrix.bot }}
+  #         PLATFORM: vm
+  #         ONLY_GOLDEN: ${{ matrix.only_golden }}
+  #       run: ./tool/bots.sh
 
-      - name: Upload Golden Failure Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-        if: failure()
-        with:
-          name: golden_image_failures.${{ matrix.bot }}
-          path: packages/devtools_app/test/**/failures/*.png
-      - name: Notify of Quick Fix
-        if: failure()
-        env:
-          WORKFLOW_ID: ${{ github.run_id }}
-        run: |
-          echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
+  #     - name: Upload Golden Failure Artifacts
+  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+  #       if: failure()
+  #       with:
+  #         name: golden_image_failures.${{ matrix.bot }}
+  #         path: packages/devtools_app/test/**/failures/*.png
+  #     - name: Notify of Quick Fix
+  #       if: failure()
+  #       env:
+  #         WORKFLOW_ID: ${{ github.run_id }}
+  #       run: |
+  #         echo "::notice title=To Quickly Fix Goldens:: Run \`./tool/fix_goldens.sh $WORKFLOW_ID\` on your local branch."
 
   integration-test:
     name: integration-test ${{ matrix.bot }} - ${{ matrix.device }}
@@ -122,6 +122,11 @@ jobs:
           - flutter
           - flutter-web
           - dart-cli
+        include:
+          - device: flutter
+            shard: 1/2
+          - device: flutter
+            shard: 2/2
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -120,9 +120,7 @@ jobs:
         device: [flutter, flutter-web, dart-cli]
         include:
           - device: flutter
-            shard: "1/2"
-          - device: flutter
-            shard: "2/2"
+            shard: [1/2, 2/2]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -36,11 +36,15 @@ void main(List<String> args) async {
       // of a single file.
       await _runTest(testRunnerArgs);
     } else {
-      // Run all tests since a target test was not provided.
+      // Run all supported tests since a specific target test was not provided.
       final testDirectory = Directory(_testDirectory);
       var testFiles = testDirectory
           .listSync(recursive: true)
-          .where((testFile) => testFile.path.endsWith(_testSuffix))
+          .where(
+            (testFile) =>
+                testFile.path.endsWith(_testSuffix) &&
+                !testRunnerArgs.testAppDevice.supportsTest(testFile.path),
+          )
           .toList();
 
       final shard = testRunnerArgs.shard;
@@ -53,8 +57,6 @@ void main(List<String> args) async {
             : shardStart + shardSize;
         testFiles = testFiles.sublist(shardStart, shardEnd);
       }
-
-      print('testing files: $testFiles');
 
       for (final testFile in testFiles) {
         final testTarget = testFile.path;

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -25,11 +25,11 @@ void main(List<String> args) async {
     return;
   }
 
-  // final chromedriver = ChromeDriver();
+  final chromedriver = ChromeDriver();
 
   try {
     // Start chrome driver before running the flutter integration test.
-    // await chromedriver.start();
+    await chromedriver.start();
 
     if (testRunnerArgs.testTarget != null) {
       // TODO(kenz): add support for specifying a directory as the target instead
@@ -54,19 +54,19 @@ void main(List<String> args) async {
         testFiles = testFiles.sublist(shardStart, shardEnd);
       }
 
-      print('would be testing files: $testFiles');
+      print('testing files: $testFiles');
 
-      // for (final testFile in testFiles) {
-      //   final testTarget = testFile.path;
-      //   final newArgsWithTarget = TestRunnerArgs([
-      //     ...args,
-      //     '--${TestRunnerArgs.testTargetArg}=$testTarget',
-      //   ]);
-      //   await _runTest(newArgsWithTarget);
-      // }
+      for (final testFile in testFiles) {
+        final testTarget = testFile.path;
+        final newArgsWithTarget = TestRunnerArgs([
+          ...args,
+          '--${TestRunnerArgs.testTargetArg}=$testTarget',
+        ]);
+        await _runTest(newArgsWithTarget);
+      }
     }
   } finally {
-    // await chromedriver.stop();
+    await chromedriver.stop();
   }
 }
 

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -25,11 +25,11 @@ void main(List<String> args) async {
     return;
   }
 
-  final chromedriver = ChromeDriver();
+  // final chromedriver = ChromeDriver();
 
   try {
     // Start chrome driver before running the flutter integration test.
-    await chromedriver.start();
+    // await chromedriver.start();
 
     if (testRunnerArgs.testTarget != null) {
       // TODO(kenz): add support for specifying a directory as the target instead
@@ -54,17 +54,19 @@ void main(List<String> args) async {
         testFiles = testFiles.sublist(shardStart, shardEnd);
       }
 
-      for (final testFile in testFiles) {
-        final testTarget = testFile.path;
-        final newArgsWithTarget = TestRunnerArgs([
-          ...args,
-          '--${TestRunnerArgs.testTargetArg}=$testTarget',
-        ]);
-        await _runTest(newArgsWithTarget);
-      }
+      print('would be testing files: $testFiles');
+
+      // for (final testFile in testFiles) {
+      //   final testTarget = testFile.path;
+      //   final newArgsWithTarget = TestRunnerArgs([
+      //     ...args,
+      //     '--${TestRunnerArgs.testTargetArg}=$testTarget',
+      //   ]);
+      //   await _runTest(newArgsWithTarget);
+      // }
     }
   } finally {
-    await chromedriver.stop();
+    // await chromedriver.stop();
   }
 }
 

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -38,9 +38,21 @@ void main(List<String> args) async {
     } else {
       // Run all tests since a target test was not provided.
       final testDirectory = Directory(_testDirectory);
-      final testFiles = testDirectory
+      var testFiles = testDirectory
           .listSync(recursive: true)
-          .where((testFile) => testFile.path.endsWith(_testSuffix));
+          .where((testFile) => testFile.path.endsWith(_testSuffix))
+          .toList();
+
+      final shard = testRunnerArgs.shard;
+      if (shard != null) {
+        final shardSize = testFiles.length ~/ shard.totalShards;
+        // Subtract 1 since the [shard.shardNumber] index is 1-based.
+        final shardStart = (shard.shardNumber - 1) * shardSize;
+        final shardEnd = shard.shardNumber == shard.totalShards
+            ? null
+            : shardStart + shardSize;
+        testFiles = testFiles.sublist(shardStart, shardEnd);
+      }
 
       for (final testFile in testFiles) {
         final testTarget = testFile.path;

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -43,7 +43,7 @@ void main(List<String> args) async {
           .where(
             (testFile) =>
                 testFile.path.endsWith(_testSuffix) &&
-                !testRunnerArgs.testAppDevice.supportsTest(testFile.path),
+                testRunnerArgs.testAppDevice.supportsTest(testFile.path),
           )
           .toList();
 

--- a/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
@@ -43,6 +43,7 @@ void main() {
         ExtensionEnabledState.none,
         ExtensionEnabledState.none,
       ],
+      closeMenuWhenDone: false,
     );
 
     await _verifyExtensionVisibilitySetting(tester);
@@ -248,8 +249,9 @@ Future<void> _verifyContextMenuActions(WidgetTester tester) async {
 
 Future<void> _verifyExtensionsSettingsMenu(
   WidgetTester tester,
-  List<ExtensionEnabledState> enabledStates,
-) async {
+  List<ExtensionEnabledState> enabledStates, {
+  bool closeMenuWhenDone = true,
+}) async {
   await _openExtensionSettingsMenu(tester);
 
   expect(find.byType(ExtensionSetting), findsNWidgets(enabledStates.length));
@@ -266,8 +268,9 @@ Future<void> _verifyExtensionsSettingsMenu(
     };
     expect(group.selectedStates, expectedStates);
   }
-
-  await _closeExtensionSettingsMenu(tester);
+  if (closeMenuWhenDone) {
+    await _closeExtensionSettingsMenu(tester);
+  }
 }
 
 Future<void> _openExtensionSettingsMenu(WidgetTester tester) async {
@@ -316,6 +319,7 @@ Future<void> _verifyExtensionVisibilitySetting(WidgetTester tester) async {
     isFalse,
   );
   expect(extensionService.visibleExtensions.value.length, 3);
+  // No need to open the settings menu as it should already be open.
   await _toggleShowOnlyEnabledExtensions(tester);
   expect(
     preferences.devToolsExtensions.showOnlyEnabledExtensions.value,
@@ -330,10 +334,11 @@ Future<void> _verifyExtensionVisibilitySetting(WidgetTester tester) async {
     isFalse,
   );
   expect(extensionService.visibleExtensions.value.length, 3);
+
+  await _closeExtensionSettingsMenu(tester);
 }
 
 Future<void> _toggleShowOnlyEnabledExtensions(WidgetTester tester) async {
-  await _openExtensionSettingsMenu(tester);
   await tester.tap(
     find.descendant(
       of: find.byType(ExtensionSettingsDialog),
@@ -341,5 +346,4 @@ Future<void> _toggleShowOnlyEnabledExtensions(WidgetTester tester) async {
     ),
   );
   await tester.pumpAndSettle(shortPumpDuration);
-  await _closeExtensionSettingsMenu(tester);
 }

--- a/packages/devtools_app/integration_test/test_infra/run/run_test.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/run_test.dart
@@ -290,6 +290,22 @@ class TestRunnerArgs {
   /// instead of 'chrome'.
   bool get headless => _argResults[_headlessArg];
 
+  /// Sharding information for this test run.
+  ({int shardNumber, int totalShards})? get shard {
+    final shardValue = _argResults[_shardArg];
+    if (shardValue != null) {
+      final shardParts = shardValue.split('/');
+      if (shardParts.length == 2) {
+        final shardNumber = int.tryParse(shardParts[0]);
+        final totalShards = int.tryParse(shardParts[1]);
+        if (shardNumber is int && totalShards is int) {
+          return (shardNumber: shardNumber, totalShards: totalShards);
+        }
+      }
+    }
+    return null;
+  }
+
   /// Whether the help flag `-h` was passed to the integration test command.
   bool get help => _argResults[_helpArg];
 
@@ -304,6 +320,7 @@ class TestRunnerArgs {
   static const _testAppDeviceArg = 'test-app-device';
   static const _updateGoldensArg = 'update-goldens';
   static const _headlessArg = 'headless';
+  static const _shardArg = 'shard';
 
   /// Builds an arg parser for DevTools integration tests.
   static ArgParser _buildArgParser() {
@@ -343,6 +360,12 @@ class TestRunnerArgs {
             'Runs the integration test on the \'web-server\' device instead of '
             'the \'chrome\' device. For headless test runs, you will not be '
             'able to see the integration test run visually in a Chrome browser.',
+      )
+      ..addOption(
+        _shardArg,
+        valueHelp: '1/3',
+        help: 'The shard number for this run out of the total number of shards '
+            '(e.g. 1/3)',
       );
     return argParser;
   }

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -169,7 +169,7 @@ $ dart run integration_test/run_tests.dart --headless"
 
     if [ "$DEVICE" = "flutter" ]; then
 
-        dart run integration_test/run_tests.dart --headless
+        dart run integration_test/run_tests.dart --headless --shard="$SHARD"
 
     elif [ "$DEVICE" = "flutter-web" ]; then
 

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -173,11 +173,11 @@ $ dart run integration_test/run_tests.dart --headless"
 
     elif [ "$DEVICE" = "flutter-web" ]; then
 
-        dart run integration_test/run_tests.dart --test-app-device=chrome --headless
+        dart run integration_test/run_tests.dart --test-app-device=chrome --headless --shard="$SHARD"
 
     elif [ "$DEVICE" = "dart-cli" ]; then
 
-        dart run integration_test/run_tests.dart --test-app-device=cli --headless
+        dart run integration_test/run_tests.dart --test-app-device=cli --headless --shard="$SHARD"
 
     fi
 fi


### PR DESCRIPTION
Attempt to speed up integration tests by running the `flutter` and `flutter-web` tests in shards.

Results:
- `flutter` integration tests runtime reduced by 40% (~33min to ~19min)
- `flutter-web` integration tests runtime reduced by 24% (~23min to ~17min)

Work towards https://github.com/flutter/devtools/issues/5938.