### PR TITLE
[DevTools extensions] Use `Uri.parse` for windows platforms too

### DIFF
--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -4,7 +4,7 @@
   argument.
 * `SemanticVersion` now mixes in `CompareMixin<SemanticVersion>`, and it's
   `compareTo` method therefore now accepts a `SemanticVersion`.
-* Fix an issue parsing file paths on Mac that could prevent extensions from being detected.
+* Fix an issue parsing file paths that could prevent extensions from being detected.
 
 # 6.0.2
 * Fix an issue parsing file paths on Windows that could prevent extensions from being detected.

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -44,33 +44,33 @@ class ExtensionsManager {
   /// [serveAvailableExtensions] is called.
   final devtoolsExtensions = <DevToolsExtensionConfig>[];
 
-  /// Serves any available DevTools extensions for the given [rootPath], where
-  /// [rootPath] is the root for a Dart or Flutter project containing the
-  /// `.dart_tool/` directory.
+  /// Serves any available DevTools extensions for the given [rootPathFileUri],
+  /// where [rootPathFileUri] is the root for a Dart or Flutter project
+  /// containing the `.dart_tool/` directory.
+  ///
+  /// [rootPathFileUri] is expected to be a file uri (e.g. starting with
+  /// 'file://').
   ///
   /// This method first looks up the available extensions using
   /// package:extension_discovery, and the available extension's
   /// assets will be copied to the `build/devtools_extensions` directory that
   /// DevTools server is serving.
-  Future<void> serveAvailableExtensions(String? rootPath) async {
+  Future<void> serveAvailableExtensions(String? rootPathFileUri) async {
     devtoolsExtensions.clear();
     final parsingErrors = StringBuffer();
 
-    if (rootPath != null) {
+    if (rootPathFileUri != null) {
       late final List<Extension> extensions;
       try {
-        final packageConfigPath = path.join(
-          rootPath,
-          '.dart_tool',
-          'package_config.json',
-        );
-        // Only use [Uri.file] for windows platforms (https://github.com/dart-lang/tools/issues/220).
-        final packageConfigUri = Platform.isWindows
-            ? Uri.file(packageConfigPath)
-            : Uri.parse(packageConfigPath);
         extensions = await findExtensions(
           'devtools',
-          packageConfig: packageConfigUri,
+          packageConfig: Uri.parse(
+            path.join(
+              rootPathFileUri,
+              '.dart_tool',
+              'package_config.json',
+            ),
+          ),
         );
       } catch (e) {
         extensions = <Extension>[];

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -56,6 +56,14 @@ class ExtensionsManager {
   /// assets will be copied to the `build/devtools_extensions` directory that
   /// DevTools server is serving.
   Future<void> serveAvailableExtensions(String? rootPathFileUri) async {
+    if (rootPathFileUri != null && !rootPathFileUri.startsWith('file://')) {
+      throw ArgumentError.value(
+        rootPathFileUri,
+        'rootPathFileUri',
+        'must be a file:// URI String',
+      );
+    }
+
     devtoolsExtensions.clear();
     final parsingErrors = StringBuffer();
 
@@ -65,7 +73,7 @@ class ExtensionsManager {
         extensions = await findExtensions(
           'devtools',
           packageConfig: Uri.parse(
-            path.join(
+            path.posix.join(
               rootPathFileUri,
               '.dart_tool',
               'package_config.json',


### PR DESCRIPTION
context: https://github.com/dart-lang/tools/issues/220.
The fix committed here should actually apply to windows too: https://github.com/flutter/devtools/pull/6961