### PR TITLE
Remove unnecessary imports of 'package:collection' `IterableExtension`

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:collection/collection.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';
 

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -21,7 +21,7 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
       final extensionsAsJson =
           (parsedResult[ExtensionsApi.extensionsResultPropertyName]!
                   as List<Object?>)
-              .whereNotNull()
+              .nonNulls
               .cast<Map<String, Object?>>();
 
       final warningMessage =

--- a/packages/devtools_app/lib/src/shared/server/server.dart
+++ b/packages/devtools_app/lib/src/shared/server/server.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:devtools_shared/devtools_deeplink.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
 import 'package:devtools_shared/devtools_shared.dart';

--- a/packages/devtools_shared/lib/src/test/integration_test_runner.dart
+++ b/packages/devtools_shared/lib/src/test/integration_test_runner.dart
@@ -8,7 +8,6 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
 import 'chrome_driver.dart';


### PR DESCRIPTION
* Replace `.whereNotNull()` with `.nonNulls` which is now in Dart core.
* `.firstOrNull`, `.lastOrNull`, `.singleOrNull` and `.elementAtOrNull(i)` are also in Dart core and even under the same name, so simply drop the import of 'package:collection' whenever possible.

release-notes-not-required: no user-visible (or even developer-visible) change

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
