### PR TITLE
Use an extension type for ide theme query parameters

### DIFF
--- a/packages/devtools_app_shared/lib/src/ui/theme/_ide_theme_web.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/_ide_theme_web.dart
@@ -2,28 +2,22 @@
 // Use of this source code is governed by a BSD-style license that can be found
 // in the LICENSE file.
 
-import 'package:flutter/widgets.dart';
-import 'package:logging/logging.dart';
 import 'package:web/web.dart';
 
 import '../../utils/url/url.dart';
 import '../../utils/utils.dart';
 import 'ide_theme.dart';
-import 'theme.dart';
-
-final _log = Logger('ide_theme_web');
 
 /// Load any IDE-supplied theming.
 IdeTheme getIdeTheme() {
-  final queryParams = loadQueryParams();
+  final queryParams = IdeThemeQueryParams(loadQueryParams());
 
   final overrides = IdeTheme(
-    backgroundColor: _tryParseColor(queryParams['backgroundColor']),
-    foregroundColor: _tryParseColor(queryParams['foregroundColor']),
-    fontSize:
-        _tryParseDouble(queryParams['fontSize']) ?? unscaledDefaultFontSize,
-    embed: queryParams['embed'] == 'true',
-    isDarkMode: queryParams['theme'] != 'light',
+    backgroundColor: queryParams.backgroundColor,
+    foregroundColor: queryParams.foregroundColor,
+    fontSize: queryParams.fontSize,
+    embed: queryParams.embed,
+    isDarkMode: queryParams.darkMode,
   );
 
   // If the environment has provided a background color, set it immediately
@@ -34,38 +28,4 @@ IdeTheme getIdeTheme() {
   }
 
   return overrides;
-}
-
-Color? _tryParseColor(String? input) {
-  if (input == null) return null;
-
-  try {
-    return parseCssHexColor(input);
-  } catch (e, st) {
-    // The user can manipulate the query string so if the value is invalid
-    // print the value but otherwise continue.
-    _log.warning(
-      'Failed to parse "$input" as a color from the querystring, ignoring: $e',
-      e,
-      st,
-    );
-    return null;
-  }
-}
-
-double? _tryParseDouble(String? input) {
-  try {
-    if (input != null) {
-      return double.parse(input);
-    }
-  } catch (e, st) {
-    // The user can manipulate the query string so if the value is invalid
-    // print the value but otherwise continue.
-    _log.warning(
-      'Failed to parse "$input" as a double from the querystring, ignoring: $e',
-      e,
-      st,
-    );
-  }
-  return null;
 }

--- a/packages/devtools_app_shared/lib/src/ui/theme/ide_theme.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/ide_theme.dart
@@ -3,11 +3,15 @@
 // in the LICENSE file.
 
 import 'package:flutter/widgets.dart';
+import 'package:logging/logging.dart';
 
+import '../../utils/utils.dart';
 import 'theme.dart';
 
 export '_ide_theme_desktop.dart'
     if (dart.library.js_interop) '_ide_theme_web.dart';
+
+final _log = Logger('ide_theme');
 
 /// IDE-supplied theming.
 final class IdeTheme {
@@ -26,4 +30,58 @@ final class IdeTheme {
   final bool isDarkMode;
 
   double get fontSizeFactor => fontSize / unscaledDefaultFontSize;
+}
+
+extension type IdeThemeQueryParams(Map<String, String?> params) {
+  Color? get backgroundColor => _tryParseColor(params[backgroundColorKey]);
+
+  Color? get foregroundColor => _tryParseColor(params[foregroundColorKey]);
+
+  double get fontSize =>
+      _tryParseDouble(params[fontSizeKey]) ?? unscaledDefaultFontSize;
+
+  bool get embed => params[embedKey] == 'true';
+
+  bool get darkMode => params[devToolsThemeKey] != lightThemeValue;
+
+  static const backgroundColorKey = 'backgroundColor';
+  static const foregroundColorKey = 'foregroundColor';
+  static const fontSizeKey = 'fontSize';
+  static const embedKey = 'embed';
+  static const devToolsThemeKey = 'theme';
+  static const lightThemeValue = 'light';
+
+  Color? _tryParseColor(String? input) {
+    if (input == null) return null;
+
+    try {
+      return parseCssHexColor(input);
+    } catch (e, st) {
+      // The user can manipulate the query string so if the value is invalid
+      // print the value but otherwise continue.
+      _log.warning(
+        'Failed to parse "$input" as a color from the querystring, ignoring: $e',
+        e,
+        st,
+      );
+      return null;
+    }
+  }
+
+  double? _tryParseDouble(String? input) {
+    try {
+      if (input != null) {
+        return double.parse(input);
+      }
+    } catch (e, st) {
+      // The user can manipulate the query string so if the value is invalid
+      // print the value but otherwise continue.
+      _log.warning(
+        'Failed to parse "$input" as a double from the querystring, ignoring: $e',
+        e,
+        st,
+      );
+    }
+    return null;
+  }
 }


### PR DESCRIPTION
Part of a series of changes to cleanup how we handle query parameters in DevTools