### PR TITLE
Type Function variables with actual function signatures

### DIFF
--- a/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/lib/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/lib/main.dart
@@ -82,7 +82,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 }
 
-Map<String, Function> navigateCallbacks = {};
+Map<String, void Function()> navigateCallbacks = {};
 
 // Hook to navigate to a specific screen.
 void navigateToScreen(String title) {

--- a/packages/devtools_app_shared/lib/src/ui/dialogs.dart
+++ b/packages/devtools_app_shared/lib/src/ui/dialogs.dart
@@ -231,7 +231,7 @@ final class DialogCancelButton extends StatelessWidget {
 final class DialogApplyButton extends StatelessWidget {
   const DialogApplyButton({super.key, required this.onPressed});
 
-  final Function onPressed;
+  final void Function() onPressed;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_test/lib/src/helpers/utils.dart
+++ b/packages/devtools_test/lib/src/helpers/utils.dart
@@ -37,8 +37,8 @@ final screenIds = <String>[
 /// Tests that `listener` has actually been invoked.
 Future<void> addListenerScope({
   required Listenable listenable,
-  required Function listener,
-  required Function callback,
+  required void Function() listener,
+  required Future<void> Function() callback,
 }) async {
   bool listenerCalled = false;
   void listenerWrapped() {

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -156,7 +156,7 @@ class FakeServiceManager extends Fake
 
   final List<String> availableLibraries;
 
-  final Function? onVmServiceOpened;
+  final void Function()? onVmServiceOpened;
 
   final Map<String, Response> serviceExtensionResponses;
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Calling `Function f; f()` is a form of dynamic invocation. All of the `Function` variables can be typed pretty easily.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
