### PR TITLE
Add support for hiding all screens except extension screens

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -467,8 +467,8 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
       screens.removeWhere((s) => s is ExtensionScreen);
     }
 
-    // When 'hide=all-except-extensions' is in the query parameters, this
-    // is an extensions-only view.
+    // When 'hide=all-except-extensions' is in the query parameters, remove all
+    // non-extension screens.
     if (params.hideAllExceptExtensions) {
       screens.removeWhere((s) => s is! ExtensionScreen);
     }

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -43,7 +43,7 @@ class DevToolsScaffold extends StatefulWidget {
     this.page,
     List<Widget>? actions,
     this.embedMode = EmbedMode.none,
-  }) : actions = actions ?? defaultActions();
+  }) : actions = actions ?? (embedMode.embedded ? [] : defaultActions());
 
   DevToolsScaffold.withChild({
     Key? key,
@@ -95,7 +95,7 @@ class DevToolsScaffold extends StatefulWidget {
   /// Actions that it's possible to perform in this Scaffold.
   ///
   /// These will generally be [RegisteredServiceExtensionButton]s.
-  final List<Widget>? actions;
+  final List<Widget> actions;
 
   @override
   State<StatefulWidget> createState() => DevToolsScaffoldState();
@@ -315,7 +315,11 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
             serviceConnection.serviceManager.connectedAppInitialized &&
                 !offlineDataController.showingOfflineData.value &&
                 _currentScreen.showConsole(widget.embedMode);
-
+        final containsSingleSimpleScreen =
+            widget.screens.length == 1 && widget.screens.first is SimpleScreen;
+        final showAppBar = widget.embedMode == EmbedMode.none ||
+            (widget.embedMode == EmbedMode.embedMany &&
+                !containsSingleSimpleScreen);
         return DragAndDrop(
           handleDrop: _importController.importData,
           child: KeyboardShortcuts(
@@ -323,9 +327,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
               context,
             ),
             child: Scaffold(
-              appBar: widget.embedMode == EmbedMode.embedOne
-                  ? null
-                  : PreferredSize(
+              appBar: showAppBar
+                  ? PreferredSize(
                       preferredSize: Size.fromHeight(defaultToolbarHeight),
                       // Place the AppBar inside of a Hero widget to keep it the same across
                       // route transitions.
@@ -337,7 +340,8 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
                           actions: widget.actions,
                         ),
                       ),
-                    ),
+                    )
+                  : null,
               body: OutlineDecoration.onlyTop(
                 child: Padding(
                   padding: widget.appPadding,

--- a/packages/devtools_app/lib/src/shared/query_parameters.dart
+++ b/packages/devtools_app/lib/src/shared/query_parameters.dart
@@ -27,7 +27,10 @@ extension type DevToolsQueryParams(Map<String, String?> params) {
 
   Set<String> get hiddenScreens => {...?params[hideScreensKey]?.split(',')};
 
-  bool get hideExtensions => hiddenScreens.contains('extensions');
+  bool get hideExtensions => hiddenScreens.contains(hideExtensionsValue);
+
+  bool get hideAllExceptExtensions =>
+      hiddenScreens.contains(hideAllExceptExtensionsValue);
 
   String? get offlineScreenId => params[offlineScreenIdKey];
 
@@ -38,6 +41,8 @@ extension type DevToolsQueryParams(Map<String, String?> params) {
 
   static const vmServiceUriKey = 'uri';
   static const hideScreensKey = 'hide';
+  static const hideExtensionsValue = 'extensions';
+  static const hideAllExceptExtensionsValue = 'all-except-extensions';
   static const offlineScreenIdKey = 'screen';
   static const inspectorRefKey = 'inspectorRef';
 

--- a/packages/devtools_app/lib/src/shared/routing.dart
+++ b/packages/devtools_app/lib/src/shared/routing.dart
@@ -37,23 +37,21 @@ class DevToolsRouteInformationParser
   DevToolsRouteInformationParser();
 
   @visibleForTesting
-  DevToolsRouteInformationParser.test(this._forceVmServiceUri);
+  DevToolsRouteInformationParser.test(this._testQueryParams);
 
-  /// The value for the 'uri' query parameter in a DevTools uri.
+  /// Query parameters that can be set on DevTools routes for testing purposes.
   ///
   /// This is to be used in a testing environment only and can be set via the
   /// [DevToolsRouteInformationParser.test] constructor.
-  String? _forceVmServiceUri;
+  DevToolsQueryParams? _testQueryParams;
 
   @override
   Future<DevToolsRouteConfiguration> parseRouteInformation(
     RouteInformation routeInformation,
   ) async {
     var uri = routeInformation.uri;
-    if (_forceVmServiceUri != null) {
-      final newQueryParams = Map<String, dynamic>.from(uri.queryParameters);
-      newQueryParams['uri'] = _forceVmServiceUri;
-      uri = uri.copyWith(queryParameters: newQueryParams);
+    if (_testQueryParams != null) {
+      uri = uri.copyWith(queryParameters: _testQueryParams!.params);
     }
 
     final uriFromParams = uri.queryParameters['uri'];
@@ -62,7 +60,7 @@ class DevToolsRouteInformationParser
       // query parameter, ensure we manually disconnect from any previously
       // connected applications.
       await serviceConnection.serviceManager.manuallyDisconnect();
-    } else if (_forceVmServiceUri == null) {
+    } else if (_testQueryParams == null) {
       // Otherwise, connect to the vm service from the query parameter before
       // loading the route (but do not do this in a testing environment).
       await FrameworkCore.initVmService(serviceUriAsString: uriFromParams);

--- a/packages/devtools_app/test/shared/query_parameters_test.dart
+++ b/packages/devtools_app/test/shared/query_parameters_test.dart
@@ -14,7 +14,8 @@ void main() {
     test('successfully creates params', () {
       final params = DevToolsQueryParams({
         DevToolsQueryParams.vmServiceUriKey: 'some_uri',
-        DevToolsQueryParams.hideScreensKey: 'foo,bar,extensions',
+        DevToolsQueryParams.hideScreensKey:
+            'foo,bar,extensions,all-except-extensions',
         DevToolsQueryParams.offlineScreenIdKey: 'performance',
         DevToolsQueryParams.legacyPageKey: 'memory',
         // IdeThemeQueryParams values
@@ -27,8 +28,12 @@ void main() {
 
       expect(params.vmServiceUri, 'some_uri');
       expect(params.embedMode, EmbedMode.embedOne);
-      expect(params.hiddenScreens, {'foo', 'bar', 'extensions'});
+      expect(
+        params.hiddenScreens,
+        {'foo', 'bar', 'extensions', 'all-except-extensions'},
+      );
       expect(params.hideExtensions, true);
+      expect(params.hideAllExceptExtensions, true);
       expect(params.offlineScreenId, 'performance');
       expect(params.legacyPage, 'memory');
       expect(params.ideThemeParams.params, isNotEmpty);

--- a/packages/devtools_app/test/shared/scaffold_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_test.dart
@@ -5,6 +5,7 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/framework/scaffold.dart';
 import 'package:devtools_app/src/shared/framework_controller.dart';
+import 'package:devtools_app/src/shared/query_parameters.dart';
 import 'package:devtools_app/src/shared/survey.dart';
 import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/shared.dart';
@@ -45,7 +46,7 @@ void main() {
     setGlobal(BannerMessagesController, BannerMessagesController());
   });
 
-  Widget wrapScaffold(Widget child) {
+  Widget wrapScaffold(Widget child, {DevToolsQueryParams? queryParams}) {
     return wrapWithControllers(
       child,
       analytics: AnalyticsController(
@@ -54,6 +55,7 @@ void main() {
         consentMessage: 'fake message',
       ),
       releaseNotes: ReleaseNotesController(),
+      queryParams: queryParams,
     );
   }
 
@@ -237,18 +239,58 @@ void main() {
   );
 
   testWidgets(
+    'hides the app bar for EmbedMode.embedMany with a single simple screen',
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrapScaffold(
+          DevToolsScaffold.withChild(
+            embedMode: EmbedMode.embedMany,
+            child: const Center(child: Text('some message')),
+          ),
+        ),
+      );
+      expect(find.byType(DevToolsAppBar), findsNothing);
+    },
+  );
+
+  testWidgets(
     'shows the app bar for EmbedMode.embedMany',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         wrapScaffold(
           DevToolsScaffold(
-            screens: const [_screen1, _screen2],
+            screens: const [_screen2],
             page: _screen2.screenId,
             embedMode: EmbedMode.embedMany,
           ),
         ),
       );
       expect(find.byType(DevToolsAppBar), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'uses empty actions as default when embedded',
+    (WidgetTester tester) async {
+      var scaffold = DevToolsScaffold(
+        screens: const [_screen1, _screen2],
+        page: _screen1.screenId,
+      );
+      expect(scaffold.actions.length, 4);
+
+      scaffold = DevToolsScaffold(
+        screens: const [_screen1, _screen2],
+        page: _screen1.screenId,
+        embedMode: EmbedMode.embedOne,
+      );
+      expect(scaffold.actions, isEmpty);
+
+      scaffold = DevToolsScaffold(
+        screens: const [_screen1, _screen2],
+        page: _screen1.screenId,
+        embedMode: EmbedMode.embedMany,
+      );
+      expect(scaffold.actions, isEmpty);
     },
   );
 }

--- a/packages/devtools_app/test/shared/screens_test.dart
+++ b/packages/devtools_app/test/shared/screens_test.dart
@@ -3,6 +3,12 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/extensions/extension_screen.dart';
+import 'package:devtools_app/src/framework/scaffold.dart';
+import 'package:devtools_app/src/shared/development_helpers.dart';
+import 'package:devtools_app/src/shared/query_parameters.dart';
+import 'package:devtools_app_shared/shared.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -18,6 +24,101 @@ void main() {
       screenOrder.removeWhereNot(enumOrder.toSet().contains);
 
       expect(enumOrder, screenOrder);
+    });
+  });
+
+  group('$DevToolsAppState', () {
+    late Screen screen1;
+    late Screen screen2;
+    late Screen extensionScreen1;
+    late Screen extensionScreen2;
+    late List<Screen> screens;
+
+    setUp(() {
+      screen1 = SimpleScreen(const Placeholder());
+      screen2 = SimpleScreen(const Placeholder());
+      extensionScreen1 = DevToolsScreen<void>(
+        ExtensionScreen(StubDevToolsExtensions.someToolExtension),
+      ).screen;
+      extensionScreen2 = DevToolsScreen<void>(
+        ExtensionScreen(StubDevToolsExtensions.barExtension),
+      ).screen;
+      screens = <Screen>[
+        screen1,
+        screen2,
+        extensionScreen1,
+        extensionScreen2,
+      ];
+    });
+
+    test(
+      'hides extension screens based on query parameters',
+      () {
+        DevToolsAppState.removeHiddenScreens(
+          screens,
+          DevToolsQueryParams({
+            DevToolsQueryParams.hideScreensKey:
+                DevToolsQueryParams.hideExtensionsValue,
+          }),
+        );
+        expect(screens.contains(screen1), true);
+        expect(screens.contains(screen2), true);
+        expect(screens.contains(extensionScreen1), false);
+        expect(screens.contains(extensionScreen2), false);
+      },
+    );
+
+    test(
+      'hides all except extension screens based on query parameters',
+      () {
+        DevToolsAppState.removeHiddenScreens(
+          screens,
+          DevToolsQueryParams({
+            DevToolsQueryParams.hideScreensKey:
+                DevToolsQueryParams.hideAllExceptExtensionsValue,
+          }),
+        );
+        expect(screens.contains(screen1), false);
+        expect(screens.contains(screen2), false);
+        expect(screens.contains(extensionScreen1), true);
+        expect(screens.contains(extensionScreen2), true);
+      },
+    );
+
+    test('maybeIncludeOnlyEmbeddedScreen', () {
+      expect(
+        DevToolsAppState.maybeIncludeOnlyEmbeddedScreen(
+          screen1,
+          page: ScreenMetaData.simple.id,
+          embedMode: EmbedMode.embedOne,
+        ),
+        true,
+      );
+      expect(
+        DevToolsAppState.maybeIncludeOnlyEmbeddedScreen(
+          extensionScreen1, // Ids do not match.
+          page: ScreenMetaData.simple.id,
+          embedMode: EmbedMode.embedOne,
+        ),
+        false,
+      );
+      // Should always return true when 'embedMode' != EmbedMode.embedOne
+      expect(
+        DevToolsAppState.maybeIncludeOnlyEmbeddedScreen(
+          extensionScreen1, // Ids do not match.
+          page: ScreenMetaData.simple.id,
+          embedMode: EmbedMode.embedMany,
+        ),
+        true,
+      );
+      expect(
+        DevToolsAppState.maybeIncludeOnlyEmbeddedScreen(
+          extensionScreen1, // Ids do not match.
+          page: ScreenMetaData.simple.id,
+          embedMode: EmbedMode.none,
+        ),
+        true,
+      );
     });
   });
 }

--- a/packages/devtools_test/lib/src/helpers/wrappers.dart
+++ b/packages/devtools_test/lib/src/helpers/wrappers.dart
@@ -2,7 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+// ignore_for_file: implementation_imports, invalid_use_of_visible_for_testing_member, fine for test only package.
+
 import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/shared/query_parameters.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/material.dart';
@@ -21,7 +24,7 @@ final _testNavigatorKey = GlobalKey<NavigatorState>();
 /// This includes a [MaterialApp] to provide context like [Theme.of], a
 /// [Material] to support elements like [TextField] that draw ink effects, and a
 /// [Directionality] to support [RenderFlex] widgets like [Row] and [Column].
-Widget wrap(Widget widget) {
+Widget wrap(Widget widget, {DevToolsQueryParams? queryParams}) {
   return MaterialApp.router(
     theme: themeFor(
       isDarkTheme: false,
@@ -45,9 +48,10 @@ Widget wrap(Widget widget) {
       ),
       _testNavigatorKey,
     ),
-    routeInformationParser:
-        // ignore: invalid_use_of_visible_for_testing_member, false positive.
-        DevToolsRouteInformationParser.test('http://test/uri'),
+    routeInformationParser: DevToolsRouteInformationParser.test(
+      DevToolsQueryParams({'uri': 'http://test/uri'})
+          .withUpdates(queryParams?.params),
+    ),
   );
 }
 
@@ -93,6 +97,7 @@ Widget wrapWithControllers(
   ReleaseNotesController? releaseNotes,
   VMDeveloperToolsController? vmDeveloperTools,
   bool includeRouter = true,
+  DevToolsQueryParams? queryParams,
 }) {
   final providers = [
     if (inspector != null)
@@ -120,7 +125,9 @@ Widget wrapWithControllers(
       child: widget,
     ),
   );
-  return includeRouter ? wrap(child) : wrapSimple(child);
+  return includeRouter
+      ? wrap(child, queryParams: queryParams)
+      : wrapSimple(child);
 }
 
 Widget wrapWithNotifications(Widget child) {


### PR DESCRIPTION
This PR adds support for hiding all screens except extension screens with the `hide` query param: `hide=all-except-extensions`. 

![Screenshot 2024-05-07 at 11 10 19 AM](https://github.com/flutter/devtools/assets/43759233/2a10b8c4-3ea6-4ea3-aa29-171b483aef1c)

Work to unblock https://github.com/flutter/flutter-intellij/issues/7195 in order to support an extensions-only tool window. CC @helin24 