### PR TITLE
Use Google Tag id for analytics setup instead of GA4 property id

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -19,10 +19,10 @@ import '../../../devtools.dart' as devtools show version;
 import '../config_specific/server/server.dart' as server;
 import '../globals.dart';
 import '../primitives/url_utils.dart';
-import '../ui/gtags.dart';
 import '../utils.dart';
 import 'analytics_common.dart';
 import 'constants.dart' as gac;
+import 'gtags.dart';
 import 'metrics.dart';
 
 // Dimensions1 AppType values:

--- a/packages/devtools_app/lib/src/shared/analytics/gtags.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/gtags.dart
@@ -10,16 +10,11 @@ library gtags;
 import 'package:flutter/foundation.dart';
 import 'package:js/js.dart';
 
-import '../analytics/analytics.dart' as ga;
+import '../../shared/development_helpers.dart';
+import 'analytics.dart' as ga;
 
 /// For gtags API see https://developers.google.com/gtagjs/reference/api
 /// For debugging install the Chrome Plugin "Google Analytics Debugger".
-
-/// Enable this flag to debug analytics when DevTools is run in debug or profile
-/// mode, otherwise analytics will only be sent in release builds.
-///
-/// `ga.isAnalyticsEnabled()` still must return true for analytics to be sent.
-bool _debugAnalytics = false;
 
 @JS('gtag')
 external void _gTagCommandName(String command, String name, [Object? params]);
@@ -35,7 +30,7 @@ class GTag {
     String eventName, {
     required GtagEvent Function() gaEventProvider,
   }) async {
-    if (_debugAnalytics || (kReleaseMode && await ga.isAnalyticsEnabled())) {
+    if (debugAnalytics || (kReleaseMode && await ga.isAnalyticsEnabled())) {
       _gTagCommandName(_event, eventName, gaEventProvider());
     }
   }
@@ -43,7 +38,7 @@ class GTag {
   static void exception({
     required GtagException Function() gaExceptionProvider,
   }) async {
-    if (_debugAnalytics || (kReleaseMode && await ga.isAnalyticsEnabled())) {
+    if (debugAnalytics || (kReleaseMode && await ga.isAnalyticsEnabled())) {
       _gTagCommandName(_event, _exception, gaExceptionProvider());
     }
   }

--- a/packages/devtools_app/lib/src/shared/development_helpers.dart
+++ b/packages/devtools_app/lib/src/shared/development_helpers.dart
@@ -7,6 +7,12 @@ import 'package:meta/meta.dart';
 
 import 'globals.dart';
 
+/// Enable this flag to debug analytics when DevTools is run in debug or profile
+/// mode, otherwise analytics will only be sent in release builds.
+///
+/// `ga.isAnalyticsEnabled()` still must return true for analytics to be sent.
+bool debugAnalytics = true;
+
 /// Whether to build DevTools for conveniently debugging DevTools extensions.
 ///
 /// Turning this flag to [true] allows for debugging the extensions framework

--- a/packages/devtools_app/web/devtools_analytics.js
+++ b/packages/devtools_app/web/devtools_analytics.js
@@ -16,7 +16,7 @@ function gtag() {
 function initializeGA() {
   gtag('js', new Date());
   gtag('event', 'config', {
-    'send_to': GA_DEVTOOLS_PROPERTY,
+    'send_to': DEVTOOLS_GOOGLE_TAG_ID,
     'custom_map': {
       // Custom dimensions:
       'dimension1': 'user_app',
@@ -31,7 +31,7 @@ function initializeGA() {
       'dimension10': 'is_embedded',
       'dimension11': 'g3_username',
       'dimension12': 'ide_launched_feature',
-       // Custom metrics:
+      // Custom metrics:
       'metric1': 'ui_duration_micros',
       'metric2': 'raster_duration_micros',
       'metric3': 'shader_compilation_duration_micros',

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -19,16 +19,18 @@
 
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script>
-    // The value of GA_DEVTOOLS_PROPERTY here must match the value of the '?id='
+    // The value of DEVTOOLS_GOOGLE_TAG_ID here must match the value of the '?id='
     // query parameter below in the 'https://www.googletagmanager.com' script.
-    const GA_DEVTOOLS_PROPERTY = '384507717'; // Dart DevTools - GA4 Property.
+    // This is the value of the "Dart DevTools - GA4" Google Tag, which is linked
+    // to the DevTools GA4 analytics property.
+    const DEVTOOLS_GOOGLE_TAG_ID = 'G-69MPZE94D5'; // 
 
     function getDevToolsPropertyID() {
-      return GA_DEVTOOLS_PROPERTY;
+      return DEVTOOLS_GOOGLE_TAG_ID;
     }
   </script>
-  <!-- The below URI ?id= must match the GA_DEVTOOLS_PROPERTY above. -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=384507717"></script>
+  <!-- The below URI ?id= must match the DEVTOOLS_GOOGLE_TAG_ID above. -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-69MPZE94D5"></script>
   <script src="devtools_analytics.js"></script>
   <!-- End of DevTools Google Analytics -->
 


### PR DESCRIPTION
Fixes missing analytics events issues with the GA4 setup. The id needs to be that of the Google Tag, which is linked to the GA4 property.