### PR TITLE
Bump vm_service to 12.0.0

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -63,7 +63,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^6.1.0
   url_launcher_web: ^2.0.6
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
   # TODO https://github.com/dart-lang/sdk/issues/52853 - unpin this version
   vm_snapshot_analysis: 0.7.2
   web_socket_channel: ^2.1.0

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   logging: ^1.1.1
   meta: ^1.9.1
   pointer_interceptor: ^0.9.3+3
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
 
 dev_dependencies:
   flutter_lints: ^2.0.3

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   io: ^1.0.4
   path: ^1.8.0
   logging: ^1.1.1
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
 
 dev_dependencies:
   flutter_driver:

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   shelf: ^1.1.0
   sse: ^4.1.2
   usage: ^4.0.0
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
   web_socket_channel: ^2.4.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"
   yaml: ^3.1.2

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   mockito: ^5.4.1
   path: ^1.8.0
   provider: ^6.0.2
-  vm_service: ^11.10.0
+  vm_service: ^12.0.0
   vm_snapshot_analysis: ^0.7.1
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 


### PR DESCRIPTION
Unblock https://github.com/flutter/flutter/pull/136734

Currently failing with:

```
| /b/s/w/ir/x/t/flutter_customer_testing.flutter_devtools.OQIHKF/tests/packages/devtools_test /b/s/w/ir/x/t/flutter_customer_testing.flutter_devtools.OQIHKF/tests
| Resolving dependencies...
| Note: vm_service is pinned to version 12.0.0 by integration_test from the flutter SDK.
| See https://dart.dev/go/sdk-version-pinning for details.
|
|
| Because every version of integration_test from sdk depends on vm_service 12.0.0 and devtools_test depends on vm_service ^11.10.0, integration_test from sdk is forbidden.
| So, because devtools_test depends on integration_test from sdk, version solving failed.
ERROR: Setup command failed: ./tool/refresh.sh >> output.txt
```