### PR TITLE
Disable DevTools extensions in g3

### DIFF
--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -71,8 +71,8 @@ abstract class FeatureFlags {
 
   /// Flag to enable DevTools extensions.
   ///
-  /// TODO(https://github.com/flutter/devtools/issues/1632): remove this flag
-  /// once the feature lands well.
+  /// TODO(https://github.com/flutter/devtools/issues/6443): remove this flag
+  /// once extension support is added in g3.
   static bool devToolsExtensions = isExternalBuild;
 
   /// Flag to enable debugging via DAP.

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -73,7 +73,7 @@ abstract class FeatureFlags {
   ///
   /// TODO(https://github.com/flutter/devtools/issues/1632): remove this flag
   /// once the feature lands well.
-  static bool devToolsExtensions = true;
+  static bool devToolsExtensions = isExternalBuild;
 
   /// Flag to enable debugging via DAP.
   ///


### PR DESCRIPTION
The assumptions we use externally about the location of the `.dart_tool/package_config.json` file do not apply in g3, so enabling extensions there will take some special configuration around that.