### PR TITLE
Add a helper for running DevTools extensions tests

### DIFF
--- a/packages/devtools_app/test/shared/json_to_service_cache_test.dart
+++ b/packages/devtools_app/test/shared/json_to_service_cache_test.dart
@@ -137,41 +137,43 @@ void main() {
     });
   });
 
-  test('instanceToJson converts Instances back to the JSON that created them',
-      () {
-    const data = <String, Object?>{
-      'id': 1,
-      'map': {
-        'foo': 'bar',
-        'baz': [
-          'a',
-          null,
-        ],
-      },
-      'list': [
-        [
-          7,
-          '8',
-          9.0,
-        ],
-        1,
-        '2',
-        4.9,
-        true,
-        null,
-        {
-          'a': 'b',
-          'c': 'd',
+  test(
+    'instanceToJson converts Instances back to the JSON that created them',
+    () {
+      const data = <String, Object?>{
+        'id': 1,
+        'map': {
+          'foo': 'bar',
+          'baz': [
+            'a',
+            null,
+          ],
         },
-      ],
-      'aNullValue': null,
-    };
+        'list': [
+          [
+            7,
+            '8',
+            9.0,
+          ],
+          1,
+          '2',
+          4.9,
+          true,
+          null,
+          {
+            'a': 'b',
+            'c': 'd',
+          },
+        ],
+        'aNullValue': null,
+      };
 
-    final cache = JsonToServiceCache();
-    final root = cache.insertJsonObject(data);
+      final cache = JsonToServiceCache();
+      final root = cache.insertJsonObject(data);
 
-    final rootConvertedBackToJson = cache.instanceToJson(root);
+      final rootConvertedBackToJson = cache.instanceToJson(root);
 
-    expect(rootConvertedBackToJson, data);
-  });
+      expect(rootConvertedBackToJson, data);
+    },
+  );
 }

--- a/packages/devtools_shared/test/helpers/extension_test_manager.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager.dart
@@ -1,0 +1,387 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+import 'package:test/test.dart';
+
+import 'helpers.dart';
+
+class ExtensionTestManager {
+  /// The Directory for this test.
+  ///
+  /// This should be created and destroyed for each test.
+  Directory get testDirectory => _testDirectory!;
+  Directory? _testDirectory;
+
+  /// The `file://` URI for the directory containing the Dart packages we will
+  /// detect extensions for.
+  Uri get packagesRootUri => _packagesRootUri!;
+  Uri? _packagesRootUri;
+
+  /// The `file://` URI string for the package root of the app that we may
+  /// consider DevTools connected to for testing the extension APIs.
+  String get runtimeAppRoot => _runtimeAppRoot!;
+  String? _runtimeAppRoot;
+
+  Future<void> reset() async {
+    // Run with retry to ensure this deletes properly on Windows.
+    await deleteDirectoryWithRetry(testDirectory);
+    _testDirectory = null;
+    _packagesRootUri = null;
+    _runtimeAppRoot = null;
+  }
+
+  /// packages/
+  ///   my_app/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  ///   other_root_1/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  ///   other_root_2/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  /// extensions/
+  ///   static_extension_1/
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  ///     pubspec.yaml
+  ///   static_extension_2/
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  ///     pubspec.yaml
+  ///   newer/
+  ///     static_extension_1/
+  ///       extension/
+  ///         devtools/
+  ///           build/
+  ///           config.yaml
+  ///       pubspec.yaml
+  ///   bad_extension/            # Only added when [includeBadExtension] is true.
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  ///     pubspec.yaml
+  Future<void> setupTestDirectoryStructure({
+    bool includeDependenciesWithExtensions = true,
+    bool includeBadExtension = false,
+  }) async {
+    _testDirectory = Directory.systemTemp.createTempSync();
+
+    _setupPackages(
+      includeDependenciesWithExtensions: includeDependenciesWithExtensions,
+      includeBadExtension: includeBadExtension,
+    );
+    _setupExtensions(includeBadExtension: includeBadExtension);
+
+    // Generate the .dart_tool/package_config.json file for each Dart package.
+    final testDirectoryContents = testDirectory.listSync();
+    expect(testDirectoryContents.length, 2);
+    final packageRoots =
+        Directory.fromUri(packagesRootUri).listSync().whereType<Directory>();
+    expect(packageRoots.length, 3);
+
+    for (final packageRoot in packageRoots) {
+      expect(File(p.join(packageRoot.path, 'pubspec.yaml')).existsSync(), true);
+
+      // Run `dart pub get` on this package to generate the
+      // `.dart_tool/package_config.json` file.
+      final process = await Process.run(
+        Platform.resolvedExecutable,
+        ['pub', 'get'],
+        workingDirectory: packageRoot.path,
+      );
+      if (process.exitCode != 0) {
+        throw Exception(
+          'Encountered error while running pub get. Exit code: '
+          '${process.exitCode}, error: ${process.stderr}.',
+        );
+      }
+
+      final packageConfigFile = File(
+        p.join(packageRoot.path, '.dart_tool', 'package_config.json'),
+      );
+      expect(packageConfigFile.existsSync(), isTrue);
+    }
+  }
+
+  /// packages/
+  ///   my_app/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  ///   other_root_1/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  ///   other_root_2/
+  ///     .dart_tool/             # Generated from 'pub get'
+  ///       package_config.json   # Generated from 'pub get'
+  ///     pubspec.yaml
+  void _setupPackages({
+    required bool includeDependenciesWithExtensions,
+    required bool includeBadExtension,
+  }) {
+    _setupPackage(
+      createTestPackageFrom(
+        includeBadExtension ? myAppPackageWithBadExtension : myAppPackage,
+        includeDependenciesWithExtensions: includeDependenciesWithExtensions,
+      ),
+      isRuntimeRoot: true,
+    );
+    _setupPackage(
+      createTestPackageFrom(
+        otherRoot1Package,
+        includeDependenciesWithExtensions: includeDependenciesWithExtensions,
+      ),
+    );
+    _setupPackage(
+      createTestPackageFrom(
+        otherRoot2Package,
+        includeDependenciesWithExtensions: includeDependenciesWithExtensions,
+      ),
+    );
+  }
+
+  /// extensions/
+  ///   bad_extension/            # Only added when [includeBadExtension] is true.
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  ///     pubspec.yaml
+  ///   newer/
+  ///     static_extension_1/
+  ///       extension/
+  ///         devtools/
+  ///           build/
+  ///           config.yaml
+  ///   static_extension_1/
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  ///   static_extension_2/
+  ///     extension/
+  ///       devtools/
+  ///         build/
+  ///         config.yaml
+  void _setupExtensions({required bool includeBadExtension}) {
+    _setupExtension(staticExtension1Package);
+    _setupExtension(staticExtension2Package);
+
+    // This extension is a duplicate of 'static_extension_1' with a newer
+    // version (2.0.0 vs 1.0.0), and it lives in a different directory.
+    _setupExtension(newerStaticExtension1Package);
+
+    if (includeBadExtension) _setupExtension(badExtensionPackage);
+  }
+
+  void _setupPackage(TestPackage package, {bool isRuntimeRoot = false}) {
+    final packagesDirectory = Directory(p.join(testDirectory.path, 'packages'))
+      ..createSync(recursive: true);
+    _packagesRootUri = Uri.file(packagesDirectory.uri.toFilePath());
+
+    final projectRootDirectory =
+        Directory(p.join(packagesDirectory.path, package.name))
+          ..createSync(recursive: true);
+    if (isRuntimeRoot) {
+      final directoryPath =
+          Uri.file(projectRootDirectory.uri.toFilePath()).toString();
+      // Remove the trailing slash and set the value of [packagesRoot].
+      _runtimeAppRoot = directoryPath.substring(0, directoryPath.length - 1);
+    }
+
+    File(p.join(projectRootDirectory.path, 'pubspec.yaml'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(package.pubspecContent, flush: true);
+  }
+
+  void _setupExtension(TestPackageWithExtension package) {
+    final extensionDirectory = Directory(
+      p.join(
+        testDirectory.path,
+        'extensions',
+        package.relativePathFromExtensions,
+      ),
+    )..createSync(recursive: true);
+    final extensionDir =
+        Directory(p.join(extensionDirectory.path, 'extension', 'devtools'))
+          ..createSync(recursive: true);
+    Directory(p.join(extensionDir.path, 'build')).createSync(recursive: true);
+
+    File(p.join(extensionDir.path, 'config.yaml'))
+      ..createSync()
+      ..writeAsStringSync(package.configYamlContent, flush: true);
+
+    File(p.join(extensionDirectory.path, 'pubspec.yaml'))
+      ..createSync(recursive: true)
+      ..writeAsStringSync(package.pubspecContent, flush: true);
+  }
+}
+
+TestPackage createTestPackageFrom(
+  TestPackage originalPackage, {
+  required bool includeDependenciesWithExtensions,
+}) {
+  return TestPackage(
+    name: originalPackage.name,
+    dependencies:
+        includeDependenciesWithExtensions ? originalPackage.dependencies : [],
+  );
+}
+
+final myAppPackage = TestPackage(
+  name: 'my_app',
+  dependencies: [driftPackage, providerPackage, staticExtension1Package],
+);
+final myAppPackageWithBadExtension = TestPackage(
+  name: myAppPackage.name,
+  dependencies: [...myAppPackage.dependencies, badExtensionPackage],
+);
+final otherRoot1Package = TestPackage(
+  name: 'other_root_1',
+  dependencies: [staticExtension1Package, staticExtension2Package],
+);
+final otherRoot2Package = TestPackage(
+  name: 'other_root_2',
+  dependencies: [newerStaticExtension1Package],
+);
+
+final driftPackage = TestPackageWithExtension(
+  name: 'drift',
+  issueTracker: 'https://github.com/simolus3/drift/issues',
+  version: '0.0.1',
+  materialIconCodePoint: 62494,
+  requiresConnection: true,
+  isPubliclyHosted: true,
+  packageVersion: '2.16.0',
+);
+final providerPackage = TestPackageWithExtension(
+  name: 'provider',
+  issueTracker: 'https://github.com/rrousselGit/provider/issues',
+  version: '0.0.1',
+  materialIconCodePoint: 57521,
+  requiresConnection: true,
+  isPubliclyHosted: true,
+  packageVersion: '6.1.2',
+);
+final staticExtension1Package = TestPackageWithExtension(
+  name: 'static_extension_1',
+  issueTracker: 'https://www.google.com/',
+  version: '1.0.0',
+  materialIconCodePoint: 0xe50a,
+  requiresConnection: false,
+  isPubliclyHosted: false,
+  packageVersion: null,
+);
+final staticExtension2Package = TestPackageWithExtension(
+  name: 'static_extension_2',
+  issueTracker: 'https://www.google.com/',
+  version: '2.0.0',
+  materialIconCodePoint: 0xe50a,
+  requiresConnection: false,
+  isPubliclyHosted: false,
+  packageVersion: null,
+);
+final newerStaticExtension1Package = TestPackageWithExtension(
+  name: 'static_extension_1',
+  issueTracker: 'https://www.google.com/',
+  version: '2.0.0',
+  materialIconCodePoint: 0xe50a,
+  requiresConnection: false,
+  isPubliclyHosted: false,
+  packageVersion: null,
+  relativePathFromExtensions: p.join('newer', 'static_extension_1'),
+);
+final badExtensionPackage = TestPackageWithExtension(
+  // Extension names must be only lowercase letters and underscores.
+  name: 'BAD_EXTENSION',
+  issueTracker: 'https://www.google.com/',
+  version: '1.0.0',
+  materialIconCodePoint: 0xe50a,
+  requiresConnection: true,
+  isPubliclyHosted: false,
+  packageVersion: null,
+);
+
+class TestPackageWithExtension {
+  TestPackageWithExtension({
+    required this.name,
+    required this.issueTracker,
+    required this.version,
+    required this.materialIconCodePoint,
+    required this.requiresConnection,
+    required this.isPubliclyHosted,
+    required this.packageVersion,
+    String? relativePathFromExtensions,
+  })  : assert(isPubliclyHosted == (packageVersion != null)),
+        relativePathFromExtensions =
+            relativePathFromExtensions ?? name.toLowerCase();
+
+  final String name;
+  final String issueTracker;
+  final String version;
+  final Object? materialIconCodePoint;
+  final bool requiresConnection;
+  final bool isPubliclyHosted;
+  final String? packageVersion;
+  final String relativePathFromExtensions;
+
+  String get configYamlContent => '''
+name: $name
+issueTracker: $issueTracker
+version: $version
+materialIconCodePoint: $materialIconCodePoint
+${!requiresConnection ? 'requiresConnection: false' : ''}
+''';
+
+  String get pubspecContent => '''
+name: ${name.toLowerCase()}
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+''';
+}
+
+class TestPackage {
+  const TestPackage({required this.name, required this.dependencies});
+
+  final String name;
+  final List<TestPackageWithExtension> dependencies;
+
+  String get pubspecContent => '''
+name: $name
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+${_dependenciesAsString()}
+''';
+
+  String _dependenciesAsString() {
+    final sb = StringBuffer();
+    for (final dep in dependencies) {
+      sb.write('  ${dep.name.toLowerCase()}:');
+      if (dep.isPubliclyHosted) {
+        sb.writeln(' ${dep.packageVersion!}');
+      } else {
+        sb
+          ..writeln() // Add a new line for the path dependency.
+          ..writeln(
+            '    path: ../../extensions/${dep.relativePathFromExtensions}',
+          );
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
@@ -1,0 +1,309 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:test/test.dart';
+
+import 'extension_test_manager.dart';
+
+void main() {
+  group('$ExtensionTestManager', () {});
+
+  group('$TestPackageWithExtension', () {
+    test('$driftPackage', () {
+      expect(driftPackage.name, 'drift');
+      expect(
+        driftPackage.issueTracker,
+        'https://github.com/simolus3/drift/issues',
+      );
+      expect(driftPackage.version, '0.0.1');
+      expect(driftPackage.materialIconCodePoint, 62494);
+      expect(driftPackage.requiresConnection, true);
+      expect(driftPackage.isPubliclyHosted, true);
+      expect(driftPackage.packageVersion, '2.16.0');
+      expect(driftPackage.relativePathFromExtensions, driftPackage.name);
+    });
+
+    test('$providerPackage', () {
+      expect(providerPackage.name, 'provider');
+      expect(
+        providerPackage.issueTracker,
+        'https://github.com/rrousselGit/provider/issues',
+      );
+      expect(providerPackage.version, '0.0.1');
+      expect(providerPackage.materialIconCodePoint, 57521);
+      expect(providerPackage.requiresConnection, true);
+      expect(providerPackage.isPubliclyHosted, true);
+      expect(providerPackage.packageVersion, '6.1.2');
+      expect(providerPackage.relativePathFromExtensions, providerPackage.name);
+    });
+
+    test('$staticExtension1Package', () {
+      expect(staticExtension1Package.name, 'static_extension_1');
+      expect(staticExtension1Package.issueTracker, 'https://www.google.com/');
+      expect(staticExtension1Package.version, '1.0.0');
+      expect(staticExtension1Package.materialIconCodePoint, 0xe50a);
+      expect(staticExtension1Package.requiresConnection, false);
+      expect(staticExtension1Package.isPubliclyHosted, false);
+      expect(staticExtension1Package.packageVersion, null);
+      expect(
+        staticExtension1Package.relativePathFromExtensions,
+        staticExtension1Package.name,
+      );
+      expect(
+        staticExtension1Package.pubspecContent,
+        '''
+name: static_extension_1
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+''',
+      );
+      expect(
+        staticExtension1Package.configYamlContent,
+        '''
+name: static_extension_1
+issueTracker: https://www.google.com/
+version: 1.0.0
+materialIconCodePoint: 0xe50a
+requiresConnection: false
+''',
+      );
+    });
+
+    test('$staticExtension2Package', () {
+      expect(staticExtension2Package.name, 'static_extension_2');
+      expect(staticExtension2Package.issueTracker, 'https://www.google.com/');
+      expect(staticExtension2Package.version, '2.0.0');
+      expect(staticExtension2Package.materialIconCodePoint, 0xe50a);
+      expect(staticExtension2Package.requiresConnection, false);
+      expect(staticExtension2Package.isPubliclyHosted, false);
+      expect(staticExtension2Package.packageVersion, null);
+      expect(
+        staticExtension2Package.relativePathFromExtensions,
+        staticExtension2Package.name,
+      );
+      expect(
+        staticExtension2Package.pubspecContent,
+        '''
+name: static_extension_2
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+''',
+      );
+      expect(
+        staticExtension2Package.configYamlContent,
+        '''
+name: static_extension_2
+issueTracker: https://www.google.com/
+version: 2.0.0
+materialIconCodePoint: 0xe50a
+requiresConnection: false
+''',
+      );
+    });
+
+    test('$newerStaticExtension1Package', () {
+      expect(newerStaticExtension1Package.name, 'static_extension_1');
+      expect(
+        newerStaticExtension1Package.issueTracker,
+        'https://www.google.com/',
+      );
+      expect(newerStaticExtension1Package.version, '2.0.0');
+      expect(newerStaticExtension1Package.materialIconCodePoint, 0xe50a);
+      expect(newerStaticExtension1Package.requiresConnection, false);
+      expect(newerStaticExtension1Package.isPubliclyHosted, false);
+      expect(newerStaticExtension1Package.packageVersion, null);
+      expect(
+        newerStaticExtension1Package.relativePathFromExtensions,
+        'newer/static_extension_1',
+      );
+      expect(
+        newerStaticExtension1Package.pubspecContent,
+        '''
+name: static_extension_1
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+''',
+      );
+      expect(
+        newerStaticExtension1Package.configYamlContent,
+        '''
+name: static_extension_1
+issueTracker: https://www.google.com/
+version: 2.0.0
+materialIconCodePoint: 0xe50a
+requiresConnection: false
+''',
+      );
+    });
+
+    test('$badExtensionPackage', () {
+      expect(badExtensionPackage.name, 'BAD_EXTENSION');
+      expect(badExtensionPackage.issueTracker, 'https://www.google.com/');
+      expect(badExtensionPackage.version, '1.0.0');
+      expect(badExtensionPackage.materialIconCodePoint, 0xe50a);
+      expect(badExtensionPackage.requiresConnection, true);
+      expect(badExtensionPackage.isPubliclyHosted, false);
+      expect(badExtensionPackage.packageVersion, null);
+      expect(
+        badExtensionPackage.relativePathFromExtensions,
+        badExtensionPackage.name.toLowerCase(),
+      );
+      expect(
+        badExtensionPackage.pubspecContent,
+        '''
+name: bad_extension
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+''',
+      );
+      expect(
+        badExtensionPackage.configYamlContent,
+        '''
+name: BAD_EXTENSION
+issueTracker: https://www.google.com/
+version: 1.0.0
+materialIconCodePoint: 0xe50a
+
+''',
+      );
+    });
+  });
+
+  group('$TestPackage', () {
+    test('$myAppPackage', () {
+      expect(myAppPackage.name, 'my_app');
+      expect(myAppPackage.dependencies.length, 3);
+      expect(
+        myAppPackage.pubspecContent,
+        '''
+name: my_app
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+  drift: 2.16.0
+  provider: 6.1.2
+  static_extension_1:
+    path: ../../extensions/static_extension_1
+
+''',
+      );
+    });
+
+    test('$myAppPackageWithBadExtension', () {
+      expect(myAppPackageWithBadExtension.name, 'my_app');
+      expect(myAppPackageWithBadExtension.dependencies.length, 4);
+      expect(
+        myAppPackageWithBadExtension.pubspecContent,
+        '''
+name: my_app
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+  drift: 2.16.0
+  provider: 6.1.2
+  static_extension_1:
+    path: ../../extensions/static_extension_1
+  bad_extension:
+    path: ../../extensions/bad_extension
+
+''',
+      );
+    });
+
+    test('$otherRoot1Package', () {
+      expect(otherRoot1Package.name, 'other_root_1');
+      expect(otherRoot1Package.dependencies.length, 2);
+      expect(
+        otherRoot1Package.pubspecContent,
+        '''
+name: other_root_1
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+  static_extension_1:
+    path: ../../extensions/static_extension_1
+  static_extension_2:
+    path: ../../extensions/static_extension_2
+
+''',
+      );
+    });
+
+    test('$otherRoot2Package', () {
+      expect(otherRoot2Package.name, 'other_root_2');
+      expect(otherRoot2Package.dependencies.length, 1);
+      expect(
+        otherRoot2Package.pubspecContent,
+        '''
+name: other_root_2
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+  static_extension_1:
+    path: ../../extensions/newer/static_extension_1
+
+''',
+      );
+    });
+
+    test('createTestPackageFrom when excluding dependencies', () {
+      var pkg = createTestPackageFrom(
+        myAppPackage,
+        includeDependenciesWithExtensions: false,
+      );
+      expect(
+        pkg.pubspecContent,
+        '''
+name: my_app
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+
+''',
+      );
+      pkg = createTestPackageFrom(
+        myAppPackageWithBadExtension,
+        includeDependenciesWithExtensions: false,
+      );
+      expect(
+        pkg.pubspecContent,
+        '''
+name: my_app
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+
+''',
+      );
+      pkg = createTestPackageFrom(
+        otherRoot1Package,
+        includeDependenciesWithExtensions: false,
+      );
+      expect(
+        pkg.pubspecContent,
+        '''
+name: other_root_1
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+
+''',
+      );
+      pkg = createTestPackageFrom(
+        otherRoot2Package,
+        includeDependenciesWithExtensions: false,
+      );
+      expect(
+        pkg.pubspecContent,
+        '''
+name: other_root_2
+environment:
+  sdk: ">=3.4.0-282.1.beta <4.0.0"
+dependencies:
+
+''',
+      );
+    });
+  });
+}

--- a/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
@@ -64,7 +64,7 @@ environment:
 name: static_extension_1
 issueTracker: https://www.google.com/
 version: 1.0.0
-materialIconCodePoint: 0xe50a
+materialIconCodePoint: 58634
 requiresConnection: false
 ''',
       );
@@ -96,7 +96,7 @@ environment:
 name: static_extension_2
 issueTracker: https://www.google.com/
 version: 2.0.0
-materialIconCodePoint: 0xe50a
+materialIconCodePoint: 58634
 requiresConnection: false
 ''',
       );
@@ -131,7 +131,7 @@ environment:
 name: static_extension_1
 issueTracker: https://www.google.com/
 version: 2.0.0
-materialIconCodePoint: 0xe50a
+materialIconCodePoint: 58634
 requiresConnection: false
 ''',
       );
@@ -163,7 +163,7 @@ environment:
 name: BAD_EXTENSION
 issueTracker: https://www.google.com/
 version: 1.0.0
-materialIconCodePoint: 0xe50a
+materialIconCodePoint: 58634
 
 ''',
       );

--- a/packages/devtools_shared/test/helpers/helpers.dart
+++ b/packages/devtools_shared/test/helpers/helpers.dart
@@ -151,3 +151,4 @@ Future<void> deleteDirectoryWithRetry(Directory directory) async {
         print('Failed to delete directory on attempt $attempt. Retrying...'),
   );
 }
+

--- a/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
+++ b/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
@@ -14,10 +14,10 @@ import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 import '../fakes.dart';
+import '../helpers/helpers.dart';
 
 late Directory testDirectory;
 late String projectRoot;
-import '../helpers/helpers.dart';
 
 void main() {
   late ExtensionsManager extensionsManager;

--- a/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
+++ b/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
@@ -14,10 +14,10 @@ import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 import '../fakes.dart';
-import '../helpers.dart';
 
 late Directory testDirectory;
 late String projectRoot;
+import '../helpers/helpers.dart';
 
 void main() {
   late ExtensionsManager extensionsManager;

--- a/packages/devtools_shared/test/server/general_api_test.dart
+++ b/packages/devtools_shared/test/server/general_api_test.dart
@@ -14,7 +14,7 @@ import 'package:shelf/shelf.dart';
 import 'package:test/test.dart';
 
 import '../fakes.dart';
-import '../helpers.dart';
+import '../helpers/helpers.dart';
 
 void main() {
   group('General DevTools server API', () {

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -9,7 +9,7 @@ import 'package:dtd/dtd.dart';
 import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
-import '../helpers.dart';
+import '../helpers/helpers.dart';
 
 const projectRootParts = ['absolute_path_to', 'my_app_root'];
 late String projectRoot;
@@ -34,10 +34,6 @@ void main() {
   group('file uri helpers', () {
     TestDtdConnectionInfo? dtd;
     DartToolingDaemon? testDtdConnection;
-
-    setUpAll(() {
-      _setupTestDirectoryStructure();
-    });
 
     setUp(() async {
       dtd = await startDtd();


### PR DESCRIPTION
This sets up a directory for testing that includes multiple packages and devtools extensions. This will be used in a follow up CL for adding static extension support.

This PR also adds a test to verify that the test directory structure and generated files are what we expect.

Work towards https://github.com/flutter/devtools/issues/7569