### PR TITLE
Clean up `devtools_test` versioning

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -71,7 +71,8 @@ dependencies:
 dev_dependencies:
   args: ^2.4.2
   build_runner: ^2.3.3
-  devtools_test: 2.35.0-dev.8
+  devtools_test:
+    path: ../devtools_test
   fake_async: ^1.3.1
   flutter_driver:
     sdk: flutter

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -11,12 +11,12 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared:
-    path: ../devtools_shared
   devtools_app:
     path: ../devtools_app
   devtools_app_shared:
     path: ../devtools_app_shared
+  devtools_shared:
+    path: ../devtools_shared
   flutter:
     sdk: flutter
   flutter_test:

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -2,13 +2,6 @@ name: devtools_test
 description: A package containing shared test helpers for Dart DevTools tests.
 publish_to: none
 
-# Note: this version should only be updated by running tools/update_version.dart
-# that updates all versions of packages from packages/devtools.
-# When publishing new versions of this package be sure to publish a new version
-# of package:devtools as well. package:devtools contains a compiled snapshot of
-# this package.
-version: 2.35.0-dev.8
-
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_test
 
 environment:
@@ -18,8 +11,10 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
-  devtools_shared: ^6.0.1
-  devtools_app: 2.35.0-dev.8
+  devtools_shared:
+    path: ../devtools_shared
+  devtools_app:
+    path: ../devtools_app
   devtools_app_shared:
     path: ../devtools_app_shared
   flutter:


### PR DESCRIPTION
The `devtools_test` package is never published and is only ever used from `devtools_app` as a path dependency, or in g3 as a BUILD file dependency. So we do not need to maintain a versioning strategy for this file.

This PR updates the `devtools_tool update-version` command accordingly.