### PR TITLE
Fix typing bug in network_request_inspector_views

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -161,9 +161,13 @@ class HttpRequestView extends StatelessWidget {
           );
         }
 
-        final isJson = requestContentType is List
-            ? requestContentType.any((element) => element.contains('json'))
-            : requestContentType.contains('json');
+        final isJson = switch (requestContentType) {
+          List() => requestContentType.any((e) => e.contains('json')),
+          String() => requestContentType.contains('json'),
+          _ => throw StateError(
+              "Expected 'content-type' to be a List or String, but got: "
+              '$requestContentType'),
+        };
 
         Widget child;
         child = isJson


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

In the old version of this code, we query `requestContentType` for whether it is a List. If it is _not_ a List, we still call `requestContentType.contains` on it. 🤔 What other type are we expecting here that has a `contains` method? I'm hoping it's just String, but it's not clear. This change makes the types explicit, and avoids dynamic dispatch.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
