### PR TITLE
Fix a routing bug caused by disabling an extension

### DIFF
--- a/packages/devtools_app/lib/src/extensions/extension_settings.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_settings.dart
@@ -12,6 +12,8 @@ import '../shared/analytics/analytics.dart' as ga;
 import '../shared/analytics/constants.dart' as gac;
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
+import '../shared/routing.dart';
+import 'extension_screen.dart';
 
 /// A [ScaffoldAction] that, when clicked, will open a dialog menu for
 /// managing DevTools extension states.
@@ -169,6 +171,10 @@ class ExtensionSetting extends StatelessWidget {
               enable: false,
             ),
           );
+          final router = DevToolsRouterDelegate.of(context);
+          if (router.currentConfiguration?.page == extension.screenId) {
+            router.navigateHome(clearScreenParam: true);
+          }
         },
       ),
     ];

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -62,6 +62,8 @@ projects. - [#7742](https://github.com/flutter/devtools/pull/7742)
 * Add an example to `package:devtools_extensions` that shows how to
 interact with the Dart Tooling Daemon from a DevTools
 extension. - [#7752](https://github.com/flutter/devtools/pull/7752)
+* Fix a DevTools routing bug related to disabling an
+extension. - [#7791](https://github.com/flutter/devtools/pull/7791)
 
 ## Full commit history
 

--- a/packages/devtools_app/test/extensions/extension_settings_test.dart
+++ b/packages/devtools_app/test/extensions/extension_settings_test.dart
@@ -57,7 +57,7 @@ void main() {
       'builds dialog with no available extensions',
       (WidgetTester tester) async {
         await tester.pumpWidget(
-          wrapSimple(const ExtensionSettingsDialog(extensions: [])),
+          wrap(const ExtensionSettingsDialog(extensions: [])),
         );
         await tester.pumpAndSettle();
         expect(find.text('DevTools Extensions'), findsOneWidget);
@@ -74,7 +74,7 @@ void main() {
     testWidgets(
       'builds dialog with available extensions',
       (WidgetTester tester) async {
-        await tester.pumpWidget(wrapSimple(dialog));
+        await tester.pumpWidget(wrap(dialog));
         await tester.pumpAndSettle();
         expect(find.text('DevTools Extensions'), findsOneWidget);
         expect(
@@ -96,7 +96,7 @@ void main() {
     testWidgets(
       'pressing toggle buttons makes calls to the $ExtensionService',
       (WidgetTester tester) async {
-        await tester.pumpWidget(wrapSimple(dialog));
+        await tester.pumpWidget(wrap(dialog));
         await tester.pumpAndSettle();
 
         expect(
@@ -246,7 +246,7 @@ void main() {
           ExtensionEnabledState.enabled,
         );
 
-        await tester.pumpWidget(wrapSimple(dialog));
+        await tester.pumpWidget(wrap(dialog));
         await tester.pumpAndSettle();
         await expectLater(
           find.byWidget(dialog),
@@ -260,7 +260,7 @@ void main() {
     testWidgets(
       'toggle buttons update for changes to value notifiers',
       (WidgetTester tester) async {
-        await tester.pumpWidget(wrapSimple(dialog));
+        await tester.pumpWidget(wrap(dialog));
         await tester.pumpAndSettle();
         await expectLater(
           find.byWidget(dialog),
@@ -290,7 +290,7 @@ void main() {
           enable: true,
         );
 
-        await tester.pumpWidget(wrapSimple(dialog));
+        await tester.pumpWidget(wrap(dialog));
         await tester.pumpAndSettle();
         await expectLater(
           find.byWidget(dialog),


### PR DESCRIPTION
When on an extension screen, the extension can be disabled from the extensions menu. Without this change, we would show a screen not found error when the extension was disabled. After this change, we will properly navigate to the home screen like we do when a user disables an extension from the initial prompt.