### PR TITLE
Clean up devtools_tool dependencies

### DIFF
--- a/tool/json_to_map.dart
+++ b/tool/json_to_map.dart
@@ -10,11 +10,11 @@ import 'dart:io';
 
 /// Generates a dart file with a [Map] variable 'data' that contains the JSON
 /// data contained in the given json file (first argument).
-/// 
+///
 /// To use:
-/// 
+///
 /// `dart json_to_map.dart ~/path/to/my_file.json`
-/// 
+///
 /// This will generate a file with the same name but with a '.dart' extension
 /// instead of '.json' (e.g. ~/path/to/my_file.dart). This will be a valid dart
 /// file with a single [Map] variable [data].

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -3,20 +3,18 @@ description: A repo management tool for DevTools.
 publish_to: none
 
 environment:
-  sdk: ">=3.0.0 <4.0.0"
+  sdk: ^3.2.0
 
 executables:
   devtools_tool: devtools_tool
 
 dependencies:
-  args: ^2.1.0
-  cli_util: ^0.3.3
-  devtools_shared: ^6.0.1
-  http: ^0.13.3
+  args: ^2.4.2
+  cli_util: ^0.4.1
   io: ^1.0.4
-  lints: any
-  path: ^1.8.0
+  path: ^1.9.0
 
 dependency_overrides:
   devtools_shared:
     path: ../packages/devtools_shared
+  lints: ^3.0.0


### PR DESCRIPTION
- Remove dependencies on `package:devtools_shared` and `package:http` as they are both unused.
- Updates `package:cli_util` version constraint to allow latest version.
- Moves `package:lints` to a dev dependency with a constraint so CI doesn't fail on a new release.