### PR TITLE
Change dtdUri handle parameter to be a string

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -16,7 +16,7 @@ an IDE. - [#7030](https://github.com/flutter/devtools/pull/7030)
 * Removed the "Dense mode" setting. - [#7086](https://github.com/flutter/devtools/pull/7086)
 * Added support for filtering with regular expressions in the Logging, Network, and CPU profiler
 pages - [#7027](https://github.com/flutter/devtools/pull/7027)
-* Add a DevTools server interaction for getting the DTD uri. - [#7054](https://github.com/flutter/devtools/pull/7054)
+* Add a DevTools server interaction for getting the DTD uri. - [#7054](https://github.com/flutter/devtools/pull/7054), [#7164](https://github.com/flutter/devtools/pull/7164)
 * Enabled expression evaluation with scope for the web, allowing evaluation of inspected widgets. - [#7144](https://github.com/flutter/devtools/pull/7144)
 * Update `package:vm_service` constraint to `^14.0.0`. - [#6953](https://github.com/flutter/devtools/pull/6953)
 

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -255,9 +255,7 @@ class ServerApi {
         );
       case DtdApi.apiGetDtdUri:
         return api.setCompleted(
-          json.encode({
-            DtdApi.uriPropertyName: dtdUri,
-          }),
+          json.encode({DtdApi.uriPropertyName: dtdUri}),
         );
       default:
         return api.notImplemented();

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -36,7 +36,7 @@ class ServerApi {
     required ExtensionsManager extensionsManager,
     required DeeplinkManager deeplinkManager,
     ServerApi? api,
-    String? Function()? dtdUri,
+    String? dtdUri,
   }) {
     api ??= ServerApi();
     final queryParams = request.requestedUri.queryParameters;
@@ -256,7 +256,7 @@ class ServerApi {
       case DtdApi.apiGetDtdUri:
         return api.setCompleted(
           json.encode({
-            DtdApi.uriPropertyName: dtdUri?.call(),
+            DtdApi.uriPropertyName: dtdUri,
           }),
         );
       default:

--- a/packages/devtools_shared/test/server/server_api_test.dart
+++ b/packages/devtools_shared/test/server/server_api_test.dart
@@ -167,7 +167,7 @@ void main() {
       request,
       extensionsManager: ExtensionsManager(buildDir: '/'),
       deeplinkManager: fakeManager,
-      dtdUri: () => dtdUri,
+      dtdUri: dtdUri,
     );
     expect(response.statusCode, HttpStatus.ok);
     expect(


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExODZzMGtzcGJ3b2EwMW5obTExdzU4cjMyam5rOHF1ejdqY256aW5wZSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/flbElEhvXDf7W/giphy.gif)

For now we will only ever get one dtdUri so we don't need the ability to get a fresh version in the future.

This PR changesthe devtools server handler so it just takes a String instead of a callback for that same string .