### PR TITLE
Switch back to dart:html for postMessage

### DIFF
--- a/packages/devtools_app/lib/src/shared/config_specific/copy_to_clipboard/_copy_to_clipboard_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/copy_to_clipboard/_copy_to_clipboard_web.dart
@@ -2,18 +2,17 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-import 'dart:js_interop';
-import 'package:web/web.dart';
+import '../post_message/post_message.dart';
 
 void copyToClipboardVSCode(String data) {
   // This post message is only relevant in VSCode. If the parent frame is
   // listening for this command, then it will attempt to copy the contents
   // to the clipboard in the context of the parent frame.
-  window.parent?.postMessage(
+  postMessage(
     {
       'command': 'clipboard-write',
       'data': data,
-    }.jsify(),
-    '*'.toJS,
+    },
+    '*',
   );
 }

--- a/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -12,6 +12,7 @@ import '../../../service/service_manager.dart';
 import '../../globals.dart';
 import '../../primitives/storage.dart';
 import '../../server/server_api_client.dart';
+import '../post_message/post_message.dart';
 
 /// Return the url the application is launched from.
 Future<String> initializePlatform() async {
@@ -82,9 +83,9 @@ void _sendKeyPressToParent(KeyboardEvent event) {
     'repeat': event.repeat,
     'shiftKey': event.shiftKey,
   };
-  window.parent?.postMessage(
-    {'command': 'keydown', 'data': data}.jsify(),
-    '*'.toJS,
+  postMessage(
+    {'command': 'keydown', 'data': data},
+    '*',
   );
 }
 

--- a/packages/devtools_app/lib/src/shared/config_specific/launch_url/_launch_url_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/launch_url/_launch_url_web.dart
@@ -2,16 +2,14 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-import 'dart:js_interop';
-
-import 'package:web/web.dart';
+import '../post_message/post_message.dart';
 
 void launchUrlVSCode(String url) {
-  window.parent?.postMessage(
+  postMessage(
     {
       'command': 'launchUrl',
       'data': {'url': url},
-    }.jsify(),
-    '*'.toJS,
+    },
+    '*',
   );
 }

--- a/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-// ignore: avoid_web_libraries_in_flutter
+// ignore: avoid_web_libraries_in_flutter, workaround for https://github.com/dart-lang/sdk/issues/54938
 import 'dart:html' as html;
 import 'dart:js_interop';
 

--- a/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/post_message/_post_message_web.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
 import 'dart:js_interop';
 
 import 'package:web/web.dart';
@@ -18,4 +20,10 @@ Stream<PostMessageEvent> get onPostMessage {
 }
 
 void postMessage(Object? message, String targetOrigin) =>
-    window.parent?.postMessage(message.jsify(), targetOrigin.toJS);
+    // TODO(dantup): Switch back to package:web version of this code once
+    //  https://github.com/dart-lang/sdk/issues/54938 is fixed.
+    //
+    // package:web version:
+    //   window.parent?.postMessage(message.jsify(), targetOrigin.toJS);
+    // legacy dart:html version:
+    html.window.parent?.postMessage(message, targetOrigin);


### PR DESCRIPTION
This is a workaround for https://github.com/dart-lang/sdk/issues/54938 because the `package:web` version of `postMessage` causes security exceptions.

Fixes https://github.com/Dart-Code/Dart-Code/issues/5049

@kenzieschmoll @jacob314 I verified running DevTools from source had the issue shown in the bug above, and with this change it can communicate with VS Code correctly:

![image](https://github.com/flutter/devtools/assets/1078012/44fe1532-86e2-4a48-977c-e0601a59b549)

I don't know if a release has been made for the next beta already, but if so this might need to be included (I'm assuming https://github.com/dart-lang/sdk/issues/54938 won't be fixed before then.. if it is, we can ofcourse drop this).

I don't know if there are other implications of using `dart:html` here (since work had been done to remove it).

(This also reinforces that we need a better way to test all of this end-to-end against bleeding-edge code!).