### PR TITLE
Add a Process Memory view to VM Tools

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_tree_columns.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_tree_columns.dart
@@ -20,11 +20,11 @@ class DescriptionColumn extends ColumnData<TreemapNode> {
   String getValue(TreemapNode dataObject) => dataObject.caption ?? '';
 }
 
-class MemoryColumn extends MemoryAndPercentageColumn<TreemapNode> {
+class MemoryColumn extends SizeAndPercentageColumn<TreemapNode> {
   MemoryColumn({required VMProcessMemoryViewController controller})
       : super(
           title: 'Memory Usage',
-          memoryProvider: (node) => node.byteSize,
+          sizeProvider: (node) => node.byteSize,
           percentAsDoubleProvider: (node) =>
               node.byteSize / controller.treeRoot.value!.byteSize,
         );

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_tree_columns.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_tree_columns.dart
@@ -1,0 +1,31 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import '../../../shared/charts/treemap.dart';
+import '../../../shared/table/table_data.dart';
+import 'process_memory_view_controller.dart';
+
+class CategoryColumn extends TreeColumnData<TreemapNode> {
+  CategoryColumn() : super('Category');
+
+  @override
+  String getValue(TreemapNode dataObject) => dataObject.name;
+}
+
+class DescriptionColumn extends ColumnData<TreemapNode> {
+  DescriptionColumn() : super.wide('Description');
+
+  @override
+  String getValue(TreemapNode dataObject) => dataObject.caption ?? '';
+}
+
+class MemoryColumn extends MemoryAndPercentageColumn<TreemapNode> {
+  MemoryColumn({required VMProcessMemoryViewController controller})
+      : super(
+          title: 'Memory Usage',
+          memoryProvider: (node) => node.byteSize,
+          percentAsDoubleProvider: (node) =>
+              node.byteSize / controller.treeRoot.value!.byteSize,
+        );
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
@@ -1,0 +1,253 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/material.dart';
+
+import '../../../shared/analytics/constants.dart' as gac;
+import '../../../shared/charts/treemap.dart';
+import '../../../shared/common_widgets.dart';
+import '../../../shared/primitives/utils.dart';
+import '../../../shared/table/table.dart';
+import '../../../shared/table/table_data.dart';
+import '../../../shared/ui/tab.dart';
+import '../vm_developer_tools_screen.dart';
+import 'process_memory_tree_columns.dart';
+import 'process_memory_view_controller.dart';
+
+/// Displays a breakdown of the target application's overall memory footprint.
+/// This allows for developers to determine:
+/// 
+///  - The total resident set size (RSS)
+///  - How much memory can be attributed to each isolate group's heap,
+///    including system isolate groups like the vm-service and kernel-service
+///  - How much memory can be attributed to developer tooling functionality
+///    (e.g., CPU profiler buffer size, size of all recorded timeline events)
+/// 
+/// This view provides both a tree table and a tree map to explore the
+/// process's memory footprint. 
+class VMProcessMemoryView extends VMDeveloperView {
+  const VMProcessMemoryView()
+      : super(
+          title: 'Process Memory',
+          icon: Icons.memory,
+        );
+  static const id = 'vm-process-memory';
+
+  @override
+  Widget build(BuildContext context) => VMProcessMemoryViewBody();
+}
+
+enum ProcessMemoryTab {
+  tree('Tree', _treeTab),
+  treeMap('Tree Map', _treeMapTab);
+
+  const ProcessMemoryTab(this.title, this.key);
+
+  final String title;
+  final Key key;
+
+  static const Key _treeTab = Key('process memory usage tree tab');
+  static const Key _treeMapTab = Key('process memory usage tree map tab');
+
+  static ProcessMemoryTab byKey(Key? k) {
+    return ProcessMemoryTab.values.firstWhere((tab) => tab.key == k);
+  }
+}
+
+/// Displays general information about the state of the Dart VM.
+class VMProcessMemoryViewBody extends StatefulWidget {
+  VMProcessMemoryViewBody({super.key})
+      : tabs = [
+          _buildTab(ProcessMemoryTab.tree),
+          _buildTab(ProcessMemoryTab.treeMap),
+        ];
+
+  static DevToolsTab _buildTab(ProcessMemoryTab processMemoryTab) {
+    return DevToolsTab.create(
+      key: processMemoryTab.key,
+      tabName: processMemoryTab.title,
+      gaPrefix: 'processMemoryTab',
+    );
+  }
+
+  final List<DevToolsTab> tabs;
+
+  @override
+  State<VMProcessMemoryViewBody> createState() =>
+      _VMProcessMemoryViewBodyState();
+}
+
+class _VMProcessMemoryViewBodyState extends State<VMProcessMemoryViewBody>
+    with TickerProviderStateMixin, AutoDisposeMixin {
+  static const _expandCollapseMinIncludeTextWidth = 610.0;
+
+  final controller = VMProcessMemoryViewController();
+
+  bool _tabControllerInitialized = false;
+  late TabController _tabController;
+
+  @override
+  void initState() {
+    super.initState();
+    _initTabController();
+  }
+
+  @override
+  void didUpdateWidget(VMProcessMemoryViewBody oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.tabs.length != oldWidget.tabs.length) {
+      _initTabController();
+    }
+  }
+
+  void _initTabController() {
+    if (_tabControllerInitialized) {
+      _tabController.removeListener(_onTabChanged);
+      _tabController.dispose();
+    }
+
+    _tabController = TabController(
+      length: widget.tabs.length,
+      vsync: this,
+    );
+    _tabController.addListener(_onTabChanged);
+    _tabControllerInitialized = true;
+  }
+
+  void _onTabChanged() {
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final textTheme = theme.textTheme;
+    final colorScheme = theme.colorScheme;
+    final currentTab = widget.tabs[_tabController.index];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        RefreshButton(
+          gaScreen: gac.vmTools,
+          gaSelection: gac.refreshProcessMemoryStatistics,
+          onPressed: controller.refresh,
+        ),
+        const SizedBox(height: denseRowSpacing),
+        AreaPaneHeader(
+          leftPadding: 0,
+          tall: true,
+          title: TabBar(
+            labelColor: textTheme.bodyLarge?.color ?? colorScheme.onSurface,
+            isScrollable: true,
+            controller: _tabController,
+            tabs: widget.tabs,
+          ),
+          actions: [
+            if (currentTab.key == ProcessMemoryTab.tree.key) ...[
+              ExpandAllButton(
+                gaScreen: gac.cpuProfiler,
+                gaSelection: gac.expandAll,
+                minScreenWidthForTextBeforeScaling:
+                    _expandCollapseMinIncludeTextWidth,
+                onPressed: () => setState(controller.expandTree),
+              ),
+              const SizedBox(width: denseSpacing),
+              CollapseAllButton(
+                gaScreen: gac.cpuProfiler,
+                gaSelection: gac.collapseAll,
+                minScreenWidthForTextBeforeScaling:
+                    _expandCollapseMinIncludeTextWidth,
+                onPressed: () => setState(controller.collapseTree),
+              ),
+            ],
+          ],
+        ),
+        Expanded(
+          child: OutlineDecoration(
+            showTop: false,
+            child: TabBarView(
+              physics: defaultTabBarViewPhysics,
+              controller: _tabController,
+              children: [
+                _ProcessMemoryTree(controller: controller),
+                _ProcessMemoryTreeMap(controller: controller),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _ProcessMemoryTree extends StatelessWidget {
+  _ProcessMemoryTree({
+    required this.controller,
+  });
+
+  final VMProcessMemoryViewController controller;
+
+  static final categoryColumn = CategoryColumn();
+  static final descriptionColumn = DescriptionColumn();
+
+  late final memoryColumn = MemoryColumn(controller: controller);
+  late final columns = List<ColumnData<TreemapNode>>.unmodifiable([
+    memoryColumn,
+    categoryColumn,
+    descriptionColumn,
+  ]);
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<TreemapNode?>(
+      valueListenable: controller.treeRoot,
+      builder: (context, root, _) {
+        return TreeTable<TreemapNode>(
+          keyFactory: (e) =>
+              PageStorageKey<String>('${e.name}+${e.depth}+${e.byteSize}'),
+          displayTreeGuidelines: true,
+          dataRoots: [
+            if (root != null) root,
+          ],
+          dataKey: 'process-memory-tree',
+          columns: columns,
+          treeColumn: categoryColumn,
+          defaultSortColumn: memoryColumn,
+          defaultSortDirection: SortDirection.descending,
+        );
+      },
+    );
+  }
+}
+
+class _ProcessMemoryTreeMap extends StatelessWidget {
+  const _ProcessMemoryTreeMap({
+    required this.controller,
+  });
+
+  final VMProcessMemoryViewController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return ValueListenableBuilder<TreemapNode?>(
+          valueListenable: controller.treeMapRoot,
+          builder: (context, root, __) {
+            return Treemap.fromRoot(
+              rootNode: root!,
+              levelsVisible: 2,
+              width: constraints.maxWidth,
+              height: constraints.maxHeight,
+              isOutermostLevel: true,
+              onRootChangedCallback: controller.setTreeMapRoot,
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
@@ -19,15 +19,15 @@ import 'process_memory_view_controller.dart';
 
 /// Displays a breakdown of the target application's overall memory footprint.
 /// This allows for developers to determine:
-/// 
+///
 ///  - The total resident set size (RSS)
 ///  - How much memory can be attributed to each isolate group's heap,
 ///    including system isolate groups like the vm-service and kernel-service
 ///  - How much memory can be attributed to developer tooling functionality
 ///    (e.g., CPU profiler buffer size, size of all recorded timeline events)
-/// 
+///
 /// This view provides both a tree table and a tree map to explore the
-/// process's memory footprint. 
+/// process's memory footprint.
 class VMProcessMemoryView extends VMDeveloperView {
   const VMProcessMemoryView()
       : super(

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
@@ -18,6 +18,7 @@ import 'process_memory_tree_columns.dart';
 import 'process_memory_view_controller.dart';
 
 /// Displays a breakdown of the target application's overall memory footprint.
+///
 /// This allows for developers to determine:
 ///
 ///  - The total resident set size (RSS)
@@ -34,6 +35,7 @@ class VMProcessMemoryView extends VMDeveloperView {
           title: 'Process Memory',
           icon: Icons.memory,
         );
+
   static const id = 'vm-process-memory';
 
   @override
@@ -104,15 +106,15 @@ class _VMProcessMemoryViewBodyState extends State<VMProcessMemoryViewBody>
 
   void _initTabController() {
     if (_tabControllerInitialized) {
-      _tabController.removeListener(_onTabChanged);
-      _tabController.dispose();
+      _tabController
+        ..removeListener(_onTabChanged)
+        ..dispose();
     }
 
     _tabController = TabController(
       length: widget.tabs.length,
       vsync: this,
-    );
-    _tabController.addListener(_onTabChanged);
+    )..addListener(_onTabChanged);
     _tabControllerInitialized = true;
   }
 

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view.dart
@@ -57,7 +57,6 @@ enum ProcessMemoryTab {
   }
 }
 
-/// Displays general information about the state of the Dart VM.
 class VMProcessMemoryViewBody extends StatefulWidget {
   VMProcessMemoryViewBody({super.key})
       : tabs = [

--- a/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/process_memory/process_memory_view_controller.dart
@@ -1,0 +1,86 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/foundation.dart';
+import 'package:vm_service/vm_service.dart' hide VmService;
+
+import '../../../service/vm_service_wrapper.dart';
+import '../../../shared/charts/treemap.dart';
+import '../../../shared/globals.dart';
+
+/// Stores process memory usage state for the [VMProcessMemoryView].
+class VMProcessMemoryViewController extends DisposableController {
+  VMProcessMemoryViewController() {
+    unawaited(refresh());
+  }
+
+  /// Fetches the most up-to-date process memory information.
+  Future<void> refresh() async {
+    final processMemoryUsage = await _service.getProcessMemoryUsage();
+
+    TreemapNode processNode(ProcessMemoryItem memoryItem) {
+      final node = TreemapNode(
+        name: memoryItem.name!,
+        byteSize: memoryItem.size!,
+        caption: memoryItem.description,
+      );
+      for (final child in memoryItem.children ?? const <ProcessMemoryItem>[]) {
+        node.addChild(processNode(child));
+      }
+      return node;
+    }
+
+    final currentRoot = processNode(processMemoryUsage.root!);
+
+    // Insert a synthetic node for memory that isn't accounted for by the VM.
+    // This value includes memory allocated through malloc and other mechanisms
+    // that aren't explicitly tracked by the VM.
+    currentRoot.addChild(
+      TreemapNode(
+        name: 'Other',
+        byteSize: currentRoot.byteSize -
+            currentRoot.children.fold<int>(
+              0,
+              (sum, e) => sum + e.byteSize,
+            ),
+      ),
+    );
+
+    // Expand the tree by default since the tree should be relatively small.
+    currentRoot.expandCascading();
+
+    _treeRoot.value = currentRoot;
+    _treeMapRoot.value = currentRoot;
+  }
+
+  VmServiceWrapper get _service => serviceConnection.serviceManager.service!;
+
+  /// The root of the process memory tree, used by the tree view.
+  ValueListenable<TreemapNode?> get treeRoot => _treeRoot;
+  final _treeRoot = ValueNotifier<TreemapNode?>(null);
+
+  /// The current root of the process memory tree being used by the tree map
+  /// viewer.
+  ValueListenable<TreemapNode?> get treeMapRoot => _treeMapRoot;
+  final _treeMapRoot = ValueNotifier<TreemapNode?>(null);
+
+  /// Called when a user interacts with the tree map viewer that results in the
+  /// displayed root of the tree map being updated.
+  void setTreeMapRoot(TreemapNode? newRoot) {
+    _treeMapRoot.value = newRoot;
+  }
+
+  /// Expands all the entries in the tree viewer.
+  void expandTree() {
+    _treeRoot.value?.expandCascading();
+  }
+
+  /// Collapses all the entries in the tree viewer.
+  void collapseTree() {
+    _treeRoot.value?.collapseCascading();
+  }
+}

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_tools_screen.dart
@@ -11,6 +11,7 @@ import '../../shared/screen.dart';
 import '../../shared/utils.dart';
 import 'isolate_statistics/isolate_statistics_view.dart';
 import 'object_inspector/object_inspector_view.dart';
+import 'process_memory/process_memory_view.dart';
 import 'vm_developer_tools_controller.dart';
 import 'vm_statistics/vm_statistics_view.dart';
 
@@ -51,10 +52,11 @@ class VMDeveloperToolsScreen extends Screen {
 class VMDeveloperToolsScreenBody extends StatefulWidget {
   const VMDeveloperToolsScreenBody({super.key});
 
-  static List<VMDeveloperView> views = [
+  static final views = <VMDeveloperView>[
     const VMStatisticsView(),
     const IsolateStatisticsView(),
     ObjectInspectorView(),
+    const VMProcessMemoryView(),
   ];
 
   @override

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -102,6 +102,7 @@ const analyzeDiff = 'analyzeDiff';
 // VM Tools UX Actions:
 const refreshIsolateStatistics = 'refreshIsolateStatistics';
 const refreshVmStatistics = 'refreshVmStatistics';
+const refreshProcessMemoryStatistics = 'refreshProcessMemoryStatistics';
 const requestSize = 'requestSize';
 
 // Settings actions:

--- a/packages/devtools_app/lib/src/shared/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/shared/charts/treemap.dart
@@ -161,7 +161,9 @@ class _TreemapState extends State<Treemap> {
     final isHorizontalRectangle = width > height;
 
     final totalByteSize = computeByteSizeForNodes(nodes: children);
-    if (children.isEmpty) {
+    // If there's no children or the children have a size of zero, there's
+    // nothing to display.
+    if (children.isEmpty || totalByteSize == 0) {
       return [];
     }
 

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -260,3 +260,87 @@ abstract class TimeAndPercentageColumn<T> extends ColumnData<T> {
   String _percentDisplay(T dataObject) =>
       percent(percentAsDoubleProvider(dataObject));
 }
+
+/// Column that, for each row, shows a memory value and the percentage that the
+/// memory value is of the total memory for this data set.
+///
+/// Both memory and percentage are provided through callbacks [memoryProvider] and
+/// [percentAsDoubleProvider], respectively.
+///
+/// When [percentageOnly] is true, the memory value will be omitted, and only the
+/// percentage will be displayed.
+abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
+  MemoryAndPercentageColumn({
+    required String title,
+    required this.percentAsDoubleProvider,
+    this.memoryProvider,
+    this.tooltipProvider,
+    this.richTooltipProvider,
+    this.secondaryCompare,
+    this.percentageOnly = false,
+    double columnWidth = _defaultMemoryColumnWidth,
+    super.titleTooltip,
+  }) : super(
+          title,
+          fixedWidthPx: scaleByFontFactor(columnWidth),
+        );
+
+  static const _defaultMemoryColumnWidth =
+      TimeAndPercentageColumn._defaultTimeColumnWidth;
+
+  int Function(T)? memoryProvider;
+
+  double Function(T) percentAsDoubleProvider;
+
+  String Function(T)? tooltipProvider;
+
+  RichTooltipBuilder<T>? richTooltipProvider;
+
+  Comparable Function(T)? secondaryCompare;
+
+  final bool percentageOnly;
+
+  @override
+  bool get numeric => true;
+
+  @override
+  int compare(T a, T b) {
+    final int result = super.compare(a, b);
+    if (result == 0 && secondaryCompare != null) {
+      return secondaryCompare!(a).compareTo(secondaryCompare!(b));
+    }
+    return result;
+  }
+
+  @override
+  double getValue(T dataObject) => percentageOnly
+      ? percentAsDoubleProvider(dataObject)
+      : memoryProvider!(dataObject).toDouble();
+
+  @override
+  String getDisplayValue(T dataObject) {
+    if (percentageOnly) return _percentDisplay(dataObject);
+    return _memoryAndPercentage(dataObject);
+  }
+
+  @override
+  String getTooltip(T dataObject) {
+    if (tooltipProvider != null) {
+      return tooltipProvider!(dataObject);
+    }
+    if (percentageOnly && memoryProvider != null) {
+      return _memoryAndPercentage(dataObject);
+    }
+    return '';
+  }
+
+  @override
+  InlineSpan? getRichTooltip(T dataObject, BuildContext context) =>
+      richTooltipProvider?.call(dataObject, context);
+
+  String _memoryAndPercentage(T dataObject) =>
+      '${prettyPrintBytes(memoryProvider!(dataObject), includeUnit: true)} (${_percentDisplay(dataObject)})';
+
+  String _percentDisplay(T dataObject) =>
+      percent(percentAsDoubleProvider(dataObject));
+}

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -264,16 +264,16 @@ abstract class TimeAndPercentageColumn<T> extends ColumnData<T> {
 /// Column that, for each row, shows a memory value and the percentage that the
 /// memory value is of the total memory for this data set.
 ///
-/// Both memory and percentage are provided through callbacks [memoryProvider] and
+/// Both memory and percentage are provided through callbacks [sizeProvider] and
 /// [percentAsDoubleProvider], respectively.
 ///
 /// When [percentageOnly] is true, the memory value will be omitted, and only the
 /// percentage will be displayed.
-abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
-  MemoryAndPercentageColumn({
+abstract class SizeAndPercentageColumn<T> extends ColumnData<T> {
+  SizeAndPercentageColumn({
     required String title,
     required this.percentAsDoubleProvider,
-    this.memoryProvider,
+    this.sizeProvider,
     this.tooltipProvider,
     this.richTooltipProvider,
     this.secondaryCompare,
@@ -288,7 +288,7 @@ abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
   static const _defaultMemoryColumnWidth =
       TimeAndPercentageColumn._defaultTimeColumnWidth;
 
-  int Function(T)? memoryProvider;
+  int Function(T)? sizeProvider;
 
   double Function(T) percentAsDoubleProvider;
 
@@ -315,7 +315,7 @@ abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
   @override
   double getValue(T dataObject) => percentageOnly
       ? percentAsDoubleProvider(dataObject)
-      : memoryProvider!(dataObject).toDouble();
+      : sizeProvider!(dataObject).toDouble();
 
   @override
   String getDisplayValue(T dataObject) {
@@ -328,7 +328,7 @@ abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
     if (tooltipProvider != null) {
       return tooltipProvider!(dataObject);
     }
-    if (percentageOnly && memoryProvider != null) {
+    if (percentageOnly && sizeProvider != null) {
       return _memoryAndPercentage(dataObject);
     }
     return '';
@@ -339,7 +339,7 @@ abstract class MemoryAndPercentageColumn<T> extends ColumnData<T> {
       richTooltipProvider?.call(dataObject, context);
 
   String _memoryAndPercentage(T dataObject) =>
-      '${prettyPrintBytes(memoryProvider!(dataObject), includeUnit: true)} (${_percentDisplay(dataObject)})';
+      '${prettyPrintBytes(sizeProvider!(dataObject), includeUnit: true)} (${_percentDisplay(dataObject)})';
 
   String _percentDisplay(T dataObject) =>
       percent(percentAsDoubleProvider(dataObject));


### PR DESCRIPTION
Displays a breakdown of the target application's overall memory footprint. This allows for developers to determine:

  - The total resident set size (RSS)
  - How much memory can be attributed to each isolate group's heap, including system isolate groups like the vm-service and kernel-service
  - How much memory can be attributed to developer tooling functionality (e.g., CPU profiler buffer size, size of all recorded timeline events)

This view provides both a tree table and a tree map to explore the process's memory footprint.

Fixes https://github.com/flutter/flutter/issues/87816
Fixes https://github.com/flutter/devtools/issues/6264

**Screenshots:**

![image](https://github.com/flutter/devtools/assets/24210656/f1215f62-6011-4c41-b734-1d599c3e893f)

![image](https://github.com/flutter/devtools/assets/24210656/8afcbe7c-c7a9-4dd1-b6b0-3626c9e2fce4)