### PR TITLE
Migrate to new bootstrapping methods.

### DIFF
--- a/packages/devtools_app/web/flutter_bootstrap.js
+++ b/packages/devtools_app/web/flutter_bootstrap.js
@@ -1,0 +1,46 @@
+{{flutter_js}}
+{{flutter_build_config}}
+
+// Unregister the old custom DevTools service worker (if it exists). It was
+// removed in: https://github.com/flutter/devtools/pull/5331
+function unregisterDevToolsServiceWorker() {
+  if ('serviceWorker' in navigator) {
+    const DEVTOOLS_SW = 'service_worker.js';
+    const FLUTTER_SW = 'flutter_service_worker.js';
+    navigator.serviceWorker.getRegistrations().then(function(registrations) {
+        for (let registration of registrations) {
+            const activeWorker = registration.active;
+            if (activeWorker != null) {
+                const url = activeWorker.scriptURL;
+                if (url.includes(DEVTOOLS_SW) && !url.includes(FLUTTER_SW)) {
+                    registration.unregister();
+                }
+            }
+        }
+    });
+  }
+}
+
+// Bootstrap app for 3P environments:
+function bootstrapAppFor3P() {
+  _flutter.loader.load({
+    serviceWorkerSettings: {
+      serviceWorkerVersion: {{flutter_service_worker_version}},
+    },
+    config: {
+      canvasKitBaseUrl: 'canvaskit/'
+    }
+  });
+}
+
+// Bootstrap app for 1P environments:
+function bootstrapAppFor1P() {
+  _flutter.loader.load({
+    config: {
+      canvasKitBaseUrl: 'canvaskit/'
+    }
+  });
+}
+
+unregisterDevToolsServiceWorker();
+bootstrapAppFor3P();

--- a/packages/devtools_app/web/flutter_bootstrap.js
+++ b/packages/devtools_app/web/flutter_bootstrap.js
@@ -35,11 +35,7 @@ function bootstrapAppFor3P() {
 
 // Bootstrap app for 1P environments:
 function bootstrapAppFor1P() {
-  _flutter.loader.load({
-    config: {
-      canvasKitBaseUrl: 'canvaskit/'
-    }
-  });
+  _flutter.loader.load();
 }
 
 unregisterDevToolsServiceWorker();

--- a/packages/devtools_app/web/index.html
+++ b/packages/devtools_app/web/index.html
@@ -50,83 +50,13 @@
     }
   </script>
 
-  <script>
-    // The value below is injected by flutter build, do not touch.
-    var serviceWorkerVersion = null;
-  </script>
-  <!-- This script adds the flutter initialization JS code -->
-  <script src="flutter.js" defer></script> 
-
   <!-- TODO(elliette): Remove once https://github.com/flutter/flutter/issues/122541 is fixed. -->
   <link rel="stylesheet" href="styles.css">
 
 </head>
 
 <body>
-
-  <script>
-    // Unregister the old custom DevTools service worker (if it exists). It was
-    // removed in: https://github.com/flutter/devtools/pull/5331
-    function unregisterDevToolsServiceWorker() {
-      if ('serviceWorker' in navigator) {
-        const DEVTOOLS_SW = 'service_worker.js';
-        const FLUTTER_SW = 'flutter_service_worker.js';
-        navigator.serviceWorker.getRegistrations().then(function(registrations) {
-            for (let registration of registrations) {
-                const activeWorker = registration.active;
-                if (activeWorker != null) {
-                    const url = activeWorker.scriptURL;
-                    if (url.includes(DEVTOOLS_SW) && !url.includes(FLUTTER_SW)) {
-                        registration.unregister();
-                    }
-                }
-            }
-        });
-      }
-    }
-
-    // Bootstrap app for 3P environments:
-    function bootstrapAppFor3P() {
-      window.addEventListener('load', function(ev) {
-        // Download main.dart.js
-        _flutter.loader.loadEntrypoint({
-          serviceWorker: {
-            serviceWorkerVersion: serviceWorkerVersion,
-          },
-          onEntrypointLoaded: function(engineInitializer) {
-            engineInitializer.initializeEngine({
-              renderer: 'canvaskit',
-              canvasKitBaseUrl: 'canvaskit/'
-            })
-            .then(function(appRunner) {
-              appRunner.runApp();
-            });
-          }
-        });
-      });
-    }
-
-    // Bootstrap app for 1P environments:
-    function bootstrapAppFor1P() {
-      window.addEventListener('load', function(ev) {
-        // Download main.dart.js
-        _flutter.loader.loadEntrypoint({
-          entrypointUrl: 'main.dart.js',
-          onEntrypointLoaded: function(engineInitializer) {
-            engineInitializer.initializeEngine({
-              renderer: 'canvaskit',
-            })
-            .then(function(appRunner) {
-              appRunner.runApp();
-            });
-          }
-        });
-      });
-    }
-
-    unregisterDevToolsServiceWorker();
-    bootstrapAppFor3P();
-  </script>
+  <script src="flutter_bootstrap.js" async></script>
 </body>
 
 </html>


### PR DESCRIPTION
This fixes https://github.com/flutter/devtools/issues/7444

* Moves bootstrapping logic into templated `flutter_bootstrap.js` file.
* Changes to `FlutterLoader.load()` API from `FlutterLoader.loadEntrypoint()` API.