### PR TITLE
remove use of package:usage

### DIFF
--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -69,19 +69,11 @@ class ServerApi {
       // ----- Flutter Tool GA store. -----
       case apiGetFlutterGAEnabled:
         // Is Analytics collection enabled?
-        return _encodeResponse(
-          FlutterUsage.doesStoreExist ? _usage!.enabled : '',
-          api: api,
-        );
+        return _encodeResponse('', api: api);
       case apiGetFlutterGAClientId:
         // Flutter Tool GA clientId - ONLY get Flutter's clientId if enabled is
         // true.
-        return (FlutterUsage.doesStoreExist)
-            ? _encodeResponse(
-                _usage!.enabled ? _usage!.clientId : '',
-                api: api,
-              )
-            : _encodeResponse('', api: api);
+        return _encodeResponse('', api: api);
 
       // ----- DevTools GA store. -----
 
@@ -305,12 +297,6 @@ class ServerApi {
           )
         : null;
   }
-
-  // Accessing Flutter usage file e.g., ~/.flutter.
-  // NOTE: Only access the file if it exists otherwise Flutter Tool hasn't yet
-  //       been run.
-  static final FlutterUsage? _usage =
-      FlutterUsage.doesStoreExist ? FlutterUsage() : null;
 
   // Accessing DevTools usage file e.g., ~/.flutter-devtools/.devtools
   static final _devToolsUsage = DevToolsUsage();

--- a/packages/devtools_shared/lib/src/server/usage.dart
+++ b/packages/devtools_shared/lib/src/server/usage.dart
@@ -6,31 +6,8 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:path/path.dart' as path;
-import 'package:usage/usage_io.dart';
 
 import 'file_system.dart';
-
-/// Access the file '~/.flutter'.
-class FlutterUsage {
-  FlutterUsage({String settingsName = 'flutter'}) {
-    _analytics = AnalyticsIO('', settingsName, '');
-  }
-
-  late Analytics _analytics;
-
-  /// Does the .flutter store exist?
-  static bool get doesStoreExist {
-    return LocalFileSystem.flutterStoreExists();
-  }
-
-  bool get isFirstRun => _analytics.firstRun;
-
-  bool get enabled => _analytics.enabled;
-
-  set enabled(bool value) => _analytics.enabled = value;
-
-  String get clientId => _analytics.clientId;
-}
 
 // Access the DevTools on disk store (~/.flutter-devtools/.devtools).
 class DevToolsUsage {

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   path: ^1.8.0
   shelf: ^1.1.0
   sse: ^4.1.2
-  usage: ^4.0.0
   vm_service: ">=13.0.0 <15.0.0"
   web_socket_channel: ^2.4.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"


### PR DESCRIPTION
- remove use of `package:usage`

This removes the use of package:usage. I believe all use here of that package is obsolete? Removing the dep here will allow us to remove it from the dart sdk repo.

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
