### PR TITLE
Fix issue where null `_flutterVersion` was causing connection issues

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -6,7 +6,6 @@ import 'dart:async';
 
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
-import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
@@ -74,18 +73,6 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    maybePushUnsupportedFlutterVersionWarning(
-      PerformanceScreen.id,
-      supportedFlutterVersion: SemanticVersion(
-        major: 2,
-        minor: 3,
-        // Specifying patch makes the version number more readable.
-        // ignore: avoid_redundant_argument_values
-        patch: 0,
-        preReleaseMajor: 16,
-        preReleaseMinor: 0,
-      ),
-    );
     maybePushDebugModePerformanceMessage(context, PerformanceScreen.id);
 
     if (!initController()) return;

--- a/packages/devtools_app/lib/src/shared/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/banner_messages.dart
@@ -3,10 +3,8 @@
 // found in the LICENSE file.
 
 import 'package:collection/collection.dart' show IterableExtension;
-import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
-import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
@@ -481,61 +479,6 @@ For the most accurate absolute memory stats, relaunch your application in ''',
         ),
       ],
       screenId: screenId,
-    );
-  }
-}
-
-class UnsupportedFlutterVersionWarning {
-  const UnsupportedFlutterVersionWarning({
-    required this.screenId,
-    required this.currentFlutterVersion,
-    required this.supportedFlutterVersion,
-  });
-
-  final String screenId;
-
-  final FlutterVersion currentFlutterVersion;
-
-  final SemanticVersion supportedFlutterVersion;
-
-  BannerMessage build() {
-    return BannerWarning(
-      key: Key('UnsupportedFlutterVersionWarning - $screenId'),
-      textSpans: [
-        TextSpan(
-          text: 'This version of DevTools expects the connected app to be run'
-              ' on Flutter >= $supportedFlutterVersion, but the connected app'
-              ' is running on Flutter $currentFlutterVersion. Some'
-              ' functionality may not work. If this causes issues, try'
-              ' upgrading your Flutter version.',
-          style: TextStyle(fontSize: defaultFontSize),
-        ),
-      ],
-      screenId: screenId,
-    );
-  }
-}
-
-void maybePushUnsupportedFlutterVersionWarning(
-  String screenId, {
-  required SemanticVersion supportedFlutterVersion,
-}) {
-  final isFlutterApp =
-      serviceConnection.serviceManager.connectedApp?.isFlutterAppNow;
-  if (offlineController.offlineMode.value ||
-      isFlutterApp == null ||
-      !isFlutterApp) {
-    return;
-  }
-  final currentVersion =
-      serviceConnection.serviceManager.connectedApp!.flutterVersionNow!;
-  if (currentVersion < supportedFlutterVersion) {
-    bannerMessages.addMessage(
-      UnsupportedFlutterVersionWarning(
-        screenId: screenId,
-        currentFlutterVersion: currentVersion,
-        supportedFlutterVersion: supportedFlutterVersion,
-      ).build(),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -160,7 +160,6 @@ abstract class Screen {
     this.requiresDebugBuild = false,
     this.requiresVmDeveloperMode = false,
     this.worksOffline = false,
-    this.shouldShowForFlutterVersion,
     this.showFloatingDebuggerControls = true,
   }) : assert((title == null) || (titleGenerator == null));
 
@@ -188,7 +187,6 @@ abstract class Screen {
           requiresDebugBuild: requiresDebugBuild,
           requiresVmDeveloperMode: requiresVmDeveloperMode,
           worksOffline: worksOffline,
-          shouldShowForFlutterVersion: shouldShowForFlutterVersion,
           showFloatingDebuggerControls: showFloatingDebuggerControls,
           title: title,
           titleGenerator: titleGenerator,
@@ -279,11 +277,6 @@ abstract class Screen {
 
   /// Whether this screen works offline and should show in offline mode even if conditions are not met.
   final bool worksOffline;
-
-  /// A callback that will determine whether or not this screen should be
-  /// available for a given flutter version.
-  final bool Function(FlutterVersion? currentFlutterVersion)?
-      shouldShowForFlutterVersion;
 
   /// Whether this screen should display the isolate selector in the status
   /// line.
@@ -454,16 +447,6 @@ bool shouldShowScreen(Screen screen) {
   if (screen.requiresVmDeveloperMode) {
     if (!preferences.vmDeveloperModeEnabled.value) {
       _log.finest('screen requires vm developer mode: returning false');
-      return false;
-    }
-  }
-  if (screen.shouldShowForFlutterVersion != null) {
-    if (serviceConnection.serviceManager.connectedApp!.isFlutterAppNow ==
-            true &&
-        !screen.shouldShowForFlutterVersion!(
-          serviceConnection.serviceManager.connectedApp!.flutterVersionNow,
-        )) {
-      _log.finest('screen has flutter version restraints: returning false');
       return false;
     }
   }

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -93,7 +93,7 @@ List<ConnectionDescription> generateDeviceDescription(
     ),
     if (vmServiceConnection != null) vmServiceConnection,
     ConnectionDescription(title: 'Dart Version', description: version),
-    if (flutterVersion != null) ...{
+    if (flutterVersion != null && !flutterVersion.unknown) ...{
       ConnectionDescription(
         title: 'Flutter Version',
         description: '${flutterVersion.version} / ${flutterVersion.channel}',

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -10,7 +10,8 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed an issue preventing DevTools from connecting to Flutter apps that are not
+launched from Flutter Tools. - [#6848](https://github.com/flutter/devtools/issues/6848)
 
 ## Inspector updates
 

--- a/packages/devtools_app_shared/lib/src/service/connected_app.dart
+++ b/packages/devtools_app_shared/lib/src/service/connected_app.dart
@@ -195,7 +195,7 @@ class ConnectedApp {
         isDartWebAppKey: isDartWebAppNow,
         isRunningOnDartVMKey: isRunningOnDartVM,
         operatingSystemKey: operatingSystem,
-        if (flutterVersionNow != null)
+        if (flutterVersionNow != null && !flutterVersionNow!.unknown)
           flutterVersionKey: flutterVersionNow!.version,
       };
 }

--- a/packages/devtools_app_shared/lib/src/service/connected_app.dart
+++ b/packages/devtools_app_shared/lib/src/service/connected_app.dart
@@ -180,7 +180,7 @@ class ConnectedApp {
             'Timed out trying to fetch flutter version from '
             '`ConnectedApp.initializeValues`.',
           );
-          return Future<FlutterVersion?>.value();
+          return Future<FlutterVersion?>.value(FlutterVersion.unknown());
         },
       );
       flutterVersionServiceListenable.removeListener(listener);

--- a/packages/devtools_app_shared/lib/src/service/flutter_version.dart
+++ b/packages/devtools_app_shared/lib/src/service/flutter_version.dart
@@ -43,6 +43,18 @@ final class FlutterVersion extends SemanticVersion {
     );
   }
 
+  factory FlutterVersion.unknown() {
+    return FlutterVersion._(
+      version: null,
+      channel: null,
+      repositoryUrl: null,
+      frameworkRevision: null,
+      frameworkCommitDate: null,
+      engineRevision: null,
+      dartSdkVersion: null,
+    );
+  }
+
   final String? version;
 
   final String? channel;

--- a/packages/devtools_app_shared/lib/src/service/flutter_version.dart
+++ b/packages/devtools_app_shared/lib/src/service/flutter_version.dart
@@ -69,6 +69,15 @@ final class FlutterVersion extends SemanticVersion {
 
   final SemanticVersion? dartSdkVersion;
 
+  bool get unknown =>
+      version == null &&
+      channel == null &&
+      repositoryUrl == null &&
+      frameworkRevision == null &&
+      frameworkCommitDate == null &&
+      engineRevision == null &&
+      dartSdkVersion == null;
+
   @override
   bool operator ==(Object other) {
     if (other is! FlutterVersion) return false;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6848.

This also cleans up some cases where we had legacy code to gate logic on the flutter version of the connected app. We no longer need to do this since DevTools is shipped with the Flutter SDK.

@bkonyi @derekxu16 