### PR TITLE
Add parameter type to Future.catchError onError parameter

### DIFF
--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -360,7 +360,7 @@ abstract class IntegrationTestApp with IOMixin {
         logMessage('<timed out>');
         throw '$message';
       },
-    ).catchError((error) {
+    ).catchError((Object? error) {
       throw '$error\nReceived:\n${messages.toString()}';
     }).whenComplete(() => sub.cancel());
   }

--- a/packages/devtools_app/test/legacy_integration_tests/integration.dart
+++ b/packages/devtools_app/test/legacy_integration_tests/integration.dart
@@ -385,7 +385,7 @@ class WebBuildFixture {
       }),
     );
 
-    await buildFinished.future.catchError((e) {
+    await buildFinished.future.catchError((Object? e) {
       fail('Build failed: $e');
     });
 

--- a/packages/devtools_app/test/shared/eval_integration_test.dart
+++ b/packages/devtools_app/test/shared/eval_integration_test.dart
@@ -118,7 +118,7 @@ void main() {
                 (_) => throw Exception(
                   'The FutureFailedException was not thrown as expected.',
                 ),
-                onError: (err) => err,
+                onError: (Object? err) => err,
               );
 
           expect(

--- a/packages/devtools_shared/lib/src/service/service.dart
+++ b/packages/devtools_shared/lib/src/service/service.dart
@@ -87,9 +87,9 @@ Future<T> connect<T extends VmService>({
 }) {
   final connectedCompleter = Completer<T>();
 
-  void onError(error) {
+  void onError(Object? error) {
     if (!connectedCompleter.isCompleted) {
-      connectedCompleter.completeError(error);
+      connectedCompleter.completeError(error!);
     }
   }
 

--- a/packages/devtools_shared/lib/src/test/cli_test_driver.dart
+++ b/packages/devtools_shared/lib/src/test/cli_test_driver.dart
@@ -176,7 +176,7 @@ class CliAppFixture extends AppFixture {
               // for an isolate that hasn't started yet. We can just ignore these
               // as on the next trip around the Isolate will be returned.
               // https://github.com/dart-lang/sdk/issues/33747
-              .catchError((error) {
+              .catchError((Object error) {
             print('getIsolate(${ref.id}) failed, skipping\n$error');
             return Future<Isolate>.value(Isolate(id: skipId));
           }),


### PR DESCRIPTION
The type of the Future.catchError onError parameter is just `Function`, so no inference is performed on the parameter type. It is therefore implicitly dynamic; this PR uses `Object?` instead.

Work towards https://github.com/flutter/devtools/issues/6929

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
