### PR TITLE
Fix issue with io dependencies

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -24,8 +24,8 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
-  devtools_app_shared: ^0.1.1-dev.0
-  devtools_extensions: ^0.1.1-dev.0
+  devtools_app_shared: ^0.1.1
+  devtools_extensions: ^0.1.1
   devtools_shared: ^8.1.1
   dtd: ^2.2.0
   file: ">=6.0.0 <8.0.0"

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -24,9 +24,9 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^1.6.0
-  devtools_app_shared: ^0.1.1
-  devtools_extensions: ^0.1.1
-  devtools_shared: ^8.1.1
+  devtools_app_shared: ^0.2.0-dev.0
+  devtools_extensions: ^0.2.0-dev.0
+  devtools_shared: ^9.0.1
   dtd: ^2.2.0
   file: ">=6.0.0 <8.0.0"
   file_selector: ^1.0.0

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,5 +1,6 @@
-## 0.1.2-wip
+## 0.2.0-dev.0
 * Add `tooltipWaitExtraLong` to `utils.dart`.
+* Bump `devtools_shared` dependency to `^9.0.1`.
 
 ## 0.1.1
 * Update `package:dtd` to `^2.1.0`

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.1.1
+version: 0.2.0-dev.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  devtools_shared: ^8.1.1
+  devtools_shared: ^9.0.1
   dtd: ^2.1.0
   flutter:
     sdk: flutter

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.2.0-dev.0
+* Bump `devtools_shared` dependency to `^9.0.1`.
+
 ## 0.1.1
 * Update the simulated environment help dialogs with information about the
 new `--print-dtd` CLI flag.

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.1.1
+version: 0.2.0-dev.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
@@ -13,8 +13,8 @@ executables:
 
 dependencies:
   args: ^2.4.2
-  devtools_shared: ^8.1.1
-  devtools_app_shared: ^0.1.1
+  devtools_shared: ^9.0.1
+  devtools_app_shared: ^0.2.0-dev.0
   flutter:
     sdk: flutter
   io: ^1.0.4

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.0.1
+* Restructure `devtools_extensions.dart` and `devtools_extensions_io.dart` libraries.
+
 # 9.0.0
 * **Breaking change:** remove parameter `analytics` from `ServerApi.handle` in favor
 of DTD implementation.

--- a/packages/devtools_shared/lib/devtools_extensions.dart
+++ b/packages/devtools_shared/lib/devtools_extensions.dart
@@ -2,5 +2,5 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'src/extensions/extension_manager.dart';
+export 'src/extensions/constants.dart';
 export 'src/extensions/extension_model.dart';

--- a/packages/devtools_shared/lib/devtools_extensions_io.dart
+++ b/packages/devtools_shared/lib/devtools_extensions_io.dart
@@ -3,4 +3,5 @@
 // found in the LICENSE file.
 
 export 'src/extensions/extension_enablement.dart';
+export 'src/extensions/extension_manager.dart';
 export 'src/extensions/yaml_utils.dart';

--- a/packages/devtools_shared/lib/src/extensions/constants.dart
+++ b/packages/devtools_shared/lib/src/extensions/constants.dart
@@ -1,0 +1,7 @@
+// Copyright (c) 2024, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+/// Location where DevTools extension assets will be served, relative to where
+/// DevTools assets are served (build/).
+const extensionRequestPath = 'devtools_extensions';

--- a/packages/devtools_shared/lib/src/extensions/extension_manager.dart
+++ b/packages/devtools_shared/lib/src/extensions/extension_manager.dart
@@ -8,10 +8,6 @@ import 'package:path/path.dart' as path;
 
 import 'extension_model.dart';
 
-/// Location where DevTools extension assets will be served, relative to where
-/// DevTools assets are served (build/).
-const extensionRequestPath = 'devtools_extensions';
-
 /// The default location for the DevTools extension, relative to
 /// `<parent_package_root>/extension/devtools/`.
 const extensionBuildDefault = 'build';

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 9.0.0
+version: 9.0.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 

--- a/packages/devtools_shared/test/utils/retry_test.dart
+++ b/packages/devtools_shared/test/utils/retry_test.dart
@@ -64,8 +64,7 @@ void main() {
       expect(counter, 10);
     });
 
-    test('stops early without exception if stopCondition is met',
-        () async {
+    test('stops early without exception if stopCondition is met', () async {
       expect(counter, 0);
       await runWithRetry(
         callback: () => callback(succeedOnAttempt: 5),

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -2,7 +2,10 @@ name: devtools_test
 description: A package containing shared test helpers for Dart DevTools tests.
 publish_to: none
 
-# Note: this version should only be updated by running tools/update_version.dart
+# TODO(kenz): remove the version field here since this package is never published
+# nor depended upon by anything other than a path dependency.
+
+# Note: this version should only be updated by running devtools_tool update-version
 # that updates all versions of packages from packages/devtools.
 # When publishing new versions of this package be sure to publish a new version
 # of package:devtools as well. package:devtools contains a compiled snapshot of
@@ -18,7 +21,10 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: ^6.0.1
+  devtools_shared:
+    path: ../devtools_shared
+  # TODO(kenz): use a path dependency here since devtools_app is never published.
+  # This will require updating the `devtools_tool update-version` command.
   devtools_app: 2.35.0-dev.8
   devtools_app_shared:
     path: ../devtools_app_shared


### PR DESCRIPTION
This prevents build issues in g3 where io deps are not tree shaken out. Will publish these changes as devtools_shared 9.0.1.