### PR TITLE
Add a flag to `devtools_tool serve` to support debugging the devtools server

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -30,7 +30,7 @@ const _debugServerFlag = 'debug-server';
 /// If the [_debugServerFlag] argument is present, the DevTools server will be
 /// started with the `--observe` flag. This will allow you to debug and profile
 /// the server with a local VM service connection. By default, this will set
-/// `--pause-osolates-on-start` and `--pause-isolates-on-unhandled-exception`
+/// `--pause-isolates-on-start` and `--pause-isolates-on-unhandled-exceptions`
 /// for the DevTools server VM service connection.
 ///
 /// If the [BuildCommandArgs.useFlutterFromPath] argument is present, the

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -178,7 +178,7 @@ class ServeCommand extends Command {
         [
           if (debugServer) ...[
             'run',
-            '--observe',
+            '--observe=0',
           ],
           serveLocalScriptPath,
           '--devtools-build=$devToolsBuildLocation',

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -29,7 +29,9 @@ const _debugServerFlag = 'debug-server';
 ///
 /// If the [_debugServerFlag] argument is present, the DevTools server will be
 /// started with the `--observe` flag. This will allow you to debug and profile
-/// the server with a local VM service connection.
+/// the server with a local VM service connection. By default, this will set
+/// `--pause-osolates-on-start` and `--pause-isolates-on-unhandled-exception`
+/// for the DevTools server VM service connection.
 ///
 /// If the [BuildCommandArgs.useFlutterFromPath] argument is present, the
 /// Flutter SDK will not be updated to the latest Flutter candidate before


### PR DESCRIPTION
CC @hangyujin this PR combined with https://dart-review.googlesource.com/c/sdk/+/350360 will unblock profiling the deep links code that runs on the devtools server. 