### PR TITLE
Fix some Windows issues in update-flutter-sdk

### DIFF
--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -132,7 +132,7 @@ class UpdateFlutterSdkCommand extends Command {
       repo.toolDirectoryPath,
       flutterSdkDirName,
     );
-    final toolFlutterSdk = Directory.fromUri(Uri.parse(toolSdkPath));
+    final toolFlutterSdk = Directory.fromUri(Uri.file(toolSdkPath));
     log.stdout('Updating "$toolSdkPath" to branch $flutterTag');
 
     if (toolFlutterSdk.existsSync()) {
@@ -141,7 +141,7 @@ class UpdateFlutterSdkCommand extends Command {
         commands: [
           CliCommand.git('fetch'),
           CliCommand.git('checkout $flutterTag -f'),
-          CliCommand('./bin/flutter --version'),
+          CliCommand.flutter('--version'),
         ],
         workingDirectory: toolFlutterSdk.path,
       );
@@ -156,7 +156,7 @@ class UpdateFlutterSdkCommand extends Command {
       await processManager.runAll(
         commands: [
           CliCommand.git('checkout $flutterTag -f'),
-          CliCommand('./bin/flutter --version'),
+          CliCommand.flutter('--version'),
         ],
         workingDirectory: toolFlutterSdk.path,
       );


### PR DESCRIPTION
Some minor issues when running on Windows:

- Using `Uri.parse()` doesn't work on a Windows file path like `C:\foo\` (`Unsupported operation: Cannot extract a file path from a c URI`) so changed to `Uri.file()`
- Some calls to `flutter --version` were using `./bin/flutter` which fails on Windows (because programmatic executions require `flutter.bat`) so changed to `CliCommand.flutter`

@kenzieschmoll 