### PR TITLE
Include main package subdirectories in the `devtools_tool pub-get` command

### DIFF
--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -23,7 +23,7 @@ class PubGetCommand extends Command {
         _onlyMainFlag,
         negatable: false,
         help: 'Only execute on the top-level `devtools/packages/devtools_*` '
-            'packages',
+            'packages and any of their subdirectories',
       );
   }
 
@@ -55,10 +55,10 @@ class PubGetCommand extends Command {
 
     for (Package p in packages) {
       final packagePathParts = path.split(p.relativePath);
-      final isMainPackage = packagePathParts.length == 2 &&
+      final isMainPackageOrSubdirectory = packagePathParts.length >= 2 &&
           packagePathParts.first == 'packages' &&
           packagePathParts[1].startsWith('devtools_');
-      if (onlyMainPackages && !isMainPackage) continue;
+      if (onlyMainPackages && !isMainPackageOrSubdirectory) continue;
 
       final progress = log.progress('  ${p.relativePath}');
 


### PR DESCRIPTION
This will ensure `example/` directories and test fixtures are included.

Example running `devtools_tool pub-get --only-main`:

Before
```
Running flutter pub get...
  packages/devtools_app...             4.5s
  packages/devtools_app_shared...      2.3s
  packages/devtools_extensions...      2.4s
  packages/devtools_shared...          2.0s
  packages/devtools_test...            3.0s
```
After:
```
Running flutter pub get...
  packages/devtools_app...             3.6s
  packages/devtools_app/test/test_infra/fixtures/flutter_app... 1.7s
  packages/devtools_app/test/test_infra/fixtures/flutter_error_app... 1.9s
  packages/devtools_app/test/test_infra/fixtures/memory_app... 2.1s
  packages/devtools_app/test/test_infra/fixtures/provider_app... 2.0s
  packages/devtools_app/test/test_infra/fixtures/riverpod_app... 2.1s
  packages/devtools_app_shared...      2.2s
  packages/devtools_extensions...      2.2s
  packages/devtools_extensions/example/app_that_uses_foo... 1.8s
  packages/devtools_extensions/example/foo/packages/foo... 2.2s
  packages/devtools_extensions/example/foo/packages/foo_devtools_extension... 27.4s
  packages/devtools_shared...          2.2s
  packages/devtools_test...            3.0s
```