### PR TITLE
Remove unnecessary async keywords

### DIFF
--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -114,7 +114,7 @@ class VmServiceWrapper extends VmService {
     String isolateId, {
     bool? reset,
     bool? gc,
-  }) async {
+  }) {
     return callMethod(
       // TODO(bkonyi): add _new and _old to public response.
       '_getAllocationProfile',
@@ -131,7 +131,7 @@ class VmServiceWrapper extends VmService {
     String isolateId,
     int timeOriginMicros,
     int timeExtentMicros,
-  ) async {
+  ) {
     return callMethod(
       'getCpuSamples',
       isolateId: isolateId,

--- a/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -86,7 +86,7 @@ class ServerConnectionStorage implements Storage {
   final DevToolsServerConnection connection;
 
   @override
-  Future<String> getValue(String key) async {
+  Future<String> getValue(String key) {
     return connection.getPreferenceValue(key);
   }
 

--- a/packages/devtools_app/lib/src/shared/config_specific/server/_server_stub.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/server/_server_stub.dart
@@ -18,64 +18,64 @@ const unsupportedMessage =
 bool get isDevToolsServerAvailable => false;
 
 // This is used in g3.
-Future<Object?> request(String url) async {
+Future<Object?> request(String url) {
   throw Exception(unsupportedMessage);
 }
 
-Future<bool> isFirstRun() async {
+Future<bool> isFirstRun() {
   throw Exception(unsupportedMessage);
 }
 
-Future<bool> isAnalyticsEnabled() async {
+Future<bool> isAnalyticsEnabled() {
   throw Exception(unsupportedMessage);
 }
 
-Future<bool> setAnalyticsEnabled([bool value = true]) async {
+Future<bool> setAnalyticsEnabled([bool value = true]) {
   throw Exception(unsupportedMessage);
 }
 
-Future<String> flutterGAClientID() async {
+Future<String> flutterGAClientID() {
   throw Exception(unsupportedMessage);
 }
 
-Future<bool> setActiveSurvey(String value) async {
+Future<bool> setActiveSurvey(String value) {
   throw Exception(unsupportedMessage);
 }
 
-Future<bool> surveyActionTaken() async {
+Future<bool> surveyActionTaken() {
   throw Exception(unsupportedMessage);
 }
 
-Future<void> setSurveyActionTaken() async {
+Future<void> setSurveyActionTaken() {
   throw Exception(unsupportedMessage);
 }
 
-Future<int> surveyShownCount() async {
+Future<int> surveyShownCount() {
   throw Exception(unsupportedMessage);
 }
 
-Future<int> incrementSurveyShownCount() async {
+Future<int> incrementSurveyShownCount() {
   throw Exception(unsupportedMessage);
 }
 
-Future<String> getLastShownReleaseNotesVersion() async {
+Future<String> getLastShownReleaseNotesVersion() {
   throw Exception(unsupportedMessage);
 }
 
-Future<String> setLastShownReleaseNotesVersion(String version) async {
+Future<String> setLastShownReleaseNotesVersion(String version) {
   throw Exception(unsupportedMessage);
 }
 
 // currently unused
-Future<void> resetDevToolsFile() async {
+Future<void> resetDevToolsFile() {
   throw Exception(unsupportedMessage);
 }
 
-Future<DevToolsJsonFile?> requestBaseAppSizeFile(String path) async {
+Future<DevToolsJsonFile?> requestBaseAppSizeFile(String path) {
   throw Exception(unsupportedMessage);
 }
 
-Future<DevToolsJsonFile?> requestTestAppSizeFile(String path) async {
+Future<DevToolsJsonFile?> requestTestAppSizeFile(String path) {
   throw Exception(unsupportedMessage);
 }
 

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -136,7 +136,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
   }
 
   /// Simulates executing a VS Code command requested by the embedded panel.
-  Future<Object?> executeCommand(json_rpc_2.Parameters parameters) async {
+  Future<Object?> executeCommand(json_rpc_2.Parameters parameters) {
     final params = parameters.asMap;
     final command = params['command'];
     switch (command) {

--- a/packages/devtools_app_shared/lib/src/service/service_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_manager.dart
@@ -142,7 +142,7 @@ class ServiceManager<T extends VmService> {
     String name, {
     String? isolateId,
     Map<String, dynamic>? args,
-  }) async {
+  }) {
     final registeredMethod = _registeredMethodsForService[name];
     if (registeredMethod == null) {
       throw Exception('There is no registered method for service "$name"');


### PR DESCRIPTION
Latest version of DCM flags these so the bots turned red. This fixes the build by removing the unnecessary `async`s.
