### PR TITLE
[deep link] Update the deep link error tooltip to use " enableTapToDismiss: false"

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -159,6 +159,7 @@ class _ErrorAwareText extends StatelessWidget {
               right: defaultSpacing,
             ),
             preferBelow: true,
+            enableTapToDismiss: false,
             richMessage: WidgetSpan(
               child: SizedBox(
                 width: kToolTipWidth,

--- a/packages/devtools_app_shared/lib/src/ui/common.dart
+++ b/packages/devtools_app_shared/lib/src/ui/common.dart
@@ -469,6 +469,7 @@ final class DevToolsTooltip extends StatelessWidget {
     required this.child,
     this.waitDuration = tooltipWait,
     this.preferBelow = false,
+    this.enableTapToDismiss = true,
     this.padding = const EdgeInsets.all(defaultSpacing),
     this.decoration,
     this.textStyle,
@@ -480,6 +481,7 @@ final class DevToolsTooltip extends StatelessWidget {
   final Widget child;
   final Duration waitDuration;
   final bool preferBelow;
+  final bool enableTapToDismiss;
   final EdgeInsetsGeometry? padding;
   final Decoration? decoration;
   final TextStyle? textStyle;
@@ -498,6 +500,7 @@ final class DevToolsTooltip extends StatelessWidget {
       richMessage: richMessage,
       waitDuration: waitDuration,
       preferBelow: preferBelow,
+      enableTapToDismiss: enableTapToDismiss,
       padding: padding,
       textStyle: style,
       decoration: decoration,


### PR DESCRIPTION
... , so when user tap the  "fix domain" action in the tooltip, the tooltip will not dismiss.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
