### PR TITLE
Specify type arguments on raw types

### DIFF
--- a/packages/devtools_app/benchmark/test_infra/automators/devtools_automator.dart
+++ b/packages/devtools_app/benchmark/test_infra/automators/devtools_automator.dart
@@ -101,7 +101,7 @@ const Duration _animationCheckingInterval = Duration(milliseconds: 50);
 Future<void> animationStops() async {
   if (!WidgetsBinding.instance.hasScheduledFrame) return;
 
-  final Completer stopped = Completer<void>();
+  final stopped = Completer<void>();
 
   Timer.periodic(_animationCheckingInterval, (timer) {
     if (!WidgetsBinding.instance.hasScheduledFrame) {

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -438,7 +438,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
 ///
 /// [C] corresponds to the type of the screen's controller, which is created by
 /// [createController] or provided by [controllerProvider].
-class DevToolsScreen<C> {
+class DevToolsScreen<C extends Object?> {
   const DevToolsScreen(
     this.screen, {
     this.createController,

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -36,7 +36,7 @@ abstract class ServiceExtensionInterface {
 /// A subclass of [extensions.ToggleableServiceExtension] that includes metadata
 /// for displaying and interacting with a toggleable service extension in the
 /// DevTools UI.
-class ToggleableServiceExtensionDescription<T> extends extensions
+class ToggleableServiceExtensionDescription<T extends Object> extends extensions
     .ToggleableServiceExtension implements ServiceExtensionInterface {
   ToggleableServiceExtensionDescription._({
     required super.extension,

--- a/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
+++ b/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
@@ -102,7 +102,7 @@ class EvalOnDartLibrary extends DisposableController
 
   late Completer<LibraryRef> _libraryRef;
 
-  Completer? allPendingRequestsDone;
+  Completer<void>? allPendingRequestsDone;
 
   Isolate? get isolate => _isolate;
   Isolate? _isolate;
@@ -596,7 +596,7 @@ class EvalOnDartLibrary extends DisposableController
         return response.future;
       }
 
-      final Future previousDone = allPendingRequestsDone!.future;
+      final Future<void> previousDone = allPendingRequestsDone!.future;
       allPendingRequestsDone = response;
       // Schedule this request only after the previous request completes.
       try {

--- a/packages/devtools_app_shared/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extensions.dart
@@ -21,7 +21,7 @@ class ServiceExtension<T> {
   final bool shouldCallOnAllIsolates;
 }
 
-class ToggleableServiceExtension<T> extends ServiceExtension {
+class ToggleableServiceExtension<T extends Object> extends ServiceExtension<T> {
   ToggleableServiceExtension({
     required super.extension,
     required T enabledValue,
@@ -228,11 +228,11 @@ final profilePlatformChannels = ToggleableServiceExtension<bool>(
 final String didSendFirstFrameEvent =
     '$flutterExtensionPrefix${WidgetsServiceExtensions.didSendFirstFrameEvent.name}';
 
-final serviceExtensionsAllowlist = <String, ServiceExtension>{
+final serviceExtensionsAllowlist = <String, ServiceExtension<Object>>{
   for (var extension in _extensionDescriptions) extension.extension: extension,
 };
 
-final List<ServiceExtension> _extensionDescriptions = [
+final List<ServiceExtension<Object>> _extensionDescriptions = [
   debugAllowBanner,
   debugPaint,
   debugPaintBaselines,
@@ -266,7 +266,8 @@ final List<ServiceExtension> _extensionDescriptions = [
 /// extensions are safe to run before the first frame as there is little harm
 /// in setting these extensions after one frame has rendered without the
 /// extension set.
-final Set<String> _unsafeBeforeFirstFrameFlutterExtensions = <ServiceExtension>[
+final Set<String> _unsafeBeforeFirstFrameFlutterExtensions =
+    <ServiceExtension<Object>>[
   debugPaint,
   debugPaintBaselines,
   repaintRainbow,

--- a/packages/devtools_app_shared/lib/src/service/service_utils.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_utils.dart
@@ -53,7 +53,7 @@ Future<void> forEachIsolateHelper(
   Future<void> Function(IsolateRef) callback,
 ) async {
   final vm = await vmService.getVM();
-  final futures = <Future>[];
+  final futures = <Future<void>>[];
   for (final isolate in vm.isolates ?? []) {
     futures.add(callback(isolate));
   }

--- a/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
+++ b/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
@@ -16,7 +16,7 @@ class AutoDisposeContoller extends DisposableController
 class AutoDisposedWidget extends StatefulWidget {
   const AutoDisposedWidget(this.stream, {Key? key}) : super(key: key);
 
-  final Stream stream;
+  final Stream<Object?> stream;
 
   @override
   State<AutoDisposedWidget> createState() => _AutoDisposedWidgetState();

--- a/packages/devtools_app_shared/test/utils/list_test.dart
+++ b/packages/devtools_app_shared/test/utils/list_test.dart
@@ -35,7 +35,7 @@ void main() {
     });
 
     test('value returns ImmutableList', () {
-      expect(notifier.value, isA<ImmutableList>());
+      expect(notifier.value, isA<ImmutableList<Object?>>());
     });
 
     test('notifies on add', () {


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929.

Avoiding raw types (`like Completer c =`) reduces the amount of dynamic types, and dynamic calls.

Specifying a type argument bound of `Object?` (rather than `dynamic`) also helps to reduce dynamic types, and makes things a little easier by tightening the type at the declaration, rather than each subclass or instantiation.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
