### PR TITLE
Hide the isolate selector on extension screens

### DIFF
--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -29,11 +29,7 @@ class ExtensionScreen extends Screen {
         );
 
   final DevToolsExtensionConfig extensionConfig;
-
-  @override
-  ValueListenable<bool> get showIsolateSelector =>
-      const FixedValueListenable<bool>(true);
-
+  
   @override
   Widget build(BuildContext context) =>
       _ExtensionScreenBody(extensionConfig: extensionConfig);

--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -5,12 +5,10 @@
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_extensions/api.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
-import '../shared/primitives/listenable.dart';
 import '../shared/primitives/utils.dart';
 import '../shared/screen.dart';
 import 'embedded/controller.dart';

--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -29,7 +29,7 @@ class ExtensionScreen extends Screen {
         );
 
   final DevToolsExtensionConfig extensionConfig;
-  
+
   @override
   Widget build(BuildContext context) =>
       _ExtensionScreenBody(extensionConfig: extensionConfig);


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6399