### PR TITLE
Add type arguments on class declaration clauses

### DIFF
--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -56,7 +56,7 @@ enum ScrollKind {
 ///
 /// This table will automatically refresh search matches on the
 /// [searchController] after sort operations that are triggered from the table.
-class SearchableFlatTable<T extends SearchableDataMixin> extends FlatTable {
+class SearchableFlatTable<T extends SearchableDataMixin> extends FlatTable<T> {
   SearchableFlatTable({
     super.key,
     required SearchControllerMixin<T> searchController,

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 6.0.3-wip
+* `CompareMixin` is now generic, implementing `Comparable<T>` instead of
+  `Comparable<dynamic>`, and it's operators each therefore accept a `T`
+  argument.
+* `SemanticVersion` now mixes in `CompareMixin<SemanticVersion>`, and it's
+  `compareTo` method therefore now accepts a `SemanticVersion`.
+
 # 6.0.2
 * Fix an issue parsing file paths on Windows that could prevent extensions from being detected.
 

--- a/packages/devtools_shared/lib/src/utils/compare.dart
+++ b/packages/devtools_shared/lib/src/utils/compare.dart
@@ -3,19 +3,19 @@
 // found in the LICENSE file.
 
 mixin CompareMixin<T> implements Comparable<T> {
-  bool operator <(other) {
+  bool operator <(T other) {
     return compareTo(other) < 0;
   }
 
-  bool operator >(other) {
+  bool operator >(T other) {
     return compareTo(other) > 0;
   }
 
-  bool operator <=(other) {
+  bool operator <=(T other) {
     return compareTo(other) <= 0;
   }
 
-  bool operator >=(other) {
+  bool operator >=(T other) {
     return compareTo(other) >= 0;
   }
 }

--- a/packages/devtools_shared/lib/src/utils/compare.dart
+++ b/packages/devtools_shared/lib/src/utils/compare.dart
@@ -2,9 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// ignore_for_file: avoid-dynamic
-
-mixin CompareMixin implements Comparable {
+mixin CompareMixin<T> implements Comparable<T> {
   bool operator <(other) {
     return compareTo(other) < 0;
   }

--- a/packages/devtools_shared/lib/src/utils/semantic_version.dart
+++ b/packages/devtools_shared/lib/src/utils/semantic_version.dart
@@ -6,7 +6,7 @@ import 'dart:math' as math;
 
 import 'compare.dart';
 
-class SemanticVersion with CompareMixin {
+class SemanticVersion with CompareMixin<SemanticVersion> {
   SemanticVersion({
     this.major = 0,
     this.minor = 0,
@@ -121,8 +121,7 @@ class SemanticVersion with CompareMixin {
       compareTo(minSupportedVersion) >= 0;
 
   @override
-  // ignore: avoid-dynamic, necessary here.
-  int compareTo(other) {
+  int compareTo(SemanticVersion other) {
     if (major == other.major &&
         minor == other.minor &&
         patch == other.patch &&
@@ -139,7 +138,7 @@ class SemanticVersion with CompareMixin {
       if (isPreRelease != other.isPreRelease) {
         return isPreRelease ? -1 : 1;
       }
-      if (preReleaseMajor! > other.preReleaseMajor ||
+      if (preReleaseMajor! > other.preReleaseMajor! ||
           (preReleaseMajor == other.preReleaseMajor &&
               (preReleaseMinor ?? 0) > (other.preReleaseMinor ?? 0))) {
         return 1;

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 6.0.2
+version: 6.0.3-wip
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Without explicit type arguments, `dynamic` is implicit. Adding type arguments prevents dynamic calls, and you can see the bug catch at the end of the diff, where `preReleaseMajor` is no longer `dynamic`, and the type system can determine that it needs to be null checked.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
