### PR TITLE
Move screen conditional flags to ScreenMetaData

### DIFF
--- a/packages/devtools_app/lib/src/framework/home_screen.dart
+++ b/packages/devtools_app/lib/src/framework/home_screen.dart
@@ -29,10 +29,8 @@ import 'framework_core.dart';
 
 class HomeScreen extends Screen {
   HomeScreen({this.sampleData = const []})
-      : super.conditional(
-          id: id,
-          requiresConnection: false,
-          icon: ScreenMetaData.home.icon,
+      : super.fromMetaData(
+          ScreenMetaData.home,
           titleGenerator: () => devToolsTitle.value,
         );
 

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
@@ -30,14 +30,7 @@ const initialFractionForTreemap = 0.67;
 const initialFractionForTreeTable = 0.33;
 
 class AppSizeScreen extends Screen {
-  AppSizeScreen()
-      : super.conditional(
-          id: id,
-          requiresConnection: false,
-          requiresDartVm: true,
-          title: ScreenMetaData.appSize.title,
-          icon: ScreenMetaData.appSize.icon,
-        );
+  AppSizeScreen() : super.fromMetaData(ScreenMetaData.appSize);
 
   static const analysisTabKey = Key('Analysis Tab');
   static const diffTabKey = Key('Diff Tab');

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -38,11 +38,8 @@ import 'variables.dart';
 
 class DebuggerScreen extends Screen {
   DebuggerScreen()
-      : super.conditional(
-          id: id,
-          requiresDebugBuild: true,
-          title: ScreenMetaData.debugger.title,
-          icon: ScreenMetaData.debugger.icon,
+      : super.fromMetaData(
+          ScreenMetaData.debugger,
           showFloatingDebuggerControls: false,
         );
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_screen.dart
@@ -7,14 +7,7 @@ import 'package:flutter/material.dart';
 import '../../shared/screen.dart';
 
 class DeepLinksScreen extends Screen {
-  DeepLinksScreen()
-      : super.conditional(
-          id: id,
-          requiresConnection: false,
-          requiresDartVm: true,
-          title: ScreenMetaData.deepLinks.title,
-          icon: ScreenMetaData.deepLinks.icon,
-        );
+  DeepLinksScreen() : super.fromMetaData(ScreenMetaData.deepLinks);
 
   static final id = ScreenMetaData.deepLinks.id;
 

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -28,14 +28,7 @@ import 'inspector_screen_details_tab.dart';
 import 'inspector_tree_controller.dart';
 
 class InspectorScreen extends Screen {
-  InspectorScreen()
-      : super.conditional(
-          id: id,
-          requiresFlutter: true,
-          requiresDebugBuild: true,
-          title: ScreenMetaData.inspector.title,
-          icon: ScreenMetaData.inspector.icon,
-        );
+  InspectorScreen() : super.fromMetaData(ScreenMetaData.inspector);
 
   static final id = ScreenMetaData.inspector.id;
 

--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
@@ -11,13 +11,7 @@ import '../../../shared/screen.dart';
 import 'connected/connected_screen_body.dart';
 
 class MemoryScreen extends Screen {
-  MemoryScreen()
-      : super.conditional(
-          id: id,
-          requiresDartVm: true,
-          title: ScreenMetaData.memory.title,
-          icon: ScreenMetaData.memory.icon,
-        );
+  MemoryScreen() : super.fromMetaData(ScreenMetaData.memory);
 
   static final id = ScreenMetaData.memory.id;
 

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -28,13 +28,7 @@ import 'network_model.dart';
 import 'network_request_inspector.dart';
 
 class NetworkScreen extends Screen {
-  NetworkScreen()
-      : super.conditional(
-          id: id,
-          requiresDartVm: true,
-          title: ScreenMetaData.network.title,
-          icon: ScreenMetaData.network.icon,
-        );
+  NetworkScreen() : super.fromMetaData(ScreenMetaData.network);
 
   static final id = ScreenMetaData.network.id;
 

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -26,13 +26,7 @@ import 'tabbed_performance_view.dart';
 // where applicable.
 
 class PerformanceScreen extends Screen {
-  PerformanceScreen()
-      : super.conditional(
-          id: id,
-          worksOffline: true,
-          title: ScreenMetaData.performance.title,
-          icon: ScreenMetaData.performance.icon,
-        );
+  PerformanceScreen() : super.fromMetaData(ScreenMetaData.performance);
 
   static final id = ScreenMetaData.performance.id;
 

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -23,14 +23,7 @@ import 'profiler_screen_controller.dart';
 import 'profiler_status.dart';
 
 class ProfilerScreen extends Screen {
-  ProfilerScreen()
-      : super.conditional(
-          id: id,
-          requiresDartVm: true,
-          worksOffline: true,
-          title: ScreenMetaData.cpuProfiler.title,
-          icon: ScreenMetaData.cpuProfiler.icon,
-        );
+  ProfilerScreen() : super.fromMetaData(ScreenMetaData.cpuProfiler);
 
   static final id = ScreenMetaData.cpuProfiler.id;
 

--- a/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
+++ b/packages/devtools_app/lib/src/screens/provider/provider_screen.dart
@@ -47,14 +47,7 @@ final _selectedProviderNode = AutoDisposeProvider<ProviderNode?>((ref) {
 final _showInternals = StateProvider<bool>((ref) => false);
 
 class ProviderScreen extends Screen {
-  ProviderScreen()
-      : super.conditional(
-          id: id,
-          requiresLibrary: 'package:provider/',
-          title: ScreenMetaData.provider.title,
-          icon: ScreenMetaData.provider.icon,
-          requiresDebugBuild: true,
-        );
+  ProviderScreen() : super.fromMetaData(ScreenMetaData.provider);
 
   static final id = ScreenMetaData.provider.id;
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -39,13 +39,7 @@ abstract class VMDeveloperView {
 }
 
 class VMDeveloperToolsScreen extends Screen {
-  VMDeveloperToolsScreen()
-      : super.conditional(
-          id: id,
-          title: ScreenMetaData.vmTools.title,
-          icon: ScreenMetaData.vmTools.icon,
-          requiresVmDeveloperMode: true,
-        );
+  VMDeveloperToolsScreen() : super.fromMetaData(ScreenMetaData.vmTools);
 
   static final id = ScreenMetaData.vmTools.id;
 

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -17,31 +17,105 @@ import 'ui/icons.dart';
 final _log = Logger('screen.dart');
 
 enum ScreenMetaData {
-  home('home', icon: Icons.home_rounded),
+  home(
+    'home',
+    icon: Icons.home_rounded,
+    requiresConnection: false,
+  ),
   inspector(
     'inspector',
     title: 'Flutter Inspector',
     icon: Octicons.deviceMobile,
+    requiresFlutter: true,
+    requiresDebugBuild: true,
   ),
-  performance('performance', title: 'Performance', icon: Octicons.pulse),
-  cpuProfiler('cpu-profiler', title: 'CPU Profiler', icon: Octicons.dashboard),
-  memory('memory', title: 'Memory', icon: Octicons.package),
-  debugger('debugger', title: 'Debugger', icon: Octicons.bug),
-  network('network', title: 'Network', icon: Icons.network_check),
+  performance(
+    'performance',
+    title: 'Performance',
+    icon: Octicons.pulse,
+    worksOffline: true,
+  ),
+  cpuProfiler(
+    'cpu-profiler',
+    title: 'CPU Profiler',
+    icon: Octicons.dashboard,
+    requiresDartVm: true,
+    worksOffline: true,
+  ),
+  memory(
+    'memory',
+    title: 'Memory',
+    icon: Octicons.package,
+    requiresDartVm: true,
+  ),
+  debugger(
+    'debugger',
+    title: 'Debugger',
+    icon: Octicons.bug,
+    requiresDebugBuild: true,
+  ),
+  network(
+    'network',
+    title: 'Network',
+    icon: Icons.network_check,
+    requiresDartVm: true,
+  ),
   logging('logging', title: 'Logging', icon: Octicons.clippy),
-  provider('provider', title: 'Provider', icon: Icons.attach_file),
-  appSize('app-size', title: 'App Size', icon: Octicons.fileZip),
-  deepLinks('deep-links', title: 'Deep Links', icon: Icons.link_rounded),
-  vmTools('vm-tools', title: 'VM Tools', icon: Icons.settings_applications),
+  provider(
+    'provider',
+    title: 'Provider',
+    icon: Icons.attach_file,
+    requiresLibrary: 'package:provider/',
+    requiresDebugBuild: true,
+  ),
+  appSize(
+    'app-size',
+    title: 'App Size',
+    icon: Octicons.fileZip,
+    requiresConnection: false,
+    requiresDartVm: true,
+  ),
+  deepLinks(
+    'deep-links',
+    title: 'Deep Links',
+    icon: Icons.link_rounded,
+    requiresConnection: false,
+    requiresDartVm: true,
+  ),
+  vmTools(
+    'vm-tools',
+    title: 'VM Tools',
+    icon: Icons.settings_applications,
+    requiresVmDeveloperMode: true,
+  ),
   simple('simple');
 
-  const ScreenMetaData(this.id, {this.title, this.icon});
+  const ScreenMetaData(
+    this.id, {
+    this.title,
+    this.icon,
+    this.requiresConnection = true,
+    this.requiresDartVm = false,
+    this.requiresFlutter = false,
+    this.requiresDebugBuild = false,
+    this.requiresVmDeveloperMode = false,
+    this.worksOffline = false,
+    this.requiresLibrary,
+  });
 
   final String id;
 
   final String? title;
 
   final IconData? icon;
+
+  final bool requiresConnection;
+  final bool requiresDartVm;
+  final bool requiresFlutter;
+  final bool requiresDebugBuild;
+  final bool requiresVmDeveloperMode;
+  final bool worksOffline;
+  final String? requiresLibrary;
 }
 
 /// Defines a page shown in the DevTools [TabBar].
@@ -93,6 +167,29 @@ abstract class Screen {
           title: title,
           titleGenerator: titleGenerator,
           icon: icon,
+          tabKey: tabKey,
+        );
+
+  Screen.fromMetaData(
+    ScreenMetaData metadata, {
+    bool Function(FlutterVersion? currentVersion)? shouldShowForFlutterVersion,
+    bool showFloatingDebuggerControls = true,
+    String Function()? titleGenerator,
+    Key? tabKey,
+  }) : this.conditional(
+          id: metadata.id,
+          requiresLibrary: metadata.requiresLibrary,
+          requiresConnection: metadata.requiresConnection,
+          requiresDartVm: metadata.requiresDartVm,
+          requiresFlutter: metadata.requiresFlutter,
+          requiresDebugBuild: metadata.requiresDebugBuild,
+          requiresVmDeveloperMode: metadata.requiresVmDeveloperMode,
+          worksOffline: metadata.worksOffline,
+          shouldShowForFlutterVersion: shouldShowForFlutterVersion,
+          showFloatingDebuggerControls: showFloatingDebuggerControls,
+          title: metadata.title,
+          titleGenerator: titleGenerator,
+          icon: metadata.icon,
           tabKey: tabKey,
         );
 


### PR DESCRIPTION
@kenzieschmoll this just moves the flags to `ScreenMetaData` without any other changes.

I wasn't sure how much to move - `shouldShowForFlutterVersion`, `showFloatingDebuggerControls`, `titleGenerator` are still on `Screen`. Let me know if you think they should move too (or if any I did move you think I shouldn't).

