### PR TITLE
Remove unnecessary file_selector_* imports

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -29,10 +29,6 @@ dependencies:
   devtools_shared: ^6.0.1
   file: ">=6.0.0 <8.0.0"
   file_selector: ^1.0.0
-  file_selector_linux: ^0.9.0
-  file_selector_macos: ^0.9.0
-  file_selector_web: ^0.9.0
-  file_selector_windows: ^0.9.0
   flutter:
     sdk: flutter
   flutter_markdown: ^0.6.8


### PR DESCRIPTION
These are transitive deps of `file_selector` already