### PR TITLE
Don't compile DevTools with unminified JS

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -62,7 +62,9 @@ flutter pub get
 flutter build web \
   --web-renderer canvaskit \
   --pwa-strategy=offline-first \
-  --dart2js-optimization=O1 \
+  # TODO(elliette): Compile with O1 optimization once
+  # https://github.com/dart-lang/sdk/issues/55234 is fixed:
+  # --dart2js-optimization=O1 \
   --release \
   --no-tree-shake-icons
 

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -95,8 +95,10 @@ class BuildCommand extends Command {
             '--web-renderer',
             'canvaskit',
             '--pwa-strategy=offline-first',
+            // TODO(elliette): Compile with O1 optimization once
+            // https://github.com/dart-lang/sdk/issues/55234 is fixed:
             // Enable default optimizations: https://dart.dev/tools/dart-compile#js
-            '--dart2js-optimization=O1',
+            // '--dart2js-optimization=O1',
             if (buildMode != 'debug') '--$buildMode',
             '--no-tree-shake-icons',
           ],


### PR DESCRIPTION
Reverts the changes in https://github.com/flutter/devtools/pull/7335

Using the unminified dart2js optimization levels breaks serving DevTools due to an unexpected type error. I've opened https://github.com/dart-lang/sdk/issues/55234 in the SDK with details.
