### PR TITLE
Add a benchmark test for the DevTools web bundle size

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,7 @@ jobs:
           - build_dart2js
           - test_ddc
           - test_dart2js
+          - benchmarks_dart2js
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -82,8 +82,9 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   mockito: ^5.4.1
-  webkit_inspection_protocol: ">=0.5.0 <2.0.0"
   stager: ^1.0.1
+  test: ^1.21.1
+  webkit_inspection_protocol: ">=0.5.0 <2.0.0"
 
 flutter:
   uses-material-design: true

--- a/packages/devtools_app/test_benchmarks/README.md
+++ b/packages/devtools_app/test_benchmarks/README.md
@@ -1,0 +1,12 @@
+# DevTools benchmark tests
+
+## Running a benchmark test locally
+
+To run a benchmark test locally, run:
+```sh
+dart run test_benchmarks/<test_name.dart>
+```
+
+## Running a benchmark test on the CI
+
+The benchmark tests are run automatically on the CI. See the "benchmarks_dart2js" job.

--- a/packages/devtools_app/test_benchmarks/web_bundle_size_test.dart
+++ b/packages/devtools_app/test_benchmarks/web_bundle_size_test.dart
@@ -1,0 +1,94 @@
+// Copyright 2023 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Note: this test was modeled after the example test from Flutter Gallery:
+// https://github.com/flutter/gallery/blob/master/test_benchmarks/web_bundle_size_test.dart
+
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+
+// Benchmark size in kB.
+const int bundleSizeBenchmark = 4800;
+const int gzipBundleSizeBenchmark = 1400;
+
+void main() {
+  group('Web Compile', () {
+    test(
+      'bundle size',
+      () async {
+        final js = path.join(
+          Directory.current.path,
+          'build',
+          'web',
+          'main.dart.js',
+        );
+
+        _logStatus('Building DevTools web app in release mode...');
+        // These build arguments match the arguments used in the
+        // tool/build_release.sh script, which is how we build DevTools for
+        // release.
+        await _runProcess('flutter', [
+          'build',
+          'web',
+          '--web-renderer',
+          'canvaskit',
+          '--pwa-strategy=offline-first',
+          '--release',
+          '--no-tree-shake-icons',
+        ]);
+
+        _logStatus('Zipping bundle with gzip...');
+        await _runProcess('gzip', ['-k', '-f', js]);
+
+        final bundleSize = await _measureSize(js);
+        final gzipBundleSize = await _measureSize('$js.gz');
+        if (bundleSize > bundleSizeBenchmark) {
+          fail(
+            'The size the compiled web build "$js" was $bundleSize kB. This is '
+            'larger than the benchmark that was set at $bundleSizeBenchmark kB.'
+            '\n\n'
+            'The build size should be as minimal as possible to reduce the web '
+            'app\'s initial startup time. If this change is intentional, and'
+            ' expected, please increase the constant "bundleSizeBenchmark".',
+          );
+        } else if (gzipBundleSize > gzipBundleSizeBenchmark) {
+          fail(
+            'The size the compiled and gzipped web build "$js" was'
+            ' $gzipBundleSize kB. This is larger than the benchmark that was '
+            'set at $gzipBundleSizeBenchmark kB.\n\n'
+            'The build size should be as minimal as possible to reduce the '
+            'web app\'s initial startup time. If this change is intentional, '
+            'and expected, please increase the constant '
+            '"gzipBundleSizeBenchmark".',
+          );
+        }
+      },
+      timeout: const Timeout(Duration(minutes: 5)),
+    );
+  });
+}
+
+Future<int> _measureSize(String file) async {
+  final result = await _runProcess('du', ['-k', file]);
+  return int.parse(
+    (result.stdout as String).split(RegExp(r'\s+')).first.trim(),
+  );
+}
+
+Future<ProcessResult> _runProcess(
+  String executable,
+  List<String> arguments,
+) async {
+  final result = await Process.run(executable, arguments);
+  stdout.write(result.stdout);
+  stderr.write(result.stderr);
+  return result;
+}
+
+void _logStatus(String log) {
+  // ignore: avoid_print, expected log output.
+  print(log);
+}

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -182,6 +182,11 @@ elif [ "$BOT" = "integration_dart2js" ]; then
         dart run integration_test/run_tests.dart --headless
         popd
     fi
+
+elif [ "$BOT" = "benchmarks_dart2js" ]; then
+
+    dart run test_benchmarks/web_bundle_size_test.dart
+
 fi
 
 popd


### PR DESCRIPTION
This is modeled after the web bundle size test in flutter gallery: https://github.com/flutter/gallery/blob/master/test_benchmarks/web_bundle_size_test.dart

At this time the bundle sizes for DevTools are:
```
main.dart.js: 4556 kb 
main.dart.js.gz: 1352 kb
```

Work towards https://github.com/flutter/devtools/issues/6552