### PR TITLE
Use a switch over object patterns instead of runtime type

### DIFF
--- a/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
@@ -104,17 +104,11 @@ base class FakeServiceExtensionManager extends Fake
   }
 
   Object? _getExtensionValueFromJson(String name, String valueFromJson) {
-    final expectedValueType =
-        serviceExtensionsAllowlist[name]!.values.first.runtimeType;
-    switch (expectedValueType) {
-      case bool:
-        return valueFromJson == 'true' ? true : false;
-      case int:
-      case double:
-        return num.parse(valueFromJson);
-      default:
-        return valueFromJson;
-    }
+    return switch (serviceExtensionsAllowlist[name]!.values.first) {
+      bool() => valueFromJson == 'true' ? true : false,
+      num() => num.parse(valueFromJson),
+      _ => valueFromJson,
+    };
   }
 
   Future<void> _onFrameEventReceived() async {


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

This is certainly shorter! But actually I just thought it would be more readable as a switch. One consequence of not using `runtime` is explicit accountings for `int` and `double`. (And don't various backends have other internal runtime types for these? Maybe not.) The `avoid_dynamic_calls` lint rule was upset about calling `runtimeType` on `dynamic`, which is a little weird, but led to this refactoring.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
