### PR TITLE
Fix extensions not showing in sidebar on Windows

### DIFF
--- a/packages/devtools_app/lib/src/shared/development_helpers.dart
+++ b/packages/devtools_app/lib/src/shared/development_helpers.dart
@@ -27,14 +27,14 @@ const _debugDevToolsExtensions = false;
 
 List<DevToolsExtensionConfig> debugHandleRefreshAvailableExtensions(
   // ignore: avoid-unused-parameters, false positive due to conditional imports
-  String rootPath,
+  Uri appRoot,
 ) {
   return debugExtensions;
 }
 
 ExtensionEnabledState debugHandleExtensionEnabledState({
   // ignore: avoid-unused-parameters, false positive due to conditional imports
-  required String rootPath,
+  required Uri appRoot,
   required String extensionName,
   bool? enable,
 }) {

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -8,12 +8,14 @@ part of 'server.dart';
 /// serve their assets on the server, and return the list of available
 /// extensions here.
 Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
-  String rootPath,
+  Uri appRoot,
 ) async {
   if (isDevToolsServerAvailable) {
     final uri = Uri(
       path: ExtensionsApi.apiServeAvailableExtensions,
-      queryParameters: {ExtensionsApi.extensionRootPathPropertyName: rootPath},
+      queryParameters: {
+        ExtensionsApi.extensionRootPathPropertyName: appRoot.toString(),
+      },
     );
     final resp = await request(uri.toString());
     if (resp?.statusOk ?? false) {
@@ -38,7 +40,7 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
       return [];
     }
   } else if (debugDevToolsExtensions) {
-    return debugHandleRefreshAvailableExtensions(rootPath);
+    return debugHandleRefreshAvailableExtensions(appRoot);
   }
   return [];
 }
@@ -51,7 +53,7 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
 /// to the value set forth by [enable] and then return the value that is saved
 /// to disk.
 Future<ExtensionEnabledState> extensionEnabledState({
-  required String rootPath,
+  required Uri appRoot,
   required String extensionName,
   bool? enable,
 }) async {
@@ -59,7 +61,7 @@ Future<ExtensionEnabledState> extensionEnabledState({
     final uri = Uri(
       path: ExtensionsApi.apiExtensionEnabledState,
       queryParameters: {
-        ExtensionsApi.extensionRootPathPropertyName: rootPath,
+        ExtensionsApi.extensionRootPathPropertyName: appRoot.toString(),
         ExtensionsApi.extensionNamePropertyName: extensionName,
         if (enable != null)
           ExtensionsApi.enabledStatePropertyName: enable.toString(),
@@ -74,7 +76,7 @@ Future<ExtensionEnabledState> extensionEnabledState({
     }
   } else if (debugDevToolsExtensions) {
     return debugHandleExtensionEnabledState(
-      rootPath: rootPath,
+      appRoot: appRoot,
       extensionName: extensionName,
       enable: enable,
     );

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -157,12 +157,11 @@ class _DevToolsMenuState extends State<_DevToolsMenu> {
       // This file path might be a Windows path but because this code runs in
       // the web, Uri.file() will not handle it correctly.
       //
-      // Since all paths are absolute, assume that if the path does not start
-      // with '/' that it's Windows, and parse with Windows semantics.
-      final fileUri = Uri.file(
-        sessionRootPath,
-        windows: !sessionRootPath.startsWith('/'),
-      );
+      // Since all paths are absolute, assume that if the path contains `\` and
+      // not `/` then it's Windows.
+      final isWindows =
+          sessionRootPath.contains(r'\') && !sessionRootPath.contains(r'/');
+      final fileUri = Uri.file(sessionRootPath, windows: isWindows);
       assert(fileUri.isScheme('file'));
       _extensionServiceForSession = ExtensionService(fixedAppRoot: fileUri);
       unawaited(_extensionServiceForSession!.initialize());

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/debug_sessions.dart
@@ -154,9 +154,17 @@ class _DevToolsMenuState extends State<_DevToolsMenu> {
   void _initExtensions() {
     final sessionRootPath = widget.session.projectRootPath;
     if (sessionRootPath != null) {
-      final fileUri = Uri.file(sessionRootPath);
-      _extensionServiceForSession =
-          ExtensionService(fixedAppRootPath: fileUri.toString());
+      // This file path might be a Windows path but because this code runs in
+      // the web, Uri.file() will not handle it correctly.
+      //
+      // Since all paths are absolute, assume that if the path does not start
+      // with '/' that it's Windows, and parse with Windows semantics.
+      final fileUri = Uri.file(
+        sessionRootPath,
+        windows: !sessionRootPath.startsWith('/'),
+      );
+      assert(fileUri.isScheme('file'));
+      _extensionServiceForSession = ExtensionService(fixedAppRoot: fileUri);
       unawaited(_extensionServiceForSession!.initialize());
     }
   }

--- a/packages/devtools_app/test/standalone_ui/vs_code/debug_sessions_test.dart
+++ b/packages/devtools_app/test/standalone_ui/vs_code/debug_sessions_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'dart:io';
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/constants.dart';
 import 'package:devtools_app/src/standalone_ui/api/impl/vs_code_api.dart';
@@ -266,6 +268,7 @@ VsCodeDebugSession generateDebugSession({
     flutterMode: flutterMode,
     flutterDeviceId: deviceId,
     debuggerType: debuggerType,
-    projectRootPath: '/mock/root/path',
+    projectRootPath:
+        Platform.isWindows ? r'C:\mock\root\path' : '/mock/root/path',
   );
 }

--- a/packages/devtools_shared/lib/src/devtools_api.dart
+++ b/packages/devtools_shared/lib/src/devtools_api.dart
@@ -76,6 +76,8 @@ abstract class ExtensionsApi {
   /// The property name for the query parameter passed along with
   /// extension-related requests to the server that describes the package root
   /// for the app whose extensions are being queried.
+  ///
+  /// This field is a file:// URI string and NOT a path.
   static const extensionRootPathPropertyName = 'rootPath';
 
   /// The property name for the response that the server sends back upon


### PR DESCRIPTION
+ remove "Path" from variables that are URIs and change them from Strings to Uris to avoid confusion.

Fixes https://github.com/flutter/devtools/issues/7115

Unfortunately despite the change to the tests, they don't currently catch the bug because when running in the VM `Uri.file()` does the expected thing on Windows. To cover this with tests, we really need to have some real integration tests testing through the browser (@kenzieschmoll do we already have the ability to do this? if not and it's non trivial, I think we should land this fix first).

Note: I have assumed that renaming variables and changing `String` ->`Uri`s is non-breaking for `devtools_app` but let me know if that's not the case and I'll revert those and document this in comments. It would be nice to change though, variables named "Path" that are `Strings` but are actually URIs is really confusing.