### PR TITLE
Do not show release notes in the Flutter sidebar.

### DIFF
--- a/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
@@ -4,14 +4,18 @@
 
 import 'dart:async';
 
+import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
 import '../../../devtools.dart' as devtools;
+import '../../shared/primitives/url_utils.dart';
 import '../../shared/server/server.dart' as server;
 import '../../shared/side_panel.dart';
+import '../../shared/utils.dart';
+import '../../standalone_ui/standalone_screen.dart';
 
 final _log = Logger('release_notes');
 
@@ -57,6 +61,15 @@ class ReleaseNotesController extends SidePanelController {
   }
 
   void _maybeShowReleaseNotes() async {
+    final currentUrl = getWebUrl();
+    final currentPage =
+        currentUrl != null ? extractCurrentPageFromUrl(currentUrl) : null;
+    if (isEmbedded() &&
+        currentPage == StandaloneScreenType.vsCodeFlutterPanel.name) {
+      // Do not show release notes in the Flutter sidebar.
+      return;
+    }
+
     SemanticVersion previousVersion = SemanticVersion();
     if (server.isDevToolsServerAvailable) {
       final lastReleaseNotesShownVersion =

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -54,7 +54,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## VS Code Sidebar updates
 
-TODO: Remove this section if there are not any general updates.
+* Do not show DevTools release notes in the Flutter sidebar. - [#7166](https://github.com/flutter/devtools/pull/7166)
 
 ## DevTools Extension updates
 

--- a/packages/devtools_app/test/shared/release_notes_test.dart
+++ b/packages/devtools_app/test/shared/release_notes_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -10,6 +12,7 @@ void main() {
   group('$ReleaseNotesController', () {
     late ReleaseNotesController controller;
     setUp(() {
+      setGlobal(IdeTheme, IdeTheme());
       debugTestReleaseNotes = true;
       controller = ReleaseNotesController();
     });


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6958