### PR TITLE
Protect service restoration against SentinelException

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -21,6 +21,7 @@ DevTools extension for your pub package, see the getting started guide for
 * Fixed theming bug in isolate selector - [#6403](https://github.com/flutter/devtools/pull/6403)
 * Show the hot reload button for Dart server apps that support hot reload -
 [#6341](https://github.com/flutter/devtools/pull/6341)
+* Fixed exceptions on hot restart - [#6451](https://github.com/flutter/devtools/pull/6451)
 
 ## Inspector updates
 

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -249,10 +249,14 @@ final class ServiceExtensionManager with DisposerMixin {
       // extension. This will restore extension states on the device after a hot
       // restart. [_enabledServiceExtensions] will be empty on page refresh or
       // initial start.
-      return await _callServiceExtension(
-        name,
-        _enabledServiceExtensions[name]!.value,
-      );
+      try {
+        return await _callServiceExtension(
+          name,
+          _enabledServiceExtensions[name]!.value,
+        );
+      } on SentinelException catch (_) {
+        // Service stopped existing while calling, so do nothing.
+      }
     } else {
       // Set any extensions that are already enabled on the device. This will
       // enable extension states in DevTools on page refresh or initial start.

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -255,7 +255,8 @@ final class ServiceExtensionManager with DisposerMixin {
           _enabledServiceExtensions[name]!.value,
         );
       } on SentinelException catch (_) {
-        // Service stopped existing while calling, so do nothing.
+        // Service extension stopped existing while calling, so do nothing.
+        // This typically happens during hot restarts.
       }
     } else {
       // Set any extensions that are already enabled on the device. This will


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGp4enR5aDdodmY5cnllN2U1bWN1bnFpM3ZqZGo3cHN4YjBmMnB5NiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/3ofSBwHeQWYpdpxtPa/giphy.gif)

Fixes https://github.com/flutter/devtools/issues/6449

When spamming hot restart these service refreshes commonly throw SentinelExceptions. Meaning they stopped existing while being called.

This PR handles those expections with a do nothing, since we will need to recall these for the next service to start anyways