### PR TITLE
Upgrade lints packages to v4 and address lints

### DIFF
--- a/case_study/code_size/optimized/code_size_images/pubspec.yaml
+++ b/case_study/code_size/optimized/code_size_images/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter project demonstrating code size issues with images.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/case_study/code_size/optimized/code_size_package/pubspec.yaml
+++ b/case_study/code_size/optimized/code_size_package/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter project demonstrating code size issues with packages.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter project demonstrating code size issues with images.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Flutter project demonstrating code size issues with packages.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/case_study/memory_leaks/images_1/pubspec.yaml
+++ b/case_study/memory_leaks/images_1/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter image memory leak example for a DevTools case study.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
 
 flutter:
   uses-material-design: true

--- a/case_study/memory_leaks/leaking_counter_1/pubspec.yaml
+++ b/case_study/memory_leaks/leaking_counter_1/pubspec.yaml
@@ -4,7 +4,7 @@ description: A new Flutter project.
 publish_to: none
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:
@@ -13,7 +13,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
 
 flutter:
   uses-material-design: true

--- a/case_study/memory_leaks/memory_leak_app/pubspec.yaml
+++ b/case_study/memory_leaks/memory_leak_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: memory_leak
 description: Flutter memory leak example app to serve as a DevTools case study.
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/case_study/platform_channel/pubspec.yaml
+++ b/case_study/platform_channel/pubspec.yaml
@@ -4,7 +4,7 @@ description: A Flutter example that uses a platform channel.
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -73,7 +73,7 @@ dev_dependencies:
   fake_async: ^1.3.1
   flutter_driver:
     sdk: flutter
-  flutter_lints: ^3.0.2
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
   integration_test:

--- a/packages/devtools_app/test/inspector/inspector_service_test.dart
+++ b/packages/devtools_app/test/inspector/inspector_service_test.dart
@@ -5,6 +5,8 @@
 // ignore_for_file: avoid_print
 
 @TestOn('vm')
+library;
+
 import 'dart:async';
 
 import 'package:devtools_app/devtools_app.dart';

--- a/packages/devtools_app/test/legacy_integration_tests/integration.dart
+++ b/packages/devtools_app/test/legacy_integration_tests/integration.dart
@@ -5,6 +5,8 @@
 // ignore_for_file: avoid_print
 
 @TestOn('vm')
+library;
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/devtools_app/test/legacy_integration_tests/integration_test.dart
+++ b/packages/devtools_app/test/legacy_integration_tests/integration_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging/logging_controller_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:convert';
 
 import 'package:devtools_app/src/screens/logging/logging_controller.dart';

--- a/packages/devtools_app/test/logging/logging_screen_data_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_data_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/logging/_log_details.dart';

--- a/packages/devtools_app/test/logging/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/logging/_log_details.dart';
 import 'package:devtools_app/src/screens/logging/_logs_table.dart';

--- a/packages/devtools_app/test/logging/logging_screen_v2/logging_controller_v2_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_v2/logging_controller_v2_test.dart
@@ -5,6 +5,8 @@
 // ignore_for_file: unused_import
 
 @TestOn('vm')
+library;
+
 import 'dart:convert';
 
 import 'package:devtools_app/devtools_app.dart';

--- a/packages/devtools_app/test/logging/logging_screen_v2/logging_screen_v2_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_v2/logging_screen_v2_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';

--- a/packages/devtools_app/test/memory/diff/controller/memory_footprint_test.dart
+++ b/packages/devtools_app/test/memory/diff/controller/memory_footprint_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
 
 import 'dart:io';
 

--- a/packages/devtools_app/test/network/network_controller_test.dart
+++ b/packages/devtools_app/test/network/network_controller_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
 
 import 'package:devtools_app/src/screens/network/network_controller.dart';
 import 'package:devtools_app/src/screens/network/network_model.dart';

--- a/packages/devtools_app/test/network/network_profiler_test.dart
+++ b/packages/devtools_app/test/network/network_profiler_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/network/network_request_inspector.dart';

--- a/packages/devtools_app/test/network/network_table_test.dart
+++ b/packages/devtools_app/test/network/network_table_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/ui.dart';

--- a/packages/devtools_app/test/performance/flutter_frames/flutter_frames_chart_test.dart
+++ b/packages/devtools_app/test/performance/flutter_frames/flutter_frames_chart_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/ui/colors.dart';
 import 'package:devtools_app_shared/ui.dart';

--- a/packages/devtools_app/test/performance/flutter_frames/flutter_frames_controller_test.dart
+++ b/packages/devtools_app/test/performance/flutter_frames/flutter_frames_controller_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/ui.dart';

--- a/packages/devtools_app/test/performance/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance/performance_screen_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:async';
 
 import 'package:devtools_app/devtools_app.dart';

--- a/packages/devtools_app/test/shared/ansi_up_test.dart
+++ b/packages/devtools_app/test/shared/ansi_up_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('chrome')
+library;
 
 import 'package:ansi_up/ansi_up.dart';
 import 'package:ansicolor/ansicolor.dart';

--- a/packages/devtools_app/test/shared/extent_delegate_list_view_test.dart
+++ b/packages/devtools_app/test/shared/extent_delegate_list_view_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/src/shared/primitives/custom_pointer_scroll_view.dart';
 import 'package:devtools_app/src/shared/primitives/extent_delegate_list.dart';
 import 'package:flutter/gestures.dart';

--- a/packages/devtools_app/test/shared/extent_delegate_test.dart
+++ b/packages/devtools_app/test/shared/extent_delegate_test.dart
@@ -5,6 +5,8 @@
 // ignore_for_file: avoid_print
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/src/shared/primitives/extent_delegate_list.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/shared/initializer_test.dart
+++ b/packages/devtools_app/test/shared/initializer_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/framework/initializer.dart';
 import 'package:devtools_app/src/shared/framework_controller.dart';

--- a/packages/devtools_app/test/shared/span_parser_test.dart
+++ b/packages/devtools_app/test/shared/span_parser_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/devtools_app/test/shared/syntax_highlighter_test.dart
+++ b/packages/devtools_app/test/shared/syntax_highlighter_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/packages/devtools_app/test/shared/timeline_streams_test.dart
+++ b/packages/devtools_app/test/shared/timeline_streams_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_shared/devtools_test_utils.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/shared/vm_flags_test.dart
+++ b/packages/devtools_app/test/shared/vm_flags_test.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/src/shared/globals.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+2
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/flutter_error_app/pubspec.yaml
@@ -10,7 +10,7 @@ description: App for running DevTools integration tests.
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_app/test/test_infra/fixtures/memory_app/pubspec.yaml
+++ b/packages/devtools_app/test/test_infra/fixtures/memory_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: 'none'
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_app/test/test_infra/utils/extent_delegate_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/extent_delegate_utils.dart
@@ -3,6 +3,8 @@
 // found in the LICENSE file.
 
 @TestOn('vm')
+library;
+
 import 'package:devtools_app/src/shared/primitives/extent_delegate_list.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -129,10 +129,10 @@ final class ServiceExtensionManager with DisposerMixin {
     final expectedValueType =
         extensions.serviceExtensionsAllowlist[name]!.values.first.runtimeType;
     switch (expectedValueType) {
-      case bool:
+      case const (bool):
         return encodedValue == 'true';
-      case int:
-      case double:
+      case const (int):
+      case const (double):
         return num.parse(encodedValue);
       default:
         return encodedValue;
@@ -289,17 +289,17 @@ final class ServiceExtensionManager with DisposerMixin {
         if (isolateRef != _mainIsolate) return;
 
         switch (expectedValueType) {
-          case bool:
+          case const (bool):
             final bool enabled =
                 response.json!['enabled'] == 'true' ? true : false;
             await _maybeRestoreExtension(name, enabled);
             return;
-          case String:
+          case const (String):
             final String? value = response.json!['value'];
             await _maybeRestoreExtension(name, value);
             return;
-          case int:
-          case double:
+          case const (int):
+          case const (double):
             final num value = num.parse(
               response.json![name.substring(name.lastIndexOf('.') + 1)],
             );

--- a/packages/devtools_app_shared/lib/src/utils/utils.dart
+++ b/packages/devtools_app_shared/lib/src/utils/utils.dart
@@ -50,7 +50,7 @@ int sortFieldsByName(String a, String b) {
 
 /// A value notifier that calls each listener immediately when registered.
 final class ImmediateValueNotifier<T> extends ValueNotifier<T> {
-  ImmediateValueNotifier(T value) : super(value);
+  ImmediateValueNotifier(super.value);
 
   /// Adds a listener and calls the listener upon registration.
   @override

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -22,10 +22,10 @@ dependencies:
   web: ^0.4.1
 
 dev_dependencies:
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
-  lints: ^2.1.1
+  lints: ^4.0.0
   test: ^1.21.0
 
 flutter:

--- a/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
+++ b/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
@@ -10,11 +10,11 @@ import 'package:devtools_shared/devtools_test_utils.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-class AutoDisposeContoller extends DisposableController
+class AutoDisposeController extends DisposableController
     with AutoDisposeControllerMixin {}
 
 class AutoDisposedWidget extends StatefulWidget {
-  const AutoDisposedWidget(this.stream, {Key? key}) : super(key: key);
+  const AutoDisposedWidget(this.stream, {super.key});
 
   final Stream<Object?> stream;
 
@@ -347,7 +347,7 @@ void main() {
   });
 
   test('Test Listenable auto dispose', () {
-    final controller = AutoDisposeContoller();
+    final controller = AutoDisposeController();
     final notifier = ValueNotifier<int>(42);
     final values = <int>[];
     controller.addAutoDisposeListener(notifier, () {

--- a/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
+++ b/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:
@@ -19,7 +19,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0
   standalone_extension:
     path: ../packages_with_extensions/standalone_extension
   test: ^1.21.0

--- a/packages/devtools_extensions/example/packages_with_extensions/dart_foo/packages/dart_foo_devtools_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/dart_foo/packages/dart_foo_devtools_extension/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo/pubspec.yaml
@@ -3,7 +3,7 @@ description: A package with stuff (an example package that has a DevTools extens
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:
@@ -13,4 +13,4 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0

--- a/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo_devtools_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/foo/packages/foo_devtools_extension/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:

--- a/packages/devtools_extensions/example/packages_with_extensions/standalone_extension/pubspec.yaml
+++ b/packages/devtools_extensions/example/packages_with_extensions/standalone_extension/pubspec.yaml
@@ -5,7 +5,7 @@ publish_to: 'none'
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
   flutter: '>=3.0.0'
 
 dependencies:
@@ -26,4 +26,4 @@ dependency_overrides:
     path: ../../../../devtools_extensions 
   devtools_shared:
     path: ../../../../devtools_shared
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
 dev_dependencies:
   flutter_driver:
     sdk: flutter
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0
   flutter_test:
     sdk: flutter
   flutter_web_plugins:

--- a/packages/devtools_extensions/test/web/devtools_extension_test.dart
+++ b/packages/devtools_extensions/test/web/devtools_extension_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 @TestOn('browser')
+library;
 
 import 'package:devtools_extensions/devtools_extensions.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -24,5 +24,5 @@ dependencies:
   yaml_edit: ^2.1.1
 
 dev_dependencies:
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0
   test: ^1.21.2

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -42,4 +42,4 @@ dependency_overrides:
 
 dev_dependencies:
   build_runner: ^2.3.3
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0

--- a/packages/pubspec.yaml
+++ b/packages/pubspec.yaml
@@ -3,7 +3,7 @@ name: devtools_root
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ^3.2.0
 
 dev_dependencies:
-  flutter_lints: ^2.0.3
+  flutter_lints: ^4.0.0

--- a/third_party/packages/ansi_up/pubspec.yaml
+++ b/third_party/packages/ansi_up/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/a
 version: 1.0.0
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^4.0.0

--- a/third_party/packages/codicon/pubspec.yaml
+++ b/third_party/packages/codicon/pubspec.yaml
@@ -4,14 +4,14 @@ homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/c
 version: 1.0.0
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
 
 flutter:
   fonts:

--- a/third_party/packages/perfetto_ui_compiled/pubspec.yaml
+++ b/third_party/packages/perfetto_ui_compiled/pubspec.yaml
@@ -4,4 +4,4 @@ homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/p
 version: 0.0.1
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0

--- a/third_party/packages/widget_icons/example/pubspec.yaml
+++ b/third_party/packages/widget_icons/example/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 version: 0.0.2
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
 
 dependencies:
   flutter:
@@ -16,7 +16,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
 
 flutter:
   uses-material-design: true

--- a/third_party/packages/widget_icons/pubspec.yaml
+++ b/third_party/packages/widget_icons/pubspec.yaml
@@ -4,7 +4,7 @@ version: 0.0.2
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/widget_icons
 
 environment:
-  sdk: ^3.0.0
+  sdk: ^3.2.0
   flutter: ">=3.7.0"
 
 dependencies:
@@ -14,7 +14,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^3.0.1
+  flutter_lints: ^4.0.0
 
 flutter:
   fonts:

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -18,4 +18,4 @@ dependencies:
 dependency_overrides:
   devtools_shared:
     path: ../packages/devtools_shared
-  lints: ^3.0.0
+  lints: ^4.0.0


### PR DESCRIPTION
Also updates various SDK constraints to `^3.2.0` for consistency and support for the new `package:lints` releases.