### PR TITLE
Only display 'Performance Settings' for Flutter applications

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_controls.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_controls.dart
@@ -130,11 +130,12 @@ class _SecondaryPerformanceControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final isFlutterApp =
+        serviceConnection.serviceManager.connectedApp!.isFlutterAppNow!;
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        if (serviceConnection
-            .serviceManager.connectedApp!.isFlutterAppNow!) ...[
+        if (isFlutterApp) ...[
           ServiceExtensionButtonGroup(
             minScreenWidthForTextBeforeScaling:
                 PerformanceControls.minScreenWidthForTextBeforeScaling,
@@ -152,12 +153,14 @@ class _SecondaryPerformanceControls extends StatelessWidget {
           screenId: ScreenMetaData.performance.id,
           onSave: controller.exportData,
         ),
-        const SizedBox(width: denseSpacing),
-        SettingsOutlinedButton(
-          gaScreen: gac.performance,
-          gaSelection: gac.PerformanceEvents.performanceSettings.name,
-          onPressed: () => _openSettingsDialog(context),
-        ),
+        if (isFlutterApp) ...[
+          const SizedBox(width: denseSpacing),
+          SettingsOutlinedButton(
+            gaScreen: gac.performance,
+            gaSelection: gac.PerformanceEvents.performanceSettings.name,
+            onPressed: () => _openSettingsDialog(context),
+          ),
+        ],
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/performance_settings.dart
@@ -17,6 +17,9 @@ class PerformanceSettingsDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // This settings dialog currently only supports settings for Flutter apps
+    // and shouldn't be accessible for Dart CLI programs.
+    assert(serviceConnection.serviceManager.connectedApp!.isFlutterAppNow!);
     return DevToolsDialog(
       title: const DialogTitleText('Performance Settings'),
       includeDivider: false,
@@ -24,12 +27,9 @@ class PerformanceSettingsDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          if (serviceConnection
-              .serviceManager.connectedApp!.isFlutterAppNow!) ...[
-            FlutterSettings(
-              flutterFramesController: controller.flutterFramesController,
-            ),
-          ],
+          FlutterSettings(
+            flutterFramesController: controller.flutterFramesController,
+          ),
         ],
       ),
       actions: const [

--- a/packages/devtools_app/test/performance/controls/performance_controls_test.dart
+++ b/packages/devtools_app/test/performance/controls/performance_controls_test.dart
@@ -102,7 +102,7 @@ void main() {
         expect(find.text('Enhance Tracing'), findsNothing);
         expect(find.text('More debugging options'), findsNothing);
         expect(find.byType(OpenSaveButtonGroup), findsOneWidget);
-        expect(find.byIcon(Icons.settings_outlined), findsOneWidget);
+        expect(find.byIcon(Icons.settings_outlined), findsNothing);
       },
     );
 


### PR DESCRIPTION
The 'Performance Settings' dialog on the Performance page only contains settings for Flutter applications and would render a mostly empty dialog when DevTools was connected to a Dart CLI application.