### PR TITLE
Fix first run for `devtools_tool`

### DIFF
--- a/tool/bin/devtools_tool
+++ b/tool/bin/devtools_tool
@@ -4,17 +4,16 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 if [ ! -z "$DEVTOOLS_TOOL_FLUTTER_FROM_PATH" ]
 then
-	echo Running devtools_tool using Dart/Flutter from PATH because DEVTOOLS_TOOL_FLUTTER_FROM_PATH is set
-	dart run "$SCRIPT_DIR/devtools_tool.dart" "$@"
+  echo Running devtools_tool using Dart/Flutter from PATH because DEVTOOLS_TOOL_FLUTTER_FROM_PATH is set
+  dart run "$SCRIPT_DIR/devtools_tool.dart" "$@"
 else
-	
-	if [ ! -d $SCRIPT_DIR/../flutter-sdk ]
-	then
-		# If the `devtools/tool/flutter-sdk` directory does not exist yet, use whatever Dart
-		# is on the user's path to update it before proceeding.
-		echo "Running devtools_tool using the Dart SDK from `which dart` to create the Flutter SDK in tool/flutter-sdk."
-    	dart run "$SCRIPT_DIR/devtools_tool.dart" update-flutter-sdk
-  	fi
+  if [ ! -d $SCRIPT_DIR/../flutter-sdk ]
+  then
+	# If the `devtools/tool/flutter-sdk` directory does not exist yet, use whatever Dart
+	# is on the user's path to update it before proceeding.
+	echo "Running devtools_tool using the Dart SDK from `which dart` to create the Flutter SDK in tool/flutter-sdk."
+   	dart run "$SCRIPT_DIR/devtools_tool.dart" update-flutter-sdk
+  fi
 
-	"$SCRIPT_DIR/../flutter-sdk/bin/dart" run "$SCRIPT_DIR/devtools_tool.dart" "$@"
+  "$SCRIPT_DIR/../flutter-sdk/bin/dart" run "$SCRIPT_DIR/devtools_tool.dart" "$@"
 fi

--- a/tool/bin/devtools_tool
+++ b/tool/bin/devtools_tool
@@ -7,5 +7,14 @@ then
 	echo Running devtools_tool using Dart/Flutter from PATH because DEVTOOLS_TOOL_FLUTTER_FROM_PATH is set
 	dart run "$SCRIPT_DIR/devtools_tool.dart" "$@"
 else
+	
+	if [ ! -d $SCRIPT_DIR/../flutter-sdk ]
+	then
+		# If the `devtools/tool/flutter-sdk` directory does not exist yet, use whatever Dart
+		# is on the user's path to update it before proceeding.
+		echo "Running devtools_tool using the Dart SDK from `which dart` to create the Flutter SDK in tool/flutter-sdk."
+    	dart run "$SCRIPT_DIR/devtools_tool.dart" update-flutter-sdk
+  	fi
+
 	"$SCRIPT_DIR/../flutter-sdk/bin/dart" run "$SCRIPT_DIR/devtools_tool.dart" "$@"
 fi


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6969 so that the first execution of `devtools_tool` after a fresh clone of DevTools works as intended. As part of our Contributing guide, we first tell users to get Flutter and Dart set up on their path, so at the point they begin to interact with the `devtools_tool` script, we can assume that `dart` will be available.