### PR TITLE
Use type promotion in vm_developer_common_widgets

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -1000,8 +1000,8 @@ class _ObjectInspectorCodeViewState extends State<ObjectInspectorCodeView> {
             // although showing a "No Source Available" message is another
             // option.
             final owner = obj.owner;
-            if (location.line == null && obj.owner is ClassRef) {
-              location = owner!.location;
+            if (location.line == null && owner is ClassRef) {
+              location = owner.location;
             }
           } else if (obj is FieldRef) {
             location = obj.location!;


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Uses promotion to avoid a dynamic call, and a null assertion.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
