### PR TITLE
Add `forceReload` endpoint to the extensions API

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -100,7 +100,7 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   }) {
     extensionPostEventStream.add(DevToolsExtensionEvent(type, data: data));
   }
-  
+
   @override
   void dispose() async {
     await extensionPostEventStream.close();

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -11,6 +11,7 @@ import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_extensions/api.dart';
 import 'package:path/path.dart' as path;
 
+import '../../shared/config_specific/server/server.dart';
 import '../../shared/development_helpers.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/utils.dart';
@@ -38,7 +39,7 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   late final viewId = 'ext-${extensionConfig.name}-${_viewIdIncrementer++}';
 
   String get extensionUrl {
-    if (debugDevToolsExtensions) {
+    if (debugDevToolsExtensions && !isDevToolsServerAvailable) {
       return 'https://flutter.dev/';
     }
 
@@ -99,15 +100,7 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
   }) {
     extensionPostEventStream.add(DevToolsExtensionEvent(type, data: data));
   }
-
-  @override
-  void forceReload() {
-    if (_extensionIFrame.contentWindow != null) {
-      // ignore: unsafe_html, forcing reload by resetting the pre-existing IFrame src.
-      _extensionIFrame.src = _extensionIFrame.src;
-    }
-  }
-
+  
   @override
   void dispose() async {
     await extensionPostEventStream.close();

--- a/packages/devtools_app/lib/src/extensions/embedded/controller.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/controller.dart
@@ -25,6 +25,4 @@ abstract class EmbeddedExtensionController extends DisposableController {
     DevToolsExtensionEventType type, {
     Map<String, String> data = const <String, String>{},
   }) {}
-
-  void forceReload() {}
 }

--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_extensions/api.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -44,10 +45,10 @@ class _ExtensionScreenBody extends StatefulWidget {
   final DevToolsExtensionConfig extensionConfig;
 
   @override
-  State<_ExtensionScreenBody> createState() => __ExtensionScreenBodyState();
+  State<_ExtensionScreenBody> createState() => _ExtensionScreenBodyState();
 }
 
-class __ExtensionScreenBodyState extends State<_ExtensionScreenBody> {
+class _ExtensionScreenBodyState extends State<_ExtensionScreenBody> {
   EmbeddedExtensionController? extensionController;
 
   @override
@@ -99,7 +100,8 @@ class ExtensionView extends StatelessWidget {
       children: [
         EmbeddedExtensionHeader(
           extension: extension,
-          onForceReload: controller.forceReload,
+          onForceReload: () =>
+              controller.postMessage(DevToolsExtensionEventType.forceReload),
         ),
         const SizedBox(height: intermediateSpacing),
         Expanded(

--- a/packages/devtools_app/lib/src/shared/development_helpers.dart
+++ b/packages/devtools_app/lib/src/shared/development_helpers.dart
@@ -14,7 +14,8 @@ import 'globals.dart';
 ///
 /// This flag should never be checked in with a value of true - this is covered
 /// by a test.
-final debugDevToolsExtensions = false || integrationTestMode;
+final debugDevToolsExtensions = _debugDevToolsExtensions || integrationTestMode;
+const _debugDevToolsExtensions = false;
 
 List<DevToolsExtensionConfig> debugHandleRefreshAvailableExtensions(
   // ignore: avoid-unused-parameters, false positive due to conditional imports

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,9 +1,11 @@
 ## 0.0.5
+* Add a `forceReload` endpoint to the extensions API.
+* Add a `toString()` representation for `DevToolsExtensionEvent`.
 * Add `ignoreIfAlreadyDismissed` parameter to `ExtensionManager.showBannerMessage` api.
 * Update README.md to include package publishing instructions.
 
 ## 0.0.4
-* Bump `package:vm_service` dependency to ^11.10.0
+* Bump `package:vm_service` dependency to ^11.10.0.
 * Fix a leaking event listener in the simulated DevTools environment.
 
 ## 0.0.3

--- a/packages/devtools_extensions/lib/src/api/api.dart
+++ b/packages/devtools_extensions/lib/src/api/api.dart
@@ -15,6 +15,10 @@ enum DevToolsExtensionEventType {
   /// [ping] event.
   pong(ExtensionEventDirection.toDevTools),
 
+  /// An event that DevTools will send to an extension to force the extension
+  /// iFrame to reload.
+  forceReload(ExtensionEventDirection.toExtension),
+
   /// An event that DevTools will send to an extension to notify of the
   /// connected vm service uri.
   vmServiceConnection(ExtensionEventDirection.bidirectional),
@@ -103,13 +107,17 @@ abstract interface class DevToolsExtensionHostInterface {
   /// DevTools extension to check that it is ready.
   void ping();
 
+  /// This method should send a [DevToolsExtensionEventType.forceReload] event
+  /// to the extension to notify it to perform a reload on itself.
+  void forceReload();
+
   /// This method should send a [DevToolsExtensionEventType.vmServiceConnection]
   /// event to the extension to notify it of the vm service uri it should
   /// establish a connection to.
   void updateVmServiceConnection({required String? uri});
 
   /// This method should send a [DevToolsExtensionEventType.themeUpdate] event
-  /// to the extension to notify if of a theme change in DevTools.
+  /// to the extension to notify it of a theme change in DevTools.
   ///
   /// [theme] should be one of [ExtensionEventParameters.themeValueLight] or
   /// [ExtensionEventParameters.themeValueDark].

--- a/packages/devtools_extensions/lib/src/api/model.dart
+++ b/packages/devtools_extensions/lib/src/api/model.dart
@@ -110,14 +110,14 @@ class ShowBannerMessageExtensionEvent extends DevToolsExtensionEvent {
     final message = eventData.checkValid<String>(_messageKey);
     final type = eventData.checkValid<String>(_bannerMessageTypeKey);
     final extensionName = eventData.checkValid<String>(_extensionNameKey);
-    final skipIfAlreadyDismissed =
+    final ignoreIfAlreadyDismissed =
         (eventData[_ignoreIfAlreadyDismissedKey] as bool?) ?? true;
     return ShowBannerMessageExtensionEvent(
       id: id,
       bannerMessageType: type,
       message: message,
       extensionName: extensionName,
-      ignoreIfAlreadyDismissed: skipIfAlreadyDismissed,
+      ignoreIfAlreadyDismissed: ignoreIfAlreadyDismissed,
     );
   }
 

--- a/packages/devtools_extensions/lib/src/api/model.dart
+++ b/packages/devtools_extensions/lib/src/api/model.dart
@@ -49,6 +49,12 @@ class DevToolsExtensionEvent {
       if (data != null) _dataKey: data!,
     };
   }
+
+  @override
+  String toString() {
+    return '[$type, data: ${data.toString()}'
+        '${source != null ? ', source: $source' : ''}]';
+  }
 }
 
 /// A void callback that handles a [DevToolsExtensionEvent].

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_controller.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_controller.dart
@@ -60,6 +60,10 @@ class _SimulatedDevToolsController extends DisposableController
 
   @override
   void updateVmServiceConnection({required String? uri}) {
+    // TODO(https://github.com/flutter/devtools/issues/6416): write uri to the
+    // window location query parameters so that the vm service connection
+    // persists on hot restart.
+
     // TODO(kenz): add some validation and error handling if [uri] is bad input.
     final normalizedUri =
         uri != null ? normalizeVmServiceUri(uri).toString() : null;
@@ -142,6 +146,13 @@ class _SimulatedDevToolsController extends DisposableController
       theme: darkThemeEnabled
           ? ExtensionEventParameters.themeValueLight
           : ExtensionEventParameters.themeValueDark,
+    );
+  }
+
+  @override
+  void forceReload() {
+    _postMessageToExtension(
+      DevToolsExtensionEvent(DevToolsExtensionEventType.forceReload),
     );
   }
 }

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -160,6 +160,11 @@ class _SimulatedApi extends StatelessWidget {
               label: 'TOGGLE THEME',
               onPressed: simController.toggleTheme,
             ),
+            const SizedBox(width: denseSpacing),
+            DevToolsButton(
+              label: 'FORCE RELOAD',
+              onPressed: simController.forceReload,
+            ),
             // TODO(kenz): add buttons for other simulated events as the extension
             // API expands.
           ],

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -115,7 +115,8 @@ class ExtensionManager {
             value == null || value == ExtensionEventParameters.themeValueDark;
         darkThemeEnabled.value = useDarkTheme;
         break;
-      case DevToolsExtensionEventType.unknown:
+      case DevToolsExtensionEventType.forceReload:
+        html.window.location.reload();
       default:
         _log.warning(
           'Unrecognized event received by extension: '

--- a/packages/devtools_extensions/test/api_test.dart
+++ b/packages/devtools_extensions/test/api_test.dart
@@ -82,6 +82,11 @@ void main() {
       );
 
       expect(
+        DevToolsExtensionEventType.from('forceReload'),
+        DevToolsExtensionEventType.forceReload,
+      );
+
+      expect(
         DevToolsExtensionEventType.from('showNotification'),
         DevToolsExtensionEventType.showNotification,
       );
@@ -121,6 +126,10 @@ void main() {
       verifyEventDirection(
         DevToolsExtensionEventType.pong,
         (bidirectional: false, toDevTools: true, toExtension: false),
+      );
+      verifyEventDirection(
+        DevToolsExtensionEventType.forceReload,
+        (bidirectional: false, toDevTools: false, toExtension: true),
       );
       verifyEventDirection(
         DevToolsExtensionEventType.vmServiceConnection,
@@ -216,7 +225,7 @@ void main() {
 
   group('$ShowBannerMessageExtensionEvent', () {
     test('constructs for expected values', () {
-      final event = DevToolsExtensionEvent.parse({
+      var event = DevToolsExtensionEvent.parse({
         'type': 'showBannerMessage',
         'data': {
           'id': 'fooMessageId',
@@ -225,13 +234,31 @@ void main() {
           'extensionName': 'foo',
         },
       });
-      final showBannerMessageEvent =
-          ShowBannerMessageExtensionEvent.from(event);
+      var showBannerMessageEvent = ShowBannerMessageExtensionEvent.from(event);
 
       expect(showBannerMessageEvent.messageId, 'fooMessageId');
       expect(showBannerMessageEvent.message, 'foo message');
       expect(showBannerMessageEvent.bannerMessageType, 'warning');
       expect(showBannerMessageEvent.extensionName, 'foo');
+      expect(showBannerMessageEvent.ignoreIfAlreadyDismissed, true);
+
+      event = DevToolsExtensionEvent.parse({
+        'type': 'showBannerMessage',
+        'data': {
+          'id': 'blah',
+          'message': 'blah message',
+          'bannerMessageType': 'error',
+          'extensionName': 'blah',
+          'ignoreIfAlreadyDismissed': false,
+        },
+      });
+      showBannerMessageEvent = ShowBannerMessageExtensionEvent.from(event);
+
+      expect(showBannerMessageEvent.messageId, 'blah');
+      expect(showBannerMessageEvent.message, 'blah message');
+      expect(showBannerMessageEvent.bannerMessageType, 'error');
+      expect(showBannerMessageEvent.extensionName, 'blah');
+      expect(showBannerMessageEvent.ignoreIfAlreadyDismissed, false);
     });
     test('throws for unexpected values', () async {
       final event1 = DevToolsExtensionEvent.parse({

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 4.0.1
+
+- Override equality operator and hashCode for `DevToolsExtensionConfig`
+to be based on the values of its fields.
+
 # 4.0.0
 
 - Bump `package:extension_discovery` version to ^2.0.0

--- a/packages/devtools_shared/lib/src/extensions/extension_model.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_model.dart
@@ -124,6 +124,25 @@ class DevToolsExtensionConfig implements Comparable {
     }
     return compare;
   }
+
+  @override
+  bool operator ==(Object? other) {
+    return other is DevToolsExtensionConfig &&
+        other.name == name &&
+        other.path == path &&
+        other.issueTrackerLink == issueTrackerLink &&
+        other.version == version &&
+        other.materialIconCodePoint == materialIconCodePoint;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        name,
+        path,
+        issueTrackerLink,
+        version,
+        materialIconCodePoint,
+      );
 }
 
 /// Describes the enablement state of a DevTools extension.

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 4.0.0
+version: 4.0.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
We cannot call `location.reload()` directly on the iFrame object due to cross origin protections. In order to do a full reload, we need the iFrame to reload itself. This PR adds an endpoint to the extensions API to do so, and calls this endpoint from the existing force reload action in DevTools.

Part of fixing the hot reload action required fixing a state management issue where we were calling didUpdateWidget and cancelling a stream subscription when we shouldn't be. Fix for this is implementing equality and hashCode for DevToolsExtensionConfig, which is part of this PR.

Fixes https://github.com/flutter/devtools/issues/6391.