### PR TITLE
Remove splitting by spaces from process/command helpers

### DIFF
--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -38,7 +38,7 @@ class AnalyzeCommand extends Command {
 
       final process = await processManager.runProcess(
         CliCommand.dart(
-          'analyze --fatal-infos',
+          'analyze --fatal-infos'.split(' '),
           // Run all so we can see the full set of results instead of stopping
           // on the first error.
           throwOnException: false,

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -38,7 +38,7 @@ class AnalyzeCommand extends Command {
 
       final process = await processManager.runProcess(
         CliCommand.dart(
-          'analyze --fatal-infos'.split(' '),
+          ['analyze', '--fatal-infos'],
           // Run all so we can see the full set of results instead of stopping
           // on the first error.
           throwOnException: false,

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -85,7 +85,7 @@ class BuildCommand extends Command {
     logStatus('building DevTools in release mode');
     await processManager.runAll(
       commands: [
-        if (runPubGet) CliCommand.tool('pub-get --only-main'.split(' ')),
+        if (runPubGet) CliCommand.tool(['pub-get', '--only-main']),
         CliCommand.flutter(
           [
             'build',

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -65,12 +65,12 @@ class BuildCommand extends Command {
 
     if (updateFlutter) {
       logStatus('updating tool/flutter-sdk to the latest flutter candidate');
-      await processManager.runProcess(CliCommand.tool('update-flutter-sdk'));
+      await processManager.runProcess(CliCommand.tool(['update-flutter-sdk']));
     }
 
     if (updatePerfetto) {
       logStatus('updating the bundled Perfetto assets');
-      await processManager.runProcess(CliCommand.tool('update-perfetto'));
+      await processManager.runProcess(CliCommand.tool(['update-perfetto']));
     }
 
     logStatus('cleaning project');
@@ -78,14 +78,14 @@ class BuildCommand extends Command {
       webBuildDir.deleteSync(recursive: true);
     }
     await processManager.runProcess(
-      CliCommand.flutter('clean'),
+      CliCommand.flutter(['clean']),
       workingDirectory: repo.devtoolsAppDirectoryPath,
     );
 
     logStatus('building DevTools in release mode');
     await processManager.runAll(
       commands: [
-        if (runPubGet) CliCommand.tool('pub-get --only-main'),
+        if (runPubGet) CliCommand.tool('pub-get --only-main'.split(' ')),
         CliCommand.flutter(
           [
             'build',
@@ -95,7 +95,7 @@ class BuildCommand extends Command {
             '--pwa-strategy=offline-first',
             if (buildMode != 'debug') '--$buildMode',
             '--no-tree-shake-icons',
-          ].join(' '),
+          ],
         ),
       ],
       workingDirectory: repo.devtoolsAppDirectoryPath,
@@ -108,7 +108,7 @@ class BuildCommand extends Command {
       for (final file in canvaskitDir.listSync()) {
         if (RegExp(r'canvaskit\..*').hasMatch(file.path)) {
           await processManager
-              .runProcess(CliCommand('chmod 0755 ${file.path}'));
+              .runProcess(CliCommand('chmod', ['0755', file.path]));
         }
       }
     }

--- a/tool/lib/commands/fix_goldens.dart
+++ b/tool/lib/commands/fix_goldens.dart
@@ -41,7 +41,7 @@ class FixGoldensCommand extends Command {
     try {
       print('Downloading the artifacts to ${tmpDownloadDir.path}');
       await processManager.runProcess(
-        CliCommand.from(
+        CliCommand(
           'gh',
           [
             'run',

--- a/tool/lib/commands/generate_code.dart
+++ b/tool/lib/commands/generate_code.dart
@@ -38,7 +38,7 @@ class GenerateCodeCommand extends Command {
     final upgrade = argResults![_upgradeFlag];
     if (upgrade) {
       await processManager.runProcess(
-        CliCommand.tool('pub-get --only-main --upgrade'),
+        CliCommand.tool('pub-get --only-main --upgrade'.split(' ')),
       );
     }
 
@@ -47,7 +47,7 @@ class GenerateCodeCommand extends Command {
       final directoryPath = path.join(repo.repoPath, 'packages', packageName);
       await processManager.runProcess(
         CliCommand.flutter(
-          'pub run build_runner build --delete-conflicting-outputs',
+          'pub run build_runner build --delete-conflicting-outputs'.split(' '),
         ),
         workingDirectory: directoryPath,
       );

--- a/tool/lib/commands/generate_code.dart
+++ b/tool/lib/commands/generate_code.dart
@@ -38,7 +38,7 @@ class GenerateCodeCommand extends Command {
     final upgrade = argResults![_upgradeFlag];
     if (upgrade) {
       await processManager.runProcess(
-        CliCommand.tool('pub-get --only-main --upgrade'.split(' ')),
+        CliCommand.tool(['pub-get', '--only-main', '--upgrade']),
       );
     }
 
@@ -47,7 +47,13 @@ class GenerateCodeCommand extends Command {
       final directoryPath = path.join(repo.repoPath, 'packages', packageName);
       await processManager.runProcess(
         CliCommand.flutter(
-          'pub run build_runner build --delete-conflicting-outputs'.split(' '),
+          [
+            'pub',
+            'run',
+            'build_runner',
+            'build',
+            '--delete-conflicting-outputs',
+          ],
         ),
         workingDirectory: directoryPath,
       );

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -59,7 +59,7 @@ class PubGetCommand extends Command {
 
       final process = await processManager.runProcess(
         CliCommand.flutter(
-          'pub $command',
+          'pub $command'.split(' '),
           // Run all so we can see the full set of results instead of stopping
           // on the first error.
           throwOnException: false,

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -59,7 +59,7 @@ class PubGetCommand extends Command {
 
       final process = await processManager.runProcess(
         CliCommand.flutter(
-          'pub $command'.split(' '),
+          ['pub', command],
           // Run all so we can see the full set of results instead of stopping
           // on the first error.
           throwOnException: false,

--- a/tool/lib/commands/release_helper.dart
+++ b/tool/lib/commands/release_helper.dart
@@ -31,7 +31,7 @@ class ReleaseHelperCommand extends Command {
 
     final useCurrentBranch = argResults!['use-current-branch']!;
     final currentBranchResult = await processManager.runProcess(
-      CliCommand.git('rev-parse --abbrev-ref HEAD'.split(' ')),
+      CliCommand.git(['rev-parse', '--abbrev-ref', 'HEAD']),
     );
     final initialBranch = currentBranchResult.stdout.trim();
     String? releaseBranch;
@@ -44,7 +44,7 @@ class ReleaseHelperCommand extends Command {
       );
 
       final gitStatusResult = await processManager.runProcess(
-        CliCommand.git('status -s'.split(' ')),
+        CliCommand.git(['status', '-s']),
       );
       final gitStatus = gitStatusResult.stdout;
       if (gitStatus.isNotEmpty) {
@@ -57,7 +57,7 @@ class ReleaseHelperCommand extends Command {
       if (!useCurrentBranch) {
         print("Preparing the release branch.");
         await processManager.runProcess(
-          CliCommand.git('fetch $remoteUpstream master'.split(' ')),
+          CliCommand.git(['fetch', remoteUpstream, 'master']),
         );
       }
 
@@ -67,7 +67,7 @@ class ReleaseHelperCommand extends Command {
             'checkout',
             '-b',
             releaseBranch,
-            if (useCurrentBranch) 'remoteUpstream/master',
+            if (useCurrentBranch) '$remoteUpstream/master',
           ],
         ),
       );
@@ -75,17 +75,17 @@ class ReleaseHelperCommand extends Command {
       print("Ensuring ./tool packages are ready.");
       Directory.current = pathFromRepoRoot("tool");
       await processManager.runProcess(
-        CliCommand.dart('pub get'.split(' ')),
+        CliCommand.dart(['pub', 'get']),
         workingDirectory: pathFromRepoRoot("tool"),
       );
 
       print("Setting the release version.");
       await processManager.runProcess(
-        CliCommand.tool('update-version auto --type release'.split(' ')),
+        CliCommand.tool(['update-version', 'auto', '--type', 'release']),
       );
 
       final getNewVersionResult = await processManager.runProcess(
-        CliCommand.tool('update-version current-version'.split(' ')),
+        CliCommand.tool(['update-version', 'current-version']),
       );
 
       final newVersion = getNewVersionResult.stdout.trim();

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -128,13 +128,13 @@ class ServeCommand extends Command {
 
     if (buildApp) {
       final process = await processManager.runProcess(
-        CliCommand.tool(
-          'build'
-          ' ${BuildCommandArgs.updateFlutter.asArg(negated: !updateFlutter)}'
-          '${updatePerfetto ? ' ${BuildCommandArgs.updatePerfetto.asArg()}' : ''}'
-          ' ${BuildCommandArgs.buildMode.asArg()}=$devToolsAppBuildMode'
-          ' ${BuildCommandArgs.pubGet.asArg(negated: !runPubGet)}',
-        ),
+        CliCommand.tool([
+          'build',
+          BuildCommandArgs.updateFlutter.asArg(negated: !updateFlutter),
+          if (updatePerfetto) BuildCommandArgs.updatePerfetto.asArg(),
+          '${BuildCommandArgs.buildMode.asArg()}=$devToolsAppBuildMode',
+          BuildCommandArgs.pubGet.asArg(negated: !runPubGet),
+        ]),
       );
       if (process.exitCode == 1) {
         throw Exception(
@@ -146,7 +146,7 @@ class ServeCommand extends Command {
 
     logStatus('running pub get for DDS in the local dart sdk');
     await processManager.runProcess(
-      CliCommand.dart('pub get'),
+      CliCommand.dart('pub get'.split(' ')),
       workingDirectory: path.join(localDartSdkLocation, 'pkg', 'dds'),
     );
 
@@ -169,7 +169,7 @@ class ServeCommand extends Command {
           // to pass `--machine` (etc.) so that this script can behave the same as
           // the "dart devtools" command for testing local DevTools/server changes.
           ...remainingArguments,
-        ].join(' '),
+        ],
       ),
       workingDirectory: localDartSdkLocation,
     );

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -146,7 +146,7 @@ class ServeCommand extends Command {
 
     logStatus('running pub get for DDS in the local dart sdk');
     await processManager.runProcess(
-      CliCommand.dart('pub get'.split(' ')),
+      CliCommand.dart(['pub', 'get']),
       workingDirectory: path.join(localDartSdkLocation, 'pkg', 'dds'),
     );
 

--- a/tool/lib/commands/sync.dart
+++ b/tool/lib/commands/sync.dart
@@ -19,10 +19,10 @@ class SyncCommand extends Command {
   Future run() async {
     final processManager = ProcessManager();
     await processManager.runProcess(
-      CliCommand.git('pull upstream master'.split(' ')),
+      CliCommand.git(['pull', 'upstream', 'master']),
     );
     await processManager.runProcess(
-      CliCommand.tool('generate-code --upgrade'.split(' ')),
+      CliCommand.tool(['generate-code', '--upgrade']),
     );
   }
 }

--- a/tool/lib/commands/sync.dart
+++ b/tool/lib/commands/sync.dart
@@ -19,10 +19,10 @@ class SyncCommand extends Command {
   Future run() async {
     final processManager = ProcessManager();
     await processManager.runProcess(
-      CliCommand.git(cmd: 'pull upstream master'),
+      CliCommand.git('pull upstream master'.split(' ')),
     );
     await processManager.runProcess(
-      CliCommand.tool('generate-code --upgrade'),
+      CliCommand.tool('generate-code --upgrade'.split(' ')),
     );
   }
 }

--- a/tool/lib/commands/update_dart_sdk_deps.dart
+++ b/tool/lib/commands/update_dart_sdk_deps.dart
@@ -50,10 +50,10 @@ class UpdateDartSdkDepsCommand extends Command {
       additionalErrorMessage: DartSdkHelper.commandDebugMessage,
       commands: [
         CliCommand.git(
-          cmd: 'branch -D devtools-$commit',
+          ['branch', '-D', 'devtools-$commit'],
           throwOnException: false,
         ),
-        CliCommand.git(cmd: 'new-branch devtools-$commit'),
+        CliCommand.git(['new-branch', 'devtools-$commit']),
       ],
     );
 
@@ -65,16 +65,15 @@ class UpdateDartSdkDepsCommand extends Command {
       workingDirectory: dartSdkLocation,
       additionalErrorMessage: DartSdkHelper.commandDebugMessage,
       commands: [
-        CliCommand.git(cmd: 'add DEPS'),
-        CliCommand.from(
-          'git',
+        CliCommand.git('add DEPS'.split(' ')),
+        CliCommand.git(
           [
             'commit',
             '-m',
             'Update DevTools rev to $commit',
           ],
         ),
-        CliCommand.git(cmd: 'cl upload -s -f'),
+        CliCommand.git('cl upload -s -f'.split(' ')),
       ],
     );
   }

--- a/tool/lib/commands/update_dart_sdk_deps.dart
+++ b/tool/lib/commands/update_dart_sdk_deps.dart
@@ -65,7 +65,7 @@ class UpdateDartSdkDepsCommand extends Command {
       workingDirectory: dartSdkLocation,
       additionalErrorMessage: DartSdkHelper.commandDebugMessage,
       commands: [
-        CliCommand.git('add DEPS'.split(' ')),
+        CliCommand.git(['add', 'DEPS']),
         CliCommand.git(
           [
             'commit',
@@ -73,7 +73,7 @@ class UpdateDartSdkDepsCommand extends Command {
             'Update DevTools rev to $commit',
           ],
         ),
-        CliCommand.git('cl upload -s -f'.split(' ')),
+        CliCommand.git(['cl', 'upload', '-s', '-f']),
       ],
     );
   }

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -85,7 +85,7 @@ class UpdateFlutterSdkCommand extends Command {
           'tags/${repo.readFile(Uri.parse('flutter-candidate.txt')).trim()}';
     } else {
       flutterTag = (await processManager.runProcess(
-        CliCommand('sh latest_flutter_candidate.sh'),
+        CliCommand('sh', ['latest_flutter_candidate.sh']),
         workingDirectory: repo.toolDirectoryPath,
       ))
           .stdout
@@ -116,12 +116,12 @@ class UpdateFlutterSdkCommand extends Command {
 
       await processManager.runAll(
         commands: [
-          CliCommand.git(cmd: 'stash'),
-          CliCommand.git(cmd: 'fetch upstream'),
-          CliCommand.git(cmd: 'checkout upstream/master'),
-          CliCommand.git(cmd: 'reset --hard upstream/master'),
-          CliCommand.git(cmd: 'checkout $flutterTag -f'),
-          CliCommand.flutter('--version'),
+          CliCommand.git(['stash']),
+          CliCommand.git('fetch upstream'.split(' ')),
+          CliCommand.git('checkout upstream/master'.split(' ')),
+          CliCommand.git('reset --hard upstream/master'.split(' ')),
+          CliCommand.git(['checkout', flutterTag, '-f']),
+          CliCommand.flutter(['--version']),
         ],
         workingDirectory: pathSdk.sdkPath,
       );
@@ -133,9 +133,9 @@ class UpdateFlutterSdkCommand extends Command {
       log.stdout('Updating Flutter at $toolSdkPath');
       await processManager.runAll(
         commands: [
-          CliCommand.git(cmd: 'fetch'),
-          CliCommand.git(cmd: 'checkout $flutterTag -f'),
-          CliCommand.flutter('--version'),
+          CliCommand.git(['fetch']),
+          CliCommand.git(['checkout', flutterTag, '-f']),
+          CliCommand.flutter(['--version']),
         ],
         workingDirectory: toolSdkPath,
       );
@@ -143,14 +143,14 @@ class UpdateFlutterSdkCommand extends Command {
       log.stdout('Cloning Flutter into $toolSdkPath');
       await processManager.runProcess(
         CliCommand.git(
-          cmd: 'clone https://github.com/flutter/flutter $flutterSdkDirName',
+          ['clone', 'https://github.com/flutter/flutter', flutterSdkDirName],
         ),
         workingDirectory: repo.toolDirectoryPath,
       );
       await processManager.runAll(
         commands: [
-          CliCommand.git(cmd: 'checkout $flutterTag -f'),
-          CliCommand.flutter('--version'),
+          CliCommand.git(['checkout', flutterTag, '-f']),
+          CliCommand.flutter(['--version']),
         ],
         workingDirectory: toolSdkPath,
       );

--- a/tool/lib/commands/update_flutter_sdk.dart
+++ b/tool/lib/commands/update_flutter_sdk.dart
@@ -117,9 +117,9 @@ class UpdateFlutterSdkCommand extends Command {
       await processManager.runAll(
         commands: [
           CliCommand.git(['stash']),
-          CliCommand.git('fetch upstream'.split(' ')),
-          CliCommand.git('checkout upstream/master'.split(' ')),
-          CliCommand.git('reset --hard upstream/master'.split(' ')),
+          CliCommand.git(['fetch', 'upstream']),
+          CliCommand.git(['checkout', 'upstream/master']),
+          CliCommand.git(['reset', '--hard', 'upstream/master']),
           CliCommand.git(['checkout', flutterTag, '-f']),
           CliCommand.flutter(['--version']),
         ],

--- a/tool/lib/commands/update_perfetto.dart
+++ b/tool/lib/commands/update_perfetto.dart
@@ -76,8 +76,8 @@ class UpdatePerfettoCommand extends Command {
           Directory.systemTemp.createTempSync('perfetto_clone');
       await processManager.runProcess(
         CliCommand.git(
-          cmd:
-              'clone https://android.googlesource.com/platform/external/perfetto',
+          'clone https://android.googlesource.com/platform/external/perfetto'
+              .split(' '),
         ),
         workingDirectory: tempPerfettoClone.path,
       );
@@ -85,8 +85,8 @@ class UpdatePerfettoCommand extends Command {
       logStatus('installing build deps and building the Perfetto UI');
       await processManager.runAll(
         commands: [
-          CliCommand('${path.join('tools', 'install-build-deps')} --ui'),
-          CliCommand(path.join('ui', 'build')),
+          CliCommand(path.join('tools', 'install-build-deps'), ['--ui']),
+          CliCommand(path.join('ui', 'build'), []),
         ],
         workingDirectory: path.join(tempPerfettoClone.path, 'perfetto'),
       );

--- a/tool/lib/commands/update_perfetto.dart
+++ b/tool/lib/commands/update_perfetto.dart
@@ -76,8 +76,10 @@ class UpdatePerfettoCommand extends Command {
           Directory.systemTemp.createTempSync('perfetto_clone');
       await processManager.runProcess(
         CliCommand.git(
-          'clone https://android.googlesource.com/platform/external/perfetto'
-              .split(' '),
+          [
+            'clone',
+            'https://android.googlesource.com/platform/external/perfetto',
+          ],
         ),
         workingDirectory: tempPerfettoClone.path,
       );

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -22,9 +22,9 @@ abstract class DartSdkHelper {
       workingDirectory: dartSdkLocation,
       additionalErrorMessage: commandDebugMessage,
       commands: [
-        CliCommand.git('fetch origin'.split(' ')),
-        CliCommand.git('rebase-update'.split(' ')),
-        CliCommand.git('checkout origin/main'.split(' ')),
+        CliCommand.git(['fetch', 'origin']),
+        CliCommand.git(['rebase-update']),
+        CliCommand.git(['checkout', 'origin/main']),
       ],
     );
   }
@@ -41,18 +41,6 @@ String localDartSdkLocation() {
 }
 
 class CliCommand {
-  CliCommand._({
-    String? command,
-    String? exe,
-    List<String>? args,
-    this.throwOnException = true,
-  }) {
-    assert((command == null) != ((exe == null) && (args == null)));
-    final commandElements = command?.split(' ');
-    this.exe = exe ?? commandElements!.first;
-    this.args = args ?? commandElements!.sublist(1);
-  }
-
   CliCommand(
     this.exe,
     // Args is mandatory to make it clearer to the caller that they should
@@ -66,9 +54,9 @@ class CliCommand {
     List<String> args, {
     bool throwOnException = true,
   }) {
-    return CliCommand._(
-      exe: FlutterSdk.current.flutterExePath,
-      args: args,
+    return CliCommand(
+      FlutterSdk.current.flutterExePath,
+      args,
       throwOnException: throwOnException,
     );
   }
@@ -77,9 +65,9 @@ class CliCommand {
     List<String> args, {
     bool throwOnException = true,
   }) {
-    return CliCommand._(
-      exe: FlutterSdk.current.dartExePath,
-      args: args,
+    return CliCommand(
+      FlutterSdk.current.dartExePath,
+      args,
       throwOnException: throwOnException,
     );
   }
@@ -89,9 +77,9 @@ class CliCommand {
     List<String> args, {
     bool throwOnException = true,
   }) {
-    return CliCommand._(
-      exe: 'git',
-      args: args,
+    return CliCommand(
+      'git',
+      args,
       throwOnException: throwOnException,
     );
   }
@@ -100,14 +88,14 @@ class CliCommand {
     List<String> args, {
     bool throwOnException = true,
   }) {
-    return CliCommand._(
+    return CliCommand(
       // We must use the Dart VM from FlutterSdk.current here to ensure we
       // consistently use the selected version for child invocations. We do
       // not need to pass the --flutter-from-path flag down because using the
       // tool will automatically select the one that's running the VM and we'll
       // have selected that here.
-      exe: FlutterSdk.current.dartExePath,
-      args: [
+      FlutterSdk.current.dartExePath,
+      [
         Platform.script.toFilePath(),
         ...args,
       ],
@@ -194,7 +182,7 @@ Future<String> findRemote(
 }) async {
   print('Searching for a remote that points to $remoteId.');
   final remotesResult = await processManager.runProcess(
-    CliCommand.git('remote -v'.split(' ')),
+    CliCommand.git(['remote', '-v']),
     workingDirectory: workingDirectory,
   );
   final String remotes = remotesResult.stdout;

--- a/tool/lib/utils.dart
+++ b/tool/lib/utils.dart
@@ -22,9 +22,9 @@ abstract class DartSdkHelper {
       workingDirectory: dartSdkLocation,
       additionalErrorMessage: commandDebugMessage,
       commands: [
-        CliCommand.git(cmd: 'fetch origin'),
-        CliCommand.git(cmd: 'rebase-update'),
-        CliCommand.git(cmd: 'checkout origin/main'),
+        CliCommand.git('fetch origin'.split(' ')),
+        CliCommand.git('rebase-update'.split(' ')),
+        CliCommand.git('checkout origin/main'.split(' ')),
       ],
     );
   }
@@ -54,66 +54,41 @@ class CliCommand {
   }
 
   CliCommand(
-    String command, {
+    this.exe,
+    // Args is mandatory to make it clearer to the caller that they should
+    // not be passing a full exe+args into the first string argument, because
+    // this can lead to bugs if paths have spaces and everything is not escaped.
+    this.args, {
     this.throwOnException = true,
-  })  : exe = command.split(' ').first,
-        args = command.split(' ').sublist(1);
+  });
 
-  factory CliCommand.from(
-    String exe,
+  factory CliCommand.flutter(
     List<String> args, {
     bool throwOnException = true,
   }) {
     return CliCommand._(
-      exe: exe,
+      exe: FlutterSdk.current.flutterExePath,
       args: args,
       throwOnException: throwOnException,
     );
   }
 
-  factory CliCommand.flutter(
-    String args, {
-    bool throwOnException = true,
-  }) {
-    return CliCommand._(
-      exe: FlutterSdk.current.flutterExePath,
-      args: args.split(' '),
-      throwOnException: throwOnException,
-    );
-  }
-
   factory CliCommand.dart(
-    String args, {
+    List<String> args, {
     bool throwOnException = true,
   }) {
     return CliCommand._(
       exe: FlutterSdk.current.dartExePath,
-      args: args.split(' '),
+      args: args,
       throwOnException: throwOnException,
     );
   }
 
   /// CliCommand helper for running git commands.
-  ///
-  /// Arguments can be passed in as a single string using [cmd], this will split
-  /// the string into args using spaces. e.g. CliCommand.git(cmd: 'checkout test-branch')
-  ///
-  /// If you instead want to specify args explicitly, you can use the
-  /// [args] param. e.g. CliCommand.git(args: ['checkout', 'test-branch'])
-  factory CliCommand.git({
-    String? cmd,
-    List<String>? args,
+  factory CliCommand.git(
+    List<String> args, {
     bool throwOnException = true,
-    bool split = true,
   }) {
-    if ((cmd == null) == (args == null)) {
-      throw ('Only one of `cmd` and `args` must be specified.');
-    }
-
-    if (cmd != null) {
-      args = cmd.split(' ');
-    }
-
     return CliCommand._(
       exe: 'git',
       args: args,
@@ -122,7 +97,7 @@ class CliCommand {
   }
 
   factory CliCommand.tool(
-    String args, {
+    List<String> args, {
     bool throwOnException = true,
   }) {
     return CliCommand._(
@@ -134,7 +109,7 @@ class CliCommand {
       exe: FlutterSdk.current.dartExePath,
       args: [
         Platform.script.toFilePath(),
-        ...args.split(' '),
+        ...args,
       ],
       throwOnException: throwOnException,
     );
@@ -219,7 +194,7 @@ Future<String> findRemote(
 }) async {
   print('Searching for a remote that points to $remoteId.');
   final remotesResult = await processManager.runProcess(
-    CliCommand.git(cmd: 'remote -v'),
+    CliCommand.git('remote -v'.split(' ')),
     workingDirectory: workingDirectory,
   );
   final String remotes = remotesResult.stdout;


### PR DESCRIPTION
Accepting strings and splitting by spaces is unsafe if paths or arguments could contain spaces. Accepting strings makes it really easy to make this mistake.

I propose we stop taking strings in this way and if we want to use strings for convenience we force calling `.split(' ')` at the call site (on the literal string). This makes it easier to spot these kinds of bugs... if you are calling `.split(' ')` on a string that contains a variable, you might have a bug. It's safe to call it on a simple literal string where you can easily see that it can't split incorrectly.

An example of a previous bug because of splitting args is https://github.com/flutter/devtools/issues/6679 and a recent change that accidentally adds this elsewhere is https://github.com/flutter/devtools/pull/7085#pullrequestreview-1838567159

@kenzieschmoll thoughts?