### PR TITLE
Improve doc comment and remove dynamic variable in AppSizeController

### DIFF
--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -623,15 +623,18 @@ class AppSizeController {
     }
   }
 
-  /// Recursively generates a diff tree from [treeJson] that contains the difference
-  /// between an old size analysis file and a new size analysis file.
+  /// Recursively generates a diff tree from [treeJson] that contains the
+  /// difference between an old size analysis file and a new size analysis file.
   ///
-  /// Each node in the resulting tree represents a change in size for the given node.
+  /// Each node in the resulting tree represents a change in size for the given
+  /// node.
   ///
   /// The tree can be filtered with different [DiffTreeType] values:
-  /// * [DiffTreeType.increaseOnly]: returns a tree with nodes with positive [byteSize].
-  /// * [DiffTreeType.decreaseOnly]: returns a tree with nodes with negative [byteSize].
-  /// * [DiffTreeType.combined]: returns a tree with all nodes.
+  /// * [DiffTreeType.increaseOnly] - returns a tree with nodes with positive
+  ///   [byteSize].
+  /// * [DiffTreeType.decreaseOnly] - returns a tree with nodes with negative
+  ///   [byteSize].
+  /// * [DiffTreeType.combined] - returns a tree with all nodes.
   TreemapNode? generateDiffTree(
     Map<String, dynamic> treeJson,
     DiffTreeType diffTreeType, {
@@ -647,7 +650,7 @@ class AppSizeController {
       );
     } else {
       // TODO(peterdjlee): Investigate why there are leaf nodes with size of null.
-      final byteSize = treeJson['value'];
+      final byteSize = treeJson['value'] as int?;
       if (byteSize == null) {
         return null;
       }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/6929.

There is a "bug" / "shortcoming" of the analyzer's comment reference resolution; when there is a `:` right after the `]`, it won't parse as a reference, so you don't get jump-to-definition, etc. Using hyphens helps.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
