### PR TITLE
Fix analytics bug from the migration to GA4

### DIFF
--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -19,6 +19,8 @@
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>
+    // The value of GA_DEVTOOLS_PROPERTY here must match the value of the '?id='
+    // query parameter below in the 'https://www.googletagmanager.com' script.
     const GA_DEVTOOLS_PROPERTY = '384507717'; // Dart DevTools - GA4 Property.
 
     function getDevToolsPropertyID() {

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -26,7 +26,7 @@
     }
   </script>
   <!-- The below URI ?id= must match the GA_DEVTOOLS_PROPERTY above. -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-26406144-34"></script>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=384507717"></script>
   <script src="devtools_analytics.js"></script>
   <!-- End of DevTools Google Analytics -->
 


### PR DESCRIPTION
In https://github.com/flutter/devtools/pull/5939/files#diff-6d53ee2501c4b40ff45a02891ffcab128cd2233706a395f77be8a0edc5ad44fb, we changed from the UA analytics id to the new GA4 id, but we only changed the analytics id in one of two required places.