### PR TITLE
Tidy up sidebar + use screen metadata

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -343,8 +343,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
             ),
           );
         },
-      if (FeatureFlags.vsCodeSidebarTooling)
-        if (FeatureFlags.vsCodeSidebarTooling) ..._standaloneScreens,
+      if (FeatureFlags.vsCodeSidebarTooling) ..._standaloneScreens,
     };
   }
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -343,14 +343,9 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
             ),
           );
         },
-      if (FeatureFlags.vsCodeSidebarTooling) ..._standaloneScreens,
-    };
-  }
-
-  Map<String, UrlParametersBuilder> get _standaloneScreens {
-    return {
-      for (final type in StandaloneScreenType.values)
-        type.name: (_, __, args, ___) => type.screen,
+      if (FeatureFlags.vsCodeSidebarTooling)
+        for (final type in StandaloneScreenType.values)
+          type.name: (_, __, args, ___) => type.build(_screens),
     };
   }
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -111,6 +111,8 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
         (e) => DevToolsScreen<void>(ExtensionScreen(e)).screen,
       );
 
+  // TODO(dantup): This does not take IDE preference into account, so results
+  //  in Dark mode embedded sidebar in VS Code.
   bool get isDarkThemeEnabled => _isDarkThemeEnabled;
   bool _isDarkThemeEnabled = true;
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -344,8 +344,14 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
           );
         },
       if (FeatureFlags.vsCodeSidebarTooling)
-        for (final type in StandaloneScreenType.values)
-          type.name: (_, __, args, ___) => type.build(_screens),
+        if (FeatureFlags.vsCodeSidebarTooling) ..._standaloneScreens,
+    };
+  }
+
+  Map<String, UrlParametersBuilder> get _standaloneScreens {
+    return {
+      for (final type in StandaloneScreenType.values)
+        type.name: (_, __, args, ___) => type.screen,
     };
   }
 

--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -4,6 +4,7 @@
 
 import 'package:flutter/material.dart';
 
+import '../../devtools_app.dart';
 import 'api/impl/dart_tooling_api.dart';
 import 'vs_code/flutter_panel.dart';
 
@@ -16,6 +17,7 @@ import 'vs_code/flutter_panel.dart';
 enum StandaloneScreenType {
   vsCodeFlutterPanel;
 
+  // TODO(dantup): This seems unused, is it needed?
   static StandaloneScreenType? parse(String? id) {
     if (id == null) return null;
 
@@ -25,10 +27,10 @@ enum StandaloneScreenType {
     return null;
   }
 
-  Widget get screen {
+  Widget build(List<Screen> screens) {
     return switch (this) {
       StandaloneScreenType.vsCodeFlutterPanel =>
-        VsCodeFlutterPanel(DartToolingApiImpl.postMessage()),
+        VsCodeFlutterPanel(screens, DartToolingApiImpl.postMessage()),
     };
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -4,7 +4,6 @@
 
 import 'package:flutter/material.dart';
 
-import '../../devtools_app.dart';
 import 'api/impl/dart_tooling_api.dart';
 import 'vs_code/flutter_panel.dart';
 
@@ -27,10 +26,10 @@ enum StandaloneScreenType {
     return null;
   }
 
-  Widget build(List<Screen> screens) {
+  Widget get screen {
     return switch (this) {
       StandaloneScreenType.vsCodeFlutterPanel =>
-        VsCodeFlutterPanel(screens, DartToolingApiImpl.postMessage()),
+        VsCodeFlutterPanel(DartToolingApiImpl.postMessage()),
     };
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -132,29 +132,24 @@ class _DevToolsMenu extends StatelessWidget {
         disabledReason = 'Not available when running on the web';
       }
 
-      Widget button = TextButton.icon(
-        style: TextButton.styleFrom(
-          alignment: Alignment.centerRight,
-          shape: const ContinuousRectangleBorder(),
-        ),
-        onPressed: disabledReason != null
-            ? null
-            : () => unawaited(api.openDevToolsPage(session.id, screen.id)),
-        label: Directionality(
-          textDirection: normalDirection,
-          child: Text(title),
-        ),
-        icon: Icon(screen.icon, size: actionsIconSize),
+      // Because we flipped the direction so the menu is aligned to the end, we
+      // should revert the text direction back to normal for the label.
+      Widget text = Directionality(
+        textDirection: normalDirection,
+        child: Text(title),
       );
 
       if (disabledReason != null) {
-        button =
-            Tooltip(preferBelow: false, message: disabledReason, child: button);
+        text =
+            Tooltip(preferBelow: false, message: disabledReason, child: text);
       }
 
-      return SizedBox(
-        width: double.infinity,
-        child: button,
+      return MenuItemButton(
+        leadingIcon: Icon(screen.icon, size: actionsIconSize),
+        onPressed: disabledReason != null
+            ? null
+            : () => unawaited(api.openDevToolsPage(session.id, screen.id)),
+        child: text,
       );
     }
 

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -12,10 +12,11 @@ import '../../shared/screen.dart';
 import '../api/vs_code_api.dart';
 
 class DebugSessions extends StatelessWidget {
-  const DebugSessions(this.api, this.sessions, {super.key});
+  const DebugSessions(this.api, this.sessions, this.deviceMap, {super.key});
 
   final VsCodeApi api;
   final List<VsCodeDebugSession> sessions;
+  final Map<String, VsCodeDevice> deviceMap;
 
   @override
   Widget build(BuildContext context) {
@@ -51,8 +52,7 @@ class DebugSessions extends StatelessWidget {
     final isProfile = mode == 'profile';
     final isRelease = mode == 'release' || mode == 'jit_release';
     final isFlutter = session.debuggerType?.contains('Flutter') ?? false;
-    // TODO(dantup): Detect web so we can handle requiresDartVm correctly.
-    const isWeb = false;
+    final isWeb = deviceMap[session.flutterDeviceId]?.platformType == 'web';
 
     final label = session.flutterMode != null
         ? '${session.name} (${session.flutterMode})'

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -8,6 +8,7 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../shared/constants.dart';
+import '../../shared/feature_flags.dart';
 import '../../shared/screen.dart';
 import '../api/vs_code_api.dart';
 
@@ -184,11 +185,15 @@ class _DevToolsMenu extends StatelessWidget {
   }
 
   bool _shouldIncludeScreen(ScreenMetaData screen) {
-    // Don't show home screen or debugger in the menu.
+    // Some screens shouldn't show up in the menu.
     return screen != ScreenMetaData.home &&
         screen != ScreenMetaData.debugger &&
+        screen != ScreenMetaData.vmTools &&
         // Or the generic "simple" screen.
         screen != ScreenMetaData.simple &&
+        // DeepLink is currently behind a feature flag.
+        (screen != ScreenMetaData.deepLinks ||
+            FeatureFlags.deepLinkValidation) &&
         // Or anything that requires some specific library that we can't
         // check (`requiresLibrary` will be removed for extensions
         // in future, and those will need some extra work to detect).

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -193,18 +193,18 @@ class _DevToolsMenu extends StatelessWidget {
   }
 
   bool _shouldIncludeScreen(ScreenMetaData screen) {
-    // Some screens shouldn't show up in the menu.
-    return screen != ScreenMetaData.home &&
-        screen != ScreenMetaData.debugger &&
-        screen != ScreenMetaData.vmTools &&
-        // Or the generic "simple" screen.
-        screen != ScreenMetaData.simple &&
-        // DeepLink is currently behind a feature flag.
-        (screen != ScreenMetaData.deepLinks ||
-            FeatureFlags.deepLinkValidation) &&
-        // Or anything that requires some specific library that we can't
-        // check (`requiresLibrary` will be removed for extensions
-        // in future, and those will need some extra work to detect).
-        screen.requiresLibrary == null;
+    return switch (screen) {
+      // Some screens shouldn't show up in the menu.
+      ScreenMetaData.home => false,
+      ScreenMetaData.debugger => false,
+      ScreenMetaData.simple => false, // generic screen isn't a screen itself
+      // TODO(dantup): Check preferences.vmDeveloperModeEnabled
+      ScreenMetaData.vmTools => false,
+      // DeepLink is currently behind a feature flag.
+      ScreenMetaData.deepLinks => FeatureFlags.deepLinkValidation,
+      // Anything else can be shown as long as it doesn't require a specific
+      // library.
+      _ => screen.requiresLibrary == null,
+    };
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -13,7 +13,12 @@ import '../../shared/screen.dart';
 import '../api/vs_code_api.dart';
 
 class DebugSessions extends StatelessWidget {
-  const DebugSessions(this.api, this.sessions, this.deviceMap, {super.key});
+  const DebugSessions({
+    required this.api,
+    required this.sessions,
+    required this.deviceMap,
+    super.key,
+  });
 
   final VsCodeApi api;
   final List<VsCodeDebugSession> sessions;
@@ -141,8 +146,11 @@ class _DevToolsMenu extends StatelessWidget {
       );
 
       if (disabledReason != null) {
-        text =
-            Tooltip(preferBelow: false, message: disabledReason, child: text);
+        text = Tooltip(
+          preferBelow: false,
+          message: disabledReason,
+          child: text,
+        );
       }
 
       return MenuItemButton(

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -7,7 +7,6 @@ import 'dart:async';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
-import '../../screens/inspector/layout_explorer/ui/theme.dart';
 import '../api/vs_code_api.dart';
 
 class Devices extends StatelessWidget {

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -7,6 +7,7 @@ import 'dart:async';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
+import '../../screens/inspector/layout_explorer/ui/theme.dart';
 import '../api/vs_code_api.dart';
 
 class Devices extends StatelessWidget {
@@ -54,21 +55,28 @@ class Devices extends StatelessWidget {
     VsCodeDevice device, {
     required bool isSelected,
   }) {
-    final backgroundColor = isSelected ? theme.colorScheme.primary : null;
-    final foregroundColor = isSelected ? theme.colorScheme.onPrimary : null;
+    final backgroundColor = isSelected ? theme.colorScheme.secondary : null;
+    final foregroundColor = isSelected
+        ? theme.colorScheme.onSecondary
+        : theme.colorScheme.secondary;
 
     return TableRow(
       decoration: BoxDecoration(color: backgroundColor),
       children: [
         SizedBox(
           width: double.infinity,
-          child: TextButton(
+          child: TextButton.icon(
             style: TextButton.styleFrom(
               alignment: Alignment.centerLeft,
               shape: const ContinuousRectangleBorder(),
               textStyle: theme.regularTextStyle,
             ),
-            child: Text(
+            icon: Icon(
+              device.iconData,
+              size: actionsIconSize,
+              color: foregroundColor,
+            ),
+            label: Text(
               device.name,
               style: theme.regularTextStyle.copyWith(color: foregroundColor),
             ),
@@ -77,5 +85,20 @@ class Devices extends StatelessWidget {
         ),
       ],
     );
+  }
+}
+
+extension on VsCodeDevice {
+  IconData get iconData {
+    return switch ((category, platformType)) {
+      ('desktop', 'macos') => Icons.desktop_mac_outlined,
+      ('desktop', 'windows') => Icons.desktop_windows_outlined,
+      ('desktop', _) => Icons.computer_outlined,
+      ('mobile', 'android') => Icons.phone_android_outlined,
+      ('mobile', 'ios') => Icons.phone_iphone_outlined,
+      ('mobile', _) => Icons.smartphone_outlined,
+      ('web', _) => Icons.web_outlined,
+      _ => Icons.device_unknown_outlined,
+    };
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -19,9 +19,8 @@ import 'devices.dart';
 /// Provides some basic functionality to improve discoverability of features
 /// such as creation of new projects, device selection and DevTools features.
 class VsCodeFlutterPanel extends StatelessWidget {
-  const VsCodeFlutterPanel(this._screens, this.api, {super.key});
+  const VsCodeFlutterPanel(this.api, {super.key});
 
-  final List<Screen> _screens;
   final DartToolingApi api;
 
   @override
@@ -35,7 +34,7 @@ class VsCodeFlutterPanel extends StatelessWidget {
           builder: (context, snapshot) =>
               switch ((snapshot.connectionState, snapshot.data)) {
             (ConnectionState.done, final vsCodeApi?) =>
-              _VsCodeConnectedPanel(_screens, vsCodeApi),
+              _VsCodeConnectedPanel(vsCodeApi),
             (ConnectionState.done, null) =>
               const Text('VS Code is not available'),
             _ => const CenteredCircularProgressIndicator(),
@@ -49,9 +48,8 @@ class VsCodeFlutterPanel extends StatelessWidget {
 /// The panel shown once we know VS Code is available (the host has responded to
 /// the `vsCode.getCapabilities` request).
 class _VsCodeConnectedPanel extends StatefulWidget {
-  const _VsCodeConnectedPanel(this.screens, this.api);
+  const _VsCodeConnectedPanel(this.api);
 
-  final List<Screen> screens;
   final VsCodeApi api;
 
   @override
@@ -78,7 +76,7 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
             stream: widget.api.debugSessionsChanged,
             builder: (context, snapshot) {
               final sessions = snapshot.data?.sessions ?? const [];
-              return DebugSessions(widget.screens, widget.api, sessions);
+              return DebugSessions(widget.api, sessions);
             },
           ),
           const SizedBox(height: defaultSpacing),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -19,8 +19,9 @@ import 'devices.dart';
 /// Provides some basic functionality to improve discoverability of features
 /// such as creation of new projects, device selection and DevTools features.
 class VsCodeFlutterPanel extends StatelessWidget {
-  const VsCodeFlutterPanel(this.api, {super.key});
+  const VsCodeFlutterPanel(this._screens, this.api, {super.key});
 
+  final List<Screen> _screens;
   final DartToolingApi api;
 
   @override
@@ -34,7 +35,7 @@ class VsCodeFlutterPanel extends StatelessWidget {
           builder: (context, snapshot) =>
               switch ((snapshot.connectionState, snapshot.data)) {
             (ConnectionState.done, final vsCodeApi?) =>
-              _VsCodeConnectedPanel(vsCodeApi),
+              _VsCodeConnectedPanel(_screens, vsCodeApi),
             (ConnectionState.done, null) =>
               const Text('VS Code is not available'),
             _ => const CenteredCircularProgressIndicator(),
@@ -48,8 +49,9 @@ class VsCodeFlutterPanel extends StatelessWidget {
 /// The panel shown once we know VS Code is available (the host has responded to
 /// the `vsCode.getCapabilities` request).
 class _VsCodeConnectedPanel extends StatefulWidget {
-  const _VsCodeConnectedPanel(this.api);
+  const _VsCodeConnectedPanel(this.screens, this.api);
 
+  final List<Screen> screens;
   final VsCodeApi api;
 
   @override
@@ -76,7 +78,7 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
             stream: widget.api.debugSessionsChanged,
             builder: (context, snapshot) {
               final sessions = snapshot.data?.sessions ?? const [];
-              return DebugSessions(widget.api, sessions);
+              return DebugSessions(widget.screens, widget.api, sessions);
             },
           ),
           const SizedBox(height: defaultSpacing),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -67,33 +67,39 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
   @override
   Widget build(BuildContext context) {
     return Padding(
-      padding: const EdgeInsets.all(denseSpacing),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          const SizedBox(height: defaultSpacing),
-          StreamBuilder(
-            stream: widget.api.debugSessionsChanged,
-            builder: (context, snapshot) {
-              final sessions = snapshot.data?.sessions ?? const [];
-              return DebugSessions(widget.api, sessions);
-            },
-          ),
-          const SizedBox(height: defaultSpacing),
-          if (widget.api.capabilities.selectDevice)
-            StreamBuilder(
-              stream: widget.api.devicesChanged,
-              builder: (context, snapshot) {
-                final devices = snapshot.data?.devices ?? const [];
-                final selectedDeviceId = snapshot.data?.selectedDeviceId;
-                return Devices(
+      padding: const EdgeInsets.symmetric(
+        horizontal: denseSpacing,
+        vertical: defaultSpacing,
+      ),
+      // Debug sessions rely on devices too, because they look up the sessions
+      // device for some capabilities (for example to know if the session is
+      // running on a web device).
+      child: StreamBuilder(
+        stream: widget.api.devicesChanged,
+        builder: (context, devicesSnapshot) {
+          final devices = devicesSnapshot.data?.devices ?? const [];
+          final deviceMap = {for (final device in devices) device.id: device};
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              StreamBuilder(
+                stream: widget.api.debugSessionsChanged,
+                builder: (context, debugSessionsSnapshot) {
+                  final sessions =
+                      debugSessionsSnapshot.data?.sessions ?? const [];
+                  return DebugSessions(widget.api, sessions, deviceMap);
+                },
+              ),
+              const SizedBox(height: defaultSpacing),
+              if (widget.api.capabilities.selectDevice)
+                Devices(
                   widget.api,
                   devices,
-                  selectedDeviceId: selectedDeviceId,
-                );
-              },
-            ),
-        ],
+                  selectedDeviceId: devicesSnapshot.data?.selectedDeviceId,
+                ),
+            ],
+          );
+        },
       ),
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -87,7 +87,11 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
                 builder: (context, debugSessionsSnapshot) {
                   final sessions =
                       debugSessionsSnapshot.data?.sessions ?? const [];
-                  return DebugSessions(widget.api, sessions, deviceMap);
+                  return DebugSessions(
+                    api: widget.api,
+                    sessions: sessions,
+                    deviceMap: deviceMap,
+                  );
                 },
               ),
               const SizedBox(height: defaultSpacing),

--- a/packages/devtools_app/test/shared/screens_test.dart
+++ b/packages/devtools_app/test/shared/screens_test.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/test/shared/screens_test.dart
+++ b/packages/devtools_app/test/shared/screens_test.dart
@@ -1,0 +1,29 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ScreenMetaData', () {
+    test('values matches order of screens', () async {
+      final enumOrder = ScreenMetaData.values.map((s) => s.id).toList();
+      final screenOrder =
+          defaultScreens().map((screen) => screen.screen.screenId).toList();
+
+      // Remove any items that don't exist in both - we can't verify
+      // the order of those.
+      enumOrder.removeWhereNot(screenOrder.toSet().contains);
+      screenOrder.removeWhereNot(enumOrder.toSet().contains);
+
+      expect(enumOrder, screenOrder);
+    });
+  });
+}
+
+extension _ListExtension<T> on List<T> {
+  void removeWhereNot(bool Function(T) test) {
+    removeWhere((item) => !test(item));
+  }
+}

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
@@ -38,7 +38,10 @@ class VsCodeScene extends Scene {
       home: Scaffold(
         body: VsCodeFlutterPanelMockEditor(
           api: _api,
-          child: VsCodeFlutterPanel(_api),
+          child: VsCodeFlutterPanel(
+            defaultScreens().map((screen) => screen.screen).toList(),
+            _api,
+          ),
         ),
       ),
     );

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
@@ -38,10 +38,7 @@ class VsCodeScene extends Scene {
       home: Scaffold(
         body: VsCodeFlutterPanelMockEditor(
           api: _api,
-          child: VsCodeFlutterPanel(
-            defaultScreens().map((screen) => screen.screen).toList(),
-            _api,
-          ),
+          child: VsCodeFlutterPanel(_api),
         ),
       ),
     );

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code_mock_editor.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code_mock_editor.dart
@@ -131,24 +131,25 @@ class _VsCodeFlutterPanelMockEditorState
                     children: [
                       const Text('Debug Sessions: '),
                       ElevatedButton(
-                        onPressed: () => api.startSession(null),
-                        child: const Text('Start null'),
+                        onPressed: () => api.startSession('debug', 'myMac'),
+                        child: const Text('Desktop debug'),
                       ),
                       ElevatedButton(
-                        onPressed: () => api.startSession('debug'),
-                        child: const Text('Start debug'),
+                        onPressed: () => api.startSession('debug', 'chrome'),
+                        child: const Text('Web debug'),
                       ),
                       ElevatedButton(
-                        onPressed: () => api.startSession('profile'),
-                        child: const Text('Start profile'),
+                        onPressed: () => api.startSession('profile', 'myMac'),
+                        child: const Text('Desktop profile'),
                       ),
                       ElevatedButton(
-                        onPressed: () => api.startSession('release'),
-                        child: const Text('Start release'),
+                        onPressed: () => api.startSession('release', 'myMac'),
+                        child: const Text('Desktop release'),
                       ),
                       ElevatedButton(
-                        onPressed: () => api.startSession('jit_release'),
-                        child: const Text('Start jit_release'),
+                        onPressed: () =>
+                            api.startSession('jit_release', 'myMac'),
+                        child: const Text('Desktop jit_release'),
                       ),
                       ElevatedButton(
                         onPressed: () => api.endSessions(),

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -103,6 +103,16 @@ class MockDartToolingApi extends DartToolingApiImpl {
       platform: 'android-x64',
       platformType: 'android',
     ),
+    VsCodeDeviceImpl(
+      id: 'chrome',
+      name: 'Chrome',
+      category: 'web',
+      emulator: false,
+      emulatorId: null,
+      ephemeral: true,
+      platform: 'web-javascript',
+      platformType: 'web',
+    ),
   ];
 
   /// The current set of devices being presented to the embedded panel.
@@ -159,7 +169,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
   }
 
   /// Simulates starting a debug session.
-  void startSession(String? mode) {
+  void startSession(String mode, String deviceId) {
     final sessionNum = _nextDebugSessionNumber++;
     _debugSessions.add(
       VsCodeDebugSessionImpl(
@@ -167,7 +177,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
         name: 'Session $sessionNum',
         vmServiceUri: 'ws://127.0.0.1:1234/ws',
         flutterMode: mode,
-        flutterDeviceId: 'flutter-tester',
+        flutterDeviceId: deviceId,
         debuggerType: 'Flutter',
       ),
     );


### PR DESCRIPTION
This switches to using the screen metadata for the sidebar menu rather than a hard-coded list. Also has some tidying up suck as detecting web devices and showing tooltips for disabled items on the menu.

https://github.com/flutter/devtools/assets/1078012/b02c6019-0285-47a3-8c1d-895dc7c87f01

