### PR TITLE
Add the ability to enable platform types from the device list in the sidebar

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/constants/_vs_code_sidebar_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_vs_code_sidebar_constants.dart
@@ -10,7 +10,11 @@ enum VsCodeFlutterSidebar {
 
   /// Analytics event that is sent when a device selection occurs from the list
   /// of available devices in the sidebar.
-  changeSelectedDevice;
+  changeSelectedDevice,
+
+  /// Analytics event that is sent when a platform type is selected to be enable
+  /// from the list of devices in the sidebar.
+  enablePlatformType;
 
   static String get id => VsCodeFlutterSidebar.vsCodeFlutterSidebar.name;
 

--- a/packages/devtools_app/lib/src/shared/analytics/constants/_vs_code_sidebar_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_vs_code_sidebar_constants.dart
@@ -10,13 +10,14 @@ enum VsCodeFlutterSidebar {
 
   /// Analytics event that is sent when a device selection occurs from the list
   /// of available devices in the sidebar.
-  changeSelectedDevice,
-
-  /// Analytics event that is sent when a platform type is selected to be enable
-  /// from the list of devices in the sidebar.
-  enablePlatformType;
+  changeSelectedDevice;
 
   static String get id => VsCodeFlutterSidebar.vsCodeFlutterSidebar.name;
+
+  /// Analytics event for when a request to enable a new platform type is sent
+  /// to VS Code.
+  static String enablePlatformType(String platformType) =>
+      'enablePlatformType-$platformType';
 
   /// Analytics event that is sent when a DevTools screen is opened from the
   /// actions toolbar for a debug session.

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/dart_tooling_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/dart_tooling_api.dart
@@ -43,12 +43,20 @@ class DartToolingApiImpl implements DartToolingApi {
     }
     final postMessageController = StreamController();
     postMessageController.stream.listen((message) {
-      _log.info('==> $message');
+      // TODO(dantup): Using fine here doesn't work even though the
+      // `setDevToolsLoggingLevel` call above seems like it should show finest
+      // logs. For now, use info (which always logs) with a condition here
+      // and below.
+      if (_enablePostMessageVerboseLogging) {
+        _log.info('==> $message');
+      }
       postMessage(message, '*');
     });
     final channel = StreamChannel(
       onPostMessage.map((event) {
-        _log.info('<== ${jsonEncode(event.data)}');
+        if (_enablePostMessageVerboseLogging) {
+          _log.info('<== ${jsonEncode(event.data)}');
+        }
         return event.data;
       }),
       postMessageController,

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -60,6 +60,14 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
   }
 
   @override
+  Future<bool> enablePlatformType(String platformType) {
+    return sendRequest(
+      VsCodeApi.jsonEnablePlatformTypeMethod,
+      {VsCodeApi.jsonPlatformTypeParameter: platformType},
+    );
+  }
+
+  @override
   Future<void> openDevToolsPage(String debugSessionId, String page) {
     return sendRequest(
       VsCodeApi.jsonOpenDevToolsPageMethod,
@@ -206,6 +214,7 @@ class VsCodeDevicesEventImpl implements VsCodeDevicesEvent {
   VsCodeDevicesEventImpl({
     required this.selectedDeviceId,
     required this.devices,
+    required this.unsupportedDevices,
   });
 
   VsCodeDevicesEventImpl.fromJson(Map<String, Object?> json)
@@ -216,6 +225,11 @@ class VsCodeDevicesEventImpl implements VsCodeDevicesEvent {
               .map((item) => Map<String, Object?>.from(item))
               .map((map) => VsCodeDeviceImpl.fromJson(map))
               .toList(),
+          unsupportedDevices:
+              (json[VsCodeDevicesEvent.jsonUnsupportedDevicesField] as List?)
+                  ?.map((item) => Map<String, Object?>.from(item))
+                  .map((map) => VsCodeDeviceImpl.fromJson(map))
+                  .toList(),
         );
 
   @override
@@ -224,9 +238,13 @@ class VsCodeDevicesEventImpl implements VsCodeDevicesEvent {
   @override
   final List<VsCodeDevice> devices;
 
+  @override
+  final List<VsCodeDevice>? unsupportedDevices;
+
   Map<String, Object?> toJson() => {
         VsCodeDevicesEvent.jsonSelectedDeviceIdField: selectedDeviceId,
         VsCodeDevicesEvent.jsonDevicesField: devices,
+        VsCodeDevicesEvent.jsonUnsupportedDevicesField: unsupportedDevices,
       };
 }
 

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -47,6 +47,16 @@ abstract interface class VsCodeApi {
   /// Calling this API will update the device for the whole VS Code extension.
   Future<bool> selectDevice(String id);
 
+  /// Enables the selected platform type.
+  ///
+  /// Calling this method may cause a UI prompt in the editor to ask the user to
+  /// confirm they'd like to run `flutter create` to create the required files
+  /// for the project to support this platform type.
+  ///
+  /// This method has no capability because it is only (and always) valid to
+  /// call if some `unsupportedDevices` were provided in a device event.
+  Future<bool> enablePlatformType(String platformType);
+
   /// Opens a specific DevTools [page] for the debug session with ID
   /// [debugSessionId].
   ///
@@ -69,6 +79,7 @@ abstract interface class VsCodeApi {
   static const jsonOpenDevToolsPageMethod = 'openDevToolsPage';
   static const jsonHotReloadMethod = 'hotReload';
   static const jsonHotRestartMethod = 'hotRestart';
+  static const jsonEnablePlatformTypeMethod = 'enablePlatformType';
 
   static const jsonDevicesChangedEvent = 'devicesChanged';
   static const jsonDebugSessionsChangedEvent = 'debugSessionsChanged';
@@ -78,6 +89,7 @@ abstract interface class VsCodeApi {
   static const jsonIdParameter = 'id';
   static const jsonOpenPageParameter = 'page';
   static const jsonDebugSessionIdParameter = 'debugSessionId';
+  static const jsonPlatformTypeParameter = 'platformType';
 }
 
 /// This class defines a device exposed by the Dart/Flutter extensions in VS
@@ -163,8 +175,19 @@ abstract interface class VsCodeDevicesEvent {
   /// A list of the devices that are available to select.
   List<VsCodeDevice> get devices;
 
+  /// A list of the devices that are unavailable to select because the platform
+  /// is not enabled.
+  ///
+  /// A devices platform type can be enabled by calling the `enablePlatformType`
+  /// method.
+  ///
+  /// This field is nullable because it was not in the initial sidebar API so
+  /// older versions of VS Code might not provide it.
+  List<VsCodeDevice>? get unsupportedDevices;
+
   static const jsonSelectedDeviceIdField = 'selectedDeviceId';
   static const jsonDevicesField = 'devices';
+  static const jsonUnsupportedDevicesField = 'unsupportedDevices';
 }
 
 /// This class defines a debug session event sent by the Dart/Flutter extensions

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -125,7 +125,7 @@ class Devices extends StatelessWidget {
             onPressed: () {
               ga.select(
                 gac.VsCodeFlutterSidebar.id,
-                gac.VsCodeFlutterSidebar.enablePlatformType.name,
+                gac.VsCodeFlutterSidebar.enablePlatformType(platformType),
               );
               unawaited(api.enablePlatformType(platformType));
             },

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devices.dart
@@ -12,15 +12,21 @@ import '../../shared/analytics/constants.dart' as gac;
 import '../api/vs_code_api.dart';
 
 class Devices extends StatelessWidget {
-  const Devices(
-    this.api,
-    this.devices, {
+  Devices(
+    this.api, {
+    required this.devices,
+    required this.unsupportedDevices,
     required this.selectedDeviceId,
     super.key,
-  });
+  }) : unsupportedDevicePlatformTypes = unsupportedDevices
+            .map((device) => device.platformType)
+            .nonNulls
+            .toSet();
 
   final VsCodeApi api;
   final List<VsCodeDevice> devices;
+  final List<VsCodeDevice> unsupportedDevices;
+  final Set<String> unsupportedDevicePlatformTypes;
   final String? selectedDeviceId;
 
   @override
@@ -44,6 +50,11 @@ class Devices extends StatelessWidget {
                   theme,
                   device,
                   isSelected: device.id == selectedDeviceId,
+                ),
+              for (final platformType in unsupportedDevicePlatformTypes)
+                _createPlatformTypeEnablerRow(
+                  theme,
+                  platformType,
                 ),
             ],
           ),
@@ -87,6 +98,36 @@ class Devices extends StatelessWidget {
                 gac.VsCodeFlutterSidebar.changeSelectedDevice.name,
               );
               unawaited(api.selectDevice(device.id));
+            },
+          ),
+        ),
+      ],
+    );
+  }
+
+  TableRow _createPlatformTypeEnablerRow(ThemeData theme, String platformType) {
+    final foregroundColor = theme.colorScheme.secondary;
+
+    return TableRow(
+      children: [
+        SizedBox(
+          width: double.infinity,
+          child: TextButton(
+            style: TextButton.styleFrom(
+              alignment: Alignment.centerLeft,
+              shape: const ContinuousRectangleBorder(),
+              textStyle: theme.regularTextStyle,
+            ),
+            child: Text(
+              'Enable $platformType for this project',
+              style: theme.regularTextStyle.copyWith(color: foregroundColor),
+            ),
+            onPressed: () {
+              ga.select(
+                gac.VsCodeFlutterSidebar.id,
+                gac.VsCodeFlutterSidebar.enablePlatformType.name,
+              );
+              unawaited(api.enablePlatformType(platformType));
             },
           ),
         ),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/flutter_panel.dart
@@ -75,6 +75,8 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
         stream: widget.api.devicesChanged,
         builder: (context, devicesSnapshot) {
           final devices = devicesSnapshot.data?.devices ?? const [];
+          final unsupportedDevices =
+              devicesSnapshot.data?.unsupportedDevices ?? const [];
           final deviceMap = {for (final device in devices) device.id: device};
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -95,7 +97,8 @@ class _VsCodeConnectedPanelState extends State<_VsCodeConnectedPanel> {
               if (widget.api.capabilities.selectDevice)
                 Devices(
                   widget.api,
-                  devices,
+                  devices: devices,
+                  unsupportedDevices: unsupportedDevices,
                   selectedDeviceId: devicesSnapshot.data?.selectedDeviceId,
                 ),
             ],

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -47,6 +47,14 @@ TODO: Remove this section if there are not any general updates.
 
 TODO: Remove this section if there are not any general updates.
 
+## VS Code Sidebar updates
+
+* The Flutter Sidebar provided to VS Code now has the ability to enable new
+  platforms if a device is available for a platform that is not enabled for
+  the current project. This also requires a corresponding Dart extension for
+  VS Code update to appear
+  - [#6688](https://github.com/flutter/devtools/pull/6688)
+
 ## Full commit history
 
 To find a complete list of changes in this release, check out the

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -73,6 +73,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
     server.registerMethod('vsCode.initialize', initialize);
     server.registerMethod('vsCode.executeCommand', executeCommand);
     server.registerMethod('vsCode.selectDevice', selectDevice);
+    server.registerMethod('vsCode.enablePlatformType', enablePlatformType);
     server.registerMethod('vsCode.openDevToolsPage', noOpHandler);
     server.registerMethod('vsCode.hotReload', noOpHandler);
     server.registerMethod('vsCode.hotRestart', noOpHandler);
@@ -113,10 +114,35 @@ class MockDartToolingApi extends DartToolingApiImpl {
       platform: 'web-javascript',
       platformType: 'web',
     ),
+    VsCodeDeviceImpl(
+      id: 'web-server',
+      name: 'Web Server',
+      category: 'web',
+      emulator: false,
+      emulatorId: null,
+      ephemeral: true,
+      platform: 'web-javascript',
+      platformType: 'web',
+    ),
   ];
+
+  /// The current set of enabled platform types.
+  ///
+  /// Defauls are set in [connectDevices].
+  final _enabledPlatformTypes = <String>{};
 
   /// The current set of devices being presented to the embedded panel.
   final _devices = <VsCodeDevice>[];
+
+  /// The current set of devices whose platform types are enabled.
+  List<VsCodeDevice> get _enabledDevices => _devices
+      .where((device) => _enabledPlatformTypes.contains(device.platformType))
+      .toList();
+
+  /// The current set of devices whose platform types are not enabled.
+  List<VsCodeDevice> get _disabledDevices => _devices
+      .where((device) => !_enabledPlatformTypes.contains(device.platformType))
+      .toList();
 
   /// The current set of debug sessions that are running.
   final _debugSessions = <VsCodeDebugSession>[];
@@ -154,6 +180,18 @@ class MockDartToolingApi extends DartToolingApiImpl {
     return true;
   }
 
+  /// Simulates a request to enable a platform type to allow additional devices
+  /// to be used.
+  Future<bool> enablePlatformType(json_rpc_2.Parameters parameters) async {
+    final params = parameters.asMap;
+    _enabledPlatformTypes.add(params['platformType'] as String);
+    // Add some delay because the real impl will need to prompt + run
+    // `flutter create`.
+    await Future.delayed(const Duration(seconds: 1));
+    _sendDevicesChanged();
+    return true;
+  }
+
   /// A no-op handler for method handlers that don't require an implementation
   /// but need to exist so that the request/response is successful.
   void noOpHandler(json_rpc_2.Parameters _) {}
@@ -164,7 +202,10 @@ class MockDartToolingApi extends DartToolingApiImpl {
     _devices
       ..clear()
       ..addAll(_mockDevices);
-    _selectedDeviceId = _devices.lastOrNull?.id;
+    _enabledPlatformTypes
+      ..clear()
+      ..addAll(['macos', 'android']);
+    _selectedDeviceId = _enabledDevices.lastOrNull?.id;
     _sendDevicesChanged();
   }
 
@@ -202,7 +243,8 @@ class MockDartToolingApi extends DartToolingApiImpl {
     server.sendNotification(
       '${VsCodeApi.jsonApiName}.${VsCodeApi.jsonDevicesChangedEvent}',
       VsCodeDevicesEventImpl(
-        devices: _devices,
+        devices: _enabledDevices,
+        unsupportedDevices: _disabledDevices,
         selectedDeviceId: _selectedDeviceId,
       ).toJson(),
     );


### PR DESCRIPTION
For each unique platform type in the set of unsupported devices, this adds a new row ("Enable web for this project"). Clicking it triggers the same flow as VS Code (which currently involves a toast in the corner to confirm we can run `flutter create`).

In future we might want to change this prompt to be in the sidebar (so it's less likely you'll miss it).

Related PR for Dart-Code is at https://github.com/Dart-Code/Dart-Code/pull/4831

See https://github.com/Dart-Code/Dart-Code/issues/4820
See https://github.com/flutter/devtools/issues/6563

https://github.com/flutter/devtools/assets/1078012/aaeb254f-a227-4038-8503-0edc7f823f9f

