### PR TITLE
Change Release Note template url so it's url is ready for the flutter…

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -6,7 +6,7 @@ This is draft for future release notes, that are going to land on
 The 2.34.0 release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools/overview).
+[DevTools overview]({{site.url}}/tools/devtools/overview).
 
 ## General updates
 

--- a/packages/devtools_app/release_notes/helpers/release_notes_template.md
+++ b/packages/devtools_app/release_notes/helpers/release_notes_template.md
@@ -6,7 +6,7 @@ This is draft for future release notes, that are going to land on
 The <number> release of the Dart and Flutter DevTools
 includes the following changes among other general improvements.
 To learn more about DevTools, check out the
-[DevTools overview](https://docs.flutter.dev/tools/devtools/overview).
+[DevTools overview]({{site.url}}/tools/devtools/overview).
 
 ## General updates
 


### PR DESCRIPTION
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExejI1YXBoeWxkNzY5bGdlNnpkb2htNzR3dWdjdjVzZHlncDNicWJnNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l1ydPyGCoN43kpdwRO/giphy.gif)
[Shams pointed out](https://github.com/flutter/website/pull/10223#discussion_r1507708646) that this should be {{site.url}} when putting this in a flutter website PR.

I'm changing it here to make sure future PRs don't need to revisit this :)