### PR TITLE
Update analysis_options.yaml for removed missing_return lint

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -7,8 +7,6 @@ analyzer:
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning
-    # treat missing returns as a warning (not a hint)
-    missing_return: warning
   exclude:
     - build/**
     - '**.freezed.dart'


### PR DESCRIPTION
The Dart analyzer has removed the missing_return lint. If the lint is present in analysis_options.yaml,
the analyzer gives a warning.

This PR removes the lint, so the warning does not appear in our CI systems, which report it as a failure.
The lint is removed in Dart CL https://dart-review.googlesource.com/c/sdk/+/346182

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


