### PR TITLE
Tweak Windows instructions to mirror macOS

### DIFF
--- a/tool/RELEASE_INSTRUCTIONS.md
+++ b/tool/RELEASE_INSTRUCTIONS.md
@@ -28,22 +28,20 @@ Make sure:
 
 > If you need to install the [Github CLI](https://cli.github.com/manual/installation) you can run: `brew install gh`
 
-- Ensure that you have access to `devtools_tool`
-  - For MacOS Users
-    - Ensure the `devtools_tool` executable is in your path:
-      - add the following to your `~/.bashrc` file.
-        - `export PATH=$PATH:<DEVTOOLS_DIR>/tool/bin`
-          > [!NOTE]  
-          > Replace `<DEVTOOLS_DIR>` with the local path to your DevTools
-          > repo path.
-  - For Windows Users
-    - Ensure the `devtools_tool` executable has been globally activated:
-      - `flutter pub global activate --source path tool`
-        > [!WARNING]  
-        > Always do this activation step before running
-        > `devtools_tool`. If there have been changes to the tool since the
-        > last time you have run the activate, then it needs to be rerun to
-        > pick up those changes.
+- Ensure that you have access to `devtools_tool` by adding the `tool/bin` folder to your `PATH` environment variable
+  - **MacOS Users**
+    - add the following to your `~/.bashrc` file.
+    - `export PATH=$PATH:<DEVTOOLS_DIR>/tool/bin`
+      > [!NOTE]  
+      > Replace `<DEVTOOLS_DIR>` with the local path to your DevTools
+      > repo path.
+  - **Windows Users**
+    - Open "Edit environment variables for your account" from Control Panel
+    - Locate the `Path` variable and click **Edit**
+    - Click the **New** button and paste in `<DEVTOOLS_DIR>/tool/bin`
+      > [!NOTE]  
+      > Replace `<DEVTOOLS_DIR>` with the local path to your DevTools
+      > repo path.
 
 - Run: `devtools_tool release-helper`
 - This will create a PR for you using the tip of master.

--- a/tool/bin/devtools_tool.bat
+++ b/tool/bin/devtools_tool.bat
@@ -1,3 +1,12 @@
 pushd "%~dp0"
 dart run ./devtools_tool.dart %*
+
+IF %errorlevel% NEQ 0 GOTO :error
+
 popd
+EXIT /B 0
+
+:error
+popd
+EXIT /B %errorlevel%
+

--- a/tool/bin/devtools_tool.bat
+++ b/tool/bin/devtools_tool.bat
@@ -1,0 +1,3 @@
+pushd "%~dp0"
+dart run ./devtools_tool.dart %*
+popd

--- a/tool/bin/devtools_tool.bat
+++ b/tool/bin/devtools_tool.bat
@@ -1,3 +1,5 @@
+@echo off
+
 pushd "%~dp0"
 dart run ./devtools_tool.dart %*
 

--- a/tool/lib/commands/list.dart
+++ b/tool/lib/commands/list.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 
 import 'package:args/command_runner.dart';
+import 'package:path/path.dart' as path;
 
 import '../model.dart';
 
@@ -25,7 +26,7 @@ class ListCommand extends Command {
     print('\n${packages.length} packages:');
 
     for (Package p in packages) {
-      print('  ${p.relativePath}/');
+      print('  ${p.relativePath}${path.separator}');
     }
   }
 }


### PR DESCRIPTION
@CoderDake @kenzieschmoll this tweaks the Windows setup to be the same as the macOS version:

https://github.com/CoderDake/devtools/assets/1078012/82ae3cc2-4dc7-4a0e-80ae-d8c526d46809

Error codes are also propagated as expected:

![Screenshot 2023-09-28 145600](https://github.com/CoderDake/devtools/assets/1078012/7c5b15a8-1a78-47c2-919d-077edf9432e1)

![Screenshot 2023-09-28 145730](https://github.com/CoderDake/devtools/assets/1078012/5041b50e-98f4-4c8f-8371-41311c32c590)
