### PR TITLE
Add back Open In Browser button to VS code sidebar devtools menu

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -217,6 +217,23 @@ class _DevToolsMenuState extends State<_DevToolsMenu> {
             .where(_shouldIncludeScreen)
             .map(devToolsButton)
             .toList(),
+        if (widget.supportsOpenExternal)
+          DevToolsScreenMenuItem(
+            title: 'Open in Browser',
+            icon: Icons.open_in_browser,
+            onPressed: () {
+              ga.select(
+                gac.VsCodeFlutterSidebar.id,
+                gac.VsCodeFlutterSidebar.openDevToolsExternally.name,
+              );
+              unawaited(
+                widget.api.openDevToolsPage(
+                  widget.session.id,
+                  forceExternal: true,
+                ),
+              );
+            },
+          ),
         if (_extensionServiceForSession != null)
           ValueListenableBuilder(
             valueListenable: _extensionServiceForSession!.visibleExtensions,


### PR DESCRIPTION
This was accidentally removed in https://github.com/flutter/devtools/commit/0fba4006fe0cf21681b0d6ef810366fe9366cd19