### PR TITLE
Enable memory screen in disconnected mode.

### DIFF
--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -56,8 +56,7 @@ enum ScreenMetaData {
     title: 'Memory',
     icon: Octicons.package,
     requiresDartVm: true,
-    // ignore: avoid_redundant_argument_values, false positive
-    requiresConnection: !FeatureFlags.memoryOffline,
+    requiresConnection: false,
     tutorialVideoTimestamp: '?t=420',
     // ignore: avoid_redundant_argument_values, false positive
     worksWithOfflineData: FeatureFlags.memoryOffline,


### PR DESCRIPTION
We need to enable it before offline data mode to create test automation.
Tests cannot flip constant flags. So, we need disconnected mode to be without constant flag.