### PR TITLE
Compile devtools with `release` mode (no dart2js optimization set)

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -62,7 +62,7 @@ flutter pub get
 flutter build web \
   --web-renderer canvaskit \
   --pwa-strategy=offline-first \
-  --profile \
+  --release \
   --no-tree-shake-icons
 
 # Ensure permissions are set correctly on canvaskit binaries.

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -62,8 +62,7 @@ flutter pub get
 flutter build web \
   --web-renderer canvaskit \
   --pwa-strategy=offline-first \
-  --dart2js-optimization=O1 \
-  --release \
+  --profile \
   --no-tree-shake-icons
 
 # Ensure permissions are set correctly on canvaskit binaries.

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -85,7 +85,6 @@ class BuildCommand extends Command {
     );
 
     logStatus('building DevTools in release mode');
-    final mode = buildMode == 'release' ? 'profile' : buildMode;
     await processManager.runAll(
       commands: [
         if (runPubGet) CliCommand.tool(['pub-get', '--only-main']),
@@ -96,7 +95,7 @@ class BuildCommand extends Command {
             '--web-renderer',
             'canvaskit',
             '--pwa-strategy=offline-first',
-            if (mode != 'debug') '--$mode',
+            if (buildMode != 'debug') '--$buildMode',
             '--no-tree-shake-icons',
           ],
         ),

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -85,6 +85,7 @@ class BuildCommand extends Command {
     );
 
     logStatus('building DevTools in release mode');
+    final mode = buildMode == 'release' ? 'profile' : buildMode;
     await processManager.runAll(
       commands: [
         if (runPubGet) CliCommand.tool(['pub-get', '--only-main']),
@@ -95,9 +96,7 @@ class BuildCommand extends Command {
             '--web-renderer',
             'canvaskit',
             '--pwa-strategy=offline-first',
-            // Enable default optimizations: https://dart.dev/tools/dart-compile#js
-            '--dart2js-optimization=O1',
-            if (buildMode != 'debug') '--$buildMode',
+            if (mode != 'debug') '--$mode',
             '--no-tree-shake-icons',
           ],
         ),


### PR DESCRIPTION
Fixes https://github.com/Dart-Code/Dart-Code/issues/5049

Without this change, seeing infinite spinner:

![Screenshot 2024-03-27 at 2 33 21 PM](https://github.com/flutter/devtools/assets/21270878/ef00dcd2-0705-4cd1-8dd5-05321a27bfe8)

With this change, Flutter sidebar loads:

![Screenshot 2024-03-27 at 2 39 49 PM](https://github.com/flutter/devtools/assets/21270878/9d00c614-8c04-4092-a36d-86694f330a9b)

