### PR TITLE
chart_test: memoryJson has HeapSamples

### DIFF
--- a/packages/devtools_app/test/memory/chart/chart_test.dart
+++ b/packages/devtools_app/test/memory/chart/chart_test.dart
@@ -30,7 +30,7 @@ void main() {
   group(
     'Chart Timeseries',
     () {
-      late MemoryJson memoryJson;
+      late MemoryJson<HeapSample> memoryJson;
       bool memoryJasonInitialized = false;
 
       void loadData() {
@@ -575,7 +575,7 @@ void main() {
           } else if (event.isEventAllocationAccumulator) {
             final monitorType = event.allocationAccumulator;
             final rawData = Data(datum.timestamp, visibleMonitorEvent);
-            if (monitorType.isEmpty) continue;
+            if (monitorType!.isEmpty) continue;
             if (monitorType.isStart) {
               addDataToTrace(controller, monitorTraceIndex, rawData);
             } else if (monitorType.isReset) {


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929

Another example of catching an issue, `monitorType` was previously `dynamic`, but when we know it's type, we learn it can be `null`, and must null-check it.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
