### PR TITLE
Skip flaky debugger test

### DIFF
--- a/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_evaluation_test.dart
@@ -169,6 +169,9 @@ void main() {
       );
       test(
         'returns privates only from library',
+        // TODO(https://github.com/flutter/devtools/issues/7099): unskip once
+        // this test flake is fixed.
+        skip: true,
         () async {
           await runMethodAndWaitForPause(
             'AnotherClass().pauseWithScopedVariablesMethod()',


### PR DESCRIPTION
Skips the test causing this flake: https://github.com/flutter/devtools/issues/7099