### PR TITLE
Make widget search snap to entries while typing

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -250,7 +250,22 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
     _searchFieldFocusNode?.dispose();
     _searchTextFieldController = SearchTextEditingController()
       ..text = _searchNotifier.value;
-    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
+    _searchFieldFocusNode = FocusNode(
+      debugLabel: 'search-field',
+      onKey: (FocusNode node, RawKeyEvent event) {
+        if (event.logicalKey.keyLabel == 'Enter') {
+          if (event is RawKeyDownEvent) {
+            if (event.isShiftPressed) {
+              previousMatch();
+            } else {
+              nextMatch();
+            }
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+    );
   }
 
   @mustCallSuper
@@ -1041,6 +1056,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
       onChanged: (value) {
         onChanged?.call(value);
         controller.search = value;
+        controller.searchFieldFocusNode.requestFocus();
       },
       onEditingComplete: () {
         controller.searchFieldFocusNode.requestFocus();

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -16,8 +16,8 @@ under `lib` (e.g. a unit test or integration test). Thanks to
 [#6644](https://github.com/flutter/devtools/pull/6644)
 
 ## Inspector updates
-
-TODO: Remove this section if there are not any general updates.
+* When done typing in the search field, the next selection is now automatically selected - [#6677](https://github.com/flutter/devtools/pull/6677)
+* When typing in the search field, hitting `Enter` will now select the next search result, hitting `Shift+Enter` will now select the previous result. - [#6677](https://github.com/flutter/devtools/pull/6677)
 
 ## Performance updates
 


### PR DESCRIPTION
![](https://media.giphy.com/media/3oKIPa8aoMmpUz5xKg/giphy.gif)

1. While typing, in the search field for the inspector, the next result will automatically be selected when the user stops typing.
2. I've also updated the key focus so that if the user hits "Enter", then next Widget will be selected. If they hit "Shift+Enter" then the previous  Widget will be selected (of the search results).

Fixes https://github.com/flutter/devtools/issues/6602