### PR TITLE
Make SemanticsNode.isMergedIntoParent Readonly

### DIFF
--- a/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
@@ -812,7 +812,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
     }
 
     _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
-    _innerNode!..rect = Offset.zero & node.rect.size;
+    _innerNode!.rect = Offset.zero & node.rect.size;
 
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];

--- a/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
@@ -811,8 +811,8 @@ class _RenderScrollSemantics extends RenderProxyBox {
       return;
     }
 
-    _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
-    _innerNode!.rect = Offset.zero & node.rect.size;
+    (_innerNode ??= SemanticsNode(showOnScreen: showOnScreen)).rect = node.rect;
+    
 
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];

--- a/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
@@ -812,9 +812,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
     }
 
     _innerNode ??= SemanticsNode(showOnScreen: showOnScreen);
-    _innerNode!
-      ..isMergedIntoParent = node.isPartOfNodeMerging
-      ..rect = Offset.zero & node.rect.size;
+    _innerNode!..rect = Offset.zero & node.rect.size;
 
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];

--- a/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
@@ -812,7 +812,6 @@ class _RenderScrollSemantics extends RenderProxyBox {
     }
 
     (_innerNode ??= SemanticsNode(showOnScreen: showOnScreen)).rect = node.rect;
-    
 
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];


### PR DESCRIPTION
Follow up from https://github.com/flutter/flutter/pull/137304

Breaks Google testing (b/308325747)

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.
