### PR TITLE
Add a setup script to be run from the Flutter customer test registry

### DIFF
--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+# Script to generate mocks for Devtools from the flutter/tests registry
+# https://github.com/flutter/tests
+# This is executed as a pre-submit check for every PR in flutter/flutter
+
+cd tool
+flutter pub get
+dart bin/devtools_tool generate-code --upgrade
+cd ..


### PR DESCRIPTION
Unblocks re-enabling the DevTools tests in the Flutter customer test registry, see: https://github.com/flutter/tests/pull/310