### PR TITLE
Post ToolEvent when widget in rebuild table is selected

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:dds_service_extensions/dds_service_extensions.dart';
 import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
@@ -10,6 +11,7 @@ import 'package:flutter/material.dart';
 
 import '../../../../service/service_extension_widgets.dart';
 import '../../../../service/service_extensions.dart' as extensions;
+import '../../../../service/vm_service_wrapper.dart';
 import '../../../../shared/analytics/constants.dart' as gac;
 import '../../../../shared/common_widgets.dart';
 import '../../../../shared/globals.dart';
@@ -171,6 +173,8 @@ class _RebuildTableState extends State<RebuildTable> {
   /// column objects for the same column.
   final _columnCache = <String, _RebuildCountColumn>{};
 
+  VmServiceWrapper? get _service => serviceConnection.serviceManager.service;
+
   List<_RebuildCountColumn> get _metricsColumns {
     final columns = <_RebuildCountColumn>[];
     for (var i = 0; i < widget.metricNames.length; i++) {
@@ -207,8 +211,15 @@ class _RebuildTableState extends State<RebuildTable> {
         defaultSortColumn: _metricsColumns.first,
         defaultSortDirection: sortDirection,
         onItemSelected: (item) {
-          // TODO(jacobr): navigate to selected widget in IDE or display the
-          // content side by side with the rebuild table.
+          final location = item?.location;
+          if (location?.path != null) {
+            _service?.postEvent('ToolEvent', 'navigate', <String, Object>{
+              'fileUri': location?.path ?? '',
+              'line': location?.line ?? 0,
+              'column': location?.column ?? 0,
+              'source': 'flutter.performance'
+            });
+          }
         },
       ),
     );

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:dds_service_extensions/dds_service_extensions.dart';
 import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
@@ -213,12 +212,12 @@ class _RebuildTableState extends State<RebuildTable> {
         onItemSelected: (item) async {
           final location = item?.location;
           if (location?.path != null) {
-            await _service?.postEvent('ToolEvent', 'navigate', <String, Object>{
-              'fileUri': location?.path ?? '',
-              'line': location?.line ?? 0,
-              'column': location?.column ?? 0,
-              'source': 'flutter.performance',
-            });
+            await _service?.navigateToCode(
+              fileUri: location?.path ?? '',
+              line: location?.line ?? 0,
+              column: location?.column ?? 0,
+              source: 'flutter.performance',
+            );
           }
         },
       ),

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -211,12 +211,12 @@ class _RebuildTableState extends State<RebuildTable> {
         defaultSortDirection: sortDirection,
         onItemSelected: (item) async {
           final location = item?.location;
-          if (location?.path != null) {
+          if (location?.fileUri != null) {
             await _service?.navigateToCode(
-              fileUri: location?.path ?? '',
+              fileUri: location?.fileUri ?? '',
               line: location?.line ?? 0,
               column: location?.column ?? 0,
-              source: 'flutter.performance',
+              source: 'devtools.rebuildStats',
             );
           }
         },
@@ -243,7 +243,7 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
 
   @override
   String getValue(RebuildLocationStats dataObject) {
-    final path = dataObject.location.path;
+    final path = dataObject.location.fileUri;
     if (path == null) {
       return '<resolving location>';
     }
@@ -253,11 +253,11 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
 
   @override
   String getTooltip(RebuildLocationStats dataObject) {
-    if (dataObject.location.path == null) {
+    if (dataObject.location.fileUri == null) {
       return '<resolving location>';
     }
 
-    return '${dataObject.location.path}:${dataObject.location.line}';
+    return '${dataObject.location.fileUri}:${dataObject.location.line}';
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -243,12 +243,12 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
 
   @override
   String getValue(RebuildLocationStats dataObject) {
-    final path = dataObject.location.fileUriString;
-    if (path == null) {
+    final fileUriString = dataObject.location.fileUriString;
+    if (fileUriString == null) {
       return '<resolving location>';
     }
 
-    return '${path.split('/').last}:${dataObject.location.line}';
+    return '${fileUriString.split('/').last}:${dataObject.location.line}';
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -210,14 +210,14 @@ class _RebuildTableState extends State<RebuildTable> {
             ValueKey<String?>('${location.location.id}'),
         defaultSortColumn: _metricsColumns.first,
         defaultSortDirection: sortDirection,
-        onItemSelected: (item) {
+        onItemSelected: (item) async {
           final location = item?.location;
           if (location?.path != null) {
-            _service?.postEvent('ToolEvent', 'navigate', <String, Object>{
+            await _service?.postEvent('ToolEvent', 'navigate', <String, Object>{
               'fileUri': location?.path ?? '',
               'line': location?.line ?? 0,
               'column': location?.column ?? 0,
-              'source': 'flutter.performance'
+              'source': 'flutter.performance',
             });
           }
         },

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -211,9 +211,9 @@ class _RebuildTableState extends State<RebuildTable> {
         defaultSortDirection: sortDirection,
         onItemSelected: (item) async {
           final location = item?.location;
-          if (location?.fileUri != null) {
+          if (location?.fileUriString != null) {
             await _service?.navigateToCode(
-              fileUri: location?.fileUri ?? '',
+              fileUri: location?.fileUriString ?? '',
               line: location?.line ?? 0,
               column: location?.column ?? 0,
               source: 'devtools.rebuildStats',
@@ -243,7 +243,7 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
 
   @override
   String getValue(RebuildLocationStats dataObject) {
-    final path = dataObject.location.fileUri;
+    final path = dataObject.location.fileUriString;
     if (path == null) {
       return '<resolving location>';
     }
@@ -253,11 +253,11 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
 
   @override
   String getTooltip(RebuildLocationStats dataObject) {
-    if (dataObject.location.fileUri == null) {
+    if (dataObject.location.fileUriString == null) {
       return '<resolving location>';
     }
 
-    return '${dataObject.location.fileUri}:${dataObject.location.line}';
+    return '${dataObject.location.fileUriString}:${dataObject.location.line}';
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -213,7 +213,7 @@ class _RebuildTableState extends State<RebuildTable> {
           final location = item?.location;
           if (location?.fileUriString != null) {
             await _service?.navigateToCode(
-              fileUri: location?.fileUriString ?? '',
+              fileUriString: location?.fileUriString ?? '',
               line: location?.line ?? 0,
               column: location?.column ?? 0,
               source: 'devtools.rebuildStats',

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -96,7 +96,7 @@ class LocationMap {
     for (var location in _locationMap.values) {
       if (location.isResolved) {
         pathToLocations
-            .putIfAbsent(location.path!, () => <Location>[])
+            .putIfAbsent(location.fileUri!, () => <Location>[])
             .add(location);
       }
     }
@@ -134,10 +134,10 @@ class LocationMap {
         final id = ids[i];
         final existing = _locationMap[id];
         if (existing != null) {
-          if (existing.path == null) {
+          if (existing.fileUri == null) {
             // Fill in the empty placeholder location in _locationsMap for this
             // location id. The empty placeholder entry must be completely empty.
-            existing.path = path;
+            existing.fileUri = path;
             assert(existing.line == null);
             existing.line = lines[i];
             assert(existing.column == null);
@@ -149,7 +149,7 @@ class LocationMap {
             // Existing entry already has a path. Ensure it is consistent.
             // Data could become inconsistent if we had a bug and comingled data
             // from before and after a hot restart.
-            assert(existing.path == path);
+            assert(existing.fileUri == path);
             assert(existing.line == lines[i]);
             assert(existing.column == columns[i]);
             assert(existing.name == names[i]);
@@ -157,7 +157,7 @@ class LocationMap {
         } else {
           final location = Location(
             id: id,
-            path: path,
+            fileUri: path,
             line: lines[i],
             column: columns[i],
             name: names[i],
@@ -276,17 +276,17 @@ class RebuildCountModel {
 }
 
 class Location {
-  Location({required this.id, this.path, this.line, this.column, this.name});
+  Location({required this.id, this.fileUri, this.line, this.column, this.name});
 
   final int id;
 
   /// Either all of path, line, column, and name are null or none are.
-  String? path;
+  String? fileUri;
   int? line;
   int? column;
   String? name;
 
-  bool get isResolved => path != null;
+  bool get isResolved => fileUri != null;
 }
 
 class RebuildLocation {

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -276,7 +276,13 @@ class RebuildCountModel {
 }
 
 class Location {
-  Location({required this.id, this.fileUriString, this.line, this.column, this.name});
+  Location({
+    required this.id,
+    this.fileUriString,
+    this.line,
+    this.column,
+    this.name,
+  });
 
   final int id;
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -96,7 +96,7 @@ class LocationMap {
     for (var location in _locationMap.values) {
       if (location.isResolved) {
         pathToLocations
-            .putIfAbsent(location.fileUri!, () => <Location>[])
+            .putIfAbsent(location.fileUriString!, () => <Location>[])
             .add(location);
       }
     }
@@ -134,10 +134,10 @@ class LocationMap {
         final id = ids[i];
         final existing = _locationMap[id];
         if (existing != null) {
-          if (existing.fileUri == null) {
+          if (existing.fileUriString == null) {
             // Fill in the empty placeholder location in _locationsMap for this
             // location id. The empty placeholder entry must be completely empty.
-            existing.fileUri = path;
+            existing.fileUriString = path;
             assert(existing.line == null);
             existing.line = lines[i];
             assert(existing.column == null);
@@ -149,7 +149,7 @@ class LocationMap {
             // Existing entry already has a path. Ensure it is consistent.
             // Data could become inconsistent if we had a bug and comingled data
             // from before and after a hot restart.
-            assert(existing.fileUri == path);
+            assert(existing.fileUriString == path);
             assert(existing.line == lines[i]);
             assert(existing.column == columns[i]);
             assert(existing.name == names[i]);
@@ -157,7 +157,7 @@ class LocationMap {
         } else {
           final location = Location(
             id: id,
-            fileUri: path,
+            fileUriString: path,
             line: lines[i],
             column: columns[i],
             name: names[i],
@@ -276,17 +276,17 @@ class RebuildCountModel {
 }
 
 class Location {
-  Location({required this.id, this.fileUri, this.line, this.column, this.name});
+  Location({required this.id, this.fileUriString, this.line, this.column, this.name});
 
   final int id;
 
   /// Either all of path, line, column, and name are null or none are.
-  String? fileUri;
+  String? fileUriString;
   int? line;
   int? column;
   String? name;
 
-  bool get isResolved => fileUri != null;
+  bool get isResolved => fileUriString != null;
 }
 
 class RebuildLocation {

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^2.0.0
-  devtools_app_shared: ^0.2.0-dev.0
+  devtools_app_shared: ^0.3.0-dev.0
   devtools_extensions: ^0.2.0-dev.0
   devtools_shared: ^10.0.0-dev.1
   dtd: ^2.2.0

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   collection: ^1.15.0
   dap: ^1.1.0
   dds_service_extensions: ^2.0.0
-  devtools_app_shared: ^0.3.0-dev.0
+  devtools_app_shared: ^0.2.0-dev.1
   devtools_extensions: ^0.2.0-dev.0
   devtools_shared: ^10.0.0-dev.1
   dtd: ^2.2.0

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.3.0-dev.0
+## 0.2.0-dev.1
 * Add `navigateToCode` utility method for jumping to code in IDEs.
 
 ## 0.2.0-dev.0

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.3.0-dev.0
+* Add `navigateToCode` utility method for jumping to code in IDEs.
+
 ## 0.2.0-dev.0
 * Add `tooltipWaitExtraLong` to `utils.dart`.
 * Bump `devtools_shared` dependency to `^10.0.0`.

--- a/packages/devtools_app_shared/lib/src/service/service_utils.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_utils.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:dds_service_extensions/dds_service_extensions.dart';
 import 'package:vm_service/vm_service.dart';
 
 extension VmServiceExtension on VmService {
@@ -45,6 +46,23 @@ extension VmServiceExtension on VmService {
     Future<void> Function(IsolateRef) callback,
   ) async {
     await forEachIsolateHelper(this, callback);
+  }
+
+  /// Posts an event to jump to code at the specified [line] and [column] in the
+  /// specified [fileUri]. The [source] should indicate the tool and/or feature
+  /// that is making the jump to code request.
+  Future<void> navigateToCode({
+    required String fileUri,
+    required int line,
+    required int column,
+    required String source,
+  }) async {
+    await postEvent('ToolEvent', 'navigate', <String, Object>{
+      'fileUri': fileUri,
+      'line': line,
+      'column': column,
+      'source': source,
+    });
   }
 }
 

--- a/packages/devtools_app_shared/lib/src/service/service_utils.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_utils.dart
@@ -48,17 +48,21 @@ extension VmServiceExtension on VmService {
     await forEachIsolateHelper(this, callback);
   }
 
-  /// Posts an event to jump to code at the specified [line] and [column] in the
-  /// specified [fileUri]. The [source] should indicate the tool and/or feature
-  /// that is making the jump to code request.
+  /// Posts an event to jump to code.
+  ///
+  /// The event directs an IDE to move to the [line] and [column] in the
+  /// specified [fileUriString], which is expected to be a proper file URI (i.e.
+  /// starts with "file://"). The [source] should indicate the tool and/or
+  /// feature (i.e. in the format "someTool.someFeature") that is making the
+  /// jump to code request.
   Future<void> navigateToCode({
-    required String fileUri,
+    required String fileUriString,
     required int line,
     required int column,
     required String source,
   }) async {
     await postEvent('ToolEvent', 'navigate', <String, Object>{
-      'fileUri': fileUri,
+      'fileUri': fileUriString,
       'line': line,
       'column': column,
       'source': source,

--- a/packages/devtools_app_shared/lib/src/service/service_utils.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_utils.dart
@@ -55,6 +55,8 @@ extension VmServiceExtension on VmService {
   /// starts with "file://"). The [source] should indicate the tool and/or
   /// feature (i.e. in the format "someTool.someFeature") that is making the
   /// jump to code request.
+  ///
+  /// If there are no IDEs listening for this event, then this will be a no-op.
   Future<void> navigateToCode({
     required String fileUriString,
     required int line,

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.3.0-dev.0
+version: 0.2.0-dev.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.2.0-dev.0
+version: 0.3.0-dev.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:


### PR DESCRIPTION
Part of https://github.com/flutter/devtools/issues/4564

This sends a navigate to code `ToolEvent` to IDEs so that clicking on a widget in the rebuilds table opens the associated code in an editor.

This change still has an issue in that IntelliJ expects an event to include a field `type`, which this one doesn't. I'm not sure if that will require a change in IntelliJ code or in DDS somewhere. It works without further changes for VS Code.

It seems like since this is still gated by a feature flag that I shouldn't add a release note yet, but let me know if otherwise.

Fixes https://github.com/flutter/devtools/issues/4880