### PR TITLE
Don't render not-found page during initial setup

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -204,13 +204,15 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     Map<String, String?> args,
     DevToolsNavigationState? state,
   ) {
-    if (FrameworkCore.initializationInProgress) {
+    // `page` will initially be null while the router is set up, then we will
+    // be called again with an empty string for the root.
+    if (FrameworkCore.initializationInProgress || page == null) {
       return const MaterialPage(child: CenteredCircularProgressIndicator());
     }
 
     // Provide the appropriate page route.
     if (pages.containsKey(page)) {
-      Widget widget = pages[page!]!(
+      Widget widget = pages[page]!(
         context,
         page,
         args,
@@ -367,6 +369,9 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
   }
 
   Map<String, UrlParametersBuilder> get _standaloneScreens {
+    // TODO(dantup): Standalone screens do not use DevToolsScaffold which means
+    //  they do not currently send an initial "currentPage" event to inform
+    //  the server which page they are rendering.
     return {
       for (final type in StandaloneScreenType.values)
         type.name: (_, __, args, ___) => type.screen,


### PR DESCRIPTION
The router is always called with a `null` page when the app first loads. Previously this would render a not-found page and because there are also no args, it would be marked as not-embedded and would register with the server as a page that can be reused which (partly) caused https://github.com/Dart-Code/Dart-Code/issues/4832.

In my testing, this change does not seem to impact any behaviour of loading the sidebar, homepage or directly accessing other pages.

I added a TODO about standalone screens not transmitting their pages. This is not causing any problems, but it feels a little odd. We could:

a) ignore this, it doesn't affect much since they're always embedded so the server will never try to reuse them
b) add a wrapper around standalone screens that just sends `currentPage` inside its `initState`
c) split `DevToolsScaffold` up into the parts that are only used by non-embedded pages (the nav, etc.) and the parts that should be used by everything (initialisation of things like `currentPage`)



