### PR TITLE
Fork the inspector panel and hide the forked version behind a feature flag

### DIFF
--- a/packages/devtools_app/benchmark/web_bundle_size_test.dart
+++ b/packages/devtools_app/benchmark/web_bundle_size_test.dart
@@ -12,7 +12,7 @@ import 'package:test/test.dart';
 
 // Benchmark size in kB.
 const int bundleSizeBenchmark = 5000;
-const int gzipBundleSizeBenchmark = 1450;
+const int gzipBundleSizeBenchmark = 1500;
 
 void main() {
   group('Web Compile', () {

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -599,32 +599,31 @@ List<DevToolsScreen> defaultScreens({
     DevToolsScreen<void>(HomeScreen(sampleData: sampleData)),
     // TODO(https://github.com/flutter/devtools/issues/7860): Clean-up after
     // Inspector V2 has been released.
-    if (FeatureFlags.inspectorV2)
-      DevToolsScreen<inspector_v2.InspectorController>(
-        inspector_v2.InspectorScreen(),
-        createController: (_) => inspector_v2.InspectorController(
-          inspectorTree: inspector_v2.InspectorTreeController(
-            gaId: InspectorScreenMetrics.summaryTreeGaId,
+    FeatureFlags.inspectorV2
+        ? DevToolsScreen<inspector_v2.InspectorController>(
+            inspector_v2.InspectorScreen(),
+            createController: (_) => inspector_v2.InspectorController(
+              inspectorTree: inspector_v2.InspectorTreeController(
+                gaId: InspectorScreenMetrics.summaryTreeGaId,
+              ),
+              detailsTree: inspector_v2.InspectorTreeController(
+                gaId: InspectorScreenMetrics.detailsTreeGaId,
+              ),
+              treeType: FlutterTreeType.widget,
+            ),
+          )
+        : DevToolsScreen<InspectorController>(
+            InspectorScreen(),
+            createController: (_) => InspectorController(
+              inspectorTree: InspectorTreeController(
+                gaId: InspectorScreenMetrics.summaryTreeGaId,
+              ),
+              detailsTree: InspectorTreeController(
+                gaId: InspectorScreenMetrics.detailsTreeGaId,
+              ),
+              treeType: FlutterTreeType.widget,
+            ),
           ),
-          detailsTree: inspector_v2.InspectorTreeController(
-            gaId: InspectorScreenMetrics.detailsTreeGaId,
-          ),
-          treeType: FlutterTreeType.widget,
-        ),
-      ),
-    if (!FeatureFlags.inspectorV2)
-      DevToolsScreen<InspectorController>(
-        InspectorScreen(),
-        createController: (_) => InspectorController(
-          inspectorTree: InspectorTreeController(
-            gaId: InspectorScreenMetrics.summaryTreeGaId,
-          ),
-          detailsTree: InspectorTreeController(
-            gaId: InspectorScreenMetrics.detailsTreeGaId,
-          ),
-          treeType: FlutterTreeType.widget,
-        ),
-      ),
     DevToolsScreen<PerformanceController>(
       PerformanceScreen(),
       createController: (_) => PerformanceController(),

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -28,6 +28,9 @@ import 'screens/deep_link_validation/deep_links_screen.dart';
 import 'screens/inspector/inspector_controller.dart';
 import 'screens/inspector/inspector_screen.dart';
 import 'screens/inspector/inspector_tree_controller.dart';
+import 'screens/inspector_v2/inspector_controller.dart' as inspector_v2;
+import 'screens/inspector_v2/inspector_screen.dart' as inspector_v2;
+import 'screens/inspector_v2/inspector_tree_controller.dart' as inspector_v2;
 import 'screens/logging/logging_controller.dart';
 import 'screens/logging/logging_screen.dart';
 import 'screens/logging/logging_screen_v2/logging_controller_v2.dart';
@@ -594,18 +597,34 @@ List<DevToolsScreen> defaultScreens({
 }) {
   return devtoolsScreens ??= <DevToolsScreen>[
     DevToolsScreen<void>(HomeScreen(sampleData: sampleData)),
-    DevToolsScreen<InspectorController>(
-      InspectorScreen(),
-      createController: (_) => InspectorController(
-        inspectorTree: InspectorTreeController(
-          gaId: InspectorScreenMetrics.summaryTreeGaId,
+    // TODO(https://github.com/flutter/devtools/issues/7860): Clean-up after
+    // Inspector V2 has been released.
+    if (FeatureFlags.inspectorV2)
+      DevToolsScreen<inspector_v2.InspectorController>(
+        inspector_v2.InspectorScreen(),
+        createController: (_) => inspector_v2.InspectorController(
+          inspectorTree: inspector_v2.InspectorTreeController(
+            gaId: InspectorScreenMetrics.summaryTreeGaId,
+          ),
+          detailsTree: inspector_v2.InspectorTreeController(
+            gaId: InspectorScreenMetrics.detailsTreeGaId,
+          ),
+          treeType: FlutterTreeType.widget,
         ),
-        detailsTree: InspectorTreeController(
-          gaId: InspectorScreenMetrics.detailsTreeGaId,
-        ),
-        treeType: FlutterTreeType.widget,
       ),
-    ),
+    if (!FeatureFlags.inspectorV2)
+      DevToolsScreen<InspectorController>(
+        InspectorScreen(),
+        createController: (_) => InspectorController(
+          inspectorTree: InspectorTreeController(
+            gaId: InspectorScreenMetrics.summaryTreeGaId,
+          ),
+          detailsTree: InspectorTreeController(
+            gaId: InspectorScreenMetrics.detailsTreeGaId,
+          ),
+          treeType: FlutterTreeType.widget,
+        ),
+      ),
     DevToolsScreen<PerformanceController>(
       PerformanceScreen(),
       createController: (_) => PerformanceController(),

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_breadcrumbs.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_breadcrumbs.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_breadcrumbs.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_breadcrumbs.dart
@@ -1,0 +1,209 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../shared/common_widgets.dart';
+import '../../shared/console/eval/inspector_tree.dart';
+import '../../shared/diagnostics_text_styles.dart';
+import '../../shared/primitives/utils.dart';
+
+class InspectorBreadcrumbNavigator extends StatelessWidget {
+  const InspectorBreadcrumbNavigator({
+    super.key,
+    required this.items,
+    required this.onTap,
+  });
+
+  /// Max number of visible breadcrumbs including root item but not 'more' item.
+  /// E.g. value 5 means root and 4 breadcrumbs can be displayed, other
+  /// breadcrumbs (if any) will be replaced by '...' item.
+  static const _maxNumberOfBreadcrumbs = 5;
+
+  final List<InspectorTreeNode> items;
+  final void Function(InspectorTreeNode?) onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    if (items.isEmpty) {
+      return const SizedBox();
+    }
+
+    final breadcrumbs = _generateBreadcrumbs(items);
+    return SizedBox(
+      height: Breadcrumb.height,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 6),
+        child: Row(
+          children: breadcrumbs.map((item) {
+            if (item.isChevron) {
+              return Icon(
+                Icons.chevron_right,
+                size: defaultIconSize,
+              );
+            }
+
+            return Flexible(
+              child: _InspectorBreadcrumb(
+                data: item,
+                onTap: () => onTap(item.node),
+              ),
+            );
+          }).toList(),
+        ),
+      ),
+    );
+  }
+
+  List<_InspectorBreadcrumbData> _generateBreadcrumbs(
+    List<InspectorTreeNode> nodes,
+  ) {
+    final lastNode = nodes.safeLast;
+    final List<_InspectorBreadcrumbData> items = nodes.map((node) {
+      return _InspectorBreadcrumbData.wrap(
+        node: node,
+        isSelected: node == lastNode,
+      );
+    }).toList();
+    List<_InspectorBreadcrumbData> breadcrumbs;
+    breadcrumbs = items.length > _maxNumberOfBreadcrumbs
+        ? [
+            items[0],
+            _InspectorBreadcrumbData.more(),
+            ...items.sublist(
+              items.length - _maxNumberOfBreadcrumbs + 1,
+              items.length,
+            ),
+          ]
+        : items;
+
+    return breadcrumbs.joinWith(_InspectorBreadcrumbData.chevron());
+  }
+}
+
+class _InspectorBreadcrumb extends StatelessWidget {
+  const _InspectorBreadcrumb({
+    required this.data,
+    required this.onTap,
+  });
+
+  static const _iconScale = 0.75;
+
+  final _InspectorBreadcrumbData data;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = Text(
+      data.text,
+      maxLines: 1,
+      overflow: TextOverflow.ellipsis,
+      style: DiagnosticsTextStyles.regular(Theme.of(context).colorScheme)
+          .copyWith(fontSize: scaleByFontFactor(11)),
+    );
+
+    final icon = data.icon == null
+        ? null
+        : Transform.scale(
+            scale: _iconScale,
+            child: Padding(
+              padding: const EdgeInsets.only(right: iconPadding),
+              child: data.icon,
+            ),
+          );
+
+    return InkWell(
+      onTap: data.isClickable ? onTap : null,
+      borderRadius: defaultBorderRadius,
+      child: Container(
+        padding: const EdgeInsets.symmetric(
+          horizontal: densePadding,
+          vertical: borderPadding,
+        ),
+        decoration: BoxDecoration(
+          borderRadius: defaultBorderRadius,
+          color: data.isSelected
+              ? Theme.of(context).colorScheme.selectedRowBackgroundColor
+              : Colors.transparent,
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (icon != null) icon,
+            Flexible(child: text),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InspectorBreadcrumbData {
+  const _InspectorBreadcrumbData._({
+    required this.node,
+    required this.isSelected,
+    required this.alternativeText,
+    required this.alternativeIcon,
+  });
+
+  factory _InspectorBreadcrumbData.wrap({
+    required InspectorTreeNode node,
+    required bool isSelected,
+  }) {
+    return _InspectorBreadcrumbData._(
+      node: node,
+      isSelected: isSelected,
+      alternativeText: null,
+      alternativeIcon: null,
+    );
+  }
+
+  /// Construct a special item for showing '…' symbol between other items
+  factory _InspectorBreadcrumbData.more() {
+    return const _InspectorBreadcrumbData._(
+      node: null,
+      isSelected: false,
+      alternativeText: _ellipsisValue,
+      alternativeIcon: null,
+    );
+  }
+
+  factory _InspectorBreadcrumbData.chevron() {
+    return const _InspectorBreadcrumbData._(
+      node: null,
+      isSelected: false,
+      alternativeText: null,
+      alternativeIcon: _breadcrumbSeparatorIcon,
+    );
+  }
+
+  static const _ellipsisValue = '…';
+  static const _breadcrumbSeparatorIcon = Icons.chevron_right;
+
+  final InspectorTreeNode? node;
+  final IconData? alternativeIcon;
+  final String? alternativeText;
+  final bool isSelected;
+
+  String get text => alternativeText ?? node?.diagnostic?.description ?? '';
+
+  Widget? get icon {
+    if (alternativeIcon != null) {
+      return Icon(
+        _breadcrumbSeparatorIcon,
+        size: defaultIconSize,
+      );
+    }
+
+    return node?.diagnostic?.icon;
+  }
+
+  bool get isChevron =>
+      node == null && alternativeIcon == _breadcrumbSeparatorIcon;
+
+  bool get isEllipsis => node == null && alternativeText == _ellipsisValue;
+
+  bool get isClickable => !isSelected && !isEllipsis;
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -1,0 +1,941 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// This library must not have direct dependencies on dart:html.
+///
+/// This allows tests of the complicated logic in this class to run on the VM
+/// and will help simplify porting this code to work with Hummingbird.
+///
+/// This code is directly based on
+/// src/io/flutter/view/InspectorPanel.java
+/// with some refactors to make the code more of a controller than a combination
+/// of view and controller. View specific portions of InspectorPanel.java have
+/// been moved to inspector.dart.
+library;
+
+import 'dart:async';
+
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:vm_service/vm_service.dart';
+
+import '../../service/service_extensions.dart' as extensions;
+import '../../shared/console/eval/inspector_tree.dart';
+import '../../shared/console/primitives/simple_items.dart';
+import '../../shared/diagnostics/diagnostics_node.dart';
+import '../../shared/diagnostics/inspector_service.dart';
+import '../../shared/diagnostics/primitives/instance_ref.dart';
+import '../../shared/globals.dart';
+import '../../shared/primitives/utils.dart';
+import 'inspector_screen.dart';
+import 'inspector_tree_controller.dart';
+
+final _log = Logger('inspector_controller');
+
+const inspectorRefQueryParam = 'inspectorRef';
+
+/// This class is based on the InspectorPanel class from the Flutter IntelliJ
+/// plugin with some refactors to make it more of a true controller than a view.
+class InspectorController extends DisposableController
+    with AutoDisposeControllerMixin
+    implements InspectorServiceClient {
+  InspectorController({
+    required this.inspectorTree,
+    InspectorTreeController? detailsTree,
+    required this.treeType,
+    this.parent,
+    this.isSummaryTree = true,
+  }) : assert((detailsTree != null) == isSummaryTree) {
+    unawaited(_init(detailsTree: detailsTree));
+  }
+
+  Future<void> _init({
+    InspectorTreeController? detailsTree,
+  }) async {
+    _refreshRateLimiter = RateLimiter(refreshFramesPerSecond, refresh);
+
+    inspectorTree.config = InspectorTreeConfig(
+      onNodeAdded: _onNodeAdded,
+      onSelectionChange: selectionChanged,
+      onExpand: _onExpand,
+      onClientActiveChange: _onClientChange,
+    );
+    details = isSummaryTree
+        ? InspectorController(
+            inspectorTree: detailsTree!,
+            treeType: treeType,
+            parent: this,
+            isSummaryTree: false,
+          )
+        : null;
+
+    await serviceConnection.serviceManager.onServiceAvailable;
+
+    if (inspectorService is InspectorService) {
+      _treeGroups = InspectorObjectGroupManager(
+        serviceConnection.inspectorService as InspectorService,
+        'tree',
+      );
+      _selectionGroups = InspectorObjectGroupManager(
+        serviceConnection.inspectorService as InspectorService,
+        'selection',
+      );
+    }
+
+    addAutoDisposeListener(
+      serviceConnection.serviceManager.isolateManager.mainIsolate,
+      () {
+        final isolate =
+            serviceConnection.serviceManager.isolateManager.mainIsolate.value;
+        if (isolate != _mainIsolate) {
+          onIsolateStopped();
+        }
+        _mainIsolate = isolate;
+      },
+    );
+
+    // This logic only needs to be run once so run it in the outermost
+    // controller.
+    if (parent == null) {
+      // If select mode is available, enable the on device inspector as it
+      // won't interfere with users.
+      addAutoDisposeListener(_supportsToggleSelectWidgetMode, () {
+        if (_supportsToggleSelectWidgetMode.value) {
+          serviceConnection.serviceManager.serviceExtensionManager
+              .setServiceExtensionState(
+            extensions.enableOnDeviceInspector.extension,
+            enabled: true,
+            value: true,
+          );
+        }
+      });
+    }
+
+    addAutoDisposeListener(serviceConnection.serviceManager.connectedState, () {
+      if (serviceConnection.serviceManager.connectedState.value.connected) {
+        _handleConnectionStart();
+      } else {
+        _handleConnectionStop();
+      }
+    });
+
+    if (serviceConnection.serviceManager.connectedAppInitialized) {
+      _handleConnectionStart();
+    }
+
+    serviceConnection.consoleService.ensureServiceInitialized();
+  }
+
+  void _handleConnectionStart() {
+    // Clear any existing badge/errors for older errors that were collected.
+    // Do this in a post frame callback so that we are not trying to clear the
+    // error notifiers for this screen while the framework is already in the
+    // process of building widgets.
+    // TODO(kenz): When this method is called outside  createState(), this post
+    // frame callback can be removed.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+    });
+    filterErrors();
+  }
+
+  void _handleConnectionStop() {
+    setActivate(false);
+    if (isSummaryTree) {
+      dispose();
+    }
+  }
+
+  IsolateRef? _mainIsolate;
+
+  ValueListenable<bool> get _supportsToggleSelectWidgetMode =>
+      serviceConnection.serviceManager.serviceExtensionManager
+          .hasServiceExtension(extensions.toggleSelectWidgetMode.extension);
+
+  void _onClientChange(bool added) {
+    if (!added && _clientCount == 0) {
+      // Don't try to remove clients if there are none
+      return;
+    }
+
+    _clientCount += added ? 1 : -1;
+    assert(_clientCount >= 0);
+    if (_clientCount == 1) {
+      setVisibleToUser(true);
+      setActivate(true);
+    } else if (_clientCount == 0) {
+      setVisibleToUser(false);
+    }
+  }
+
+  int _clientCount = 0;
+
+  /// Maximum frame rate to refresh the inspector at to avoid taxing the
+  /// physical device with too many requests to recompute properties and trees.
+  ///
+  /// A value up to around 30 frames per second could be reasonable for
+  /// debugging highly interactive cases particularly when the user is on a
+  /// simulator or high powered native device. The frame rate is set low
+  /// for now mainly to minimize risk.
+  static const double refreshFramesPerSecond = 5.0;
+
+  final bool isSummaryTree;
+
+  /// Parent InspectorController if this is a details subtree.
+  InspectorController? parent;
+
+  InspectorController? details;
+
+  InspectorTreeController inspectorTree;
+  final FlutterTreeType treeType;
+
+  bool _disposed = false;
+
+  late RateLimiter _refreshRateLimiter;
+
+  InspectorServiceBase get inspectorService =>
+      serviceConnection.inspectorService as InspectorServiceBase;
+
+  /// Groups used to manage and cancel requests to load data to display directly
+  /// in the tree.
+  InspectorObjectGroupManager? _treeGroups;
+
+  /// Groups used to manage and cancel requests to determine what the current
+  /// selection is.
+  ///
+  /// This group needs to be kept separate from treeGroups as the selection is
+  /// shared more with the details subtree.
+  /// TODO(jacobr): is there a way we can unify the selection and tree groups?
+  InspectorObjectGroupManager? _selectionGroups;
+
+  /// Node being highlighted due to the current hover.
+  InspectorTreeNode? get currentShowNode => inspectorTree.hover;
+
+  set currentShowNode(InspectorTreeNode? node) => inspectorTree.hover = node;
+
+  bool flutterAppFrameReady = false;
+
+  bool treeLoadStarted = false;
+
+  RemoteDiagnosticsNode? subtreeRoot;
+
+  bool programmaticSelectionChangeInProgress = false;
+
+  ValueListenable<InspectorTreeNode?> get selectedNode => _selectedNode;
+  final ValueNotifier<InspectorTreeNode?> _selectedNode = ValueNotifier(null);
+
+  InspectorTreeNode? lastExpanded;
+
+  bool isActive = false;
+
+  final Map<InspectorInstanceRef, InspectorTreeNode> valueToInspectorTreeNode =
+      {};
+
+  /// When visibleToUser is false we should dispose all allocated objects and
+  /// not perform any actions.
+  bool visibleToUser = false;
+
+  bool highlightNodesShownInBothTrees = false;
+
+  bool get detailsSubtree => parent != null;
+
+  RemoteDiagnosticsNode? get selectedDiagnostic =>
+      selectedNode.value?.diagnostic;
+
+  final ValueNotifier<int?> _selectedErrorIndex = ValueNotifier<int?>(null);
+
+  ValueListenable<int?> get selectedErrorIndex => _selectedErrorIndex;
+
+  /// Tracks whether the first load of the inspector tree has been completed.
+  ///
+  /// This field is used to prevent sending multiple analytics events for
+  /// inspector tree load timing.
+  bool firstInspectorTreeLoadCompleted = false;
+
+  FlutterTreeType getTreeType() {
+    return treeType;
+  }
+
+  void setVisibleToUser(bool visible) {
+    if (visibleToUser == visible) {
+      return;
+    }
+    visibleToUser = visible;
+
+    if (visibleToUser) {
+      if (parent == null) {
+        unawaited(maybeLoadUI());
+      }
+    } else {
+      shutdownTree(false);
+    }
+  }
+
+  bool hasDiagnosticsValue(InspectorInstanceRef ref) {
+    return valueToInspectorTreeNode.containsKey(ref);
+  }
+
+  RemoteDiagnosticsNode? findDiagnosticsValue(InspectorInstanceRef ref) {
+    return valueToInspectorTreeNode[ref]?.diagnostic;
+  }
+
+  void endShowNode() {
+    highlightShowNode(null);
+  }
+
+  bool highlightShowFromNodeInstanceRef(InspectorInstanceRef ref) {
+    return highlightShowNode(valueToInspectorTreeNode[ref]);
+  }
+
+  bool highlightShowNode(InspectorTreeNode? node) {
+    if (node == null && parent != null) {
+      // If nothing is highlighted, highlight the node selected in the parent
+      // tree so user has context of where the node selected in the parent is
+      // in the details tree.
+      node = findMatchingInspectorTreeNode(parent?.selectedDiagnostic);
+    }
+
+    currentShowNode = node;
+    return true;
+  }
+
+  InspectorTreeNode? findMatchingInspectorTreeNode(
+    RemoteDiagnosticsNode? node,
+  ) {
+    final valueRef = node?.valueRef;
+    if (valueRef == null) {
+      return null;
+    }
+    return valueToInspectorTreeNode[valueRef];
+  }
+
+  Future<void> _waitForPendingUpdateDone() async {
+    // Wait for the selection to be resolved followed by waiting for the tree to be computed.
+    await _selectionGroups?.pendingUpdateDone;
+    await _treeGroups?.pendingUpdateDone;
+    // TODO(jacobr): are there race conditions we need to think more carefully about here?
+  }
+
+  Future<void> refresh() {
+    if (!visibleToUser) {
+      // We will refresh again once we are visible.
+      // There is a risk a refresh got triggered before the view was visble.
+      return Future.value();
+    }
+
+    // TODO(jacobr): refresh the tree as well as just the properties.
+    final detailsLocal = details;
+    if (detailsLocal == null) return _waitForPendingUpdateDone();
+
+    return Future.wait([
+      _waitForPendingUpdateDone(),
+      detailsLocal._waitForPendingUpdateDone(),
+    ]);
+  }
+
+  // Note that this may be called after the controller is disposed.  We need to handle nulls in the fields.
+  void shutdownTree(bool isolateStopped) {
+    // It is critical we clear all data that is kept alive by inspector object
+    // references in this method as that stale data will trigger inspector
+    // exceptions.
+    programmaticSelectionChangeInProgress = true;
+    _treeGroups?.clear(isolateStopped);
+    _selectionGroups?.clear(isolateStopped);
+
+    currentShowNode = null;
+    _selectedNode.value = null;
+    lastExpanded = null;
+
+    subtreeRoot = null;
+
+    inspectorTree.root = inspectorTree.createNode();
+    programmaticSelectionChangeInProgress = false;
+    valueToInspectorTreeNode.clear();
+  }
+
+  void onIsolateStopped() {
+    flutterAppFrameReady = false;
+    treeLoadStarted = false;
+    shutdownTree(true);
+  }
+
+  @override
+  Future<void> onForceRefresh() async {
+    assert(!_disposed);
+    if (!visibleToUser || _disposed) {
+      return;
+    }
+    await _recomputeTreeRoot(null, null, false);
+    if (_disposed) {
+      return;
+    }
+
+    filterErrors();
+
+    return _waitForPendingUpdateDone();
+  }
+
+  void filterErrors() {
+    if (isSummaryTree) {
+      serviceConnection.errorBadgeManager.filterErrors(
+        InspectorScreen.id,
+        (id) => hasDiagnosticsValue(InspectorInstanceRef(id)),
+      );
+    }
+  }
+
+  void setActivate(bool enabled) {
+    if (!enabled) {
+      onIsolateStopped();
+      isActive = false;
+      return;
+    }
+    if (isActive) {
+      // Already activated.
+      return;
+    }
+
+    isActive = true;
+    inspectorService.addClient(this);
+    unawaited(maybeLoadUI());
+  }
+
+  Future<void> maybeLoadUI() async {
+    if (parent != null) {
+      // The parent controller will drive loading the UI.
+      return;
+    }
+    if (!visibleToUser || !isActive) {
+      return;
+    }
+
+    if (flutterAppFrameReady) {
+      if (_disposed) return;
+      // We need to start by querying the inspector service to find out the
+      // current state of the UI.
+
+      final queryParams = loadQueryParams();
+      final inspectorRef = queryParams.containsKey(inspectorRefQueryParam)
+          ? queryParams[inspectorRefQueryParam]
+          : null;
+      await updateSelectionFromService(
+        firstFrame: true,
+        inspectorRef: inspectorRef,
+      );
+    } else {
+      if (_disposed) return;
+      if (inspectorService is InspectorService) {
+        final widgetTreeReady =
+            await (inspectorService as InspectorService).isWidgetTreeReady();
+        flutterAppFrameReady = widgetTreeReady;
+      }
+      if (isActive && flutterAppFrameReady) {
+        await maybeLoadUI();
+      }
+    }
+  }
+
+  Future<void> _recomputeTreeRoot(
+    RemoteDiagnosticsNode? newSelection,
+    RemoteDiagnosticsNode? detailsSelection,
+    bool setSubtreeRoot, {
+    int subtreeDepth = 2,
+  }) async {
+    assert(!_disposed);
+    final treeGroups = _treeGroups;
+    if (_disposed || treeGroups == null) {
+      return;
+    }
+
+    treeGroups.cancelNext();
+    try {
+      final group = treeGroups.next;
+      final node = await (detailsSubtree
+          ? group.getDetailsSubtree(subtreeRoot, subtreeDepth: subtreeDepth)
+          : group.getRoot(treeType));
+      if (node == null || group.disposed || _disposed) {
+        return;
+      }
+      // TODO(jacobr): as a performance optimization we should check if the
+      // new tree is identical to the existing tree in which case we should
+      // dispose the new tree and keep the old tree.
+      treeGroups.promoteNext();
+      _clearValueToInspectorTreeNodeMapping();
+
+      final InspectorTreeNode rootNode = inspectorTree.setupInspectorTreeNode(
+        inspectorTree.createNode(),
+        node,
+        expandChildren: true,
+        expandProperties: false,
+      );
+      inspectorTree.root = rootNode;
+
+      refreshSelection(newSelection, detailsSelection, setSubtreeRoot);
+    } catch (error, st) {
+      _log.shout(error, error, st);
+      treeGroups.cancelNext();
+      return;
+    }
+  }
+
+  void _clearValueToInspectorTreeNodeMapping() {
+    valueToInspectorTreeNode.clear();
+  }
+
+  /// Show the details subtree starting with node subtreeRoot highlighting
+  /// node subtreeSelection.
+  void _showDetailSubtrees(
+    RemoteDiagnosticsNode? subtreeRoot,
+    RemoteDiagnosticsNode? subtreeSelection,
+  ) {
+    this.subtreeRoot = subtreeRoot;
+    details?.setSubtreeRoot(subtreeRoot, subtreeSelection);
+  }
+
+  void setSubtreeRoot(
+    RemoteDiagnosticsNode? node,
+    RemoteDiagnosticsNode? selection,
+  ) {
+    assert(detailsSubtree);
+    selection ??= node;
+    if (node != null && node == subtreeRoot) {
+      //  Select the new node in the existing subtree.
+      applyNewSelection(selection, null, false);
+      return;
+    }
+    subtreeRoot = node;
+    if (node == null) {
+      // Passing in a null node indicates we should clear the subtree and free any memory allocated.
+      shutdownTree(false);
+      return;
+    }
+
+    // Clear now to eliminate frame of highlighted nodes flicker.
+    _clearValueToInspectorTreeNodeMapping();
+    unawaited(_recomputeTreeRoot(selection, null, false));
+  }
+
+  InspectorTreeNode? getSubtreeRootNode() {
+    if (subtreeRoot == null) {
+      return null;
+    }
+    return valueToInspectorTreeNode[subtreeRoot!.valueRef];
+  }
+
+  void refreshSelection(
+    RemoteDiagnosticsNode? newSelection,
+    RemoteDiagnosticsNode? detailsSelection,
+    bool setSubtreeRoot,
+  ) {
+    newSelection ??= selectedDiagnostic;
+    setSelectedNode(findMatchingInspectorTreeNode(newSelection));
+    syncSelectionHelper(
+      maybeRerootDetailsTree: setSubtreeRoot,
+      selection: newSelection,
+      detailsSelection: detailsSelection,
+    );
+
+    final detailsLocal = details;
+    if (detailsLocal != null) {
+      if (subtreeRoot != null && getSubtreeRootNode() == null) {
+        subtreeRoot = newSelection;
+        detailsLocal.setSubtreeRoot(newSelection, detailsSelection);
+      }
+    }
+    syncTreeSelection();
+  }
+
+  void syncTreeSelection() {
+    programmaticSelectionChangeInProgress = true;
+    inspectorTree.selection = selectedNode.value;
+    inspectorTree.expandPath(selectedNode.value);
+    programmaticSelectionChangeInProgress = false;
+    animateTo(selectedNode.value);
+  }
+
+  void selectAndShowNode(RemoteDiagnosticsNode? node) {
+    if (node == null) {
+      return;
+    }
+    selectAndShowInspectorInstanceRef(node.valueRef);
+  }
+
+  void selectAndShowInspectorInstanceRef(InspectorInstanceRef ref) {
+    final node = valueToInspectorTreeNode[ref];
+    if (node == null) {
+      return;
+    }
+    setSelectedNode(node);
+    syncTreeSelection();
+  }
+
+  InspectorTreeNode? getTreeNode(RemoteDiagnosticsNode node) {
+    return valueToInspectorTreeNode[node.valueRef];
+  }
+
+  void maybeUpdateValueUI(InspectorInstanceRef valueRef) {
+    final node = valueToInspectorTreeNode[valueRef];
+    if (node == null) {
+      // The value isn't shown in the parent tree. Nothing to do.
+      return;
+    }
+    inspectorTree.nodeChanged(node);
+  }
+
+  @override
+  void onFlutterFrame() {
+    flutterAppFrameReady = true;
+    if (!visibleToUser) {
+      return;
+    }
+
+    if (!treeLoadStarted) {
+      treeLoadStarted = true;
+      // This was the first frame.
+      unawaited(maybeLoadUI());
+    }
+    _refreshRateLimiter.scheduleRequest();
+  }
+
+  @override
+  void onInspectorSelectionChanged() {
+    if (!visibleToUser) {
+      // Don't do anything. We will update the view once it is visible again.
+      return;
+    }
+    if (detailsSubtree) {
+      // Wait for the master to update.
+      return;
+    }
+    unawaited(updateSelectionFromService(firstFrame: false));
+  }
+
+  Future<void> updateSelectionFromService({
+    required bool firstFrame,
+    String? inspectorRef,
+  }) async {
+    if (parent != null) {
+      // If we have a parent controller we should wait for the parent to update
+      // our selection rather than updating it our self.
+      return;
+    }
+    final selectionGroups = _selectionGroups;
+    if (selectionGroups == null) {
+      // Already disposed. Ignore this requested to update selection.
+      return;
+    }
+    treeLoadStarted = true;
+
+    selectionGroups.cancelNext();
+
+    final group = selectionGroups.next;
+
+    if (inspectorRef != null) {
+      await group.setSelectionInspector(
+        InspectorInstanceRef(inspectorRef),
+        false,
+      );
+      if (_disposed) return;
+    }
+    final pendingSelectionFuture = group.getSelection(
+      selectedDiagnostic,
+      treeType,
+      isSummaryTree: isSummaryTree,
+    );
+
+    final Future<RemoteDiagnosticsNode?>? pendingDetailsFuture = isSummaryTree
+        ? group.getSelection(selectedDiagnostic, treeType, isSummaryTree: false)
+        : null;
+
+    try {
+      final RemoteDiagnosticsNode? newSelection = await pendingSelectionFuture;
+      if (_disposed || group.disposed) return;
+      RemoteDiagnosticsNode? detailsSelection;
+
+      if (pendingDetailsFuture != null) {
+        detailsSelection = await pendingDetailsFuture;
+        if (_disposed || group.disposed) return;
+      }
+
+      if (!firstFrame &&
+          detailsSelection?.valueRef == details?.selectedDiagnostic?.valueRef &&
+          newSelection?.valueRef == selectedDiagnostic?.valueRef) {
+        // No need to change the selection as it didn't actually change.
+        selectionGroups.cancelNext();
+        return;
+      }
+      selectionGroups.promoteNext();
+
+      subtreeRoot = newSelection;
+
+      applyNewSelection(newSelection, detailsSelection, true);
+    } catch (error, st) {
+      if (selectionGroups.next == group) {
+        _log.shout(error, error, st);
+        selectionGroups.cancelNext();
+      }
+    }
+  }
+
+  void applyNewSelection(
+    RemoteDiagnosticsNode? newSelection,
+    RemoteDiagnosticsNode? detailsSelection,
+    bool setSubtreeRoot,
+  ) {
+    final InspectorTreeNode? nodeInTree =
+        findMatchingInspectorTreeNode(newSelection);
+
+    if (nodeInTree == null) {
+      // The tree has probably changed since we last updated. Do a full refresh
+      // so that the tree includes the new node we care about.
+      unawaited(
+        _recomputeTreeRoot(newSelection, detailsSelection, setSubtreeRoot),
+      );
+    }
+
+    refreshSelection(newSelection, detailsSelection, setSubtreeRoot);
+  }
+
+  void animateTo(InspectorTreeNode? node) {
+    if (node == null) {
+      return;
+    }
+
+    inspectorTree.animateToTargets([node]);
+  }
+
+  void setSelectedNode(InspectorTreeNode? newSelection) {
+    if (newSelection == selectedNode.value) {
+      return;
+    }
+
+    _selectedNode.value = newSelection;
+
+    lastExpanded = null; // New selected node takes precedence.
+    endShowNode();
+    final detailsLocal = details;
+    final parantLocal = parent;
+    if (detailsLocal != null) {
+      detailsLocal.endShowNode();
+    } else if (parantLocal != null) {
+      parantLocal.endShowNode();
+    }
+
+    _updateSelectedErrorFromNode(_selectedNode.value);
+    animateTo(selectedNode.value);
+  }
+
+  /// Update the index of the selected error based on a node that has been
+  /// selected in the tree.
+  void _updateSelectedErrorFromNode(InspectorTreeNode? node) {
+    final inspectorRef = node?.diagnostic?.valueRef.id;
+
+    final errors = serviceConnection.errorBadgeManager
+        .erroredItemsForPage(InspectorScreen.id)
+        .value;
+
+    // Check whether the node that was just selected has any errors associated
+    // with it.
+    var errorIndex = inspectorRef != null
+        ? errors.keys.toList().indexOf(inspectorRef)
+        : null;
+    if (errorIndex == -1) {
+      errorIndex = null;
+    }
+
+    _selectedErrorIndex.value = errorIndex;
+
+    if (errorIndex != null) {
+      // Mark the error as "seen" as this will render slightly differently
+      // so the user can track which errored nodes they've viewed.
+      serviceConnection.errorBadgeManager
+          .markErrorAsRead(InspectorScreen.id, errors[inspectorRef!]!);
+      // Also clear the error badge since new errors may have arrived while
+      // the inspector was visible (normally they're cleared when visiting
+      // the screen) and visiting an errored node seems an appropriate
+      // acknowledgement of the errors.
+      serviceConnection.errorBadgeManager.clearErrors(InspectorScreen.id);
+    }
+  }
+
+  /// Updates the index of the selected error and selects its node in the tree.
+  void selectErrorByIndex(int index) {
+    _selectedErrorIndex.value = index;
+
+    final errors = serviceConnection.errorBadgeManager
+        .erroredItemsForPage(InspectorScreen.id)
+        .value;
+
+    unawaited(
+      updateSelectionFromService(
+        firstFrame: false,
+        inspectorRef: errors.keys.elementAt(index),
+      ),
+    );
+  }
+
+  void _onExpand(InspectorTreeNode node) {
+    unawaited(inspectorTree.maybePopulateChildren(node));
+  }
+
+  Future<void> _addNodeToConsole(InspectorTreeNode node) async {
+    final valueRef = node.diagnostic!.valueRef;
+    final isolateRef = inspectorService.isolateRef;
+    final instanceRef = await node.diagnostic!.objectGroupApi
+        ?.toObservatoryInstanceRef(valueRef);
+    if (_disposed) return;
+
+    if (instanceRef != null) {
+      await serviceConnection.consoleService.appendInstanceRef(
+        value: instanceRef,
+        diagnostic: node.diagnostic,
+        isolateRef: isolateRef,
+        forceScrollIntoView: true,
+      );
+    }
+  }
+
+  void selectionChanged() {
+    if (!visibleToUser) {
+      return;
+    }
+
+    final InspectorTreeNode? node = inspectorTree.selection;
+    if (node != null) {
+      unawaited(inspectorTree.maybePopulateChildren(node));
+    }
+    if (programmaticSelectionChangeInProgress) {
+      return;
+    }
+    if (node != null) {
+      setSelectedNode(node);
+      unawaited(_addNodeToConsole(node));
+
+      // Don't reroot if the selected value is already visible in the details tree.
+      final bool maybeReroot = isSummaryTree &&
+          details != null &&
+          selectedDiagnostic != null &&
+          !details!.hasDiagnosticsValue(selectedDiagnostic!.valueRef);
+      syncSelectionHelper(
+        maybeRerootDetailsTree: maybeReroot,
+        selection: selectedDiagnostic,
+        detailsSelection: selectedDiagnostic,
+      );
+
+      if (!maybeReroot) {
+        final parantLocal = parent;
+        final detailsLocal = details;
+
+        if (isSummaryTree && detailsLocal != null) {
+          detailsLocal.selectAndShowNode(selectedDiagnostic);
+        } else if (parantLocal != null) {
+          parantLocal
+              .selectAndShowNode(firstAncestorInParentTree(selectedNode.value));
+        }
+      }
+    }
+  }
+
+  RemoteDiagnosticsNode? firstAncestorInParentTree(InspectorTreeNode? node) {
+    final parentLocal = parent;
+
+    if (parentLocal == null) {
+      return node?.diagnostic;
+    }
+    while (node != null) {
+      final diagnostic = node.diagnostic;
+      if (diagnostic != null &&
+          parentLocal.hasDiagnosticsValue(diagnostic.valueRef)) {
+        return parentLocal.findDiagnosticsValue(diagnostic.valueRef);
+      }
+      node = node.parent;
+    }
+    return null;
+  }
+
+  void syncSelectionHelper({
+    required bool maybeRerootDetailsTree,
+    required RemoteDiagnosticsNode? selection,
+    required RemoteDiagnosticsNode? detailsSelection,
+  }) {
+    if (selection != null) {
+      if (selection.isCreatedByLocalProject) {
+        _navigateTo(selection);
+      }
+    }
+    if (detailsSubtree || details == null) {
+      if (selection != null) {
+        var toSelect = selectedNode.value;
+
+        while (toSelect != null && toSelect.diagnostic!.isProperty) {
+          toSelect = toSelect.parent;
+        }
+
+        if (toSelect != null) {
+          final diagnosticToSelect = toSelect.diagnostic!;
+          unawaited(diagnosticToSelect.setSelectionInspector(true));
+        }
+      }
+    }
+
+    if (maybeRerootDetailsTree) {
+      _showDetailSubtrees(selection, detailsSelection);
+    } else if (selection != null) {
+      // We can't rely on the details tree to update the selection on the server in this case.
+      unawaited(selection.setSelectionInspector(true));
+    }
+  }
+
+  // TODO(jacobr): implement this method and use the parameter.
+  // ignore: avoid-unused-parameters
+  void _navigateTo(RemoteDiagnosticsNode diagnostic) {
+    // TODO(jacobr): dispatch an event over the inspectorService requesting a
+    //  navigate operation.
+  }
+
+  @override
+  void dispose() {
+    assert(!_disposed);
+    _disposed = true;
+    if (serviceConnection.inspectorService != null) {
+      shutdownTree(false);
+    }
+    _treeGroups?.clear(false);
+    _treeGroups = null;
+    _selectionGroups?.clear(false);
+    _selectionGroups = null;
+    details?.dispose();
+    super.dispose();
+  }
+
+  void _onNodeAdded(
+    InspectorTreeNode node,
+    RemoteDiagnosticsNode diagnosticsNode,
+  ) {
+    final InspectorInstanceRef valueRef = diagnosticsNode.valueRef;
+    // Properties do not have unique values so should not go in the valueToInspectorTreeNode map.
+    if (valueRef.id != null && !diagnosticsNode.isProperty) {
+      valueToInspectorTreeNode[valueRef] = node;
+    }
+  }
+
+  Future<void> expandAllNodesInDetailsTree() async {
+    final detailsLocal = details!;
+    await detailsLocal._recomputeTreeRoot(
+      inspectorTree.selection?.diagnostic,
+      detailsLocal.inspectorTree.selection?.diagnostic ??
+          detailsLocal.inspectorTree.root?.diagnostic,
+      false,
+      subtreeDepth: maxJsInt,
+    );
+  }
+
+  void collapseDetailsToSelected() {
+    final detailsLocal = details!;
+    detailsLocal.inspectorTree.collapseToSelected();
+    detailsLocal.animateTo(detailsLocal.inspectorTree.selection);
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -1,0 +1,870 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math' as math;
+
+import 'package:flutter/rendering.dart';
+
+import '../../shared/diagnostics/diagnostics_node.dart';
+import '../../shared/primitives/enum_utils.dart';
+import '../../shared/primitives/math_utils.dart';
+import '../../shared/primitives/utils.dart';
+import 'layout_explorer/flex/utils.dart';
+
+const overflowEpsilon = 0.1;
+
+/// Compute real widget sizes into rendered sizes to be displayed on the details tab.
+/// The sum of the resulting render sizes may or may not be greater than the [maxSizeAvailable]
+/// In the case where it is greater, we should render it with scrolling capability.
+///
+/// Variables:
+/// - [sizes] : real size for widgets that want to be rendered / scaled
+/// - [smallestSize] : the smallest element in the array [sizes]
+/// - [largestSize] : the largest element in the array [sizes]
+/// - [smallestRenderSize] : render size for smallest element
+/// - [largestRenderSize] : render size for largest element
+/// - [maxSizeAvailable] : maximum size available for rendering the widget
+/// - [useMaxSizeAvailable] : flag for forcing the widget dimension to be at least [maxSizeAvailable]
+///
+/// if [useMaxSizeAvailable] is set to true,
+/// this method will ignore the largestRenderSize
+/// and compute its own largestRenderSize to force
+/// the sum of the render size to be equals to [maxSizeAvailable]
+///
+/// Formula for computing render size:
+///   renderSize[i] = (size[i] - smallestSize)
+///               * (largestRenderSize - smallestRenderSize)
+///               / (largestSize - smallestSize) + smallestRenderSize
+/// Explanation:
+/// - The computation formula for transforming size to renderSize is based on these two things:
+///   - smallest element will be rendered to [smallestRenderSize]
+///   - largest element will be rendered to [largestRenderSize]
+///   - any other size will be scaled accordingly
+/// - The formula above is derived from:
+///    (renderSize[i] - smallestRenderSize) / (largestRenderSize - smallestRenderSize)
+///     = (size[i] - smallestSize) / (size[i] - smallestSize)
+///
+/// Formula for computing forced [largestRenderSize]:
+///   largestRenderSize = (maxSizeAvailable - sizes.length * smallestRenderSize)
+///     * (largestSize - smallestSize) / sum(s[i] - ss) + smallestRenderSize
+/// Explanation:
+/// - This formula is derived from the equation:
+///    sum(renderSize) = maxSizeAvailable
+///
+List<double> computeRenderSizes({
+  required Iterable<double> sizes,
+  required double smallestSize,
+  required double largestSize,
+  required double smallestRenderSize,
+  required double largestRenderSize,
+  required double maxSizeAvailable,
+  bool useMaxSizeAvailable = true,
+}) {
+  final n = sizes.length;
+
+  if (smallestSize == largestSize) {
+    // It means that all widget have the same size
+    // and we can just divide the size evenly
+    // but it should be at least as big as [smallestRenderSize]
+    final renderSize = math.max(smallestRenderSize, maxSizeAvailable / n);
+    return [for (var _ in sizes) renderSize];
+  }
+
+  List<double> transformToRenderSize(double largestRenderSize) => [
+        for (var s in sizes)
+          (s - smallestSize) *
+                  (largestRenderSize - smallestRenderSize) /
+                  (largestSize - smallestSize) +
+              smallestRenderSize,
+      ];
+
+  var renderSizes = transformToRenderSize(largestRenderSize);
+
+  if (useMaxSizeAvailable && sum(renderSizes) < maxSizeAvailable) {
+    largestRenderSize = (maxSizeAvailable - n * smallestRenderSize) *
+            (largestSize - smallestSize) /
+            sum([for (var s in sizes) s - smallestSize]) +
+        smallestRenderSize;
+    renderSizes = transformToRenderSize(largestRenderSize);
+  }
+  return renderSizes;
+}
+
+// TODO(albertusangga): Move this to [RemoteDiagnosticsNode] once dart:html app is removed
+/// Represents parsed layout information for a specific [RemoteDiagnosticsNode].
+class LayoutProperties {
+  LayoutProperties(this.node, {int copyLevel = 1})
+      : description = node.description,
+        size = node.size,
+        constraints = node.constraints,
+        isFlex = node.isFlex,
+        flexFactor = node.flexFactor,
+        flexFit = node.flexFit,
+        children = copyLevel == 0
+            ? []
+            : node.childrenNow
+                .map(
+                  (child) => LayoutProperties(child, copyLevel: copyLevel - 1),
+                )
+                .toList(growable: false) {
+    for (var child in children) {
+      child.parent = this;
+    }
+  }
+
+  LayoutProperties.values({
+    required this.node,
+    required this.children,
+    required this.constraints,
+    required this.description,
+    required this.flexFactor,
+    required this.isFlex,
+    required this.size,
+    required this.flexFit,
+  }) {
+    for (var child in children) {
+      child.parent = this;
+    }
+  }
+
+  LayoutProperties? parent;
+  final RemoteDiagnosticsNode node;
+  final List<LayoutProperties> children;
+  final BoxConstraints? constraints;
+  final String? description;
+  final num? flexFactor;
+  final FlexFit? flexFit;
+  final bool isFlex;
+  final Size size;
+
+  /// Represents the order of [children] to be displayed.
+  List<LayoutProperties> get displayChildren => children;
+
+  bool get hasFlexFactor {
+    final flexFactorLocal = flexFactor;
+    if (flexFactorLocal == null) return false;
+    return flexFactorLocal > 0;
+  }
+
+  int get totalChildren => children.length;
+
+  bool get hasChildren => children.isNotEmpty;
+
+  double get width => size.width;
+
+  double get height => size.height;
+
+  double dimension(Axis axis) => axis == Axis.horizontal ? width : height;
+
+  List<double> childrenDimensions(Axis axis) {
+    return displayChildren.map((child) => child.dimension(axis)).toList();
+  }
+
+  List<double> get childrenWidths => childrenDimensions(Axis.horizontal);
+
+  List<double> get childrenHeights => childrenDimensions(Axis.vertical);
+
+  String describeWidthConstraints() {
+    final constraintsLocal = constraints;
+    if (constraintsLocal == null) return '';
+    return constraintsLocal.hasBoundedWidth
+        ? describeAxis(
+            constraintsLocal.minWidth,
+            constraintsLocal.maxWidth,
+            'w',
+          )
+        : 'width is unconstrained';
+  }
+
+  String describeHeightConstraints() {
+    final constraintsLocal = constraints;
+    if (constraintsLocal == null) return '';
+    return constraintsLocal.hasBoundedHeight
+        ? describeAxis(
+            constraintsLocal.minHeight,
+            constraintsLocal.maxHeight,
+            'h',
+          )
+        : 'height is unconstrained';
+  }
+
+  String describeWidth() => 'w=${toStringAsFixed(size.width)}';
+
+  String describeHeight() => 'h=${toStringAsFixed(size.height)}';
+
+  bool get isOverflowWidth {
+    final parentWidth = parent?.width;
+    if (parentWidth == null) return false;
+    final parentData = node.parentData;
+    double widthUsed = width;
+
+    widthUsed += parentData.offset.dx;
+
+    // TODO(jacobr): certain widgets may allow overflow so this may false
+    // positive a bit for cases like Stack.
+    return widthUsed > parentWidth + overflowEpsilon;
+  }
+
+  bool get isOverflowHeight {
+    final parentHeight = parent?.height;
+    if (parentHeight == null) return false;
+    final parentData = node.parentData;
+    double heightUsed = height;
+
+    heightUsed += parentData.offset.dy;
+
+    return heightUsed > parentHeight + overflowEpsilon;
+  }
+
+  static String describeAxis(double min, double max, String axis) {
+    if (min == max) return '$axis=${min.toStringAsFixed(1)}';
+    return '${min.toStringAsFixed(1)}<=$axis<=${max.toStringAsFixed(1)}';
+  }
+
+  LayoutProperties copyWith({
+    List<LayoutProperties>? children,
+    BoxConstraints? constraints,
+    String? description,
+    int? flexFactor,
+    FlexFit? flexFit,
+    bool? isFlex,
+    Size? size,
+  }) {
+    return LayoutProperties.values(
+      node: node,
+      children: children ?? this.children,
+      constraints: constraints ?? this.constraints,
+      description: description ?? this.description,
+      flexFactor: flexFactor ?? this.flexFactor,
+      isFlex: isFlex ?? this.isFlex,
+      size: size ?? this.size,
+      flexFit: flexFit ?? this.flexFit,
+    );
+  }
+}
+
+/// Enum object to represent which side of the widget is overflowing.
+///
+/// See also:
+/// * [OverflowIndicatorPainter]
+enum OverflowSide {
+  right,
+  bottom,
+}
+
+// TODO(jacobr): is it possible to overflow on multiple sides?
+// TODO(jacobr): do we need to worry about overflowing on the left side in RTL
+// layouts? We need to audit the Flutter semantics for determining overflow to
+// make sure we are consistent.
+extension LayoutPropertiesExtension on LayoutProperties {
+  OverflowSide? get overflowSide {
+    if (isOverflowWidth) return OverflowSide.right;
+    if (isOverflowHeight) return OverflowSide.bottom;
+    return null;
+  }
+}
+
+final Expando<FlexLayoutProperties> _flexLayoutExpando = Expando();
+
+extension MainAxisAlignmentExtension on MainAxisAlignment {
+  MainAxisAlignment get reversed {
+    switch (this) {
+      case MainAxisAlignment.start:
+        return MainAxisAlignment.end;
+      case MainAxisAlignment.end:
+        return MainAxisAlignment.start;
+      default:
+        return this;
+    }
+  }
+}
+
+/// TODO(albertusangga): Move this to [RemoteDiagnosticsNode] once dart:html app is removed.
+class FlexLayoutProperties extends LayoutProperties {
+  FlexLayoutProperties({
+    required super.size,
+    required super.children,
+    required super.node,
+    super.constraints,
+    super.isFlex = false,
+    super.description,
+    super.flexFactor,
+    super.flexFit,
+    this.direction = Axis.vertical,
+    this.mainAxisAlignment,
+    this.crossAxisAlignment,
+    this.mainAxisSize,
+    required this.textDirection,
+    required this.verticalDirection,
+    this.textBaseline,
+  }) : super.values();
+
+  FlexLayoutProperties._fromNode(
+    super.node, {
+    this.direction = Axis.vertical,
+    this.mainAxisAlignment,
+    this.mainAxisSize,
+    this.crossAxisAlignment,
+    required this.textDirection,
+    required this.verticalDirection,
+    this.textBaseline,
+  });
+
+  factory FlexLayoutProperties.fromDiagnostics(RemoteDiagnosticsNode node) {
+    // Cache the properties on an expando so that local tweaks to
+    // FlexLayoutProperties persist across multiple lookups from an
+    // RemoteDiagnosticsNode.
+    return _flexLayoutExpando[node] ??= _buildNode(node);
+  }
+
+  @override
+  FlexLayoutProperties copyWith({
+    Size? size,
+    List<LayoutProperties>? children,
+    BoxConstraints? constraints,
+    bool? isFlex,
+    String? description,
+    num? flexFactor,
+    FlexFit? flexFit,
+    Axis? direction,
+    MainAxisAlignment? mainAxisAlignment,
+    MainAxisSize? mainAxisSize,
+    CrossAxisAlignment? crossAxisAlignment,
+    TextDirection? textDirection,
+    VerticalDirection? verticalDirection,
+    TextBaseline? textBaseline,
+  }) {
+    return FlexLayoutProperties(
+      size: size ?? this.size,
+      children: children ?? this.children,
+      node: node,
+      constraints: constraints ?? this.constraints,
+      isFlex: isFlex ?? this.isFlex,
+      description: description ?? this.description,
+      flexFactor: flexFactor ?? this.flexFactor,
+      flexFit: flexFit ?? this.flexFit,
+      direction: direction ?? this.direction,
+      mainAxisAlignment: mainAxisAlignment ?? this.mainAxisAlignment,
+      mainAxisSize: mainAxisSize ?? this.mainAxisSize,
+      crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
+      textDirection: textDirection ?? this.textDirection,
+      verticalDirection: verticalDirection ?? this.verticalDirection,
+      textBaseline: textBaseline ?? this.textBaseline,
+    );
+  }
+
+  static FlexLayoutProperties _buildNode(RemoteDiagnosticsNode node) {
+    final Map<String, Object?> renderObjectJson = node.renderObject!.json;
+    final properties = (renderObjectJson['properties'] as List<Object?>)
+        .cast<Map<String, Object?>>();
+
+    final data = {
+      for (final property in properties)
+        property['name']: property['description'] as String?,
+    };
+
+    return FlexLayoutProperties._fromNode(
+      node,
+      direction: _directionUtils.enumEntry(data['direction']) ?? Axis.vertical,
+      mainAxisAlignment:
+          _mainAxisAlignmentUtils.enumEntry(data['mainAxisAlignment']),
+      mainAxisSize: _mainAxisSizeUtils.enumEntry(data['mainAxisSize']),
+      crossAxisAlignment:
+          _crossAxisAlignmentUtils.enumEntry(data['crossAxisAlignment']),
+      textDirection: _textDirectionUtils.enumEntry(data['textDirection']) ??
+          TextDirection.ltr,
+      verticalDirection:
+          _verticalDirectionUtils.enumEntry(data['verticalDirection']) ??
+              VerticalDirection.down,
+      textBaseline: _textBaselineUtils.enumEntry(data['textBaseline']),
+    );
+  }
+
+  final Axis direction;
+  final MainAxisAlignment? mainAxisAlignment;
+  final CrossAxisAlignment? crossAxisAlignment;
+  final MainAxisSize? mainAxisSize;
+  final TextDirection textDirection;
+  final VerticalDirection verticalDirection;
+  final TextBaseline? textBaseline;
+
+  List<LayoutProperties>? _displayChildren;
+
+  @override
+  List<LayoutProperties> get displayChildren {
+    final displayChildren = _displayChildren;
+    if (displayChildren != null) return displayChildren;
+    return _displayChildren =
+        startIsTopLeft ? children : children.reversed.toList();
+  }
+
+  int? _totalFlex;
+
+  bool get isMainAxisHorizontal => direction == Axis.horizontal;
+
+  bool get isMainAxisVertical => direction == Axis.vertical;
+
+  String get horizontalDirectionDescription {
+    return direction == Axis.horizontal ? 'Main Axis' : 'Cross Axis';
+  }
+
+  String get verticalDirectionDescription {
+    return direction == Axis.vertical ? 'Main Axis' : 'Cross Axis';
+  }
+
+  String get type => direction.flexType;
+
+  num get totalFlex {
+    if (children.isEmpty) return 0;
+    _totalFlex ??= children
+        .map((child) => child.flexFactor ?? 0)
+        .reduce((value, element) => value + element)
+        .toInt();
+    return _totalFlex!;
+  }
+
+  Axis get crossAxisDirection {
+    return direction == Axis.horizontal ? Axis.vertical : Axis.horizontal;
+  }
+
+  double get mainAxisDimension => dimension(direction);
+
+  double get crossAxisDimension => dimension(crossAxisDirection);
+
+  @override
+  bool get isOverflowWidth {
+    if (direction == Axis.horizontal) {
+      return width + overflowEpsilon < sum(childrenWidths);
+    }
+    return width + overflowEpsilon < max(childrenWidths);
+  }
+
+  @override
+  bool get isOverflowHeight {
+    if (direction == Axis.vertical) {
+      return height + overflowEpsilon < sum(childrenHeights);
+    }
+    return height + overflowEpsilon < max(childrenHeights);
+  }
+
+  bool get startIsTopLeft {
+    switch (direction) {
+      case Axis.horizontal:
+        switch (textDirection) {
+          case TextDirection.ltr:
+            return true;
+          case TextDirection.rtl:
+            return false;
+        }
+      case Axis.vertical:
+        switch (verticalDirection) {
+          case VerticalDirection.down:
+            return true;
+          case VerticalDirection.up:
+            return false;
+        }
+    }
+  }
+
+  /// render properties for laying out rendered Flex & Flex children widgets
+  /// the computation is similar to [RenderFlex].performLayout() method
+  List<RenderProperties> childrenRenderProperties({
+    required double smallestRenderWidth,
+    required double largestRenderWidth,
+    required double smallestRenderHeight,
+    required double largestRenderHeight,
+    required double Function(Axis) maxSizeAvailable,
+  }) {
+    /// calculate the render empty spaces
+    final freeSpace = dimension(direction) - sum(childrenDimensions(direction));
+    final displayMainAxisAlignment =
+        startIsTopLeft ? mainAxisAlignment : mainAxisAlignment?.reversed;
+
+    double leadingSpace(double freeSpace) {
+      if (children.isEmpty) return 0.0;
+      switch (displayMainAxisAlignment) {
+        case MainAxisAlignment.start:
+        case MainAxisAlignment.end:
+          return freeSpace;
+        case MainAxisAlignment.center:
+          return freeSpace * 0.5;
+        case MainAxisAlignment.spaceBetween:
+          return 0.0;
+        case MainAxisAlignment.spaceAround:
+          final spaceBetweenChildren = freeSpace / children.length;
+          return spaceBetweenChildren * 0.5;
+        case MainAxisAlignment.spaceEvenly:
+          return freeSpace / (children.length + 1);
+        default:
+          return 0.0;
+      }
+    }
+
+    double betweenSpace(double freeSpace) {
+      if (children.isEmpty) return 0.0;
+      switch (displayMainAxisAlignment) {
+        case MainAxisAlignment.start:
+        case MainAxisAlignment.end:
+        case MainAxisAlignment.center:
+          return 0.0;
+        case MainAxisAlignment.spaceBetween:
+          if (children.length == 1) return freeSpace;
+          return freeSpace / (children.length - 1);
+        case MainAxisAlignment.spaceAround:
+          return freeSpace / children.length;
+        case MainAxisAlignment.spaceEvenly:
+          return freeSpace / (children.length + 1);
+        default:
+          return 0.0;
+      }
+    }
+
+    double smallestRenderSize(Axis axis) {
+      return axis == Axis.horizontal
+          ? smallestRenderWidth
+          : smallestRenderHeight;
+    }
+
+    double largestRenderSize(Axis axis) {
+      final lrs =
+          axis == Axis.horizontal ? largestRenderWidth : largestRenderHeight;
+      // use all the space when visualizing cross axis
+      return (axis == direction) ? lrs : maxSizeAvailable(axis);
+    }
+
+    List<double> renderSizes(Axis axis) {
+      final sizes = childrenDimensions(axis);
+      if (freeSpace > 0.0 && axis == direction) {
+        /// include free space in the computation
+        sizes.add(freeSpace);
+      }
+      final smallestSize = min(sizes);
+      final largestSize = max(sizes);
+      if (axis == direction ||
+          (crossAxisAlignment != CrossAxisAlignment.stretch &&
+              smallestSize != largestSize)) {
+        return computeRenderSizes(
+          sizes: sizes,
+          smallestSize: smallestSize,
+          largestSize: largestSize,
+          smallestRenderSize: smallestRenderSize(axis),
+          largestRenderSize: largestRenderSize(axis),
+          maxSizeAvailable: maxSizeAvailable(axis),
+        );
+      } else {
+        // uniform cross axis sizes.
+        double size = crossAxisAlignment == CrossAxisAlignment.stretch
+            ? maxSizeAvailable(axis)
+            : largestSize /
+                math.max(dimension(axis), 1.0) *
+                maxSizeAvailable(axis);
+        size = math.max(size, smallestRenderSize(axis));
+        return sizes.map((_) => size).toList();
+      }
+    }
+
+    final widths = renderSizes(Axis.horizontal);
+    final heights = renderSizes(Axis.vertical);
+
+    final renderFreeSpace = freeSpace > 0.0
+        ? (isMainAxisHorizontal ? widths.last : heights.last)
+        : 0.0;
+
+    final renderLeadingSpace = leadingSpace(renderFreeSpace);
+    final renderBetweenSpace = betweenSpace(renderFreeSpace);
+
+    final childrenRenderProps = <RenderProperties>[];
+
+    double lastMainAxisOffset() {
+      if (childrenRenderProps.isEmpty) return 0.0;
+      return childrenRenderProps.last.mainAxisOffset;
+    }
+
+    double lastMainAxisDimension() {
+      if (childrenRenderProps.isEmpty) return 0.0;
+      return childrenRenderProps.last.mainAxisDimension;
+    }
+
+    double space(int index) {
+      if (index == 0) {
+        if (displayMainAxisAlignment == MainAxisAlignment.start) return 0.0;
+        return renderLeadingSpace;
+      }
+      return renderBetweenSpace;
+    }
+
+    double calculateMainAxisOffset(int i) {
+      return lastMainAxisOffset() + lastMainAxisDimension() + space(i);
+    }
+
+    double calculateCrossAxisOffset(int i) {
+      final maxDimension = maxSizeAvailable(crossAxisDirection);
+      final usedDimension =
+          crossAxisDirection == Axis.horizontal ? widths[i] : heights[i];
+
+      if (crossAxisAlignment == CrossAxisAlignment.start ||
+          crossAxisAlignment == CrossAxisAlignment.stretch ||
+          maxDimension == usedDimension) return 0.0;
+      final emptySpace = math.max(0.0, maxDimension - usedDimension);
+      if (crossAxisAlignment == CrossAxisAlignment.end) return emptySpace;
+      return emptySpace * 0.5;
+    }
+
+    for (var i = 0; i < children.length; ++i) {
+      childrenRenderProps.add(
+        RenderProperties(
+          axis: direction,
+          size: Size(widths[i], heights[i]),
+          offset: Offset.zero,
+          realSize: displayChildren[i].size,
+        )
+          ..mainAxisOffset = calculateMainAxisOffset(i)
+          ..crossAxisOffset = calculateCrossAxisOffset(i)
+          ..layoutProperties = displayChildren[i],
+      );
+    }
+
+    final spaces = <RenderProperties>[];
+    final actualLeadingSpace = leadingSpace(freeSpace);
+    final actualBetweenSpace = betweenSpace(freeSpace);
+    final renderPropsWithFullCrossAxisDimension =
+        RenderProperties(axis: direction)
+          ..crossAxisDimension = maxSizeAvailable(crossAxisDirection)
+          ..crossAxisRealDimension = dimension(crossAxisDirection)
+          ..crossAxisOffset = 0.0
+          ..isFreeSpace = true
+          ..layoutProperties = this;
+    if (actualLeadingSpace > 0.0 &&
+        displayMainAxisAlignment != MainAxisAlignment.start) {
+      spaces.add(
+        renderPropsWithFullCrossAxisDimension.clone()
+          ..mainAxisOffset = 0.0
+          ..mainAxisDimension = renderLeadingSpace
+          ..mainAxisRealDimension = actualLeadingSpace,
+      );
+    }
+    if (actualBetweenSpace > 0.0) {
+      for (var i = 0; i < childrenRenderProps.length - 1; ++i) {
+        final child = childrenRenderProps[i];
+        spaces.add(
+          renderPropsWithFullCrossAxisDimension.clone()
+            ..mainAxisDimension = renderBetweenSpace
+            ..mainAxisRealDimension = actualBetweenSpace
+            ..mainAxisOffset = child.mainAxisOffset + child.mainAxisDimension,
+        );
+      }
+    }
+    if (actualLeadingSpace > 0.0 &&
+        displayMainAxisAlignment != MainAxisAlignment.end) {
+      spaces.add(
+        renderPropsWithFullCrossAxisDimension.clone()
+          ..mainAxisOffset = childrenRenderProps.last.mainAxisDimension +
+              childrenRenderProps.last.mainAxisOffset
+          ..mainAxisDimension = renderLeadingSpace
+          ..mainAxisRealDimension = actualLeadingSpace,
+      );
+    }
+    return [...childrenRenderProps, ...spaces];
+  }
+
+  List<RenderProperties> crossAxisSpaces({
+    required List<RenderProperties> childrenRenderProperties,
+    required double Function(Axis) maxSizeAvailable,
+  }) {
+    if (crossAxisAlignment == CrossAxisAlignment.stretch) return [];
+    final spaces = <RenderProperties>[];
+    for (var i = 0; i < children.length; ++i) {
+      if (dimension(crossAxisDirection) ==
+              displayChildren[i].dimension(crossAxisDirection) ||
+          childrenRenderProperties[i].crossAxisDimension ==
+              maxSizeAvailable(crossAxisDirection)) continue;
+
+      final renderProperties = childrenRenderProperties[i];
+      final space = renderProperties.clone()..isFreeSpace = true;
+
+      space.crossAxisRealDimension =
+          crossAxisDimension - space.crossAxisRealDimension;
+      space.crossAxisDimension =
+          maxSizeAvailable(crossAxisDirection) - space.crossAxisDimension;
+      if (space.crossAxisDimension <= 0.0) continue;
+      if (crossAxisAlignment == CrossAxisAlignment.center) {
+        space.crossAxisDimension *= 0.5;
+        final crossAxisRealDimension = space.crossAxisRealDimension;
+        space.crossAxisRealDimension = crossAxisRealDimension * 0.5;
+        spaces.add(space.clone()..crossAxisOffset = 0.0);
+        spaces.add(
+          space.clone()
+            ..crossAxisOffset = renderProperties.crossAxisDimension +
+                renderProperties.crossAxisOffset,
+        );
+      } else {
+        space.crossAxisOffset = crossAxisAlignment == CrossAxisAlignment.end
+            ? 0
+            : renderProperties.crossAxisDimension;
+        spaces.add(space);
+      }
+    }
+    return spaces;
+  }
+
+  static final _directionUtils = EnumUtils<Axis>(Axis.values);
+  static final _mainAxisAlignmentUtils =
+      EnumUtils<MainAxisAlignment>(MainAxisAlignment.values);
+  static final _mainAxisSizeUtils =
+      EnumUtils<MainAxisSize>(MainAxisSize.values);
+  static final _crossAxisAlignmentUtils =
+      EnumUtils<CrossAxisAlignment>(CrossAxisAlignment.values);
+  static final _textDirectionUtils =
+      EnumUtils<TextDirection>(TextDirection.values);
+  static final _verticalDirectionUtils =
+      EnumUtils<VerticalDirection>(VerticalDirection.values);
+  static final _textBaselineUtils =
+      EnumUtils<TextBaseline>(TextBaseline.values);
+}
+
+/// RenderProperties contains information for rendering a [LayoutProperties] node
+class RenderProperties {
+  RenderProperties({
+    required this.axis,
+    Size? size,
+    Offset? offset,
+    Size? realSize,
+    this.layoutProperties,
+    this.isFreeSpace = false,
+  })  : width = size?.width ?? 0.0,
+        height = size?.height ?? 0.0,
+        realWidth = realSize?.width ?? 0.0,
+        realHeight = realSize?.height ?? 0.0,
+        dx = offset?.dx ?? 0.0,
+        dy = offset?.dy ?? 0.0;
+
+  final Axis axis;
+
+  /// represents which node is rendered for this object.
+  LayoutProperties? layoutProperties;
+
+  double dx, dy;
+  double width, height;
+  double realWidth, realHeight;
+
+  bool isFreeSpace;
+
+  Size get size => Size(width, height);
+
+  Size get realSize => Size(realWidth, realHeight);
+
+  Offset get offset => Offset(dx, dy);
+
+  double get mainAxisDimension => axis == Axis.horizontal ? width : height;
+
+  set mainAxisDimension(double dim) {
+    if (axis == Axis.horizontal) {
+      width = dim;
+    } else {
+      height = dim;
+    }
+  }
+
+  double get crossAxisDimension => axis == Axis.horizontal ? height : width;
+
+  set crossAxisDimension(double dim) {
+    if (axis == Axis.horizontal) {
+      height = dim;
+    } else {
+      width = dim;
+    }
+  }
+
+  double get mainAxisOffset => axis == Axis.horizontal ? dx : dy;
+
+  set mainAxisOffset(double offset) {
+    if (axis == Axis.horizontal) {
+      dx = offset;
+    } else {
+      dy = offset;
+    }
+  }
+
+  double get crossAxisOffset => axis == Axis.horizontal ? dy : dx;
+
+  set crossAxisOffset(double offset) {
+    if (axis == Axis.horizontal) {
+      dy = offset;
+    } else {
+      dx = offset;
+    }
+  }
+
+  double get mainAxisRealDimension =>
+      axis == Axis.horizontal ? realWidth : realHeight;
+
+  set mainAxisRealDimension(double newVal) {
+    if (axis == Axis.horizontal) {
+      realWidth = newVal;
+    } else {
+      realHeight = newVal;
+    }
+  }
+
+  double get crossAxisRealDimension =>
+      axis == Axis.horizontal ? realHeight : realWidth;
+
+  set crossAxisRealDimension(double newVal) {
+    if (axis == Axis.horizontal) {
+      realHeight = newVal;
+    } else {
+      realWidth = newVal;
+    }
+  }
+
+  RenderProperties clone() {
+    return RenderProperties(
+      axis: axis,
+      size: size,
+      offset: offset,
+      realSize: realSize,
+      layoutProperties: layoutProperties,
+      isFreeSpace: isFreeSpace,
+    );
+  }
+
+  @override
+  int get hashCode =>
+      axis.hashCode ^
+      size.hashCode ^
+      offset.hashCode ^
+      realSize.hashCode ^
+      isFreeSpace.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    return other is RenderProperties &&
+        axis == other.axis &&
+        size.closeTo(other.size) &&
+        offset.closeTo(other.offset) &&
+        realSize.closeTo(other.realSize) &&
+        isFreeSpace == other.isFreeSpace;
+  }
+
+  @override
+  String toString() {
+    return '{ axis: $axis, size: $size, offset: $offset, realSize: $realSize, isFreeSpace: $isFreeSpace }';
+  }
+}
+
+bool _closeTo(double a, double b, {int precision = 1}) {
+  return a.toStringAsPrecision(precision) == b.toStringAsPrecision(precision);
+}
+
+extension on Size {
+  bool closeTo(Size other) {
+    return _closeTo(width, other.width) && _closeTo(height, other.height);
+  }
+}
+
+extension on Offset {
+  bool closeTo(Offset other) {
+    return _closeTo(dx, other.dx) && _closeTo(dy, other.dy);
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen.dart
@@ -1,0 +1,668 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:devtools_app_shared/shared.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/material.dart';
+import 'package:vm_service/vm_service.dart' hide Stack;
+
+import '../../service/service_extension_widgets.dart';
+import '../../service/service_extensions.dart' as extensions;
+import '../../shared/analytics/analytics.dart' as ga;
+import '../../shared/analytics/constants.dart' as gac;
+import '../../shared/common_widgets.dart';
+import '../../shared/console/eval/inspector_tree.dart';
+import '../../shared/editable_list.dart';
+import '../../shared/error_badge_manager.dart';
+import '../../shared/globals.dart';
+import '../../shared/preferences/preferences.dart';
+import '../../shared/primitives/blocking_action_mixin.dart';
+import '../../shared/primitives/simple_items.dart';
+import '../../shared/screen.dart';
+import '../../shared/ui/search.dart';
+import '../../shared/utils.dart';
+import 'inspector_controller.dart';
+import 'inspector_screen_details_tab.dart';
+import 'inspector_tree_controller.dart';
+
+class InspectorScreen extends Screen {
+  InspectorScreen() : super.fromMetaData(ScreenMetaData.inspector);
+
+  static final id = ScreenMetaData.inspector.id;
+
+  // There is not enough room to safely show the console in the embed view of
+  // the DevTools and IDEs have their own consoles.
+  @override
+  bool showConsole(EmbedMode embedMode) => !embedMode.embedded;
+
+  @override
+  String get docPageId => screenId;
+
+  @override
+  Widget buildScreenBody(BuildContext context) => const InspectorScreenBody();
+}
+
+class InspectorScreenBody extends StatefulWidget {
+  const InspectorScreenBody({super.key});
+
+  @override
+  InspectorScreenBodyState createState() => InspectorScreenBodyState();
+}
+
+class InspectorScreenBodyState extends State<InspectorScreenBody>
+    with
+        BlockingActionMixin,
+        AutoDisposeMixin,
+        ProvidedControllerMixin<InspectorController, InspectorScreenBody>,
+        SearchFieldMixin<InspectorScreenBody> {
+  InspectorTreeController get _summaryTreeController =>
+      controller.inspectorTree;
+
+  InspectorTreeController get _detailsTreeController =>
+      controller.details!.inspectorTree;
+
+  bool searchVisible = false;
+
+  @override
+  SearchControllerMixin get searchController => _summaryTreeController;
+
+  /// Indicates whether search can be closed. The value is set to true when
+  /// search target type dropdown is displayed
+  /// TODO(https://github.com/flutter/devtools/issues/3489) use this variable when adding the scope dropdown
+  bool searchPreventClose = false;
+
+  SearchTargetType searchTarget = SearchTargetType.widget;
+
+  static const summaryTreeKey = Key('Summary Tree');
+  static const detailsTreeKey = Key('Details Tree');
+  static const minScreenWidthForTextBeforeScaling = 900.0;
+  static const serviceExtensionButtonsIncludeTextWidth = 1200.0;
+
+  @override
+  void dispose() {
+    _summaryTreeController.dispose();
+    if (controller.isSummaryTree && controller.details != null) {
+      _detailsTreeController.dispose();
+    }
+    super.dispose();
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    ga.screen(InspectorScreen.id);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!initController()) return;
+
+    if (serviceConnection.inspectorService == null) {
+      // The app must not be a Flutter app.
+      return;
+    }
+
+    cancelListeners();
+    searchVisible = searchController.search.isNotEmpty;
+    addAutoDisposeListener(searchController.searchFieldFocusNode, () {
+      // Close the search once focus is lost and following conditions are met:
+      //  1. Search string is empty.
+      //  2. [searchPreventClose] == false (this is set true when searchTargetType Dropdown is opened).
+      if (!searchController.searchFieldFocusNode.hasFocus &&
+          searchController.search.isEmpty &&
+          !searchPreventClose) {
+        setState(() {
+          searchVisible = false;
+        });
+      }
+
+      // Reset [searchPreventClose] state to false after the search field gains focus.
+      // Focus is returned automatically once the Dropdown menu is closed.
+      if (searchController.searchFieldFocusNode.hasFocus) {
+        searchPreventClose = false;
+      }
+    });
+    addAutoDisposeListener(preferences.inspectorV2.pubRootDirectories, () {
+      if (serviceConnection.serviceManager.hasConnection &&
+          controller.firstInspectorTreeLoadCompleted) {
+        _refreshInspector();
+      }
+    });
+
+    if (!controller.firstInspectorTreeLoadCompleted) {
+      ga.timeStart(InspectorScreen.id, gac.pageReady);
+    }
+
+    _summaryTreeController.setSearchTarget(searchTarget);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final summaryTree = _buildSummaryTreeColumn();
+
+    final detailsTree = InspectorTree(
+      key: detailsTreeKey,
+      treeController: _detailsTreeController,
+      summaryTreeController: _summaryTreeController,
+      screenId: InspectorScreen.id,
+    );
+
+    final splitAxis = SplitPane.axisFor(context, 0.85);
+    final widgetTrees = SplitPane(
+      axis: splitAxis,
+      initialFractions: const [0.33, 0.67],
+      children: [
+        summaryTree,
+        InspectorDetails(
+          detailsTree: detailsTree,
+          controller: controller,
+        ),
+      ],
+    );
+    return Column(
+      children: <Widget>[
+        Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ValueListenableBuilder<bool>(
+              valueListenable: serviceConnection
+                  .serviceManager.serviceExtensionManager
+                  .hasServiceExtension(
+                extensions.toggleSelectWidgetMode.extension,
+              ),
+              builder: (_, selectModeSupported, __) {
+                return ServiceExtensionButtonGroup(
+                  extensions: [
+                    selectModeSupported
+                        ? extensions.toggleSelectWidgetMode
+                        : extensions.toggleOnDeviceWidgetInspector,
+                  ],
+                  minScreenWidthForTextBeforeScaling:
+                      minScreenWidthForTextBeforeScaling,
+                );
+              },
+            ),
+            const Spacer(),
+            Row(children: getServiceExtensionWidgets()),
+          ],
+        ),
+        const SizedBox(height: intermediateSpacing),
+        Expanded(
+          child: widgetTrees,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSummaryTreeColumn() {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        return RoundedOutlinedBorder(
+          child: Column(
+            children: [
+              InspectorSummaryTreeControls(
+                isSearchVisible: searchVisible,
+                constraints: constraints,
+                onRefreshInspectorPressed: _refreshInspector,
+                onSearchVisibleToggle: _onSearchVisibleToggle,
+                searchFieldBuilder: () =>
+                    StatelessSearchField<InspectorTreeRow>(
+                  controller: _summaryTreeController,
+                  searchFieldEnabled: true,
+                  shouldRequestFocus: searchVisible,
+                  supportsNavigation: true,
+                  onClose: _onSearchVisibleToggle,
+                ),
+              ),
+              Expanded(
+                child: ValueListenableBuilder(
+                  valueListenable: serviceConnection.errorBadgeManager
+                      .erroredItemsForPage(InspectorScreen.id),
+                  builder:
+                      (_, LinkedHashMap<String, DevToolsError> errors, __) {
+                    final inspectableErrors = errors.map(
+                      (key, value) =>
+                          MapEntry(key, value as InspectableWidgetError),
+                    ) as LinkedHashMap<String, InspectableWidgetError>;
+                    return Stack(
+                      children: [
+                        InspectorTree(
+                          key: summaryTreeKey,
+                          treeController: _summaryTreeController,
+                          isSummaryTree: true,
+                          widgetErrors: inspectableErrors,
+                          screenId: InspectorScreen.id,
+                        ),
+                        if (errors.isNotEmpty)
+                          ValueListenableBuilder<int?>(
+                            valueListenable: controller.selectedErrorIndex,
+                            builder: (_, selectedErrorIndex, __) => Positioned(
+                              top: 0,
+                              right: 0,
+                              child: ErrorNavigator(
+                                errors: inspectableErrors,
+                                errorIndex: selectedErrorIndex,
+                                onSelectError: controller.selectErrorByIndex,
+                              ),
+                            ),
+                          ),
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  void _onSearchVisibleToggle() {
+    setState(() {
+      searchVisible = !searchVisible;
+    });
+    _summaryTreeController.resetSearch();
+  }
+
+  List<Widget> getServiceExtensionWidgets() {
+    return [
+      ServiceExtensionButtonGroup(
+        minScreenWidthForTextBeforeScaling:
+            serviceExtensionButtonsIncludeTextWidth,
+        extensions: [
+          extensions.slowAnimations,
+          extensions.debugPaint,
+          extensions.debugPaintBaselines,
+          extensions.repaintRainbow,
+          extensions.invertOversizedImages,
+        ],
+      ),
+      const SizedBox(width: defaultSpacing),
+      SettingsOutlinedButton(
+        gaScreen: gac.inspector,
+        gaSelection: gac.inspectorSettings,
+        tooltip: 'Flutter Inspector Settings',
+        onPressed: () {
+          unawaited(
+            showDialog(
+              context: context,
+              builder: (context) => const FlutterInspectorSettingsDialog(),
+            ),
+          );
+        },
+      ),
+      // TODO(jacobr): implement TogglePlatformSelector.
+      //  TogglePlatformSelector().selector
+    ];
+  }
+
+  void _refreshInspector() {
+    ga.select(gac.inspector, gac.refresh);
+    unawaited(
+      blockWhileInProgress(() async {
+        // If the user is force refreshing the inspector before the first load has
+        // completed, this could indicate a slow load time or that the inspector
+        // failed to load the tree once available.
+        if (!controller.firstInspectorTreeLoadCompleted) {
+          // We do not want to complete this timing operation because the force
+          // refresh will skew the results.
+          ga.cancelTimingOperation(
+            InspectorScreen.id,
+            gac.pageReady,
+          );
+          ga.select(
+            gac.inspector,
+            gac.refreshEmptyTree,
+          );
+          controller.firstInspectorTreeLoadCompleted = true;
+        }
+        await controller.onForceRefresh();
+      }),
+    );
+  }
+}
+
+class FlutterInspectorSettingsDialog extends StatelessWidget {
+  const FlutterInspectorSettingsDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dialogHeight = scaleByFontFactor(500.0);
+    return DevToolsDialog(
+      title: const DialogTitleText('Flutter Inspector Settings'),
+      content: SizedBox(
+        width: defaultDialogWidth,
+        height: dialogHeight,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ...dialogSubHeader(
+              theme,
+              'General',
+            ),
+            CheckboxSetting(
+              notifier: preferences.inspectorV2.hoverEvalModeEnabled
+                  as ValueNotifier<bool?>,
+              title: 'Enable hover inspection',
+              description:
+                  'Hovering over any widget displays its properties and values.',
+              gaItem: gac.inspectorHoverEvalMode,
+            ),
+            const SizedBox(height: denseSpacing),
+            const InspectorDefaultDetailsViewOption(),
+            const SizedBox(height: denseSpacing),
+            ...dialogSubHeader(theme, 'Package Directories'),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(
+                  child: Text(
+                    'Widgets in these directories will show up in your summary tree.',
+                    style: theme.subtleTextStyle,
+                  ),
+                ),
+                MoreInfoLink(
+                  url: DocLinks.inspectorPackageDirectories.value,
+                  gaScreenName: gac.inspector,
+                  gaSelectedItemDescription:
+                      gac.InspectorDocs.packageDirectoriesDocs.name,
+                ),
+              ],
+            ),
+            Text(
+              '(e.g. /absolute/path/to/myPackage/)',
+              style: theme.subtleTextStyle,
+            ),
+            const SizedBox(height: denseSpacing),
+            const Expanded(
+              child: PubRootDirectorySection(),
+            ),
+          ],
+        ),
+      ),
+      actions: const [
+        DialogCloseButton(),
+      ],
+    );
+  }
+}
+
+class InspectorSummaryTreeControls extends StatelessWidget {
+  const InspectorSummaryTreeControls({
+    super.key,
+    required this.constraints,
+    required this.isSearchVisible,
+    required this.onRefreshInspectorPressed,
+    required this.onSearchVisibleToggle,
+    required this.searchFieldBuilder,
+  });
+
+  static const _searchBreakpoint = 375.0;
+
+  final bool isSearchVisible;
+  final BoxConstraints constraints;
+  final VoidCallback onRefreshInspectorPressed;
+  final VoidCallback onSearchVisibleToggle;
+  final Widget Function() searchFieldBuilder;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _controlsContainer(
+          context,
+          Row(
+            children: <Widget>[
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: denseSpacing),
+                child: Text(
+                  'Widget Tree 2.0',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+              ),
+              ...!isSearchVisible
+                  ? [
+                      const Spacer(),
+                      ToolbarAction(
+                        icon: Icons.search,
+                        onPressed: onSearchVisibleToggle,
+                        tooltip: 'Search Tree',
+                      ),
+                    ]
+                  : [
+                      constraints.maxWidth >= _searchBreakpoint
+                          ? _buildSearchControls()
+                          : const Spacer(),
+                    ],
+              ToolbarAction(
+                icon: Icons.refresh,
+                onPressed: onRefreshInspectorPressed,
+                tooltip: 'Refresh Tree',
+              ),
+            ],
+          ),
+        ),
+        if (isSearchVisible && constraints.maxWidth < _searchBreakpoint)
+          _controlsContainer(
+            context,
+            Row(children: [_buildSearchControls()]),
+          ),
+      ],
+    );
+  }
+
+  Container _controlsContainer(BuildContext context, Widget child) {
+    return Container(
+      height: defaultHeaderHeight,
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: defaultBorderSide(Theme.of(context)),
+        ),
+      ),
+      child: child,
+    );
+  }
+
+  Widget _buildSearchControls() {
+    return Expanded(
+      child: SizedBox(
+        height: defaultTextFieldHeight,
+        child: searchFieldBuilder(),
+      ),
+    );
+  }
+}
+
+class ErrorNavigator extends StatelessWidget {
+  const ErrorNavigator({
+    super.key,
+    required this.errors,
+    required this.errorIndex,
+    required this.onSelectError,
+  });
+
+  final LinkedHashMap<String, InspectableWidgetError> errors;
+
+  final int? errorIndex;
+
+  final void Function(int) onSelectError;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final label = errorIndex != null
+        ? 'Error ${errorIndex! + 1}/${errors.length}'
+        : 'Errors: ${errors.length}';
+    return Container(
+      color: colorScheme.errorContainer,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(
+          horizontal: defaultSpacing,
+          vertical: denseSpacing,
+        ),
+        child: Row(
+          children: [
+            Padding(
+              padding: const EdgeInsets.only(right: denseSpacing),
+              child: Text(
+                label,
+                style: TextStyle(
+                  color: colorScheme.onErrorContainer,
+                ),
+              ),
+            ),
+            _ErrorNavigatorButton(
+              icon: Icons.keyboard_arrow_up,
+              onPressed: _previousError,
+            ),
+            _ErrorNavigatorButton(
+              icon: Icons.keyboard_arrow_down,
+              onPressed: _nextError,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _previousError() {
+    var newIndex = errorIndex == null ? errors.length - 1 : errorIndex! - 1;
+    while (newIndex < 0) {
+      newIndex += errors.length;
+    }
+
+    onSelectError(newIndex);
+  }
+
+  void _nextError() {
+    final newIndex = errorIndex == null ? 0 : (errorIndex! + 1) % errors.length;
+
+    onSelectError(newIndex);
+  }
+}
+
+class _ErrorNavigatorButton extends StatelessWidget {
+  const _ErrorNavigatorButton({required this.icon, required this.onPressed});
+
+  final IconData icon;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      // This is required to force the button size.
+      height: defaultButtonHeight,
+      width: defaultButtonHeight,
+      child: IconButton(
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints(),
+        splashRadius: defaultIconSize,
+        icon: Icon(icon),
+        color: Theme.of(context).colorScheme.onErrorContainer,
+        onPressed: onPressed,
+      ),
+    );
+  }
+}
+
+class InspectorDefaultDetailsViewOption extends StatelessWidget {
+  const InspectorDefaultDetailsViewOption({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder(
+      valueListenable: preferences.inspectorV2.defaultDetailsView,
+      builder: (context, selection, _) {
+        final theme = Theme.of(context);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Select the default tab for the inspector.',
+              style: theme.subtleTextStyle,
+            ),
+            const SizedBox(height: denseSpacing),
+            Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Radio<InspectorV2DetailsViewType>(
+                  value: InspectorV2DetailsViewType.layoutExplorer,
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  groupValue: selection,
+                  onChanged: _onChanged,
+                ),
+                Text(InspectorV2DetailsViewType.layoutExplorer.key),
+                const SizedBox(width: denseSpacing),
+                Radio<InspectorV2DetailsViewType>(
+                  materialTapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                  value: InspectorV2DetailsViewType.widgetDetailsTree,
+                  groupValue: selection,
+                  onChanged: _onChanged,
+                ),
+                Text(InspectorV2DetailsViewType.widgetDetailsTree.key),
+              ],
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  void _onChanged(InspectorV2DetailsViewType? value) {
+    if (value != null) {
+      preferences.inspectorV2.setDefaultInspectorDetailsView(value);
+      final item = value.name == InspectorV2DetailsViewType.layoutExplorer.name
+          ? gac.defaultDetailsViewToLayoutExplorer
+          : gac.defaultDetailsViewToWidgetDetails;
+      ga.select(
+        gac.inspector,
+        item,
+      );
+    }
+  }
+}
+
+class PubRootDirectorySection extends StatelessWidget {
+  const PubRootDirectorySection({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<IsolateRef?>(
+      valueListenable:
+          serviceConnection.serviceManager.isolateManager.mainIsolate,
+      builder: (_, __, ___) {
+        return SizedBox(
+          height: 200.0,
+          child: EditableList(
+            gaScreen: gac.inspector,
+            gaRefreshSelection: gac.refreshPubRoots,
+            entries: preferences.inspectorV2.pubRootDirectories,
+            textFieldLabel: 'Enter a new package directory',
+            isRefreshing:
+                preferences.inspectorV2.isRefreshingPubRootDirectories,
+            onEntryAdded: (p0) => unawaited(
+              preferences.inspectorV2.addPubRootDirectories(
+                [p0],
+                shouldCache: true,
+              ),
+            ),
+            onEntryRemoved: (p0) => unawaited(
+              preferences.inspectorV2.removePubRootDirectories([p0]),
+            ),
+            onRefreshTriggered: () =>
+                unawaited(preferences.inspectorV2.loadPubRootDirectories()),
+          ),
+        );
+      },
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_details_tab.dart
@@ -1,0 +1,150 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../shared/analytics/analytics.dart' as ga;
+import '../../shared/analytics/constants.dart' as gac;
+import '../../shared/common_widgets.dart';
+import '../../shared/globals.dart';
+import '../../shared/preferences/preferences.dart';
+import '../../shared/primitives/blocking_action_mixin.dart';
+import '../../shared/ui/tab.dart';
+import 'inspector_controller.dart';
+import 'inspector_screen.dart';
+import 'layout_explorer/layout_explorer.dart';
+
+class InspectorDetails extends StatelessWidget {
+  const InspectorDetails({
+    required this.detailsTree,
+    required this.controller,
+    super.key,
+  });
+
+  final Widget detailsTree;
+  final InspectorController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    final tabs = [
+      (
+        tab: _buildTab(tabName: InspectorV2DetailsViewType.layoutExplorer.key),
+        tabView: LayoutExplorerTab(controller: controller),
+      ),
+      (
+        tab: _buildTab(
+          tabName: InspectorV2DetailsViewType.widgetDetailsTree.key,
+          trailing: InspectorExpandCollapseButtons(controller: controller),
+        ),
+        tabView: detailsTree,
+      ),
+    ];
+    return ValueListenableBuilder(
+      valueListenable: preferences.inspectorV2.defaultDetailsView,
+      builder: (BuildContext context, value, Widget? child) {
+        int defaultInspectorViewIndex = 0;
+
+        if (preferences.inspectorV2.defaultDetailsView.value ==
+            InspectorV2DetailsViewType.widgetDetailsTree) {
+          defaultInspectorViewIndex = 1;
+        }
+
+        return AnalyticsTabbedView(
+          tabs: tabs,
+          gaScreen: gac.inspector,
+          initialSelectedIndex: defaultInspectorViewIndex,
+        );
+      },
+    );
+  }
+
+  DevToolsTab _buildTab({required String tabName, Widget? trailing}) {
+    return DevToolsTab.create(
+      tabName: tabName,
+      gaPrefix: 'inspectorDetailsTab',
+      trailing: trailing,
+    );
+  }
+}
+
+class InspectorExpandCollapseButtons extends StatefulWidget {
+  const InspectorExpandCollapseButtons({
+    super.key,
+    required this.controller,
+  });
+
+  final InspectorController controller;
+
+  @override
+  State<InspectorExpandCollapseButtons> createState() =>
+      _InspectorExpandCollapseButtonsState();
+}
+
+class _InspectorExpandCollapseButtonsState
+    extends State<InspectorExpandCollapseButtons> with BlockingActionMixin {
+  bool get enableButtons => !actionInProgress;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      alignment: Alignment.centerRight,
+      decoration: BoxDecoration(
+        border: Border(
+          left: defaultBorderSide(Theme.of(context)),
+        ),
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          SizedBox(
+            child: GaDevToolsButton(
+              icon: Icons.unfold_more,
+              onPressed: enableButtons ? _onExpandClick : null,
+              label: 'Expand all',
+              minScreenWidthForTextBeforeScaling:
+                  InspectorScreenBodyState.minScreenWidthForTextBeforeScaling,
+              gaScreen: gac.inspector,
+              gaSelection: gac.expandAll,
+              outlined: false,
+            ),
+          ),
+          const SizedBox(width: denseSpacing),
+          SizedBox(
+            child: GaDevToolsButton(
+              icon: Icons.unfold_less,
+              onPressed: enableButtons ? _onCollapseClick : null,
+              label: 'Collapse to selected',
+              minScreenWidthForTextBeforeScaling:
+                  InspectorScreenBodyState.minScreenWidthForTextBeforeScaling,
+              gaScreen: gac.inspector,
+              gaSelection: gac.collapseAll,
+              outlined: false,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _onExpandClick() {
+    unawaited(
+      blockWhileInProgress(() async {
+        ga.select(gac.inspector, gac.expandAll);
+        await widget.controller.expandAllNodesInDetailsTree();
+      }),
+    );
+  }
+
+  void _onCollapseClick() {
+    ga.select(
+      gac.inspector,
+      gac.collapseAll,
+    );
+    widget.controller.collapseDetailsToSelected();
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_details_tab.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_details_tab.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -109,7 +109,7 @@ class InspectorTreeController extends DisposableController
       gac.inspector,
       gac.inspectorTreeControllerInitialized,
       nonInteraction: true,
-      screenMetricsProvider: () => InspectorScreenMetrics.legacy(
+      screenMetricsProvider: () => InspectorScreenMetrics.v2(
         inspectorTreeControllerId: gaId,
         rootSetCount: _rootSetCount,
         rowCount: _root?.subtreeSize,
@@ -170,7 +170,7 @@ class InspectorTreeController extends DisposableController
         gac.inspector,
         gac.inspectorTreeControllerRootChange,
         nonInteraction: true,
-        screenMetricsProvider: () => InspectorScreenMetrics.legacy(
+        screenMetricsProvider: () => InspectorScreenMetrics.v2(
           inspectorTreeControllerId: gaId,
           rootSetCount: ++_rootSetCount,
           rowCount: _root?.subtreeSize,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
@@ -1,0 +1,446 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../shared/diagnostics/diagnostics_node.dart';
+import '../../../../shared/primitives/math_utils.dart';
+import '../../../../shared/primitives/utils.dart';
+import '../../inspector_data_models.dart';
+import '../ui/free_space.dart';
+import '../ui/layout_explorer_widget.dart';
+import '../ui/theme.dart';
+import '../ui/utils.dart';
+import '../ui/widget_constraints.dart';
+import '../ui/widgets_theme.dart';
+
+class BoxLayoutExplorerWidget extends LayoutExplorerWidget {
+  const BoxLayoutExplorerWidget(
+    super.inspectorController, {
+    super.key,
+  });
+
+  static bool shouldDisplay(RemoteDiagnosticsNode _) {
+    // Pretend this layout explorer is always available. This layout explorer
+    // will gracefully fall back to an error message if the required properties
+    // are not needed.
+    // TODO(jacobr) pass a RemoteDiagnosticsNode to this method that contains
+    // the layout explorer related supplemental properties so that we can
+    // accurately determine whether the widget uses box layout.
+    return true;
+  }
+
+  @override
+  State<BoxLayoutExplorerWidget> createState() =>
+      BoxLayoutExplorerWidgetState();
+}
+
+class BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
+    BoxLayoutExplorerWidget, LayoutProperties> {
+  @override
+  RemoteDiagnosticsNode? getRoot(RemoteDiagnosticsNode? node) {
+    final nodeLocal = node;
+    if (nodeLocal == null) return null;
+    if (!shouldDisplay(nodeLocal)) return null;
+    return node;
+  }
+
+  @override
+  bool shouldDisplay(RemoteDiagnosticsNode node) {
+    final selectedNodeLocal = selectedNode;
+    if (selectedNodeLocal == null) return false;
+    return BoxLayoutExplorerWidget.shouldDisplay(selectedNodeLocal);
+  }
+
+  @override
+  AnimatedLayoutProperties computeAnimatedProperties(
+    LayoutProperties nextProperties,
+  ) {
+    return AnimatedLayoutProperties(
+      // If an animation is in progress, freeze it and start animating from there, else start a fresh animation from widget.properties.
+      animatedProperties?.copyWith() ?? properties!,
+      nextProperties,
+      changeAnimation,
+    );
+  }
+
+  @override
+  LayoutProperties computeLayoutProperties(RemoteDiagnosticsNode node) =>
+      LayoutProperties(node);
+
+  @override
+  void updateHighlighted(LayoutProperties? newProperties) {
+    setState(() {
+      // This implementation will need to change if we support showing more than
+      // a single widget in the box visualization for the layout explorer.
+      highlighted = newProperties != null && selectedNode == newProperties.node
+          ? newProperties
+          : null;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (properties == null) {
+      final selectedNodeLocal = selectedNode;
+      return Center(
+        child: Text(
+          '${selectedNodeLocal?.description ?? 'Widget'} has no layout properties to display.',
+          textAlign: TextAlign.center,
+          overflow: TextOverflow.clip,
+        ),
+      );
+    }
+    return Container(
+      margin: const EdgeInsets.all(denseSpacing),
+      child: AnimatedBuilder(
+        animation: changeController,
+        builder: (context, _) {
+          return LayoutBuilder(builder: _buildLayout);
+        },
+      ),
+    );
+  }
+
+  /// Simplistic layout algorithm to roughly match minFraction restrictions for
+  /// each sizes attempting to render a stylized version of the original layout.
+  /// TODO(jacobr): see if we can unify with the stylized version of the overall
+  /// layout used for Flex. Our constraints are quite different as we can
+  /// guarantee that the entire layout fits without scrolling while in the Flex
+  /// case that would be difficult.
+  ///
+  /// The overall layout will expand to use the full availableSize treating null
+  /// values in [sizes] as an indication that the items should have zero size.
+  /// On the other hand, a non-null size indicates that the minFractions
+  /// constraints should be obeyed. This is needed to ensure that negative sizes
+  /// are visualized reasonably.
+  /// The minFractions aren't exactly obeyed but they are approximated in a way
+  /// that keeps this algorithm simple and has the nice property that an initial
+  /// value much smaller than the minSize results in a slightly smaller value
+  /// than a value that is almost minSize.
+  /// In the most extreme case an item will get not minFraction but will instead
+  /// get the slightly smaller value of minFraction / (1 + minFraction)
+  /// which is close enough for the simple values we need this for.
+  static List<double> minFractionLayout({
+    required double availableSize,
+    required List<double?> sizes,
+    required List<double> minFractions,
+  }) {
+    assert(sizes.length == minFractions.length);
+    final length = sizes.length;
+    double total = 1.0; // This isn't set to zero to avoid divide by zero bugs.
+    final fractions = minFractions.toList();
+    for (var size in sizes) {
+      if (size != null) {
+        total += math.max(0, size);
+      }
+    }
+
+    double totalFraction = 0.0;
+    for (int i = 0; i < length; i++) {
+      final size = sizes[i];
+      if (size != null) {
+        fractions[i] = math.max(size / total, minFractions[i]);
+        totalFraction += fractions[i];
+      } else {
+        fractions[i] = 0.0;
+      }
+    }
+    if (totalFraction != 1.0) {
+      for (int i = 0; i < length; i++) {
+        fractions[i] = fractions[i] / totalFraction;
+      }
+    }
+    final output = <double>[];
+    for (var fraction in fractions) {
+      output.add(fraction * availableSize);
+    }
+    return output;
+  }
+
+  Widget _buildChild(BuildContext context) {
+    final propertiesLocal = properties!;
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final parentProperties = this.parentProperties ??
+        propertiesLocal; // Fall back to this node's properties if there is no parent.
+
+    final parentSize = parentProperties.size;
+    final offset = propertiesLocal.node.parentData;
+
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        // Subtract out one pixel border on each side.
+        final availableHeight = constraints.maxHeight - 2;
+        final availableWidth = constraints.maxWidth - 2;
+
+        final minFractions = [0.2, 0.5, 0.2];
+        // TODO(polinach, jacobr): consider using zeros for zero values,
+        // without replacing them with nulls.
+        // See https://github.com/flutter/devtools/issues/3931.
+        double? nullOutZero(double value) => value != 0.0 ? value : null;
+        final widths = [
+          nullOutZero(offset.offset.dx),
+          propertiesLocal.size.width,
+          nullOutZero(
+            parentSize.width - (propertiesLocal.size.width + offset.offset.dx),
+          ),
+        ];
+        final heights = [
+          nullOutZero(offset.offset.dy),
+          propertiesLocal.size.height,
+          nullOutZero(
+            parentSize.height -
+                (propertiesLocal.size.height + offset.offset.dy),
+          ),
+        ];
+        // 3 element array with [left padding, widget width, right padding].
+        final displayWidths = minFractionLayout(
+          availableSize: availableWidth,
+          sizes: widths,
+          minFractions: minFractions,
+        );
+        // 3 element array with [top padding, widget height, bottom padding].
+        final displayHeights = minFractionLayout(
+          availableSize: availableHeight,
+          sizes: heights,
+          minFractions: minFractions,
+        );
+        final widgetWidth = displayWidths[1];
+        final widgetHeight = displayHeights[1];
+        final safeParentSize = parentSize;
+        final width0 = widths[0];
+        final width2 = widths[2];
+        final height0 = heights[0];
+        final height2 = heights[2];
+        return Container(
+          width: constraints.maxWidth,
+          height: constraints.maxHeight,
+          decoration: BoxDecoration(
+            border: Border.all(
+              color:
+                  WidgetTheme.fromName(propertiesLocal.node.description).color,
+            ),
+          ),
+          child: Stack(
+            children: [
+              LayoutExplorerBackground(colorScheme: colorScheme),
+              // Left padding.
+              if (width0 != null)
+                PaddingVisualizerWidget(
+                  RenderProperties(
+                    axis: Axis.horizontal,
+                    size: Size(displayWidths[0], widgetHeight),
+                    offset: Offset(0, displayHeights[0]),
+                    realSize: Size(width0, safeParentSize.height),
+                    layoutProperties: propertiesLocal,
+                    isFreeSpace: true,
+                  ),
+                  horizontal: true,
+                ),
+              // Top padding.
+              if (height0 != null)
+                PaddingVisualizerWidget(
+                  RenderProperties(
+                    axis: Axis.horizontal,
+                    size: Size(widgetWidth, displayHeights[0]),
+                    offset: Offset(displayWidths[0], 0),
+                    realSize: Size(safeParentSize.width, height0),
+                    layoutProperties: propertiesLocal,
+                    isFreeSpace: true,
+                  ),
+                  horizontal: false,
+                ),
+              // Right padding.
+              if (width2 != null)
+                PaddingVisualizerWidget(
+                  RenderProperties(
+                    axis: Axis.horizontal,
+                    size: Size(displayWidths[2], widgetHeight),
+                    offset: Offset(
+                      displayWidths[0] + displayWidths[1],
+                      displayHeights[0],
+                    ),
+                    realSize: Size(width2, safeParentSize.height),
+                    layoutProperties: propertiesLocal,
+                    isFreeSpace: true,
+                  ),
+                  horizontal: true,
+                ),
+              // Bottom padding.
+              if (height2 != null)
+                PaddingVisualizerWidget(
+                  RenderProperties(
+                    axis: Axis.horizontal,
+                    size: Size(widgetWidth, displayHeights[2]),
+                    offset: Offset(
+                      displayWidths[0],
+                      displayHeights[0] + displayHeights[1],
+                    ),
+                    realSize: Size(safeParentSize.width, height2),
+                    layoutProperties: propertiesLocal,
+                    isFreeSpace: true,
+                  ),
+                  horizontal: false,
+                ),
+              BoxChildVisualizer(
+                isSelected: true,
+                state: this,
+                layoutProperties: propertiesLocal,
+                renderProperties: RenderProperties(
+                  axis: Axis.horizontal,
+                  size: Size(widgetWidth, widgetHeight),
+                  offset: Offset(displayWidths[0], displayHeights[0]),
+                  realSize: propertiesLocal.size,
+                  layoutProperties: propertiesLocal,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  LayoutProperties? get parentProperties {
+    final parentElement = properties?.node.parentRenderElement;
+    if (parentElement == null) return null;
+    final parentProperties = computeLayoutProperties(parentElement);
+    return parentProperties;
+  }
+
+  Widget _buildLayout(BuildContext context, BoxConstraints constraints) {
+    final maxHeight = constraints.maxHeight;
+    final maxWidth = constraints.maxWidth;
+
+    Widget widget = _buildChild(context);
+    final parentProperties = this.parentProperties;
+    if (parentProperties != null) {
+      // Wrap with a widget visualizer for the parent if there is a valid parent.
+      widget = WidgetVisualizer(
+        // TODO(jacobr): this node's name can be misleading more often than
+        // in the flex case the widget doesn't have its own RenderObject.
+        // Consider showing the true ancestor for the summary tree that first
+        // has a different render object.
+        title: describeBoxName(parentProperties),
+        largeTitle: true,
+        layoutProperties: parentProperties,
+        isSelected: false,
+        child: VisualizeWidthAndHeightWithConstraints(
+          properties: parentProperties,
+          warnIfUnconstrained: false,
+          child: Padding(
+            padding: const EdgeInsets.all(denseSpacing),
+            child: widget,
+          ),
+        ),
+      );
+    }
+    return Container(
+      constraints: BoxConstraints(maxWidth: maxWidth, maxHeight: maxHeight),
+      child: widget,
+    );
+  }
+}
+
+String describeBoxName(LayoutProperties properties) {
+  // Displaying a high quality name is more ambiguous for the Box case than the
+  // Flex case because the RenderObject for each widget is often quite
+  // different than the user expected as not all widgets have RenderObjects.
+  // As a compromise we currently show 'WidgetName - RenderObjectName'.
+  // This is clearer but risks more confusion
+
+  // Widget name.
+  var title = properties.node.description ?? '';
+  final renderDescription = properties.node.renderObject?.description;
+  // TODO(jacobr): consider de-emphasizing the render object name by putting it
+  // in more transparent text or just calling the widget Parent instead of
+  // surfacing a widget name.
+  if (renderDescription != null) {
+    // Name of the associated RenderObject if one is available.
+    title += ' - $renderDescription';
+  }
+  return title;
+}
+
+/// Widget that represents and visualize a direct child of Flex widget.
+class BoxChildVisualizer extends StatelessWidget {
+  const BoxChildVisualizer({
+    super.key,
+    required this.state,
+    required this.layoutProperties,
+    required this.renderProperties,
+    required this.isSelected,
+  });
+
+  final BoxLayoutExplorerWidgetState state;
+
+  final bool isSelected;
+  final LayoutProperties layoutProperties;
+  final RenderProperties renderProperties;
+
+  LayoutProperties? get properties => renderProperties.layoutProperties;
+
+  @override
+  Widget build(BuildContext context) {
+    final renderSize = renderProperties.size;
+    final renderOffset = renderProperties.offset;
+
+    Widget buildEntranceAnimation(BuildContext _, Widget? child) {
+      final size = renderSize;
+      // TODO(jacobr): does this entrance animation really add value.
+      return Opacity(
+        opacity: min([state.entranceCurve.value * 5, 1.0]),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: math.max(0.0, (renderSize.width - size.width) / 2),
+            vertical: math.max(0.0, (renderSize.height - size.height) / 2),
+          ),
+          child: child,
+        ),
+      );
+    }
+
+    final propertiesLocal = properties!;
+
+    return Positioned(
+      top: renderOffset.dy,
+      left: renderOffset.dx,
+      child: InkWell(
+        onTap: () => unawaited(state.onTap(propertiesLocal)),
+        onDoubleTap: () => state.onDoubleTap(propertiesLocal),
+        child: SizedBox(
+          width: safePositiveDouble(renderSize.width),
+          height: safePositiveDouble(renderSize.height),
+          child: AnimatedBuilder(
+            animation: state.entranceController,
+            builder: buildEntranceAnimation,
+            child: WidgetVisualizer(
+              isSelected: isSelected,
+              layoutProperties: layoutProperties,
+              title: describeBoxName(propertiesLocal),
+              // TODO(jacobr): consider surfacing the overflow size information
+              // if we determine
+              // overflowSide: properties.overflowSide,
+
+              // We only show one child at a time so a large title is safe.
+              largeTitle: true,
+              child: VisualizeWidthAndHeightWithConstraints(
+                arrowHeadSize: arrowHeadSize,
+                properties: propertiesLocal,
+                warnIfUnconstrained: false,
+                child: const SizedBox.shrink(),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
@@ -1,0 +1,779 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../shared/common_widgets.dart';
+import '../../../../shared/diagnostics/diagnostics_node.dart';
+import '../../../../shared/diagnostics/inspector_service.dart';
+import '../../../../shared/primitives/math_utils.dart';
+import '../../inspector_data_models.dart';
+import '../ui/arrow.dart';
+import '../ui/free_space.dart';
+import '../ui/layout_explorer_widget.dart';
+import '../ui/theme.dart';
+import '../ui/utils.dart';
+import '../ui/widget_constraints.dart';
+import 'utils.dart';
+
+// TODO(kenz): clean up this file so that we use helper widgets instead of
+// methods that pass around build context.
+
+// TODO(kenz): densify the layout explorer visualization for flex widgets.
+
+double get alignmentDropdownMaxSize => scaleByFontFactor(140.0);
+
+class FlexLayoutExplorerWidget extends LayoutExplorerWidget {
+  const FlexLayoutExplorerWidget(
+    super.inspectorController, {
+    super.key,
+  });
+
+  static bool shouldDisplay(RemoteDiagnosticsNode node) {
+    return (node.isFlex) || (node.parent?.isFlex ?? false);
+  }
+
+  @override
+  State<FlexLayoutExplorerWidget> createState() =>
+      FlexLayoutExplorerWidgetState();
+}
+
+class FlexLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
+    FlexLayoutExplorerWidget, FlexLayoutProperties> {
+  final scrollController = ScrollController();
+
+  Axis get direction => properties!.direction;
+
+  ObjectGroup? get objectGroup =>
+      properties!.node.objectGroupApi as ObjectGroup?;
+
+  Color horizontalColor(ColorScheme colorScheme) =>
+      properties!.isMainAxisHorizontal
+          ? colorScheme.mainAxisColor
+          : colorScheme.crossAxisColor;
+
+  Color verticalColor(ColorScheme colorScheme) => properties!.isMainAxisVertical
+      ? colorScheme.mainAxisColor
+      : colorScheme.crossAxisColor;
+
+  Color horizontalTextColor(ColorScheme colorScheme) =>
+      properties!.isMainAxisHorizontal
+          ? colorScheme.mainAxisTextColor
+          : colorScheme.crossAxisTextColor;
+
+  Color verticalTextColor(ColorScheme colorScheme) =>
+      properties!.isMainAxisVertical
+          ? colorScheme.mainAxisTextColor
+          : colorScheme.crossAxisTextColor;
+
+  String get flexType => properties!.type;
+
+  @override
+  RemoteDiagnosticsNode? getRoot(RemoteDiagnosticsNode? node) {
+    if (node == null) return null;
+    if (!shouldDisplay(node)) return null;
+    if (node.isFlex) return node;
+    return node.parent;
+  }
+
+  @override
+  bool shouldDisplay(RemoteDiagnosticsNode node) {
+    final selectedNodeLocal = selectedNode;
+    if (selectedNodeLocal == null) return false;
+    return FlexLayoutExplorerWidget.shouldDisplay(selectedNodeLocal);
+  }
+
+  @override
+  AnimatedFlexLayoutProperties computeAnimatedProperties(
+    FlexLayoutProperties nextProperties,
+  ) {
+    return AnimatedFlexLayoutProperties(
+      // If an animation is in progress, freeze it and start animating from there, else start a fresh animation from widget.properties.
+      animatedProperties?.copyWith() as FlexLayoutProperties? ?? properties!,
+      nextProperties,
+      changeAnimation,
+    );
+  }
+
+  @override
+  FlexLayoutProperties computeLayoutProperties(RemoteDiagnosticsNode node) =>
+      FlexLayoutProperties.fromDiagnostics(node);
+
+  @override
+  void updateHighlighted(FlexLayoutProperties? newProperties) {
+    setState(() {
+      if (selectedNode!.isFlex) {
+        highlighted = newProperties;
+      } else {
+        final idx =
+            selectedNode?.parent?.childrenNow.indexOf(selectedNode!) ?? -1;
+        if (newProperties == null) return;
+        if (idx != -1) highlighted = newProperties.children[idx];
+      }
+    });
+  }
+
+  Widget _buildAxisAlignmentDropdown(Axis axis, ThemeData theme) {
+    final colorScheme = theme.colorScheme;
+    final color = axis == direction
+        ? colorScheme.mainAxisTextColor
+        : colorScheme.crossAxisTextColor;
+    List<Enum> alignmentEnumEntries;
+    Object? selected;
+    final propertiesLocal = properties!;
+    if (axis == direction) {
+      alignmentEnumEntries = MainAxisAlignment.values;
+      selected = propertiesLocal.mainAxisAlignment;
+    } else {
+      alignmentEnumEntries = CrossAxisAlignment.values.toList(growable: true);
+      if (propertiesLocal.textBaseline == null) {
+        // TODO(albertusangga): Look for ways to visualize baseline when it is null
+        alignmentEnumEntries.remove(CrossAxisAlignment.baseline);
+      }
+      selected = propertiesLocal.crossAxisAlignment;
+    }
+    return RotatedBox(
+      quarterTurns: axis == Axis.vertical ? 3 : 0,
+      child: Container(
+        constraints: BoxConstraints(
+          maxWidth: alignmentDropdownMaxSize,
+          maxHeight: defaultButtonHeight,
+        ),
+        child: DropdownButton(
+          value: selected,
+          isDense: true,
+          isExpanded: true,
+          // Avoid showing an underline for the main axis and cross-axis drop downs.
+          underline: const SizedBox(),
+          iconEnabledColor: axis == propertiesLocal.direction
+              ? colorScheme.mainAxisColor
+              : colorScheme.crossAxisColor,
+          selectedItemBuilder: (context) {
+            return [
+              for (var alignment in alignmentEnumEntries)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Expanded(
+                      child: Text(
+                        alignment.name,
+                        style: theme.regularTextStyleWithColor(color),
+                        textAlign: TextAlign.center,
+                        overflow: TextOverflow.ellipsis,
+                      ),
+                    ),
+                    SizedBox(
+                      height: actionsIconSize,
+                      width: actionsIconSize,
+                      child: Image.asset(
+                        (axis == direction)
+                            ? mainAxisAssetImageUrl(
+                                direction,
+                                alignment as MainAxisAlignment,
+                              )
+                            : crossAxisAssetImageUrl(
+                                direction,
+                                alignment as CrossAxisAlignment,
+                              ),
+                        height: axisAlignmentAssetImageHeight,
+                        fit: BoxFit.fitHeight,
+                        color: color,
+                      ),
+                    ),
+                  ],
+                ),
+            ];
+          },
+          items: [
+            for (var alignment in alignmentEnumEntries)
+              DropdownMenuItem(
+                value: alignment,
+                child: Container(
+                  padding: const EdgeInsets.symmetric(vertical: margin),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      Expanded(
+                        child: Text(
+                          alignment.name,
+                          style: theme.regularTextStyleWithColor(color),
+                          textAlign: TextAlign.center,
+                          overflow: TextOverflow.ellipsis,
+                        ),
+                      ),
+                      SizedBox(
+                        height: actionsIconSize,
+                        width: actionsIconSize,
+                        child: Image.asset(
+                          (axis == direction)
+                              ? mainAxisAssetImageUrl(
+                                  direction,
+                                  alignment as MainAxisAlignment,
+                                )
+                              : crossAxisAssetImageUrl(
+                                  direction,
+                                  alignment as CrossAxisAlignment,
+                                ),
+                          fit: BoxFit.fitHeight,
+                          color: color,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+          ],
+          onChanged: (Object? newSelection) async {
+            // newSelection is an object instead of type here because
+            // the type is dependent on the `axis` parameter
+            // if the axis is the main axis the type should be [MainAxisAlignment]
+            // if the axis is the cross axis the type should be [CrossAxisAlignment]
+            FlexLayoutProperties changedProperties;
+            changedProperties = axis == direction
+                ? propertiesLocal.copyWith(
+                    mainAxisAlignment: newSelection as MainAxisAlignment?,
+                  )
+                : propertiesLocal.copyWith(
+                    crossAxisAlignment: newSelection as CrossAxisAlignment?,
+                  );
+            final valueRef = propertiesLocal.node.valueRef;
+            markAsDirty();
+            await objectGroup!.invokeSetFlexProperties(
+              valueRef,
+              changedProperties.mainAxisAlignment,
+              changedProperties.crossAxisAlignment,
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (properties == null) return const SizedBox();
+    return Container(
+      margin: const EdgeInsets.all(margin),
+      padding: const EdgeInsets.only(bottom: margin, right: margin),
+      child: AnimatedBuilder(
+        animation: changeController,
+        builder: (context, _) {
+          return LayoutBuilder(builder: _buildLayout);
+        },
+      ),
+    );
+  }
+
+  Widget _buildLayout(BuildContext context, BoxConstraints constraints) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final maxHeight = constraints.maxHeight;
+    final maxWidth = constraints.maxWidth;
+    final propertiesLocal = properties!;
+    final flexDescription = Align(
+      alignment: Alignment.centerLeft,
+      child: Container(
+        margin: EdgeInsets.only(
+          top: mainAxisArrowIndicatorSize,
+          left: crossAxisArrowIndicatorSize + margin,
+        ),
+        child: InkWell(
+          onTap: () => unawaited(onTap(propertiesLocal)),
+          child: WidgetVisualizer(
+            title: flexType,
+            layoutProperties: propertiesLocal,
+            isSelected: highlighted == properties,
+            overflowSide: propertiesLocal.overflowSide,
+            hint: Container(
+              padding: const EdgeInsets.all(4.0),
+              child: Text(
+                'Total Flex Factor: ${propertiesLocal.totalFlex.toInt()}',
+                style: theme.regularTextStyleWithColor(emphasizedTextColor),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+            child: VisualizeFlexChildren(
+              state: this,
+              properties: propertiesLocal,
+              children: children,
+              highlighted: highlighted,
+              scrollController: scrollController,
+              direction: direction,
+            ),
+          ),
+        ),
+      ),
+    );
+
+    final verticalAxisDescription = Align(
+      alignment: Alignment.bottomLeft,
+      child: Container(
+        margin: EdgeInsets.only(top: mainAxisArrowIndicatorSize + margin),
+        width: crossAxisArrowIndicatorSize,
+        child: Column(
+          children: [
+            Expanded(
+              child: ArrowWrapper.unidirectional(
+                arrowColor: verticalColor(colorScheme),
+                type: ArrowType.down,
+                child: Truncateable(
+                  truncate: maxHeight <= minHeightToAllowTruncating,
+                  child: RotatedBox(
+                    quarterTurns: 3,
+                    child: Text(
+                      propertiesLocal.verticalDirectionDescription,
+                      overflow: TextOverflow.ellipsis,
+                      textAlign: TextAlign.center,
+                      style: theme.regularTextStyleWithColor(
+                        verticalTextColor(colorScheme),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Truncateable(
+              truncate: maxHeight <= minHeightToAllowTruncating,
+              child: _buildAxisAlignmentDropdown(Axis.vertical, theme),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    final horizontalAxisDescription = Align(
+      alignment: Alignment.topRight,
+      child: Container(
+        margin: EdgeInsets.only(left: crossAxisArrowIndicatorSize + margin),
+        height: mainAxisArrowIndicatorSize,
+        child: Row(
+          children: [
+            Expanded(
+              child: ArrowWrapper.unidirectional(
+                arrowColor: horizontalColor(colorScheme),
+                type: ArrowType.right,
+                child: Truncateable(
+                  truncate: maxWidth <= minWidthToAllowTruncating,
+                  child: Text(
+                    propertiesLocal.horizontalDirectionDescription,
+                    overflow: TextOverflow.ellipsis,
+                    textAlign: TextAlign.center,
+                    style: theme.regularTextStyleWithColor(
+                      horizontalTextColor(colorScheme),
+                    ),
+                  ),
+                ),
+              ),
+            ),
+            Truncateable(
+              truncate: maxWidth <= minWidthToAllowTruncating,
+              child: _buildAxisAlignmentDropdown(Axis.horizontal, theme),
+            ),
+          ],
+        ),
+      ),
+    );
+
+    return Container(
+      constraints: BoxConstraints(maxWidth: maxWidth, maxHeight: maxHeight),
+      child: Stack(
+        children: [
+          flexDescription,
+          verticalAxisDescription,
+          horizontalAxisDescription,
+        ],
+      ),
+    );
+  }
+}
+
+class VisualizeFlexChildren extends StatefulWidget {
+  const VisualizeFlexChildren({
+    super.key,
+    required this.state,
+    required this.properties,
+    required this.children,
+    required this.highlighted,
+    required this.scrollController,
+    required this.direction,
+  });
+
+  final FlexLayoutProperties properties;
+  final List<LayoutProperties> children;
+  final LayoutProperties? highlighted;
+  final ScrollController scrollController;
+  final Axis direction;
+  final FlexLayoutExplorerWidgetState state;
+
+  @override
+  State<VisualizeFlexChildren> createState() => _VisualizeFlexChildrenState();
+}
+
+class _VisualizeFlexChildrenState extends State<VisualizeFlexChildren> {
+  LayoutProperties? lastHighlighted;
+  static final selectedChildKey = GlobalKey(debugLabel: 'selectedChild');
+
+  @override
+  Widget build(BuildContext context) {
+    if (lastHighlighted != widget.highlighted) {
+      lastHighlighted = widget.highlighted;
+      if (widget.highlighted != null) {
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          final selectedRenderObject =
+              selectedChildKey.currentContext?.findRenderObject();
+          if (selectedRenderObject != null &&
+              widget.scrollController.hasClients) {
+            unawaited(
+              widget.scrollController.position.ensureVisible(
+                selectedRenderObject,
+                alignment: 0.5,
+                duration: defaultDuration,
+              ),
+            );
+          }
+        });
+      }
+    }
+
+    if (!widget.properties.hasChildren) {
+      return const CenteredMessage('No Children');
+    }
+
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    final contents = Container(
+      decoration: BoxDecoration(
+        border: Border.all(
+          color: theme.primaryColorLight,
+        ),
+      ),
+      margin: const EdgeInsets.only(top: margin, left: margin),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth = constraints.maxWidth;
+          final maxHeight = constraints.maxHeight;
+
+          double maxSizeAvailable(Axis axis) {
+            return axis == Axis.horizontal ? maxWidth : maxHeight;
+          }
+
+          final childrenAndMainAxisSpacesRenderProps =
+              widget.properties.childrenRenderProperties(
+            smallestRenderWidth: minRenderWidth,
+            largestRenderWidth: defaultMaxRenderWidth,
+            smallestRenderHeight: minRenderHeight,
+            largestRenderHeight: defaultMaxRenderHeight,
+            maxSizeAvailable: maxSizeAvailable,
+          );
+
+          final renderProperties = childrenAndMainAxisSpacesRenderProps
+              .where((renderProps) => !renderProps.isFreeSpace)
+              .toList();
+          final mainAxisSpaces = childrenAndMainAxisSpacesRenderProps
+              .where((renderProps) => renderProps.isFreeSpace)
+              .toList();
+          final crossAxisSpaces = widget.properties.crossAxisSpaces(
+            childrenRenderProperties: renderProperties,
+            maxSizeAvailable: maxSizeAvailable,
+          );
+
+          final childrenRenderWidgets = <Widget>[];
+          Widget? selectedWidget;
+          for (var i = 0; i < widget.children.length; i++) {
+            final child = widget.children[i];
+            final isSelected = widget.highlighted == child;
+
+            final visualizer = FlexChildVisualizer(
+              key: isSelected ? selectedChildKey : null,
+              state: widget.state,
+              layoutProperties: child,
+              isSelected: isSelected,
+              renderProperties: renderProperties[i],
+            );
+
+            if (isSelected) {
+              selectedWidget = visualizer;
+            } else {
+              childrenRenderWidgets.add(visualizer);
+            }
+          }
+
+          // Selected widget needs to be last to draw its border over other children
+          if (selectedWidget != null) {
+            childrenRenderWidgets.add(selectedWidget);
+          }
+
+          final freeSpacesWidgets = [
+            for (var renderProperties in [
+              ...mainAxisSpaces,
+              ...crossAxisSpaces,
+            ])
+              FreeSpaceVisualizerWidget(renderProperties),
+          ];
+          return Scrollbar(
+            thumbVisibility: true,
+            controller: widget.scrollController,
+            child: SingleChildScrollView(
+              scrollDirection: widget.properties.direction,
+              controller: widget.scrollController,
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  minWidth: maxWidth,
+                  minHeight: maxHeight,
+                  maxWidth: widget.direction == Axis.horizontal
+                      ? sum(
+                          childrenAndMainAxisSpacesRenderProps
+                              .map((renderSize) => renderSize.width),
+                        )
+                      : maxWidth,
+                  maxHeight: widget.direction == Axis.vertical
+                      ? sum(
+                          childrenAndMainAxisSpacesRenderProps
+                              .map((renderSize) => renderSize.height),
+                        )
+                      : maxHeight,
+                ).normalize(),
+                child: Stack(
+                  children: [
+                    LayoutExplorerBackground(colorScheme: colorScheme),
+                    ...freeSpacesWidgets,
+                    ...childrenRenderWidgets,
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+    return VisualizeWidthAndHeightWithConstraints(
+      properties: widget.properties,
+      child: contents,
+    );
+  }
+}
+
+/// Widget that represents and visualize a direct child of Flex widget.
+class FlexChildVisualizer extends StatelessWidget {
+  const FlexChildVisualizer({
+    super.key,
+    required this.state,
+    required this.layoutProperties,
+    required this.renderProperties,
+    required this.isSelected,
+  });
+
+  final FlexLayoutExplorerWidgetState state;
+
+  final bool isSelected;
+
+  final LayoutProperties layoutProperties;
+
+  final RenderProperties renderProperties;
+
+  // TODO(polina-c, jacob314): consider refactoring to remove `!`.
+  FlexLayoutProperties get root => state.properties!;
+
+  // TODO(polina-c, jacob314): consider refactoring to remove `!`.
+  LayoutProperties get properties => renderProperties.layoutProperties!;
+
+  ObjectGroup? get objectGroup =>
+      properties.node.objectGroupApi as ObjectGroup?;
+
+  void onChangeFlexFactor(int? newFlexFactor) async {
+    state.markAsDirty();
+    await objectGroup!.invokeSetFlexFactor(
+      properties.node.valueRef,
+      newFlexFactor,
+    );
+  }
+
+  void onChangeFlexFit(FlexFit? newFlexFit) async {
+    state.markAsDirty();
+    await objectGroup!.invokeSetFlexFit(
+      properties.node.valueRef,
+      newFlexFit!,
+    );
+  }
+
+  Widget _buildFlexFactorChangerDropdown(
+    int maximumFlexFactor,
+    ThemeData theme,
+  ) {
+    final propertiesLocal = properties;
+
+    Widget buildMenuitemChild(int? flexFactor) {
+      return Text(
+        'flex: $flexFactor',
+        style: flexFactor == propertiesLocal.flexFactor
+            ? theme.boldTextStyle.copyWith(color: emphasizedTextColor)
+            : theme.regularTextStyleWithColor(emphasizedTextColor),
+      );
+    }
+
+    DropdownMenuItem<int> buildMenuItem(int? flexFactor) {
+      return DropdownMenuItem(
+        value: flexFactor,
+        child: buildMenuitemChild(flexFactor),
+      );
+    }
+
+    return DropdownButton<int>(
+      value: propertiesLocal.flexFactor?.toInt().clamp(0, maximumFlexFactor),
+      onChanged: onChangeFlexFactor,
+      iconEnabledColor: textColor,
+      underline: buildUnderline(),
+      items: <DropdownMenuItem<int>>[
+        buildMenuItem(null),
+        for (var i = 0; i <= maximumFlexFactor; ++i) buildMenuItem(i),
+      ],
+    );
+  }
+
+  Widget _buildFlexFitChangerDropdown(ThemeData theme) {
+    Widget flexFitDescription(FlexFit flexFit) => Text(
+          'fit: ${flexFit.name}',
+          style: theme.regularTextStyleWithColor(emphasizedTextColor),
+        );
+
+    final propertiesLocal = properties;
+
+    // Disable FlexFit changer if widget is Expanded.
+    if (propertiesLocal.description == 'Expanded') {
+      return flexFitDescription(FlexFit.tight);
+    }
+
+    DropdownMenuItem<FlexFit> buildMenuItem(FlexFit flexFit) {
+      return DropdownMenuItem(
+        value: flexFit,
+        child: flexFitDescription(flexFit),
+      );
+    }
+
+    return DropdownButton<FlexFit>(
+      value: propertiesLocal.flexFit,
+      onChanged: onChangeFlexFit,
+      underline: buildUnderline(),
+      iconEnabledColor: emphasizedTextColor,
+      items: <DropdownMenuItem<FlexFit>>[
+        buildMenuItem(FlexFit.loose),
+        if (propertiesLocal.description != 'Expanded')
+          buildMenuItem(FlexFit.tight),
+      ],
+    );
+  }
+
+  Widget _buildContent(ThemeData theme) {
+    // TODO(https://github.com/flutter/devtools/issues/4058) allow more dynamic
+    // flex factor input
+    final currentFlexFactor = properties.flexFactor?.toInt() ?? 0;
+    final currentMaxFlexFactor =
+        math.max(currentFlexFactor, maximumFlexFactorOptions);
+
+    return Container(
+      margin: const EdgeInsets.only(
+        top: margin,
+        left: margin,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Flexible(
+            child: _buildFlexFactorChangerDropdown(currentMaxFlexFactor, theme),
+          ),
+          if (!properties.hasFlexFactor)
+            Text(
+              'unconstrained ${root.isMainAxisHorizontal ? 'horizontal' : 'vertical'}',
+              style: theme.regularTextStyle.copyWith(
+                color: theme.colorScheme.unconstrainedColor,
+                fontStyle: FontStyle.italic,
+              ),
+              maxLines: 2,
+              softWrap: true,
+              overflow: TextOverflow.ellipsis,
+              textScaler: const TextScaler.linear(smallTextScaleFactor),
+              textAlign: TextAlign.center,
+            ),
+          _buildFlexFitChangerDropdown(theme),
+        ],
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final renderSize = renderProperties.size;
+    final renderOffset = renderProperties.offset;
+    final propertiesLocal = properties;
+    final rootLocal = root;
+
+    Widget buildEntranceAnimation(BuildContext _, Widget? child) {
+      final vertical = rootLocal.isMainAxisVertical;
+      final horizontal = rootLocal.isMainAxisHorizontal;
+
+      late Size size;
+      size = propertiesLocal.hasFlexFactor
+          ? SizeTween(
+              begin: Size(
+                horizontal ? minRenderWidth - entranceMargin : renderSize.width,
+                vertical ? minRenderHeight - entranceMargin : renderSize.height,
+              ),
+              end: renderSize,
+            ).evaluate(state.entranceCurve)!
+          : renderSize;
+      // Not-expanded widgets enter much faster.
+      return Opacity(
+        opacity: min([state.entranceCurve.value * 5, 1.0]),
+        child: Padding(
+          padding: EdgeInsets.symmetric(
+            horizontal: math.max(0.0, (renderSize.width - size.width) / 2),
+            vertical: math.max(0.0, (renderSize.height - size.height) / 2),
+          ),
+          child: child,
+        ),
+      );
+    }
+
+    return Positioned(
+      top: renderOffset.dy,
+      left: renderOffset.dx,
+      child: GestureDetector(
+        onTap: () => unawaited(state.onTap(propertiesLocal)),
+        onDoubleTap: () => state.onDoubleTap(propertiesLocal),
+        onLongPress: () => state.onDoubleTap(propertiesLocal),
+        child: SizedBox(
+          width: renderSize.width,
+          height: renderSize.height,
+          child: AnimatedBuilder(
+            animation: state.entranceController,
+            builder: buildEntranceAnimation,
+            child: WidgetVisualizer(
+              isSelected: isSelected,
+              layoutProperties: layoutProperties,
+              title: propertiesLocal.description ?? '',
+              overflowSide: propertiesLocal.overflowSide,
+              child: VisualizeWidthAndHeightWithConstraints(
+                arrowHeadSize: arrowHeadSize,
+                properties: propertiesLocal,
+                child: Align(
+                  alignment: Alignment.topRight,
+                  child: _buildContent(Theme.of(context)),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  /// define the number of flex factor to be shown in the flex dropdown button
+  /// for example if it's set to 5 the dropdown will consist of 6 items (null and 0..5)
+  static const maximumFlexFactorOptions = 5;
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
@@ -1,0 +1,204 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../inspector_data_models.dart';
+import '../ui/utils.dart';
+
+String crossAxisAssetImageUrl(Axis direction, CrossAxisAlignment alignment) {
+  return 'assets/img/layout_explorer/cross_axis_alignment/'
+      '${direction.flexType.toLowerCase()}_${alignment.name}.png';
+}
+
+String mainAxisAssetImageUrl(Axis direction, MainAxisAlignment alignment) {
+  return 'assets/img/layout_explorer/main_axis_alignment/'
+      '${direction.flexType.toLowerCase()}_${alignment.name}.png';
+}
+
+class AnimatedFlexLayoutProperties
+    extends AnimatedLayoutProperties<FlexLayoutProperties>
+    implements FlexLayoutProperties {
+  AnimatedFlexLayoutProperties(
+    super.begin,
+    super.end,
+    super.animation,
+  );
+
+  @override
+  CrossAxisAlignment? get crossAxisAlignment => end.crossAxisAlignment;
+
+  @override
+  MainAxisAlignment? get mainAxisAlignment => end.mainAxisAlignment;
+
+  @override
+  List<RenderProperties> childrenRenderProperties({
+    required double smallestRenderWidth,
+    required double largestRenderWidth,
+    required double smallestRenderHeight,
+    required double largestRenderHeight,
+    required double Function(Axis) maxSizeAvailable,
+  }) {
+    final beginRenderProperties = begin.childrenRenderProperties(
+      smallestRenderHeight: smallestRenderHeight,
+      smallestRenderWidth: smallestRenderWidth,
+      largestRenderHeight: largestRenderHeight,
+      largestRenderWidth: largestRenderWidth,
+      maxSizeAvailable: maxSizeAvailable,
+    );
+    final endRenderProperties = end.childrenRenderProperties(
+      smallestRenderHeight: smallestRenderHeight,
+      smallestRenderWidth: smallestRenderWidth,
+      largestRenderHeight: largestRenderHeight,
+      largestRenderWidth: largestRenderWidth,
+      maxSizeAvailable: maxSizeAvailable,
+    );
+    final result = <RenderProperties>[];
+    for (var i = 0; i < children.length; i++) {
+      final beginProps = beginRenderProperties[i];
+      final endProps = endRenderProperties[i];
+      final t = animation.value;
+      result.add(
+        RenderProperties(
+          axis: endProps.axis,
+          offset: Offset.lerp(beginProps.offset, endProps.offset, t),
+          size: Size.lerp(beginProps.size, endProps.size, t),
+          realSize: Size.lerp(beginProps.realSize, endProps.realSize, t),
+          // TODO(polina-c, jacob314): crnsider refactoring to get rid of `!`.
+          layoutProperties: AnimatedLayoutProperties(
+            beginProps.layoutProperties!,
+            endProps.layoutProperties!,
+            animation,
+          ),
+        ),
+      );
+    }
+    // Add in the free space from the end.
+    // TODO(djshuckerow): We should make free space a part of
+    // RenderProperties so that we can animate between those.
+    result.addAll(endRenderProperties.where((prop) => prop.isFreeSpace));
+    return result;
+  }
+
+  @override
+  double get crossAxisDimension => lerpDouble(
+        begin.crossAxisDimension,
+        end.crossAxisDimension,
+        animation.value,
+      )!;
+
+  @override
+  Axis get crossAxisDirection => end.crossAxisDirection;
+
+  @override
+  List<RenderProperties> crossAxisSpaces({
+    required List<RenderProperties> childrenRenderProperties,
+    required double Function(Axis) maxSizeAvailable,
+  }) {
+    return end.crossAxisSpaces(
+      childrenRenderProperties: childrenRenderProperties,
+      maxSizeAvailable: maxSizeAvailable,
+    );
+  }
+
+  @override
+  Axis get direction => end.direction;
+
+  @override
+  String get horizontalDirectionDescription =>
+      end.horizontalDirectionDescription;
+
+  @override
+  bool get isMainAxisHorizontal => end.isMainAxisHorizontal;
+
+  @override
+  bool get isMainAxisVertical => end.isMainAxisVertical;
+
+  @override
+  double get mainAxisDimension => lerpDouble(
+        begin.mainAxisDimension,
+        end.mainAxisDimension,
+        animation.value,
+      )!;
+
+  @override
+  MainAxisSize? get mainAxisSize => end.mainAxisSize;
+
+  @override
+  TextBaseline? get textBaseline => end.textBaseline;
+
+  @override
+  TextDirection get textDirection => end.textDirection;
+
+  @override
+  double get totalFlex =>
+      lerpDouble(begin.totalFlex, end.totalFlex, animation.value)!;
+
+  @override
+  String get type => end.type;
+
+  @override
+  VerticalDirection get verticalDirection => end.verticalDirection;
+
+  @override
+  String get verticalDirectionDescription => end.verticalDirectionDescription;
+
+  /// Returns a frozen copy of these FlexLayoutProperties that does not animate.
+  ///
+  /// Useful for interrupting an animation with a transition to another [FlexLayoutProperties].
+  @override
+  FlexLayoutProperties copyWith({
+    Size? size,
+    List<LayoutProperties>? children,
+    BoxConstraints? constraints,
+    bool? isFlex,
+    String? description,
+    num? flexFactor,
+    FlexFit? flexFit,
+    Axis? direction,
+    MainAxisAlignment? mainAxisAlignment,
+    MainAxisSize? mainAxisSize,
+    CrossAxisAlignment? crossAxisAlignment,
+    TextDirection? textDirection,
+    VerticalDirection? verticalDirection,
+    TextBaseline? textBaseline,
+  }) {
+    return FlexLayoutProperties(
+      size: size ?? this.size,
+      children: children ?? this.children,
+      node: node,
+      constraints: constraints ?? this.constraints,
+      isFlex: isFlex ?? this.isFlex,
+      description: description ?? this.description,
+      flexFactor: flexFactor ?? this.flexFactor,
+      direction: direction ?? this.direction,
+      mainAxisAlignment: mainAxisAlignment ?? this.mainAxisAlignment,
+      mainAxisSize: mainAxisSize ?? this.mainAxisSize,
+      crossAxisAlignment: crossAxisAlignment ?? this.crossAxisAlignment,
+      textDirection: textDirection ?? this.textDirection,
+      verticalDirection: verticalDirection ?? this.verticalDirection,
+      textBaseline: textBaseline ?? this.textBaseline,
+    );
+  }
+
+  @override
+  bool get startIsTopLeft => end.startIsTopLeft;
+}
+
+/// LayoutProperties extension to be reused on LayoutProperties and AnimatedLayoutProperties
+
+extension AxisExtension on Axis {
+  String get flexType {
+    switch (this) {
+      case Axis.horizontal:
+        return 'Row';
+      case Axis.vertical:
+      default:
+        return 'Column';
+    }
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/layout_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/layout_explorer.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/layout_explorer.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/layout_explorer.dart
@@ -1,0 +1,71 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/utils.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../../shared/diagnostics/diagnostics_node.dart';
+import '../inspector_controller.dart';
+import '../layout_explorer/box/box.dart';
+import '../layout_explorer/flex/flex.dart';
+
+/// Tab that acts as a proxy to decide which widget to be displayed
+class LayoutExplorerTab extends StatefulWidget {
+  const LayoutExplorerTab({super.key, required this.controller});
+
+  final InspectorController controller;
+
+  @override
+  State<LayoutExplorerTab> createState() => _LayoutExplorerTabState();
+}
+
+class _LayoutExplorerTabState extends State<LayoutExplorerTab>
+    with AutomaticKeepAliveClientMixin<LayoutExplorerTab>, AutoDisposeMixin {
+  InspectorController get controller => widget.controller;
+
+  RemoteDiagnosticsNode? get selected =>
+      controller.selectedNode.value?.diagnostic;
+
+  RemoteDiagnosticsNode? previousSelection;
+
+  Widget rootWidget(RemoteDiagnosticsNode? node) {
+    if (node != null && FlexLayoutExplorerWidget.shouldDisplay(node)) {
+      return FlexLayoutExplorerWidget(controller);
+    }
+    if (node != null && BoxLayoutExplorerWidget.shouldDisplay(node)) {
+      return BoxLayoutExplorerWidget(controller);
+    }
+    return Center(
+      child: Text(
+        node != null
+            ? 'Currently, Layout Explorer only supports Box and Flex-based widgets.'
+            : 'Select a widget to view its layout.',
+        textAlign: TextAlign.center,
+        overflow: TextOverflow.clip,
+      ),
+    );
+  }
+
+  void onSelectionChanged() {
+    if (rootWidget(previousSelection).runtimeType !=
+        rootWidget(selected).runtimeType) {
+      setState(() => previousSelection = selected);
+    }
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    addAutoDisposeListener(controller.selectedNode, onSelectionChanged);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return rootWidget(selected);
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/arrow.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/arrow.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/arrow.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/arrow.dart
@@ -1,0 +1,290 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:math';
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+const defaultArrowColor = Colors.white;
+const defaultArrowStrokeWidth = 2.0;
+const defaultDistanceToArrow = 4.0;
+
+enum ArrowType {
+  up,
+  left,
+  right,
+  down,
+}
+
+Axis axis(ArrowType type) => (type == ArrowType.up || type == ArrowType.down)
+    ? Axis.vertical
+    : Axis.horizontal;
+
+/// Widget that draws a bidirectional arrow around another widget.
+///
+/// This widget is typically used to help draw diagrams.
+@immutable
+class ArrowWrapper extends StatelessWidget {
+  ArrowWrapper.unidirectional({
+    super.key,
+    this.child,
+    required ArrowType type,
+    this.arrowColor = defaultArrowColor,
+    double? arrowHeadSize,
+    this.arrowStrokeWidth = defaultArrowStrokeWidth,
+    this.childMarginFromArrow = defaultDistanceToArrow,
+  })  : assert(childMarginFromArrow > 0.0),
+        direction = axis(type),
+        isBidirectional = false,
+        startArrowType = type,
+        endArrowType = type,
+        arrowHeadSize = arrowHeadSize ?? defaultIconSize;
+
+  const ArrowWrapper.bidirectional({
+    super.key,
+    this.child,
+    required this.direction,
+    this.arrowColor = defaultArrowColor,
+    required this.arrowHeadSize,
+    this.arrowStrokeWidth = defaultArrowStrokeWidth,
+    this.childMarginFromArrow = defaultDistanceToArrow,
+  })  : assert(arrowHeadSize >= 0.0),
+        assert(childMarginFromArrow >= 0.0),
+        isBidirectional = true,
+        startArrowType =
+            direction == Axis.horizontal ? ArrowType.left : ArrowType.up,
+        endArrowType =
+            direction == Axis.horizontal ? ArrowType.right : ArrowType.down;
+
+  final Color arrowColor;
+  final double arrowHeadSize;
+  final double arrowStrokeWidth;
+  final Widget? child;
+
+  final Axis direction;
+  final double childMarginFromArrow;
+
+  final bool isBidirectional;
+  final ArrowType startArrowType;
+  final ArrowType endArrowType;
+
+  double get verticalMarginFromArrow {
+    if (child == null || direction == Axis.horizontal) return 0.0;
+    return childMarginFromArrow;
+  }
+
+  double get horizontalMarginFromArrow {
+    if (child == null || direction == Axis.vertical) return 0.0;
+    return childMarginFromArrow;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Flex(
+      direction: direction,
+      children: <Widget>[
+        Expanded(
+          child: Container(
+            margin: EdgeInsets.only(
+              bottom: verticalMarginFromArrow,
+              right: horizontalMarginFromArrow,
+            ),
+            child: ArrowWidget(
+              color: arrowColor,
+              headSize: arrowHeadSize,
+              strokeWidth: arrowStrokeWidth,
+              type: startArrowType,
+              shouldDrawHead: isBidirectional
+                  ? true
+                  : (startArrowType == ArrowType.left ||
+                      startArrowType == ArrowType.up),
+            ),
+          ),
+        ),
+        if (child != null) child!,
+        Expanded(
+          child: Container(
+            margin: EdgeInsets.only(
+              top: verticalMarginFromArrow,
+              left: horizontalMarginFromArrow,
+            ),
+            child: ArrowWidget(
+              color: arrowColor,
+              headSize: arrowHeadSize,
+              strokeWidth: arrowStrokeWidth,
+              type: endArrowType,
+              shouldDrawHead: isBidirectional
+                  ? true
+                  : (endArrowType == ArrowType.right ||
+                      endArrowType == ArrowType.down),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Widget that draws a fully sized, centered, unidirectional arrow according to its constraints
+@immutable
+class ArrowWidget extends StatelessWidget {
+  ArrowWidget({
+    this.color = defaultArrowColor,
+    required this.headSize,
+    super.key,
+    this.shouldDrawHead = true,
+    this.strokeWidth = defaultArrowStrokeWidth,
+    required this.type,
+  })  : assert(headSize > 0.0),
+        assert(strokeWidth > 0.0),
+        _painter = _ArrowPainter(
+          headSize: headSize,
+          color: color,
+          strokeWidth: strokeWidth,
+          type: type,
+          shouldDrawHead: shouldDrawHead,
+        );
+
+  final Color color;
+
+  /// The arrow head is a Equilateral triangle
+  final double headSize;
+
+  final double strokeWidth;
+
+  final ArrowType type;
+
+  final CustomPainter _painter;
+
+  final bool shouldDrawHead;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomPaint(
+      painter: _painter,
+      child: Container(),
+    );
+  }
+}
+
+class _ArrowPainter extends CustomPainter {
+  _ArrowPainter({
+    required this.headSize,
+    this.strokeWidth = defaultArrowStrokeWidth,
+    this.color = defaultArrowColor,
+    this.shouldDrawHead = true,
+    required this.type,
+  }) : // the height of an equilateral triangle
+        headHeight = 0.5 * sqrt(3) * headSize;
+
+  final Color color;
+  final double headSize;
+  final bool shouldDrawHead;
+  final double strokeWidth;
+  final ArrowType type;
+
+  final double headHeight;
+
+  bool headIsGreaterThanConstraint(Size size) {
+    if (type == ArrowType.left || type == ArrowType.right) {
+      return headHeight >= (size.width);
+    }
+    return headHeight >= (size.height);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) =>
+      !(oldDelegate is _ArrowPainter &&
+          headSize == oldDelegate.headSize &&
+          strokeWidth == oldDelegate.strokeWidth &&
+          color == oldDelegate.color &&
+          type == oldDelegate.type);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..strokeWidth = strokeWidth;
+
+    final originX = size.width / 2, originY = size.height / 2;
+    Offset lineStartingPoint = Offset.zero;
+    Offset lineEndingPoint = Offset.zero;
+
+    if (!headIsGreaterThanConstraint(size) && shouldDrawHead) {
+      Offset p1, p2, p3;
+      final headSizeDividedBy2 = headSize / 2;
+      switch (type) {
+        case ArrowType.up:
+          p1 = Offset(originX, 0);
+          p2 = Offset(originX - headSizeDividedBy2, headHeight);
+          p3 = Offset(originX + headSizeDividedBy2, headHeight);
+          break;
+        case ArrowType.left:
+          p1 = Offset(0, originY);
+          p2 = Offset(headHeight, originY - headSizeDividedBy2);
+          p3 = Offset(headHeight, originY + headSizeDividedBy2);
+          break;
+        case ArrowType.right:
+          final startingX = size.width - headHeight;
+          p1 = Offset(size.width, originY);
+          p2 = Offset(startingX, originY - headSizeDividedBy2);
+          p3 = Offset(startingX, originY + headSizeDividedBy2);
+          break;
+        case ArrowType.down:
+          final startingY = size.height - headHeight;
+          p1 = Offset(originX, size.height);
+          p2 = Offset(originX - headSizeDividedBy2, startingY);
+          p3 = Offset(originX + headSizeDividedBy2, startingY);
+          break;
+      }
+      final path = Path()
+        ..moveTo(p1.dx, p1.dy)
+        ..lineTo(p2.dx, p2.dy)
+        ..lineTo(p3.dx, p3.dy)
+        ..close();
+      canvas.drawPath(path, paint);
+
+      switch (type) {
+        case ArrowType.up:
+          lineStartingPoint = Offset(originX, headHeight);
+          lineEndingPoint = Offset(originX, size.height);
+          break;
+        case ArrowType.left:
+          lineStartingPoint = Offset(headHeight, originY);
+          lineEndingPoint = Offset(size.width, originY);
+          break;
+        case ArrowType.right:
+          final arrowHeadStartingX = size.width - headHeight;
+          lineStartingPoint = Offset(0, originY);
+          lineEndingPoint = Offset(arrowHeadStartingX, originY);
+          break;
+        case ArrowType.down:
+          final headStartingY = size.height - headHeight;
+          lineStartingPoint = Offset(originX, 0);
+          lineEndingPoint = Offset(originX, headStartingY);
+          break;
+      }
+    } else {
+      // draw full line
+      switch (type) {
+        case ArrowType.up:
+        case ArrowType.down:
+          lineStartingPoint = Offset(originX, 0);
+          lineEndingPoint = Offset(originX, size.height);
+          break;
+        case ArrowType.left:
+        case ArrowType.right:
+          lineStartingPoint = Offset(0, originY);
+          lineEndingPoint = Offset(size.width, originY);
+          break;
+      }
+    }
+    canvas.drawLine(
+      lineStartingPoint,
+      lineEndingPoint,
+      paint,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/dimension.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/dimension.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/dimension.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/dimension.dart
@@ -1,0 +1,37 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+import 'theme.dart';
+
+/// Text widget for displaying width / height.
+Widget dimensionDescription(
+  TextSpan description,
+  bool overflow,
+  ColorScheme colorScheme,
+) {
+  final text = Text.rich(
+    description,
+    textAlign: TextAlign.center,
+    style: overflow
+        ? overflowingDimensionIndicatorTextStyle(colorScheme)
+        : dimensionIndicatorTextStyle,
+    overflow: TextOverflow.ellipsis,
+  );
+  if (overflow) {
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        vertical: minPadding,
+        horizontal: overflowTextHorizontalPadding,
+      ),
+      decoration: BoxDecoration(
+        color: colorScheme.overflowBackgroundColor,
+        borderRadius: BorderRadius.circular(4.0),
+      ),
+      child: Center(child: text),
+    );
+  }
+  return text;
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/free_space.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/free_space.dart
@@ -1,0 +1,163 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../shared/primitives/utils.dart';
+import '../../inspector_data_models.dart';
+import 'arrow.dart';
+import 'dimension.dart';
+import 'theme.dart';
+
+class FreeSpaceVisualizerWidget extends StatelessWidget {
+  const FreeSpaceVisualizerWidget(
+    this.renderProperties, {
+    super.key,
+  });
+
+  final RenderProperties renderProperties;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final heightDescription =
+        'h=${toStringAsFixed(renderProperties.realHeight)}';
+    final widthDescription = 'w=${toStringAsFixed(renderProperties.realWidth)}';
+    final showWidth =
+        renderProperties.realWidth != renderProperties.layoutProperties?.width;
+    final widthWidget = Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: dimensionDescription(
+            TextSpan(
+              text: widthDescription,
+            ),
+            false,
+            colorScheme,
+          ),
+        ),
+        Container(
+          margin: EdgeInsets.symmetric(vertical: arrowMargin),
+          child: ArrowWrapper.bidirectional(
+            arrowColor: widthIndicatorColor,
+            direction: Axis.horizontal,
+            arrowHeadSize: arrowHeadSize,
+          ),
+        ),
+      ],
+    );
+    final heightWidget = SizedBox(
+      width: heightOnlyIndicatorSize,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            child: dimensionDescription(
+              TextSpan(text: heightDescription),
+              false,
+              colorScheme,
+            ),
+          ),
+          Container(
+            margin: EdgeInsets.symmetric(horizontal: arrowMargin),
+            child: ArrowWrapper.bidirectional(
+              arrowColor: heightIndicatorColor,
+              direction: Axis.vertical,
+              arrowHeadSize: arrowHeadSize,
+              childMarginFromArrow: 0.0,
+            ),
+          ),
+        ],
+      ),
+    );
+    return Positioned(
+      top: renderProperties.offset.dy,
+      left: renderProperties.offset.dx,
+      child: SizedBox(
+        width: renderProperties.width,
+        height: renderProperties.height,
+        child: DevToolsTooltip(
+          message: '$widthDescription\n$heightDescription',
+          child: showWidth ? widthWidget : heightWidget,
+        ),
+      ),
+    );
+  }
+}
+
+class PaddingVisualizerWidget extends StatelessWidget {
+  const PaddingVisualizerWidget(
+    this.renderProperties, {
+    required this.horizontal,
+    super.key,
+  });
+
+  final RenderProperties renderProperties;
+  final bool horizontal;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final heightDescription =
+        'h=${toStringAsFixed(renderProperties.realHeight)}';
+    final widthDescription = 'w=${toStringAsFixed(renderProperties.realWidth)}';
+    final widthWidget = Column(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: [
+        Flexible(
+          child: dimensionDescription(
+            TextSpan(
+              text: widthDescription,
+            ),
+            false,
+            colorScheme,
+          ),
+        ),
+        Container(
+          margin: EdgeInsets.symmetric(vertical: arrowMargin),
+          child: ArrowWrapper.bidirectional(
+            arrowColor: widthIndicatorColor,
+            direction: Axis.horizontal,
+            arrowHeadSize: arrowHeadSize,
+          ),
+        ),
+      ],
+    );
+    final heightWidget = SizedBox(
+      width: heightOnlyIndicatorSize,
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Flexible(
+            child: dimensionDescription(
+              TextSpan(text: heightDescription),
+              false,
+              colorScheme,
+            ),
+          ),
+          Container(
+            margin: EdgeInsets.symmetric(horizontal: arrowMargin),
+            child: ArrowWrapper.bidirectional(
+              arrowColor: heightIndicatorColor,
+              direction: Axis.vertical,
+              arrowHeadSize: arrowHeadSize,
+              childMarginFromArrow: 0.0,
+            ),
+          ),
+        ],
+      ),
+    );
+    return Positioned(
+      top: renderProperties.offset.dy,
+      left: renderProperties.offset.dx,
+      child: SizedBox(
+        width: safePositiveDouble(renderProperties.width),
+        height: safePositiveDouble(renderProperties.height),
+        child: horizontal ? widthWidget : heightWidget,
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/free_space.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/free_space.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/layout_explorer_widget.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/layout_explorer_widget.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/layout_explorer_widget.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/layout_explorer_widget.dart
@@ -1,0 +1,296 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:async';
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
+
+import '../../../../shared/diagnostics/diagnostics_node.dart';
+import '../../../../shared/diagnostics/inspector_service.dart';
+import '../../../../shared/globals.dart';
+import '../../../../shared/primitives/utils.dart';
+import '../../inspector_controller.dart';
+import '../../inspector_data_models.dart';
+import 'utils.dart';
+
+const maxRequestsPerSecond = 3.0;
+
+/// Base class for layout widgets for all widget types.
+abstract class LayoutExplorerWidget extends StatefulWidget {
+  const LayoutExplorerWidget(
+    this.inspectorController, {
+    super.key,
+  });
+
+  final InspectorController inspectorController;
+}
+
+/// Base class for state objects for layout widgets for all widget types.
+abstract class LayoutExplorerWidgetState<W extends LayoutExplorerWidget,
+        L extends LayoutProperties> extends State<W>
+    with TickerProviderStateMixin
+    implements InspectorServiceClient {
+  LayoutExplorerWidgetState() {
+    _onSelectionChangedCallback = onSelectionChanged;
+  }
+
+  late AnimationController entranceController;
+  late CurvedAnimation entranceCurve;
+  late AnimationController changeController;
+
+  late CurvedAnimation changeAnimation;
+
+  L? _previousProperties;
+
+  L? _properties;
+
+  InspectorObjectGroupManager? objectGroupManager;
+
+  AnimatedLayoutProperties<L>? get animatedProperties => _animatedProperties;
+  AnimatedLayoutProperties<L>? _animatedProperties;
+
+  L? get properties =>
+      _previousProperties ?? _animatedProperties as L? ?? _properties;
+
+  RemoteDiagnosticsNode? get selectedNode =>
+      inspectorController.selectedNode.value?.diagnostic;
+
+  InspectorController get inspectorController => widget.inspectorController;
+
+  InspectorService? get inspectorService =>
+      serviceConnection.inspectorService as InspectorService?;
+
+  late RateLimiter rateLimiter;
+
+  late Future<void> Function() _onSelectionChangedCallback;
+
+  Future<void> onSelectionChanged() async {
+    if (!mounted) return;
+    final selectedNodeLocal = selectedNode;
+    if (selectedNodeLocal == null) return;
+    if (!shouldDisplay(selectedNodeLocal)) return;
+    final prevRootId = id(_properties?.node);
+    final newRootId = id(getRoot(selectedNodeLocal));
+    final shouldFetch = prevRootId != newRootId;
+    if (shouldFetch) {
+      _dirty = false;
+      final newSelection = await fetchLayoutProperties();
+      _setProperties(newSelection);
+    } else {
+      updateHighlighted(_properties);
+    }
+  }
+
+  /// Whether this layout explorer can work with this kind of node.
+  bool shouldDisplay(RemoteDiagnosticsNode node);
+
+  List<LayoutProperties> get children => properties!.displayChildren;
+
+  LayoutProperties? highlighted;
+
+  /// Returns the root widget to show.
+  ///
+  /// For cases such as Flex widgets or in the future ListView widgets we may
+  /// want to show the layout for all widgets under a root that is the parent
+  /// of the current widget.
+  RemoteDiagnosticsNode? getRoot(RemoteDiagnosticsNode? node);
+
+  Future<L?> fetchLayoutProperties() async {
+    objectGroupManager?.cancelNext();
+    final manager = objectGroupManager!;
+    final nextObjectGroup = manager.next;
+    final node = await nextObjectGroup.getLayoutExplorerNode(
+      getRoot(selectedNode),
+    );
+    if (node == null || node.renderObject == null) return null;
+
+    if (!nextObjectGroup.disposed) {
+      assert(manager.next == nextObjectGroup);
+      manager.promoteNext();
+    }
+    return computeLayoutProperties(node);
+  }
+
+  L computeLayoutProperties(RemoteDiagnosticsNode node);
+
+  AnimatedLayoutProperties<L> computeAnimatedProperties(L nextProperties);
+
+  void updateHighlighted(L? newProperties);
+
+  String? id(RemoteDiagnosticsNode? node) => node?.valueRef.id;
+
+  void _registerInspectorControllerService() {
+    inspectorController.selectedNode.addListener(_onSelectionChangedCallback);
+    inspectorService?.addClient(this);
+  }
+
+  void _unregisterInspectorControllerService() {
+    inspectorController.selectedNode
+        .removeListener(_onSelectionChangedCallback);
+    inspectorService?.removeClient(this);
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    rateLimiter = RateLimiter(maxRequestsPerSecond, refresh);
+    _registerInspectorControllerService();
+    _initAnimationStates();
+    _updateObjectGroupManager();
+    // TODO(jacobr): put inspector controller in Controllers and
+    // update on didChangeDependencies.
+    _animateProperties();
+  }
+
+  @override
+  void didUpdateWidget(W oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _updateObjectGroupManager();
+    _animateProperties();
+    if (oldWidget.inspectorController != inspectorController) {
+      _unregisterInspectorControllerService();
+      _registerInspectorControllerService();
+    }
+  }
+
+  @override
+  void dispose() {
+    entranceController.dispose();
+    changeController.dispose();
+    _unregisterInspectorControllerService();
+    super.dispose();
+  }
+
+  void _animateProperties() {
+    if (_animatedProperties != null) {
+      changeController.forward();
+    }
+    if (_previousProperties != null) {
+      entranceController.reverse();
+    } else {
+      entranceController.forward();
+    }
+  }
+
+  // update selected widget in the device without triggering selection listener event.
+  // this is required so that we don't change focus
+  //   when tapping on a child is also Flex-based widget.
+  Future<void> setSelectionInspector(RemoteDiagnosticsNode node) async {
+    final service = node.objectGroupApi;
+    if (service != null && service is ObjectGroup) {
+      await service.setSelectionInspector(node.valueRef, false);
+    }
+  }
+
+  // update selected widget and trigger selection listener event to change focus.
+  void refreshSelection(RemoteDiagnosticsNode node) {
+    inspectorController.refreshSelection(node, node, true);
+  }
+
+  Future<void> onTap(LayoutProperties properties) async {
+    setState(() => highlighted = properties);
+    await setSelectionInspector(properties.node);
+  }
+
+  void onDoubleTap(LayoutProperties properties) {
+    refreshSelection(properties.node);
+  }
+
+  Future<void> refresh() async {
+    if (!_dirty) return;
+    _dirty = false;
+    final updatedProperties = await fetchLayoutProperties();
+    if (updatedProperties != null) {
+      _changeProperties(updatedProperties);
+    }
+  }
+
+  void _changeProperties(L nextProperties) {
+    if (!mounted) return;
+    updateHighlighted(nextProperties);
+    setState(() {
+      _animatedProperties = computeAnimatedProperties(nextProperties);
+      changeController.forward(from: 0.0);
+    });
+  }
+
+  void _setProperties(L? newProperties) {
+    if (!mounted) return;
+    updateHighlighted(newProperties);
+    if (_properties == newProperties) {
+      return;
+    }
+    setState(() {
+      _previousProperties ??= _properties;
+      _properties = newProperties;
+    });
+    _animateProperties();
+  }
+
+  void _initAnimationStates() {
+    entranceController = longAnimationController(
+      this,
+    )..addStatusListener((status) {
+        if (status == AnimationStatus.dismissed) {
+          setState(() {
+            _previousProperties = null;
+            entranceController.forward();
+          });
+        }
+      });
+    entranceCurve = defaultCurvedAnimation(entranceController);
+    changeController = longAnimationController(this)
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          setState(() {
+            _properties = _animatedProperties!.end;
+            _animatedProperties = null;
+            changeController.value = 0.0;
+          });
+        }
+      });
+    changeAnimation = defaultCurvedAnimation(changeController);
+  }
+
+  void _updateObjectGroupManager() {
+    final service = serviceConnection.inspectorService;
+    if (service != objectGroupManager?.inspectorService) {
+      objectGroupManager = InspectorObjectGroupManager(
+        service as InspectorService,
+        'flex-layout',
+      );
+    }
+    unawaited(onSelectionChanged());
+  }
+
+  bool _dirty = false;
+
+  @override
+  void onFlutterFrame() {
+    if (!mounted) return;
+    if (_dirty) {
+      rateLimiter.scheduleRequest();
+    }
+  }
+
+  // TODO(albertusangga): Investigate why onForceRefresh is not getting called.
+  @override
+  Future<void> onForceRefresh() async {
+    final properties = await fetchLayoutProperties();
+    if (properties != null) {
+      _setProperties(properties);
+    }
+  }
+
+  /// Currently this is not working so we should listen to controller selection event instead.
+  @override
+  Future<void> onInspectorSelectionChanged() async {}
+
+  /// Register callback to be executed once Flutter frame is ready.
+  void markAsDirty() {
+    _dirty = true;
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/overflow_indicator_painter.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/overflow_indicator_painter.dart
@@ -1,0 +1,63 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+
+import '../../inspector_data_models.dart';
+
+/// CustomPainter for drawing [DebugOverflowIndicatorMixin]'s patterned background.
+/// Draws overflow pattern on the [OverflowSide] of the widget.
+///
+/// [DebugOverflowIndicatorMixin] can not be reused here
+/// because it is a mixin on RenderObject and requires real overflows on the widget.
+///
+/// If [side] is set to [OverflowSide.right],
+/// the pattern will occupy the whole height
+/// and the width will be the given [size].
+///
+/// If [side] is set to [OverflowSide.bottom],
+/// the pattern will occupy the whole width
+/// and the height will be the given [size].
+///
+/// See also:
+/// * [DebugOverflowIndicatorMixin]
+class OverflowIndicatorPainter extends CustomPainter {
+  const OverflowIndicatorPainter(this.side, this.size);
+
+  final OverflowSide side;
+  final double size;
+
+  /// These static variables  are taken from [DebugOverflowIndicatorMixin]
+  /// since all of them are private.
+  static const Color black = Color(0xBF000000);
+  static const Color yellow = Color(0xBFFFFF00);
+  static final Paint indicatorPaint = Paint()
+    ..shader = ui.Gradient.linear(
+      const Offset(0.0, 0.0),
+      const Offset(10.0, 10.0),
+      <Color>[black, yellow, yellow, black],
+      <double>[0.25, 0.25, 0.75, 0.75],
+      TileMode.repeated,
+    );
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final bottomOverflow = OverflowSide.bottom == side;
+    final width = bottomOverflow ? size.width : this.size;
+    final height = !bottomOverflow ? size.height : this.size;
+
+    final left = bottomOverflow ? 0.0 : size.width - width;
+    final top = side == OverflowSide.right ? 0.0 : size.height - height;
+    final rect = Rect.fromLTWH(left, top, width, height);
+    canvas.drawRect(rect, indicatorPaint);
+  }
+
+  @override
+  bool shouldRepaint(CustomPainter oldDelegate) {
+    return oldDelegate is OverflowIndicatorPainter &&
+        (side != oldDelegate.side || size != oldDelegate.size);
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/overflow_indicator_painter.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/overflow_indicator_painter.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/theme.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/theme.dart
@@ -1,0 +1,144 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+const margin = 6.0;
+
+double get arrowHeadSize => scaleByFontFactor(8.0);
+double get arrowMargin => scaleByFontFactor(4.0);
+const arrowStrokeWidth = 1.5;
+
+/// Hardcoded sizes for scaling the flex children widget properly.
+double get minRenderWidth => scaleByFontFactor(250.0);
+double get minRenderHeight => scaleByFontFactor(250.0);
+
+const minPadding = 2.0;
+const overflowTextHorizontalPadding = 8.0;
+
+/// The size to shrink a widget by when animating it in.
+const entranceMargin = 50.0;
+
+double get defaultMaxRenderWidth => scaleByFontFactor(400.0);
+double get defaultMaxRenderHeight => scaleByFontFactor(400.0);
+
+const widgetTitleMaxWidthPercentage = 0.75;
+
+/// Hardcoded arrow size respective to its cross axis (because it's unconstrained).
+double get heightAndConstraintIndicatorSize => scaleByFontFactor(48.0);
+double get widthAndConstraintIndicatorSize => scaleByFontFactor(56.0);
+double get mainAxisArrowIndicatorSize => scaleByFontFactor(48.0);
+double get crossAxisArrowIndicatorSize => scaleByFontFactor(48.0);
+
+double get heightOnlyIndicatorSize => scaleByFontFactor(72.0);
+
+/// Minimum size to display width/height inside the arrow
+double get minWidthToDisplayWidthInsideArrow => scaleByFontFactor(200.0);
+double get minHeightToDisplayHeightInsideArrow => scaleByFontFactor(200.0);
+
+const smallTextScaleFactor = 0.8;
+
+/// Height for limiting asset image (selected one in the drop down).
+double get axisAlignmentAssetImageHeight => scaleByFontFactor(24.0);
+
+double get minHeightToAllowTruncating => scaleByFontFactor(375.0);
+double get minWidthToAllowTruncating => scaleByFontFactor(375.0);
+
+// Story of Layout colors
+const mainAxisLightColor = Color(0xff2c5daa);
+const mainAxisDarkColor = Color(0xff2c5daa);
+
+const textColor = Color(0xff55767f);
+const emphasizedTextColor = Color(0xff009aca);
+
+const crossAxisLightColor = Color(0xff8ac652);
+const crossAxisDarkColor = Color(0xff8ac652);
+
+const mainAxisTextColorLight = Color(0xFF1375bc);
+const mainAxisTextColorDark = Color(0xFF1375bc);
+
+const crossAxisTextColorLight = Color(0xFF66672C);
+const crossAxisTextColorsDark = Color(0xFFB3D25A);
+
+const overflowBackgroundColorDark = Color(0xFFB00020);
+const overflowBackgroundColorLight = Color(0xFFB00020);
+
+const overflowTextColorDark = Color(0xfff5846b);
+const overflowTextColorLight = Color(0xffdea089);
+
+const backgroundColorSelectedDark = Color(
+  0x4d474747,
+); // TODO(jacobr): we would like Color(0x4dedeeef) but that makes the background show through.
+const backgroundColorSelectedLight = Color(0x4dedeeef);
+
+extension LayoutExplorerColorScheme on ColorScheme {
+  Color get mainAxisColor => isLight ? mainAxisLightColor : mainAxisDarkColor;
+
+  Color get widgetNameColor => isLight ? Colors.white : Colors.black;
+
+  Color get crossAxisColor =>
+      isLight ? crossAxisLightColor : crossAxisDarkColor;
+
+  Color get mainAxisTextColor =>
+      isLight ? mainAxisTextColorLight : mainAxisTextColorDark;
+
+  Color get crossAxisTextColor =>
+      isLight ? crossAxisTextColorLight : crossAxisTextColorsDark;
+
+  Color get overflowBackgroundColor =>
+      isLight ? overflowBackgroundColorLight : overflowBackgroundColorDark;
+
+  Color get overflowTextColor =>
+      isLight ? overflowTextColorLight : overflowTextColorDark;
+
+  Color get backgroundColorSelected =>
+      isLight ? backgroundColorSelectedLight : backgroundColorSelectedDark;
+
+  Color get unconstrainedColor =>
+      isLight ? unconstrainedLightColor : unconstrainedDarkColor;
+}
+
+const backgroundColorDark = Color(0xff30302f);
+const backgroundColorLight = Color(0xffffffff);
+
+const unconstrainedDarkColor = Color(0xffdea089);
+const unconstrainedLightColor = Color(0xfff5846b);
+
+const widthIndicatorColor = textColor;
+const heightIndicatorColor = textColor;
+
+const negativeSpaceDarkAssetName =
+    'assets/img/layout_explorer/negative_space_dark.png';
+const negativeSpaceLightAssetName =
+    'assets/img/layout_explorer/negative_space_light.png';
+
+final dimensionIndicatorTextStyle = TextStyle(
+  height: 1.0,
+  letterSpacing: 1.1,
+  color: emphasizedTextColor,
+  fontSize: defaultFontSize,
+);
+
+TextStyle overflowingDimensionIndicatorTextStyle(ColorScheme colorScheme) =>
+    dimensionIndicatorTextStyle.merge(
+      TextStyle(
+        fontWeight: FontWeight.bold,
+        color: colorScheme.overflowTextColor,
+      ),
+    );
+
+Widget buildUnderline() {
+  return Container(
+    height: 1.0,
+    decoration: const BoxDecoration(
+      border: Border(
+        bottom: BorderSide(
+          color: textColor,
+          width: 0.0,
+        ),
+      ),
+    ),
+  );
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/theme.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/theme.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
@@ -1,0 +1,443 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:ui';
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../shared/common_widgets.dart';
+import '../../../../shared/diagnostics/diagnostics_node.dart';
+import '../../../../shared/primitives/utils.dart';
+import '../../inspector_data_models.dart';
+import 'overflow_indicator_painter.dart';
+import 'theme.dart';
+import 'widgets_theme.dart';
+
+/// A widget for positioning sized widgets that follows layout as follows:
+///      | top    |
+/// left | center | right
+///      | bottom |
+@immutable
+class BorderLayout extends StatelessWidget {
+  const BorderLayout({
+    super.key,
+    this.left,
+    this.leftWidth,
+    this.top,
+    this.topHeight,
+    this.right,
+    this.rightWidth,
+    this.bottom,
+    this.bottomHeight,
+    this.center,
+  }) : assert(
+          left != null ||
+              top != null ||
+              right != null ||
+              bottom != null ||
+              center != null,
+        );
+
+  final Widget? center;
+  final Widget? top;
+  final Widget? left;
+  final Widget? right;
+  final Widget? bottom;
+
+  final double? leftWidth;
+  final double? rightWidth;
+  final double? topHeight;
+  final double? bottomHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    return Stack(
+      children: <Widget>[
+        Center(
+          child: Container(
+            margin: EdgeInsets.only(
+              left: leftWidth ?? 0,
+              right: rightWidth ?? 0,
+              top: topHeight ?? 0,
+              bottom: bottomHeight ?? 0,
+            ),
+            child: center,
+          ),
+        ),
+        if (top != null)
+          Align(
+            alignment: Alignment.topCenter,
+            child: SizedBox(height: topHeight, child: top),
+          ),
+        if (left != null)
+          Align(
+            alignment: Alignment.centerLeft,
+            child: SizedBox(width: leftWidth, child: left),
+          ),
+        if (right != null)
+          Align(
+            alignment: Alignment.centerRight,
+            child: SizedBox(width: rightWidth, child: right),
+          ),
+        if (bottom != null)
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: SizedBox(height: bottomHeight, child: bottom),
+          ),
+      ],
+    );
+  }
+}
+
+@immutable
+class Truncateable extends StatelessWidget {
+  const Truncateable({super.key, this.truncate = false, required this.child});
+
+  final Widget child;
+  final bool truncate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Flexible(flex: truncate ? 1 : 0, child: child);
+  }
+}
+
+/// Widget that draws bounding box with the title (usually widget name) in its top left
+///
+/// [hint] is an optional widget to be placed in the top right of the box
+/// [child] is an optional widget to be placed in the center of the box
+/// [borderColor] outer box border color and background color for the title
+/// [textColor] color for title text
+class WidgetVisualizer extends StatelessWidget {
+  const WidgetVisualizer({
+    super.key,
+    required this.title,
+    this.hint,
+    required this.isSelected,
+    required this.layoutProperties,
+    required this.child,
+    this.overflowSide,
+    this.largeTitle = false,
+  });
+
+  final LayoutProperties layoutProperties;
+  final String title;
+  final Widget child;
+  final Widget? hint;
+  final bool isSelected;
+  final bool largeTitle;
+
+  final OverflowSide? overflowSide;
+
+  static const _overflowIndicatorSize = 20.0;
+  static const _borderUnselectedWidth = 1.0;
+  static const _borderSelectedWidth = 3.0;
+  static const _selectedPadding = 4.0;
+
+  bool get drawOverflow => overflowSide != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final properties = layoutProperties;
+    final borderColor = WidgetTheme.fromName(properties.node.description).color;
+    final boxAdjust = isSelected ? _selectedPadding : 0.0;
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final hintLocal = hint;
+        return OverflowBox(
+          minWidth: constraints.minWidth + boxAdjust,
+          maxWidth: constraints.maxWidth + boxAdjust,
+          maxHeight: constraints.maxHeight + boxAdjust,
+          minHeight: constraints.minHeight + boxAdjust,
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border.all(
+                color: borderColor,
+                width:
+                    isSelected ? _borderSelectedWidth : _borderUnselectedWidth,
+              ),
+              color: isSelected
+                  ? theme.canvasColor.brighten()
+                  : theme.canvasColor.darken(),
+              boxShadow: isSelected
+                  ? [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.5),
+                        blurRadius: 20,
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Stack(
+              children: [
+                if (drawOverflow)
+                  Positioned.fill(
+                    child: CustomPaint(
+                      painter: OverflowIndicatorPainter(
+                        overflowSide!,
+                        _overflowIndicatorSize,
+                      ),
+                    ),
+                  ),
+                Container(
+                  margin: EdgeInsets.only(
+                    right: overflowSide == OverflowSide.right
+                        ? _overflowIndicatorSize
+                        : 0.0,
+                    bottom: overflowSide == OverflowSide.bottom
+                        ? _overflowIndicatorSize
+                        : 0.0,
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.stretch,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      IntrinsicHeight(
+                        child: Row(
+                          crossAxisAlignment: CrossAxisAlignment.stretch,
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Flexible(
+                              child: Container(
+                                constraints: BoxConstraints(
+                                  maxWidth: largeTitle
+                                      ? defaultMaxRenderWidth
+                                      : minRenderWidth *
+                                          widgetTitleMaxWidthPercentage,
+                                ),
+                                decoration: BoxDecoration(color: borderColor),
+                                padding: const EdgeInsets.all(4.0),
+                                child: Center(
+                                  child: Text(
+                                    title,
+                                    style: theme.regularTextStyleWithColor(
+                                      colorScheme.widgetNameColor,
+                                    ),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ),
+                              ),
+                            ),
+                            if (hintLocal != null) Flexible(child: hintLocal),
+                          ],
+                        ),
+                      ),
+                      Expanded(child: child),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+}
+
+class AnimatedLayoutProperties<T extends LayoutProperties>
+    implements LayoutProperties {
+  AnimatedLayoutProperties(this.begin, this.end, this.animation)
+      : assert(begin.children.length == end.children.length),
+        _children = [
+          for (var i = 0; i < begin.children.length; i++)
+            AnimatedLayoutProperties(
+              begin.children[i],
+              end.children[i],
+              animation,
+            ),
+        ];
+
+  final T begin;
+  final T end;
+  final Animation<double> animation;
+  final List<LayoutProperties> _children;
+
+  @override
+  LayoutProperties? get parent => end.parent;
+
+  @override
+  set parent(LayoutProperties? parent) {
+    end.parent = parent;
+  }
+
+  @override
+  List<LayoutProperties> get children {
+    return _children;
+  }
+
+  List<double> _lerpList(List<double> l1, List<double> l2) {
+    assert(l1.length == l2.length);
+    if (l1.isEmpty) return [];
+    final animationLocal = animation;
+    return [
+      for (var i = 0; i < children.length; i++)
+        lerpDouble(l1[i], l2[i], animationLocal.value)!,
+    ];
+  }
+
+  @override
+  List<double> childrenDimensions(Axis axis) {
+    final beginDimensions = begin.childrenDimensions(axis);
+    final endDimensions = end.childrenDimensions(axis);
+    return _lerpList(beginDimensions, endDimensions).cast<double>();
+  }
+
+  @override
+  List<double> get childrenHeights =>
+      _lerpList(begin.childrenHeights, end.childrenHeights).cast<double>();
+
+  @override
+  List<double> get childrenWidths =>
+      _lerpList(begin.childrenWidths, end.childrenWidths).cast<double>();
+
+  @override
+  BoxConstraints? get constraints {
+    try {
+      return BoxConstraints.lerp(
+        begin.constraints,
+        end.constraints,
+        animation.value,
+      );
+    } catch (e) {
+      return end.constraints;
+    }
+  }
+
+  @override
+  String describeWidthConstraints() {
+    final constraintsLocal = constraints!;
+    return constraintsLocal.hasBoundedWidth
+        ? LayoutProperties.describeAxis(
+            constraintsLocal.minWidth,
+            constraintsLocal.maxWidth,
+            'w',
+          )
+        : 'w=unconstrained';
+  }
+
+  @override
+  String describeHeightConstraints() {
+    final constraintsLocal = constraints!;
+    return constraintsLocal.hasBoundedHeight
+        ? LayoutProperties.describeAxis(
+            constraintsLocal.minHeight,
+            constraintsLocal.maxHeight,
+            'h',
+          )
+        : 'h=unconstrained';
+  }
+
+  @override
+  String describeWidth() => 'w=${toStringAsFixed(size.width)}';
+
+  @override
+  String describeHeight() => 'h=${toStringAsFixed(size.height)}';
+
+  @override
+  String? get description => end.description;
+
+  @override
+  double dimension(Axis axis) {
+    return lerpDouble(
+      begin.dimension(axis),
+      end.dimension(axis),
+      animation.value,
+    )!;
+  }
+
+  @override
+  num? get flexFactor =>
+      lerpDouble(begin.flexFactor, end.flexFactor, animation.value);
+
+  @override
+  bool get hasChildren => children.isNotEmpty;
+
+  @override
+  double get height => size.height;
+
+  @override
+  bool get isFlex => begin.isFlex && end.isFlex;
+
+  @override
+  RemoteDiagnosticsNode get node => end.node;
+
+  @override
+  Size get size {
+    return Size.lerp(begin.size, end.size, animation.value)!;
+  }
+
+  @override
+  int get totalChildren => end.totalChildren;
+
+  @override
+  double get width => size.width;
+
+  @override
+  bool get hasFlexFactor => begin.hasFlexFactor && end.hasFlexFactor;
+
+  @override
+  LayoutProperties copyWith({
+    List<LayoutProperties>? children,
+    BoxConstraints? constraints,
+    String? description,
+    int? flexFactor,
+    FlexFit? flexFit,
+    bool? isFlex,
+    Size? size,
+  }) {
+    return LayoutProperties.values(
+      node: node,
+      children: children ?? this.children,
+      constraints: constraints ?? this.constraints,
+      description: description ?? this.description,
+      flexFactor: flexFactor ?? this.flexFactor,
+      flexFit: flexFit ?? this.flexFit,
+      isFlex: isFlex ?? this.isFlex,
+      size: size ?? this.size,
+    );
+  }
+
+  @override
+  bool get isOverflowWidth => end.isOverflowWidth;
+
+  @override
+  bool get isOverflowHeight => end.isOverflowHeight;
+
+  @override
+  FlexFit? get flexFit => end.flexFit;
+
+  @override
+  List<LayoutProperties> get displayChildren => end.displayChildren;
+}
+
+class LayoutExplorerBackground extends StatelessWidget {
+  const LayoutExplorerBackground({
+    super.key,
+    required this.colorScheme,
+  });
+
+  final ColorScheme colorScheme;
+
+  @override
+  Widget build(BuildContext context) {
+    return Positioned.fill(
+      child: Opacity(
+        opacity: colorScheme.isLight ? 0.3 : 0.2,
+        child: Image.asset(
+          colorScheme.isLight
+              ? negativeSpaceLightAssetName
+              : negativeSpaceDarkAssetName,
+          fit: BoxFit.none,
+          repeat: ImageRepeat.repeat,
+          alignment: Alignment.topLeft,
+        ),
+      ),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widget_constraints.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widget_constraints.dart
@@ -1,0 +1,179 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/ui.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../shared/primitives/math_utils.dart';
+import '../../../../shared/primitives/utils.dart';
+import '../../inspector_data_models.dart';
+import 'arrow.dart';
+import 'dimension.dart';
+import 'theme.dart';
+import 'utils.dart';
+
+class VisualizeWidthAndHeightWithConstraints extends StatelessWidget {
+  VisualizeWidthAndHeightWithConstraints({
+    super.key,
+    required this.properties,
+    double? arrowHeadSize,
+    required this.child,
+    this.warnIfUnconstrained = true,
+  }) : arrowHeadSize = arrowHeadSize ?? defaultIconSize;
+
+  final Widget child;
+  final LayoutProperties properties;
+  final double arrowHeadSize;
+  final bool warnIfUnconstrained;
+
+  @override
+  Widget build(BuildContext context) {
+    final propertiesLocal = properties;
+    final showChildrenWidthsSum = propertiesLocal is FlexLayoutProperties &&
+        propertiesLocal.isOverflowWidth;
+    final bottomHeight = widthAndConstraintIndicatorSize;
+    final rightWidth = heightAndConstraintIndicatorSize;
+    final colorScheme = Theme.of(context).colorScheme;
+
+    final showOverflowHeight =
+        properties is FlexLayoutProperties && propertiesLocal.isOverflowHeight;
+    final heightDescription = RotatedBox(
+      quarterTurns: 1,
+      child: dimensionDescription(
+        TextSpan(
+          children: [
+            TextSpan(
+              text: propertiesLocal.describeHeight(),
+            ),
+            if (propertiesLocal.constraints != null) ...[
+              if (!showOverflowHeight) const TextSpan(text: '\n'),
+              TextSpan(
+                text: ' (${propertiesLocal.describeHeightConstraints()})',
+                style: propertiesLocal.constraints!.hasBoundedHeight ||
+                        !warnIfUnconstrained
+                    ? null
+                    : TextStyle(
+                        color: colorScheme.unconstrainedColor,
+                      ),
+              ),
+            ],
+            if (showOverflowHeight)
+              TextSpan(
+                text: '\nchildren take: '
+                    '${toStringAsFixed(sum(propertiesLocal.childrenHeights.cast<double>()))}',
+              ),
+          ],
+        ),
+        propertiesLocal.isOverflowHeight,
+        colorScheme,
+      ),
+    );
+    final right = Container(
+      margin: EdgeInsets.only(
+        top: margin,
+        left: margin,
+        bottom: bottomHeight,
+        right: minPadding, // custom margin for not sticking to the corner
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final displayHeightOutsideArrow =
+              constraints.maxHeight < minHeightToDisplayHeightInsideArrow;
+          return Row(
+            children: [
+              Truncateable(
+                truncate: !displayHeightOutsideArrow,
+                child: Container(
+                  margin: EdgeInsets.symmetric(horizontal: arrowMargin),
+                  child: ArrowWrapper.bidirectional(
+                    arrowColor: heightIndicatorColor,
+                    arrowStrokeWidth: arrowStrokeWidth,
+                    arrowHeadSize: arrowHeadSize,
+                    direction: Axis.vertical,
+                    child: displayHeightOutsideArrow ? null : heightDescription,
+                  ),
+                ),
+              ),
+              if (displayHeightOutsideArrow)
+                Flexible(
+                  child: heightDescription,
+                ),
+            ],
+          );
+        },
+      ),
+    );
+
+    final widthDescription = dimensionDescription(
+      TextSpan(
+        children: [
+          TextSpan(text: '${propertiesLocal.describeWidth()}; '),
+          if (propertiesLocal.constraints != null) ...[
+            if (!showChildrenWidthsSum) const TextSpan(text: '\n'),
+            TextSpan(
+              text: '(${propertiesLocal.describeWidthConstraints()})',
+              style: propertiesLocal.constraints!.hasBoundedWidth ||
+                      !warnIfUnconstrained
+                  ? null
+                  : TextStyle(color: colorScheme.unconstrainedColor),
+            ),
+          ],
+          if (showChildrenWidthsSum)
+            TextSpan(
+              text: '\nchildren take '
+                  '${toStringAsFixed(sum(propertiesLocal.childrenWidths.cast<double>()))}',
+            ),
+        ],
+      ),
+      propertiesLocal.isOverflowWidth,
+      colorScheme,
+    );
+    final bottom = Container(
+      margin: EdgeInsets.only(
+        top: margin,
+        left: margin,
+        right: rightWidth,
+        bottom: minPadding,
+      ),
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final maxWidth = constraints.maxWidth;
+          final displayWidthOutsideArrow =
+              maxWidth < minWidthToDisplayWidthInsideArrow;
+          return Column(
+            children: [
+              Truncateable(
+                truncate: !displayWidthOutsideArrow,
+                child: Container(
+                  margin: EdgeInsets.symmetric(vertical: arrowMargin),
+                  child: ArrowWrapper.bidirectional(
+                    arrowColor: widthIndicatorColor,
+                    arrowHeadSize: arrowHeadSize,
+                    arrowStrokeWidth: arrowStrokeWidth,
+                    direction: Axis.horizontal,
+                    child: displayWidthOutsideArrow ? null : widthDescription,
+                  ),
+                ),
+              ),
+              if (displayWidthOutsideArrow)
+                Flexible(
+                  child: Container(
+                    padding: const EdgeInsets.only(top: minPadding),
+                    child: widthDescription,
+                  ),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+    return BorderLayout(
+      center: child,
+      right: right,
+      rightWidth: rightWidth,
+      bottom: bottom,
+      bottomHeight: bottomHeight,
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widget_constraints.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widget_constraints.dart
@@ -1,4 +1,4 @@
-// Copyright 2019 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widgets_theme.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widgets_theme.dart
@@ -1,4 +1,4 @@
-// Copyright 2021 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widgets_theme.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/widgets_theme.dart
@@ -1,0 +1,254 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+
+class WidgetTheme {
+  const WidgetTheme({
+    this.iconAsset,
+    this.color = otherWidgetColor,
+  });
+
+  final String? iconAsset;
+  final Color color;
+
+  static WidgetTheme fromName(String? widgetType) {
+    if (widgetType == null) {
+      return const WidgetTheme();
+    }
+
+    return themeMap[_stripBrackets(widgetType)] ?? const WidgetTheme();
+  }
+
+  /// Strips the brackets off the widget name.
+  ///
+  /// For example: `AnimatedBuilder<String>` -> `AnimatedBuilder`.
+  static String _stripBrackets(String widgetType) {
+    final bracketIndex = widgetType.indexOf('<');
+    if (bracketIndex == -1) {
+      return widgetType;
+    }
+
+    return widgetType.substring(0, bracketIndex);
+  }
+
+  static const contentWidgetColor = Color(0xff06AC3B);
+  static const highLevelWidgetColor = Color(0xffAEAEB1);
+  static const animationWidgetColor = Color(0xffE09D0E);
+  static const otherWidgetColor = Color(0xff0EA7E0);
+
+  static const animatedTheme = WidgetTheme(
+    iconAsset: WidgetIcons.animated,
+    color: animationWidgetColor,
+  );
+
+  static const transitionTheme = WidgetTheme(
+    iconAsset: WidgetIcons.transition,
+    color: animationWidgetColor,
+  );
+
+  static const textTheme = WidgetTheme(
+    iconAsset: WidgetIcons.text,
+    color: contentWidgetColor,
+  );
+
+  static const imageTheme = WidgetTheme(
+    iconAsset: WidgetIcons.image,
+    color: contentWidgetColor,
+  );
+
+  static const tabTheme = WidgetTheme(iconAsset: WidgetIcons.tab);
+  static const scrollTheme = WidgetTheme(iconAsset: WidgetIcons.scroll);
+  static const highLevelTheme = WidgetTheme(color: highLevelWidgetColor);
+  static const listTheme = WidgetTheme(iconAsset: WidgetIcons.listView);
+  static const expandTheme = WidgetTheme(iconAsset: WidgetIcons.expand);
+  static const alignTheme = WidgetTheme(iconAsset: WidgetIcons.align);
+  static const gestureTheme = WidgetTheme(iconAsset: WidgetIcons.gesture);
+  static const textButtonTheme = WidgetTheme(iconAsset: WidgetIcons.textButton);
+  static const toggleTheme = WidgetTheme(
+    iconAsset: WidgetIcons.toggle,
+    color: contentWidgetColor,
+  );
+
+  static const Map<String, WidgetTheme> themeMap = {
+    // High-level
+    'RenderObjectToWidgetAdapter': WidgetTheme(
+      iconAsset: WidgetIcons.root,
+      color: highLevelWidgetColor,
+    ),
+    'CupertinoApp': highLevelTheme,
+    'MaterialApp': WidgetTheme(iconAsset: WidgetIcons.materialApp),
+    'WidgetsApp': highLevelTheme,
+
+    // Text
+    'DefaultTextStyle': textTheme,
+    'RichText': textTheme,
+    'SelectableText': textTheme,
+    'Text': textTheme,
+
+    // Images
+    'Icon': imageTheme,
+    'Image': imageTheme,
+    'RawImage': imageTheme,
+
+    // Animations
+    'AnimatedAlign': animatedTheme,
+    'AnimatedBuilder': animatedTheme,
+    'AnimatedContainer': animatedTheme,
+    'AnimatedCrossFade': animatedTheme,
+    'AnimatedDefaultTextStyle': animatedTheme,
+    'AnimatedListState': animatedTheme,
+    'AnimatedModalBarrier': animatedTheme,
+    'AnimatedOpacity': animatedTheme,
+    'AnimatedPhysicalModel': animatedTheme,
+    'AnimatedPositioned': animatedTheme,
+    'AnimatedSize': animatedTheme,
+    'AnimatedWidget': animatedTheme,
+
+    // Transitions
+    'DecoratedBoxTransition': transitionTheme,
+    'FadeTransition': transitionTheme,
+    'PositionedTransition': transitionTheme,
+    'RotationTransition': transitionTheme,
+    'ScaleTransition': transitionTheme,
+    'SizeTransition': transitionTheme,
+    'SlideTransition': transitionTheme,
+    'Hero': WidgetTheme(
+      iconAsset: WidgetIcons.hero,
+      color: animationWidgetColor,
+    ),
+
+    // Scroll
+    'CustomScrollView': scrollTheme,
+    'DraggableScrollableSheet': scrollTheme,
+    'SingleChildScrollView': scrollTheme,
+    'Scrollable': scrollTheme,
+    'Scrollbar': scrollTheme,
+    'ScrollConfiguration': scrollTheme,
+    'GridView': WidgetTheme(iconAsset: WidgetIcons.gridView),
+    'ListView': listTheme,
+    'ReorderableListView': listTheme,
+    'NestedScrollView': listTheme,
+
+    // Input
+    'Checkbox': WidgetTheme(
+      iconAsset: WidgetIcons.checkbox,
+      color: contentWidgetColor,
+    ),
+    'Radio': WidgetTheme(
+      iconAsset: WidgetIcons.radio,
+      color: contentWidgetColor,
+    ),
+    'Switch': toggleTheme,
+    'CupertinoSwitch': toggleTheme,
+
+    // Layout
+    'Container': WidgetTheme(iconAsset: WidgetIcons.container),
+    'Center': WidgetTheme(iconAsset: WidgetIcons.center),
+    'Row': WidgetTheme(iconAsset: WidgetIcons.row),
+    'Column': WidgetTheme(iconAsset: WidgetIcons.column),
+    'Padding': WidgetTheme(iconAsset: WidgetIcons.padding),
+    'SizedBox': WidgetTheme(iconAsset: WidgetIcons.sizedBox),
+    'ConstrainedBox': WidgetTheme(iconAsset: WidgetIcons.constrainedBox),
+    'Align': alignTheme,
+    'Positioned': alignTheme,
+    'Expanded': expandTheme,
+    'Flexible': expandTheme,
+    'Stack': WidgetTheme(iconAsset: WidgetIcons.stack),
+    'Wrap': WidgetTheme(iconAsset: WidgetIcons.wrap),
+
+    // Buttons
+    'FloatingActionButton': WidgetTheme(
+      iconAsset: WidgetIcons.floatingActionButton,
+      color: contentWidgetColor,
+    ),
+    'InkWell': WidgetTheme(iconAsset: WidgetIcons.inkWell),
+    'GestureDetector': gestureTheme,
+    'RawGestureDetector': gestureTheme,
+    'TextButton': textButtonTheme,
+    'CupertinoButton': textButtonTheme,
+    'ElevatedButton': textButtonTheme,
+    'OutlinedButton': WidgetTheme(iconAsset: WidgetIcons.outlinedButton),
+
+    // Tabs
+    'Tab': tabTheme,
+    'TabBar': tabTheme,
+    'TabBarView': tabTheme,
+    'BottomNavigationBar':
+        WidgetTheme(iconAsset: WidgetIcons.bottomNavigationBar),
+    'CupertinoTabScaffold': tabTheme,
+    'CupertinoTabView': tabTheme,
+
+    // Other
+    'Scaffold': WidgetTheme(iconAsset: WidgetIcons.scaffold),
+    'CircularProgressIndicator':
+        WidgetTheme(iconAsset: WidgetIcons.circularProgress),
+    'Card': WidgetTheme(iconAsset: WidgetIcons.card),
+    'Divider': WidgetTheme(iconAsset: WidgetIcons.divider),
+    'AlertDialog': WidgetTheme(iconAsset: WidgetIcons.alertDialog),
+    'CircleAvatar': WidgetTheme(iconAsset: WidgetIcons.circleAvatar),
+    'Opacity': WidgetTheme(iconAsset: WidgetIcons.opacity),
+    'Drawer': WidgetTheme(iconAsset: WidgetIcons.drawer),
+    'PageView': WidgetTheme(iconAsset: WidgetIcons.pageView),
+    'Material': WidgetTheme(iconAsset: WidgetIcons.material),
+    'AppBar': WidgetTheme(iconAsset: WidgetIcons.appBar),
+  };
+}
+
+class WidgetIcons {
+  static const String root = 'icons/inspector/widget_icons/root.png';
+  static const String text = 'icons/inspector/widget_icons/text.png';
+  static const String icon = 'icons/inspector/widget_icons/icon.png';
+  static const String image = 'icons/inspector/widget_icons/image.png';
+  static const String floatingActionButton =
+      'icons/inspector/widget_icons/floatingab.png';
+  static const String checkbox = 'icons/inspector/widget_icons/checkbox.png';
+  static const String radio = 'icons/inspector/widget_icons/radio.png';
+  static const String toggle = 'icons/inspector/widget_icons/toggle.png';
+  static const String animated = 'icons/inspector/widget_icons/animated.png';
+  static const String transition =
+      'icons/inspector/widget_icons/transition.png';
+  static const String hero = 'icons/inspector/widget_icons/hero.png';
+  static const String container = 'icons/inspector/widget_icons/container.png';
+  static const String center = 'icons/inspector/widget_icons/center.png';
+  static const String row = 'icons/inspector/widget_icons/row.png';
+  static const String column = 'icons/inspector/widget_icons/column.png';
+  static const String padding = 'icons/inspector/widget_icons/padding.png';
+  static const String scaffold = 'icons/inspector/widget_icons/scaffold.png';
+  static const String sizedBox = 'icons/inspector/widget_icons/sizedbox.png';
+  static const String align = 'icons/inspector/widget_icons/align.png';
+  static const String scroll = 'icons/inspector/widget_icons/scroll.png';
+  static const String stack = 'icons/inspector/widget_icons/stack.png';
+  static const String inkWell = 'icons/inspector/widget_icons/inkwell.png';
+  static const String gesture = 'icons/inspector/widget_icons/gesture.png';
+  static const String textButton =
+      'icons/inspector/widget_icons/textbutton.png';
+  static const String outlinedButton =
+      'icons/inspector/widget_icons/outlinedbutton.png';
+  static const String gridView = 'icons/inspector/widget_icons/gridview.png';
+  static const String listView = 'icons/inspector/widget_icons/listView.png';
+
+  static const String alertDialog =
+      'icons/inspector/widget_icons/alertdialog.png';
+  static const String card = 'icons/inspector/widget_icons/card.png';
+  static const String circleAvatar =
+      'icons/inspector/widget_icons/circleavatar.png';
+  static const String circularProgress =
+      'icons/inspector/widget_icons/circularprogress.png';
+  static const String constrainedBox =
+      'icons/inspector/widget_icons/constrainedbox.png';
+  static const String divider = 'icons/inspector/widget_icons/divider.png';
+  static const String drawer = 'icons/inspector/widget_icons/drawer.png';
+  static const String expand = 'icons/inspector/widget_icons/expand.png';
+  static const String material = 'icons/inspector/widget_icons/material.png';
+  static const String opacity = 'icons/inspector/widget_icons/opacity.png';
+  static const String tab = 'icons/inspector/widget_icons/tab.png';
+  static const String wrap = 'icons/inspector/widget_icons/wrap.png';
+  static const String pageView = 'icons/inspector/widget_icons/pageView.png';
+  static const String appBar = 'icons/inspector/widget_icons/appbar.png';
+  static const String materialApp =
+      'icons/inspector/widget_icons/materialapp.png';
+  static const String bottomNavigationBar =
+      'icons/inspector/widget_icons/bottomnavigationbar.png';
+}

--- a/packages/devtools_app/lib/src/shared/analytics/metrics.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/metrics.dart
@@ -63,14 +63,23 @@ class ProfilerScreenMetrics extends ScreenAnalyticsMetrics {
 }
 
 class InspectorScreenMetrics extends ScreenAnalyticsMetrics {
-  InspectorScreenMetrics({
+  InspectorScreenMetrics.legacy({
     required this.rootSetCount,
     required this.rowCount,
     required this.inspectorTreeControllerId,
-  });
+  }) : isV2 = false;
+
+  InspectorScreenMetrics.v2({
+    required this.rootSetCount,
+    required this.rowCount,
+    required this.inspectorTreeControllerId,
+  }) : isV2 = true;
 
   static const int summaryTreeGaId = 0;
   static const int detailsTreeGaId = 1;
+
+  /// Whether these metrics are for the V2 inspector.
+  final bool isV2;
 
   /// The number of times the root has been set, since the
   /// [InspectorTreeController] with id [inspectorTreeControllerId], has been

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -89,6 +89,11 @@ abstract class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/6056
   static bool dapDebugging = enableExperiments;
 
+  /// Flag to enable the new Inspector panel.
+  ///
+  /// https://github.com/flutter/devtools/issues/7854
+  static bool inspectorV2 = enableExperiments;
+
   /// Stores a map of all the feature flags for debugging purposes.
   ///
   /// When adding a new flag, you are responsible for adding it to this map as
@@ -99,6 +104,7 @@ abstract class FeatureFlags {
     'dapDebugging': dapDebugging,
     'loggingV2': loggingV2,
     'deepLinkIosCheck': deepLinkIosCheck,
+    'inspectorV2': inspectorV2,
   };
 
   /// A helper to print the status of all the feature flags.

--- a/packages/devtools_app/lib/src/shared/preferences/_inspector_v2_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_inspector_v2_preferences.dart
@@ -1,0 +1,379 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of 'preferences.dart';
+
+enum InspectorV2DetailsViewType {
+  layoutExplorer(nameOverride: 'Layout Explorer 2.0'),
+  widgetDetailsTree(nameOverride: 'Widget Details Tree 2.0');
+
+  const InspectorV2DetailsViewType({String? nameOverride})
+      : _nameOverride = nameOverride;
+
+  final String? _nameOverride;
+
+  String get key => _nameOverride ?? name;
+}
+
+class InspectorV2PreferencesController extends DisposableController
+    with AutoDisposeControllerMixin {
+  ValueListenable<bool> get hoverEvalModeEnabled => _hoverEvalMode;
+  ValueListenable<InspectorV2DetailsViewType> get defaultDetailsView =>
+      _defaultDetailsView;
+  ListValueNotifier<String> get pubRootDirectories => _pubRootDirectories;
+  ValueListenable<bool> get isRefreshingPubRootDirectories =>
+      _pubRootDirectoriesAreBusy;
+  InspectorServiceBase? get _inspectorService =>
+      serviceConnection.inspectorService;
+
+  final _hoverEvalMode = ValueNotifier<bool>(false);
+  final _pubRootDirectories = ListValueNotifier<String>([]);
+  final _pubRootDirectoriesAreBusy = ValueNotifier<bool>(false);
+  final _busyCounter = ValueNotifier<int>(0);
+  final _defaultDetailsView = ValueNotifier<InspectorV2DetailsViewType>(
+    InspectorV2DetailsViewType.layoutExplorer,
+  );
+
+  static const _hoverEvalModeStorageId = 'inspector.hoverEvalMode';
+  static const _defaultDetailsViewStorageId =
+      'inspector.defaultDetailsViewType';
+  static const _customPubRootDirectoriesStoragePrefix =
+      'inspector.customPubRootDirectories';
+  String? _mainScriptDir;
+  bool _checkedFlutterPubRoot = false;
+
+  Future<void> _updateMainScriptRef() async {
+    final rootLibUriString =
+        (await serviceConnection.serviceManager.tryToDetectMainRootInfo())
+            ?.library;
+    final rootLibUri = Uri.parse(rootLibUriString ?? '');
+    final directorySegments =
+        rootLibUri.pathSegments.sublist(0, rootLibUri.pathSegments.length - 1);
+    final rootLibDirectory = rootLibUri.replace(
+      pathSegments: directorySegments,
+    );
+    _mainScriptDir = rootLibDirectory.path;
+  }
+
+  Future<void> init() async {
+    await _initHoverEvalMode();
+    // TODO(jacobr): consider initializing this first as it is not blocking.
+    _initPubRootDirectories();
+    await _initDefaultInspectorDetailsView();
+  }
+
+  Future<void> _initHoverEvalMode() async {
+    await _updateHoverEvalMode();
+
+    addAutoDisposeListener(_hoverEvalMode, () {
+      storage.setValue(
+        _hoverEvalModeStorageId,
+        _hoverEvalMode.value.toString(),
+      );
+    });
+  }
+
+  Future<void> _updateHoverEvalMode() async {
+    String? hoverEvalModeEnabledValue =
+        await storage.getValue(_hoverEvalModeStorageId);
+
+    hoverEvalModeEnabledValue ??=
+        (_inspectorService?.hoverEvalModeEnabledByDefault ?? false).toString();
+    setHoverEvalMode(hoverEvalModeEnabledValue == 'true');
+  }
+
+  Future<void> _initDefaultInspectorDetailsView() async {
+    await _updateInspectorDetailsViewSelection();
+
+    addAutoDisposeListener(_defaultDetailsView, () {
+      storage.setValue(
+        _defaultDetailsViewStorageId,
+        _defaultDetailsView.value.name.toString(),
+      );
+    });
+  }
+
+  Future<void> _updateInspectorDetailsViewSelection() async {
+    final inspectorDetailsView =
+        await storage.getValue(_defaultDetailsViewStorageId);
+
+    if (inspectorDetailsView != null) {
+      _defaultDetailsView.value = InspectorV2DetailsViewType.values
+          .firstWhere((e) => e.name.toString() == inspectorDetailsView);
+    }
+  }
+
+  void _initPubRootDirectories() {
+    addAutoDisposeListener(
+      serviceConnection.serviceManager.connectedState,
+      () async {
+        if (serviceConnection.serviceManager.connectedState.value.connected) {
+          await handleConnectionToNewService();
+        } else {
+          _handleConnectionClosed();
+        }
+      },
+    );
+    addAutoDisposeListener(_busyCounter, () {
+      _pubRootDirectoriesAreBusy.value = _busyCounter.value != 0;
+    });
+    addAutoDisposeListener(
+      serviceConnection.serviceManager.isolateManager.mainIsolate,
+      () {
+        if (_mainScriptDir != null &&
+            serviceConnection.serviceManager.isolateManager.mainIsolate.value !=
+                null) {
+          final debuggerState =
+              serviceConnection.serviceManager.isolateManager.mainIsolateState;
+
+          if (debuggerState?.isPaused.value == false) {
+            // the isolate is already unpaused, we can try to load
+            // the directories
+            unawaited(preferences.inspector.loadPubRootDirectories());
+          } else {
+            late void Function() pausedListener;
+
+            pausedListener = () {
+              if (debuggerState?.isPaused.value == false) {
+                unawaited(preferences.inspector.loadPubRootDirectories());
+
+                debuggerState?.isPaused.removeListener(pausedListener);
+              }
+            };
+
+            // The isolate is still paused, listen for when it becomes unpaused.
+            addAutoDisposeListener(debuggerState?.isPaused, pausedListener);
+          }
+        }
+      },
+    );
+  }
+
+  void _handleConnectionClosed() {
+    _mainScriptDir = null;
+    _pubRootDirectories.clear();
+  }
+
+  @visibleForTesting
+  Future<void> handleConnectionToNewService() async {
+    _checkedFlutterPubRoot = false;
+    await _updateMainScriptRef();
+    await _updateHoverEvalMode();
+    await loadPubRootDirectories();
+    await _updateInspectorDetailsViewSelection();
+  }
+
+  Future<void> loadPubRootDirectories() async {
+    await _pubRootDirectoryBusyTracker(() async {
+      await addPubRootDirectories(await _determinePubRootDirectories());
+      await _refreshPubRootDirectoriesFromService();
+    });
+  }
+
+  Future<List<String>> _determinePubRootDirectories() async {
+    final cachedDirectories = await readCachedPubRootDirectories();
+    final inferredDirectory = await _inferPubRootDirectory();
+
+    if (inferredDirectory == null) return cachedDirectories;
+    return {inferredDirectory, ...cachedDirectories}.toList();
+  }
+
+  @visibleForTesting
+  Future<List<String>> readCachedPubRootDirectories() async {
+    final cachedDirectoriesJson =
+        await storage.getValue(_customPubRootStorageId());
+    if (cachedDirectoriesJson == null) return <String>[];
+    final cachedDirectories = List<String>.from(
+      jsonDecode(cachedDirectoriesJson),
+    );
+
+    // Remove the Flutter pub root directory if it was accidentally cached.
+    // See:
+    // - https://github.com/flutter/devtools/issues/6882
+    // - https://github.com/flutter/devtools/issues/6841
+    if (!_checkedFlutterPubRoot && cachedDirectories.any(_isFlutterPubRoot)) {
+      // Set [_checkedFlutterPubRoot] to true to avoid an infinite loop on the
+      // next call to [removePubRootDirectories]:
+      _checkedFlutterPubRoot = true;
+      final flutterPubRootDirectories =
+          cachedDirectories.where(_isFlutterPubRoot).toList();
+      await removePubRootDirectories(flutterPubRootDirectories);
+      cachedDirectories.removeWhere(_isFlutterPubRoot);
+    }
+
+    return cachedDirectories;
+  }
+
+  bool _isFlutterPubRoot(String directory) =>
+      directory.endsWith('packages/flutter');
+
+  /// As we aren't running from an IDE, we don't know exactly what the pub root
+  /// directories are for the current project so we make a best guess based on
+  /// the root library for the main isolate.
+  Future<String?> _inferPubRootDirectory() async {
+    final fileUriString =
+        await serviceConnection.mainIsolateRootLibraryUriAsString();
+    if (fileUriString == null) {
+      return null;
+    }
+    // TODO(jacobr): Once https://github.com/flutter/flutter/issues/26615 is
+    // fixed we will be able to use package: paths. Temporarily all tools
+    // tracking widget locations will need to support both path formats.
+    // TODO(jacobr): use the list of loaded scripts to determine the appropriate
+    // package root directory given that the root script of this project is in
+    // this directory rather than guessing based on url structure.
+    final parts = fileUriString.split('/');
+    String? pubRootDirectory;
+    // For google3, we grab the top-level directory in the google3 directory
+    // (e.g. /education), or the top-level directory in third_party (e.g.
+    // /third_party/dart):
+    if (isGoogle3Path(parts)) {
+      pubRootDirectory = _pubRootDirectoryForGoogle3(parts);
+    } else {
+      final parts = fileUriString.split('/');
+
+      for (int i = parts.length - 1; i >= 0; i--) {
+        final part = parts[i];
+        if (part == 'lib' || part == 'web') {
+          pubRootDirectory = parts.sublist(0, i).join('/');
+          break;
+        }
+
+        if (part == 'packages') {
+          pubRootDirectory = parts.sublist(0, i + 1).join('/');
+          break;
+        }
+      }
+    }
+    pubRootDirectory ??= (parts..removeLast()).join('/');
+    // Make sure the root directory ends with /, otherwise we will patch with
+    // other directories that start the same.
+    pubRootDirectory = pubRootDirectory.endsWith('/')
+        ? pubRootDirectory
+        : '$pubRootDirectory/';
+    return pubRootDirectory;
+  }
+
+  String? _pubRootDirectoryForGoogle3(List<String> pathParts) {
+    final strippedParts = stripGoogle3(pathParts);
+    if (strippedParts.isEmpty) return null;
+
+    final topLevelDirectory = strippedParts.first;
+    if (topLevelDirectory == _thirdPartyPathSegment &&
+        strippedParts.length >= 2) {
+      return '/${strippedParts.sublist(0, 2).join('/')}';
+    } else {
+      return '/${strippedParts.first}';
+    }
+  }
+
+  Future<void> _cachePubRootDirectories(
+    List<String> pubRootDirectories,
+  ) async {
+    final cachedDirectories = await readCachedPubRootDirectories();
+    await storage.setValue(
+      _customPubRootStorageId(),
+      jsonEncode([
+        ...cachedDirectories,
+        ...pubRootDirectories,
+      ]),
+    );
+  }
+
+  Future<void> _uncachePubRootDirectories(
+    List<String> pubRootDirectories,
+  ) async {
+    final directoriesToCache = (await readCachedPubRootDirectories())
+        .where((dir) => !pubRootDirectories.contains(dir))
+        .toList();
+    await storage.setValue(
+      _customPubRootStorageId(),
+      jsonEncode(directoriesToCache),
+    );
+  }
+
+  Future<void> addPubRootDirectories(
+    List<String> pubRootDirectories, {
+    bool shouldCache = false,
+  }) async {
+    // TODO(https://github.com/flutter/devtools/issues/4380):
+    // Add validation to EditableList Input.
+    // Directories of just / will break the inspector tree local package checks.
+    pubRootDirectories.removeWhere(
+      (element) => RegExp('^[/\\s]*\$').firstMatch(element) != null,
+    );
+
+    if (!serviceConnection.serviceManager.hasConnection) return;
+    await _pubRootDirectoryBusyTracker(() async {
+      final localInspectorService = _inspectorService;
+      if (localInspectorService is! InspectorService) return;
+
+      await localInspectorService.addPubRootDirectories(pubRootDirectories);
+      if (shouldCache) {
+        await _cachePubRootDirectories(pubRootDirectories);
+      }
+      await _refreshPubRootDirectoriesFromService();
+    });
+  }
+
+  Future<void> removePubRootDirectories(
+    List<String> pubRootDirectories,
+  ) async {
+    if (!serviceConnection.serviceManager.hasConnection) return;
+    await _pubRootDirectoryBusyTracker(() async {
+      final localInspectorService = _inspectorService;
+      if (localInspectorService is! InspectorService) return;
+
+      await localInspectorService.removePubRootDirectories(pubRootDirectories);
+      await _uncachePubRootDirectories(pubRootDirectories);
+      await _refreshPubRootDirectoriesFromService();
+    });
+  }
+
+  Future<void> _refreshPubRootDirectoriesFromService() async {
+    await _pubRootDirectoryBusyTracker(() async {
+      final localInspectorService = _inspectorService;
+      if (localInspectorService is! InspectorService) return;
+
+      final freshPubRootDirectories =
+          await localInspectorService.getPubRootDirectories();
+      if (freshPubRootDirectories != null) {
+        final newSet = Set<String>.of(freshPubRootDirectories);
+        final oldSet = Set<String>.of(_pubRootDirectories.value);
+        final directoriesToAdd = newSet.difference(oldSet);
+        final directoriesToRemove = oldSet.difference(newSet);
+
+        _pubRootDirectories
+          ..removeAll(directoriesToRemove)
+          ..addAll(directoriesToAdd);
+      }
+    });
+  }
+
+  String _customPubRootStorageId() {
+    assert(_mainScriptDir != null);
+    final packageId = _mainScriptDir ?? '_fallback';
+    return '${_customPubRootDirectoriesStoragePrefix}_$packageId';
+  }
+
+  Future<void> _pubRootDirectoryBusyTracker(
+    Future<void> Function() callback,
+  ) async {
+    try {
+      _busyCounter.value++;
+      await callback();
+    } finally {
+      _busyCounter.value--;
+    }
+  }
+
+  /// Change the value for the hover eval mode setting.
+  void setHoverEvalMode(bool enableHoverEvalMode) {
+    _hoverEvalMode.value = enableHoverEvalMode;
+  }
+
+  void setDefaultInspectorDetailsView(InspectorV2DetailsViewType value) {
+    _defaultDetailsView.value = value;
+  }
+}

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -21,6 +21,7 @@ import '../utils.dart';
 
 part '_extension_preferences.dart';
 part '_inspector_preferences.dart';
+part '_inspector_v2_preferences.dart';
 part '_memory_preferences.dart';
 part '_performance_preferences.dart';
 
@@ -37,8 +38,13 @@ class PreferencesController extends DisposableController
       ValueNotifier<bool>(Logger.root.level == verboseLoggingLevel);
   static const _verboseLoggingStorageId = 'verboseLogging';
 
+  // TODO(https://github.com/flutter/devtools/issues/7860): Clean-up after
+  // Inspector V2 has been released.
   InspectorPreferencesController get inspector => _inspector;
   final _inspector = InspectorPreferencesController();
+
+  InspectorV2PreferencesController get inspectorV2 => _inspectorV2;
+  final _inspectorV2 = InspectorV2PreferencesController();
 
   MemoryPreferencesController get memory => _memory;
   final _memory = MemoryPreferencesController();


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/7861

This PR:
- Forks the inspector panel
- Hides the V2 fork behind a new feature flag `inspectorV2`

Currently the only change between the current inspector panel and the forked version is that the forked version has appends "2.0" to the Widget Tree, Layout Explorer, and Widget Details Tree:

<img width="799" alt="Screenshot 2024-05-30 at 1 50 32 PM" src="https://github.com/flutter/devtools/assets/21270878/54a1b313-e260-4a96-b172-d4536abf2207">

Follow up will be forking the inspector tests as well
