### PR TITLE
Fix incoming postMessages for package:web

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
@@ -12,7 +12,7 @@ Stream<PostMessageEvent> get onPostMessage {
   return window.onMessage.map(
     (message) => PostMessageEvent(
       origin: message.origin,
-      data: message.data,
+      data: message.data.dartify(),
     ),
   );
 }

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -53,7 +53,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## VS Code Sidebar updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed an issue that prevented the VS code sidebar from loading in recent beta/master builds. - [#6984](https://github.com/flutter/devtools/pull/6984)
 
 ## DevTools Extension updates
 


### PR DESCRIPTION
`message.data` here is `LegacyJavaScriptObject` which is different to the `dart:html` version. We need to call `dartify()` to get this back to the Dart map we expect (which matches the `jsify()` call on the way out.

Fixes https://github.com/flutter/devtools/issues/6981

We need to look at whether we can have better automated tests for things that go over postMessage (our current mock VS Code environment doesn't go via postMessage because it's just hosted as a widget inside a single Flutter page - but perhaps it should be real iframes), but we should get this fix landed first.

@jacob314 @kenzieschmoll 