### PR TITLE
Update `devtools_extensions` readme

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -25,8 +25,8 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
-  devtools_app_shared: ^0.0.2
-  devtools_extensions: ^0.0.3
+  devtools_app_shared: ^0.0.3
+  devtools_extensions: ^0.0.5
   devtools_shared: ^4.0.0
   file: ^6.0.0
   file_selector: ^0.8.0

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.5
+* Update README.md to include package publishing instructions.
+
 ## 0.0.4
 * Bump `package:vm_service` dependency to ^11.10.0
 * Fix a leaking event listener in the simulated DevTools environment.

--- a/packages/devtools_extensions/README.md
+++ b/packages/devtools_extensions/README.md
@@ -14,6 +14,14 @@ Follow the instructions below to get started, and use the
 [end-to-end example](https://github.com/flutter/devtools/tree/master/packages/devtools_extensions/example/)
 for reference.
 
+# Table of contents
+1. [Setup your package to provide a DevTools extension](#setup-your-package-to-provide-a-DevTools-extension)
+2. [Create a DevTools extension](#create-a-devtools-extension)
+    - [Where to put your source code](#where-to-put-your-source-code)
+    - [Development](#create-the-extension-web-app)
+    - [Debugging](#debug-the-extension-web-app)
+3. [Publish your package with a DevTools extension](#publish-your-package-with-a-DevTools-extension)
+
 ## Setup your package to provide a DevTools extension
 
 DevTools extensions must be written as Flutter web apps. This is because DevTools embeds
@@ -78,7 +86,7 @@ flutter create --template app --platforms web foo_package_devtools_extension
 
 In `foo_package_devtools_extension/pubspec.yaml`, add a dependency on `devtools_extensions`:
 ```yaml
-devtools_extensions: ^0.0.3
+devtools_extensions: ^0.0.5
 ```
 
 In `lib/main.dart`, place a `DevToolsExtension` widget at the root of your app:
@@ -183,3 +191,46 @@ source code. Once you have done this, run `pub get`, and run the application.
 in the DevTools app bar for your extension. The enabled or disabled state of your extension is
 managed by DevTools, which is exposed from an "Extensions" menu in DevTools, available from the
 action buttons in the upper right corner of the screen.
+
+## Publish your package with a DevTools extension
+
+In order for a package to provide a DevTools extension to its users, it must be published with the
+expected content in the `your_package/extension/devtools/` directory (see the
+[setup instructions](#setup-your-package-to-provide-a-DevTools-extension) above).
+
+1. Ensure the `extension/devtools/config.yaml` file exists and is configured per the
+[specifications above](#setup-your-package-to-provide-a-DevTools-extension).
+2. Use the `build_and_copy` command provided by `package:devtools_extensions` to build
+your extension and copy the output to the `extension/devtools` directory:
+```sh
+cd your_extension_web_app &&
+flutter pub get &&
+dart run devtools_extensions build_and_copy \
+  --source=. \
+  --dest=path/to/your_pub_package/extension/devtools 
+```
+
+### What if I don't want the `extension/devtools/build/` contents checked into source control?
+
+As a package author, the content that you check into your git repository is completely up to you.
+If you want the contents of `extension/devtools/build/` to be git ignored, then you'll just need
+to ensure that the extension web app is always built and included in `extension/devtools/build/`
+when you publish your package.
+
+Consider adding a tool script to your repo that looks something like this:
+
+**publish.sh**
+```sh
+pushd your_extension_web_app
+
+flutter pub get &&
+dart run devtools_extensions build_and_copy \
+  --source=. \
+  --dest=path/to/your_pub_package/extension/devtools 
+
+popd
+
+pushd your_pub_package
+flutter pub publish
+popd
+```

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.0.4
+version: 0.0.5
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:
@@ -13,7 +13,7 @@ executables:
 dependencies:
   args: ^2.4.2
   devtools_shared: ^4.0.0
-  devtools_app_shared: ^0.0.2
+  devtools_app_shared: ^0.0.3
   flutter:
     sdk: flutter
   io: ^1.0.4


### PR DESCRIPTION
This adds a table of contents to the readme and adds information for package authors about publishing their package with a DevTools extension