### PR TITLE
[deep link] add isRowHovered in column render

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -177,6 +177,7 @@ class DomainColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return _ErrorAwareText(
@@ -231,6 +232,7 @@ class PathColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return _ErrorAwareText(
@@ -302,6 +304,7 @@ class SchemeColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return Text(getValue(dataObject));
@@ -347,6 +350,7 @@ class OSColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return Text(getValue(dataObject));
@@ -415,6 +419,7 @@ class StatusColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     if (dataObject.domainErrors.isNotEmpty || dataObject.pathError) {
@@ -433,7 +438,6 @@ class StatusColumn extends ColumnData<LinkData>
   }
 }
 
-// TODO: Implement this column.
 class NavigationColumn extends ColumnData<LinkData>
     implements ColumnRenderer<LinkData> {
   NavigationColumn()
@@ -450,9 +454,12 @@ class NavigationColumn extends ColumnData<LinkData>
     BuildContext context,
     LinkData dataObject, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
-    return const Icon(Icons.arrow_forward);
+    return isRowHovered
+        ? const Icon(Icons.arrow_forward)
+        : const SizedBox.shrink();
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/logging/_kind_column.dart
+++ b/packages/devtools_app/lib/src/screens/logging/_kind_column.dart
@@ -28,6 +28,7 @@ class KindColumn extends ColumnData<LogData>
     BuildContext context,
     LogData item, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final String kind = item.kind;

--- a/packages/devtools_app/lib/src/screens/logging/_message_column.dart
+++ b/packages/devtools_app/lib/src/screens/logging/_message_column.dart
@@ -49,6 +49,7 @@ class MessageColumn extends ColumnData<LogData>
     BuildContext context,
     LogData data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final textStyle = Theme.of(context).fixedFontStyle;

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
@@ -56,6 +56,7 @@ class _ClassNameColumn extends ColumnData<DiffClassStats>
     BuildContext context,
     DiffClassStats data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return HeapClassView(
@@ -140,6 +141,7 @@ class _InstanceColumn extends ColumnData<DiffClassStats>
     BuildContext context,
     DiffClassStats data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final objects = _instances(data);

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_single.dart
@@ -48,6 +48,7 @@ class _ClassNameColumn extends ColumnData<SingleClassStats>
     BuildContext context,
     SingleClassStats data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return HeapClassView(
@@ -96,6 +97,7 @@ class _InstanceColumn extends ColumnData<SingleClassStats>
     BuildContext context,
     SingleClassStats data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return HeapInstanceTableCell(

--- a/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
@@ -58,6 +58,7 @@ class _FieldClassNameColumn extends ColumnData<ProfileRecord>
     BuildContext context,
     ProfileRecord data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     if (data.isTotal) return null;
@@ -137,6 +138,7 @@ class _FieldInstanceCountColumn extends ColumnData<ProfileRecord>
     BuildContext context,
     ProfileRecord data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return ProfileInstanceTableCell(

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/class_table.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/class_table.dart
@@ -41,6 +41,7 @@ class _TraceCheckBoxColumn extends ColumnData<TracedClass>
     BuildContext context,
     TracedClass item, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return Checkbox(
@@ -85,6 +86,7 @@ class _ClassNameColumn extends ColumnData<TracedClass>
     BuildContext context,
     TracedClass data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return HeapClassView(

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -379,6 +379,7 @@ class UriColumn extends ColumnData<NetworkRequest>
     BuildContext context,
     NetworkRequest data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final value = getDisplayValue(data);
@@ -460,6 +461,7 @@ class ActionsColumn extends ColumnData<NetworkRequest>
     BuildContext context,
     NetworkRequest data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final options = _buildOptions(data);
@@ -502,6 +504,7 @@ class StatusColumn extends ColumnData<NetworkRequest>
     BuildContext context,
     NetworkRequest data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final theme = Theme.of(context);

--- a/packages/devtools_app/lib/src/screens/profiler/panes/cpu_profile_columns.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/cpu_profile_columns.dart
@@ -65,6 +65,7 @@ class MethodAndSourceColumn extends TreeColumnData<CpuStackFrame>
     BuildContext context,
     CpuStackFrame data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return MethodAndSourceDisplay(

--- a/packages/devtools_app/lib/src/screens/profiler/panes/method_table/method_table.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/method_table/method_table.dart
@@ -261,6 +261,7 @@ class _MethodColumn extends ColumnData<MethodTableGraphNode>
     BuildContext context,
     MethodTableGraphNode data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return MethodAndSourceDisplay(

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_store.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_store.dart
@@ -45,6 +45,7 @@ class _ObjectColumn extends ColumnData<ObjectStoreEntry>
     // ignore: avoid-dynamic, requires refactor.
     data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return VmServiceObjectLink(

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_code_display.dart
@@ -69,6 +69,7 @@ class _FunctionsColumn extends _CodeColumnData<InliningEntry>
     BuildContext context,
     InliningEntry data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     return Row(
@@ -177,6 +178,7 @@ class _InstructionColumn extends _CodeColumnData<Instruction>
     BuildContext context,
     Instruction data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     final theme = Theme.of(context);
@@ -277,6 +279,7 @@ class _DartObjectColumn extends _CodeColumnData<Instruction>
     BuildContext context,
     Instruction data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     if (data.object == null) return Container();

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_object_pool_display.dart
@@ -55,6 +55,7 @@ class _DartObjectColumn extends _ObjectPoolColumnData
     BuildContext context,
     ObjectPoolEntry data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   }) {
     if (data.value is int) return Text(data.value.toString());

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -1149,6 +1149,7 @@ abstract class ColumnRenderer<T> {
     BuildContext context,
     T data, {
     bool isRowSelected = false,
+    bool isRowHovered = false,
     VoidCallback? onPressed,
   });
 }
@@ -1335,6 +1336,8 @@ class _TableRowState<T> extends State<TableRow<T>>
 
   bool isActiveSearchMatch = false;
 
+  bool isHovering = false;
+
   @override
   void initState() {
     super.initState();
@@ -1497,6 +1500,7 @@ class _TableRowState<T> extends State<TableRow<T>>
             context,
             node,
             isRowSelected: widget.isSelected,
+            isRowHovered: isHovered,
             onPressed: onPressed,
           );
         }
@@ -1640,30 +1644,34 @@ class _TableRowState<T> extends State<TableRow<T>>
       }
     }
 
-    final rowContent = Padding(
-      padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        controller: scrollController,
-        itemCount: widget.columns.length + widget.columns.numSpacers,
-        itemBuilder: (context, int i) {
-          final displayTypeForIndex = rowDisplayParts[i];
-          switch (displayTypeForIndex) {
-            case _TableRowPartDisplayType.column:
-              final index = columnIndexMap[i]!;
-              return columnFor(
-                widget.columns[index],
-                widget.columnWidths[index],
-              );
-            case _TableRowPartDisplayType.columnSpacer:
-              return const SizedBox(
-                width: columnSpacing,
-                child: VerticalDivider(width: columnSpacing),
-              );
-            case _TableRowPartDisplayType.columnGroupSpacer:
-              return const _ColumnGroupSpacer();
-          }
-        },
+    final rowContent = MouseRegion(
+      onEnter: (_) => setState(() => isHovering = true),
+      onExit: (_) => setState(() => isHovering = false),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: defaultSpacing),
+        child: ListView.builder(
+          scrollDirection: Axis.horizontal,
+          controller: scrollController,
+          itemCount: widget.columns.length + widget.columns.numSpacers,
+          itemBuilder: (context, int i) {
+            final displayTypeForIndex = rowDisplayParts[i];
+            switch (displayTypeForIndex) {
+              case _TableRowPartDisplayType.column:
+                final index = columnIndexMap[i]!;
+                return columnFor(
+                  widget.columns[index],
+                  widget.columnWidths[index],
+                );
+              case _TableRowPartDisplayType.columnSpacer:
+                return const SizedBox(
+                  width: columnSpacing,
+                  child: VerticalDivider(width: columnSpacing),
+                );
+              case _TableRowPartDisplayType.columnGroupSpacer:
+                return const _ColumnGroupSpacer();
+            }
+          },
+        ),
       ),
     );
     if (widget._rowType == _TableRowType.columnHeader) {

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -1500,7 +1500,7 @@ class _TableRowState<T> extends State<TableRow<T>>
             context,
             node,
             isRowSelected: widget.isSelected,
-            isRowHovered: isHovered,
+            isRowHovered: isHovering,
             onPressed: onPressed,
           );
         }


### PR DESCRIPTION

The last column in deep link table is a navigation column, when the row is hovered, the column content is an icon, otherwise it's empty.
  
<img width="1486" alt="WeChat23c7fe6bf78ef1ede95094d70f84523c" src="https://github.com/flutter/devtools/assets/108393416/7df8fed8-da9b-459f-a510-eeaff5d0ea42">



*List which issues are fixed by this PR.*

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
