### PR TITLE
Remove dynamic index operator, replace with map pattern destructuring

### DIFF
--- a/packages/devtools_shared/lib/src/deeplink/app_link_settings.dart
+++ b/packages/devtools_shared/lib/src/deeplink/app_link_settings.dart
@@ -12,10 +12,14 @@ class AppLinkSettings {
   const AppLinkSettings._(this.applicationId, this.deeplinks);
 
   factory AppLinkSettings.fromJson(String json) {
-    final jsonObject = jsonDecode(json);
+    final jsonObject = jsonDecode(json) as Map;
+    final {
+      _kApplicationIdKey: String applicationId,
+      _kDeeplinksKey: List<Object?> deepLinks,
+    } = jsonObject;
     return AppLinkSettings._(
-      jsonObject[_kApplicationIdKey] as String,
-      (jsonObject[_kDeeplinksKey] as List<dynamic>)
+      applicationId,
+      deepLinks
           .cast<Map<String, dynamic>>()
           .map<AndroidDeeplink>(AndroidDeeplink._fromJsonObject)
           .toList(),

--- a/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
+++ b/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
@@ -20,8 +20,7 @@ class ClassHeapDetailStats {
         isStacktraced = traceAllocations;
 
   factory ClassHeapDetailStats.fromJson(Map<String, dynamic> json) {
-    final classId = json['class']['id'];
-    final className = json['class']['name'];
+    final {'id': classId, 'name': className} = json['class'] as Map;
 
     return ClassHeapDetailStats(
       ClassRef(id: classId, name: className),


### PR DESCRIPTION
I separated out these two changes; it's still removing dynamic `[]` access, but I tried playing with destructuring in a map pattern, with a variable type, as a replacement. I think it looks nice! I totally get that it might look totally weird though. So if this code is more surprising, or harder to read, I'm not married to it. Kind of fun though.

Work towards https://github.com/flutter/devtools/issues/6929

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
