### PR TITLE
Add a return type to all function types, avoiding implicit dynamic

### DIFF
--- a/packages/devtools_app/lib/src/framework/app_bar.dart
+++ b/packages/devtools_app/lib/src/framework/app_bar.dart
@@ -159,7 +159,7 @@ class TabOverflowButton extends StatelessWidget {
 
   bool get overflowTabSelected => selectedIndex >= 0;
 
-  final Function(int) onItemSelected;
+  final void Function(int) onItemSelected;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_screen.dart
@@ -535,7 +535,7 @@ class _AppSizeView extends StatelessWidget {
 
   final TreemapNode treemapRoot;
 
-  final Function(TreemapNode?) onRootChangedCallback;
+  final void Function(TreemapNode?) onRootChangedCallback;
 
   final Widget analysisTable;
 

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer.dart
@@ -299,8 +299,8 @@ class _FileExplorer extends StatefulWidget {
   });
 
   final ProgramExplorerController controller;
-  final Function(VMServiceObjectNode) onItemSelected;
-  final Function(VMServiceObjectNode) onItemExpanded;
+  final void Function(VMServiceObjectNode) onItemSelected;
+  final void Function(VMServiceObjectNode) onItemExpanded;
 
   @override
   State<_FileExplorer> createState() => _FileExplorerState();
@@ -378,8 +378,8 @@ class _ProgramOutlineView extends StatelessWidget {
   });
 
   final ProgramExplorerController controller;
-  final Function(VMServiceObjectNode) onItemSelected;
-  final Function(VMServiceObjectNode) onItemExpanded;
+  final void Function(VMServiceObjectNode) onItemSelected;
+  final void Function(VMServiceObjectNode) onItemExpanded;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_breadcrumbs.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_breadcrumbs.dart
@@ -23,7 +23,7 @@ class InspectorBreadcrumbNavigator extends StatelessWidget {
   static const _maxNumberOfBreadcrumbs = 5;
 
   final List<InspectorTreeNode> items;
-  final Function(InspectorTreeNode?) onTap;
+  final void Function(InspectorTreeNode?) onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_screen.dart
@@ -490,7 +490,7 @@ class ErrorNavigator extends StatelessWidget {
 
   final int? errorIndex;
 
-  final Function(int) onSelectError;
+  final void Function(int) onSelectError;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_tree.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_tree.dart
@@ -171,7 +171,7 @@ class _TracingTreeHeader extends StatelessWidget {
   }) : super(key: key);
 
   final TracingPaneController controller;
-  final Function(VoidCallback) updateTreeStateCallback;
+  final void Function(VoidCallback) updateTreeStateCallback;
   final TabController tabController;
   final List<DevToolsTab> tabs;
 

--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/class_filter.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/class_filter.dart
@@ -37,7 +37,7 @@ enum FilteringTask {
   reuse,
 }
 
-typedef ApplyFilterCallback = Function(ClassFilter);
+typedef ApplyFilterCallback = void Function(ClassFilter);
 
 @immutable
 class ClassFilter {

--- a/packages/devtools_app/lib/src/screens/memory/shared/widgets/class_filter.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/widgets/class_filter.dart
@@ -67,7 +67,7 @@ class ClassFilterDialog extends StatefulWidget {
   });
 
   final ClassFilter classFilter;
-  final Function(ClassFilter filter) onChanged;
+  final void Function(ClassFilter filter) onChanged;
   final String rootPackage;
 
   @override

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/timeline_flame_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/legacy/timeline_flame_chart.dart
@@ -122,7 +122,7 @@ class TimelineFlameChart extends FlameChart<PerformanceData, TimelineEvent> {
     required ValueListenable<TimelineEvent?> selectionNotifier,
     required ValueListenable<List<TimelineEvent>> searchMatchesNotifier,
     required ValueListenable<TimelineEvent?> activeSearchMatchNotifier,
-    required Function(TimelineEvent event) onDataSelected,
+    required void Function(TimelineEvent event) onDataSelected,
   }) : super(
           data,
           time: data.time,

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -477,7 +477,7 @@ class _RetainingObjectDescription extends StatelessWidget {
   });
 
   final RetainingObject object;
-  final Function(ObjRef? obj) onTap;
+  final void Function(ObjRef? obj) onTap;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/shared/common_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/common_widgets.dart
@@ -665,7 +665,7 @@ abstract class ScaffoldAction extends StatelessWidget {
 
   final String tooltip;
 
-  final Function(BuildContext) onPressed;
+  final void Function(BuildContext) onPressed;
 
   final Color? color;
 
@@ -845,8 +845,8 @@ class DevToolsClearableTextField extends StatelessWidget {
   final Widget? prefixIcon;
   final List<Widget> additionalSuffixActions;
   final String labelText;
-  final Function(String)? onChanged;
-  final Function(String)? onSubmitted;
+  final void Function(String)? onChanged;
+  final void Function(String)? onSubmitted;
   final bool autofocus;
 
   static const _contentVerticalPadding = 6.0;

--- a/packages/devtools_app/lib/src/shared/editable_list.dart
+++ b/packages/devtools_app/lib/src/shared/editable_list.dart
@@ -25,8 +25,8 @@ class EditableList extends StatefulWidget {
     required this.gaRefreshSelection,
     this.isRefreshing,
     this.onRefreshTriggered,
-    Function(String)? onEntryAdded,
-    Function(String)? onEntryRemoved,
+    void Function(String)? onEntryAdded,
+    void Function(String)? onEntryRemoved,
   })  : onEntryAdded = onEntryAdded ?? ((entry) => entries.add(entry)),
         onEntryRemoved = onEntryRemoved ?? ((entry) => entries.remove(entry));
 
@@ -48,16 +48,16 @@ class EditableList extends StatefulWidget {
   /// Triggered when an entry is added, using the interface.
   ///
   /// When not overridden, the default behaviour adds the entry to [entries]
-  late final Function(String) onEntryAdded;
+  late final void Function(String) onEntryAdded;
 
   /// Triggered when an entry is removed, using the interface.
   ///
   /// When not overridden, the default behaviour removes the entry
   /// from [entries].
-  late final Function(String) onEntryRemoved;
+  late final void Function(String) onEntryRemoved;
 
   /// Triggered when the refresh is triggered, using the interface.
-  final Function()? onRefreshTriggered;
+  final void Function()? onRefreshTriggered;
 
   final String gaScreen;
 
@@ -137,8 +137,8 @@ class EditableListActionBar extends StatelessWidget {
   final TextEditingController textFieldController;
   final ValueListenable<bool>? isRefreshing;
   final String textFieldLabel;
-  final Function(String) onEntryAdded;
-  final Function()? onRefresh;
+  final void Function(String) onEntryAdded;
+  final void Function()? onRefresh;
   final String gaScreen;
   final String gaRefreshSelection;
 
@@ -206,7 +206,7 @@ class _EditableListContentView extends StatelessWidget {
   }) : super(key: key);
 
   final ListValueNotifier<String> entries;
-  final Function(String) onEntryRemoved;
+  final void Function(String) onEntryRemoved;
   final ScrollController _listContentScrollController = ScrollController();
 
   @override
@@ -237,7 +237,7 @@ class EditableListRow extends StatelessWidget {
   }) : super(key: key);
 
   final String entry;
-  final Function(String) onEntryRemoved;
+  final void Function(String) onEntryRemoved;
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/shared/file_import.dart
+++ b/packages/devtools_app/lib/src/shared/file_import.dart
@@ -337,7 +337,7 @@ class DualFileImportContainer extends StatefulWidget {
   /// The title of the action button.
   final String actionText;
 
-  final Function(
+  final void Function(
     DevToolsJsonFile firstImportedFile,
     DevToolsJsonFile secondImportedFile,
     void Function(String error) onError,

--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -223,7 +223,7 @@ class InspectorPreferencesController extends DisposableController
             // the directories
             unawaited(preferences.inspector.loadPubRootDirectories());
           } else {
-            late Function() pausedListener;
+            late void Function() pausedListener;
 
             pausedListener = () {
               if (debuggerState?.isPaused.value == false) {

--- a/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/extent_delegate_list.dart
@@ -173,7 +173,7 @@ class ExtentDelegateListView extends CustomPointerScrollView {
     required this.childrenDelegate,
     required this.extentDelegate,
     int? semanticChildCount,
-    Function(PointerSignalEvent event)? customPointerSignalHandler,
+    void Function(PointerSignalEvent event)? customPointerSignalHandler,
   }) : super(
           key: key,
           scrollDirection: scrollDirection,

--- a/packages/devtools_app/lib/src/shared/table/_table_column.dart
+++ b/packages/devtools_app/lib/src/shared/table/_table_column.dart
@@ -53,7 +53,7 @@ class _ColumnHeader<T> extends StatelessWidget {
 
   final SortDirection sortDirection;
 
-  final Function(
+  final void Function(
     ColumnData<T> column,
     SortDirection direction, {
     ColumnData<T>? secondarySortColumn,

--- a/packages/devtools_app/lib/src/shared/table/_table_row.dart
+++ b/packages/devtools_app/lib/src/shared/table/_table_row.dart
@@ -253,7 +253,7 @@ class _TableRowState<T> extends State<TableRow<T>>
     final node = widget.node;
     final widgetOnPressed = widget.onPressed;
 
-    Function()? onPressed;
+    void Function()? onPressed;
     if (node != null && widgetOnPressed != null) {
       onPressed = () => widgetOnPressed(node);
     }

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -786,10 +786,10 @@ mixin SearchableMixin<T> {
 }
 
 /// Callback when item in the drop-down list is selected.
-typedef SelectAutoComplete = Function(String selection);
+typedef SelectAutoComplete = void Function(String selection);
 
 /// Callback to handle highlighting item in the drop-down list.
-typedef HighlightAutoComplete = Function(
+typedef HighlightAutoComplete = void Function(
   AutoCompleteSearchControllerMixin controller,
   bool directionDown,
 );

--- a/packages/devtools_app/test/shared/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/shared/syntax_highlighter_test.dart
@@ -324,8 +324,6 @@ void main() {
                   );
 
                   expect(children[18].toPlainText(), '\n');
-
-                  return Container();
                 },
               ),
             );
@@ -556,7 +554,6 @@ void main() {
                         color: colorCallback(Theme.of(context).colorScheme),
                       ),
                     );
-                    return Container();
                   },
                 ),
               );

--- a/packages/devtools_app/test/shared/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/shared/syntax_highlighter_test.dart
@@ -171,7 +171,7 @@ void main() {
       'Syntax Highlighting (${useDarkTheme ? 'Dark' : 'Light'} Theme)',
       () {
         Widget buildSyntaxHighlightingTestContext(
-          Function(BuildContext) callback,
+          void Function(BuildContext) callback,
         ) {
           return MaterialApp.router(
             theme: themeFor(

--- a/packages/devtools_app/test/test_infra/utils/test_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/test_utils.dart
@@ -27,7 +27,7 @@ TraceEventWrapper testTraceEventWrapper(Map<String, dynamic> json) {
 /// [clipboardContentsCallback]  when Clipboard.setData is triggered, the text
 /// contents will be passed to [clipboardContentsCallback]
 void setupClipboardCopyListener({
-  required Function(String?) clipboardContentsCallback,
+  required void Function(String?) clipboardContentsCallback,
 }) {
   // This intercepts the Clipboard.setData SystemChannel message,
   // and stores the contents that were (attempted) to be copied.


### PR DESCRIPTION
This helps reduce implicit dynamics by explicitly calling out the return type on function types (usually `void`). This would also help prevent attempting to use the result of a `void`-returning function, but maybe that's not a big deal.

Work towards https://github.com/flutter/devtools/issues/6929


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
