### PR TITLE
Clean up lint violations across packages

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -43,6 +43,7 @@ linter:
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
     - avoid_null_checks_in_equality_operators
     # - avoid_positional_boolean_parameters # not yet tested
+    - avoid_print
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
     - avoid_redundant_argument_values
     - avoid_relative_lib_imports

--- a/packages/devtools_app/analysis_options.yaml
+++ b/packages/devtools_app/analysis_options.yaml
@@ -11,10 +11,6 @@ analyzer:
     # expected.
     - test/test_infra/test_data/syntax_highlighting/**
 
-linter:
-  rules:
-    - avoid_print
-
 dart_code_metrics:
   metrics-exclude:
     - test/**

--- a/packages/devtools_app_shared/analysis_options.yaml
+++ b/packages/devtools_app_shared/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - bin/**
+    - example/**

--- a/packages/devtools_app_shared/lib/src/service/service_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_manager.dart
@@ -127,7 +127,7 @@ class ServiceManager<T extends VmService> {
   }
 
   /// Set the device as busy during the duration of the given async task.
-  Future<T> runDeviceBusyTask<T>(Future<T> task) async {
+  Future<V> runDeviceBusyTask<V>(Future<V> task) async {
     try {
       setDeviceBusy(true);
       return await task;

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   vm_service: ^11.10.0
 
 dev_dependencies:
+  flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
   lints: ^2.0.0

--- a/packages/devtools_extensions/analysis_options.yaml
+++ b/packages/devtools_extensions/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: ../analysis_options.yaml
+
+analyzer:
+  exclude:
+    - bin/**
+    - example/**

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore: avoid_web_libraries_in_flutter, as designed
 import 'dart:async';
+// ignore: avoid_web_libraries_in_flutter, as designed
 import 'dart:html' as html;
 
 import 'package:devtools_app_shared/service.dart';

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore: avoid_web_libraries_in_flutter, as designed
 import 'dart:async';
+// ignore: avoid_web_libraries_in_flutter, as designed
 import 'dart:html' as html;
 
 import 'package:devtools_app_shared/service.dart';

--- a/packages/devtools_extensions/lib/src/template/extension_manager.dart
+++ b/packages/devtools_extensions/lib/src/template/extension_manager.dart
@@ -147,7 +147,7 @@ class ExtensionManager {
   Future<void> _connectToVmService(String? vmServiceUri) async {
     // TODO(kenz): investigate. this is weird but `vmServiceUri` != null even
     // when the `toString()` representation is 'null'.
-    if (vmServiceUri == null || '$vmServiceUri' == 'null') {
+    if (vmServiceUri == null || vmServiceUri == 'null') {
       if (serviceManager.hasConnection) {
         await serviceManager.manuallyDisconnect();
       }

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   vm_service: ^11.10.0
 
 dev_dependencies:
+  flutter_lints: ^2.0.0
   flutter_test:
     sdk: flutter
 

--- a/packages/devtools_shared/lib/src/extensions/extension_enablement.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_enablement.dart
@@ -117,6 +117,7 @@ $_extensionsKey:
   File? _lookupOptionsFile(Uri rootUri) {
     final rootDir = Directory.fromUri(rootUri);
     if (!rootDir.existsSync()) {
+      // ignore: avoid_print
       print('Directory does not exist at path: ${rootUri.toString()}');
       return null;
     }

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// ignore_for_file: avoid_print
+
 import 'dart:io';
 
 import 'package:extension_discovery/extension_discovery.dart';

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: avoid_classes_with_only_static_members
+// ignore_for_file: avoid_classes_with_only_static_members, avoid_print
 
 import 'dart:async';
 import 'dart:convert';

--- a/packages/devtools_shared/lib/src/test/chrome.dart
+++ b/packages/devtools_shared/lib/src/test/chrome.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:io';
 

--- a/packages/devtools_shared/lib/src/test/cli_test_driver.dart
+++ b/packages/devtools_shared/lib/src/test/cli_test_driver.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid_print
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -144,6 +144,7 @@ Future<void> disconnectFromTestApp(WidgetTester tester) async {
 }
 
 void logStatus(String log) {
+  // ignore: avoid_print
   print('TEST STATUS: $log');
 }
 


### PR DESCRIPTION
This PR applies the `avoid_print` lint to the top level analysis options and cleans up a few other lint violations that were triggered after the `analysis_options.yaml` changes in this PR