### PR TITLE
Run integration tests on ubuntu-latest

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -111,7 +111,7 @@ jobs:
   devtools-app-integration-test:
     name: devtools_app integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}
     needs: flutter-prep
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,6 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   flutter-prep:
-    with:
-      os-name: ubuntu
     uses: ./.github/workflows/flutter-prep.yaml
 
   main:
@@ -69,46 +67,46 @@ jobs:
           PLATFORM: vm
         run: ./tool/bots.sh
 
-  # macos-test:
-  #   needs: flutter-prep
-  #   name: macos goldens ${{ matrix.bot }}
-  #   runs-on: macos-latest
-  #   strategy:
-  #     fail-fast: false
-  #     matrix:
-  #       bot:
-  #         - test_dart2js
-  #       only_golden:
-  #         - true
+  macos-test:
+    needs: flutter-prep
+    name: macos goldens ${{ matrix.bot }}
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bot:
+          - test_dart2js
+        only_golden:
+          - true
 
-  #   steps:
-  #     - name: git clone
-  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-  #     - name: Load Cached Flutter SDK
-  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-  #       with:
-  #         path: |
-  #           ./flutter-sdk
-  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-  #     - name: tool/bots.sh
-  #       env:
-  #         BOT: ${{ matrix.bot }}
-  #         PLATFORM: vm
-  #         ONLY_GOLDEN: ${{ matrix.only_golden }}
-  #       run: ./tool/bots.sh
+    steps:
+      - name: git clone
+        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+      - name: Load Cached Flutter SDK
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ./flutter-sdk
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+      - name: tool/bots.sh
+        env:
+          BOT: ${{ matrix.bot }}
+          PLATFORM: vm
+          ONLY_GOLDEN: ${{ matrix.only_golden }}
+        run: ./tool/bots.sh
 
-  #     - name: Upload Golden Failure Artifacts
-  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-  #       if: failure()
-  #       with:
-  #         name: golden_image_failures.${{ matrix.bot }}
-  #         path: packages/devtools_app/test/**/failures/*.png
-  #     - name: Notify of Quick Fix
-  #       if: failure()
-  #       env:
-  #         WORKFLOW_ID: ${{ github.run_id }}
-  #       run: |
-  #         echo "::notice title=To Quickly Fix Goldens:: Run \`devtools_tool fix-goldens --run-id=$WORKFLOW_ID\` on your local branch."
+      - name: Upload Golden Failure Artifacts
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+        if: failure()
+        with:
+          name: golden_image_failures.${{ matrix.bot }}
+          path: packages/devtools_app/test/**/failures/*.png
+      - name: Notify of Quick Fix
+        if: failure()
+        env:
+          WORKFLOW_ID: ${{ github.run_id }}
+        run: |
+          echo "::notice title=To Quickly Fix Goldens:: Run \`devtools_tool fix-goldens --run-id=$WORKFLOW_ID\` on your local branch."
 
   devtools-app-integration-test:
     name: devtools_app integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ env:
 jobs:
   flutter-prep:
     uses: ./.github/workflows/flutter-prep.yaml
+    os-name: ubuntu
 
   main:
     name: main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,8 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   flutter-prep:
-    os-name: "ubuntu"
+    with:
+      os-name: ubuntu
     uses: ./.github/workflows/flutter-prep.yaml
 
   main:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,8 +17,8 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
   flutter-prep:
+    os-name: "ubuntu"
     uses: ./.github/workflows/flutter-prep.yaml
-    os-name: ubuntu
 
   main:
     name: main

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,46 +67,46 @@ jobs:
           PLATFORM: vm
         run: ./tool/bots.sh
 
-  macos-test:
-    needs: flutter-prep
-    name: macos goldens ${{ matrix.bot }}
-    runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bot:
-          - test_dart2js
-        only_golden:
-          - true
+  # macos-test:
+  #   needs: flutter-prep
+  #   name: macos goldens ${{ matrix.bot }}
+  #   runs-on: macos-latest
+  #   strategy:
+  #     fail-fast: false
+  #     matrix:
+  #       bot:
+  #         - test_dart2js
+  #       only_golden:
+  #         - true
 
-    steps:
-      - name: git clone
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
-      - name: Load Cached Flutter SDK
-        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
-        with:
-          path: |
-            ./flutter-sdk
-          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
-      - name: tool/bots.sh
-        env:
-          BOT: ${{ matrix.bot }}
-          PLATFORM: vm
-          ONLY_GOLDEN: ${{ matrix.only_golden }}
-        run: ./tool/bots.sh
+  #   steps:
+  #     - name: git clone
+  #       uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
+  #     - name: Load Cached Flutter SDK
+  #       uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+  #       with:
+  #         path: |
+  #           ./flutter-sdk
+  #         key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
+  #     - name: tool/bots.sh
+  #       env:
+  #         BOT: ${{ matrix.bot }}
+  #         PLATFORM: vm
+  #         ONLY_GOLDEN: ${{ matrix.only_golden }}
+  #       run: ./tool/bots.sh
 
-      - name: Upload Golden Failure Artifacts
-        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
-        if: failure()
-        with:
-          name: golden_image_failures.${{ matrix.bot }}
-          path: packages/devtools_app/test/**/failures/*.png
-      - name: Notify of Quick Fix
-        if: failure()
-        env:
-          WORKFLOW_ID: ${{ github.run_id }}
-        run: |
-          echo "::notice title=To Quickly Fix Goldens:: Run \`devtools_tool fix-goldens --run-id=$WORKFLOW_ID\` on your local branch."
+  #     - name: Upload Golden Failure Artifacts
+  #       uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+  #       if: failure()
+  #       with:
+  #         name: golden_image_failures.${{ matrix.bot }}
+  #         path: packages/devtools_app/test/**/failures/*.png
+  #     - name: Notify of Quick Fix
+  #       if: failure()
+  #       env:
+  #         WORKFLOW_ID: ${{ github.run_id }}
+  #       run: |
+  #         echo "::notice title=To Quickly Fix Goldens:: Run \`devtools_tool fix-goldens --run-id=$WORKFLOW_ID\` on your local branch."
 
   devtools-app-integration-test:
     name: devtools_app integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -419,7 +419,7 @@ enum FlutterDaemonConstants {
 
 enum TestAppDevice {
   flutterTester('flutter-tester'),
-  flutterChrome('chrome'),
+  flutterWebServer('web-server'),
   cli('cli');
 
   const TestAppDevice(this.argName);
@@ -429,7 +429,7 @@ enum TestAppDevice {
   /// A mapping of test app device to the unsupported tests for that device.
   static final _unsupportedTestsForDevice = <TestAppDevice, List<String>>{
     TestAppDevice.flutterTester: [],
-    TestAppDevice.flutterChrome: [
+    TestAppDevice.flutterWebServer: [
       // TODO(https://github.com/flutter/devtools/issues/5874): Remove once supported on web.
       'eval_and_browse_test.dart',
       'perfetto_test.dart',

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -173,7 +173,7 @@ elif [ "$BOT" = "integration_dart2js" ]; then
         if [ "$DEVICE" = "flutter" ]; then
             dart run integration_test/run_tests.dart --headless --shard="$SHARD"
         elif [ "$DEVICE" = "flutter-web" ]; then
-            dart run integration_test/run_tests.dart --test-app-device=chrome --headless --shard="$SHARD"
+            dart run integration_test/run_tests.dart --test-app-device=web-server --headless --shard="$SHARD"
         elif [ "$DEVICE" = "dart-cli" ]; then
             dart run integration_test/run_tests.dart --test-app-device=cli --headless --shard="$SHARD"
         fi        


### PR DESCRIPTION
There is no reason that these were running on macos originally. Likely was due to copy & paste from the macos-test job. For example, the devtools_extensions integration tests run on ubuntu-latest as well.