### PR TITLE
[deep link] Update `recheck` button

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -207,26 +207,26 @@ class DeepLinksController extends DisposableController {
 
   Future<void> loadAndroidAppLinksAndValidate() async {
     pagePhase.value = PagePhase.linksLoading;
-    if (!_androidAppLinks.containsKey(selectedVariantIndex.value)) {
-      final variant =
-          selectedProject.value!.androidVariants[selectedVariantIndex.value];
-      await ga.timeAsync(
-        gac.deeplink,
-        gac.AnalyzeFlutterProject.loadAppLinks.name,
-        asyncOperation: () async {
-          final AppLinkSettings result;
-          try {
-            result = await server.requestAndroidAppLinkSettings(
-              selectedProject.value!.path,
-              buildVariant: variant,
-            );
-            _androidAppLinks[selectedVariantIndex.value] = result;
-          } catch (_) {
-            pagePhase.value = PagePhase.errorPage;
-          }
-        },
-      );
-    }
+
+    final variant =
+        selectedProject.value!.androidVariants[selectedVariantIndex.value];
+    await ga.timeAsync(
+      gac.deeplink,
+      gac.AnalyzeFlutterProject.loadAppLinks.name,
+      asyncOperation: () async {
+        final AppLinkSettings result;
+        try {
+          result = await server.requestAndroidAppLinkSettings(
+            selectedProject.value!.path,
+            buildVariant: variant,
+          );
+          _androidAppLinks[selectedVariantIndex.value] = result;
+        } catch (_) {
+          pagePhase.value = PagePhase.errorPage;
+        }
+      },
+    );
+
     if (pagePhase.value == PagePhase.errorPage) {
       return;
     }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -202,10 +202,10 @@ class DeepLinksController extends DisposableController {
 
   late final selectedVariantIndex = ValueNotifier<int>(0);
   void _handleSelectedVariantIndexChanged() {
-    unawaited(loadAndValidateAndroidAppLinks());
+    unawaited(loadAndroidAppLinksAndValidate());
   }
 
-  Future<void> loadAndValidateAndroidAppLinks() async {
+  Future<void> loadAndroidAppLinksAndValidate() async {
     pagePhase.value = PagePhase.linksLoading;
     if (!_androidAppLinks.containsKey(selectedVariantIndex.value)) {
       final variant =

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -202,10 +202,10 @@ class DeepLinksController extends DisposableController {
 
   late final selectedVariantIndex = ValueNotifier<int>(0);
   void _handleSelectedVariantIndexChanged() {
-    unawaited(_loadAndroidAppLinks());
+    unawaited(loadAndValidateAndroidAppLinks());
   }
 
-  Future<void> _loadAndroidAppLinks() async {
+  Future<void> loadAndValidateAndroidAppLinks() async {
     pagePhase.value = PagePhase.linksLoading;
     if (!_androidAppLinks.containsKey(selectedVariantIndex.value)) {
       final variant =

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -66,7 +66,7 @@ class ValidationDetailView extends StatelessWidget {
                   alignment: Alignment.bottomRight,
                   child: FilledButton(
                     onPressed: () async =>
-                        await controller.loadAndValidateAndroidAppLinks(),
+                        await controller.loadAndroidAppLinksAndValidate(),
                     child: const Text('Recheck all'),
                   ),
                 ),

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -62,14 +62,14 @@ class ValidationDetailView extends StatelessWidget {
                     viewType == TableViewType.singleUrlView)
                   _PathCheckTable(controller: controller),
                 const SizedBox(height: extraLargeSpacing),
-                if (linkData.domainErrors.isNotEmpty)
-                  Align(
-                    alignment: Alignment.bottomRight,
-                    child: FilledButton(
-                      onPressed: () async => await controller.validateLinks(),
-                      child: const Text('Recheck all'),
-                    ),
+                Align(
+                  alignment: Alignment.bottomRight,
+                  child: FilledButton(
+                    onPressed: () async =>
+                        await controller.loadAndValidateAndroidAppLinks(),
+                    child: const Text('Recheck all'),
                   ),
+                ),
                 if (viewType == TableViewType.domainView)
                   _DomainAssociatedLinksPanel(controller: controller),
                 const SizedBox(height: largeSpacing),

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -65,8 +65,7 @@ class ValidationDetailView extends StatelessWidget {
                 Align(
                   alignment: Alignment.bottomRight,
                   child: FilledButton(
-                    onPressed: () async =>
-                        await controller.loadAndroidAppLinksAndValidate(),
+                    onPressed: controller.loadAndroidAppLinksAndValidate,
                     child: const Text('Recheck all'),
                   ),
                 ),


### PR DESCRIPTION
before: the `recheck` button is only displayed when there are domain errors, tap it will call the rpc to re-check web checks.

after:   the `recheck` button is always displayed, tap it will reload all links from the project, recheck app checks and web checks.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
