### PR TITLE
Remove flag for sidebar

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -357,7 +357,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
             ),
           );
         },
-      if (FeatureFlags.vsCodeSidebarTooling) ..._standaloneScreens,
+      ..._standaloneScreens,
     };
   }
 

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -53,11 +53,6 @@ abstract class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/4564.
   static bool widgetRebuildstats = enableExperiments;
 
-  /// Flag to enable VS code sidebar tooling GUIs powered by DevTools.
-  ///
-  /// https://github.com/flutter/devtools/issues/5868.
-  static bool vsCodeSidebarTooling = enableExperiments;
-
   /// Flag to enable analysis of snapshots in disconnected mode.
   ///
   /// https://github.com/flutter/devtools/issues/5606

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -8,7 +8,6 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../../devtools_app.dart';
-import '../../shared/feature_flags.dart';
 import '../api/dart_tooling_api.dart';
 import '../api/vs_code_api.dart';
 import 'debug_sessions.dart';
@@ -25,8 +24,6 @@ class VsCodeFlutterPanel extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    assert(FeatureFlags.vsCodeSidebarTooling);
-
     return Column(
       children: [
         FutureBuilder(

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
@@ -3,7 +3,6 @@
 // in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
-import 'package:devtools_app/src/shared/feature_flags.dart';
 import 'package:devtools_app/src/standalone_ui/vs_code/flutter_panel.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
@@ -58,7 +57,6 @@ class VsCodeScene extends Scene {
 
   @override
   Future<void> setUp() async {
-    FeatureFlags.vsCodeSidebarTooling = true;
     setGlobal(IdeTheme, IdeTheme());
   }
 }


### PR DESCRIPTION
@kenzieschmoll are you happy to remove this now? I did some testing today with a release build in the Dart SDK locally and everything worked fine (once I remembered this flag 😄).

It's still behind a preview flag (and Dart SDK 3.2.0-0 version check) in VS Code, but this flag needs removing (unless we can set it at runtime for a release build?) for it to show up.

(Added release-notes-not-required on the assumption this will initially only be a preview and not in the main release notes, but let me know if that's not the case)

Fixes https://github.com/flutter/devtools/issues/5868