### PR TITLE
Add a command to generate release notes on the flutter website

### DIFF
--- a/packages/devtools_app/release_notes/README.md
+++ b/packages/devtools_app/release_notes/README.md
@@ -55,7 +55,7 @@ Before continuing, ensure you have your local environment set up for
 
 Draft release notes on a local `flutter/website` branch using the following command:
 ```console
-devtools_tool release-notes -w /Users/me/absolute/path/to/website
+devtools_tool release-notes -w /Users/me/absolute/path/to/flutter/website
 ```
 
 Clean up the drafted notes on your local `flutter/website` branch and open a PR.

--- a/packages/devtools_app/release_notes/README.md
+++ b/packages/devtools_app/release_notes/README.md
@@ -46,22 +46,19 @@ viewer can be used efficiently.
 Release notes for DevTools are hosted on the Flutter website.
 They are indexed at https://docs.flutter.dev/tools/devtools/release-notes.
 
-To add release notes for the latest release, create a PR with the appropriate
-changes for your release:
+### Prerequisite
 
-  1. Copy the markdown from [NEXT_RELEASE_NOTES.md](NEXT_RELEASE_NOTES.md) over
-  to the Flutter website. This file contains the running release notes for
-  the current DevTools version.
-      - See this [PR](https://github.com/flutter/website/pull/10113) for
-        an example of how to add these notes to the Flutter website.
-  2. Copy any images from the `images/` directory over to the Flutter website.
-      - Make sure to copy all images over to the proper website directory:
-        - `.../tools/devtools/release-notes/images-<VERSION>/`
-      - Make sure to update all image links in the markdown with the `site_url` tag:
-        - `/tools/devtools/release-notes/images-<VERSION>/<IMAGE_FILE>`
-  3. Once you are satisfied with the release notes,
-  create a new branch directly on the `flutter/website` repo and open a PR,
-  and then proceed to the testing steps below.
+Before continuing, ensure you have your local environment set up for
+[contributing](https://github.com/flutter/website) to the `flutter/website` repo.
+
+### Creating the release notes PR
+
+Draft release notes on a local `flutter/website` branch using the following command:
+```console
+devtools_tool release-notes -w /Users/me/absolute/path/to/website
+```
+
+Clean up the drafted notes on your local `flutter/website` branch and open a PR.
 
 ### Testing the release notes in DevTools
 

--- a/tool/RELEASE_INSTRUCTIONS.md
+++ b/tool/RELEASE_INSTRUCTIONS.md
@@ -195,6 +195,15 @@ just released into the Dart SDK (the hash you updated the DEPS file with):
    version for the tag is automatically determined from `packages/devtools/pubspec.yaml`
    so there is no need to manually enter the version.
 
+### Verify and Submit the release notes
+
+1. Follow the instructions outlined in the release notes
+[README.md](https://github.com/flutter/devtools/blob/master/packages/devtools_app/release_notes/README.md)
+to add DevTools release notes to Flutter website and test them in DevTools.
+2. Once release notes are submitted to the Flutter website, send an announcement to
+[g/flutter-internal-announce](http://g/flutter-internal-announce) with a link to
+the new release notes.
+
 ### Prepare DevTools for the next beta release
 1. Update the DevTools version for the next release:
    ```shell
@@ -206,15 +215,6 @@ just released into the Dart SDK (the hash you updated the DEPS file with):
    - See the workflow run [here](https://github.com/flutter/devtools/actions/workflows/daily-dev-bump.yaml)
    - Go to https://github.com/flutter/devtools/pulls to see the pull request that
    ends up being created
-
-### Verify and Submit the release notes
-
-1. Follow the instructions outlined in the release notes
-[README.md](https://github.com/flutter/devtools/blob/master/packages/devtools_app/release_notes/README.md)
-to add DevTools release notes to Flutter website and test them in DevTools.
-2. Once release notes are submitted to the Flutter website, send an announcement to
-[g/flutter-internal-announce](http://g/flutter-internal-announce) with a link to
-the new release notes.
 
 ## Dev release into the Dart SDK master branch
 

--- a/tool/lib/commands/release_notes_helper.dart
+++ b/tool/lib/commands/release_notes_helper.dart
@@ -54,7 +54,7 @@ class ReleaseNotesCommand extends Command {
     try {
       await processManager.runAll(
         commands: [
-          CliCommand.git(['checkout', '.']),
+          CliCommand.git(['stash']),
           CliCommand.git(['checkout', 'main']),
           CliCommand.git(['pull']),
           CliCommand.git(['submodule', 'update', '--init', '--recursive']),

--- a/tool/lib/devtools_command_runner.dart
+++ b/tool/lib/devtools_command_runner.dart
@@ -7,6 +7,7 @@ import 'package:args/command_runner.dart';
 import 'package:devtools_tool/commands/build.dart';
 import 'package:devtools_tool/commands/fix_goldens.dart';
 import 'package:devtools_tool/commands/generate_code.dart';
+import 'package:devtools_tool/commands/release_notes_helper.dart';
 import 'package:devtools_tool/commands/serve.dart';
 import 'package:devtools_tool/commands/sync.dart';
 import 'package:devtools_tool/commands/tag_version.dart';
@@ -35,6 +36,7 @@ class DevToolsCommandRunner extends CommandRunner {
     addCommand(ListCommand());
     addCommand(PubGetCommand());
     addCommand(ReleaseHelperCommand());
+    addCommand(ReleaseNotesCommand());
     addCommand(RepoCheckCommand());
     addCommand(RollbackCommand());
     addCommand(ServeCommand());


### PR DESCRIPTION
Running `devtools_tool release-notes -w /absolute/path/to/website/repo` will take the release notes in `NEXT_RELEASE_NOTES.md` and draft a set of changes on a local `flutter/website` branch.

Example set of changes created:
![Screenshot 2024-05-01 at 3 51 25 PM](https://github.com/flutter/devtools/assets/43759233/27bace4b-4a3c-4740-bd1f-30c7622a5817)

Fixes https://github.com/flutter/devtools/issues/7154