### PR TITLE
Allow --machine/--allow-embedding to be passed to devtools_tool serve

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -14,6 +14,8 @@ import '../utils.dart';
 const _useLocalFlutterFlag = 'use-local-flutter';
 const _updatePerfettoFlag = 'update-perfetto';
 const _buildAppFlag = 'build-app';
+const _machineFlag = 'machine';
+const _allowEmbeddingFlag = 'allow-embedding';
 
 /// This command builds DevTools in release mode by running the
 /// `devtools_tool build-release` command and then serves DevTools with a
@@ -54,10 +56,15 @@ class ServeCommand extends Command {
             'Whether to build the DevTools app in release mode before starting '
             'the DevTools server.',
       )
+      // Flags defined in the server in DDS.
       ..addFlag(
-        'machine',
+        _machineFlag,
         negatable: false,
         help: 'Sets output format to JSON for consumption in tools.',
+      )
+      ..addFlag(
+        _allowEmbeddingFlag,
+        help: 'Allow embedding DevTools inside an iframe.',
       );
   }
 

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -53,6 +53,11 @@ class ServeCommand extends Command {
         help:
             'Whether to build the DevTools app in release mode before starting '
             'the DevTools server.',
+      )
+      ..addFlag(
+        'machine',
+        negatable: false,
+        help: 'Sets output format to JSON for consumption in tools.',
       );
   }
 


### PR DESCRIPTION
The arg parser allows additional arguments, but not additional "options", so we need to add this explicitly* to allow `--machine` to work. The code already passes the extra args through to the server correctly, it just wasn't allowing this option to be provided on the command line.

\* Or use the `AllowAnythingParser`, but looks like that would affect the existing options.