### PR TITLE
Allow for null responses from `ServerConnectionStorage.getValue`

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -94,7 +94,7 @@ class ServerConnectionStorage implements Storage {
   final DevToolsServerConnection connection;
 
   @override
-  Future<String> getValue(String key) {
+  Future<String?> getValue(String key) {
     return connection.getPreferenceValue(key);
   }
 

--- a/packages/devtools_app/lib/src/shared/server/server_api_client.dart
+++ b/packages/devtools_app/lib/src/shared/server/server_api_client.dart
@@ -203,7 +203,7 @@ class DevToolsServerConnection {
 
   /// Retrieves a preference value from the DevTools configuration file at
   /// ~/.flutter-devtools/.devtools.
-  Future<String> getPreferenceValue(String key) {
+  Future<String?> getPreferenceValue(String key) {
     return _callMethod('getPreferenceValue', {
       'key': key,
     });


### PR DESCRIPTION
The `Storage` interface already specifies that the return type should be nullable, but `ServerConnectionStorage` further restricted it to be non-nullable. If a key was looked up and it did not have an entry in storage, this would cause a type error and cause DevTools to hang on start in some situations.

Fixes https://github.com/flutter/devtools/issues/7373

FYI @eliasyishak 