### PR TITLE
[deep link] Fix the issue that table is not updated when user change sorting option.

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -194,7 +194,13 @@ class _DataTable extends StatelessWidget {
     final domain = DomainColumn(controller);
     final path = PathColumn(controller);
 
-    return Padding(
+     
+    return ValueListenableBuilder<DisplayOptions>(
+            valueListenable: controller.displayOptionsNotifier,
+            builder: (context, d, _) {
+
+      return
+    Padding(
       padding: const EdgeInsets.only(top: denseSpacing),
       child: FlatTable<LinkData>(
         keyFactory: (node) => ValueKey(node.toString),
@@ -216,7 +222,7 @@ class _DataTable extends StatelessWidget {
           })(),
           SchemeColumn(controller),
           OSColumn(controller),
-          if (!controller.displayOptionsNotifier.value.showSplitScreen) ...[
+          if (!d.showSplitScreen) ...[
             StatusColumn(controller, viewType),
             NavigationColumn(),
           ],
@@ -225,6 +231,7 @@ class _DataTable extends StatelessWidget {
         defaultSortColumn: (viewType == TableViewType.pathView ? path : domain)
             as ColumnData<LinkData>,
         defaultSortDirection: SortDirection.ascending,
+        sortOriginalData: true,
         onItemSelected: (linkdata) {
           controller.selectLink(linkdata!);
           controller.updateDisplayOptions(showSplitScreen: true);
@@ -232,6 +239,8 @@ class _DataTable extends StatelessWidget {
         enableHoverHandling: true,
       ),
     );
+    
+    });
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -216,7 +216,7 @@ class _DataTable extends StatelessWidget {
           })(),
           SchemeColumn(controller),
           OSColumn(controller),
-          if (!controller.displayOptions.showSplitScreen) ...[
+          if (!controller.displayOptionsNotifier.value.showSplitScreen) ...[
             StatusColumn(controller, viewType),
             NavigationColumn(),
           ],

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_link_list_view.dart
@@ -194,13 +194,7 @@ class _DataTable extends StatelessWidget {
     final domain = DomainColumn(controller);
     final path = PathColumn(controller);
 
-     
-    return ValueListenableBuilder<DisplayOptions>(
-            valueListenable: controller.displayOptionsNotifier,
-            builder: (context, d, _) {
-
-      return
-    Padding(
+    return Padding(
       padding: const EdgeInsets.only(top: denseSpacing),
       child: FlatTable<LinkData>(
         keyFactory: (node) => ValueKey(node.toString),
@@ -222,7 +216,7 @@ class _DataTable extends StatelessWidget {
           })(),
           SchemeColumn(controller),
           OSColumn(controller),
-          if (!d.showSplitScreen) ...[
+          if (!controller.displayOptions.showSplitScreen) ...[
             StatusColumn(controller, viewType),
             NavigationColumn(),
           ],
@@ -239,8 +233,6 @@ class _DataTable extends StatelessWidget {
         enableHoverHandling: true,
       ),
     );
-    
-    });
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -459,7 +459,26 @@ class DeepLinksController extends DisposableController {
           displayOptionsNotifier.value.updateFilter(removedFilter, false);
     }
 
-    displayLinkDatasNotifier.value = getFilterredLinks(allValidatedLinkDatas!);
+    if (addedFilter != null || removedFilter != null) {
+      applyFilters();
+    }
+
+    if(domainSortingOption!=null ||pathSortingOption!=null){
+      displayLinkDatasNotifier.value = ValidatedLinkDatas(
+      all: getFilterredLinks([...validatedLinkDatas.all]),
+      byDomain: getFilterredLinks([...validatedLinkDatas.byDomain]),
+      byPath: getFilterredLinks([...validatedLinkDatas.byPath]),
+    );
+
+    }
+  }
+
+  void applyFilters() {
+    displayLinkDatasNotifier.value = ValidatedLinkDatas(
+      all: getFilterredLinks(validatedLinkDatas.all),
+      byDomain: getFilterredLinks(validatedLinkDatas.byDomain),
+      byPath: getFilterredLinks(validatedLinkDatas.byPath),
+    );
   }
 
   @visibleForTesting

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -474,15 +474,6 @@ class DeepLinksController extends DisposableController {
     if (addedFilter != null || removedFilter != null) {
       applyFilters();
     }
-
-    if(domainSortingOption!=null ||pathSortingOption!=null){
-      displayLinkDatasNotifier.value = ValidatedLinkDatas(
-      all: getFilterredLinks([...validatedLinkDatas.all]),
-      byDomain: getFilterredLinks([...validatedLinkDatas.byDomain]),
-      byPath: getFilterredLinks([...validatedLinkDatas.byPath]),
-    );
-
-    }
   }
 
   void applyFilters() {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -286,9 +286,12 @@ class _ErrorAwareText extends StatelessWidget {
 
 class DomainColumn extends ColumnData<LinkData>
     implements ColumnRenderer<LinkData>, ColumnHeaderRenderer<LinkData> {
-  DomainColumn(this.controller) : super.wide('Domain');
+  DomainColumn(this.controller)
+      : sortingOption = controller.displayOptions.domainSortingOption,
+        super.wide('Domain');
 
   DeepLinksController controller;
+  SortingOption? sortingOption;
 
   @override
   Widget? buildHeader(
@@ -334,16 +337,22 @@ class DomainColumn extends ColumnData<LinkData>
   int compare(LinkData a, LinkData b) => _compareLinkData(
         a,
         b,
-        sortingOption: controller.displayOptions.domainSortingOption,
+        sortingOption: sortingOption,
         compareDomain: true,
       );
+
+  @override
+  String get config => sortingOption.toString();
 }
 
 class PathColumn extends ColumnData<LinkData>
     implements ColumnRenderer<LinkData>, ColumnHeaderRenderer<LinkData> {
-  PathColumn(this.controller) : super.wide('Path');
+  PathColumn(this.controller)
+      : sortingOption = controller.displayOptions.pathSortingOption,
+        super.wide('Path');
 
   DeepLinksController controller;
+  SortingOption? sortingOption;
 
   @override
   Widget? buildHeader(
@@ -389,9 +398,12 @@ class PathColumn extends ColumnData<LinkData>
   int compare(LinkData a, LinkData b) => _compareLinkData(
         a,
         b,
-        sortingOption: controller.displayOptions.pathSortingOption,
+        sortingOption: sortingOption,
         compareDomain: false,
       );
+
+  @override
+  String get config => sortingOption.toString();
 }
 
 class NumberOfAssociatedPathColumn extends ColumnData<LinkData> {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -342,7 +342,7 @@ class DomainColumn extends ColumnData<LinkData>
       );
 
   @override
-  String get config => sortingOption.toString();
+  String get config => '$title $sortingOption';
 }
 
 class PathColumn extends ColumnData<LinkData>
@@ -403,7 +403,7 @@ class PathColumn extends ColumnData<LinkData>
       );
 
   @override
-  String get config => sortingOption.toString();
+  String get config => '$title $sortingOption';
 }
 
 class NumberOfAssociatedPathColumn extends ColumnData<LinkData> {

--- a/packages/devtools_app/lib/src/shared/table/_flat_table.dart
+++ b/packages/devtools_app/lib/src/shared/table/_flat_table.dart
@@ -277,6 +277,7 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
         );
     return columnsChanged;
   }
+  //
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/shared/table/_flat_table.dart
+++ b/packages/devtools_app/lib/src/shared/table/_flat_table.dart
@@ -274,10 +274,13 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
         !collectionEquals(
           oldWidget.columnGroups?.map((c) => c.title),
           newWidget.columnGroups?.map((c) => c.title),
+        ) ||
+        !collectionEquals(
+          oldWidget.columns.map((c) => c.compare),
+          newWidget.columns.map((c) => c.compare),
         );
     return columnsChanged;
   }
-  //
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/shared/table/_flat_table.dart
+++ b/packages/devtools_app/lib/src/shared/table/_flat_table.dart
@@ -268,16 +268,12 @@ class FlatTableState<T> extends State<FlatTable<T>> with AutoDisposeMixin {
     FlatTable<T> newWidget,
   ) {
     final columnsChanged = !collectionEquals(
-          oldWidget.columns.map((c) => c.title),
-          newWidget.columns.map((c) => c.title),
+          oldWidget.columns.map((c) => c.config),
+          newWidget.columns.map((c) => c.config),
         ) ||
         !collectionEquals(
           oldWidget.columnGroups?.map((c) => c.title),
           newWidget.columnGroups?.map((c) => c.title),
-        ) ||
-        !collectionEquals(
-          oldWidget.columns.map((c) => c.compare),
-          newWidget.columns.map((c) => c.compare),
         );
     return columnsChanged;
   }

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -102,6 +102,9 @@ abstract class ColumnData<T> {
     return theme.regularTextStyleWithColor(textColor);
   }
 
+  // Configuration changes to columns will cause the table to be rebuilt.
+  String get config => title;
+
   @override
   String toString() => title;
 }

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -102,7 +102,9 @@ abstract class ColumnData<T> {
     return theme.regularTextStyleWithColor(textColor);
   }
 
-  /// Configuration changes to columns will cause the table to be rebuilt.
+  /// The configuration for the column. Configuration changes to columns
+  /// will cause the table to be rebuilt.
+  /// 
   /// Defaults to title.
   String get config => title;
 

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -104,7 +104,7 @@ abstract class ColumnData<T> {
 
   /// The configuration for the column. Configuration changes to columns
   /// will cause the table to be rebuilt.
-  /// 
+  ///
   /// Defaults to title.
   String get config => title;
 

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -102,7 +102,8 @@ abstract class ColumnData<T> {
     return theme.regularTextStyleWithColor(textColor);
   }
 
-  // Configuration changes to columns will cause the table to be rebuilt.
+  /// Configuration changes to columns will cause the table to be rebuilt.
+  /// Defaults to title.
   String get config => title;
 
   @override

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -436,7 +436,7 @@ void main() {
         expect(find.text('www.google.com'), findsOneWidget);
       },
     );
-
+    //TODO(hangyujin): Fix the sorting issue.
     testWidgetsWithWindowSize(
       'sort links',
       windowSize,
@@ -463,7 +463,11 @@ void main() {
 
         deepLinksController.selectedProject.value =
             FlutterProject(path: '/abc', androidVariants: ['debug', 'release']);
-        deepLinksController.allValidatedLinkDatas = linkDatas;
+        deepLinksController.validatedLinkDatas = ValidatedLinkDatas(
+          all: linkDatas,
+          byDomain: deepLinksController.linkDatasByDomain(linkDatas),
+          byPath: deepLinksController.linkDatasByPath(linkDatas),
+        );
 
         await pumpDeepLinkScreen(
           tester,

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -456,7 +456,7 @@ void main() {
         expect(find.text('www.google.com'), findsOneWidget);
       },
     );
-    //TODO(hangyujin): Fix the sorting issue.
+
     testWidgetsWithWindowSize(
       'sort links',
       windowSize,
@@ -487,6 +487,11 @@ void main() {
           all: linkDatas,
           byDomain: deepLinksController.linkDatasByDomain(linkDatas),
           byPath: deepLinksController.linkDatasByPath(linkDatas),
+        );
+
+        await pumpDeepLinkScreen(
+          tester,
+          controller: deepLinksController,
         );
 
         expect(find.text('www.domain1.com'), findsOneWidget);


### PR DESCRIPTION
Currently FlatTable is only rebuilt when data is changed or columns titles are change, 

To make sure the FlatTable is rebuilt when deep links sortingOption changes, 

Add a `config` to Columns that it will cause the table to be rebuilt.





## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
