### PR TITLE
Add some ignores for nullable vlues into non-nullable Futures.

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/logger/_allowed_error_default.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/logger/_allowed_error_default.dart
@@ -16,6 +16,9 @@ Future<T> allowedError<T>(Future<T> future, {bool logError = true}) {
       _log.shout('[${error.runtimeType}] ${errorLines.first}');
       _log.shout(errorLines.skip(1).join('\n'));
     }
+    // TODO(srawlins): This is an illegal return value (`null`) for all `T`.
+    // This function must return an actual `T`.
+    // ignore: null_argument_to_non_null_type
     return Future<T>.value();
   });
 }

--- a/packages/devtools_app/lib/src/shared/config_specific/logger/_allowed_error_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/logger/_allowed_error_web.dart
@@ -17,6 +17,9 @@ Future<T> allowedError<T>(Future<T> future, {bool logError = true}) {
       console.log(errorLines.skip(1).join('\n').toJS);
       console.groupEnd();
     }
+    // TODO(srawlins): This is an illegal return value (`null`) for all `T`.
+    // This function must return an actual `T`.
+    // ignore: null_argument_to_non_null_type
     return Future<T>.value();
   });
 }


### PR DESCRIPTION
Implicitly passing a nullable value to a Future.value instantiation of a non-nullable type can lead to surprising null-asserting exceptions. See https://github.com/dart-lang/sdk/issues/53253 for more details. In this PR, we add ignore, because it requires business knowledge to fix it for real.

For https://github.com/flutter/flutter/issues/137294

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
