### PR TITLE
Handle breaking changes in package:vm_service v14

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -266,7 +266,7 @@ class NetworkController extends DisposableController
           _NetworkTrafficType.http =>
             service.httpEnableTimelineLoggingWrapper(isolate.id!),
           _NetworkTrafficType.socket =>
-            service.socketProfilingEnabled(isolate.id!),
+            service.socketProfilingEnabledWrapper(isolate.id!),
         };
         // The above call won't complete immediately if the isolate is paused,
         // so give up waiting after 500ms.

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -216,7 +216,7 @@ class NetworkController extends DisposableController
     // Cancel existing polling timer before starting recording.
     _updatePollingState(false);
 
-    await _networkService.updateLastHttpDataRefreshTime(
+    _networkService.updateLastHttpDataRefreshTime(
       alreadyRecordingHttp: alreadyRecordingHttp,
     );
     final timestamp = await _networkService.updateLastSocketDataRefreshTime(

--- a/packages/devtools_app/lib/src/screens/network/network_model.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_model.dart
@@ -8,10 +8,6 @@ import '../../shared/primitives/utils.dart';
 import '../../shared/ui/search.dart';
 
 abstract class NetworkRequest with SearchableDataMixin {
-  NetworkRequest(this._timelineMicrosBase);
-
-  final int _timelineMicrosBase;
-
   String get method;
 
   String get uri;
@@ -46,10 +42,6 @@ abstract class NetworkRequest with SearchableDataMixin {
           )
         : 'Pending';
     return 'Duration: $text';
-  }
-
-  int timelineMicrosecondsSinceEpoch(int micros) {
-    return _timelineMicrosBase + micros;
   }
 
   @override
@@ -90,9 +82,16 @@ abstract class NetworkRequest with SearchableDataMixin {
 }
 
 class WebSocket extends NetworkRequest {
-  WebSocket(this._socket, int timelineMicrosBase) : super(timelineMicrosBase);
+  WebSocket(this._socket, this._timelineMicrosBase);
+
+  final int _timelineMicrosBase;
 
   final SocketStatistic _socket;
+
+  int timelineMicrosecondsSinceEpoch(int micros) {
+    return _timelineMicrosBase + micros;
+  }
+
   @override
   String get id => _socket.id;
 

--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -786,8 +786,7 @@ class NetworkRequestOverviewView extends StatelessWidget {
     }
     final duration = Duration(
       microseconds: data.endTimestamp!.microsecondsSinceEpoch -
-          data.instantEvents.last.timestampMicros -
-          data.timelineMicrosecondsSinceEpoch(0),
+          data.instantEvents.last.timestamp.microsecondsSinceEpoch,
     );
     timingWidgets.add(
       _buildTimingRow(nextColor(), 'Response', duration),

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -44,7 +44,7 @@ class NetworkService {
   /// time.
   void updateLastHttpDataRefreshTime({
     bool alreadyRecordingHttp = false,
-  }) async {
+  }) {
     if (!alreadyRecordingHttp) {
       networkController.lastHttpDataRefreshTime = DateTime.now();
     }

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -15,21 +15,21 @@ class NetworkService {
 
   /// Updates the last Socket data refresh time to the current time.
   ///
-  /// If [alreadyRecordingHttp] is true it's unclear when the last refresh time
-  /// would have occurred, so the refresh time is not updated. Otherwise,
-  /// [NetworkController.lastSocketDataRefreshMicros] is updated to the current
-  /// timeline timestamp.
+  /// If [alreadyRecordingSocketData] is true, it's unclear when the last
+  /// refresh time would have occurred, so the refresh time is not updated.
+  /// Otherwise, [NetworkController.lastSocketDataRefreshMicros] is updated to
+  /// the current timeline timestamp.
   ///
   /// Returns the current timeline timestamp.
   Future<int> updateLastSocketDataRefreshTime({
-    bool alreadyRecordingHttp = false,
+    bool alreadyRecordingSocketData = false,
   }) async {
     // Set the current timeline time as the time of the last refresh.
     final timestampObj =
         await serviceConnection.serviceManager.service!.getVMTimelineMicros();
 
     final timestamp = timestampObj.timestamp!;
-    if (!alreadyRecordingHttp) {
+    if (!alreadyRecordingSocketData) {
       // Only include Socket requests issued after the current time.
       networkController.lastSocketDataRefreshMicros = timestamp;
     }

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -42,7 +42,7 @@ class NetworkService {
   /// would have occurred, so the refresh time is not updated. Otherwise,
   /// [NetworkController.lastHttpDataRefreshTime] is updated to the current
   /// time.
-  Future<void> updateLastHttpDataRefreshTime({
+  void updateLastHttpDataRefreshTime({
     bool alreadyRecordingHttp = false,
   }) async {
     if (!alreadyRecordingHttp) {
@@ -164,7 +164,7 @@ class NetworkService {
 
   Future<void> clearData() async {
     await updateLastSocketDataRefreshTime();
-    await updateLastHttpDataRefreshTime();
+    updateLastHttpDataRefreshTime();
     await _clearSocketProfile();
     await _clearHttpProfile();
   }

--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -264,7 +264,7 @@ class VmServiceWrapper extends VmService {
 
   Future<HttpProfile> getHttpProfileWrapper(
     String isolateId, {
-    int? updatedSince,
+    DateTime? updatedSince,
   }) {
     return getHttpProfile(isolateId, updatedSince: updatedSince);
   }

--- a/packages/devtools_app/lib/src/shared/http/http_request_data.dart
+++ b/packages/devtools_app/lib/src/shared/http/http_request_data.dart
@@ -26,7 +26,7 @@ class DartIOHttpInstantEvent {
   String get name => _event.event;
 
   /// The time the instant event was recorded.
-  int get timestampMicros => _event.timestamp;
+  DateTime get timestamp => _event.timestamp;
 
   /// The amount of time since the last instant event completed.
   TimeRange? get timeRange => _timeRange;
@@ -38,10 +38,9 @@ class DartIOHttpInstantEvent {
 /// An abstraction of an HTTP request made through dart:io.
 class DartIOHttpRequestData extends NetworkRequest {
   DartIOHttpRequestData(
-    int timelineMicrosBase,
     this._request, {
     bool requestFullDataFromVmService = true,
-  }) : super(timelineMicrosBase) {
+  }) {
     if (requestFullDataFromVmService && _request.isResponseComplete) {
       unawaited(getFullRequestData());
     }
@@ -89,17 +88,14 @@ class DartIOHttpRequestData extends NetworkRequest {
 
   bool get _hasError => _request.request?.hasError ?? false;
 
-  int? get _endTime =>
+  DateTime? get _endTime =>
       _hasError ? _request.endTime : _request.response?.endTime;
 
   @override
   Duration? get duration {
     if (inProgress || !isValid) return null;
     // Timestamps are in microseconds
-    final range = TimeRange()
-      ..start = Duration(microseconds: _request.startTime)
-      ..end = Duration(microseconds: _endTime!);
-    return range.duration;
+    return _endTime!.difference(_request.startTime);
   }
 
   /// Whether the request is safe to display in the UI.
@@ -189,10 +185,8 @@ class DartIOHttpRequestData extends NetworkRequest {
   /// All instant events logged to the timeline for this HTTP request.
   List<DartIOHttpInstantEvent> get instantEvents {
     if (_instantEvents == null) {
-      _instantEvents = [
-        for (final event in _request.request?.events ?? [])
-          DartIOHttpInstantEvent._(event),
-      ];
+      _instantEvents =
+          _request.events.map((e) => DartIOHttpInstantEvent._(e)).toList();
       _recalculateInstantEventTimes();
     }
     return _instantEvents!;
@@ -245,19 +239,10 @@ class DartIOHttpRequestData extends NetworkRequest {
   }
 
   @override
-  DateTime? get endTimestamp {
-    final endTime = _endTime;
-    return endTime == null
-        ? null
-        : DateTime.fromMicrosecondsSinceEpoch(
-            timelineMicrosecondsSinceEpoch(endTime),
-          );
-  }
+  DateTime? get endTimestamp => _endTime;
 
   @override
-  DateTime get startTimestamp => DateTime.fromMicrosecondsSinceEpoch(
-        timelineMicrosecondsSinceEpoch(_request.startTime),
-      );
+  DateTime get startTimestamp => _request.startTime;
 
   @override
   String? get status =>
@@ -310,12 +295,12 @@ class DartIOHttpRequestData extends NetworkRequest {
   String? _requestBody;
 
   void _recalculateInstantEventTimes() {
-    int lastTime = _request.startTime;
+    DateTime lastTime = _request.startTime;
     for (final instant in instantEvents) {
-      final instantTime = instant.timestampMicros;
+      final instantTime = instant.timestamp;
       instant._timeRange = TimeRange()
-        ..start = Duration(microseconds: lastTime)
-        ..end = Duration(microseconds: instantTime);
+        ..start = Duration(microseconds: lastTime.microsecondsSinceEpoch)
+        ..end = Duration(microseconds: instantTime.microsecondsSinceEpoch);
       lastTime = instantTime;
     }
   }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -58,7 +58,7 @@ dependencies:
   string_scanner: ^1.1.0
   url_launcher: ^6.1.0
   url_launcher_web: ^2.0.6
-  vm_service: ^13.0.0
+  vm_service: ^14.0.0
   # TODO https://github.com/dart-lang/sdk/issues/52853 - unpin this version
   vm_snapshot_analysis: 0.7.2
   web: ^0.4.1

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -34,10 +34,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
 
-* The network profiler now only supports apps running on versions of
-  Dart/Flutter that implement version 4.0 of the [dart:io VM Service Protocol
-  Extensions](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service_extension.md). -
-[#6953](https://github.com/flutter/devtools/pull/6953)
+TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -10,7 +10,7 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+* Update `package:vm_service` constraint to `^14.0.0`. - [#6953](https://github.com/flutter/devtools/pull/6953)
 
 ## Inspector updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -34,7 +34,10 @@ TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any general updates.
+* The network profiler now only supports apps running on versions of
+  Dart/Flutter that implement version 4.0 of the [dart:io VM Service Protocol
+  Extensions](https://github.com/dart-lang/sdk/blob/main/runtime/vm/service/service_extension.md). -
+[#6953](https://github.com/flutter/devtools/pull/6953)
 
 ## Logging updates
 

--- a/packages/devtools_app/test/http/curl_command_test.dart
+++ b/packages/devtools_app/test/http/curl_command_test.dart
@@ -249,7 +249,6 @@ DartIOHttpRequestData _testDartIOHttpRequestData({
       method: method,
       uri: uri,
       requestBody: requestBody,
-      responseBody: null,
       events: [],
       startTime: DateTime.fromMicrosecondsSinceEpoch(0),
       endTime: DateTime.fromMicrosecondsSinceEpoch(0),

--- a/packages/devtools_app/test/http/curl_command_test.dart
+++ b/packages/devtools_app/test/http/curl_command_test.dart
@@ -210,9 +210,8 @@ void main() {
 
 class _TestDartIOHttpRequestData extends DartIOHttpRequestData {
   _TestDartIOHttpRequestData(
-    int timelineMicrosBase,
     this._request,
-  ) : super(timelineMicrosBase, _request);
+  ) : super(_request);
 
   final HttpProfileRequest _request;
 
@@ -244,7 +243,6 @@ DartIOHttpRequestData _testDartIOHttpRequestData({
   List<String>? cookies,
 }) {
   return _TestDartIOHttpRequestData(
-    0,
     HttpProfileRequest(
       id: '0',
       isolateId: '0',
@@ -252,8 +250,9 @@ DartIOHttpRequestData _testDartIOHttpRequestData({
       uri: uri,
       requestBody: requestBody,
       responseBody: null,
-      startTime: 0,
-      endTime: 0,
+      events: [],
+      startTime: DateTime.fromMicrosecondsSinceEpoch(0),
+      endTime: DateTime.fromMicrosecondsSinceEpoch(0),
       response: HttpProfileResponseData(
         compressionState: '',
         connectionInfo: {},
@@ -264,9 +263,9 @@ DartIOHttpRequestData _testDartIOHttpRequestData({
         persistentConnection: false,
         reasonPhrase: '',
         redirects: [],
-        startTime: 0,
+        startTime: DateTime.fromMicrosecondsSinceEpoch(0),
         statusCode: 200,
-        endTime: 0,
+        endTime: DateTime.fromMicrosecondsSinceEpoch(0),
       ),
       request: HttpProfileRequestData.buildSuccessfulRequest(
         headers: headers ?? {},
@@ -275,9 +274,7 @@ DartIOHttpRequestData _testDartIOHttpRequestData({
         cookies: cookies ?? [],
         followRedirects: false,
         maxRedirects: 0,
-        method: method,
         persistentConnection: false,
-        events: [],
       ),
     ),
   );

--- a/packages/devtools_app/test/network/network_request_inspector_test.dart
+++ b/packages/devtools_app/test/network/network_request_inspector_test.dart
@@ -40,7 +40,7 @@ void main() {
             requests: [
               httpRequest!,
             ],
-            timestamp: 0,
+            timestamp: DateTime.fromMicrosecondsSinceEpoch(0),
           ),
         ),
       );

--- a/packages/devtools_app/test/network/utils/network_test_utils.dart
+++ b/packages/devtools_app/test/network/utils/network_test_utils.dart
@@ -26,6 +26,6 @@ HttpProfile loadHttpProfile() {
       HttpProfileRequest.parse(httpWsHandshakeJson)!,
       HttpProfileRequest.parse(httpGetPendingJson)!,
     ],
-    timestamp: 0,
+    timestamp: DateTime.fromMicrosecondsSinceEpoch(0),
   );
 }

--- a/packages/devtools_app/test/test_infra/test_data/network.dart
+++ b/packages/devtools_app/test/test_infra/test_data/network.dart
@@ -116,7 +116,6 @@ final Map<String, dynamic> testSocket3Json = {
 
 final httpGetRequest = HttpProfileRequest.parse(httpGetJson)!;
 final httpGet = DartIOHttpRequestData(
-  0,
   httpGetRequest,
   requestFullDataFromVmService: false,
 );
@@ -126,15 +125,15 @@ final Map<String, dynamic> httpGetJson = {
   'isolateId': 'isolates/2013291945734727',
   'method': 'GET',
   'uri': 'https://jsonplaceholder.typicode.com/albums/1',
+  'events': [
+    {'timestamp': 6326808941, 'event': 'Connection established'},
+    {'timestamp': 6326808965, 'event': 'Request sent'},
+    {'timestamp': 6327090622, 'event': 'Waiting (TTFB)'},
+    {'timestamp': 6327091650, 'event': 'Content Download'},
+  ],
   'startTime': 6326279935,
   'endTime': 6326808974,
   'request': {
-    'events': [
-      {'timestamp': 6326808941, 'event': 'Connection established'},
-      {'timestamp': 6326808965, 'event': 'Request sent'},
-      {'timestamp': 6327090622, 'event': 'Waiting (TTFB)'},
-      {'timestamp': 6327091650, 'event': 'Content Download'},
-    ],
     'headers': {
       'content-length': ['0'],
     },
@@ -182,7 +181,6 @@ final Map<String, dynamic> httpGetJson = {
 
 final httpPostRequest = HttpProfileRequest.parse(httpPostJson)!;
 final httpPost = DartIOHttpRequestData(
-  0,
   httpPostRequest,
   requestFullDataFromVmService: false,
 );
@@ -192,15 +190,15 @@ final Map<String, dynamic> httpPostJson = {
   'isolateId': 'isolates/979700762893215',
   'method': 'POST',
   'uri': 'https://jsonplaceholder.typicode.com/posts',
+  'events': [
+    {'timestamp': 2400314657, 'event': 'Connection established'},
+    {'timestamp': 2400320066, 'event': 'Request sent'},
+    {'timestamp': 2400994822, 'event': 'Waiting (TTFB)'},
+    {'timestamp': 2401000729, 'event': 'Content Download'},
+  ],
   'startTime': 2399492629,
   'endTime': 2400321715,
   'request': {
-    'events': [
-      {'timestamp': 2400314657, 'event': 'Connection established'},
-      {'timestamp': 2400320066, 'event': 'Request sent'},
-      {'timestamp': 2400994822, 'event': 'Waiting (TTFB)'},
-      {'timestamp': 2401000729, 'event': 'Content Download'},
-    ],
     'headers': {
       'transfer-encoding': [],
     },
@@ -259,7 +257,6 @@ final httpPostResponseBodyData = [
 
 final httpPutRequest = HttpProfileRequest.parse(httpPutJson)!;
 final httpPut = DartIOHttpRequestData(
-  0,
   httpPutRequest,
   requestFullDataFromVmService: false,
 );
@@ -269,15 +266,15 @@ final Map<String, dynamic> httpPutJson = {
   'isolateId': 'isolates/4447876918484683',
   'method': 'PUT',
   'uri': 'https://jsonplaceholder.typicode.com/posts/1',
+  'events': [
+    {'timestamp': 1205855316, 'event': 'Connection established'},
+    {'timestamp': 1205858323, 'event': 'Request sent'},
+    {'timestamp': 1206602445, 'event': 'Waiting (TTFB)'},
+    {'timestamp': 1206609213, 'event': 'Content Download'},
+  ],
   'startTime': 1205283313,
   'endTime': 1205859179,
   'request': {
-    'events': [
-      {'timestamp': 1205855316, 'event': 'Connection established'},
-      {'timestamp': 1205858323, 'event': 'Request sent'},
-      {'timestamp': 1206602445, 'event': 'Waiting (TTFB)'},
-      {'timestamp': 1206609213, 'event': 'Content Download'},
-    ],
     'headers': {
       'transfer-encoding': [],
     },
@@ -338,7 +335,6 @@ final httpPutResponseBodyData = [
 
 final httpPatchRequest = HttpProfileRequest.parse(httpPatchJson)!;
 final httpPatch = DartIOHttpRequestData(
-  0,
   httpPatchRequest,
   requestFullDataFromVmService: false,
 );
@@ -348,15 +344,15 @@ final Map<String, dynamic> httpPatchJson = {
   'isolateId': 'isolates/4447876918484683',
   'method': 'PATCH',
   'uri': 'https://jsonplaceholder.typicode.com/posts/1',
+  'events': [
+    {'timestamp': 1910722654, 'event': 'Connection established'},
+    {'timestamp': 1910722783, 'event': 'Request sent'},
+    {'timestamp': 1911415225, 'event': 'Waiting (TTFB)'},
+    {'timestamp': 1911421003, 'event': 'Content Download'},
+  ],
   'startTime': 1910177192,
   'endTime': 1910722856,
   'request': {
-    'events': [
-      {'timestamp': 1910722654, 'event': 'Connection established'},
-      {'timestamp': 1910722783, 'event': 'Request sent'},
-      {'timestamp': 1911415225, 'event': 'Waiting (TTFB)'},
-      {'timestamp': 1911421003, 'event': 'Content Download'},
-    ],
     'headers': {
       'transfer-encoding': [],
     },
@@ -420,7 +416,6 @@ final httpPatchResponseBodyData = [
 
 final httpGetWithErrorRequest = HttpProfileRequest.parse(httpGetWithErrorJson)!;
 final httpGetWithError = DartIOHttpRequestData(
-  0,
   httpGetWithErrorRequest,
   requestFullDataFromVmService: false,
 );
@@ -430,17 +425,16 @@ final Map<String, dynamic> httpGetWithErrorJson = {
   'isolateId': 'isolates/1939772779732043',
   'method': 'GET',
   'uri': 'https://www.examplez.com/1',
+  'events': [],
   'startTime': 5385227316,
   'endTime': 5387256813,
   'request': {
-    'events': [],
     'error': 'HandshakeException: Connection terminated during handshake',
   },
 };
 
 final httpWsHandshakeRequest = HttpProfileRequest.parse(httpWsHandshakeJson)!;
 final httpWsHandshake = DartIOHttpRequestData(
-  0,
   httpWsHandshakeRequest,
   requestFullDataFromVmService: false,
 );
@@ -450,14 +444,14 @@ final Map<String, dynamic> httpWsHandshakeJson = {
   'isolateId': 'isolates/1350291957483171',
   'method': 'GET',
   'uri': 'http://localhost:8080',
+  'events': [
+    {'timestamp': 8140247076, 'event': 'Connection established'},
+    {'timestamp': 8140247156, 'event': 'Request sent'},
+    {'timestamp': 8140261573, 'event': 'Waiting (TTFB)'},
+  ],
   'startTime': 8140222102,
   'endTime': 8140247377,
   'request': {
-    'events': [
-      {'timestamp': 8140247076, 'event': 'Connection established'},
-      {'timestamp': 8140247156, 'event': 'Request sent'},
-      {'timestamp': 8140261573, 'event': 'Waiting (TTFB)'},
-    ],
     'headers': {
       'content-length': ['0'],
     },
@@ -510,15 +504,15 @@ final Map<String, dynamic> httpGetPendingJson = {
   'isolateId': 'isolates/2013291945734727',
   'method': 'GET',
   'uri': 'https://jsonplaceholder.typicode.com/albums/10',
+  'events': [
+    {'timestamp': 6326808941, 'event': 'Connection established'},
+    {'timestamp': 6326808965, 'event': 'Request sent'},
+    {'timestamp': 6327090622, 'event': 'Waiting (TTFB)'},
+    {'timestamp': 6327091650, 'event': 'Content Download'},
+  ],
   'startTime': 6326279935,
   'endTime': 6326808974,
   'request': {
-    'events': [
-      {'timestamp': 6326808941, 'event': 'Connection established'},
-      {'timestamp': 6326808965, 'event': 'Request sent'},
-      {'timestamp': 6327090622, 'event': 'Waiting (TTFB)'},
-      {'timestamp': 6327091650, 'event': 'Content Download'},
-    ],
     'headers': {
       'content-length': ['0'],
     },

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.10-wip
 * Add `DTDManager` class and export from `service.dart`.
 * Add `showDevToolsDialog` helper method.
+* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.9
 * Bump `package:web` to `^0.4.1`.
@@ -15,7 +16,6 @@ hitting a narrow screen threshold, specified by `minScreenWidthForTextBeforeScal
 * Change default styling of `regularTextStyle` to inherit from `TextTheme.bodySmall`.
 * Change default styling of `TextTheme.bodySmall`, `TextTheme.bodyMedium`,
 `TextTheme.titleSmall` in the base theme.
-* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.8
 * Add `ServiceManager.resolvedUriManager` for looking up package and file uris from

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -15,6 +15,7 @@ hitting a narrow screen threshold, specified by `minScreenWidthForTextBeforeScal
 * Change default styling of `regularTextStyle` to inherit from `TextTheme.bodySmall`.
 * Change default styling of `TextTheme.bodySmall`, `TextTheme.bodyMedium`,
 `TextTheme.titleSmall` in the base theme.
+* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.8
 * Add `ServiceManager.resolvedUriManager` for looking up package and file uris from

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   logging: ^1.1.1
   meta: ^1.9.1
   pointer_interceptor: ^0.9.3+3
-  vm_service: ^13.0.0
+  vm_service: ^14.0.0
   web: ^0.4.1
 
 dev_dependencies:

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 0.0.14-wip
 * Add a global `dtdManager` for interacting with the Dart Tooling Daemon.
+* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.13
 * Bump `package:web` to `^0.4.1`.
 * Fix `README.md` instructions for adding a `.pubignore` file.
 * Make Simulated DevTools Environment Panel collapsible.
-* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.12
 * Fix a bug preventing Dart server apps from connecting to DevTools extensions.

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Bump `package:web` to `^0.4.1`.
 * Fix `README.md` instructions for adding a `.pubignore` file.
 * Make Simulated DevTools Environment Panel collapsible.
+* Bump `package:vm_service` dependency to ^14.0.0.
 
 ## 0.0.12
 * Fix a bug preventing Dart server apps from connecting to DevTools extensions.

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   io: ^1.0.4
   path: ^1.8.0
   logging: ^1.1.1
-  vm_service: ^13.0.0
+  vm_service: ^14.0.0
   web: ^0.4.1
 
 dev_dependencies:

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -416,10 +416,14 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
   @override
   Future<HttpProfile> getHttpProfileWrapper(
     String isolateId, {
-    int? updatedSince,
+    DateTime? updatedSince,
   }) {
     return Future.value(
-      _httpProfile ?? HttpProfile(requests: [], timestamp: 0),
+      _httpProfile ??
+          HttpProfile(
+            requests: [],
+            timestamp: DateTime.fromMicrosecondsSinceEpoch(0),
+          ),
     );
   }
 
@@ -430,7 +434,10 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
   }
 
   void restoreFakeHttpProfileRequests() {
-    _httpProfile = HttpProfile(requests: _startingRequests, timestamp: 0);
+    _httpProfile = HttpProfile(
+      requests: _startingRequests,
+      timestamp: DateTime.fromMicrosecondsSinceEpoch(0),
+    );
   }
 
   @override

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   mockito: ^5.4.1
   path: ^1.8.0
   provider: ^6.0.2
-  vm_service: ^13.0.0
+  vm_service: ^14.0.0
   webkit_inspection_protocol: '>=0.5.0 <2.0.0'
 
 dependency_overrides:


### PR DESCRIPTION
`package:vm_service` v14 includes breaking changes to the dart:io service extensions. This PR updates the `package:vm_service` constraint to `^14.0.0` and updates DevTools in response to those changes.