### PR TITLE
Update the extension iFrame's query parameters for theme and vm service uri changes

### DIFF
--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -44,6 +44,7 @@ class VmServiceWrapper implements VmService {
     _vmService = VmService(
       inStream,
       writeMessage,
+      wsUri: connectedUri.toString(),
     );
     unawaited(_initSupportedProtocols());
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
@@ -48,7 +49,9 @@ class PreferencesController extends DisposableController
   Future<void> init() async {
     // Get the current values and listen for and write back changes.
     String? value = await storage.getValue('ui.darkMode');
-    final useDarkMode = value == null || value == 'true';
+
+    final useDarkMode =
+        (value == null && useDarkThemeAsDefault) || value == 'true';
     toggleDarkModeTheme(useDarkMode);
     addAutoDisposeListener(darkModeTheme, () {
       storage.setValue('ui.darkMode', '${darkModeTheme.value}');

--- a/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/theme.dart
@@ -12,6 +12,10 @@ import 'ide_theme.dart';
 // TODO(kenz): try to eliminate as many custom colors as possible, and pull
 // colors only from the [lightColorScheme] and the [darkColorScheme].
 
+/// Whether dark theme should be used as the default theme if none has been
+/// explicitly set.
+const useDarkThemeAsDefault = true;
+
 /// Constructs the light or dark theme for the app taking into account
 /// IDE-supplied theming.
 ThemeData themeFor({
@@ -494,8 +498,7 @@ bool isScreenWiderThan(
   double? width,
 ) {
   return width == null ||
-      MediaQuery.of(context).size.width >
-          scaleByFontFactor(width);
+      MediaQuery.of(context).size.width > scaleByFontFactor(width);
 }
 
 ButtonStyle denseAwareOutlinedButtonStyle(

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.0.5
+* Ensure theme and vm service connection are preserved on refresh of the extension
+iFrame or the simulated DevTools environment.
 * Add a `forceReload` endpoint to the extensions API.
 * Add a `toString()` representation for `DevToolsExtensionEvent`.
 * Add `ignoreIfAlreadyDismissed` parameter to `ExtensionManager.showBannerMessage` api.

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -21,16 +21,16 @@ class _VmServiceConnection extends StatelessWidget {
     return SizedBox(
       height: _totalControlsHeight,
       child: connected
-          ? const _ConnectedVmServiceDisplay()
-          : _DisconnectedVmServiceDisplay(
-              simController: simController,
-            ),
+          ? _ConnectedVmServiceDisplay(simController: simController)
+          : _DisconnectedVmServiceDisplay(simController: simController),
     );
   }
 }
 
 class _ConnectedVmServiceDisplay extends StatelessWidget {
-  const _ConnectedVmServiceDisplay();
+  const _ConnectedVmServiceDisplay({required this.simController});
+
+  final _SimulatedDevToolsController simController;
 
   @override
   Widget build(BuildContext context) {
@@ -58,7 +58,7 @@ class _ConnectedVmServiceDisplay extends StatelessWidget {
           elevated: true,
           label: 'Disconnect',
           onPressed: () {
-            unawaited(serviceManager.manuallyDisconnect());
+            simController.updateVmServiceConnection(uri: null);
           },
         ),
       ],

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -45,8 +45,7 @@ class ExtensionManager {
     // TODO(kenz): handle the ide theme that may be part of the query params.
     final queryParams = loadQueryParams();
     final themeValue = queryParams[ExtensionEventParameters.theme];
-    darkThemeEnabled.value = themeValue == null ||
-        themeValue == ExtensionEventParameters.themeValueDark;
+    _setThemeForValue(themeValue);
 
     final vmServiceUri = queryParams['uri'];
     if (connectToVmService) {
@@ -110,10 +109,7 @@ class ExtensionManager {
       case DevToolsExtensionEventType.themeUpdate:
         final value =
             extensionEvent.data?[ExtensionEventParameters.theme] as String?;
-        // Default to use dark theme if [value] is null.
-        final useDarkTheme =
-            value == null || value == ExtensionEventParameters.themeValueDark;
-        darkThemeEnabled.value = useDarkTheme;
+        _setThemeForValue(value);
         break;
       case DevToolsExtensionEventType.forceReload:
         html.window.location.reload();
@@ -151,7 +147,15 @@ class ExtensionManager {
   Future<void> _connectToVmService(String? vmServiceUri) async {
     // TODO(kenz): investigate. this is weird but `vmServiceUri` != null even
     // when the `toString()` representation is 'null'.
-    if (vmServiceUri == null || '$vmServiceUri' == 'null') return;
+    if (vmServiceUri == null || '$vmServiceUri' == 'null') {
+      if (serviceManager.hasConnection) {
+        await serviceManager.manuallyDisconnect();
+      }
+      if (loadQueryParams().containsKey('uri')) {
+        _updateQueryParameter('uri', null);
+      }
+      return;
+    }
 
     try {
       final finishedCompleter = Completer<void>();
@@ -167,6 +171,7 @@ class ExtensionManager {
           return VmService(
             inStream,
             writeMessage,
+            wsUri: connectedUri.toString(),
           );
         },
       );
@@ -174,11 +179,30 @@ class ExtensionManager {
         vmService,
         onClosed: finishedCompleter.future,
       );
+      _updateQueryParameter('uri', serviceManager.service!.wsUri!);
     } catch (e) {
-      // TODO(kenz): post a notification to DevTools for errors
-      // or create an error panel for the extensions screens.
-      print('Unable to connect to VM service at $vmServiceUri: $e');
+      final errorMessage =
+          'Unable to connect extension to VM service at $vmServiceUri: $e';
+      showNotification('Error: $errorMessage');
+      _log.shout(errorMessage);
     }
+  }
+
+  void _setThemeForValue(String? themeValue) {
+    // Default to use dark theme if [value] is null.
+    final useDarkTheme = themeValue == null ||
+        themeValue == ExtensionEventParameters.themeValueDark;
+    darkThemeEnabled.value = useDarkTheme;
+    // Use a post frame callback so that we do not try to update this while a
+    // build is in progress.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _updateQueryParameter(
+        'theme',
+        useDarkTheme
+            ? ExtensionEventParameters.themeValueDark
+            : ExtensionEventParameters.themeValueLight,
+      );
+    });
   }
 
   void showNotification(String message) async {
@@ -203,5 +227,17 @@ class ExtensionManager {
         ignoreIfAlreadyDismissed: ignoreIfAlreadyDismissed,
       ),
     );
+  }
+
+  void _updateQueryParameter(String key, String? value) {
+    final newQueryParams = Map.of(loadQueryParams());
+    if (value == null) {
+      newQueryParams.remove(key);
+    } else {
+      newQueryParams[key] = value;
+    }
+    final newUri = Uri.parse(html.window.location.toString())
+        .replace(queryParameters: newQueryParams);
+    html.window.history.replaceState(null, '', newUri.toString());
   }
 }

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -14,7 +14,7 @@ class ExtensionManager {
   ///
   /// The DevTools extension will rebuild with the appropriate theme on
   /// notifications from this notifier.
-  final darkThemeEnabled = ValueNotifier<bool>(true);
+  final darkThemeEnabled = ValueNotifier<bool>(useDarkThemeAsDefault);
 
   /// Registers an event handler for [DevToolsExtensionEvent]s of type [type].
   ///
@@ -189,8 +189,7 @@ class ExtensionManager {
   }
 
   void _setThemeForValue(String? themeValue) {
-    // Default to use dark theme if [value] is null.
-    final useDarkTheme = themeValue == null ||
+    final useDarkTheme = (themeValue == null && useDarkThemeAsDefault) ||
         themeValue == ExtensionEventParameters.themeValueDark;
     darkThemeEnabled.value = useDarkTheme;
     // Use a post frame callback so that we do not try to update this while a


### PR DESCRIPTION
The extension iFrame's URL query parameters are now updated when the theme changes and when the vm service uri changes. This ensures the theme and service connection state are preserved on reload of the iFrame window.

Fixes https://github.com/flutter/devtools/issues/6389
Fixes https://github.com/flutter/devtools/issues/6416