### PR TITLE
Use located Flutter instead of PATH flutter for Command.flutter() + support FLUTTER_ROOT override

### DIFF
--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -20,7 +20,7 @@ class AnalyzeCommand extends Command {
 
   @override
   Future run() async {
-    final sdk = FlutterSdk.getSdk();
+    final sdk = FlutterSdk.current;
     if (sdk == null) {
       print('Unable to locate a Flutter sdk.');
       return 1;

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -35,7 +35,7 @@ class PubGetCommand extends Command {
 
   @override
   Future run() async {
-    final sdk = FlutterSdk.getSdk();
+    final sdk = FlutterSdk.current;
     if (sdk == null) {
       print('Unable to locate a Flutter sdk.');
       return 1;

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -99,7 +99,7 @@ class UpdateFlutterSdkCommand extends Command {
     );
 
     if (updateLocalFlutter) {
-      final sdk = FlutterSdk.getSdk();
+      final sdk = FlutterSdk.current;
       if (sdk == null) {
         print('Unable to locate a Flutter sdk.');
         return 1;

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -97,10 +97,15 @@ class DevToolsRepo {
 class FlutterSdk {
   FlutterSdk._(this.sdkPath);
 
+  /// The current located Flutter SDK (or `null` if one could not be found).
+  ///
+  /// Tries to locate from the running Dart VM, FLUTTER_ROOT or searching PATH.
+  static final current = _findSdk();
+
   /// Return the Flutter SDK.
   ///
   /// This can return null if the Flutter SDK can't be found.
-  static FlutterSdk? getSdk() {
+  static FlutterSdk? _findSdk() {
     // TODO(dantup): Everywhere that calls this just prints and exits - should
     //  we just make this throw like DevToolsRepo.getInstance();
     // Look for it relative to the current Dart process.
@@ -125,6 +130,15 @@ class FlutterSdk {
       if (expectedSegments.isEmpty) {
         return FlutterSdk._(path.joinAll(pathSegments));
       }
+    }
+
+    // Next try FLUTTER_ROOT to allow using a custom flutter (eg. from
+    // `tool/flutter-sdk`) when invoking this without needing to override `PATH`
+    // (it's easier to set override an entire env variable than prepend to one
+    // in some places like the `dart.customDevTools` setting in VS Code).
+    final flutterRootEnv = Platform.environment['FLUTTER_ROOT'];
+    if (flutterRootEnv != null && flutterRootEnv.isNotEmpty) {
+      return FlutterSdk._(flutterRootEnv);
     }
 
     // Look to see if we can find the 'flutter' command in the PATH.

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -76,10 +76,13 @@ class CliCommand {
     String args, {
     bool throwOnException = true,
   }) {
+    final sdk = FlutterSdk.current;
+    if (sdk == null) {
+      throw Exception('Unable to locate a Flutter sdk.');
+    }
+
     return CliCommand._(
-      // TODO(dantup): Accept an instance of FlutterSdk instead of relying on
-      //  PATH here?
-      exe: FlutterSdk.flutterExecutableName,
+      exe: sdk.flutterToolPath,
       args: args.split(' '),
       throwOnException: throwOnException,
     );


### PR DESCRIPTION
This fixes a TODO where Command.flutter() would always run the version of Flutter from PATH and not the same one we would detect.

This will allow me to fix an issue when using a custom version of DevTools in VS Code (calling "devtools_tool serve") without having to ensure my PATH points at the same version (which it probably doesn't when I'm just opening test apps that use my "normal" checkout of Flutter).