### PR TITLE
Add a query parameter hide function for extension screens

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -268,6 +268,9 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
               .where((p) => embed && page != null ? p.screenId == page : true)
               .where((p) => !hiddenScreens.contains(p.screenId))
               .toList();
+          if (hiddenScreens.contains('extensions')) {
+            screens.removeWhere((s) => s is ExtensionScreen);
+          }
           final connectedToFlutterApp =
               serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
                   false;

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -268,7 +268,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
               .where((p) => embed && page != null ? p.screenId == page : true)
               .where((p) => !hiddenScreens.contains(p.screenId))
               .toList();
-          if (hiddenScreens.contains('extensions')) {
+          if (queryParams.hideExtensions) {
             screens.removeWhere((s) => s is ExtensionScreen);
           }
           final connectedToFlutterApp =

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -58,7 +58,8 @@ class DevToolsScaffold extends StatefulWidget {
 
   static List<Widget> defaultActions({Color? color}) => [
         OpenSettingsAction(color: color),
-        if (FeatureFlags.devToolsExtensions)
+        if (FeatureFlags.devToolsExtensions &&
+            !DevToolsQueryParams.load().hideExtensions)
           ExtensionSettingsAction(color: color),
         ReportFeedbackButton(color: color),
         OpenAboutAction(color: color),

--- a/packages/devtools_app/lib/src/shared/query_parameters.dart
+++ b/packages/devtools_app/lib/src/shared/query_parameters.dart
@@ -3,9 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
 
 extension type DevToolsQueryParams(Map<String, String?> params) {
   static DevToolsQueryParams empty() => DevToolsQueryParams({});
+
+  static DevToolsQueryParams load() => DevToolsQueryParams(loadQueryParams());
 
   DevToolsQueryParams withUpdates(Map<String, String?>? updates) {
     return DevToolsQueryParams({...params, ...?updates});
@@ -16,6 +19,8 @@ extension type DevToolsQueryParams(Map<String, String?> params) {
   bool get embed => ideThemeParams.embed;
 
   Set<String> get hiddenScreens => {...?params[hideScreensKey]?.split(',')};
+
+  bool get hideExtensions => hiddenScreens.contains('extensions');
 
   String? get offlineScreenId => params[offlineScreenIdKey];
 

--- a/packages/devtools_app/test/shared/query_parameters_test.dart
+++ b/packages/devtools_app/test/shared/query_parameters_test.dart
@@ -12,7 +12,7 @@ void main() {
     test('successfully creates params', () {
       final params = DevToolsQueryParams({
         DevToolsQueryParams.vmServiceUriKey: 'some_uri',
-        DevToolsQueryParams.hideScreensKey: 'foo,bar,baz',
+        DevToolsQueryParams.hideScreensKey: 'foo,bar,extensions',
         DevToolsQueryParams.offlineScreenIdKey: 'performance',
         DevToolsQueryParams.legacyPageKey: 'memory',
         // IdeThemeQueryParams values
@@ -26,6 +26,7 @@ void main() {
       expect(params.vmServiceUri, 'some_uri');
       expect(params.embed, true);
       expect(params.hiddenScreens, {'foo', 'bar', 'baz'});
+      expect(params.hideExtensions, true);
       expect(params.offlineScreenId, 'performance');
       expect(params.legacyPage, 'memory');
       expect(params.ideThemeParams.params, isNotEmpty);

--- a/packages/devtools_app/test/shared/query_parameters_test.dart
+++ b/packages/devtools_app/test/shared/query_parameters_test.dart
@@ -25,7 +25,7 @@ void main() {
 
       expect(params.vmServiceUri, 'some_uri');
       expect(params.embed, true);
-      expect(params.hiddenScreens, {'foo', 'bar', 'baz'});
+      expect(params.hiddenScreens, {'foo', 'bar', 'extensions'});
       expect(params.hideExtensions, true);
       expect(params.offlineScreenId, 'performance');
       expect(params.legacyPage, 'memory');


### PR DESCRIPTION
Work to unblock https://github.com/flutter/flutter-intellij/issues/7195.