### PR TITLE
Silence unnecessary cast so devtools can work with web 0.5.0 in google3

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/notifications/_notifications_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/notifications/_notifications_web.dart
@@ -17,6 +17,9 @@ class Notification {
   late final web.Notification _impl;
 
   static Future<String> requestPermission() async =>
+      // TODO(srujzs): This was needed in 0.4.0 as generics were not available.
+      // This is no longer true 0.5.0 onwards.
+      // ignore: unnecessary_cast
       ((await web.Notification.requestPermission().toDart) as JSString).toDart;
 
   void close() {


### PR DESCRIPTION
Note that 0.5.0 hasn't been released yet. After it rolls into google3, we can publish and devtools can be updated to use it. This purely enables that roll.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.
