### PR TITLE
Make Simulated DevTools Environment Panel Collapsible

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -63,6 +63,7 @@ TODO: Remove this section if there are not any general updates.
 
 * Added a description and link to documentation to the `devtools_options.yaml` file
 that is created in a user's project. - [#7052](https://github.com/flutter/devtools/pull/7052)
+* Updated the Simulated DevTools Environment Panel to be collapsible. - [#7062](https://github.com/flutter/devtools/pull/7062)
 
 ## Full commit history
 

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.0.13-wip
 * Bump `package:web` to `^0.4.1`.
 * Fix `README.md` instructions for adding a `.pubignore` file.
+* Make Simulated DevTools Environment Panel collapsible.
 
 ## 0.0.12
 * Fix a bug preventing Dart server apps from connecting to DevTools extensions.

--- a/packages/devtools_extensions/integration_test/test/simulated_environment_test.dart
+++ b/packages/devtools_extensions/integration_test/test/simulated_environment_test.dart
@@ -203,20 +203,25 @@ Future<void> _testCollapseEnvironmentPanel(
   final divider = find.byKey(split.dividerKey(0));
   final environmentPanel = split.children[1];
 
-  final RenderBox environmentPanelRenderBox =
-      tester.renderObject(find.byWidget(environmentPanel));
-  final double environmentPanelRenderBoxWidth =
-      environmentPanelRenderBox.size.width;
+  final environmentPanelSizedBox = find.descendant(
+    of: find.byWidget(environmentPanel),
+    matching: find.byType(SizedBox),
+  );
 
-  // The full width of the [environmentPanel] plus the left and right padding.
-  final double dragDistance =
-      environmentPanelRenderBoxWidth + (2 * defaultSpacing);
+  final double environmentPanelSizedBoxWidth =
+      tester.firstWidget<SizedBox>(environmentPanelSizedBox).width!;
 
-  // Drag the divider to the right by the [dragDistance].
+  // Check that the [environmentPanelSizedBoxWidth] is the expected width.
+  expect(
+    environmentPanelSizedBoxWidth,
+    VmServiceConnection.totalControlsWidth + 2 * defaultSpacing,
+  );
+
+  // Drag the divider to the right by [environmentPanelSizedBoxWidth].
   await tester.drag(
     divider,
     Offset(
-      dragDistance,
+      environmentPanelSizedBoxWidth,
       0,
     ),
   );
@@ -234,13 +239,13 @@ Future<void> _testCollapseEnvironmentPanel(
   // not overlap it.
   expect(simulatedDevToolsWrapperOverlapsEnvironmentPanel, isFalse);
 
-  // Drag the divider to the left by the [dragDistance].
+  // Drag the divider to the left by [environmentPanelSizedBoxWidth].
   //
   // This is to bring the 'Clear logs' button into view so it can be tapped.
   await tester.drag(
     divider,
     Offset(
-      -dragDistance,
+      -environmentPanelSizedBoxWidth,
       0,
     ),
   );

--- a/packages/devtools_extensions/integration_test/test/simulated_environment_test.dart
+++ b/packages/devtools_extensions/integration_test/test/simulated_environment_test.dart
@@ -232,12 +232,12 @@ Future<void> _testCollapseEnvironmentPanel(
   final Rect environmentPanelRect =
       tester.getRect(find.byWidget(environmentPanel));
 
-  final bool simulatedDevToolsWrapperOverlapsEnvironmentPanel =
-      simulatedDevToolsWrapperRect.overlaps(environmentPanelRect);
-
-  // The environment panel is collapsed so the [SimulatedDevToolsWrapper] should
-  // not overlap it.
-  expect(simulatedDevToolsWrapperOverlapsEnvironmentPanel, isFalse);
+  // Verify that the environment panel is off screen to the right of the
+  // simulated devtools wrapper.
+  expect(
+    simulatedDevToolsWrapperRect.right,
+    lessThanOrEqualTo(environmentPanelRect.left.ceil()),
+  );
 
   // Drag the divider to the left by [environmentPanelSizedBoxWidth].
   //

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -12,7 +12,9 @@ class VmServiceConnection extends StatelessWidget {
     required this.connected,
   });
 
+  @visibleForTesting
   static const totalControlsHeight = 45.0;
+  @visibleForTesting
   static const totalControlsWidth = 415.0;
 
   final SimulatedDevToolsController simController;

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_connect_ui.dart
@@ -4,14 +4,16 @@
 
 part of '_simulated_devtools_environment.dart';
 
-class _VmServiceConnection extends StatelessWidget {
-  const _VmServiceConnection({
+@visibleForTesting
+class VmServiceConnection extends StatelessWidget {
+  const VmServiceConnection({
+    super.key,
     required this.simController,
     required this.connected,
   });
 
-  static const _totalControlsHeight = 45.0;
-  static const _totalControlsWidth = 415.0;
+  static const totalControlsHeight = 45.0;
+  static const totalControlsWidth = 415.0;
 
   final SimulatedDevToolsController simController;
   final bool connected;
@@ -19,7 +21,7 @@ class _VmServiceConnection extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: _totalControlsHeight,
+      height: totalControlsHeight,
       child: connected
           ? _ConnectedVmServiceDisplay(simController: simController)
           : _DisconnectedVmServiceDisplay(simController: simController),

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -79,7 +79,7 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
       builder: (context, constraints) {
         final availableWidth = constraints.maxWidth;
         const environmentPanelMinWidth =
-            _VmServiceConnection._totalControlsWidth + 2 * defaultSpacing;
+            VmServiceConnection.totalControlsWidth + 2 * defaultSpacing;
 
         final environmentPanelFraction =
             environmentPanelMinWidth / availableWidth;
@@ -108,64 +108,10 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
                   availableEnvironmentPanelWidth,
                 );
 
-                return SingleChildScrollView(
-                  scrollDirection: Axis.horizontal,
-                  child: SizedBox(
-                    width: environmentPanelWidth,
-                    child: OutlineDecoration.onlyLeft(
-                      child: Padding(
-                        padding: const EdgeInsets.all(defaultSpacing),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'Simulated DevTools Environment',
-                              style: theme.textTheme.titleMedium,
-                            ),
-                            const PaddedDivider(),
-                            _VmServiceConnection(
-                              connected: connected,
-                              simController: simController,
-                            ),
-                            const SizedBox(height: denseSpacing),
-                            _SimulatedApi(
-                              simController: simController,
-                              requiresRunningApplication:
-                                  widget.requiresRunningApplication,
-                              connectedToApplication: connected,
-                            ),
-                            const PaddedDivider(),
-                            Expanded(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    mainAxisAlignment:
-                                        MainAxisAlignment.spaceBetween,
-                                    children: [
-                                      Text(
-                                        'Logs:',
-                                        style: theme.textTheme.titleMedium,
-                                      ),
-                                      DevToolsButton.iconOnly(
-                                        icon: Icons.clear,
-                                        outlined: false,
-                                        tooltip: 'Clear logs',
-                                        onPressed: () =>
-                                            simController.messageLogs.clear(),
-                                      ),
-                                    ],
-                                  ),
-                                  const PaddedDivider.thin(),
-                                  Expanded(
-                                    child: _LogMessages(
-                                      simController: simController,
-                                    ),
-                                  ),
-                                ],
+                              VmServiceConnection(
+                                connected: connected,
+                                simController: simController,
                               ),
-                            ),
-                          ],
                         ),
                       ),
                     ),

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_environment.dart
@@ -49,6 +49,8 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
     with AutoDisposeMixin {
   late final SimulatedDevToolsController simController;
 
+  late final ScrollController scrollController;
+
   late ConnectedState connectionState;
 
   bool get connected => connectionState.connected;
@@ -57,6 +59,8 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
   void initState() {
     super.initState();
     simController = SimulatedDevToolsController()..init();
+
+    scrollController = ScrollController();
 
     connectionState = serviceManager.connectedState.value;
     addAutoDisposeListener(serviceManager.connectedState, () {
@@ -69,6 +73,7 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
   @override
   void dispose() {
     simController.dispose();
+    scrollController.dispose();
     super.dispose();
   }
 
@@ -108,10 +113,69 @@ class SimulatedDevToolsWrapperState extends State<SimulatedDevToolsWrapper>
                   availableEnvironmentPanelWidth,
                 );
 
+                return Scrollbar(
+                  controller: scrollController,
+                  thumbVisibility: true,
+                  child: SingleChildScrollView(
+                    controller: scrollController,
+                    scrollDirection: Axis.horizontal,
+                    child: SizedBox(
+                      width: environmentPanelWidth,
+                      child: OutlineDecoration.onlyLeft(
+                        child: Padding(
+                          padding: const EdgeInsets.all(defaultSpacing),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Simulated DevTools Environment',
+                                style: theme.textTheme.titleMedium,
+                              ),
+                              const PaddedDivider(),
                               VmServiceConnection(
                                 connected: connected,
                                 simController: simController,
                               ),
+                              const SizedBox(height: denseSpacing),
+                              _SimulatedApi(
+                                simController: simController,
+                                requiresRunningApplication:
+                                    widget.requiresRunningApplication,
+                                connectedToApplication: connected,
+                              ),
+                              const PaddedDivider(),
+                              Expanded(
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Row(
+                                      mainAxisAlignment:
+                                          MainAxisAlignment.spaceBetween,
+                                      children: [
+                                        Text(
+                                          'Logs:',
+                                          style: theme.textTheme.titleMedium,
+                                        ),
+                                        DevToolsButton.iconOnly(
+                                          icon: Icons.clear,
+                                          outlined: false,
+                                          tooltip: 'Clear logs',
+                                          onPressed: () =>
+                                              simController.messageLogs.clear(),
+                                        ),
+                                      ],
+                                    ),
+                                    const PaddedDivider.thin(),
+                                    Expanded(
+                                      child: _LogMessages(
+                                        simController: simController,
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
                     ),


### PR DESCRIPTION
This PR updates the `SimulatedDevToolsWrapper` to make the environment panel collapsible. 

The panel's minimum size is removed and its width is now adjusted based on the available space.

Fixes #7021 

Before: 


https://github.com/flutter/devtools/assets/19398044/fbf5160a-e54b-43b9-9f03-a3d7070362bb



After: 



https://github.com/flutter/devtools/assets/19398044/74fcd996-cb95-4ea5-a5dd-be18845f02f1






## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
