### PR TITLE
Add search by Key to the Inspector 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -691,6 +691,11 @@ class InspectorTreeController extends DisposableController
       final diagnostic = row!.node.diagnostic;
       if (diagnostic == null) continue;
 
+      if (row.node.keyContainsSearch(search)) {
+        matches.add(row);
+        continue;
+      }
+
       // Widget search begin
       if (_searchTarget == SearchTargetType.widget) {
         debugStatsSearchOps++;

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -691,6 +691,7 @@ class InspectorTreeController extends DisposableController
       final diagnostic = row!.node.diagnostic;
       if (diagnostic == null) continue;
 
+      // Widget search by widget key
       if (row.node.keyContainsSearch(search)) {
         matches.add(row);
         continue;

--- a/packages/devtools_app/lib/src/shared/console/eval/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/shared/console/eval/inspector_tree.dart
@@ -35,13 +35,21 @@ double get inspectorRowHeight => scaleByFontFactor(16.0);
 /// tree ui node class but we choose to instead make it widget inspector
 /// specific as that is the only case we care about.
 // TODO(kenz): extend TreeNode class to share tree logic.
-class InspectorTreeNode {
+class InspectorTreeNode { 
   InspectorTreeNode({
     InspectorTreeNode? parent,
     bool expandChildren = true,
-  })  : _children = <InspectorTreeNode>[],
+    this.key,
+  })  : 
+        _children = <InspectorTreeNode>[],
         _parent = parent,
         _isExpanded = expandChildren;
+
+  final Key? key;
+
+  bool keyContainsSearch(String search) {
+    return key != null && key!.toString().contains(search);
+  }
 
   bool get showLinesToChildren {
     return _children.length > 1 && !_children.last.isProperty;


### PR DESCRIPTION
This PR is adding implementation for searching a widget in Inspector screen by widget key

Fixes https://github.com/flutter/devtools/issues/6870

Before:

https://github.com/flutter/devtools/assets/71052969/189de71e-1619-4a9c-9d45-07b13d647bd1


After:

https://github.com/flutter/devtools/assets/71052969/d913efd5-7b59-4391-a4d3-e708ee3d595d


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]


<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
