### PR TITLE
Fix type error in `IsolatePrivateViewExtension.tagCounters`

### DIFF
--- a/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics/isolate_statistics_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/isolate_statistics/isolate_statistics_view_controller.dart
@@ -73,6 +73,7 @@ class IsolateStatisticsViewController extends DisposableController
     // given tag's scope in the VM. These raw counts are reported here and
     // need to be processed.
     final tagCounters = isolate.tagCounters;
+    if (tagCounters == null) return;
     final names = tagCounters['names'] as List;
     final counters = (tagCounters['counters'] as List).cast<int>();
     final percentages = <String, double>{};

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_service_private_extensions.dart
@@ -31,7 +31,7 @@ extension VMPrivateViewExtension on VM {
 
 /// An extension on [Isolate] which allows for access to VM internal fields.
 extension IsolatePrivateViewExtension on Isolate {
-  Map<String, dynamic> get tagCounters => json!['_tagCounters'];
+  Map<String, dynamic>? get tagCounters => json!['_tagCounters'];
 
   int get dartHeapSize => newSpaceUsage + oldSpaceUsage;
   int get dartHeapCapacity => newSpaceCapacity + oldSpaceCapacity;


### PR DESCRIPTION
This field can be null if the profiler isn't enabled.

Fixes https://github.com/flutter/devtools/issues/7210