### PR TITLE
Rearrange null-safe code to avoid null-aware type issues

### DIFF
--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -37,8 +37,10 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
       }
     }
 
-    for (final flag in flags ?? []) {
-      unawaited(setFlag(flag.flagName, flag.value));
+    if (flags != null) {
+      for (final flag in flags) {
+        unawaited(setFlag(flag.flagName, flag.value));
+      }
     }
   }
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

`?? []` always seems to lead to trouble ☹️  I think Paul is working on some inference improvements for this though. Anyhow, in the code-on-the-left, each `flag` is dynamic. Checking the null state of `flags` early works. Alternatively, we can type the `[]`, but that type is `({String flagName, String value})`, and adding that type would make the code even _less_ readable, I think.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
