### PR TITLE
Do not color the DevTools footer in embedded mode

### DIFF
--- a/packages/devtools_app/lib/src/framework/status_line.dart
+++ b/packages/devtools_app/lib/src/framework/status_line.dart
@@ -45,7 +45,8 @@ class StatusLine extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = isConnected ? theme.colorScheme.onPrimary : null;
+    final color =
+        (isConnected && !isEmbedded) ? theme.colorScheme.onPrimary : null;
     final height = statusLineHeight + padding.top + padding.bottom;
     return ValueListenableBuilder<bool>(
       valueListenable: currentScreen.showIsolateSelector,


### PR DESCRIPTION
The colored footer is jarring when embedded in the IDE, and it is also redundant since the IDE has its own affordances to communicate connected / disconnected state.