### PR TITLE
Fix incorrect asset path for Dart apps ran with `--observe`

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -42,8 +42,12 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
       return 'https://flutter.dev/';
     }
 
+    final basePath = devtoolsAssetsBasePath(
+      origin: window.location.origin,
+      path: window.location.pathname,
+    );
     final baseUri = path.join(
-      window.location.origin,
+      basePath,
       'devtools_extensions',
       extensionConfig.name,
       'index.html',

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -11,7 +11,6 @@ import 'package:web/helpers.dart';
 import '../../../../../shared/globals.dart';
 import '../../../../../shared/primitives/trace_event.dart';
 import '../../../../../shared/primitives/utils.dart';
-import '../../../performance_utils.dart';
 import 'perfetto_controller.dart';
 
 /// Flag to enable embedding an instance of the Perfetto UI running on
@@ -118,7 +117,7 @@ class PerfettoControllerImpl extends PerfettoController {
     if (_debugUseLocalPerfetto) {
       return _debugPerfettoUrl;
     }
-    final basePath = assetUrlHelper(
+    final basePath = devtoolsAssetsBasePath(
       origin: window.location.origin,
       path: window.location.pathname,
     );

--- a/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_utils.dart
@@ -94,23 +94,3 @@ extension TraceEventExtension on TraceEvent {
       phase == TraceEvent.metadataEventPhase &&
       name == TraceEvent.threadNameEvent;
 }
-
-/// Returns the url (as a string) where the DevTools assets are served.
-///
-/// For Flutter apps and when DevTools is served via the `dart devtools`
-/// command, this url should be equivalent to [html.window.location.origin].
-/// However, when DevTools is served directly from DDS via the --observe flag,
-/// the authentication token and 'devtools/' path part are also required.
-///
-/// Examples:
-/// * 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools/performance'
-///     ==> 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'
-/// * 'http://127.0.0.1:61962/performance' ==> 'http://127.0.0.1:61962'
-String assetUrlHelper({required String origin, required String path}) {
-  const separator = '/';
-  final pathParts = path.split(separator);
-  // The last path part is the DevTools page (e.g. 'performance' or 'snapshot'),
-  // which is not part of the hosted asset path.
-  pathParts.removeLast();
-  return '$origin${pathParts.join(separator)}';
-}

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1244,3 +1244,23 @@ Map<K, R> subtractMaps<K, F, S, R>({
   }
   return result;
 }
+
+/// Returns the url (as a string) where the DevTools assets are served.
+///
+/// For Flutter apps and when DevTools is served via the `dart devtools`
+/// command, this url should be equivalent to [html.window.location.origin].
+/// However, when DevTools is served directly from DDS via the --observe flag,
+/// the authentication token and 'devtools/' path part are also required.
+///
+/// Examples:
+/// * 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools/performance'
+///     ==> 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'
+/// * 'http://127.0.0.1:61962/performance' ==> 'http://127.0.0.1:61962'
+String devtoolsAssetsBasePath({required String origin, required String path}) {
+  const separator = '/';
+  final pathParts = path.split(separator);
+  // The last path part is the DevTools page (e.g. 'performance' or 'snapshot'),
+  // which is not part of the hosted asset path.
+  pathParts.removeLast();
+  return '$origin${pathParts.join(separator)}';
+}

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -57,7 +57,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## DevTools Extension updates
 
-* Fixed a bug preventing Dart server apps from connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982)
+* Fixed a bug preventing Dart server apps from connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982), []()
 
 ## Full commit history
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -57,7 +57,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## DevTools Extension updates
 
-* Fixed a bug preventing Dart server apps from connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982), []()
+* Fixed a couple bugs preventing Dart server apps from connecting to DevTools extensions. - [#6982](https://github.com/flutter/devtools/pull/6982), [#6993](https://github.com/flutter/devtools/pull/6993)
 
 ## Full commit history
 

--- a/packages/devtools_app/test/performance/performance_utils_test.dart
+++ b/packages/devtools_app/test/performance/performance_utils_test.dart
@@ -108,23 +108,5 @@ void main() {
         equals(-1),
       );
     });
-
-    test('assetUrlHelper', () {
-      // This is how a DevTools url will be structured when DevTools is served
-      // directly from DDS using the `--observe` flag.
-      expect(
-        assetUrlHelper(
-          origin: 'http://127.0.0.1:61962',
-          path: '/mb9Sw4gCYvU=/devtools/performance',
-        ),
-        equals('http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'),
-      );
-      // This is how a DevTools url will be structured when served from DevTools
-      // server (e.g. from Flutter tools and from the `dart devtools` command).
-      expect(
-        assetUrlHelper(origin: 'http://127.0.0.1:61962', path: '/performance'),
-        equals('http://127.0.0.1:61962'),
-      );
-    });
   });
 }

--- a/packages/devtools_app/test/primitives/utils_test.dart
+++ b/packages/devtools_app/test/primitives/utils_test.dart
@@ -1441,7 +1441,10 @@ void main() {
     // This is how a DevTools url will be structured when served from DevTools
     // server (e.g. from Flutter tools and from the `dart devtools` command).
     expect(
-      devtoolsAssetsBasePath(origin: 'http://127.0.0.1:61962', path: '/performance'),
+      devtoolsAssetsBasePath(
+        origin: 'http://127.0.0.1:61962',
+        path: '/performance',
+      ),
       equals('http://127.0.0.1:61962'),
     );
   });

--- a/packages/devtools_app/test/primitives/utils_test.dart
+++ b/packages/devtools_app/test/primitives/utils_test.dart
@@ -1427,6 +1427,24 @@ void main() {
       expect(['A', 'B', 'C'].joinWithTrailing(':'), equals('A:B:C:'));
     });
   });
+
+  test('devtoolsAssetsBasePath', () {
+    // This is how a DevTools url will be structured when DevTools is served
+    // directly from DDS using the `--observe` flag.
+    expect(
+      devtoolsAssetsBasePath(
+        origin: 'http://127.0.0.1:61962',
+        path: '/mb9Sw4gCYvU=/devtools/performance',
+      ),
+      equals('http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'),
+    );
+    // This is how a DevTools url will be structured when served from DevTools
+    // server (e.g. from Flutter tools and from the `dart devtools` command).
+    expect(
+      devtoolsAssetsBasePath(origin: 'http://127.0.0.1:61962', path: '/performance'),
+      equals('http://127.0.0.1:61962'),
+    );
+  });
 }
 
 class _SubtractionResult {


### PR DESCRIPTION
This was preventing DevTools extensions from loading for a Dart app ran with `--observe`. This is because the DevTools assets are served on a different path when DevTools is spawned by DDS.

Tracking issue to add a regression test: https://github.com/flutter/devtools/issues/6994