### PR TITLE
Add better error messaging when accessing devtools extension globals too soon

### DIFF
--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.0.11
+* Add error messaging when `extensionManager` or `serviceManager` are accessed before they
+are initialized.
 * Improve dartdoc for `DevToolsExtension`, `extensionManager`, and `serviceManager`.
 * Migrate from `dart:html` to `package:web`.
 * Add `utils.dart` library with helper for message event parsing.

--- a/packages/devtools_extensions/lib/src/template/devtools_extension.dart
+++ b/packages/devtools_extensions/lib/src/template/devtools_extension.dart
@@ -44,36 +44,50 @@ bool get _useSimulatedEnvironment =>
 ///
 /// A couple of use case examples include posting messages to DevTools or
 /// registering an event handler from the extension.
-/// 
+///
 /// [extensionManager] can only be accessed below the [DevToolsExtension] widget
 /// in the widget tree, since it is initialized as part of the
 /// [DevToolsExtension]'s [initState] lifecycle method.
 ExtensionManager get extensionManager =>
-    globals[ExtensionManager] as ExtensionManager;
+    _accessGlobalOrThrow<ExtensionManager>(globalName: 'extensionManager');
 
 /// A manager for interacting with the connected vm service, if present.
 ///
 /// This manager provides sub-managers to interact with isolates, service
 /// extensions, etc.
-/// 
+///
 /// [serviceManager] can only be accessed below the [DevToolsExtension] widget
 /// in the widget tree, since it is initialized as part of the
 /// [DevToolsExtension]'s [initState] lifecycle method.
-ServiceManager get serviceManager => globals[ServiceManager] as ServiceManager;
+ServiceManager get serviceManager =>
+    _accessGlobalOrThrow<ServiceManager>(globalName: 'serviceManager');
+
+T _accessGlobalOrThrow<T>({required String globalName}) {
+  final manager = globals[T] as T?;
+  if (manager == null) {
+    throw StateError(
+      "'$globalName' has not been initialized yet. You can only access "
+      "'$globalName' below the 'DevToolsExtension' widget in the widget "
+      "tree, since it is initialized as part of the the 'DevToolsExtension'"
+      "state's 'initState' lifecycle method.",
+    );
+  }
+  return manager;
+}
 
 /// A wrapper widget that performs initialization for a DevTools extension.
-/// 
+///
 /// This widget is required to be at the root (or very close to the root) of
 /// your DevTools extension Flutter web app. The content of your DevTools
 /// extension should be defined by [child].
-/// 
+///
 /// This wrapper:
 ///  * initializes the [extensionManager] and [serviceManager] globals.
 ///  * initializes the [extensionManager] with the VM service connection from
 ///    DevTools when[requiresRunningApplication] is true.
 ///  * establishes a connection with DevTools for this extension to interact
 ///    over.
-/// 
+///
 /// Any use of the [extensionManager], [serviceManager], or [ideTheme] globals
 /// must occur below the [DevToolsExtension] widget in the widget tree (i.e. at
 /// the level of [child] or below).

--- a/packages/devtools_extensions/test/devtools_extension_test.dart
+++ b/packages/devtools_extensions/test/devtools_extension_test.dart
@@ -1,0 +1,23 @@
+// Copyright 2023 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_extensions/devtools_extensions.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Global managers', () {
+    test('accessing early throws error', () {
+      expect(serviceManager, throwsStateError);
+      expect(extensionManager, throwsStateError);
+    });
+
+    testWidgets('building $DevToolsExtension initializes globals',
+        (tester) async {
+      await tester.pumpWidget(const DevToolsExtension(child: SizedBox()));
+      expect(serviceManager, isNotNull);
+      expect(extensionManager, isNotNull);
+    });
+  });
+}

--- a/packages/devtools_extensions/test/web/devtools_extension_test.dart
+++ b/packages/devtools_extensions/test/web/devtools_extension_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+@TestOn('browser')
+
 import 'package:devtools_extensions/devtools_extensions.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -9,8 +11,8 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('Global managers', () {
     test('accessing early throws error', () {
-      expect(serviceManager, throwsStateError);
-      expect(extensionManager, throwsStateError);
+      expect(() => serviceManager, throwsStateError);
+      expect(() => extensionManager, throwsStateError);
     });
 
     testWidgets('building $DevToolsExtension initializes globals',

--- a/tool/bots.sh
+++ b/tool/bots.sh
@@ -111,7 +111,8 @@ if [ "$BOT" = "main" ]; then
 
     pushd $DEVTOOLS_DIR/packages/devtools_extensions
     echo `pwd`
-    flutter test test/
+    flutter test test/*_test.dart
+    flutter test test/web --platform chrome
     popd
 
     # Change the directory back to devtools_app.


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6735