### PR TITLE
Bump devtools_shared to 8.0.1

### DIFF
--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 8.0.0
+# 8.0.1
 * **Breaking change:** rename `ServerApi.getCompleted` to `ServerApi.success` and make the
 `value` parameter optional.
 * **Breaking change:** remove the `String? dtdUri` parameter from `ServerApi.handle` and replace

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 8.0.0
+version: 8.0.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
This is so we can publish. 8.0.0 was published and then retracted, but it was retracted too long ago to use the same version.