### PR TITLE
Fix an issue locating the Flutter SDK on Windows when not invoked via 'dart' inside a Flutter SDK

### DIFF
--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -128,7 +128,6 @@ class FlutterSdk {
     }
 
     // Look to see if we can find the 'flutter' command in the PATH.
-    // TODO(dantup): This won't work on Windows.
     final whichCommand = Platform.isWindows ? 'where.exe' : 'which';
     final result = Process.runSync(whichCommand, ['flutter']);
     if (result.exitCode == 0) {

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -129,7 +129,8 @@ class FlutterSdk {
 
     // Look to see if we can find the 'flutter' command in the PATH.
     // TODO(dantup): This won't work on Windows.
-    final result = Process.runSync('which', ['flutter']);
+    final whichCommand = Platform.isWindows ? 'where.exe' : 'which';
+    final result = Process.runSync(whichCommand, ['flutter']);
     if (result.exitCode == 0) {
       final sdkPath = result.stdout.toString().split('\n').first.trim();
       // 'flutter/bin'


### PR DESCRIPTION
If the current Dart VM isn't inside a Flutter SDK, we fall back to trying to find it on `PATH` with `which`. The equiv on Windows is `where.exe`.