### PR TITLE
Accept project root paths in debug sessions for sidebar

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -159,6 +159,7 @@ class VsCodeDebugSessionImpl implements VsCodeDebugSession {
     required this.flutterMode,
     required this.flutterDeviceId,
     required this.debuggerType,
+    required this.projectRootPath,
   });
 
   VsCodeDebugSessionImpl.fromJson(Map<String, Object?> json)
@@ -172,6 +173,8 @@ class VsCodeDebugSessionImpl implements VsCodeDebugSession {
               json[VsCodeDebugSession.jsonFlutterDeviceIdField] as String?,
           debuggerType:
               json[VsCodeDebugSession.jsonDebuggerTypeField] as String?,
+          projectRootPath:
+              json[VsCodeDebugSession.jsonProjectRootPathField] as String?,
         );
 
   @override
@@ -192,6 +195,9 @@ class VsCodeDebugSessionImpl implements VsCodeDebugSession {
   @override
   final String? debuggerType;
 
+  @override
+  final String? projectRootPath;
+
   Map<String, Object?> toJson() => {
         VsCodeDebugSession.jsonIdField: id,
         VsCodeDebugSession.jsonNameField: name,
@@ -199,6 +205,7 @@ class VsCodeDebugSessionImpl implements VsCodeDebugSession {
         VsCodeDebugSession.jsonFlutterModeField: flutterMode,
         VsCodeDebugSession.jsonFlutterDeviceIdField: flutterDeviceId,
         VsCodeDebugSession.jsonDebuggerTypeField: debuggerType,
+        VsCodeDebugSession.jsonProjectRootPathField: projectRootPath,
       };
 }
 

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -139,7 +139,8 @@ abstract interface class VsCodeDebugSession {
   /// - WebTest     (webdev test)
   String? get debuggerType;
 
-  /// The full path to the root of this project.
+  /// The full path to the root of this project (the folder that contains the
+  /// `pubspec.yaml`).
   ///
   /// This path might not always be available, for example:
   ///

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -139,12 +139,22 @@ abstract interface class VsCodeDebugSession {
   /// - WebTest     (webdev test)
   String? get debuggerType;
 
+  /// The full path to the root of this project.
+  ///
+  /// This path might not always be available, for example:
+  ///
+  /// - When the version of Dart-Code is from before this field was added
+  /// - When a debug session was an attach and we didn't know the source
+  /// - When the program being run is a lose file without any pubspec
+  String? get projectRootPath;
+
   static const jsonIdField = 'id';
   static const jsonNameField = 'name';
   static const jsonVmServiceUriField = 'vmServiceUri';
   static const jsonFlutterModeField = 'flutterMode';
   static const jsonFlutterDeviceIdField = 'flutterDeviceId';
   static const jsonDebuggerTypeField = 'debuggerType';
+  static const jsonProjectRootPathField = 'projectRootPath';
 }
 
 /// This class defines a device event sent by the Dart/Flutter extensions in VS

--- a/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
+++ b/packages/devtools_app/test/test_infra/test_data/dart_tooling_api/mock_api.dart
@@ -179,6 +179,7 @@ class MockDartToolingApi extends DartToolingApiImpl {
         flutterMode: mode,
         flutterDeviceId: deviceId,
         debuggerType: 'Flutter',
+        projectRootPath: null,
       ),
     );
     _sendDebugSessionsChanged();


### PR DESCRIPTION
See https://github.com/flutter/devtools/pull/6709

Dart-Code will pass a project root* for debug sessions:

![image](https://github.com/flutter/devtools/assets/1078012/7f01b54c-bbbc-408f-8074-4a3af0f99338)

\* if it's able to compute one - which it always should for the cases we care about, but there are some edge cases that mean the field might be missing.