### PR TITLE
Get Daily dev bump version working again

### DIFF
--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -28,7 +28,10 @@ env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  flutter-prep:
+    uses: ./.github/workflows/flutter-prep.yaml
   bump-version:
+    needs: flutter-prep
     if: ${{ github.repository == 'flutter/devtools' }}
     name: Bump Version
     runs-on: ubuntu-latest
@@ -39,6 +42,12 @@ jobs:
           ref: master
 
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+      - name: Load Cached Flutter SDK
+        uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84
+        with:
+          path: |
+            ./tool/flutter-sdk
+          key: flutter-sdk-${{ runner.os }}-${{ needs.flutter-prep.outputs.latest_flutter_candidate }}
 
       - name: setup git config
         run: |


### PR DESCRIPTION
![](https://media.giphy.com/media/p4iVnQZrTmJji/giphy.gif)
It looks like https://github.com/flutter/devtools/pull/6824 may have broke the daily dev bump fix.

This PR adds a dependency for the flutter sdk cache since that PR added a case that uses the flutter-sdk.

 