### PR TITLE
Only cache pub root directories set by the user

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -583,8 +583,12 @@ class PubRootDirectorySection extends StatelessWidget {
             textFieldLabel: 'Enter a new package directory',
             isRefreshing:
                 preferences.inspector.isRefreshingCustomPubRootDirectories,
-            onEntryAdded: (p0) =>
-                unawaited(preferences.inspector.addPubRootDirectories([p0])),
+            onEntryAdded: (p0) => unawaited(
+              preferences.inspector.addPubRootDirectories(
+                [p0],
+                shouldCache: true,
+              ),
+            ),
             onEntryRemoved: (p0) =>
                 unawaited(preferences.inspector.removePubRootDirectories([p0])),
             onRefreshTriggered: () =>

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -126,7 +126,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
         searchPreventClose = false;
       }
     });
-    addAutoDisposeListener(preferences.inspector.customPubRootDirectories, () {
+    addAutoDisposeListener(preferences.inspector.pubRootDirectories, () {
       if (serviceConnection.serviceManager.hasConnection &&
           controller.firstInspectorTreeLoadCompleted) {
         _refreshInspector();

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -579,10 +579,9 @@ class PubRootDirectorySection extends StatelessWidget {
           child: EditableList(
             gaScreen: gac.inspector,
             gaRefreshSelection: gac.refreshPubRoots,
-            entries: preferences.inspector.customPubRootDirectories,
+            entries: preferences.inspector.pubRootDirectories,
             textFieldLabel: 'Enter a new package directory',
-            isRefreshing:
-                preferences.inspector.isRefreshingCustomPubRootDirectories,
+            isRefreshing: preferences.inspector.isRefreshingPubRootDirectories,
             onEntryAdded: (p0) => unawaited(
               preferences.inspector.addPubRootDirectories(
                 [p0],

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -588,7 +588,7 @@ class PubRootDirectorySection extends StatelessWidget {
             onEntryRemoved: (p0) =>
                 unawaited(preferences.inspector.removePubRootDirectories([p0])),
             onRefreshTriggered: () =>
-                unawaited(preferences.inspector.loadCustomPubRootDirectories()),
+                unawaited(preferences.inspector.loadPubRootDirectories()),
           ),
         );
       },

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -21,6 +21,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../console/primitives/simple_items.dart';
 import '../globals.dart';
+import '../utils.dart';
 import 'diagnostics_node.dart';
 import 'generic_instance_reference.dart';
 import 'object_group_api.dart';
@@ -29,8 +30,6 @@ import 'primitives/source_location.dart';
 
 const _inspectorLibraryUri =
     'package:flutter/src/widgets/widget_inspector.dart';
-const _google3PathSegment = 'google3';
-const _thirdPartyPathSegment = 'third_party';
 
 abstract class InspectorServiceBase extends DisposableController
     with AutoDisposeControllerMixin {
@@ -342,8 +341,8 @@ class InspectorService extends InspectorServiceBase {
       final libIndex = parts.lastIndexOf('lib');
       final path = libIndex > 0 ? parts.sublist(0, libIndex) : parts;
       // Special case handling of bazel packages.
-      if (_isGoogle3Path(path)) {
-        var packageParts = _stripGoogle3(path);
+      if (isGoogle3Path(path)) {
+        var packageParts = stripGoogle3(path);
         // A well formed third_party dart package should be in a directory of
         // the form
         // third_party/dart/packageName                    (package:packageName)
@@ -464,17 +463,6 @@ class InspectorService extends InspectorServiceBase {
     }
 
     return response as Map<String, dynamic>;
-  }
-
-  bool _isGoogle3Path(List<String> pathParts) =>
-      pathParts.contains(_google3PathSegment);
-
-  List<String> _stripGoogle3(List<String> pathParts) {
-    final google3Index = pathParts.lastIndexOf(_google3PathSegment);
-    if (google3Index != -1 && google3Index + 1 < pathParts.length) {
-      return pathParts.sublist(google3Index + 1);
-    }
-    return pathParts;
   }
 
   RemoteDiagnosticsNode? _currentSelection;

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -253,7 +253,7 @@ class InspectorPreferencesController extends DisposableController
   }
 
   Future<void> loadPubRootDirectories() async {
-    await _customPubRootDirectoryBusyTracker(() async {
+    await _pubRootDirectoryBusyTracker(() async {
       await addPubRootDirectories(await _determinePubRootDirectories());
       await _refreshPubRootDirectoriesFromService();
     });
@@ -354,7 +354,7 @@ class InspectorPreferencesController extends DisposableController
     );
 
     if (!serviceConnection.serviceManager.hasConnection) return;
-    await _customPubRootDirectoryBusyTracker(() async {
+    await _pubRootDirectoryBusyTracker(() async {
       final localInspectorService = _inspectorService;
       if (localInspectorService is! InspectorService) return;
 
@@ -370,7 +370,7 @@ class InspectorPreferencesController extends DisposableController
     List<String> pubRootDirectories,
   ) async {
     if (!serviceConnection.serviceManager.hasConnection) return;
-    await _customPubRootDirectoryBusyTracker(() async {
+    await _pubRootDirectoryBusyTracker(() async {
       final localInspectorService = _inspectorService;
       if (localInspectorService is! InspectorService) return;
 
@@ -380,7 +380,7 @@ class InspectorPreferencesController extends DisposableController
   }
 
   Future<void> _refreshPubRootDirectoriesFromService() async {
-    await _customPubRootDirectoryBusyTracker(() async {
+    await _pubRootDirectoryBusyTracker(() async {
       final localInspectorService = _inspectorService;
       if (localInspectorService is! InspectorService) return;
 
@@ -404,7 +404,7 @@ class InspectorPreferencesController extends DisposableController
     return '${_customPubRootDirectoriesStoragePrefix}_$packageId';
   }
 
-  Future<void> _customPubRootDirectoryBusyTracker(
+  Future<void> _pubRootDirectoryBusyTracker(
     Future<void> Function() callback,
   ) async {
     try {

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -332,7 +332,7 @@ class InspectorPreferencesController extends DisposableController
     }
   }
 
-  void _cachePubRootDirectories(
+  Future<void> _cachePubRootDirectories(
     List<String> pubRootDirectories,
   ) async {
     final cachedDirectories = await readCachedPubRootDirectories();
@@ -375,7 +375,7 @@ class InspectorPreferencesController extends DisposableController
 
       await localInspectorService.addPubRootDirectories(pubRootDirectories);
       if (shouldCache) {
-        _cachePubRootDirectories(pubRootDirectories);
+        await _cachePubRootDirectories(pubRootDirectories);
       }
       await _refreshPubRootDirectoriesFromService();
     });

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -171,7 +171,7 @@ class InspectorPreferencesController extends DisposableController
   Future<void> init() async {
     await _initHoverEvalMode();
     // TODO(jacobr): consider initializing this first as it is not blocking.
-    _initCustomPubRootDirectories();
+    _initPubRootDirectories();
   }
 
   Future<void> _initHoverEvalMode() async {
@@ -194,12 +194,12 @@ class InspectorPreferencesController extends DisposableController
     setHoverEvalMode(hoverEvalModeEnabledValue == 'true');
   }
 
-  void _initCustomPubRootDirectories() {
+  void _initPubRootDirectories() {
     addAutoDisposeListener(
       serviceConnection.serviceManager.connectedState,
       () async {
         if (serviceConnection.serviceManager.connectedState.value.connected) {
-          await _handleConnectionToNewService();
+          await handleConnectionToNewService();
         } else {
           _handleConnectionClosed();
         }
@@ -245,7 +245,8 @@ class InspectorPreferencesController extends DisposableController
     _pubRootDirectories.clear();
   }
 
-  Future<void> _handleConnectionToNewService() async {
+  @visibleForTesting
+  Future<void> handleConnectionToNewService() async {
     await _updateMainScriptRef();
     await _updateHoverEvalMode();
     await loadPubRootDirectories();

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -408,8 +408,9 @@ class InspectorPreferencesController extends DisposableController
         final directoriesToAdd = newSet.difference(oldSet);
         final directoriesToRemove = oldSet.difference(newSet);
 
-        _pubRootDirectories.removeAll(directoriesToRemove);
-        _pubRootDirectories.addAll(directoriesToAdd);
+        _pubRootDirectories
+          ..removeAll(directoriesToRemove)
+          ..addAll(directoriesToAdd);
       }
     });
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -140,16 +140,15 @@ class PreferencesController extends DisposableController
 class InspectorPreferencesController extends DisposableController
     with AutoDisposeControllerMixin {
   ValueListenable<bool> get hoverEvalModeEnabled => _hoverEvalMode;
-  ListValueNotifier<String> get customPubRootDirectories =>
-      _customPubRootDirectories;
-  ValueListenable<bool> get isRefreshingCustomPubRootDirectories =>
-      _customPubRootDirectoriesAreBusy;
+  ListValueNotifier<String> get pubRootDirectories => _pubRootDirectories;
+  ValueListenable<bool> get isRefreshingPubRootDirectories =>
+      _pubRootDirectoriesAreBusy;
   InspectorServiceBase? get _inspectorService =>
       serviceConnection.inspectorService;
 
   final _hoverEvalMode = ValueNotifier<bool>(false);
-  final _customPubRootDirectories = ListValueNotifier<String>([]);
-  final _customPubRootDirectoriesAreBusy = ValueNotifier<bool>(false);
+  final _pubRootDirectories = ListValueNotifier<String>([]);
+  final _pubRootDirectoriesAreBusy = ValueNotifier<bool>(false);
   final _busyCounter = ValueNotifier<int>(0);
   static const _hoverEvalModeStorageId = 'inspector.hoverEvalMode';
   static const _customPubRootDirectoriesStoragePrefix =
@@ -207,7 +206,7 @@ class InspectorPreferencesController extends DisposableController
       },
     );
     addAutoDisposeListener(_busyCounter, () {
-      _customPubRootDirectoriesAreBusy.value = _busyCounter.value != 0;
+      _pubRootDirectoriesAreBusy.value = _busyCounter.value != 0;
     });
     addAutoDisposeListener(
       serviceConnection.serviceManager.isolateManager.mainIsolate,
@@ -243,7 +242,7 @@ class InspectorPreferencesController extends DisposableController
 
   void _handleConnectionClosed() {
     _mainScriptDir = null;
-    _customPubRootDirectories.clear();
+    _pubRootDirectories.clear();
   }
 
   Future<void> _handleConnectionToNewService() async {
@@ -388,12 +387,12 @@ class InspectorPreferencesController extends DisposableController
           await localInspectorService.getPubRootDirectories();
       if (freshPubRootDirectories != null) {
         final newSet = Set<String>.of(freshPubRootDirectories);
-        final oldSet = Set<String>.of(_customPubRootDirectories.value);
+        final oldSet = Set<String>.of(_pubRootDirectories.value);
         final directoriesToAdd = newSet.difference(oldSet);
         final directoriesToRemove = oldSet.difference(newSet);
 
-        _customPubRootDirectories.removeAll(directoriesToRemove);
-        _customPubRootDirectories.addAll(directoriesToAdd);
+        _pubRootDirectories.removeAll(directoriesToRemove);
+        _pubRootDirectories.addAll(directoriesToAdd);
       }
     });
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -264,7 +264,7 @@ class InspectorPreferencesController extends DisposableController
     final inferredDirectory = await _inferPubRootDirectory();
 
     if (inferredDirectory == null) return cachedDirectories;
-    return {...cachedDirectories, inferredDirectory}.toList();
+    return {inferredDirectory, ...cachedDirectories}.toList();
   }
 
   Future<List<String>> _readCachedPubRootDirectories() async {

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -331,9 +331,21 @@ class InspectorPreferencesController extends DisposableController
     }
   }
 
-  Future<void> addPubRootDirectories(
+  void _cacheCustomPubRootDirectories(
     List<String> pubRootDirectories,
-  ) async {
+  ) {
+    unawaited(
+      storage.setValue(
+        _customPubRootStorageId(),
+        jsonEncode(pubRootDirectories),
+      ),
+    );
+  }
+
+  Future<void> addPubRootDirectories(
+    List<String> pubRootDirectories, {
+    bool shouldCache = false,
+  }) async {
     // TODO(https://github.com/flutter/devtools/issues/4380):
     // Add validation to EditableList Input.
     // Directories of just / will break the inspector tree local package checks.
@@ -347,6 +359,9 @@ class InspectorPreferencesController extends DisposableController
       if (localInspectorService is! InspectorService) return;
 
       await localInspectorService.addPubRootDirectories(pubRootDirectories);
+      if (shouldCache) {
+        _cacheCustomPubRootDirectories(pubRootDirectories);
+      }
       await _refreshPubRootDirectoriesFromService();
     });
   }

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -17,8 +17,8 @@ import 'config_specific/logger/logger_helpers.dart';
 import 'constants.dart';
 import 'diagnostics/inspector_service.dart';
 import 'globals.dart';
+import 'utils.dart';
 
-const _google3PathSegment = 'google3';
 const _thirdPartyPathSegment = 'third_party';
 
 /// A controller for global application preferences.
@@ -296,7 +296,7 @@ class InspectorPreferencesController extends DisposableController
     // For google3, we grab the top-level directory in the google3 directory
     // (e.g. /education), or the top-level directory in third_party (e.g.
     // /third_party/dart):
-    if (_isGoogle3Path(parts)) {
+    if (isGoogle3Path(parts)) {
       pubRootDirectory = _pubRootDirectoryForGoogle3(parts);
     } else {
       final parts = path.split('/');
@@ -318,21 +318,8 @@ class InspectorPreferencesController extends DisposableController
     return pubRootDirectory;
   }
 
-  // TODO: De-duplicate with inspector_service
-  bool _isGoogle3Path(List<String> pathParts) =>
-      pathParts.contains(_google3PathSegment);
-
-  // TODO: De-duplicate with inspector_service
-  List<String> _stripGoogle3(List<String> pathParts) {
-    final google3Index = pathParts.lastIndexOf(_google3PathSegment);
-    if (google3Index != -1 && google3Index + 1 < pathParts.length) {
-      return pathParts.sublist(google3Index + 1);
-    }
-    return pathParts;
-  }
-
   String? _pubRootDirectoryForGoogle3(List<String> pathParts) {
-    final strippedParts = _stripGoogle3(pathParts);
+    final strippedParts = stripGoogle3(pathParts);
     if (strippedParts.isEmpty) return null;
 
     final topLevelDirectory = strippedParts.first;

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -213,3 +213,16 @@ String? lookupFromQueryParams(String key) {
   final queryParameters = loadQueryParams();
   return queryParameters[key];
 }
+
+const _google3PathSegment = 'google3';
+
+bool isGoogle3Path(List<String> pathParts) =>
+    pathParts.contains(_google3PathSegment);
+
+List<String> stripGoogle3(List<String> pathParts) {
+  final google3Index = pathParts.lastIndexOf(_google3PathSegment);
+  if (google3Index != -1 && google3Index + 1 < pathParts.length) {
+    return pathParts.sublist(google3Index + 1);
+  }
+  return pathParts;
+}

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -17,6 +17,7 @@ TODO: Remove this section if there are not any general updates.
 * Added link to package directory documentation, from the inspect settings dialog - [6825](https://github.com/flutter/devtools/pull/6825)
 * Fix bug where widgets owned by the Flutter framework were showing up in the widget tree view -
 [6857](https://github.com/flutter/devtools/pull/6857)
+* Only cache pub root directories added by the user - [6897](https://github.com/flutter/devtools/pull/6897)
 
 ## Performance updates
 

--- a/packages/devtools_app/test/inspector/inspector_integration_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_integration_test.dart
@@ -37,10 +37,6 @@ void main() {
         isAlive: null,
       );
     }
-
-    if (service is InspectorService) {
-      await service.inferPubRootDirectoryIfNeeded();
-    }
   };
 
   setUp(() async {

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -17,10 +17,6 @@ import '../test_infra/flutter_test_driver.dart' show FlutterRunConfiguration;
 import '../test_infra/flutter_test_environment.dart';
 import '../test_infra/matchers/matchers.dart';
 
-// TODO(elliette): Add testing that project directories can be inferred from
-// google3-paths. This will require mocking the main isolate so that we can
-// change the root library during testing instead of using the
-// LiveTestWidgetsFlutterBinding.
 void main() {
   initializeLiveTestWidgetsFlutterBindingWithAssets();
 
@@ -35,9 +31,6 @@ void main() {
     setGlobal(IdeTheme, IdeTheme());
 
     inspectorService = InspectorService();
-    // if (env.runConfig.trackWidgetCreation) {
-    //   await inspectorService!.inferPubRootDirectoryIfNeeded();
-    // }
   };
 
   env.beforeEveryTearDown = () async {
@@ -125,16 +118,17 @@ void main() {
           () async {
             await env.setupEnvironment();
             final inspectorServiceLocal = inspectorService!;
-
             final group = inspectorServiceLocal.createObjectGroup('test-group');
             // These tests are moot if widget creation is not tracked.
             expect(
               await inspectorServiceLocal.isWidgetCreationTracked(),
               isTrue,
             );
-            await inspectorServiceLocal.addPubRootDirectories([]);
+            final rootLibrary =
+                await serviceConnection.rootLibraryForMainIsolate();
+            await inspectorServiceLocal.addPubRootDirectories([rootLibrary!]);
             final List<String> rootDirectories =
-                await inspectorServiceLocal.inferPubRootDirectoryIfNeeded();
+                await inspectorServiceLocal.getPubRootDirectories() ?? [];
             expect(rootDirectories.length, 1);
             expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
             final originalRootDirectories = rootDirectories.toList();

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -35,9 +35,9 @@ void main() {
     setGlobal(IdeTheme, IdeTheme());
 
     inspectorService = InspectorService();
-    if (env.runConfig.trackWidgetCreation) {
-      await inspectorService!.inferPubRootDirectoryIfNeeded();
-    }
+    // if (env.runConfig.trackWidgetCreation) {
+    //   await inspectorService!.inferPubRootDirectoryIfNeeded();
+    // }
   };
 
   env.beforeEveryTearDown = () async {

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -86,24 +86,6 @@ void main() {
           await env.tearDownEnvironment(force: true);
         });
 
-        // TODO(elliette): Figure out why this didn't catch
-        // https://github.com/flutter/devtools/issues/6841 and fix so that it
-        // catches future regressions.
-        test('can be inferred', () async {
-          await env.setupEnvironment();
-          final inspectorServiceLocal = inspectorService!;
-
-          final group = inspectorServiceLocal.createObjectGroup('test-group');
-          // These tests are moot if widget creation is not tracked.
-          expect(await inspectorServiceLocal.isWidgetCreationTracked(), isTrue);
-          await inspectorServiceLocal.addPubRootDirectories([]);
-          final List<String> rootDirectories =
-              await inspectorServiceLocal.inferPubRootDirectoryIfNeeded();
-          expect(rootDirectories.length, 1);
-          expect(rootDirectories.first, endsWith('/fixtures/flutter_app'));
-          await group.dispose();
-        });
-
         test('can be added and removed', () async {
           await env.setupEnvironment();
           final inspectorServiceLocal = inspectorService!;
@@ -269,8 +251,7 @@ void main() {
           expect(await inspectorServiceLocal.isWidgetCreationTracked(), isTrue);
           await inspectorServiceLocal.addPubRootDirectories([]);
           final originalRootDirectories =
-              (await inspectorServiceLocal.inferPubRootDirectoryIfNeeded())
-                  .toList();
+              await inspectorServiceLocal.getPubRootDirectories();
           try {
             await inspectorServiceLocal.addPubRootDirectories(
               ['/usr/me/clients/google3/foo/bar/baz/lib/src/bla'],
@@ -379,7 +360,7 @@ void main() {
           } finally {
             // Restore.
             await inspectorServiceLocal
-                .addPubRootDirectories(originalRootDirectories);
+                .addPubRootDirectories(originalRootDirectories ?? []);
 
             await group.dispose();
           }

--- a/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
@@ -15,10 +15,10 @@ import 'generated.mocks.dart';
 
 base class FakeIsolateManager extends Fake with TestIsolateManager {
   FakeIsolateManager({
-    this.rootLibrary,
+    this.rootLibrary = 'package:my_app/main.dart',
   });
 
-  String? rootLibrary;
+  final String? rootLibrary;
 
   @override
   ValueListenable<IsolateRef?> get selectedIsolate => _selectedIsolate;
@@ -57,7 +57,7 @@ base class FakeIsolateManager extends Fake with TestIsolateManager {
   IsolateState isolateState(IsolateRef? isolate) {
     final state = MockIsolateState();
     final mockIsolate = MockIsolate();
-    final rootLib = LibraryRef(id: '0', uri: 'package:my_app/main.dart');
+    final rootLib = LibraryRef(id: '0', uri: rootLibrary);
     when(mockIsolate.libraries).thenReturn(
       [
         rootLib,

--- a/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_isolate_manager.dart
@@ -14,6 +14,12 @@ import 'package:vm_service/vm_service.dart';
 import 'generated.mocks.dart';
 
 base class FakeIsolateManager extends Fake with TestIsolateManager {
+  FakeIsolateManager({
+    this.rootLibrary,
+  });
+
+  String? rootLibrary;
+
   @override
   ValueListenable<IsolateRef?> get selectedIsolate => _selectedIsolate;
   final _selectedIsolate = ValueNotifier(

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -22,7 +22,6 @@ import 'mocks.dart';
 
 class FakeServiceConnectionManager extends Fake
     implements ServiceConnectionManager {
-  final String? rootLibrary;
 
   FakeServiceConnectionManager({
     VmServiceWrapper? service,
@@ -48,6 +47,7 @@ class FakeServiceConnectionManager extends Fake
           .thenReturn(ValueNotifier<int>(0));
     }
   }
+  final String? rootLibrary;
 
   @override
   FakeServiceManager get serviceManager =>

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -22,6 +22,8 @@ import 'mocks.dart';
 
 class FakeServiceConnectionManager extends Fake
     implements ServiceConnectionManager {
+  final String? rootLibrary;
+
   FakeServiceConnectionManager({
     VmServiceWrapper? service,
     bool hasConnection = true,
@@ -29,6 +31,7 @@ class FakeServiceConnectionManager extends Fake
     bool hasService = true,
     List<String> availableServices = const [],
     List<String> availableLibraries = const [],
+    this.rootLibrary,
   }) {
     _serviceManager = FakeServiceManager(
       service: service,
@@ -88,6 +91,9 @@ class FakeServiceConnectionManager extends Fake
   }) {
     return Future.value();
   }
+
+  @override
+  Future<String?> rootLibraryForMainIsolate() => Future.value(rootLibrary);
 }
 
 // ignore: subtype_of_sealed_class, fake for testing.

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -28,11 +28,6 @@ class FakeInspectorService extends Fake implements InspectorService {
   }
 
   @override
-  Future<List<String>> inferPubRootDirectoryIfNeeded() async {
-    return ['/some/directory'];
-  }
-
-  @override
   Future<List<String>?> getPubRootDirectories() {
     return Future.value(pubRootDirectories.toList());
   }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6882

This PR changes our caching logic around pub root directories to:
1. Always try to infer the app's pub root directory when we connect to an app
2. Only cache pub root directories that have been explicitly added by the user

This PR also:
* Renames a lot of variables that were prefixed by "customPubRootDirectoriesX" to "pubRootDirectoriesX", since the **custom** pub root directories only refer to those that have been explicitly added by the user and saved in the cache.
* Moves the logic for inferring the pub root directory from `InspectorService` to `InspectorPreferencesController` (with https://github.com/flutter/devtools/pull/6857, we no longer use the widget tree to infer the pub root directory, therefore there is no need for it to be in `InspectorService`)
* Adds test cases, including test cases to make sure that our google3-path parsing logic is sound (TODO from https://github.com/flutter/devtools/pull/6857)

Follow-up work (not included in this PR):
- Remove the Flutter pub root from the cache if we detect it there. (remediation for https://github.com/flutter/devtools/issues/6841)
- Invalidate the user's cache, so that any stale inferred directories are removed


