### PR TITLE
Fix build-release issue on Windows

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -82,7 +82,18 @@ class ServeCommand extends Command {
     if (localDartSdkLocation == null) {
       throw Exception('LOCAL_DART_SDK environment variable not set. Please add '
           'the following to your \'.bash_profile\' or \'.bashrc\' file:\n'
-          'export LOCAL_DART_SDK=<absolute/path/to/my/dart/sdk>');
+          'export LOCAL_DART_SDK=<absolute/path/to/my/dart-sdk/sdk>');
+    }
+
+    // Validate the path looks correct in case it was set without the /sdk or
+    // similar.
+    final pkgDir = Directory(path.join(localDartSdkLocation, 'pkg'));
+    if (!pkgDir.existsSync()) {
+      throw Exception(
+        'No pkg directory found in LOCAL_DART_SDK at "${pkgDir.path}"\n'
+        'Is LOCAL_DART_SDK set correctly to the dart-sdk${path.separator}sdk '
+        'directory?',
+      );
     }
 
     final devToolsBuildLocation =


### PR DESCRIPTION
@kenzieschmoll `rm -rf` won't work here, so this just uses `dart:io` instead.

Thanks for all the work on this - it makes things so much simpler won Windows than before 🙂
