### PR TITLE
Migrate analytics code to `dart:js_interop`

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -109,12 +109,85 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
     int? inspector_tree_controller_id, // metric12
   });
 
-  external String? get event_category;
-  external String? get event_label;
-  external String? get send_to;
-  external int get value; // Positive number.
-  external bool get non_interaction;
-  external JSObject? get custom_map;
+  // Custom dimensions:
+  external String? get user_app;
+  external String? get user_build;
+  external String? get user_platform;
+  external String? get devtools_platform;
+  external String? get devtools_chrome;
+  external String? get devtools_version;
+  external String? get ide_launched;
+  external String? get flutter_client_id;
+  external String? get is_external_build;
+  external String? get is_embedded;
+  external String? get g3_username;
+  external String? get ide_launched_feature;
+
+  // Custom metrics:
+  external int? get ui_duration_micros;
+  external int? get raster_duration_micros;
+  external int? get shader_compilation_duration_micros;
+  external int? get cpu_sample_count;
+  external int? get cpu_stack_depth;
+  external int? get trace_event_count;
+  external int? get heap_diff_objects_before;
+  external int? get heap_diff_objects_after;
+  external int? get heap_objects_total;
+  external int? get root_set_count;
+  external int? get row_count;
+  external int? get inspector_tree_controller_id;
+}
+
+extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
+  external factory GtagExceptionDevTools({
+    String? description,
+    bool fatal,
+
+    // NOTE: Do not reorder any of these. Order here must match the order in the
+    // Google Analytics console.
+
+    String? user_app, // dimension1 (flutter or web)
+    String? user_build, // dimension2 (debug or profile)
+    String? user_platform, // dimension3 (android or ios)
+    String? devtools_platform, // dimension4 linux/android/mac/windows
+    String? devtools_chrome, // dimension5 Chrome version #
+    String? devtools_version, // dimension6 DevTools version #
+    String? ide_launched, // dimension7 IDE launched DevTools
+    String? flutter_client_id, // dimension8 Flutter tool clientId
+    String? is_external_build, // dimension9 External build or google3
+    String? is_embedded, // dimension10 Whether devtools is embedded
+    String? g3_username, // dimension11 g3 username (null for external users)
+
+    // dimension12 IDE feature that launched Devtools
+    // The following is a non-exhaustive list of possible values for this dimension:
+    // "command" - VS Code command palette
+    // "sidebarContent" - the content of the sidebar (e.g. the DevTools dropdown for a debug session)
+    // "sidebarTitle" - the DevTools action in the sidebar title
+    // "touchbar" - MacOS touchbar button
+    // "launchConfiguration" - configured explicitly in launch configuration
+    // "onDebugAutomatic" - configured to always run on debug session start
+    // "onDebugPrompt" - user responded to prompt when running a debug session
+    // "languageStatus" - launched from the language status popout
+    String? ide_launched_feature,
+
+    // Performance screen metrics. See [PerformanceScreenMetrics].
+    int? ui_duration_micros, // metric1
+    int? raster_duration_micros, // metric2
+    int? shader_compilation_duration_micros, // metric3
+    // Profiler screen metrics. See [ProfilerScreenMetrics].
+    int? cpu_sample_count, // metric4
+    int? cpu_stack_depth, // metric5
+    // Performance screen metric. See [PerformanceScreenMetrics].
+    int? trace_event_count, // metric6
+    // Memory screen metric. See [MemoryScreenMetrics].
+    int? heap_diff_objects_before, // metric7
+    int? heap_diff_objects_after, // metric8
+    int? heap_objects_total, // metric9
+    // Inspector screen metrics. See [InspectorScreenMetrics].
+    int? root_set_count, // metric10
+    int? row_count, // metric11
+    int? inspector_tree_controller_id, // metric12
+  });
 
   // Custom dimensions:
   external String? get user_app;
@@ -279,89 +352,6 @@ GtagExceptionDevTools _gtagException(
         ? screenMetrics.inspectorTreeControllerId
         : null,
   );
-}
-
-extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
-  external factory GtagExceptionDevTools({
-    String? description,
-    bool fatal,
-
-    // NOTE: Do not reorder any of these. Order here must match the order in the
-    // Google Analytics console.
-
-    String? user_app, // dimension1 (flutter or web)
-    String? user_build, // dimension2 (debug or profile)
-    String? user_platform, // dimension3 (android or ios)
-    String? devtools_platform, // dimension4 linux/android/mac/windows
-    String? devtools_chrome, // dimension5 Chrome version #
-    String? devtools_version, // dimension6 DevTools version #
-    String? ide_launched, // dimension7 IDE launched DevTools
-    String? flutter_client_id, // dimension8 Flutter tool clientId
-    String? is_external_build, // dimension9 External build or google3
-    String? is_embedded, // dimension10 Whether devtools is embedded
-    String? g3_username, // dimension11 g3 username (null for external users)
-
-    // dimension12 IDE feature that launched Devtools
-    // The following is a non-exhaustive list of possible values for this dimension:
-    // "command" - VS Code command palette
-    // "sidebarContent" - the content of the sidebar (e.g. the DevTools dropdown for a debug session)
-    // "sidebarTitle" - the DevTools action in the sidebar title
-    // "touchbar" - MacOS touchbar button
-    // "launchConfiguration" - configured explicitly in launch configuration
-    // "onDebugAutomatic" - configured to always run on debug session start
-    // "onDebugPrompt" - user responded to prompt when running a debug session
-    // "languageStatus" - launched from the language status popout
-    String? ide_launched_feature,
-
-    // Performance screen metrics. See [PerformanceScreenMetrics].
-    int? ui_duration_micros, // metric1
-    int? raster_duration_micros, // metric2
-    int? shader_compilation_duration_micros, // metric3
-    // Profiler screen metrics. See [ProfilerScreenMetrics].
-    int? cpu_sample_count, // metric4
-    int? cpu_stack_depth, // metric5
-    // Performance screen metric. See [PerformanceScreenMetrics].
-    int? trace_event_count, // metric6
-    // Memory screen metric. See [MemoryScreenMetrics].
-    int? heap_diff_objects_before, // metric7
-    int? heap_diff_objects_after, // metric8
-    int? heap_objects_total, // metric9
-    // Inspector screen metrics. See [InspectorScreenMetrics].
-    int? root_set_count, // metric10
-    int? row_count, // metric11
-    int? inspector_tree_controller_id, // metric12
-  });
-
-  external String? get description; // Description of the error.
-  external bool get fatal; // Fatal error.
-
-  // Custom dimensions:
-  external String? get user_app;
-  external String? get user_build;
-  external String? get user_platform;
-  external String? get devtools_platform;
-  external String? get devtools_chrome;
-  external String? get devtools_version;
-  external String? get ide_launched;
-  external String? get flutter_client_id;
-  external String? get is_external_build;
-  external String? get is_embedded;
-  external String? get g3_username;
-  external String? get ide_launched_feature;
-
-  // Custom metrics:
-  external int? get ui_duration_micros;
-  external int? get raster_duration_micros;
-  external int? get shader_compilation_duration_micros;
-  external int? get cpu_sample_count;
-  external int? get cpu_stack_depth;
-  external int? get trace_event_count;
-  external int? get heap_diff_objects_before;
-  external int? get heap_diff_objects_after;
-  external int? get heap_objects_total;
-  external int? get root_set_count;
-  external int? get row_count;
-  external int? get inspector_tree_controller_id;
 }
 
 /// Whether google analytics are enabled.

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -53,14 +53,14 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
   // TODO(kenz): try to make this accept a JSON map of extra parameters rather
   // than a fixed list of fields. See
   // https://github.com/flutter/devtools/pull/3281#discussion_r692376353.
-  external  GtagEventDevTools({
+  external factory GtagEventDevTools({
     String? event_category,
     String? event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
     String? send_to, // UA ID of target GA property to receive event data.
 
     int value,
     bool non_interaction,
-    Object? custom_map,
+    JSObject? custom_map,
 
     // NOTE: Do not reorder any of these. Order here must match the order in the
     // Google Analytics console.
@@ -114,7 +114,7 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
   external String? get send_to;
   external int get value; // Positive number.
   external bool get non_interaction;
-  external Object get custom_map;
+  external JSObject? get custom_map;
 
   // Custom dimensions:
   external String? get user_app;
@@ -282,7 +282,7 @@ GtagExceptionDevTools _gtagException(
 }
 
 extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
-  external GtagExceptionDevTools({
+  external factory GtagExceptionDevTools({
     String? description,
     bool fatal,
 

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -8,9 +8,9 @@
 library;
 
 import 'dart:async';
+import 'dart:js_interop';
 
 import 'package:flutter/foundation.dart';
-import 'package:js/js.dart';
 import 'package:logging/logging.dart';
 import 'package:unified_analytics/unified_analytics.dart' as ua;
 import 'package:web/web.dart';

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -49,22 +49,18 @@ final _log = Logger('_analytics_web');
 @JS('initializeGA')
 external void initializeGA();
 
-@JS()
-@anonymous
-class GtagEventDevTools extends GtagEvent {
+extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
   // TODO(kenz): try to make this accept a JSON map of extra parameters rather
   // than a fixed list of fields. See
   // https://github.com/flutter/devtools/pull/3281#discussion_r692376353.
-  external factory GtagEventDevTools({
+  external  GtagEventDevTools({
     String? event_category,
     String? event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
     String? send_to, // UA ID of target GA property to receive event data.
 
     int value,
     bool non_interaction,
-    // This code is going away so not worth cleaning up to be free of dynamic.
-    // ignore: avoid-dynamic
-    dynamic custom_map,
+    Object? custom_map,
 
     // NOTE: Do not reorder any of these. Order here must match the order in the
     // Google Analytics console.
@@ -113,72 +109,39 @@ class GtagEventDevTools extends GtagEvent {
     int? inspector_tree_controller_id, // metric12
   });
 
-  @override
   external String? get event_category;
-
-  @override
   external String? get event_label;
-
-  @override
   external String? get send_to;
-
-  @override
   external int get value; // Positive number.
-
-  @override
   external bool get non_interaction;
-
-  @override
   external Object get custom_map;
 
   // Custom dimensions:
   external String? get user_app;
-
   external String? get user_build;
-
   external String? get user_platform;
-
   external String? get devtools_platform;
-
   external String? get devtools_chrome;
-
   external String? get devtools_version;
-
   external String? get ide_launched;
-
   external String? get flutter_client_id;
-
   external String? get is_external_build;
-
   external String? get is_embedded;
-
   external String? get g3_username;
-
   external String? get ide_launched_feature;
 
   // Custom metrics:
   external int? get ui_duration_micros;
-
   external int? get raster_duration_micros;
-
   external int? get shader_compilation_duration_micros;
-
   external int? get cpu_sample_count;
-
   external int? get cpu_stack_depth;
-
   external int? get trace_event_count;
-
   external int? get heap_diff_objects_before;
-
   external int? get heap_diff_objects_after;
-
   external int? get heap_objects_total;
-
   external int? get root_set_count;
-
   external int? get row_count;
-
   external int? get inspector_tree_controller_id;
 }
 
@@ -318,10 +281,8 @@ GtagExceptionDevTools _gtagException(
   );
 }
 
-@JS()
-@anonymous
-class GtagExceptionDevTools extends GtagException {
-  external factory GtagExceptionDevTools({
+extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
+  external GtagExceptionDevTools({
     String? description,
     bool fatal,
 
@@ -371,59 +332,35 @@ class GtagExceptionDevTools extends GtagException {
     int? inspector_tree_controller_id, // metric12
   });
 
-  @override
   external String? get description; // Description of the error.
-  @override
   external bool get fatal; // Fatal error.
 
   // Custom dimensions:
   external String? get user_app;
-
   external String? get user_build;
-
   external String? get user_platform;
-
   external String? get devtools_platform;
-
   external String? get devtools_chrome;
-
   external String? get devtools_version;
-
   external String? get ide_launched;
-
   external String? get flutter_client_id;
-
   external String? get is_external_build;
-
   external String? get is_embedded;
-
   external String? get g3_username;
-
   external String? get ide_launched_feature;
 
   // Custom metrics:
   external int? get ui_duration_micros;
-
   external int? get raster_duration_micros;
-
   external int? get shader_compilation_duration_micros;
-
   external int? get cpu_sample_count;
-
   external int? get cpu_stack_depth;
-
   external int? get trace_event_count;
-
   external int? get heap_diff_objects_before;
-
   external int? get heap_diff_objects_after;
-
   external int? get heap_objects_total;
-
   external int? get root_set_count;
-
   external int? get row_count;
-
   external int? get inspector_tree_controller_id;
 }
 

--- a/packages/devtools_app/lib/src/shared/analytics/gtags.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/gtags.dart
@@ -45,38 +45,27 @@ class GTag {
   }
 }
 
-@JS()
-@anonymous
-class GtagEvent {
-  external factory GtagEvent({
+extension type GtagEvent._(JSObject _) implements JSObject {
+  external GtagEvent({
     String? event_category,
     String? event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
     String? send_to, // UA ID of target GA property to receive event data.
 
-    int value = 0,
-    bool non_interaction = false,
+    int value,
+    bool non_interaction,
     Object? custom_map,
   });
 
   external String? get event_category;
-
   external String? get event_label;
-
   external String? get send_to;
-
   external int get value; // Positive number.
   external bool get non_interaction;
-
   external Object? get custom_map; // Custom metrics
 }
 
-@JS()
-@anonymous
-class GtagException {
-  external factory GtagException({
-    String? description,
-    bool fatal = false,
-  });
+extension type GtagException._(JSObject _) implements JSObject {
+  external GtagException({String? description, bool fatal});
 
   external String? get description; // Description of the error.
   external bool get fatal; // Fatal error.

--- a/packages/devtools_app/lib/src/shared/analytics/gtags.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/gtags.dart
@@ -7,8 +7,9 @@
 @JS()
 library;
 
+import 'dart:js_interop';
+
 import 'package:flutter/foundation.dart';
-import 'package:js/js.dart';
 
 import '../../shared/development_helpers.dart';
 import 'analytics.dart' as ga;

--- a/packages/devtools_app/lib/src/shared/analytics/gtags.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/gtags.dart
@@ -18,7 +18,7 @@ import 'analytics.dart' as ga;
 /// For debugging install the Chrome Plugin "Google Analytics Debugger".
 
 @JS('gtag')
-external void _gTagCommandName(String command, String name, [Object? params]);
+external void _gTagCommandName(String command, String name, [JSObject? params]);
 
 // TODO(jacobr): refactor this code if we do not migrate off gtags.
 // ignore: avoid_classes_with_only_static_members
@@ -46,14 +46,14 @@ class GTag {
 }
 
 extension type GtagEvent._(JSObject _) implements JSObject {
-  external GtagEvent({
+  external factory GtagEvent({
     String? event_category,
     String? event_label, // Event e.g., gaScreenViewEvent, gaSelectEvent, etc.
     String? send_to, // UA ID of target GA property to receive event data.
 
     int value,
     bool non_interaction,
-    Object? custom_map,
+    JSObject? custom_map,
   });
 
   external String? get event_category;
@@ -61,11 +61,11 @@ extension type GtagEvent._(JSObject _) implements JSObject {
   external String? get send_to;
   external int get value; // Positive number.
   external bool get non_interaction;
-  external Object? get custom_map; // Custom metrics
+  external JSObject? get custom_map; // Custom metrics
 }
 
 extension type GtagException._(JSObject _) implements JSObject {
-  external GtagException({String? description, bool fatal});
+  external factory GtagException({String? description, bool fatal});
 
   external String? get description; // Description of the error.
   external bool get fatal; // Fatal error.

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -41,7 +41,6 @@ dependencies:
   http: ^1.1.0
   image: ^4.1.3
   intl: ^0.19.0
-  js: ^0.6.1+1
   json_rpc_2: ^3.0.2
   logging: ^1.1.1
   meta: ^1.9.1


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/6606.

@srujzs are there any differences under the hood or is this migration as simple as switching the imports?