### PR TITLE
Bump devtools_shared to 7.0.0

### DIFF
--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,15 +1,15 @@
-# 6.0.5
-* Remove the `ServerApi.setCompleted` method that was a duplicate of `ServerApi.getCompleted`.
+# 7.0.0
+* **Breaking change:** remove the `ServerApi.setCompleted` method that was a
+duplicate of `ServerApi.getCompleted`.
+* **Breaking change:** add required parameter `analytics` to `ServerApi.handle`, which accepts
+an instance of `Analytics` from `package:unified_analytics`.
 * Add the ability to send debug logs in DevTools server request responses. 
 * Add an optional positional parameter `logs` to the `ServerApi.serverError` method.
 * Include debug logs with the `ExtensionsApi.apiServeAvailableExtensions` API response.
-* Add parameter to `ServerApi.handle` to accept an instance of `Analytics` from 
-  `package:unified_analytics`.
 * Devtools server API `apiGetConsentMessage` added to fetch the consent message from
   `package:unified_analytics`.
 * Devtools server API `apiMarkConsentMessageAsShown` added to mark the consent message for
   `package:unified_analytics` as shown to enable telemetry.
-
 
 # 6.0.4
 * Add `apiGetDtdUri` to the server api.

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 6.0.5
+version: 7.0.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
Create a major version bump to avoid the breakage here: https://github.com/dart-lang/sdk/issues/54919