### PR TITLE
Move sharedStdIn.terminate to only run from top level

### DIFF
--- a/tool/bin/devtools_tool.dart
+++ b/tool/bin/devtools_tool.dart
@@ -6,11 +6,14 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:devtools_tool/devtools_command_runner.dart';
+import 'package:io/io.dart';
 
 void main(List<String> args) async {
   final runner = DevToolsCommandRunner();
   try {
-    final dynamic result = await runner.run(args);
+    final dynamic result =
+        await runner.run(args).whenComplete(sharedStdIn.terminate);
+
     exit(result is int ? result : 0);
   } catch (e) {
     if (e is UsageException) {

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -35,9 +35,4 @@ class DevToolsCommandRunner extends CommandRunner {
     addCommand(UpdateDevToolsVersionCommand());
     addCommand(UpdateFlutterSdkCommand());
   }
-
-  @override
-  Future runCommand(ArgResults topLevelResults) async {
-    return await super.runCommand(topLevelResults);
-  }
 }

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -38,11 +38,6 @@ class DevToolsCommandRunner extends CommandRunner {
 
   @override
   Future runCommand(ArgResults topLevelResults) async {
-    try {
-      return await super.runCommand(topLevelResults);
-    } finally {
-      // Closes stdin for the entire program.
-      await sharedStdIn.terminate();
-    }
+    return await super.runCommand(topLevelResults);
   }
 }

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -2,13 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:devtools_tool/commands/fix_goldens.dart';
 import 'package:devtools_tool/commands/generate_code.dart';
 import 'package:devtools_tool/commands/sync.dart';
 import 'package:devtools_tool/commands/update_flutter_sdk.dart';
-import 'package:io/io.dart';
 
 import 'commands/analyze.dart';
 import 'commands/list.dart';


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6624
