### PR TITLE
Update analysis_options.yaml for lint being removed

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -26,7 +26,6 @@ linter:
     - always_declare_return_types
     # - always_put_control_body_on_new_line
     # - always_put_required_named_parameters_first # we prefer having parameters in the same order as fields https://github.com/flutter/flutter/issues/10219
-    - always_require_non_null_named_parameters
     # - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types


### PR DESCRIPTION
Removed in https://dart.googlesource.com/sdk.git/+/dd6c961bf0582b94a578ede5a6767988d0f78aed

This is blocking Dart rolls to Flutter via customer tests.
