### PR TITLE
Fix a bug where we were unnecessarily calling `manualDisconnect`

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -204,7 +204,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     Map<String, String?> args,
     DevToolsNavigationState? state,
   ) {
-    if (FrameworkCore.initializationInProgress) {
+    if (FrameworkCore.vmServiceConnectionInProgress) {
       return const MaterialPage(child: CenteredCircularProgressIndicator());
     }
 

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -52,7 +52,7 @@ class FrameworkCore {
     _log.info('DevTools version ${devtools.version}.');
   }
 
-  static bool initializationInProgress = false;
+  static bool vmServiceConnectionInProgress = false;
 
   /// Returns true if we're able to connect to a device and false otherwise.
   static Future<bool> initVmService(
@@ -70,7 +70,7 @@ class FrameworkCore {
     final normalizedUri = normalizeVmServiceUri(serviceUriAsString);
     final Uri? uri = normalizedUri ?? getServiceUriFromQueryString(url);
     if (uri != null) {
-      initializationInProgress = true;
+      vmServiceConnectionInProgress = true;
       final finishedCompleter = Completer<void>();
 
       try {
@@ -111,7 +111,7 @@ class FrameworkCore {
         errorReporter!('Unable to connect to VM service at $uri: $e', e);
         return false;
       } finally {
-        initializationInProgress = false;
+        vmServiceConnectionInProgress = false;
       }
     } else {
       // Don't report an error here because we do not have a URI to connect to.

--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -60,7 +60,9 @@ class DevToolsRouteInformationParser
       // If the uri has been modified and we do not have a vm service uri as a
       // query parameter, ensure we manually disconnect from any previously
       // connected applications.
-      await serviceConnection.serviceManager.manuallyDisconnect();
+      if (serviceConnection.serviceManager.hasConnection) {
+        await serviceConnection.serviceManager.manuallyDisconnect();
+      }
     } else if (_forceVmServiceUri == null) {
       // Otherwise, connect to the vm service from the query parameter before
       // loading the route (but do not do this in a testing environment).


### PR DESCRIPTION
Found an issue while investigating https://github.com/Dart-Code/Dart-Code/issues/4832#issuecomment-1804186076. We do not need to perform a disconnect if there is not already an existing connection.