### PR TITLE
Re-enable `debugger_evaluation_test`

### DIFF
--- a/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
@@ -169,13 +169,11 @@ void main() {
       );
       test(
         'returns privates only from library',
-        skip: true,
         () async {
           await runMethodAndWaitForPause(
             'AnotherClass().pauseWithScopedVariablesMethod()',
           );
           expect(
-            collectionEquals(
               await autoCompleteResultsFor(
                 EditingParts(
                   activeWord: '_',
@@ -184,14 +182,13 @@ void main() {
                 ),
                 evalService,
               ),
+            unorderedEquals(
               [
                 '_privateField2',
                 '_privateField1',
                 '_PrivateClass',
               ],
-              ordered: false,
             ),
-            isTrue,
           );
         },
         timeout: const Timeout.factor(8),

--- a/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
@@ -173,21 +173,23 @@ void main() {
           await runMethodAndWaitForPause(
             'AnotherClass().pauseWithScopedVariablesMethod()',
           );
-          expect(
-              await autoCompleteResultsFor(
-                EditingParts(
-                  activeWord: '_',
-                  leftSide: '',
-                  rightSide: '',
-                ),
-                evalService,
+          await expectLater(
+            autoCompleteResultsFor(
+              EditingParts(
+                activeWord: '_',
+                leftSide: '',
+                rightSide: '',
               ),
-            unorderedEquals(
-              [
-                '_privateField2',
-                '_privateField1',
-                '_PrivateClass',
-              ],
+              evalService,
+            ),
+            completion(
+              unorderedEquals(
+                [
+                  '_privateField2',
+                  '_privateField1',
+                  '_PrivateClass',
+                ],
+              ),
             ),
           );
         },


### PR DESCRIPTION
Hopefully fixes https://github.com/flutter/devtools/issues/7099

This test case was flaking with the following error: 
```
|   This test failed after it had already completed.
|   Make sure to use a matching library which informs the test runner
|   of pending async work.
```

Only difference between it and the other test cases in the file is that it was using a non-standard matcher (`collectionEquals` which is defined in DevTools) instead of a standard matcher like `equals`. 

I've switched to using `unorderedEquals` instead. I can't reproduce the flake locally to verify that it's fixed unfortunately. 

