### PR TITLE
Reland "Set version constraints for pkg:web >=0.3.0 <0.5.0 (#6730)"

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
@@ -23,11 +23,17 @@ class ExportControllerWeb extends ExportController {
     final element = document.createElement('a') as HTMLAnchorElement;
     element.setAttribute(
       'href',
-      URL.createObjectURL(Blob([content.toJS].toJS)),
+      // TODO(srujzs): This is necessary in order to support package:web 0.4.0.
+      // This was not needed with 0.3.0, hence the lint.
+      // ignore: avoid-unnecessary-type-casts
+      URL.createObjectURL(Blob([content.toJS].toJS) as JSObject),
     );
     element.setAttribute('download', fileName);
     element.style.display = 'none';
-    (document.body as HTMLBodyElement).append(element);
+    // TODO(srujzs): This is necessary in order to support package:web 0.4.0.
+    // This was not needed with 0.3.0, hence the lint.
+    // ignore: avoid-unnecessary-type-casts
+    (document.body as HTMLBodyElement).append(element as JSAny);
     element.click();
     element.remove();
   }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -65,7 +65,7 @@ dependencies:
   vm_service: ^13.0.0
   # TODO https://github.com/dart-lang/sdk/issues/52853 - unpin this version
   vm_snapshot_analysis: 0.7.2
-  web: ^0.3.0
+  web: '>=0.3.0 <0.5.0'
   web_socket_channel: ^2.1.0
   # widget_icons: ^0.0.1
 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   meta: ^1.9.1
   pointer_interceptor: ^0.9.3+3
   vm_service: ^13.0.0
-  web: ^0.3.0
+  web: '>=0.3.0 <0.5.0'
 
 dev_dependencies:
   flutter_lints: ^2.0.3

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   path: ^1.8.0
   logging: ^1.1.1
   vm_service: ^13.0.0
-  web: ^0.3.0
+  web: '>=0.3.0 <0.5.0'
 
 dev_dependencies:
   flutter_driver:


### PR DESCRIPTION
Reverts flutter/devtools#6739. False alarm - this change is unrelated to the devtools breakage.