### PR TITLE
Add pub ignore comment to devtools extensions readme

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
   devtools_app_shared: ^0.0.4
-  devtools_extensions: ^0.0.5
+  devtools_extensions: ^0.0.7
   devtools_shared: ^4.0.1
   file: ^6.0.0
   file_selector: ^0.8.0

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.0.7-wip
+## 0.0.7
 * Add integration testing.
 * Add `ExtensionManager.unregisterEventHandler` method.
+* Update README.md to include `.pubignore` recommendation.
 
 ## 0.0.6
 * Bump `package:devtools_app_shared` dependency to version ^0.0.4.

--- a/packages/devtools_extensions/README.md
+++ b/packages/devtools_extensions/README.md
@@ -86,7 +86,7 @@ flutter create --template app --platforms web foo_package_devtools_extension
 
 In `foo_package_devtools_extension/pubspec.yaml`, add a dependency on `devtools_extensions`:
 ```yaml
-devtools_extensions: ^0.0.5
+devtools_extensions: ^0.0.7
 ```
 
 In `lib/main.dart`, place a `DevToolsExtension` widget at the root of your app:
@@ -210,14 +210,25 @@ dart run devtools_extensions build_and_copy \
   --dest=path/to/your_pub_package/extension/devtools 
 ```
 
+Then publish your package.
+
 ### What if I don't want the `extension/devtools/build/` contents checked into source control?
 
 As a package author, the content that you check into your git repository is completely up to you.
 If you want the contents of `extension/devtools/build/` to be git ignored, then you'll just need
 to ensure that the extension web app is always built and included in `extension/devtools/build/`
-when you publish your package.
+when you publish your package. To do so, add the following to a `.pubignore` file at the root
+of your pub package:
 
-Consider adding a tool script to your repo that looks something like this:
+```
+!./extension/devtools/build
+```
+
+This will ensure that, even if the `extension/devtools/build` directory has been been git
+ignored, the directory will still be included when publishing the package on pub.
+
+To verify the published extension contents are always up to date, consider adding a tool
+script to your repo that looks something like this:
 
 **publish.sh**
 ```sh

--- a/packages/devtools_extensions/example/foo/packages/foo/.pubignore
+++ b/packages/devtools_extensions/example/foo/packages/foo/.pubignore
@@ -1,0 +1,1 @@
+!./extension/devtools/build

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.0.7-wip
+version: 0.0.7
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 


### PR DESCRIPTION
Adding this based on a recommendation from @rrousselGit [here](https://github.com/rrousselGit/provider/pull/832#issuecomment-1732675281). Addressed for `package:provider` in https://github.com/rrousselGit/provider/commit/25a7e18b5316113344d3aa2be82485fa41d50ef1.

FYI @jonasf - do you see any issues with this recommended use of the `.pubignore` file?