### PR TITLE
Add 'example' to the package root regexp

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -55,7 +55,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## DevTools Extension updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed an issue preventing extensions to load for run targets under the `example`
+directory. - [#7533](https://github.com/flutter/devtools/pull/7533)
 
 ## Full commit history
 

--- a/packages/devtools_shared/lib/src/utils/file_utils.dart
+++ b/packages/devtools_shared/lib/src/utils/file_utils.dart
@@ -12,7 +12,7 @@ String packageRootFromFileUriString(String fileUriString) {
   // server and having the server look for the package folder that contains the
   // `.dart_tool` directory.
   final directoryRegExp =
-      RegExp(r'\/(lib|bin|integration_test|test|benchmark)\/.+\.dart');
+      RegExp(r'\/(lib|bin|integration_test|test|benchmark|example)\/.+\.dart');
   final directoryIndex = fileUriString.indexOf(directoryRegExp);
   if (directoryIndex != -1) {
     fileUriString = fileUriString.substring(0, directoryIndex);


### PR DESCRIPTION
I will follow up with work to do this properly using DTD.

Fixes https://github.com/flutter/devtools/issues/7240.