### PR TITLE
Send `timing`, `screen`, `impression`, and `exception` events through unified_analytics

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_stub.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_stub.dart
@@ -98,7 +98,6 @@ void impression(
 void reportError(
   String errorMessage, {
   bool fatal = false,
-  ScreenAnalyticsMetrics Function()? screenMetricsProvider,
 }) {}
 
 Future<void> setupDimensions() async {}

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -680,7 +680,6 @@ String? _lastGaError;
 void reportError(
   String errorMessage, {
   bool fatal = false,
-  ScreenAnalyticsMetrics Function()? screenMetricsProvider,
 }) {
   // Don't keep recording same last error.
   if (_lastGaError == errorMessage) return;
@@ -690,10 +689,13 @@ void reportError(
     gaExceptionProvider: () => _gtagException(
       errorMessage,
       fatal: fatal,
-      screenMetrics:
-          screenMetricsProvider != null ? screenMetricsProvider() : null,
     ),
   );
+
+  // TODO(kenz): we may want to create a new event `devtoolsException` if we
+  // need all of our custom dimensions logged with exceptions.
+  final uaEvent = ua.Event.exception(exception: errorMessage);
+  unawaited(dtdManager.sendAnalyticsEvent(uaEvent));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -186,8 +186,8 @@ class GtagEventDevTools extends GtagEvent {
 // This cannot be a factory constructor in the [GtagEventDevTools] class due to
 // https://github.com/dart-lang/sdk/issues/46967.
 GtagEventDevTools _gtagEvent({
-  String? event_category,
-  String? event_label,
+  required String event_category,
+  required String event_label,
   String? send_to,
   bool non_interaction = false,
   int value = 0,
@@ -472,6 +472,7 @@ void screen(
   _log.fine('Event: Screen(screenName:$screenName, value:$value)');
   final gtagEvent = _gtagEvent(
     event_category: gac.screenViewEvent,
+    event_label: gac.init,
     value: value,
     send_to: gaDevToolsPropertyId(),
   );

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -42,6 +42,7 @@ final deeplink = ScreenMetaData.deepLinks.id;
 // GA events not associated with a any screen e.g., hotReload, hotRestart, etc
 const devToolsMain = 'main';
 const appDisconnected = 'appDisconnected';
+const init = 'init';
 
 // DevTools UI action selected (clicked).
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/7083