### PR TITLE
Increase the pump duration for app connection in integration test

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
@@ -2,9 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// TODO(kenz): remove this once the package:web version has been upgraded.
-// ignore_for_file: avoid-unused-ignores
-
 import 'dart:js_interop';
 
 import 'package:web/helpers.dart' hide NodeGlue;

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
@@ -2,7 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: avoid-unused-ignores, package:web upgrade is in progress.
+// TODO(kenz): remove this once the package:web version has been upgraded.
+// ignore_for_file: avoid-unused-ignores
 
 import 'dart:js_interop';
 

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: avoid-unused-ignores, package:web upgrade is in progress.
+
 import 'dart:js_interop';
 
 import 'package:web/helpers.dart' hide NodeGlue;

--- a/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
+++ b/packages/devtools_test/lib/src/integration_test/integration_test_utils.dart
@@ -129,7 +129,7 @@ Future<void> connectToTestApp(WidgetTester tester, TestApp testApp) async {
       matching: find.byType(ElevatedButton),
     ),
   );
-  await tester.pumpAndSettle(safePumpDuration);
+  await tester.pumpAndSettle(longPumpDuration);
 }
 
 Future<void> disconnectFromTestApp(WidgetTester tester) async {


### PR DESCRIPTION
Attempt to fix test flake by increasing the settle duration. We sometimes get the exception that the state after we click "connect" is not what we expect. Increasing the settle duration may reduce this flake.