### PR TITLE
Bump devtools_shared vm_service dep to 12.0.0

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   dds_service_extensions: ^1.6.0
   devtools_app_shared: ^0.0.5
   devtools_extensions: ^0.0.8
-  devtools_shared: ^4.0.1
+  devtools_shared: ^4.1.0
   file: ^6.0.0
   file_selector: ^0.8.0
   file_selector_linux: ^0.0.2

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  devtools_shared: ^4.0.1
+  devtools_shared: ^4.1.0
   flutter:
     sdk: flutter
   logging: ^1.1.1

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -13,7 +13,7 @@ executables:
 
 dependencies:
   args: ^2.4.2
-  devtools_shared: ^4.0.1
+  devtools_shared: ^4.1.0
   devtools_app_shared: ^0.0.5
   flutter:
     sdk: flutter

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,10 +1,7 @@
-# 4.2.0
-
+# 4.1.0
+- Bump `package:vm_service` to ^12.0.0.
 - Adds `DeeplinkApi.androidAppLinkSettings`, `DeeplinkApi.iosBuildOptions`, and
   `DeeplinkApi.iosUniversalLinkSettings` endpoints to ServerApi.
-
-# 4.1.0
-
 - Add shared integration test utilities to `package:devtools_shared`. These test
 utilities are exported as part of the existing `devtools_test_utils.dart` library.
 

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 4.2.0
+version: 4.1.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
@@ -16,7 +16,7 @@ dependencies:
   shelf: ^1.1.0
   sse: ^4.1.2
   usage: ^4.0.0
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
   web_socket_channel: ^2.4.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"
   yaml: ^3.1.2

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -18,7 +18,7 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: ^4.0.1
+  devtools_shared: ^4.1.0
   devtools_app: 2.28.1
   devtools_app_shared:
     path: ../devtools_app_shared


### PR DESCRIPTION
devtools_shared 4.1.0  has not been published yet, so I am merging some of the recent commits into this version number.