### PR TITLE
Add verbose logging to parts of the extension framework

### DIFF
--- a/packages/devtools_app/lib/src/shared/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences.dart
@@ -76,18 +76,11 @@ class PreferencesController extends DisposableController
         await storage.getValue(_verboseLoggingStorageId);
 
     toggleVerboseLogging(verboseLoggingEnabledValue == 'true');
-
     addAutoDisposeListener(verboseLoggingEnabled, () {
       storage.setValue(
         'verboseLogging',
         verboseLoggingEnabled.value.toString(),
       );
-
-      if (verboseLoggingEnabled.value) {
-        setDevToolsLoggingLevel(verboseLoggingLevel);
-      } else {
-        setDevToolsLoggingLevel(basicLoggingLevel);
-      }
     });
   }
 
@@ -118,6 +111,11 @@ class PreferencesController extends DisposableController
   void toggleVerboseLogging(bool? enableVerboseLogging) {
     if (enableVerboseLogging != null) {
       verboseLoggingEnabled.value = enableVerboseLogging;
+      if (enableVerboseLogging) {
+        setDevToolsLoggingLevel(verboseLoggingLevel);
+      } else {
+        setDevToolsLoggingLevel(basicLoggingLevel);
+      }
     }
   }
 }

--- a/packages/devtools_app/lib/src/shared/server/_analytics_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_analytics_api.dart
@@ -50,7 +50,7 @@ Future<bool> setAnalyticsEnabled([bool value = true]) async {
       assert(json.decode(resp!.body) == value);
       return true;
     } else {
-      logWarning(resp, apiSetDevToolsEnabled, resp?.body);
+      logWarning(resp, apiSetDevToolsEnabled);
     }
   }
   return false;

--- a/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_dtd_api.dart
@@ -11,10 +11,8 @@ Future<Uri?> getDtdUri() async {
     final resp = await request(uri.toString());
     if (resp?.statusOk ?? false) {
       final parsedResult = json.decode(resp!.body) as Map;
-
-      final uriString = parsedResult[DtdApi.uriPropertyName];
-
-      return Uri.parse(uriString);
+      final uriString = parsedResult[DtdApi.uriPropertyName] as String?;
+      return uriString != null ? Uri.parse(uriString) : null;
     }
   }
   return null;

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -27,7 +27,7 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
               .nonNulls
               .cast<Map<String, Object?>>();
 
-      final logs = (parsedResult['logs'] as List).cast<String>();
+      final logs = (parsedResult['logs'] as List?)?.cast<String>() ?? [];
       for (final log in logs) {
         _log.fine('[from devtools_server] $log');
       }

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -10,6 +10,7 @@ part of 'server.dart';
 Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
   Uri appRoot,
 ) async {
+  _log.fine('refreshAvailableExtensions for ${appRoot.toString()}');
   if (isDevToolsServerAvailable) {
     final uri = Uri(
       path: ExtensionsApi.apiServeAvailableExtensions,
@@ -31,6 +32,10 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
       if (warningMessage != null) {
         _log.warning(warningMessage);
       }
+
+      _log.fine(
+        'extensions returned from the server: ${extensionsAsJson.toString()}',
+      );
 
       return extensionsAsJson
           .map((p) => DevToolsExtensionConfig.parse(p))
@@ -57,6 +62,9 @@ Future<ExtensionEnabledState> extensionEnabledState({
   required String extensionName,
   bool? enable,
 }) async {
+  _log.fine(
+    '${enable != null ? 'setting' : 'getting'} extensionEnabledState for $extensionName',
+  );
   if (isDevToolsServerAvailable) {
     final uri = Uri(
       path: ExtensionsApi.apiExtensionEnabledState,
@@ -70,7 +78,9 @@ Future<ExtensionEnabledState> extensionEnabledState({
     final resp = await request(uri.toString());
     if (resp?.statusOk ?? false) {
       final parsedResult = json.decode(resp!.body);
-      return ExtensionEnabledState.from(parsedResult);
+      final state = ExtensionEnabledState.from(parsedResult);
+      _log.fine('returning $state');
+      return state;
     } else {
       logWarning(resp, ExtensionsApi.apiExtensionEnabledState);
     }

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -27,6 +27,11 @@ Future<List<DevToolsExtensionConfig>> refreshAvailableExtensions(
               .nonNulls
               .cast<Map<String, Object?>>();
 
+      final logs = (parsedResult['logs'] as List).cast<String>();
+      for (final log in logs) {
+        _log.fine('[from devtools_server] $log');
+      }
+
       final warningMessage =
           parsedResult[ExtensionsApi.extensionsResultWarningPropertyName];
       if (warningMessage != null) {

--- a/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_extensions_api.dart
@@ -79,7 +79,7 @@ Future<ExtensionEnabledState> extensionEnabledState({
     if (resp?.statusOk ?? false) {
       final parsedResult = json.decode(resp!.body);
       final state = ExtensionEnabledState.from(parsedResult);
-      _log.fine('returning $state');
+      _log.fine('returning state for $extensionName: $state');
       return state;
     } else {
       logWarning(resp, ExtensionsApi.apiExtensionEnabledState);

--- a/packages/devtools_app/lib/src/shared/server/_release_notes_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_release_notes_api.dart
@@ -30,7 +30,7 @@ Future<void> setLastShownReleaseNotesVersion(String version) async {
       '?$lastReleaseNotesVersionPropertyName=$version',
     );
     if (resp == null || !resp.statusOk || !(json.decode(resp.body) as bool)) {
-      logWarning(resp, apiSetLastReleaseNotesVersion, resp?.body);
+      logWarning(resp, apiSetLastReleaseNotesVersion);
     }
   }
 }

--- a/packages/devtools_app/lib/src/shared/server/_survey_api.dart
+++ b/packages/devtools_app/lib/src/shared/server/_survey_api.dart
@@ -59,7 +59,7 @@ Future<void> setSurveyActionTaken() async {
       '?$surveyActionTakenPropertyName=true',
     );
     if (resp == null || !resp.statusOk || !(json.decode(resp.body) as bool)) {
-      logWarning(resp, apiSetSurveyActionTaken, resp?.body);
+      logWarning(resp, apiSetSurveyActionTaken);
     }
   }
 }

--- a/packages/devtools_app/lib/src/shared/server/server.dart
+++ b/packages/devtools_app/lib/src/shared/server/server.dart
@@ -23,7 +23,7 @@ part '_release_notes_api.dart';
 part '_survey_api.dart';
 part '_dtd_api.dart';
 
-final _log = Logger('_server_web');
+final _log = Logger('devtools_server_client');
 
 // The DevTools server is only available in release mode right now.
 // TODO(kenz): design a way to run the DevTools server and DevTools app together
@@ -89,7 +89,8 @@ DevToolsJsonFile _devToolsJsonFileFromResponse(
   );
 }
 
-void logWarning(Response? response, String apiType, [String? respText]) {
+void logWarning(Response? response, String apiType) {
+  final respText = response?.body;
   _log.warning(
     'HttpRequest $apiType failed status = ${response?.statusCode}'
     '${respText != null ? ', responseText = $respText' : ''}',

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 6.0.5
+* Remove the `ServerApi.setCompleted` method that was a duplicate of `ServerApi.getCompleted`.
+* Add the ability to send debug logs in DevTools server request responses. 
+* Add an optional positional parameter `logs` to the `ServerApi.serverError` method.
+* Include debug logs with the `ExtensionsApi.apiServeAvailableExtensions` API response.
+
 # 6.0.4
 * Add `apiGetDtdUri` to the server api.
 * Add a description and link to documentation to the `devtools_options.yaml` file that

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -7,7 +7,6 @@
 import 'dart:io';
 
 import 'package:extension_discovery/extension_discovery.dart';
-import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
 import 'extension_model.dart';

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -7,6 +7,7 @@
 import 'dart:io';
 
 import 'package:extension_discovery/extension_discovery.dart';
+import 'package:logging/logging.dart';
 import 'package:path/path.dart' as path;
 
 import 'extension_model.dart';
@@ -55,7 +56,10 @@ class ExtensionsManager {
   /// package:extension_discovery, and the available extension's
   /// assets will be copied to the `build/devtools_extensions` directory that
   /// DevTools server is serving.
-  Future<void> serveAvailableExtensions(String? rootPathFileUri) async {
+  Future<void> serveAvailableExtensions(
+    String? rootPathFileUri,
+    List<String> logs,
+  ) async {
     if (rootPathFileUri != null && !rootPathFileUri.startsWith('file://')) {
       throw ArgumentError.value(
         rootPathFileUri,
@@ -63,6 +67,11 @@ class ExtensionsManager {
         'must be a file:// URI String',
       );
     }
+
+    logs.add(
+      'ExtensionsManager.serveAvailableExtensions: '
+      'rootPathFileUri: $rootPathFileUri',
+    );
 
     devtoolsExtensions.clear();
     final parsingErrors = StringBuffer();
@@ -79,6 +88,10 @@ class ExtensionsManager {
               'package_config.json',
             ),
           ),
+        );
+        logs.add(
+          'ExtensionsManager.serveAvailableExtensions: findExtensionsResult  - '
+          '${extensions.map((e) => e.package).toList()}',
         );
       } catch (e) {
         extensions = <Extension>[];
@@ -122,7 +135,7 @@ class ExtensionsManager {
     _resetServedPluginsDir();
     await Future.wait([
       for (final extension in devtoolsExtensions)
-        _moveToServedExtensionsDir(extension.name, extension.path),
+        _moveToServedExtensionsDir(extension.name, extension.path, logs: logs),
     ]);
 
     if (parsingErrors.isNotEmpty) {
@@ -150,11 +163,16 @@ class ExtensionsManager {
 
   Future<void> _moveToServedExtensionsDir(
     String extensionPackageName,
-    String extensionPath,
-  ) async {
+    String extensionPath, {
+    required List<String> logs,
+  }) async {
     final newExtensionPath = path.join(
       _servedExtensionsPath,
       extensionPackageName,
+    );
+    logs.add(
+      'ExtensionsManager._moveToServedExtensionsDir: moving '
+      '$extensionPath to $newExtensionPath',
     );
     await copyPath(extensionPath, newExtensionPath);
   }

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -21,6 +21,8 @@ import 'usage.dart';
 ///
 /// This defines endpoints that serve all requests that come in over api/.
 class ServerApi {
+  static const logsKey = 'logs';
+  static const errorKey = 'error';
   static const errorNoActiveSurvey = 'ERROR: setActiveSurvey not called.';
 
   /// Determines whether or not [request] is an API call.
@@ -273,7 +275,7 @@ class ServerApi {
     Map<String, Object?> result,
     List<String> logs,
   ) {
-    result['logs'] = logs;
+    result[logsKey] = logs;
     return result;
   }
 
@@ -337,8 +339,8 @@ class ServerApi {
       HttpStatus.internalServerError,
       body: error != null || logs != null
           ? <String, Object?>{
-              if (error != null) 'error': error,
-              if (logs != null) 'logs': logs,
+              if (error != null) errorKey: error,
+              if (logs != null) logsKey: logs,
             }
           : null,
     );

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -8,7 +8,6 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:logging/logging.dart';
 import 'package:shelf/shelf.dart' as shelf;
 
 import '../deeplink/deeplink_manager.dart';

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 6.0.4
+version: 6.0.5
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
Add verbose logging to the DevTools extensions code, both server side and client. Makes some changes to the DevTools server response code to allow forwarding logs back in the server responses.

This also fixes a bug with the verbose logging setting so that this is properly picked up and applied from the preferences file.