### PR TITLE
devtools_app: migrate _analytics_web.dart to pkg:web

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -8,12 +8,11 @@ library gtags;
 // ignore_for_file: non_constant_identifier_names
 
 import 'dart:async';
-// ignore: avoid_web_libraries_in_flutter, by design
-import 'dart:html';
 
 import 'package:devtools_app_shared/ui.dart';
 import 'package:js/js.dart';
 import 'package:logging/logging.dart';
+import 'package:web/helpers.dart';
 
 import '../../../devtools.dart' as devtools show version;
 import '../config_specific/server/server.dart' as server;
@@ -802,7 +801,7 @@ Future<bool> disableAnalytics() async {
 /// devtoolsChrome.
 void computeDevToolsCustomGTagsData() {
   // Platform
-  final String platform = window.navigator.platform!;
+  final String platform = window.navigator.platform;
   platform.replaceAll(' ', '_');
   devtoolsPlatformType = platform;
 

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   vm_service: ^12.0.0
   # TODO https://github.com/dart-lang/sdk/issues/52853 - unpin this version
   vm_snapshot_analysis: 0.7.2
+  web: ^0.3.0
   web_socket_channel: ^2.1.0
   # widget_icons: ^0.0.1
 


### PR DESCRIPTION
Towards https://github.com/flutter/devtools/issues/6606