### PR TITLE
Avoid raw types so as to avoid dynamic invocations

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart
@@ -8,6 +8,7 @@ import 'package:collection/collection.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
+import 'package:vm_service/vm_service.dart' as vm_service;
 
 import '../../../../shared/analytics/analytics.dart' as ga;
 import '../../../../shared/analytics/constants.dart' as gac;
@@ -170,7 +171,7 @@ class TimelineEventsController extends PerformanceFeatureController
     _nextPollStartMicros = currentVmTime.timestamp! + 1;
 
     final newThreadNameEvents = <ThreadNameEvent>[];
-    for (final event in timeline.traceEvents ?? []) {
+    for (final event in timeline.traceEvents ?? <vm_service.TimelineEvent>[]) {
       final traceEvent = TraceEvent(event.json!);
       final eventWrapper = TraceEventWrapper(
         traceEvent,

--- a/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
@@ -334,7 +334,7 @@ List<DartObjectNode> createVariablesForMap(
   IsolateRef? isolateRef,
 ) {
   final variables = <DartObjectNode>[];
-  final associations = instance.associations ?? [];
+  final associations = instance.associations ?? <MapAssociation>[];
 
   // If the key type for the provided associations is not primitive, we want to
   // allow for users to drill down into the key object's properties. If we're

--- a/packages/devtools_app/lib/src/shared/http/_http_date.dart
+++ b/packages/devtools_app/lib/src/shared/http/_http_date.dart
@@ -89,7 +89,7 @@ class HttpDate {
       return int.parse(s.substring(0, index));
     }
 
-    var tokens = [];
+    var tokens = <String>[];
     while (!isEnd()) {
       while (!isEnd() && isDelimiter(date[position])) {
         position++;

--- a/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
+++ b/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
@@ -59,7 +59,7 @@ void main() {
         );
 
         // Record three snapshots.
-        for (var i in Iterable.generate(3)) {
+        for (var i in Iterable<int>.generate(3)) {
           await tester.tap(find.byIcon(Icons.fiber_manual_record).first);
           await tester.pumpAndSettle();
           expect(find.text('selected-isolate-${i + 1}'), findsOneWidget);


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Each of the changed literals like `[]` is inferred to have `dynamic` type variables. This leads to a lot of dynamic calls on the elements. Putting a little type on the declaration cleans it up.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
