### PR TITLE
Update dart doc for some `devtools_extensions` members

### DIFF
--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.0.11
-* Improve dartdoc for `DevToolsExtension` widget.
+* Improve dartdoc for `DevToolsExtension`, `extensionManager`, and `serviceManager`.
 * Migrate from `dart:html` to `package:web`.
 * Add `utils.dart` library with helper for message event parsing.
 

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## 0.0.11
+* Improve dartdoc for `DevToolsExtension` widget.
 * Migrate from `dart:html` to `package:web`.
 * Add `utils.dart` library with helper for message event parsing.
 

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -44,6 +44,10 @@ bool get _useSimulatedEnvironment =>
 ///
 /// A couple of use case examples include posting messages to DevTools or
 /// registering an event handler from the extension.
+/// 
+/// [extensionManager] can only be accessed below the [DevToolsExtension] widget
+/// in the widget tree, since it is initialized as part of the
+/// [DevToolsExtension]'s [initState] lifecycle method.
 ExtensionManager get extensionManager =>
     globals[ExtensionManager] as ExtensionManager;
 
@@ -51,6 +55,10 @@ ExtensionManager get extensionManager =>
 ///
 /// This manager provides sub-managers to interact with isolates, service
 /// extensions, etc.
+/// 
+/// [serviceManager] can only be accessed below the [DevToolsExtension] widget
+/// in the widget tree, since it is initialized as part of the
+/// [DevToolsExtension]'s [initState] lifecycle method.
 ServiceManager get serviceManager => globals[ServiceManager] as ServiceManager;
 
 /// A wrapper widget that performs initialization for a DevTools extension.

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -53,8 +53,22 @@ ExtensionManager get extensionManager =>
 /// extensions, etc.
 ServiceManager get serviceManager => globals[ServiceManager] as ServiceManager;
 
-/// A wrapper widget that initializes the [extensionManager] and establishes a
-/// connection with DevTools for this extension to interact over.
+/// A wrapper widget that performs initialization for a DevTools extension.
+/// 
+/// This widget is required to be at the root (or very close to the root) of
+/// your DevTools extension Flutter web app. The content of your DevTools
+/// extension should be defined by [child].
+/// 
+/// This wrapper:
+///  * initializes the [extensionManager] and [serviceManager] globals.
+///  * initializes the [extensionManager] with the VM service connection from
+///    DevTools when[requiresRunningApplication] is true.
+///  * establishes a connection with DevTools for this extension to interact
+///    over.
+/// 
+/// Any use of the [extensionManager], [serviceManager], or [ideTheme] globals
+/// must occur below the [DevToolsExtension] widget in the widget tree (i.e. at
+/// the level of [child] or below).
 class DevToolsExtension extends StatefulWidget {
   const DevToolsExtension({
     super.key,


### PR DESCRIPTION
Addresses the feedback at https://github.com/flutter/devtools/issues/6735 by adding documentation to clarify how the `serviceManager` and `extensionManager` globals should be used.