### PR TITLE
Revert "Make widget search snap to entries while typing"

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -250,22 +250,7 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
     _searchFieldFocusNode?.dispose();
     _searchTextFieldController = SearchTextEditingController()
       ..text = _searchNotifier.value;
-    _searchFieldFocusNode = FocusNode(
-      debugLabel: 'search-field',
-      onKey: (FocusNode node, RawKeyEvent event) {
-        if (event.logicalKey.keyLabel == 'Enter') {
-          if (event is RawKeyDownEvent) {
-            if (event.isShiftPressed) {
-              previousMatch();
-            } else {
-              nextMatch();
-            }
-            return KeyEventResult.handled;
-          }
-        }
-        return KeyEventResult.ignored;
-      },
-    );
+    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
   }
 
   @mustCallSuper
@@ -1056,7 +1041,6 @@ class StatelessSearchField<T extends SearchableDataMixin>
       onChanged: (value) {
         onChanged?.call(value);
         controller.search = value;
-        controller.searchFieldFocusNode.requestFocus();
       },
       onEditingComplete: () {
         controller.searchFieldFocusNode.requestFocus();

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -16,8 +16,8 @@ under `lib` (e.g. a unit test or integration test). Thanks to
 [#6644](https://github.com/flutter/devtools/pull/6644)
 
 ## Inspector updates
-* When done typing in the search field, the next selection is now automatically selected - [#6677](https://github.com/flutter/devtools/pull/6677)
-* When typing in the search field, hitting `Enter` will now select the next search result, hitting `Shift+Enter` will now select the previous result. - [#6677](https://github.com/flutter/devtools/pull/6677)
+
+TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
 


### PR DESCRIPTION
Reverts flutter/devtools#6677. This was causing the failures seen here: https://github.com/flutter/devtools/actions/runs/7022677293/job/19107581205. Confirmed that the commit prior to this commit does not have the failure.