### PR TITLE
Fix .pubignore in devtools_extensions

### DIFF
--- a/packages/devtools_extensions/README.md
+++ b/packages/devtools_extensions/README.md
@@ -245,7 +245,7 @@ when you publish your package. To do so, add the following to a `.pubignore` fil
 `extension/devtools/` directory:
 
 ```
-!./build
+!build
 ```
 
 This will ensure that, even if the `extension/devtools/build` directory has been been git

--- a/packages/devtools_extensions/example/foo/packages/foo/extension/devtools/.pubignore
+++ b/packages/devtools_extensions/example/foo/packages/foo/extension/devtools/.pubignore
@@ -1,1 +1,1 @@
-!./build
+!build


### PR DESCRIPTION
Specifying `!./build` in .pubignore did not work, and it took me a while to realise how to resolve it. This PR corrects the path so that other people won't have to go through the same trouble.

It may be an issue of [dart-lang/pub](https://github.com/dart-lang/pub) but I'm not sure.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
