### PR TITLE
Support detecting package roots for nested Dart projects

### DIFF
--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -55,7 +55,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## DevTools Extension updates
 
-TODO: Remove this section if there are not any general updates.
+* Fix an issue with detecting extensions for nested Dart or Flutter
+projects. - [#7742](https://github.com/flutter/devtools/pull/7742)
 
 ## Full commit history
 

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,6 +1,8 @@
 # 10.0.0-dev.1
 * Export `DTDConnectionInfo` from the `devtools_shared.dart` library instead
 of the `devtools_server.dart` library.
+* Support detecting package roots for nested Dart projects in the
+`packageRootFromFileUriString` utility method.
 
 # 10.0.0-dev.0
 * **Breaking change:** rename `DevToolsExtensionConfig.path` to

--- a/packages/devtools_shared/lib/src/utils/file_utils.dart
+++ b/packages/devtools_shared/lib/src/utils/file_utils.dart
@@ -35,7 +35,8 @@ Future<String> packageRootFromFileUriString(
 }) async {
   assert(
     fileUriString.startsWith(_fileUriPrefix),
-    'Invalid URI format: expected URI String to start with "$_fileUriPrefix".',
+    'Invalid URI format: expected URI String to start with "$_fileUriPrefix", '
+    'but instead, got $fileUriString.',
   );
 
   if (dtd != null) {
@@ -67,8 +68,11 @@ Future<String> packageRootFromFileUriString(
       }
     }
     if (throwOnDtdSearchFailed) {
-      throw Exception('Expected DTD to detect the package root, but it failed'
-          '${exception != null ? ' with exception: $exception' : '.'}');
+      throw Exception(
+        'Expected DTD to detect the package root for '
+        '$fileUriString, but it failed'
+        '${exception != null ? ' with exception: $exception' : '.'}',
+      );
     }
   }
 

--- a/packages/devtools_shared/lib/src/utils/file_utils.dart
+++ b/packages/devtools_shared/lib/src/utils/file_utils.dart
@@ -76,7 +76,7 @@ Future<String> packageRootFromFileUriString(
   // by walking the directory structure, default to using a regexp heuristic.
   final directoryRegExp =
       RegExp(r'\/(lib|bin|integration_test|test|benchmark|example)\/.+\.dart');
-  final directoryIndex = fileUriString.indexOf(directoryRegExp);
+  final directoryIndex = fileUriString.lastIndexOf(directoryRegExp);
   if (directoryIndex != -1) {
     fileUriString = fileUriString.substring(0, directoryIndex);
   }

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -27,6 +27,8 @@ late File benchmarkFile;
 late File benchmarkSubFile;
 late File exampleFile;
 late File exampleSubFile;
+late File nestedProjectLibFile;
+late File nestedProjectTestFile;
 late File anyFile;
 late File anySubFile;
 
@@ -125,6 +127,16 @@ void main() {
             useDtd: useDtd,
           );
 
+          // Dart file in a nested project.
+          await verifyPackageRoot(
+            nestedProjectLibFile.uri.toString(),
+            useDtd: useDtd,
+          );
+          await verifyPackageRoot(
+            nestedProjectTestFile.uri.toString(),
+            useDtd: useDtd,
+          );
+
           // Dart file under an unknown directory.
           await verifyPackageRoot(
             anyFile.uri.toString(),
@@ -163,6 +175,11 @@ void main() {
 ///     foo.dart
 ///     sub/
 ///       foo.dart
+///     nested_project/
+///       lib/
+///         foo.dart
+///       test/
+///         foo_test.dart
 ///   integration_test/
 ///     foo_test.dart
 ///     sub/
@@ -224,6 +241,24 @@ void _setupTestDirectoryStructure() {
   exampleSubFile =
       File(p.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
         ..createSync(recursive: true);
+  nestedProjectLibFile = File(
+    p.join(
+      projectRootDirectory.path,
+      'example',
+      'nested_project',
+      'lib',
+      'foo.dart',
+    ),
+  );
+  nestedProjectTestFile = File(
+    p.join(
+      projectRootDirectory.path,
+      'example',
+      'nested_project',
+      'test',
+      'foo_test.dart',
+    ),
+  );
   anyFile = File(p.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
     ..createSync(recursive: true);
   anySubFile =

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -130,10 +130,12 @@ void main() {
           // Dart file in a nested project.
           await verifyPackageRoot(
             nestedProjectLibFile.uri.toString(),
+            expected: p.join(projectRoot, 'example', 'nested_project'),
             useDtd: useDtd,
           );
           await verifyPackageRoot(
             nestedProjectTestFile.uri.toString(),
+            expected: p.join(projectRoot, 'example', 'nested_project'),
             useDtd: useDtd,
           );
 
@@ -176,6 +178,7 @@ void main() {
 ///     sub/
 ///       foo.dart
 ///     nested_project/
+///       .dart_tool/
 ///       lib/
 ///         foo.dart
 ///       test/
@@ -241,6 +244,15 @@ void _setupTestDirectoryStructure() {
   exampleSubFile =
       File(p.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
         ..createSync(recursive: true);
+  // Setup a nested Dart project under the 'example' directory.
+  Directory(
+    p.join(
+      projectRootDirectory.path,
+      'example',
+      'nested_project',
+      '.dart_tool',
+    ),
+  ).createSync(recursive: true);
   nestedProjectLibFile = File(
     p.join(
       projectRootDirectory.path,
@@ -249,7 +261,7 @@ void _setupTestDirectoryStructure() {
       'lib',
       'foo.dart',
     ),
-  );
+  )..createSync(recursive: true);
   nestedProjectTestFile = File(
     p.join(
       projectRootDirectory.path,
@@ -258,7 +270,7 @@ void _setupTestDirectoryStructure() {
       'test',
       'foo_test.dart',
     ),
-  );
+  )..createSync(recursive: true);
   anyFile = File(p.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
     ..createSync(recursive: true);
   anySubFile =


### PR DESCRIPTION
We were not detecting the proper package root for root library like:
`path/to/some_package/example/some_other_package/lib/foo.dart`. The package root for `foo.dart` is `some_other_package`, but we were returning the path to `some_package` because we were not taking the last index of the regexp match. This PR fixes the issue so we will properly return `some_package` for a case like this.