### PR TITLE
Use the proper mounted guard in a State class

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/select_project_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/select_project_view.dart
@@ -40,7 +40,7 @@ class _SelectProjectViewState extends State<SelectProjectView>
     ga.timeStart(gac.deeplink, gac.AnalyzeFlutterProject.loadVariants.name);
     final List<String> androidVariants =
         await server.requestAndroidBuildVariants(directory);
-    if (!context.mounted) {
+    if (!mounted) {
       ga.cancelTimingOperation(
         gac.deeplink,
         gac.AnalyzeFlutterProject.loadVariants.name,


### PR DESCRIPTION
In order to guard a use of a BuildContext which is a field in a State, we need to use the State's `mounted` check.

See https://github.com/dart-lang/linter/issues/4777 for more details.


Related to https://github.com/dart-lang/linter/issues/4777


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
