### PR TITLE
Improve error running devtools_tool from a different folder

### DIFF
--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -27,7 +27,7 @@ class AnalyzeCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.requireInstance();
+    final repo = DevToolsRepo.getInstance();
     final packages = repo.getPackages();
 
     log.stdout('Running flutter analyze...');

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -27,7 +27,7 @@ class AnalyzeCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.requireInstance();
     final packages = repo.getPackages();
 
     log.stdout('Running flutter analyze...');

--- a/tool/lib/commands/list.dart
+++ b/tool/lib/commands/list.dart
@@ -17,7 +17,7 @@ class ListCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.requireInstance();
+    final repo = DevToolsRepo.getInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final packages = repo.getPackages();

--- a/tool/lib/commands/list.dart
+++ b/tool/lib/commands/list.dart
@@ -17,7 +17,7 @@ class ListCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.requireInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final packages = repo.getPackages();

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -42,7 +42,7 @@ class PubGetCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.requireInstance();
     final packages = repo.getPackages();
 
     final upgrade = argResults![_upgradeFlag];

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -42,7 +42,7 @@ class PubGetCommand extends Command {
     }
 
     final log = Logger.standard();
-    final repo = DevToolsRepo.requireInstance();
+    final repo = DevToolsRepo.getInstance();
     final packages = repo.getPackages();
 
     final upgrade = argResults![_upgradeFlag];

--- a/tool/lib/commands/repo_check.dart
+++ b/tool/lib/commands/repo_check.dart
@@ -17,7 +17,7 @@ class RepoCheckCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.requireInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final checks = <Check>[

--- a/tool/lib/commands/repo_check.dart
+++ b/tool/lib/commands/repo_check.dart
@@ -17,7 +17,7 @@ class RepoCheckCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.requireInstance();
+    final repo = DevToolsRepo.getInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final checks = <Check>[

--- a/tool/lib/commands/rollback.dart
+++ b/tool/lib/commands/rollback.dart
@@ -22,7 +22,7 @@ class RollbackCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.requireInstance();
+    final repo = DevToolsRepo.getInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final tempDir =

--- a/tool/lib/commands/rollback.dart
+++ b/tool/lib/commands/rollback.dart
@@ -22,7 +22,7 @@ class RollbackCommand extends Command {
 
   @override
   Future run() async {
-    final repo = DevToolsRepo.getInstance()!;
+    final repo = DevToolsRepo.requireInstance();
     print('DevTools repo at ${repo.repoPath}.');
 
     final tempDir =

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -17,22 +17,15 @@ class DevToolsRepo {
   /// This returns the DevToolsRepo instance based on the current working
   /// directory.
   ///
-  /// This will return null if the current working directory is not
-  /// contained within a git checkout of DevTools. Use [requireInstance] for a
-  /// descriptive exception in this case.
-  static DevToolsRepo? getInstance() {
-    final repoPath = _findRepoRoot(Directory.current);
-    return repoPath == null ? null : DevToolsRepo._create(repoPath);
-  }
-
-  /// This returns the DevToolsRepo instance based on the current working
-  /// directory.
-  ///
   /// Throws if the current working directory is not contained within a git
   /// checkout of DevTools.
-  static DevToolsRepo requireInstance() {
-    return getInstance() ??
-        (throw Exception('devtools_tool must be run from inside of the DevTools repository directory'));
+  static DevToolsRepo getInstance() {
+    final repoPath = _findRepoRoot(Directory.current);
+    if (repoPath == null) {
+      throw Exception(
+          'devtools_tool must be run from inside of the DevTools repository directory');
+    }
+    return DevToolsRepo._create(repoPath);
   }
 
   List<Package> getPackages() {

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -17,11 +17,22 @@ class DevToolsRepo {
   /// This returns the DevToolsRepo instance based on the current working
   /// directory.
   ///
-  /// This can fail and return null if the current working directory is not
-  /// contained within a git checkout of DevTools.
+  /// This will return null if the current working directory is not
+  /// contained within a git checkout of DevTools. Use [requireInstance] for a
+  /// descriptive exception in this case.
   static DevToolsRepo? getInstance() {
     final repoPath = _findRepoRoot(Directory.current);
     return repoPath == null ? null : DevToolsRepo._create(repoPath);
+  }
+
+  /// This returns the DevToolsRepo instance based on the current working
+  /// directory.
+  ///
+  /// Throws if the current working directory is not contained within a git
+  /// checkout of DevTools.
+  static DevToolsRepo requireInstance() {
+    return getInstance() ??
+        (throw Exception('devtools_tool must be run from a DevTools checkout'));
   }
 
   List<Package> getPackages() {

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -23,7 +23,8 @@ class DevToolsRepo {
     final repoPath = _findRepoRoot(Directory.current);
     if (repoPath == null) {
       throw Exception(
-          'devtools_tool must be run from inside of the DevTools repository directory');
+        'devtools_tool must be run from inside of the DevTools repository directory',
+      );
     }
     return DevToolsRepo._create(repoPath);
   }

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -32,7 +32,7 @@ class DevToolsRepo {
   /// checkout of DevTools.
   static DevToolsRepo requireInstance() {
     return getInstance() ??
-        (throw Exception('devtools_tool must be run from a DevTools checkout'));
+        (throw Exception('devtools_tool must be run from inside of the DevTools repository directory'));
   }
 
   List<Package> getPackages() {

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -135,5 +135,5 @@ extension DevToolsProcessManagerExtension on ProcessManager {
 }
 
 String pathFromRepoRoot(String pathFromRoot) {
-  return path.join(DevToolsRepo.getInstance()!.repoPath, pathFromRoot);
+  return path.join(DevToolsRepo.requireInstance().repoPath, pathFromRoot);
 }

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -135,5 +135,5 @@ extension DevToolsProcessManagerExtension on ProcessManager {
 }
 
 String pathFromRepoRoot(String pathFromRoot) {
-  return path.join(DevToolsRepo.requireInstance().repoPath, pathFromRoot);
+  return path.join(DevToolsRepo.getInstance().repoPath, pathFromRoot);
 }


### PR DESCRIPTION
This improves the error if you run the tool from the wrong folder:

![Screenshot 2023-09-28 110627](https://github.com/flutter/devtools/assets/1078012/ddf30ca6-b4da-4467-bbf8-5e7c6d22240d)

This doesn't apply to the new shell scripts since they change the directory, but invoking it manually (or using `flutter pub global run`) from the wrong folder previously gave an unhelp message.

I don't know if there's much value in `getInstance()` now (every location that called it was using `!` and now calls `requireInstance()`), so we could also just update `getInstance()` to be non-nullable and throw instead. The exception is handled by the command runner and then printed.