### PR TITLE
Improve flutter backwards compatibility for `devtools_app_shared`

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.0.7
+* Soften breaking change from 0.0.6 to add the `profilePlatformChannels` service extension,
+improving backwards compatibility for older versions of Flutter.
 * Bump the `devtools_shared` dependency to ^5.0.0
 * Remove public getter `libraryRef`, and public methods `getLibrary` and `retrieveFullValueAsString` from `EvalOnDartLibrary`.
 * Change `toString` output for `UnknownEvalException`, `EvalSentinelException`, and `EvalErrorException`.

--- a/packages/devtools_app_shared/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extensions.dart
@@ -217,8 +217,10 @@ final trackRebuildWidgets = ToggleableServiceExtension<bool>(
 );
 
 final profilePlatformChannels = ToggleableServiceExtension<bool>(
-  extension:
-      '$flutterExtensionPrefix${ServicesServiceExtensions.profilePlatformChannels.name}',
+  // TODO(kenz): use ${ServicesServiceExtensions.profilePlatformChannels.name}
+  // once this enum value has existed on Flutter stable for a reasonable amount
+  // of time (6 months, or June 2024).
+  extension: '${flutterExtensionPrefix}profilePlatformChannels',
   enabledValue: true,
   disabledValue: false,
 );

--- a/packages/devtools_app_shared/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extensions.dart
@@ -6,7 +6,6 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
 
 class ServiceExtension<T> {
   ServiceExtension({


### PR DESCRIPTION
This is causing issues for building DevTools extensions