### PR TITLE
Fix null check exception in `_dtd_api.dart`

### DIFF
--- a/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
@@ -13,7 +13,6 @@ Future<Uri?> getDtdUri() async {
       final parsedResult = json.decode(resp!.body) as Map;
       final uriString = parsedResult[DtdApi.uriPropertyName] as String?;
       return uriString != null ? Uri.parse(uriString) : null;
-
     }
   }
   return null;

--- a/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
@@ -12,7 +12,8 @@ Future<Uri?> getDtdUri() async {
     if (resp?.statusOk ?? false) {
       final parsedResult = json.decode(resp!.body) as Map;
       final uriString = parsedResult[DtdApi.uriPropertyName] as String?;
-      return uriString != null ?  Uri.parse(uriString) : null;
+      return uriString != null ? Uri.parse(uriString) : null;
+
     }
   }
   return null;

--- a/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
@@ -11,10 +11,8 @@ Future<Uri?> getDtdUri() async {
     final resp = await request(uri.toString());
     if (resp?.statusOk ?? false) {
       final parsedResult = json.decode(resp!.body) as Map;
-
-      final uriString = parsedResult[DtdApi.uriPropertyName];
-
-      return Uri.parse(uriString);
+      final uriString = parsedResult[DtdApi.uriPropertyName] as String?;
+      return uriString != null ?  Uri.parse(uriString) : null;
     }
   }
   return null;


### PR DESCRIPTION
This was throwing an exception when no DTD uri was present: `Failed to initialize the DTD connection.]: Null check operator used on a null value`
