### PR TITLE
Focus inspector when done typing

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -187,9 +187,12 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
       activeMatchIndex = 0;
       matchIndex.value = 1; // first item because [matchIndex] us 1-based
     }
+
     _activeSearchMatch.value?.isActiveSearchMatch = false;
-    _activeSearchMatch.value = searchMatches.value[activeMatchIndex]
-      ..isActiveSearchMatch = true;
+    if (searchMatches.value.isNotEmpty) {
+      _activeSearchMatch.value = searchMatches.value[activeMatchIndex]
+        ..isActiveSearchMatch = true;
+    }
     onMatchChanged(activeMatchIndex);
   }
 
@@ -250,7 +253,22 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
     _searchFieldFocusNode?.dispose();
     _searchTextFieldController = SearchTextEditingController()
       ..text = _searchNotifier.value;
-    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
+    _searchFieldFocusNode = FocusNode(
+      debugLabel: 'search-field',
+      onKey: (FocusNode node, RawKeyEvent event) {
+        if (event.logicalKey.keyLabel == 'Enter') {
+          if (event is RawKeyDownEvent) {
+            if (event.isShiftPressed) {
+              previousMatch();
+            } else {
+              nextMatch();
+            }
+            return KeyEventResult.handled;
+          }
+        }
+        return KeyEventResult.ignored;
+      },
+    );
   }
 
   @mustCallSuper
@@ -1041,6 +1059,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
       onChanged: (value) {
         onChanged?.call(value);
         controller.search = value;
+        controller.searchFieldFocusNode.requestFocus();
       },
       onEditingComplete: () {
         controller.searchFieldFocusNode.requestFocus();

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -187,12 +187,9 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
       activeMatchIndex = 0;
       matchIndex.value = 1; // first item because [matchIndex] us 1-based
     }
-
     _activeSearchMatch.value?.isActiveSearchMatch = false;
-    if (searchMatches.value.isNotEmpty) {
-      _activeSearchMatch.value = searchMatches.value[activeMatchIndex]
-        ..isActiveSearchMatch = true;
-    }
+    _activeSearchMatch.value = searchMatches.value[activeMatchIndex]
+      ..isActiveSearchMatch = true;
     onMatchChanged(activeMatchIndex);
   }
 
@@ -253,22 +250,7 @@ mixin SearchControllerMixin<T extends SearchableDataMixin> {
     _searchFieldFocusNode?.dispose();
     _searchTextFieldController = SearchTextEditingController()
       ..text = _searchNotifier.value;
-    _searchFieldFocusNode = FocusNode(
-      debugLabel: 'search-field',
-      onKey: (FocusNode node, RawKeyEvent event) {
-        if (event.logicalKey.keyLabel == 'Enter') {
-          if (event is RawKeyDownEvent) {
-            if (event.isShiftPressed) {
-              previousMatch();
-            } else {
-              nextMatch();
-            }
-            return KeyEventResult.handled;
-          }
-        }
-        return KeyEventResult.ignored;
-      },
-    );
+    _searchFieldFocusNode = FocusNode(debugLabel: 'search-field');
   }
 
   @mustCallSuper

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -16,8 +16,8 @@ under `lib` (e.g. a unit test or integration test). Thanks to
 [#6644](https://github.com/flutter/devtools/pull/6644)
 
 ## Inspector updates
-
-TODO: Remove this section if there are not any general updates.
+* When done typing in the search field, the next selection is now automatically selected - [#6677](https://github.com/flutter/devtools/pull/6677)
+* When typing in the search field, hitting `Enter` will now select the next search result, hitting `Shift+Enter` will now select the previous result. - [#6677](https://github.com/flutter/devtools/pull/6677)
 
 ## Performance updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -17,7 +17,6 @@ under `lib` (e.g. a unit test or integration test). Thanks to
 
 ## Inspector updates
 * When done typing in the search field, the next selection is now automatically selected - [#6677](https://github.com/flutter/devtools/pull/6677)
-* When typing in the search field, hitting `Enter` will now select the next search result, hitting `Shift+Enter` will now select the previous result. - [#6677](https://github.com/flutter/devtools/pull/6677)
 
 ## Performance updates
 


### PR DESCRIPTION
![](https://media.giphy.com/media/ZFFVNwIbjsKtP3lHYK/giphy-downsized.gif)

Reverts https://github.com/flutter/devtools/pull/6677

This only brings back the "Focus when done typing behaviour" and removes the "enter and shift+enter" convenience functionality.

It turns out that there is some autocomplete behaviour that overlaps with this. 

I will open up a new issue to discuss modifying the behaviour of the autocomplete so that we can still have the convenience functions