### PR TITLE
Add a global --flutter-from-path argument that overrides SDK selection

### DIFF
--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -101,11 +101,8 @@ class UpdateFlutterSdkCommand extends Command {
     final flutterSdkDirName = repo.sdkDirectoryName;
     final toolSdkPath = repo.toolFlutterSdkPath;
 
-    // Check if the Flutter SDK we're using is not the local tool/flutter-sdk
-    // one and if so update that too.
-    //
-    // Check paths case-insensitively because of potential differences like
-    // windows drive letters.
+    // If the flag was set, update the SDK on PATH in addition to the
+    // tool/flutter-sdk copy.
     if (updateOnPath) {
       final pathSdk = FlutterSdk.findFromPathEnvironmentVariable();
       log.stdout('Updating Flutter from PATH at ${pathSdk.sdkPath}');

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -8,7 +8,6 @@ import 'package:args/command_runner.dart';
 import 'package:cli_util/cli_logging.dart';
 import 'package:devtools_tool/model.dart';
 import 'package:io/io.dart';
-import 'package:path/path.dart' as path;
 
 import '../utils.dart';
 

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -91,8 +91,8 @@ class UpdateFlutterSdkCommand extends Command {
     );
 
     final sdk = FlutterSdk.current;
-    final flutterSdkDirName = 'flutter-sdk';
-    final toolSdkPath = path.join(repo.toolDirectoryPath, flutterSdkDirName);
+    final flutterSdkDirName = repo.sdkDirectoryName;
+    final toolSdkPath = repo.toolFlutterSdkPath;
     final toolFlutterSdkDirectory = Directory(toolSdkPath);
 
     // Check if the Flutter SDK we're using is not the local tool/flutter-sdk
@@ -100,8 +100,7 @@ class UpdateFlutterSdkCommand extends Command {
     //
     // Check paths case-insensitively because of potential differences like
     // windows drive letters.
-    if (sdk.sdkPath.toLowerCase() !=
-        toolFlutterSdkDirectory.path.toLowerCase()) {
+    if (sdk.sdkPath.toLowerCase() != toolSdkPath.toLowerCase()) {
       log.stdout(
         'Current Flutter SDK is not tool/flutter-sdk, updating repository '
         'at ${sdk.sdkPath}',

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:devtools_tool/commands/build.dart';
 import 'package:devtools_tool/commands/fix_goldens.dart';
@@ -10,6 +11,7 @@ import 'package:devtools_tool/commands/serve.dart';
 import 'package:devtools_tool/commands/sync.dart';
 import 'package:devtools_tool/commands/update_flutter_sdk.dart';
 import 'package:devtools_tool/commands/update_perfetto.dart';
+import 'package:devtools_tool/model.dart';
 
 import 'commands/analyze.dart';
 import 'commands/list.dart';
@@ -19,6 +21,9 @@ import 'commands/repo_check.dart';
 import 'commands/rollback.dart';
 import 'commands/update_dart_sdk_deps.dart';
 import 'commands/update_version.dart';
+
+const _flutterFromPathFlag = 'flutter-from-path';
+const _flutterFromPathAlias = 'from-path';
 
 class DevToolsCommandRunner extends CommandRunner {
   DevToolsCommandRunner()
@@ -38,5 +43,26 @@ class DevToolsCommandRunner extends CommandRunner {
     addCommand(UpdateDevToolsVersionCommand());
     addCommand(UpdateFlutterSdkCommand());
     addCommand(UpdatePerfettoCommand());
+
+    argParser.addFlag(
+      _flutterFromPathFlag,
+      aliases: [_flutterFromPathAlias],
+      abbr: 'p',
+      negatable: false,
+      help: 'Use the Flutter SDK on PATH rather than the one being used to run '
+          'devtools_tool (usually tool/flutter-sdk)',
+    );
+  }
+
+  @override
+  Future<void> runCommand(ArgResults topLevelResults) {
+    if (topLevelResults[_flutterFromPathFlag]) {
+      FlutterSdk.useFromPathEnvironmentVariable();
+    } else {
+      FlutterSdk.useFromCurrentVm();
+    }
+    print('Using Flutter SDK from ${FlutterSdk.current.sdkPath}');
+
+    return super.runCommand(topLevelResults);
   }
 }

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -23,7 +23,6 @@ import 'commands/update_dart_sdk_deps.dart';
 import 'commands/update_version.dart';
 
 const _flutterFromPathFlag = 'flutter-from-path';
-const _flutterFromPathAlias = 'from-path';
 
 class DevToolsCommandRunner extends CommandRunner {
   DevToolsCommandRunner()
@@ -46,7 +45,6 @@ class DevToolsCommandRunner extends CommandRunner {
 
     argParser.addFlag(
       _flutterFromPathFlag,
-      aliases: [_flutterFromPathAlias],
       abbr: 'p',
       negatable: false,
       help: 'Use the Flutter SDK on PATH rather than the one being used to run '

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -47,8 +47,9 @@ class DevToolsCommandRunner extends CommandRunner {
       _flutterFromPathFlag,
       abbr: 'p',
       negatable: false,
-      help: 'Use the Flutter SDK on PATH rather than the one being used to run '
-          'devtools_tool (usually tool/flutter-sdk)',
+      help: 'Use the Flutter SDK on PATH for any `flutter`, `dart` and '
+          '`devtools_tool` commands spawned by this process, instead of the '
+          'Flutter SDK from tool/flutter-sdk which is used by default.',
     );
   }
 

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -15,6 +15,13 @@ class DevToolsRepo {
   /// The path to the DevTools 'tool' directory.
   String get toolDirectoryPath => path.join(repoPath, 'tool');
 
+  /// The path to the 'tool/flutter-sdk' directory.
+  String get toolFlutterSdkPath =>
+      path.join(toolDirectoryPath, sdkDirectoryName);
+
+  /// The name of the Flutter SDK directory.
+  String get sdkDirectoryName => 'flutter-sdk';
+
   /// The path to the DevTools 'devtools_app' directory.
   String get devtoolsAppDirectoryPath =>
       path.join(repoPath, 'packages', 'devtools_app');
@@ -106,8 +113,9 @@ class FlutterSdk {
   static FlutterSdk get current {
     if (_current == null) {
       throw Exception(
-          'Cannot use FlutterSdk.current before SDK has been selected.'
-          'SDK selection is done by DevToolsCommandRunner.runCommand().');
+        'Cannot use FlutterSdk.current before SDK has been selected.'
+        'SDK selection is done by DevToolsCommandRunner.runCommand().',
+      );
     }
     return _current!;
   }

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -125,6 +125,22 @@ class FlutterSdk {
   ///
   /// Throws if the current VM is not inside a Flutter SDK.
   static void useFromCurrentVm() {
+    _current = findFromCurrentVm();
+  }
+
+  /// Sets the active Flutter SDK to the one found in the `PATH` environment
+  /// variable (by running which/where).
+  ///
+  /// Throws if an SDK is not found on PATH.
+  static void useFromPathEnvironmentVariable() {
+    _current = findFromPathEnvironmentVariable();
+  }
+
+  /// Finds the Flutter SDK that contains the Dart VM being used to run this
+  /// script.
+  ///
+  /// Throws if the current VM is not inside a Flutter SDK.
+  static FlutterSdk findFromCurrentVm() {
     // Look for it relative to the current Dart process.
     final dartVmPath = Platform.resolvedExecutable;
     final pathSegments = path.split(dartVmPath);
@@ -149,8 +165,7 @@ class FlutterSdk {
 
       if (expectedSegments.isEmpty) {
         final flutterSdkRoot = path.joinAll(pathSegments);
-        _current = FlutterSdk._(flutterSdkRoot);
-        return;
+        return FlutterSdk._(flutterSdkRoot);
       }
     }
 
@@ -160,19 +175,18 @@ class FlutterSdk {
     );
   }
 
-  /// Sets the active Flutter SDK to the one found in the `PATH` environment
-  /// variable (by running which/where).
+  /// Finds a Flutter SDK in the `PATH` environment variable
+  /// (by running which/where).
   ///
   /// Throws if an SDK is not found on PATH.
-  static void useFromPathEnvironmentVariable() {
+  static FlutterSdk findFromPathEnvironmentVariable() {
     final whichCommand = Platform.isWindows ? 'where.exe' : 'which';
     final result = Process.runSync(whichCommand, ['flutter']);
     if (result.exitCode == 0) {
       final sdkPath = result.stdout.toString().split('\n').first.trim();
       // 'flutter/bin'
       if (path.basename(path.dirname(sdkPath)) == 'bin') {
-        _current = FlutterSdk._(path.dirname(path.dirname(sdkPath)));
-        return;
+        return FlutterSdk._(path.dirname(path.dirname(sdkPath)));
       }
     }
 

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -116,8 +116,16 @@ class CliCommand {
     bool throwOnException = true,
   }) {
     return CliCommand._(
-      exe: Platform.isWindows ? 'devtools_tool.bat' : 'devtools_tool',
-      args: args.split(' '),
+      // We must use the Dart VM from FlutterSdk.current here to ensure we
+      // consistently use the selected version for child invocations. We do
+      // not need to pass the --flutter-from-path flag down because using the
+      // tool will automatically select the one that's running the VM and we'll
+      // have selected that here.
+      exe: FlutterSdk.current.dartToolPath,
+      args: [
+        Platform.script.toFilePath(),
+        ...args.split(' '),
+      ],
       throwOnException: throwOnException,
     );
   }


### PR DESCRIPTION
This promotes the `--flutter-from-path` flag to a global arg for all commands and uses it to locate the Flutter SDK before executing commands.

If set, we'll search for the SDK on PATH and fail if we don't find one.

If not set, we will infer an SDK from the one currently running the devtools_tool script (and again, fail if we're running from an SDK that doesn't have one).

When we call another instance of the tool, we bypass the shell script and instead execute it using Dart from the selected SDK (so that child processes use the selected SDK and we don't need to propagate the --flutter-from-path flag).

The update-flutter-sdk script was changed slightly to check whether the selected SDK is different to the tool/flutter-sdk one to decide whether to perform the extra update. This avoids some minor edge cases if:

- you have tool/flutter-sdk on PATH and pass the flag (it would update the Flutter SDK twice)
- you run devtools_tool from another SDK and don't pass the flag (it would not update the version being used to run the script)

Fixes https://github.com/flutter/devtools/issues/6867

