### PR TITLE
Disable broken integration test `eval_and_browse_test.dart`

### DIFF
--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -18,7 +18,7 @@ const _testDirectory = 'integration_test/test';
 const _offlineIndicator = 'integration_test/test/offline';
 
 /// The set of test that should be skipped for all devices.
-/// 
+///
 /// This list should be empty most of the time, but may contain a broken test
 /// while a fix being worked on.
 const _skipTests = <String>[

--- a/packages/devtools_app/integration_test/run_tests.dart
+++ b/packages/devtools_app/integration_test/run_tests.dart
@@ -17,6 +17,15 @@ import 'test_infra/run/run_test.dart';
 const _testDirectory = 'integration_test/test';
 const _offlineIndicator = 'integration_test/test/offline';
 
+/// The set of test that should be skipped for all devices.
+/// 
+/// This list should be empty most of the time, but may contain a broken test
+/// while a fix being worked on.
+const _skipTests = <String>[
+  // TODO(https://github.com/flutter/devtools/issues/6541): re-enable once fixed.
+  'eval_and_browse_test.dart',
+];
+
 void main(List<String> args) async {
   final testRunnerArgs = DevToolsAppTestRunnerArgs(
     args,
@@ -38,6 +47,10 @@ Future<void> _runTest(
   DevToolsAppTestRunnerArgs testRunnerArgs,
 ) async {
   final testTarget = testRunnerArgs.testTarget!;
+
+  final shouldSkip = _skipTests.any((t) => testTarget.endsWith(t));
+  if (shouldSkip) return;
+
   if (!testRunnerArgs.testAppDevice.supportsTest(testTarget)) {
     // Skip test, since it is not supported for device.
     return;


### PR DESCRIPTION
Tracking issue for broken test https://github.com/flutter/devtools/issues/6541