### PR TITLE
Remove unnecessary pub upgrade from update-version command

### DIFF
--- a/tool/lib/commands/update_version.dart
+++ b/tool/lib/commands/update_version.dart
@@ -54,12 +54,6 @@ Future<void> performTheVersionUpdate({
     File(pathFromRepoRoot('packages/devtools_app/lib/devtools.dart')),
     newVersion,
   );
-
-  await DevToolsCommandRunner().run([
-    'pub-get',
-    '--upgrade',
-    '--only-main',
-  ]);
 }
 
 Future<void> resetReleaseNotes({


### PR DESCRIPTION
We don't need to upgrade packages since this tool is just intended to use dart:io to modify pubspecs and maybe release notess markdown.