### PR TITLE
Hide theme setting when embedded

### DIFF
--- a/packages/devtools_app/lib/src/framework/settings_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/settings_dialog.dart
@@ -15,6 +15,7 @@ import '../shared/config_specific/copy_to_clipboard/copy_to_clipboard.dart';
 import '../shared/globals.dart';
 import '../shared/log_storage.dart';
 import '../shared/server/server.dart';
+import '../shared/utils.dart';
 
 class OpenSettingsAction extends ScaffoldAction {
   OpenSettingsAction({super.key, super.color})
@@ -44,14 +45,15 @@ class SettingsDialog extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Flexible(
-            child: CheckboxSetting(
-              title: 'Use a dark theme',
-              notifier: preferences.darkModeTheme,
-              onChanged: preferences.toggleDarkModeTheme,
-              gaItem: gac.darkTheme,
+          if (!isEmbedded())
+            Flexible(
+              child: CheckboxSetting(
+                title: 'Use a dark theme',
+                notifier: preferences.darkModeTheme,
+                onChanged: preferences.toggleDarkModeTheme,
+                gaItem: gac.darkTheme,
+              ),
             ),
-          ),
           if (isExternalBuild && isDevToolsServerAvailable)
             Flexible(
               child: CheckboxSetting(


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/7506 by hiding the theme setting when DevTools is embedded. When embedded, the theme will be inherited from the IDE.