### PR TITLE
Avoid implicit dynamic parameters

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_controller.dart
@@ -119,7 +119,8 @@ class ProgramExplorerController extends DisposableController
     ScriptRef? script,
     List<VMServiceObjectNode> nodes,
   ) async {
-    bool searchCondition(node) => node.script?.uri == script!.uri;
+    bool searchCondition(VMServiceObjectNode node) =>
+        node.script?.uri == script!.uri;
     for (final node in nodes) {
       final result = node.firstChildWithCondition(searchCondition);
       if (result != null) {

--- a/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
@@ -325,7 +325,10 @@ Future<void> _addValueItems(
   }
 }
 
-Future<void> _addInspectorItems(variable, IsolateRef? isolateRef) async {
+Future<void> _addInspectorItems(
+  DartObjectNode variable,
+  IsolateRef? isolateRef,
+) async {
   final inspectorService = serviceConnection.inspectorService;
   if (inspectorService != null) {
     final tasks = <Future>[];

--- a/packages/devtools_shared/lib/src/deeplink/app_link_settings.dart
+++ b/packages/devtools_shared/lib/src/deeplink/app_link_settings.dart
@@ -16,6 +16,7 @@ class AppLinkSettings {
     return AppLinkSettings._(
       jsonObject[_kApplicationIdKey] as String,
       (jsonObject[_kDeeplinksKey] as List<dynamic>)
+          .cast<Map<String, dynamic>>()
           .map<AndroidDeeplink>(AndroidDeeplink._fromJsonObject)
           .toList(),
     );
@@ -43,7 +44,7 @@ class AppLinkSettings {
 class AndroidDeeplink {
   AndroidDeeplink._(this.scheme, this.host, this.path);
 
-  factory AndroidDeeplink._fromJsonObject(dynamic json) {
+  factory AndroidDeeplink._fromJsonObject(Map<String, dynamic> json) {
     return AndroidDeeplink._(
       json[_kSchemeKey] as String,
       json[_kHostKey] as String,

--- a/packages/devtools_shared/lib/src/memory/event_sample.dart
+++ b/packages/devtools_shared/lib/src/memory/event_sample.dart
@@ -172,7 +172,7 @@ class EventSample {
 
   EventSample.snapshotEvent(
     this.timestamp, {
-    snapshotAuto = false,
+    bool snapshotAuto = false,
     ExtensionEvents? events,
   })  : isEventGC = false,
         isEventSnapshot = !snapshotAuto,

--- a/packages/devtools_test/lib/src/mocks/mocks.dart
+++ b/packages/devtools_test/lib/src/mocks/mocks.dart
@@ -106,8 +106,8 @@ void mockWebVm(VM vm) {
 void mockConnectedApp(
   ConnectedApp connectedApp, {
   required bool isFlutterApp,
-  required isProfileBuild,
-  required isWebApp,
+  required bool isProfileBuild,
+  required bool isWebApp,
   String os = 'ios',
 }) {
   assert(!(!isFlutterApp && isProfileBuild));


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Each of the parameters I touch here is implicitly (or explicitly) dynamic, but should not be. Not that a parameter declared as `foo = false` is _dynamic_.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
