### PR TITLE
Bump to web_benchmarks version 1.1.0

### DIFF
--- a/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
+++ b/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
@@ -11,7 +11,6 @@ import 'dart:io';
 import 'package:test/test.dart';
 import 'package:web_benchmarks/server.dart';
 
-import 'scripts/compare_benchmarks.dart';
 import 'test_infra/common.dart';
 import 'test_infra/project_root_directory.dart';
 
@@ -37,17 +36,6 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 10)),
   );
-
-  test('Can compare web benchmarks', () {
-    final benchmark1 = BenchmarkResults.parse(testBenchmarkResults1);
-    final benchmark2 = BenchmarkResults.parse(testBenchmarkResults2);
-    final comparison = compareBenchmarks(
-      benchmark1,
-      benchmark2,
-      baselineSource: 'path/to/baseline',
-    );
-    expect(comparison, testBenchmarkComparison);
-  });
 
   // TODO(kenz): add tests that verify performance meets some expected threshold
 }
@@ -98,134 +86,3 @@ Future<void> _runBenchmarks({bool useWasm = false}) async {
     isA<String>(),
   );
 }
-
-final testBenchmarkResults1 = {
-  'foo': [
-    {'metric': 'preroll_frame.average', 'value': 60.5},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1400},
-    {'metric': 'preroll_frame.outlierRatio', 'value': 20.2},
-    {'metric': 'preroll_frame.noise', 'value': 0.85},
-    {'metric': 'apply_frame.average', 'value': 80.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 200.6},
-    {'metric': 'apply_frame.outlierRatio', 'value': 2.5},
-    {'metric': 'apply_frame.noise', 'value': 0.4},
-    {'metric': 'drawFrameDuration.average', 'value': 2058.9},
-    {'metric': 'drawFrameDuration.outlierAverage', 'value': 24000},
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 12.05},
-    {'metric': 'drawFrameDuration.noise', 'value': 0.34},
-    {'metric': 'totalUiFrame.average', 'value': 4166},
-  ],
-  'bar': [
-    {'metric': 'preroll_frame.average', 'value': 60.5},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1400},
-    {'metric': 'preroll_frame.outlierRatio', 'value': 20.2},
-    {'metric': 'preroll_frame.noise', 'value': 0.85},
-    {'metric': 'apply_frame.average', 'value': 80.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 200.6},
-    {'metric': 'apply_frame.outlierRatio', 'value': 2.5},
-    {'metric': 'apply_frame.noise', 'value': 0.4},
-    {'metric': 'drawFrameDuration.average', 'value': 2058.9},
-    {'metric': 'drawFrameDuration.outlierAverage', 'value': 24000},
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 12.05},
-    {'metric': 'drawFrameDuration.noise', 'value': 0.34},
-    {'metric': 'totalUiFrame.average', 'value': 4166},
-  ],
-};
-
-final testBenchmarkResults2 = {
-  'foo': [
-    {'metric': 'preroll_frame.average', 'value': 65.5},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1410},
-    {'metric': 'preroll_frame.outlierRatio', 'value': 20.0},
-    {'metric': 'preroll_frame.noise', 'value': 1.5},
-    {'metric': 'apply_frame.average', 'value': 50.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 100.0},
-    {'metric': 'apply_frame.outlierRatio', 'value': 2.55},
-    {'metric': 'apply_frame.noise', 'value': 0.9},
-    {'metric': 'drawFrameDuration.average', 'value': 2000.0},
-    {'metric': 'drawFrameDuration.outlierAverage', 'value': 20000},
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 11.05},
-    {'metric': 'drawFrameDuration.noise', 'value': 1.34},
-    {'metric': 'totalUiFrame.average', 'value': 4150},
-  ],
-  'bar': [
-    {'metric': 'preroll_frame.average', 'value': 65.5},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1410},
-    {'metric': 'preroll_frame.outlierRatio', 'value': 20.0},
-    {'metric': 'preroll_frame.noise', 'value': 1.5},
-    {'metric': 'apply_frame.average', 'value': 50.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 100.0},
-    {'metric': 'apply_frame.outlierRatio', 'value': 2.55},
-    {'metric': 'apply_frame.noise', 'value': 0.9},
-    {'metric': 'drawFrameDuration.average', 'value': 2000.0},
-    {'metric': 'drawFrameDuration.outlierAverage', 'value': 20000},
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 11.05},
-    {'metric': 'drawFrameDuration.noise', 'value': 1.34},
-    {'metric': 'totalUiFrame.average', 'value': 4150},
-  ],
-};
-
-final testBenchmarkComparison = {
-  'foo': [
-    {'metric': 'preroll_frame.average', 'value': 65.5, 'delta': 5.0},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1410.0, 'delta': 10.0},
-    {
-      'metric': 'preroll_frame.outlierRatio',
-      'value': 20.0,
-      'delta': -0.1999999999999993,
-    },
-    {'metric': 'preroll_frame.noise', 'value': 1.5, 'delta': 0.65},
-    {'metric': 'apply_frame.average', 'value': 50.0, 'delta': -30.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 100.0, 'delta': -100.6},
-    {
-      'metric': 'apply_frame.outlierRatio',
-      'value': 2.55,
-      'delta': 0.04999999999999982,
-    },
-    {'metric': 'apply_frame.noise', 'value': 0.9, 'delta': 0.5},
-    {
-      'metric': 'drawFrameDuration.average',
-      'value': 2000.0,
-      'delta': -58.90000000000009,
-    },
-    {
-      'metric': 'drawFrameDuration.outlierAverage',
-      'value': 20000.0,
-      'delta': -4000.0,
-    },
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 11.05, 'delta': -1.0},
-    {'metric': 'drawFrameDuration.noise', 'value': 1.34, 'delta': 1.0},
-    {'metric': 'totalUiFrame.average', 'value': 4150.0, 'delta': -16.0},
-  ],
-  'bar': [
-    {'metric': 'preroll_frame.average', 'value': 65.5, 'delta': 5.0},
-    {'metric': 'preroll_frame.outlierAverage', 'value': 1410.0, 'delta': 10.0},
-    {
-      'metric': 'preroll_frame.outlierRatio',
-      'value': 20.0,
-      'delta': -0.1999999999999993,
-    },
-    {'metric': 'preroll_frame.noise', 'value': 1.5, 'delta': 0.65},
-    {'metric': 'apply_frame.average', 'value': 50.0, 'delta': -30.0},
-    {'metric': 'apply_frame.outlierAverage', 'value': 100.0, 'delta': -100.6},
-    {
-      'metric': 'apply_frame.outlierRatio',
-      'value': 2.55,
-      'delta': 0.04999999999999982,
-    },
-    {'metric': 'apply_frame.noise', 'value': 0.9, 'delta': 0.5},
-    {
-      'metric': 'drawFrameDuration.average',
-      'value': 2000.0,
-      'delta': -58.90000000000009,
-    },
-    {
-      'metric': 'drawFrameDuration.outlierAverage',
-      'value': 20000.0,
-      'delta': -4000.0,
-    },
-    {'metric': 'drawFrameDuration.outlierRatio', 'value': 11.05, 'delta': -1.0},
-    {'metric': 'drawFrameDuration.noise', 'value': 1.34, 'delta': 1.0},
-    {'metric': 'totalUiFrame.average', 'value': 4150.0, 'delta': -16.0},
-  ],
-};

--- a/packages/devtools_app/benchmark/scripts/compare_benchmarks.dart
+++ b/packages/devtools_app/benchmark/scripts/compare_benchmarks.dart
@@ -59,6 +59,6 @@ void compareBenchmarks(
   stdout.writeln('Baseline comparison finished.');
   stdout
     ..writeln('==== Comparison with baseline $baselineSource ====')
-    ..writeln(const JsonEncoder.withIndent('  ').convert(delta))
+    ..writeln(const JsonEncoder.withIndent('  ').convert(delta.toJson()))
     ..writeln('==== End of baseline comparison ====');
 }

--- a/packages/devtools_app/benchmark/scripts/run_benchmarks.dart
+++ b/packages/devtools_app/benchmark/scripts/run_benchmarks.dart
@@ -6,6 +6,7 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
+import 'package:web_benchmarks/analysis.dart';
 import 'package:web_benchmarks/server.dart';
 
 import '../test_infra/common.dart';
@@ -46,7 +47,7 @@ Future<void> main(List<String> args) async {
     stdout.writeln(
       'Taking the average of ${benchmarkResults.length} benchmark runs.',
     );
-    taskResult = averageBenchmarkResults(benchmarkResults);
+    taskResult = computeAverage(benchmarkResults);
   }
 
   final resultsAsMap = taskResult.toJson();
@@ -149,34 +150,4 @@ class BenchmarkArgs {
         valueHelp: '5',
       );
   }
-}
-
-// TODO(kenz): upstream the logic to average benchmarks into the
-// package:web_benchmarks
-
-/// Returns the average of the benchmark results in [results].
-///
-/// Each element in [results] is expected to have identical benchmark names and
-/// metrics; otherwise, an [Exception] will be thrown.
-BenchmarkResults averageBenchmarkResults(List<BenchmarkResults> results) {
-  if (results.isEmpty) {
-    throw Exception('Cannot take average of empty list.');
-  }
-
-  var totalSum = results.first;
-  for (int i = 1; i < results.length; i++) {
-    final current = results[i];
-    totalSum = totalSum.sumWith(current);
-  }
-
-  final average = totalSum.toJson();
-  for (final benchmark in totalSum.scores.keys) {
-    final scoresForBenchmark = totalSum.scores[benchmark]!;
-    for (int i = 0; i < scoresForBenchmark.length; i++) {
-      final score = scoresForBenchmark[i];
-      final averageValue = score.value / results.length;
-      average[benchmark]![i]['value'] = averageValue;
-    }
-  }
-  return BenchmarkResults.parse(average);
 }

--- a/packages/devtools_app/benchmark/scripts/utils.dart
+++ b/packages/devtools_app/benchmark/scripts/utils.dart
@@ -4,9 +4,6 @@
 
 import 'dart:io';
 
-import 'package:collection/collection.dart';
-import 'package:web_benchmarks/server.dart';
-
 File? checkFileExists(String path) {
   final testFile = File.fromUri(Uri.parse(path));
   if (!testFile.existsSync()) {
@@ -14,51 +11,4 @@ File? checkFileExists(String path) {
     return null;
   }
   return testFile;
-}
-
-extension BenchmarkResultsExtension on BenchmarkResults {
-  /// Sums this [BenchmarkResults] instance with [other] by adding the values
-  /// of each matching benchmark score.
-  ///
-  /// Returns a [BenchmarkResults] object with the summed values.
-  BenchmarkResults sumWith(
-    BenchmarkResults other, {
-    bool throwExceptionOnMismatch = true,
-  }) {
-    final sum = toJson();
-    for (final benchmark in scores.keys) {
-      // Look up this benchmark in [other].
-      final matchingBenchmark = other.scores[benchmark];
-      if (matchingBenchmark == null) {
-        if (throwExceptionOnMismatch) {
-          throw Exception(
-            'Cannot sum benchmarks because [other] is missing an entry for '
-            'benchmark "$benchmark".',
-          );
-        }
-        continue;
-      }
-
-      final scoresForBenchmark = scores[benchmark]!;
-      for (int i = 0; i < scoresForBenchmark.length; i++) {
-        final score = scoresForBenchmark[i];
-        // Look up this score in the [matchingBenchmark] from [other].
-        final matchingScore =
-            matchingBenchmark.firstWhereOrNull((s) => s.metric == score.metric);
-        if (matchingScore == null) {
-          if (throwExceptionOnMismatch) {
-            throw Exception(
-              'Cannot sum benchmarks because benchmark "$benchmark" is missing '
-              'a score for metric ${score.metric}.',
-            );
-          }
-          continue;
-        }
-
-        final sumScore = score.value + matchingScore.value;
-        sum[benchmark]![i]['value'] = sumScore;
-      }
-    }
-    return BenchmarkResults.parse(sum);
-  }
 }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -79,7 +79,7 @@ dev_dependencies:
   mockito: ^5.4.1
   stager: ^1.0.1
   test: ^1.21.1
-  web_benchmarks: ^1.0.1
+  web_benchmarks: ^1.1.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"
 
 flutter:


### PR DESCRIPTION
The code for computing averages and deltas is being upstreamed to `package:web_benchmarks` in https://github.com/flutter/packages/pull/5630. This removes the duplicated code on the devtools side and bumps to `web_benchmarks` version 1.1.0. 