### PR TITLE
Avoid creating a non-nullable Future with a nullable value

### DIFF
--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -80,7 +80,7 @@ class FakeServiceConnectionManager extends Fake
         Response.parse({
           'layerBytes': 0,
           'pictureBytes': 0,
-        }),
+        })!,
       );
 
   @override
@@ -276,7 +276,7 @@ class FakeServiceManager extends Fake
         'dartSdkVersion': '2.9.0 (build 2.9.0-8.0.dev d6fed1f624)',
         'frameworkRevisionShort': '74432fa91c',
         'engineRevisionShort': 'ae2222f47e',
-      }),
+      })!,
     );
   }
 


### PR DESCRIPTION
Implicitly passing a nullable value to a Completer of a non-nullable type can lead to surprising null-asserting exceptions. See https://github.com/dart-lang/sdk/issues/53253 for more details. In this PR, we add an explicit null-assertion, which makes this call in-line with the general concepts of null safety.

Fixes https://github.com/flutter/flutter/issues/137294

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
