### PR TITLE
Enable prefer_final_in_for_each for consistency

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -102,6 +102,7 @@ linter:
     - prefer_contains
     # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
     - prefer_final_fields
+    - prefer_final_in_for_each
     - prefer_final_locals
     - prefer_foreach
     # - prefer_function_declarations_over_variables # not yet tested

--- a/packages/devtools_app/lib/src/framework/app_bar.dart
+++ b/packages/devtools_app/lib/src/framework/app_bar.dart
@@ -65,7 +65,7 @@ class DevToolsAppBar extends StatelessWidget {
         isScrollable: true,
         labelPadding: EdgeInsets.zero,
         tabs: [
-          for (var screen in visibleScreens)
+          for (final screen in visibleScreens)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: tabBarSpacing),
               child: screen.buildTab(context),
@@ -73,7 +73,7 @@ class DevToolsAppBar extends StatelessWidget {
           // We need to include a widget in the tab bar for the overflow screens
           // because the [_tabController] expects a length equal to the total
           // number of screens, hidden or not.
-          for (var _ in overflowScreens) const SizedBox.shrink(),
+          for (final _ in overflowScreens) const SizedBox.shrink(),
         ],
       );
 

--- a/packages/devtools_app/lib/src/framework/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold.dart
@@ -276,7 +276,7 @@ class DevToolsScaffoldState extends State<DevToolsScaffold>
   Widget build(BuildContext context) {
     // Build the screens for each tab and wrap them in the appropriate styling.
     final tabBodies = [
-      for (var screen in widget.screens)
+      for (final screen in widget.screens)
         Align(
           alignment: Alignment.topLeft,
           child: FocusScope(

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -687,7 +687,7 @@ class AppSizeController {
     int totalByteSize = 0;
 
     // Given a child, build its subtree.
-    for (Map<String, dynamic> child in rawChildren) {
+    for (final Map<String, dynamic> child in rawChildren) {
       final childTreemapNode = showDiff
           ? generateDiffTree(child, diffTreeType!)
           : generateTree(child);
@@ -721,7 +721,7 @@ class AppSizeController {
     }
     final childrenMap = <String, TreemapNode>{};
 
-    for (TreemapNode child in children) {
+    for (final TreemapNode child in children) {
       childrenMap[child.name] = child;
     }
 

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -721,7 +721,7 @@ class AppSizeController {
     }
     final childrenMap = <String, TreemapNode>{};
 
-    for (final TreemapNode child in children) {
+    for (final child in children) {
       childrenMap[child.name] = child;
     }
 

--- a/packages/devtools_app/lib/src/screens/app_size/code_size_attribution.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/code_size_attribution.dart
@@ -336,7 +336,7 @@ class DominatorTreeNode extends TreeNode<DominatorTreeNode> {
 
   factory DominatorTreeNode.from(CallGraphNode cgNode) {
     final domNode = DominatorTreeNode._(cgNode);
-    for (var dominated in cgNode.dominated) {
+    for (final dominated in cgNode.dominated) {
       domNode.addChild(DominatorTreeNode.from(dominated));
     }
     return domNode;

--- a/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoint_manager.dart
@@ -298,10 +298,10 @@ class BreakpointManager with DisposerMixin {
 
     final positions = <SourcePosition>[];
 
-    for (SourceReportRange range in report.ranges!) {
+    for (final range in report.ranges!) {
       final possibleBreakpoints = range.possibleBreakpoints;
       if (possibleBreakpoints != null) {
-        for (int tokenPos in possibleBreakpoints) {
+        for (final tokenPos in possibleBreakpoints) {
           positions.add(SourcePosition.calculatePosition(script, tokenPos));
         }
       }
@@ -361,7 +361,7 @@ class BreakpointManager with DisposerMixin {
       case EventKind.kBreakpointResolved:
         final breakpoint = event.breakpoint!;
         _breakpoints.value = [
-          for (var b in _breakpoints.value)
+          for (final b in _breakpoints.value)
             if (b != event.breakpoint) b,
           breakpoint,
         ];
@@ -393,12 +393,12 @@ class BreakpointManager with DisposerMixin {
         final breakpoint = event.breakpoint;
 
         _breakpoints.value = [
-          for (var b in _breakpoints.value)
+          for (final b in _breakpoints.value)
             if (b != breakpoint) b,
         ];
 
         _breakpointsWithLocation.value = [
-          for (var b in _breakpointsWithLocation.value)
+          for (final b in _breakpointsWithLocation.value)
             if (b.breakpoint != breakpoint) b,
         ];
 

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -258,7 +258,7 @@ class BreakOnExceptionsControl extends StatelessWidget {
                 },
           isDense: true,
           items: [
-            for (var mode in ExceptionMode.modes)
+            for (final mode in ExceptionMode.modes)
               DropdownMenuItem<ExceptionMode>(
                 value: mode,
                 child: Text(

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
@@ -263,12 +263,12 @@ class FileNode extends TreeNode<FileNode> {
     // The name of this node is not exposed to users.
     final root = FileNode('<root>');
 
-    for (var script in scripts) {
+    for (final script in scripts) {
       final directoryParts = ScriptRefUtils.splitDirectoryParts(script);
 
       FileNode node = root;
 
-      for (var name in directoryParts) {
+      for (final name in directoryParts) {
         node = node._getCreateChild(name);
       }
 
@@ -294,7 +294,7 @@ class FileNode extends TreeNode<FileNode> {
   void _trimChildrenAsMapEntries() {
     _childrenAsMap.clear();
 
-    for (var child in children) {
+    for (final child in children) {
       child._trimChildrenAsMapEntries();
     }
   }

--- a/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/program_explorer_model.dart
@@ -376,7 +376,7 @@ class VMServiceObjectNode extends TreeNode<VMServiceObjectNode> {
   void _trimChildrenAsMapEntries() {
     _childrenAsMap.clear();
 
-    for (var child in children) {
+    for (final child in children) {
       child._trimChildrenAsMapEntries();
     }
   }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -158,7 +158,7 @@ class DeepLinksController extends DisposableController {
   @visibleForTesting
   List<LinkData> linkDatasByPath(List<LinkData> linkdatas) {
     final linkDatasByPath = <String, LinkData>{};
-    for (var linkData in linkdatas) {
+    for (final linkData in linkdatas) {
       final previousRecord = linkDatasByPath[linkData.path];
       linkDatasByPath[linkData.path] = LinkData(
         domain: linkData.domain,
@@ -186,7 +186,7 @@ class DeepLinksController extends DisposableController {
   @visibleForTesting
   List<LinkData> linkDatasByDomain(List<LinkData> linkdatas) {
     final linkDatasByDomain = <String, LinkData>{};
-    for (var linkData in linkdatas) {
+    for (final linkData in linkdatas) {
       if (linkData.domain.isNullOrEmpty) {
         continue;
       }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -63,7 +63,7 @@ class DeepLinksServices {
     required String? localFingerprint,
   }) async {
     final domainErrors = <String, List<DomainError>>{
-      for (var domain in domains) domain: <DomainError>[],
+      for (final domain in domains) domain: <DomainError>[],
     };
 
     // The request can take 1000 domains at most, make a few calls in serial with a batch of _domainBatchSize.

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
@@ -68,11 +68,11 @@ List<double> computeRenderSizes({
     // and we can just divide the size evenly
     // but it should be at least as big as [smallestRenderSize]
     final renderSize = math.max(smallestRenderSize, maxSizeAvailable / n);
-    return [for (var _ in sizes) renderSize];
+    return [for (final _ in sizes) renderSize];
   }
 
   List<double> transformToRenderSize(double largestRenderSize) => [
-        for (var s in sizes)
+        for (final s in sizes)
           (s - smallestSize) *
                   (largestRenderSize - smallestRenderSize) /
                   (largestSize - smallestSize) +
@@ -84,7 +84,7 @@ List<double> computeRenderSizes({
   if (useMaxSizeAvailable && sum(renderSizes) < maxSizeAvailable) {
     largestRenderSize = (maxSizeAvailable - n * smallestRenderSize) *
             (largestSize - smallestSize) /
-            sum([for (var s in sizes) s - smallestSize]) +
+            sum([for (final s in sizes) s - smallestSize]) +
         smallestRenderSize;
     renderSizes = transformToRenderSize(largestRenderSize);
   }
@@ -108,7 +108,7 @@ class LayoutProperties {
                   (child) => LayoutProperties(child, copyLevel: copyLevel - 1),
                 )
                 .toList(growable: false) {
-    for (var child in children) {
+    for (final child in children) {
       child.parent = this;
     }
   }
@@ -123,7 +123,7 @@ class LayoutProperties {
     required this.size,
     required this.flexFit,
   }) {
-    for (var child in children) {
+    for (final child in children) {
       child.parent = this;
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -582,7 +582,7 @@ class InspectorTreeController extends DisposableController
     }
     final inlineProperties = parent.inlineProperties;
 
-    for (final RemoteDiagnosticsNode property in inlineProperties) {
+    for (final property in inlineProperties) {
       appendChild(
         treeNode,
         setupInspectorTreeNode(
@@ -596,7 +596,7 @@ class InspectorTreeController extends DisposableController
       );
     }
     if (children != null) {
-      for (final RemoteDiagnosticsNode child in children) {
+      for (final child in children) {
         appendChild(
           treeNode,
           setupInspectorTreeNode(

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -147,13 +147,13 @@ class InspectorTreeController extends DisposableController
   // Method defined to avoid a direct Flutter dependency.
   void setState(VoidCallback fn) {
     fn();
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.onChanged();
     }
   }
 
   void requestFocus() {
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.requestFocus();
     }
   }
@@ -468,7 +468,7 @@ class InspectorTreeController extends DisposableController
   }
 
   void scrollToRect(Rect targetRect) {
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.scrollToRect(targetRect);
     }
   }
@@ -499,7 +499,7 @@ class InspectorTreeController extends DisposableController
   void animateToTargets(List<InspectorTreeNode> targets) {
     Rect? targetRect;
 
-    for (InspectorTreeNode target in targets) {
+    for (final target in targets) {
       final row = getRowForNode(target);
       if (row != null) {
         final rowRect = getBoundingBox(row);
@@ -582,7 +582,7 @@ class InspectorTreeController extends DisposableController
     }
     final inlineProperties = parent.inlineProperties;
 
-    for (RemoteDiagnosticsNode property in inlineProperties) {
+    for (final RemoteDiagnosticsNode property in inlineProperties) {
       appendChild(
         treeNode,
         setupInspectorTreeNode(
@@ -596,7 +596,7 @@ class InspectorTreeController extends DisposableController
       );
     }
     if (children != null) {
-      for (RemoteDiagnosticsNode child in children) {
+      for (final RemoteDiagnosticsNode child in children) {
         appendChild(
           treeNode,
           setupInspectorTreeNode(
@@ -1133,7 +1133,7 @@ class _RowPainter extends CustomPainter {
 
     final InspectorTreeNode node = row.node;
     final bool showExpandCollapse = node.showExpandCollapse;
-    for (int tick in row.ticks) {
+    for (final int tick in row.ticks) {
       currentX = _controller.getDepthIndent(tick) - inspectorColumnWidth * 0.5;
       // Draw a vertical line for each tick identifying a connection between
       // an ancestor of this node and some other node in the tree.

--- a/packages/devtools_app/lib/src/screens/inspector/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/layout_explorer/box/box.dart
@@ -135,7 +135,7 @@ class BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
     final length = sizes.length;
     double total = 1.0; // This isn't set to zero to avoid divide by zero bugs.
     final fractions = minFractions.toList();
-    for (var size in sizes) {
+    for (final size in sizes) {
       if (size != null) {
         total += math.max(0, size);
       }
@@ -157,7 +157,7 @@ class BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
       }
     }
     final output = <double>[];
-    for (var fraction in fractions) {
+    for (final fraction in fractions) {
       output.add(fraction * availableSize);
     }
     return output;

--- a/packages/devtools_app/lib/src/screens/inspector/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/layout_explorer/flex/flex.dart
@@ -155,7 +155,7 @@ class FlexLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
               : colorScheme.crossAxisColor,
           selectedItemBuilder: (context) {
             return [
-              for (var alignment in alignmentEnumEntries)
+              for (final alignment in alignmentEnumEntries)
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -190,7 +190,7 @@ class FlexLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
             ];
           },
           items: [
-            for (var alignment in alignmentEnumEntries)
+            for (final alignment in alignmentEnumEntries)
               DropdownMenuItem(
                 value: alignment,
                 child: Container(
@@ -510,7 +510,7 @@ class _VisualizeFlexChildrenState extends State<VisualizeFlexChildren> {
           }
 
           final freeSpacesWidgets = [
-            for (var renderProperties in [
+            for (final renderProperties in [
               ...mainAxisSpaces,
               ...crossAxisSpaces,
             ])

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -68,11 +68,11 @@ List<double> computeRenderSizes({
     // and we can just divide the size evenly
     // but it should be at least as big as [smallestRenderSize]
     final renderSize = math.max(smallestRenderSize, maxSizeAvailable / n);
-    return [for (var _ in sizes) renderSize];
+    return [for (final _ in sizes) renderSize];
   }
 
   List<double> transformToRenderSize(double largestRenderSize) => [
-        for (var s in sizes)
+        for (final s in sizes)
           (s - smallestSize) *
                   (largestRenderSize - smallestRenderSize) /
                   (largestSize - smallestSize) +
@@ -84,7 +84,7 @@ List<double> computeRenderSizes({
   if (useMaxSizeAvailable && sum(renderSizes) < maxSizeAvailable) {
     largestRenderSize = (maxSizeAvailable - n * smallestRenderSize) *
             (largestSize - smallestSize) /
-            sum([for (var s in sizes) s - smallestSize]) +
+            sum([for (final s in sizes) s - smallestSize]) +
         smallestRenderSize;
     renderSizes = transformToRenderSize(largestRenderSize);
   }
@@ -108,7 +108,7 @@ class LayoutProperties {
                   (child) => LayoutProperties(child, copyLevel: copyLevel - 1),
                 )
                 .toList(growable: false) {
-    for (var child in children) {
+    for (final child in children) {
       child.parent = this;
     }
   }
@@ -123,7 +123,7 @@ class LayoutProperties {
     required this.size,
     required this.flexFit,
   }) {
-    for (var child in children) {
+    for (final child in children) {
       child.parent = this;
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -147,13 +147,13 @@ class InspectorTreeController extends DisposableController
   // Method defined to avoid a direct Flutter dependency.
   void setState(VoidCallback fn) {
     fn();
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.onChanged();
     }
   }
 
   void requestFocus() {
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.requestFocus();
     }
   }
@@ -468,7 +468,7 @@ class InspectorTreeController extends DisposableController
   }
 
   void scrollToRect(Rect targetRect) {
-    for (var client in _clients) {
+    for (final client in _clients) {
       client.scrollToRect(targetRect);
     }
   }
@@ -499,7 +499,7 @@ class InspectorTreeController extends DisposableController
   void animateToTargets(List<InspectorTreeNode> targets) {
     Rect? targetRect;
 
-    for (InspectorTreeNode target in targets) {
+    for (final target in targets) {
       final row = getRowForNode(target);
       if (row != null) {
         final rowRect = getBoundingBox(row);
@@ -582,7 +582,7 @@ class InspectorTreeController extends DisposableController
     }
     final inlineProperties = parent.inlineProperties;
 
-    for (RemoteDiagnosticsNode property in inlineProperties) {
+    for (final property in inlineProperties) {
       appendChild(
         treeNode,
         setupInspectorTreeNode(
@@ -596,7 +596,7 @@ class InspectorTreeController extends DisposableController
       );
     }
     if (children != null) {
-      for (RemoteDiagnosticsNode child in children) {
+      for (final child in children) {
         appendChild(
           treeNode,
           setupInspectorTreeNode(
@@ -1133,7 +1133,7 @@ class _RowPainter extends CustomPainter {
 
     final InspectorTreeNode node = row.node;
     final bool showExpandCollapse = node.showExpandCollapse;
-    for (int tick in row.ticks) {
+    for (final tick in row.ticks) {
       currentX = _controller.getDepthIndent(tick) - inspectorColumnWidth * 0.5;
       // Draw a vertical line for each tick identifying a connection between
       // an ancestor of this node and some other node in the tree.

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
@@ -135,7 +135,7 @@ class BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
     final length = sizes.length;
     double total = 1.0; // This isn't set to zero to avoid divide by zero bugs.
     final fractions = minFractions.toList();
-    for (var size in sizes) {
+    for (final size in sizes) {
       if (size != null) {
         total += math.max(0, size);
       }
@@ -157,7 +157,7 @@ class BoxLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
       }
     }
     final output = <double>[];
-    for (var fraction in fractions) {
+    for (final fraction in fractions) {
       output.add(fraction * availableSize);
     }
     return output;

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/flex.dart
@@ -155,7 +155,7 @@ class FlexLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
               : colorScheme.crossAxisColor,
           selectedItemBuilder: (context) {
             return [
-              for (var alignment in alignmentEnumEntries)
+              for (final alignment in alignmentEnumEntries)
                 Row(
                   mainAxisAlignment: MainAxisAlignment.center,
                   children: [
@@ -190,7 +190,7 @@ class FlexLayoutExplorerWidgetState extends LayoutExplorerWidgetState<
             ];
           },
           items: [
-            for (var alignment in alignmentEnumEntries)
+            for (final alignment in alignmentEnumEntries)
               DropdownMenuItem(
                 value: alignment,
                 child: Container(
@@ -510,7 +510,7 @@ class _VisualizeFlexChildrenState extends State<VisualizeFlexChildren> {
           }
 
           final freeSpacesWidgets = [
-            for (var renderProperties in [
+            for (final renderProperties in [
               ...mainAxisSpaces,
               ...crossAxisSpaces,
             ])

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -480,12 +480,12 @@ class LoggingController extends DisposableController
       return node;
     }
     RemoteDiagnosticsNode? summary;
-    for (var property in node.inlineProperties) {
+    for (final property in node.inlineProperties) {
       summary = _findFirstSummary(property);
       if (summary != null) return summary;
     }
 
-    for (RemoteDiagnosticsNode child in node.childrenNow) {
+    for (final child in node.childrenNow) {
       summary = _findFirstSummary(child);
       if (summary != null) return summary;
     }

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_controller_v2.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_controller_v2.dart
@@ -408,7 +408,7 @@ class LoggingControllerV2 extends DisposableController
       if (summary != null) return summary;
     }
 
-    for (final RemoteDiagnosticsNode child in node.childrenNow) {
+    for (final child in node.childrenNow) {
       summary = _findFirstSummary(child);
       if (summary != null) return summary;
     }

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_controller_v2.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_controller_v2.dart
@@ -403,12 +403,12 @@ class LoggingControllerV2 extends DisposableController
       return node;
     }
     RemoteDiagnosticsNode? summary;
-    for (var property in node.inlineProperties) {
+    for (final property in node.inlineProperties) {
       summary = _findFirstSummary(property);
       if (summary != null) return summary;
     }
 
-    for (RemoteDiagnosticsNode child in node.childrenNow) {
+    for (final RemoteDiagnosticsNode child in node.childrenNow) {
       summary = _findFirstSummary(child);
       if (summary != null) return summary;
     }

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
@@ -137,7 +137,7 @@ class MemoryTracker {
 
     _isolateHeaps.clear();
 
-    for (final IsolateRef isolateRef in isolateMemory.keys) {
+    for (final isolateRef in isolateMemory.keys) {
       _isolateHeaps[isolateRef.id!] = isolateMemory[isolateRef]!;
     }
 

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
@@ -90,7 +90,7 @@ class MemoryTracker {
 
   Future<void> pollMemory() async {
     final isolateMemory = <IsolateRef, MemoryUsage>{};
-    for (IsolateRef isolateRef
+    for (final isolateRef
         in serviceConnection.serviceManager.isolateManager.isolates.value) {
       if (await _isIsolateLive(isolateRef.id!)) {
         isolateMemory[isolateRef] = await serviceConnection
@@ -137,7 +137,7 @@ class MemoryTracker {
 
     _isolateHeaps.clear();
 
-    for (IsolateRef isolateRef in isolateMemory.keys) {
+    for (final IsolateRef isolateRef in isolateMemory.keys) {
       _isolateHeaps[isolateRef.id!] = isolateMemory[isolateRef]!;
     }
 

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/data/charts.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/data/charts.dart
@@ -238,7 +238,8 @@ class ChartsValues {
 
     if (eventInfo.hasExtensionEvents) {
       final events = <Map<String, Object>>[];
-      for (ExtensionEvent event in eventInfo.extensionEvents?.events ?? []) {
+      for (final event
+          in eventInfo.extensionEvents?.events ?? <ExtensionEvent>[]) {
         if (event.customEventName != null) {
           events.add(
             {

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/widgets/chart_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/widgets/chart_pane.dart
@@ -91,7 +91,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
       if (details == null) return;
 
       final copied = TapLocation.copy(value);
-      for (var location in allLocations) {
+      for (final location in allLocations) {
         if (location != tapLocation) location.value = copied;
       }
 
@@ -130,7 +130,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
       widget.chart.android.tapLocation,
     ];
 
-    for (var location in allLocations) {
+    for (final location in allLocations) {
       _addTapLocationListener(location, allLocations);
     }
 
@@ -341,7 +341,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
 
     if (firstWidget != null) results.add(firstWidget);
 
-    for (var entry in dataToDisplay.entries) {
+    for (final entry in dataToDisplay.entries) {
       final keys = entry.value.keys;
       final image = keys.contains(renderImage)
           ? entry.value[renderImage] as String?
@@ -471,7 +471,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
     final colorScheme = Theme.of(context).colorScheme;
     final eventsDisplayed = chartsValues.eventsToDisplay(colorScheme.isLight);
 
-    for (var entry in eventsDisplayed.entries) {
+    for (final entry in eventsDisplayed.entries) {
       final widget = _hoverRow(name: ' ${entry.key}', image: entry.value);
       results.add(widget);
     }
@@ -486,7 +486,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
 
     final widgets = <Widget>[];
     var index = 1;
-    for (var event in allEvents) {
+    for (final event in allEvents) {
       late String? name;
       if (event[eventName] == devToolsEvent && event.containsKey(customEvent)) {
         final custom = event[customEvent] as Map<dynamic, dynamic>;
@@ -567,7 +567,7 @@ class _MemoryChartPaneState extends State<MemoryChartPane>
         event.containsKey(customEvent)) {
       final custom = event[customEvent] as Map<Object?, Object?>;
       final data = custom[customEventData] as Map<Object?, Object?>;
-      for (var key in data.keys) {
+      for (final key in data.keys) {
         output.write('$key=');
         output.writeln(_longValueToShort(data[key] as String));
       }

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/data/classes_diff.dart
@@ -21,7 +21,7 @@ class ObjectSetDiff {
 
     final allCodes = mapBefore.keys.toSet().union(mapAfter.keys.toSet());
 
-    for (var code in allCodes) {
+    for (final code in allCodes) {
       final before = mapBefore[code];
       final after = mapAfter[code];
 
@@ -88,7 +88,7 @@ class ObjectSetDiff {
   ) {
     if (ids == null || data == null) return const {};
     return {
-      for (var id in ids.indexes) data.graph.objects[id].identityHashCode: id,
+      for (final id in ids.indexes) data.graph.objects[id].identityHashCode: id,
     };
   }
 

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/data/csv.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/data/csv.dart
@@ -20,8 +20,8 @@ String classesToCsv(Iterable<ClassData> classes) {
     ].map((e) => '"$e"').join(','),
   );
 
-  for (var classData in classes) {
-    for (var pathStats in classData.byPath.entries) {
+  for (final classData in classes) {
+    for (final pathStats in classData.byPath.entries) {
       csvBuffer.writeln(
         [
           classData.className.className,

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/widgets/classes_table_diff.dart
@@ -303,7 +303,7 @@ class ClassesTableDiff extends StatelessWidget {
     required this.diffData,
   }) {
     _columns = {
-      for (var sizeType in SizeType.values)
+      for (final sizeType in SizeType.values)
         sizeType: ClassesTableDiffColumns(sizeType, diffData),
     };
   }

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
@@ -111,7 +111,7 @@ class TracingIsolateState with Serializable {
     String? selectedClass,
   }) {
     this.classes = classes ?? [];
-    classesById = {for (var e in this.classes) e.clazz.id!: e};
+    classesById = {for (final e in this.classes) e.clazz.id!: e};
     this.profiles = profiles ?? {};
   }
 

--- a/packages/devtools_app/lib/src/screens/memory/shared/heap/class_filter.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/heap/class_filter.dart
@@ -194,7 +194,7 @@ class ClassFilter with Serializable {
 
     if (filterType == ClassFilterType.showAll) return true;
 
-    for (var filter in filters) {
+    for (final filter in filters) {
       if (_isMatch(className, filter, rootPackage)) {
         return filterType == ClassFilterType.only;
       }

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -122,7 +122,7 @@ class LocationMap {
   }
 
   void processLocationMap(Map<String, dynamic> json) {
-    for (final String path in json.keys) {
+    for (final path in json.keys) {
       final entries = (json[path]! as Map).cast<String, List<Object?>>();
 
       final ids = entries[_idsKey]!.cast<int>();
@@ -214,7 +214,7 @@ class RebuildCountModel {
 
     _rebuildsForFrame.forEach((id, rebuilds) {
       final events = <int>[];
-      for (final RebuildLocation rebuild in rebuilds) {
+      for (final rebuild in rebuilds) {
         events
           ..add(rebuild.location.id)
           ..add(rebuild.buildCount);

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats_model.dart
@@ -93,7 +93,7 @@ class LocationMap {
   Map<String, Object> toJson() {
     final json = <String, Object>{};
     final pathToLocations = <String, List<Location>>{};
-    for (var location in _locationMap.values) {
+    for (final location in _locationMap.values) {
       if (location.isResolved) {
         pathToLocations
             .putIfAbsent(location.fileUriString!, () => <Location>[])
@@ -105,7 +105,7 @@ class LocationMap {
       final lines = <int>[];
       final columns = <int>[];
       final names = <String>[];
-      for (var location in locations) {
+      for (final location in locations) {
         ids.add(location.id);
         lines.add(location.line!);
         columns.add(location.column!);
@@ -214,7 +214,7 @@ class RebuildCountModel {
 
     _rebuildsForFrame.forEach((id, rebuilds) {
       final events = <int>[];
-      for (RebuildLocation rebuild in rebuilds) {
+      for (final RebuildLocation rebuild in rebuilds) {
         events
           ..add(rebuild.location.id)
           ..add(rebuild.buildCount);
@@ -319,7 +319,7 @@ List<RebuildLocationStats> combineStats(
   final output = <Location, RebuildLocationStats>{};
   for (int i = 0; i < rebuildStats.length; i++) {
     final statsForIndex = rebuildStats[i];
-    for (var entry in statsForIndex) {
+    for (final entry in statsForIndex) {
       output
           .putIfAbsent(
             entry.location,

--- a/packages/devtools_app/lib/src/screens/performance/performance_model.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_model.dart
@@ -160,7 +160,7 @@ class FlutterTimelineEvent extends TreeNode<FlutterTimelineEvent> {
   FlutterTimelineEvent deepCopy() {
     final copy = shallowCopy();
     copy.parent = parent;
-    for (FlutterTimelineEvent child in children) {
+    for (final child in children) {
       copy.addChild(child.deepCopy());
     }
     return copy;
@@ -177,7 +177,7 @@ class FlutterTimelineEvent extends TreeNode<FlutterTimelineEvent> {
     final begin = trackEvents.first;
     final end = trackEvents.safeLast;
     buf.writeln(begin.toString());
-    for (FlutterTimelineEvent child in children) {
+    for (final child in children) {
       child.writeTrackEventsToBuffer(buf);
     }
     if (end != null) {
@@ -187,7 +187,7 @@ class FlutterTimelineEvent extends TreeNode<FlutterTimelineEvent> {
 
   void format(StringBuffer buf, String indent) {
     buf.writeln('$indent$name $time');
-    for (FlutterTimelineEvent child in children) {
+    for (final child in children) {
       child.format(buf, '  $indent');
     }
   }

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -625,7 +625,7 @@ class CpuProfileData with Serializable {
       urisWithoutPackageUri.toList(),
     );
 
-    for (var stackFrameJson in stackFramesWaitingOnPackageUri) {
+    for (final stackFrameJson in stackFramesWaitingOnPackageUri) {
       final resolvedUri =
           stackFrameJson[CpuProfileData.resolvedUrlKey] as String;
       final packageUri = serviceConnection.serviceManager.resolvedUriManager
@@ -1032,7 +1032,7 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
   @override
   CpuStackFrame deepCopy() {
     final copy = shallowCopy();
-    for (CpuStackFrame child in children) {
+    for (final child in children) {
       copy.addChild(child.deepCopy());
     }
     return copy;

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -129,7 +129,7 @@ class CpuProfileTransformer {
   }
 
   void _setExclusiveSampleCountsAndTags(CpuProfileData cpuProfileData) {
-    for (CpuSampleEvent sample in cpuProfileData.cpuSamples) {
+    for (final sample in cpuProfileData.cpuSamples) {
       final leafId = sample.leafId;
       final stackFrame = cpuProfileData.stackFrames[leafId];
       assert(

--- a/packages/devtools_app/lib/src/screens/profiler/panes/cpu_flame_chart.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/cpu_flame_chart.dart
@@ -70,7 +70,7 @@ class _CpuProfileFlameChartState
 
       rows[row].addNode(node);
 
-      for (CpuStackFrame child in stackFrame.children) {
+      for (final child in stackFrame.children) {
         createChartNodes(child, row + 1);
       }
     }

--- a/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/vm_developer_common_widgets.dart
@@ -442,7 +442,7 @@ class RetainingPathWidget extends StatelessWidget {
         ],
       ),
       if (retainingPath.elements!.length > 1)
-        for (RetainingObject object in retainingPath.elements!.sublist(1))
+        for (final object in retainingPath.elements!.sublist(1))
           Row(
             children: [
               Flexible(

--- a/packages/devtools_app/lib/src/service/service_extension_widgets.dart
+++ b/packages/devtools_app/lib/src/service/service_extension_widgets.dart
@@ -79,9 +79,9 @@ class _ServiceExtensionButtonGroupState
   void _onMainIsolateChanged() => _initExtensionState();
 
   void _initExtensionState() {
-    _extensionStates = [for (var e in widget.extensions) ExtensionState(e)];
+    _extensionStates = [for (final e in widget.extensions) ExtensionState(e)];
 
-    for (var extension in _extensionStates) {
+    for (final extension in _extensionStates) {
       // Listen for changes to the state of each service extension using the
       // VMServiceManager.
       final extensionName = extension.description.extension;
@@ -128,10 +128,10 @@ class _ServiceExtensionButtonGroupState
     return SizedBox(
       height: defaultButtonHeight,
       child: DevToolsToggleButtonGroup(
-        selectedStates: [for (var e in _extensionStates) e.isSelected],
+        selectedStates: [for (final e in _extensionStates) e.isSelected],
         onPressed: available ? _onPressed : null,
         children: <Widget>[
-          for (var extensionState in _extensionStates)
+          for (final extensionState in _extensionStates)
             ServiceExtensionButton(
               extensionState: extensionState,
               minScreenWidthForTextBeforeScaling:

--- a/packages/devtools_app/lib/src/service/vm_flags.dart
+++ b/packages/devtools_app/lib/src/service/vm_flags.dart
@@ -35,7 +35,7 @@ class VmFlagManager with DisposerMixin {
     final flagList = await service.getFlagList();
     _flags.value = flagList;
 
-    for (var flag in flagList.flags ?? <Flag>[]) {
+    for (final flag in flagList.flags ?? <Flag>[]) {
       _flagNotifiers[flag.name ?? ''] = ValueNotifier<Flag>(flag);
     }
   }

--- a/packages/devtools_app/lib/src/shared/charts/chart.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart.dart
@@ -384,7 +384,7 @@ class ChartPainter extends CustomPainter {
         chartController.zeroYPosition + 1,
         (canvas) {
           // Draw the X-axis labels.
-          for (var timestamp in chartController.labelTimestamps) {
+          for (final timestamp in chartController.labelTimestamps) {
             final xCoord = chartController.timestampToXCanvasCoord(timestamp);
             drawXTick(canvas, timestamp, xCoord, axis, displayTime: true);
           }

--- a/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart_controller.dart
@@ -386,7 +386,7 @@ class ChartController extends DisposableController
 
   /// Clear all data in the chart.
   void reset() {
-    for (var trace in traces) {
+    for (final trace in traces) {
       trace.clearData();
     }
     timestampsClear();

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_file_desktop.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_file_desktop.dart
@@ -84,7 +84,7 @@ class FileSystemDesktop {
       }
 
       final allFiles = directory.listSync(followLinks: false);
-      for (FileSystemEntity entry in allFiles) {
+      for (final entry in allFiles) {
         final basename = path.basename(entry.path);
         if (_fs.isFileSync(entry.path) && basename.startsWith(prefix)) {
           logs.add(basename);

--- a/packages/devtools_app/lib/src/shared/connection_info.dart
+++ b/packages/devtools_app/lib/src/shared/connection_info.dart
@@ -70,7 +70,7 @@ class _ConnectionDescriptionColumn extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        for (var entry in entries)
+        for (final entry in entries)
           Padding(
             padding: EdgeInsets.only(
               bottom: entry == entries.last ? 0.0 : denseRowSpacing,

--- a/packages/devtools_app/lib/src/shared/console/eval/auto_complete.dart
+++ b/packages/devtools_app/lib/src/shared/console/eval/auto_complete.dart
@@ -142,7 +142,7 @@ Future<Set<String>> _libraryMemberAndImportsAutocompletes(
     final dependencies = library.dependencies;
 
     if (dependencies != null) {
-      for (var dependency in library.dependencies!) {
+      for (final dependency in library.dependencies!) {
         final prefix = dependency.prefix;
         final target = dependency.target;
         if (prefix != null && prefix.isNotEmpty) {
@@ -211,7 +211,7 @@ Future<Set<String>> _libraryMemberAutocompletes(
 
   if (debugIncludeExports) {
     final List<Future<Set<String>>> futures = <Future<Set<String>>>[];
-    for (var dependency in library.dependencies!) {
+    for (final dependency in library.dependencies!) {
       if (!dependency.isImport!) {
         final prefix = dependency.prefix;
         final target = dependency.target;
@@ -283,7 +283,7 @@ Future<Set<String>> _autoCompleteMembersFor(
 
     final functions = clazz.functions;
     if (functions != null) {
-      for (var funcRef in functions) {
+      for (final funcRef in functions) {
         if (_validFunction(funcRef, clazz, staticContext)) {
           final isConstructor = _isConstructor(funcRef, clazz);
           final funcName = funcRef.name;

--- a/packages/devtools_app/lib/src/shared/console/eval/inspector_tree.dart
+++ b/packages/devtools_app/lib/src/shared/console/eval/inspector_tree.dart
@@ -71,7 +71,7 @@ class InspectorTreeNode {
   void updateShouldShow(bool value) {
     if (value != _shouldShow) {
       _shouldShow = value;
-      for (var child in children) {
+      for (final child in children) {
         child.updateShouldShow(value);
       }
     }
@@ -113,7 +113,7 @@ class InspectorTreeNode {
       _isExpanded = value;
       isDirty = true;
       if (_shouldShow ?? false) {
-        for (var child in children) {
+        for (final child in children) {
           child.updateShouldShow(value);
         }
       }
@@ -146,7 +146,7 @@ class InspectorTreeNode {
       return childrenCountLocal;
     }
     int count = 0;
-    for (InspectorTreeNode child in _children) {
+    for (final child in _children) {
       count += child.subtreeSize;
     }
     return _childrenCount = count;
@@ -168,7 +168,7 @@ class InspectorTreeNode {
       if (parent == null) {
         break;
       }
-      for (InspectorTreeNode sibling in parent._children) {
+      for (final sibling in parent._children) {
         if (sibling == node) {
           break;
         }

--- a/packages/devtools_app/lib/src/shared/console/widgets/description.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/description.dart
@@ -206,7 +206,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
         if (isHoverStale()) return Future.value();
         await buildVariablesTree(variable);
         final tasks = <Future<void>>[];
-        for (var child in variable.children) {
+        for (final child in variable.children) {
           tasks.add(() async {
             if (!isHoverStale()) await buildVariablesTree(child);
           }());

--- a/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
@@ -603,7 +603,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     final jsonArray = json['children'] as List<Object?>?;
     if (jsonArray?.isNotEmpty == true) {
       final nodes = <RemoteDiagnosticsNode>[];
-      for (var element in jsonArray!.cast<Map<String, Object?>>()) {
+      for (final element in jsonArray!.cast<Map<String, Object?>>()) {
         final child =
             RemoteDiagnosticsNode(element, objectGroupApi, false, parent);
         child.parent = this;
@@ -622,7 +622,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
       cachedProperties = [];
       if (json.containsKey('properties')) {
         final jsonArray = json['properties'] as List<Object?>;
-        for (var element in jsonArray.cast<Map<String, Object?>>()) {
+        for (final element in jsonArray.cast<Map<String, Object?>>()) {
           cachedProperties!.add(
             RemoteDiagnosticsNode(element, objectGroupApi, true, parent),
           );
@@ -657,7 +657,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     if (entries.length != node.json.entries.length) {
       return false;
     }
-    for (var entry in entries) {
+    for (final entry in entries) {
       final String key = entry.key;
       if (key == 'valueId') {
         continue;
@@ -672,7 +672,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   @override
   void debugFillProperties(DiagnosticPropertiesBuilder properties) {
     super.debugFillProperties(properties);
-    for (var property in inlineProperties) {
+    for (final property in inlineProperties) {
       properties.add(DiagnosticsProperty(property.name, property));
     }
   }
@@ -682,7 +682,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     final children = childrenNow;
     if (children.isEmpty) return const <DiagnosticsNode>[];
     final regularChildren = <DiagnosticsNode>[];
-    for (var child in children) {
+    for (final child in children) {
       regularChildren.add(child.toDiagnosticsNode());
     }
     return regularChildren;

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -246,7 +246,7 @@ class InspectorService extends InspectorServiceBase {
 
   void onExtensionVmServiceReceived(Event e) {
     if ('Flutter.Frame' == e.extensionKind) {
-      for (InspectorServiceClient client in clients) {
+      for (final client in clients) {
         try {
           client.onFlutterFrame();
         } catch (e) {
@@ -324,7 +324,7 @@ class InspectorService extends InspectorServiceBase {
   void _onRootDirectoriesChanged(List<String> directories) {
     _rootDirectories.value = directories;
     _rootPackagePrefixes = [];
-    for (var directory in directories) {
+    for (final directory in directories) {
       // TODO(jacobr): add an API to DDS to provide the actual mapping to and
       // from absolute file paths to packages instead of having to guess it
       // here.
@@ -438,7 +438,7 @@ class InspectorService extends InspectorServiceBase {
       _currentSelection = pendingSelection;
       assert(group == _selectionGroups.next);
       _selectionGroups.promoteNext();
-      for (InspectorServiceClient client in clients) {
+      for (final client in clients) {
         client.onInspectorSelectionChanged();
       }
     }
@@ -685,7 +685,7 @@ abstract class InspectorObjectGroupBase
   ) {
     if (disposed || jsonObject == null) return const [];
     final nodes = <RemoteDiagnosticsNode>[];
-    for (var element in jsonObject.cast<Map<String, Object?>>()) {
+    for (final element in jsonObject.cast<Map<String, Object?>>()) {
       nodes.add(RemoteDiagnosticsNode(element, this, isProperty, parent));
     }
     return nodes;
@@ -794,7 +794,7 @@ abstract class InspectorObjectGroupBase
     if (disposed || clazz == null) return null;
 
     final properties = <String, InstanceRef>{};
-    for (FieldRef field in clazz.fields!) {
+    for (final field in clazz.fields!) {
       final String name = field.name!;
       if (isPrivateMember(name)) {
         // Needed to filter out _deleted_enum_sentinel synthetic property.
@@ -820,7 +820,7 @@ abstract class InspectorObjectGroupBase
     String name,
   ) async {
     final clazz = await inspectorLibrary.getClass(classRef, this) as Class;
-    for (FuncRef f in clazz.functions!) {
+    for (final f in clazz.functions!) {
       // TODO(pq): check for properties that match name.
       if (f.name == name) {
         final func = await inspectorLibrary.getFunc(f, this) as Func;

--- a/packages/devtools_app/lib/src/shared/diagnostics/references.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/references.dart
@@ -447,7 +447,7 @@ List<DartObjectNode> _createLiveOutboundReferencesForFields(
 ) {
   final variables = <DartObjectNode>[];
 
-  for (var field in instance.fields!) {
+  for (final field in instance.fields!) {
     _addLiveReferenceToNode(
       variables,
       isolateRef,

--- a/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/tree_builder.dart
@@ -30,7 +30,7 @@ Future<void> _addExpandableChildren(
   bool expandAll = false,
 }) async {
   final tasks = <Future>[];
-  for (var child in children) {
+  for (final child in children) {
     if (expandAll) {
       tasks.add(buildVariablesTree(child, expandAll: expandAll));
     }
@@ -149,7 +149,7 @@ Future<void> _addInstanceRefItems(
   assert(ref is! ObjectReferences);
 
   final existingNames = <String>{};
-  for (var child in variable.children) {
+  for (final child in variable.children) {
     final name = child.name;
     if (name != null && name.isNotEmpty) {
       existingNames.add(name);
@@ -370,7 +370,7 @@ Future<void> _addInspectorItems(
       }
     }
 
-    for (var child in variable.children) {
+    for (final child in variable.children) {
       tasks.add(maybeUpdateRef(child));
     }
     if (tasks.isNotEmpty) {

--- a/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/variable_factory.dart
@@ -321,7 +321,7 @@ Future<List<DartObjectNode>> createVariablesForDiagnostics(
   IsolateRef isolateRef,
 ) async {
   final variables = <Future<DartObjectNode>>[];
-  for (var diagnostic in diagnostics) {
+  for (final diagnostic in diagnostics) {
     // Omit hidden properties.
     if (diagnostic.level == DiagnosticLevel.hidden) continue;
     variables.add(_buildVariable(diagnostic, objectGroupApi, isolateRef));
@@ -551,7 +551,7 @@ List<DartObjectNode> createVariablesForFields(
   Set<String>? existingNames,
 }) {
   final result = <DartObjectNode>[];
-  for (var field in instance.fields!) {
+  for (final field in instance.fields!) {
     final name = field.decl?.name;
     if (name == null) {
       result.add(

--- a/packages/devtools_app/lib/src/shared/http/_http_date.dart
+++ b/packages/devtools_app/lib/src/shared/http/_http_date.dart
@@ -109,7 +109,7 @@ class HttpDate {
     String? monthStr;
     String? yearStr;
 
-    for (var token in tokens) {
+    for (final token in tokens) {
       if (token.length < 1) continue;
       if (timeStr == null &&
           token.length >= 5 &&

--- a/packages/devtools_app/lib/src/shared/memory/classes.dart
+++ b/packages/devtools_app/lib/src/shared/memory/classes.dart
@@ -138,7 +138,7 @@ class ClassDataList<T extends ClassData> {
   final List<T>? _filtered;
 
   Map<HeapClassName, T> asMap() =>
-      {for (var c in _originalList) c.className: c};
+      {for (final c in _originalList) c.className: c};
 
   ClassDataList<T> filtered(ClassFilter newFilter, String? rootPackage) {
     final filtered = ClassFilter.filter(

--- a/packages/devtools_app/lib/src/shared/memory/retaining_path.dart
+++ b/packages/devtools_app/lib/src/shared/memory/retaining_path.dart
@@ -172,7 +172,7 @@ class PathFromRoot {
     bool justAddedEllipsis = false;
     if (hideStandard) {
       data = [];
-      for (var item in path.asMap().entries) {
+      for (final item in path.asMap().entries) {
         if (item.key == 0 ||
             item.key == path.length - 1 ||
             !item.value.isCreatedByGoogle) {

--- a/packages/devtools_app/lib/src/shared/memory/simple_items.dart
+++ b/packages/devtools_app/lib/src/shared/memory/simple_items.dart
@@ -43,7 +43,7 @@ extension HeapSnapshotGraphSerialization on HeapSnapshotGraph {
   /// See https://api.flutter.dev/flutter/dart-developer/NativeRuntime/writeHeapSnapshotToFile.html
   Uint8List toUint8List() {
     final b = BytesBuilder();
-    for (var chunk in toChunks()) {
+    for (final chunk in toChunks()) {
       b.add(chunk.buffer.asUint8List());
     }
     return b.toBytes();

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -131,7 +131,7 @@ class NotificationService {
   void dismiss(String message) {
     // Remove those that were not picked up yet by UI.
     final toRemove = toPush.where((e) => e.text == message).toList();
-    for (var messageToRemove in toRemove) {
+    for (final messageToRemove in toRemove) {
       toPush.remove(messageToRemove);
       activeMessages.remove(messageToRemove);
     }

--- a/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/custom_pointer_scroll_view.dart
@@ -800,7 +800,7 @@ class _RenderScrollSemantics extends RenderProxyBox {
     int? firstVisibleIndex;
     final List<SemanticsNode> excluded = <SemanticsNode>[_innerNode!];
     final List<SemanticsNode> included = <SemanticsNode>[];
-    for (final SemanticsNode child in children) {
+    for (final child in children) {
       assert(child.isTagged(RenderViewport.useTwoPaneSemantics));
       if (child.isTagged(RenderViewport.excludeFromScrolling)) {
         excluded.add(child);

--- a/packages/devtools_app/lib/src/shared/primitives/enum_utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/enum_utils.dart
@@ -15,7 +15,7 @@
 /// ```
 class EnumUtils<T extends Enum> {
   EnumUtils(List<T> enumValues) {
-    for (var val in enumValues) {
+    for (final val in enumValues) {
       final enumDescription = val.name;
       _lookupTable[enumDescription] = val;
       _reverseLookupTable[val] = enumDescription;

--- a/packages/devtools_app/lib/src/shared/primitives/flutter_widgets/linked_scroll_controller.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/flutter_widgets/linked_scroll_controller.dart
@@ -203,7 +203,7 @@ class _LinkedScrollController extends ScrollController {
   Iterable<_LinkedScrollActivity> link(_LinkedScrollPosition driver) {
     assert(hasClients);
     final activities = <_LinkedScrollActivity>[];
-    for (ScrollPosition position in positions) {
+    for (final position in positions) {
       activities.add((position as _LinkedScrollPosition).link(driver));
     }
     return activities;
@@ -249,7 +249,7 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
     if (newActivity == null) {
       return;
     }
-    for (var activity in _peerActivities) {
+    for (final activity in _peerActivities) {
       activity.unlink(this);
     }
 
@@ -271,7 +271,7 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
 
     if (owner.canLinkWithPeers) {
       _peerActivities.addAll(owner.linkWithPeers(this));
-      for (var activity in _peerActivities) {
+      for (final activity in _peerActivities) {
         activity.moveTo(newPixels);
       }
     }
@@ -294,7 +294,7 @@ class _LinkedScrollPosition extends ScrollPositionWithSingleContext {
 
     if (owner.canLinkWithPeers) {
       _peerActivities.addAll(owner.linkWithPeers(this));
-      for (var activity in _peerActivities) {
+      for (final activity in _peerActivities) {
         activity.jumpTo(value);
       }
     }
@@ -376,7 +376,7 @@ class _LinkedScrollActivity extends ScrollActivity {
   void _updateUserScrollDirection() {
     assert(drivers.isNotEmpty);
     ScrollDirection? commonDirection;
-    for (var driver in drivers) {
+    for (final driver in drivers) {
       commonDirection ??= driver.userScrollDirection;
       if (driver.userScrollDirection != commonDirection) {
         commonDirection = ScrollDirection.idle;
@@ -387,7 +387,7 @@ class _LinkedScrollActivity extends ScrollActivity {
 
   @override
   void dispose() {
-    for (var driver in drivers) {
+    for (final driver in drivers) {
       driver.unlink(this);
     }
     super.dispose();

--- a/packages/devtools_app/lib/src/shared/primitives/syntax_highlighting.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/syntax_highlighting.dart
@@ -45,11 +45,11 @@ class TextmateGrammar {
 
   void _parseRules() {
     final Map repository = _definition['repository'];
-    for (String name in repository.keys.cast<String>()) {
+    for (final name in repository.keys.cast<String>()) {
       _ruleMap[name] = Rule(name);
     }
 
-    for (String name in _ruleMap.keys) {
+    for (final name in _ruleMap.keys) {
       _ruleMap[name]!._parse(repository[name]);
     }
 
@@ -58,7 +58,7 @@ class TextmateGrammar {
 
   void _parseFileRules() {
     final List<Object?> patterns = _definition['patterns'];
-    for (Map info in patterns.cast<Map<Object?, Object?>>()) {
+    for (final Map info in patterns.cast<Map<Object?, Object?>>()) {
       _fileRules.add(Rule(info['name']).._parse(info));
     }
     _log.info('fileRules: $_fileRules');

--- a/packages/devtools_app/lib/src/shared/primitives/trees.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/trees.dart
@@ -33,7 +33,7 @@ abstract class TreeNode<T extends TreeNode<T>> {
     if (_depth != 0) {
       return _depth;
     }
-    for (T child in children) {
+    for (final child in children) {
       _depth = max(_depth, child.depth);
     }
     return _depth = _depth + 1;
@@ -399,7 +399,7 @@ List<T> buildFlatList<T extends TreeNode<T>>(
   void Function(T node)? onTraverse,
 }) {
   final flatList = <T>[];
-  for (T root in roots) {
+  for (final root in roots) {
     _traverse(root, (T n) {
       if (onTraverse != null) onTraverse(n);
       flatList.add(n);
@@ -415,7 +415,7 @@ void _traverse<T extends TreeNode<T>>(
 ) {
   final shouldContinue = callback(node);
   if (shouldContinue) {
-    for (var child in node.children) {
+    for (final child in node.children) {
       _traverse(child, callback);
     }
   }

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -598,7 +598,7 @@ class Reporter implements Listenable {
   /// a notification callback leads to a change in the listeners,
   /// only the original listeners will be called.
   void notify() {
-    for (var callback in _listeners.toList()) {
+    for (final callback in _listeners.toList()) {
       callback();
     }
   }
@@ -1036,7 +1036,7 @@ extension ListExtension<T> on List<T> {
   }
 
   bool containsWhere(bool Function(T element) test) {
-    for (var e in this) {
+    for (final e in this) {
       if (test(e)) {
         return true;
       }
@@ -1068,7 +1068,7 @@ extension NullableListExtension<T> on List<T>? {
 
 extension SetExtension<T> on Set<T> {
   bool containsWhere(bool Function(T element) test) {
-    for (var e in this) {
+    for (final e in this) {
       if (test(e)) {
         return true;
       }
@@ -1077,7 +1077,7 @@ extension SetExtension<T> on Set<T> {
   }
 
   bool containsAny(Iterable<T> any) {
-    for (var e in any) {
+    for (final e in any) {
       if (contains(e)) {
         return true;
       }
@@ -1162,7 +1162,7 @@ String? fileNameFromUri(String? uri) => uri?.split('/').last;
 
 /// Calculates subtraction of two maps.
 ///
-/// Result map keys is union of the imput maps' keys.
+/// Result map keys is union of the input maps' keys.
 Map<K, R> subtractMaps<K, F, S, R>({
   required Map<K, S>? subtract,
   required Map<K, F>? from,
@@ -1174,7 +1174,7 @@ Map<K, R> subtractMaps<K, F, S, R>({
   final result = <K, R>{};
   final unionOfKeys = from.keys.toSet().union(subtract.keys.toSet());
 
-  for (var key in unionOfKeys) {
+  for (final key in unionOfKeys) {
     final diff = subtractor(from: from[key], subtract: subtract[key]);
     if (diff != null) result[key] = diff;
   }

--- a/packages/devtools_app/lib/src/shared/profiler_utils.dart
+++ b/packages/devtools_app/lib/src/shared/profiler_utils.dart
@@ -89,7 +89,7 @@ mixin ProfilableDataMixin<T extends TreeNode<T>> on TreeNode<T> {
               '$exclusiveSampleCount - incl: $inclusiveSampleCount'
           .trimRight(),
     );
-    for (T child in children) {
+    for (final child in children) {
       (child as ProfilableDataMixin<T>)._format(buf, '  $indent');
     }
   }

--- a/packages/devtools_app/lib/src/shared/table/column_widths.dart
+++ b/packages/devtools_app/lib/src/shared/table/column_widths.dart
@@ -65,7 +65,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
         return 0;
       });
 
-    for (var col in columns) {
+    for (final col in columns) {
       if (col.fixedWidthPx != null) {
         available -= col.fixedWidthPx!;
       } else if (col.minWidthPx != null) {
@@ -74,7 +74,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
     }
     available = max(available, 0);
     int unconstrainedCount = 0;
-    for (var column in sortedColumns) {
+    for (final column in sortedColumns) {
       if (column.fixedWidthPx == null && column.minWidthPx == null) {
         unconstrainedCount++;
       }
@@ -88,7 +88,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
       // through the columns from the smallest minWidth to largest minWidth
       // incrementally adding columns where the minWidth constraint can be
       // satisfied using the width given to unconstrained columns.
-      for (var column in sortedColumns) {
+      for (final column in sortedColumns) {
         if (column.fixedWidthPx == null && column.minWidthPx != null) {
           // Width of this column if it was not clamped to its min width.
           // We add column.minWidthPx to the available width because
@@ -113,7 +113,7 @@ extension FlatColumnWidthExtension<T> on FlatTableController<T> {
         unconstrainedCount > 0 ? available / unconstrainedCount : available;
     int unconstrainedFound = 0;
     final widths = <double>[];
-    for (ColumnData<T> column in columns) {
+    for (final column in columns) {
       double? width = column.fixedWidthPx;
       if (width == null) {
         if (column.minWidthPx != null &&

--- a/packages/devtools_app/lib/src/shared/table/table.dart
+++ b/packages/devtools_app/lib/src/shared/table/table.dart
@@ -255,7 +255,7 @@ class DevToolsTableState<T> extends State<DevToolsTable<T>>
         widget.tableController.columns.numSpacers - numColumnGroupSpacers;
     tableWidth += numColumnSpacers * columnSpacing;
     tableWidth += numColumnGroupSpacers * columnGroupSpacingWithPadding;
-    for (var columnWidth in widget.columnWidths) {
+    for (final columnWidth in widget.columnWidths) {
       tableWidth += columnWidth;
     }
     return tableWidth;

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -343,7 +343,7 @@ class QueryFilter {
       if (querySeparatorIndex != -1) {
         final value = part.substring(querySeparatorIndex + 1).trim();
         if (value.isNotEmpty) {
-          for (var arg in args.values) {
+          for (final arg in args.values) {
             if (arg.matchesKey(part)) {
               arg.isNegative =
                   part.startsWith(QueryFilterArgument.negativePrefix);

--- a/packages/devtools_app/lib/src/shared/ui/utils.dart
+++ b/packages/devtools_app/lib/src/shared/ui/utils.dart
@@ -27,7 +27,7 @@ TextSpan truncateTextSpan(TextSpan span, int length) {
     }
     if (span.children != null) {
       children = <TextSpan>[];
-      for (var child in span.children!) {
+      for (final child in span.children!) {
         if (available <= 0) break;
         children.add(truncateHelper(child as TextSpan));
       }

--- a/packages/devtools_app/test/app_size/code_size_attribution_test.dart
+++ b/packages/devtools_app/test/app_size/code_size_attribution_test.dart
@@ -166,7 +166,7 @@ void main() {
       expect(root.isExpanded, isTrue);
       expect(root.children.length, equals(18));
 
-      for (DominatorTreeNode child in root.children.cast<DominatorTreeNode>()) {
+      for (final child in root.children.cast<DominatorTreeNode>()) {
         expect(child.isExpanded, isFalse);
       }
     });
@@ -189,7 +189,7 @@ void main() {
       expect(root.children.length, equals(18));
 
       // Only the selected node should be expanded.
-      for (DominatorTreeNode child in root.children.cast<DominatorTreeNode>()) {
+      for (final child in root.children.cast<DominatorTreeNode>()) {
         expect(
           child.isExpanded,
           child.callGraphNode.display == 'package:code_size_package',
@@ -204,7 +204,7 @@ void main() {
       );
       expect(selectedNode.children.length, equals(3));
 
-      for (DominatorTreeNode child in selectedNode.children) {
+      for (final child in selectedNode.children) {
         expect(child.isExpanded, isFalse);
       }
     });

--- a/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profile_model_test.dart
@@ -368,7 +368,7 @@ void main() {
       final copy = testStackFrame.deepCopy();
       expect(copy.isExpanded, isFalse);
       expect(copy.children.length, equals(1));
-      for (CpuStackFrame child in copy.children) {
+      for (final child in copy.children) {
         expect(child.parent, equals(copy));
       }
       copy.addChild(stackFrameG);

--- a/packages/devtools_app/test/cpu_profiler/cpu_profile_transformer_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profile_transformer_test.dart
@@ -68,7 +68,7 @@ void main() {
       }) {
         expect(stackFrame.exclusiveSampleCount, targetExcl);
         expect(stackFrame.inclusiveSampleCount, targetIncl);
-        for (CpuStackFrame child in stackFrame.children) {
+        for (final child in stackFrame.children) {
           verifySampleCount(
             child,
             targetExcl: targetExcl,
@@ -105,7 +105,7 @@ void main() {
       bottomUpRoots.forEach(transformer.cascadeSampleCounts);
 
       final buf = StringBuffer();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), bottomUpPreMergeGolden);
@@ -116,7 +116,7 @@ void main() {
       expect(bottomUpRoots.length, 4);
 
       buf.clear();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), bottomUpGolden);
@@ -137,7 +137,7 @@ void main() {
       bottomUpRoots.forEach(transformer.cascadeSampleCounts);
 
       final buf = StringBuffer();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), bottomUpPreMergeGolden);
@@ -148,7 +148,7 @@ void main() {
       expect(bottomUpRoots.length, 4);
 
       buf.clear();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), bottomUpGolden);
@@ -174,7 +174,7 @@ void main() {
       expect(bottomUpRoots.length, 4);
 
       final buf = StringBuffer();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), bottomUpGolden);
@@ -204,7 +204,7 @@ void main() {
       expect(bottomUpRoots.length, equals(1));
 
       final buf = StringBuffer();
-      for (CpuStackFrame stackFrame in bottomUpRoots) {
+      for (final stackFrame in bottomUpRoots) {
         buf.writeln(stackFrame.profileAsString());
       }
       expect(buf.toString(), tagRootedBottomUpGolden);

--- a/packages/devtools_app/test/debugger/debugger_console_test.dart
+++ b/packages/devtools_app/test/debugger/debugger_console_test.dart
@@ -61,7 +61,7 @@ void main() {
     final stdio = ['First line', _ansiCodesOutput(), 'Third line'];
 
     void appendStdioLines() {
-      for (var line in stdio) {
+      for (final line in stdio) {
         serviceConnection.consoleService.appendStdio('$line\n');
       }
     }

--- a/packages/devtools_app/test/inspector/layout_explorer/flex/flex_test.dart
+++ b/packages/devtools_app/test/inspector/layout_explorer/flex/flex_test.dart
@@ -242,7 +242,7 @@ void main() {
   Future<void> pump(WidgetTester tester, Widget w) async {
     await tester.runAsync(() async {
       await tester.pumpWidget(w);
-      for (var element in find.byType(Image).evaluate()) {
+      for (final element in find.byType(Image).evaluate()) {
         final Image widget = element.widget as Image;
         final ImageProvider image = widget.image;
         await precacheImage(image, element);

--- a/packages/devtools_app/test/legacy_integration_tests/debugger.dart
+++ b/packages/devtools_app/test/legacy_integration_tests/debugger.dart
@@ -72,7 +72,7 @@ void debuggingTests() {
     await delay();
 
     // set and verify breakpoints
-    for (int line in breakpointLines) {
+    for (final line in breakpointLines) {
       await debuggingManager.addBreakpoint(appFixture.appScriptPath, line);
     }
 
@@ -161,7 +161,7 @@ void debuggingTests() {
     );
 
     // test stepping
-    for (int stepLine in steppingLines) {
+    for (final stepLine in steppingLines) {
       // step
       await debuggingManager.step();
 

--- a/packages/devtools_app/test/memory/diff/controller/memory_footprint_test.dart
+++ b/packages/devtools_app/test/memory/diff/controller/memory_footprint_test.dart
@@ -19,7 +19,7 @@ void main() {
       final snapshots = <String, HeapData>{};
 
       final before = ProcessInfo.currentRss;
-      for (var t in goldenHeapTests) {
+      for (final t in goldenHeapTests) {
         snapshots[t.fileName] =
             HeapData(await t.loadHeap(), created: DateTime.now());
         await snapshots[t.fileName]!.calculate;

--- a/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
+++ b/packages/devtools_app/test/memory/diff/widgets/diff_pane_test.dart
@@ -65,7 +65,7 @@ void main() {
         );
 
         // Record three snapshots.
-        for (var i in Iterable<int>.generate(3)) {
+        for (final i in Iterable<int>.generate(3)) {
           await takeSnapshot(tester, scene);
           expect(find.text('selected-isolate-${i + 1}'), findsOneWidget);
         }

--- a/packages/devtools_app/test/memory/framework/memory_service_test.dart
+++ b/packages/devtools_app/test/memory/framework/memory_service_test.dart
@@ -34,7 +34,7 @@ void main() {
 }
 
 void validateHeapInfo(MemoryTimeline timeline) {
-  for (final HeapSample sample in timeline.data) {
+  for (final sample in timeline.data) {
     expect(sample.timestamp, greaterThan(0));
     expect(sample.timestamp, greaterThan(previousTimestamp));
 

--- a/packages/devtools_app/test/memory/framework/memory_service_test.dart
+++ b/packages/devtools_app/test/memory/framework/memory_service_test.dart
@@ -4,7 +4,6 @@
 
 import 'package:devtools_app/src/screens/memory/framework/memory_controller.dart';
 import 'package:devtools_app/src/screens/memory/shared/primitives/memory_timeline.dart';
-import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../../test_infra/flutter_test_driver.dart' show FlutterRunConfiguration;

--- a/packages/devtools_app/test/memory/shared/heap/heap_analyzer_golden_test.dart
+++ b/packages/devtools_app/test/memory/shared/heap/heap_analyzer_golden_test.dart
@@ -11,7 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 import '../../../test_infra/test_data/memory/heap/heap_data.dart';
 
 void main() {
-  for (var t in goldenHeapTests) {
+  for (final t in goldenHeapTests) {
     group(t.fileName, () {
       late HeapData heap;
       late int appClassId;

--- a/packages/devtools_app/test/memory/shared/heap/heap_analyzer_test.dart
+++ b/packages/devtools_app/test/memory/shared/heap/heap_analyzer_test.dart
@@ -10,7 +10,7 @@ import 'package:vm_service/vm_service.dart';
 import '../../../test_infra/test_data/memory/heap/heap_graph_fakes.dart';
 
 void main() {
-  for (var t in _sizeTests) {
+  for (final t in _sizeTests) {
     test('has expected root and unreachable sizes, ${t.name}.', () async {
       final heap = HeapData(
         t.heap,

--- a/packages/devtools_app/test/memory/shared/primitives/class_name_test.dart
+++ b/packages/devtools_app/test/memory/shared/primitives/class_name_test.dart
@@ -66,7 +66,7 @@ final _classTests = [
 
 void main() {
   group('$HeapClassName', () {
-    for (var t in _classTests) {
+    for (final t in _classTests) {
       test('isCore and isDartOrFlutter for ${t.name}', () {
         final theClass =
             HeapClassName.fromPath(className: 'x', library: t.library);

--- a/packages/devtools_app/test/memory/tracing/tracing_pane_controller_test.dart
+++ b/packages/devtools_app/test/memory/tracing/tracing_pane_controller_test.dart
@@ -99,7 +99,7 @@ void main() {
     expect(_Tests.noSelection.stateForIsolate.length, 2);
   });
 
-  for (var t in _Tests.all.keys) {
+  for (final t in _Tests.all.keys) {
     test(
       '$TracePaneController serializes and deserializes correctly, $t',
       () {

--- a/packages/devtools_app/test/shared/ansi_up_test.dart
+++ b/packages/devtools_app/test/shared/ansi_up_test.dart
@@ -73,7 +73,7 @@ void main() {
       }
 
       final output = StringBuffer();
-      for (var entry in decodeAnsiColorEscapeCodes(sb.toString(), AnsiUp())) {
+      for (final entry in decodeAnsiColorEscapeCodes(sb.toString(), AnsiUp())) {
         if (entry.style.isNotEmpty) {
           output.write("<span style='${entry.style}'>${entry.text}</span>");
         } else {

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -385,7 +385,7 @@ void main() {
       );
 
       // Flip the values in storage.
-      for (var key in storage.values.keys) {
+      for (final key in storage.values.keys) {
         storage.values[key] = (!(storage.values[key] == 'true')).toString();
       }
 
@@ -445,7 +445,7 @@ void main() {
       );
 
       // Flip the values in storage.
-      for (var key in storage.values.keys) {
+      for (final key in storage.values.keys) {
         storage.values[key] = (!(storage.values[key] == 'true')).toString();
       }
 
@@ -500,7 +500,7 @@ void main() {
       );
 
       // Flip the values in storage.
-      for (var key in storage.values.keys) {
+      for (final key in storage.values.keys) {
         storage.values[key] = (!(storage.values[key] == 'true')).toString();
       }
 

--- a/packages/devtools_app/test/shared/treemap_test.dart
+++ b/packages/devtools_app/test/shared/treemap_test.dart
@@ -268,7 +268,7 @@ TreemapNode _generateTree(Map<String, dynamic> treeJson) {
   if (rawChildren != null) {
     // If not a leaf node, build all children then take the sum of the
     // children's sizes as its own size.
-    for (var child in rawChildren) {
+    for (final child in rawChildren) {
       final childTreemapNode = _generateTree(child);
       treemapNodeChildren.add(childTreemapNode);
       treemapNodeSize += childTreemapNode.byteSize;

--- a/packages/devtools_app/test/test_infra/fixtures/memory_app/lib/main.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/memory_app/lib/main.dart
@@ -105,7 +105,7 @@ class _MyGarbage {
       };
 
       map = {
-        for (var _ in Iterable<void>.generate(_width))
+        for (final _ in Iterable<void>.generate(_width))
           createInstance(): createInstance(),
       };
 

--- a/packages/devtools_app/test/test_infra/matchers/matchers.dart
+++ b/packages/devtools_app/test/test_infra/matchers/matchers.dart
@@ -20,7 +20,7 @@ RemoteDiagnosticsNode? findNodeMatching(
       node.description?.startsWith(text) == true) {
     return node;
   }
-  for (var child in node.childrenNow) {
+  for (final child in node.childrenNow) {
     final match = findNodeMatching(child, text);
     if (match != null) {
       return match;

--- a/packages/devtools_app/test/test_infra/test_data/memory/heap/heap_graph_fakes.dart
+++ b/packages/devtools_app/test/test_infra/test_data/memory/heap/heap_graph_fakes.dart
@@ -63,7 +63,7 @@ class FakeHeapSnapshotGraph extends Fake implements HeapSnapshotGraph {
   /// Returns index of the object.
   int addChain(List<String> path) {
     var referrer = heapRootIndex;
-    for (var name in path) {
+    for (final name in path) {
       final classId =
           maybeAddClass(HeapClassName(library: _library, className: name));
       final index = add();

--- a/packages/devtools_app/test/test_infra/utils/rendering_tester.dart
+++ b/packages/devtools_app/test/test_infra/utils/rendering_tester.dart
@@ -215,7 +215,7 @@ class TestRenderingFlutterBinding extends BindingBase
       if (phase == EnginePhase.paint) {
         return;
       }
-      for (final RenderView renderView in renderViews) {
+      for (final renderView in renderViews) {
         renderView.compositeFrame();
       }
       if (phase == EnginePhase.composite) {

--- a/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
+++ b/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
@@ -121,7 +121,7 @@ class EvalOnDartLibrary extends DisposableController
         return;
       }
       _isolate = isolate;
-      for (LibraryRef library in isolate?.libraries ?? []) {
+      for (final library in isolate?.libraries ?? <LibraryRef>[]) {
         if (libraryName == library.uri) {
           assert(!_libraryRef.isCompleted);
           _libraryRef.complete(library);

--- a/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/isolate_manager.dart
@@ -225,11 +225,11 @@ final class IsolateManager with DisposerMixin {
     if (_isolateStates.isEmpty) return null;
 
     final service = _service;
-    for (var isolateState in _isolateStates.values) {
+    for (final isolateState in _isolateStates.values) {
       if (_selectedIsolate.value == null) {
         final isolate = await isolateState.isolate;
         if (service != _service) return null;
-        for (String extensionName in isolate?.extensionRPCs ?? []) {
+        for (final extensionName in isolate?.extensionRPCs ?? <String>[]) {
           if (extensions.isFlutterExtension(extensionName)) {
             return isolateState.isolateRef;
           }
@@ -289,7 +289,7 @@ final class IsolateManager with DisposerMixin {
   }
 
   void _clearIsolateStates() {
-    for (var isolateState in _isolateStates.values) {
+    for (final isolateState in _isolateStates.values) {
       isolateState.dispose();
     }
     _isolateStates.clear();

--- a/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extension_manager.dart
@@ -149,7 +149,7 @@ final class ServiceExtensionManager with DisposerMixin {
     final extensionsToProcess = _pendingServiceExtensions.toList();
     _pendingServiceExtensions.clear();
     await Future.wait([
-      for (String extension in extensionsToProcess)
+      for (final extension in extensionsToProcess)
         _addServiceExtension(extension),
     ]);
   }
@@ -186,12 +186,12 @@ final class ServiceExtensionManager with DisposerMixin {
           return;
         }
         await Future.wait([
-          for (String extension in mainIsolate.extensionRPCs!)
+          for (final extension in mainIsolate.extensionRPCs!)
             _maybeAddServiceExtension(extension),
         ]);
       } else {
         await Future.wait([
-          for (String extension in mainIsolate.extensionRPCs!)
+          for (final extension in mainIsolate.extensionRPCs!)
             _addServiceExtension(extension),
         ]);
       }

--- a/packages/devtools_app_shared/lib/src/ui/flex_split_column.dart
+++ b/packages/devtools_app_shared/lib/src/ui/flex_split_column.dart
@@ -106,7 +106,7 @@ final class FlexSplitColumn extends StatelessWidget {
     double totalHeight,
   ) {
     var totalHeaderHeight = 0.0;
-    for (var header in headers) {
+    for (final header in headers) {
       totalHeaderHeight += header.preferredSize.height;
     }
     final intendedContentHeight = totalHeight - totalHeaderHeight;

--- a/packages/devtools_app_shared/lib/src/ui/split_pane.dart
+++ b/packages/devtools_app_shared/lib/src/ui/split_pane.dart
@@ -115,7 +115,7 @@ final class _SplitPaneState extends State<SplitPane> {
       if (widget.minSizes == null) return 0.0;
 
       double totalMinSize = 0;
-      for (var minSize in widget.minSizes!) {
+      for (final minSize in widget.minSizes!) {
         totalMinSize += minSize;
       }
 
@@ -285,7 +285,7 @@ final class _SplitPaneState extends State<SplitPane> {
       return numSplitters * DefaultSplitter.splitterWidth;
     } else {
       var totalSize = 0.0;
-      for (var splitter in widget.splitters!) {
+      for (final splitter in widget.splitters!) {
         totalSize += isHorizontal
             ? splitter.preferredSize.width
             : splitter.preferredSize.height;
@@ -322,7 +322,7 @@ final class DefaultSplitter extends StatelessWidget {
 
 void _verifyFractionsSumTo1(List<double> fractions) {
   var sumFractions = 0.0;
-  for (var fraction in fractions) {
+  for (final fraction in fractions) {
     sumFractions += fraction;
   }
   assert(

--- a/packages/devtools_app_shared/lib/src/ui/theme/ide_theme.dart
+++ b/packages/devtools_app_shared/lib/src/ui/theme/ide_theme.dart
@@ -37,7 +37,7 @@ final class IdeTheme {
   bool get isDarkMode => _isDarkMode ?? true;
 
   /// Whether the IDE specified the DevTools color theme.
-  /// 
+  ///
   /// If this returns false, that means the
   /// [IdeThemeQueryParams.devToolsThemeKey] query parameter was not passed to
   /// DevTools from the IDE.

--- a/packages/devtools_app_shared/lib/src/utils/auto_dispose.dart
+++ b/packages/devtools_app_shared/lib/src/utils/auto_dispose.dart
@@ -156,7 +156,7 @@ mixin DisposerMixin {
   ///
   /// It is fine to call this method and then add additional subscriptions.
   void cancelStreamSubscriptions() {
-    for (StreamSubscription subscription in _subscriptions) {
+    for (final subscription in _subscriptions) {
       unawaited(subscription.cancel());
     }
     _subscriptions.clear();
@@ -203,7 +203,7 @@ mixin DisposerMixin {
   ///
   /// It is fine to call this method and then add additional focus nodes.
   void cancelFocusNodes() {
-    for (FocusNode focusNode in _focusNodes) {
+    for (final focusNode in _focusNodes) {
       focusNode.dispose();
     }
     _focusNodes.clear();
@@ -340,7 +340,7 @@ extension _AutoDisposeListExtension<T> on List<T> {
   /// If any index in [indices] is out of range, an exception will be thrown.
   void removeAllExceptIndices(List<int> indices) {
     final tmp = [
-      for (int index in indices) this[index],
+      for (final index in indices) this[index],
     ];
     clear();
     addAll(tmp);

--- a/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
+++ b/packages/devtools_app_shared/test/utils/auto_dispose_mixin_test.dart
@@ -201,7 +201,7 @@ void main() {
     });
 
     group('callOnceWhenReady', () {
-      for (bool isReady in [false, true]) {
+      for (final isReady in [false, true]) {
         group('isReady=$isReady', () {
           test('triggers callback and cancels listeners when ready ', () async {
             final disposer = Disposer();

--- a/packages/devtools_shared/lib/src/memory/event_sample.dart
+++ b/packages/devtools_shared/lib/src/memory/event_sample.dart
@@ -134,7 +134,7 @@ class ExtensionEvents {
   Map<String, dynamic> toJson() {
     final eventsAsJson = <String, dynamic>{};
     var index = 0;
-    for (var event in events) {
+    for (final event in events) {
       eventsAsJson['$index'] = event.toJson();
       index++;
     }

--- a/packages/devtools_test/lib/src/helpers/wrappers.dart
+++ b/packages/devtools_test/lib/src/helpers/wrappers.dart
@@ -160,7 +160,7 @@ void testWidgetsWithContext(
   testWidgets(description, (WidgetTester widgetTester) async {
     // set up the context
     final Map<Type, dynamic> oldValues = {};
-    for (Type type in context.keys) {
+    for (final type in context.keys) {
       oldValues[type] = globals[type];
       setGlobal(type, context[type]);
     }
@@ -169,7 +169,7 @@ void testWidgetsWithContext(
       await callback(widgetTester);
     } finally {
       // restore previous global values
-      for (Type type in oldValues.keys) {
+      for (final type in oldValues.keys) {
         final oldGlobal = oldValues[type];
         if (oldGlobal != null) {
           setGlobal(type, oldGlobal);

--- a/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_extension_manager.dart
@@ -118,7 +118,7 @@ base class FakeServiceExtensionManager extends Fake
     }
     _firstFrameEventReceived = true;
 
-    for (String extension in _pendingServiceExtensions) {
+    for (final extension in _pendingServiceExtensions) {
       await _addServiceExtension(extension);
     }
     _pendingServiceExtensions.clear();
@@ -193,7 +193,7 @@ base class FakeServiceExtensionManager extends Fake
     _firstFrameEventReceived = false;
     _pendingServiceExtensions.clear();
     _serviceExtensions.clear();
-    for (var listenable in _serviceExtensionAvailable.values) {
+    for (final listenable in _serviceExtensionAvailable.values) {
       listenable.value = false;
     }
   }

--- a/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_service_manager.dart
@@ -39,7 +39,7 @@ class FakeServiceConnectionManager extends Fake
       availableServices: availableServices,
       rootLibrary: rootLibrary,
     );
-    for (var screenId in screenIds) {
+    for (final screenId in screenIds) {
       when(errorBadgeManager.erroredItemsForPage(screenId)).thenReturn(
         FixedValueListenable(LinkedHashMap<String, DevToolsError>()),
       );

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -32,7 +32,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
         allocationSamples = allocationSamples ?? _defaultProfile {
     _reverseResolvedUriMap = <String, String>{};
     if (_resolvedUriMap != null) {
-      for (var e in _resolvedUriMap.entries) {
+      for (final e in _resolvedUriMap.entries) {
         _reverseResolvedUriMap![e.value] = e.key;
       }
     }
@@ -170,7 +170,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     bool? gc,
   }) {
     final memberStats = <ClassHeapStats>[];
-    for (var data in _allocationData!.data) {
+    for (final data in _allocationData!.data) {
       final stats = ClassHeapStats(
         classRef: data.classRef,
         accumulatedSize: 0,

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -41,7 +41,7 @@ class AnalyzeCommand extends Command {
 
     int failureCount = 0;
 
-    for (Package p in packages) {
+    for (final p in packages) {
       if (!p.hasAnyDartCode) {
         continue;
       }

--- a/tool/lib/commands/list.dart
+++ b/tool/lib/commands/list.dart
@@ -25,7 +25,7 @@ class ListCommand extends Command {
 
     print('\n${packages.length} packages:');
 
-    for (Package p in packages) {
+    for (final p in packages) {
       print('  ${p.relativePath}${path.separator}');
     }
   }

--- a/tool/lib/commands/pub_get.dart
+++ b/tool/lib/commands/pub_get.dart
@@ -48,7 +48,7 @@ class PubGetCommand extends Command {
 
     int failureCount = 0;
 
-    for (Package p in packages) {
+    for (final p in packages) {
       final packagePathParts = path.split(p.relativePath);
       final isMainPackageOrSubdirectory = packagePathParts.length >= 2 &&
           packagePathParts.first == 'packages' &&

--- a/tool/lib/commands/release_helper.dart
+++ b/tool/lib/commands/release_helper.dart
@@ -17,8 +17,7 @@ class ReleaseHelperCommand extends Command {
     argParser.addFlag(
       _debugFlag,
       negatable: false,
-      help:
-          'Whether to run this script for development purposes. This allows '
+      help: 'Whether to run this script for development purposes. This allows '
           'local changes to be made to this script without throwing an '
           'exception, and will checkout the current branch after executing.',
     );

--- a/tool/lib/commands/repo_check.dart
+++ b/tool/lib/commands/repo_check.dart
@@ -28,7 +28,7 @@ class RepoCheckCommand extends Command {
 
     int failureCount = 0;
 
-    for (var check in checks) {
+    for (final check in checks) {
       print('\nchecking ${check.name}:');
 
       try {

--- a/tool/lib/commands/update_perfetto.dart
+++ b/tool/lib/commands/update_perfetto.dart
@@ -192,7 +192,7 @@ class UpdatePerfettoCommand extends Command {
     String newVersionNumber = '';
     final versionRegExp = RegExp(r'v\d+[.]\d+-[0-9a-fA-F]+');
     final entities = perfettoDistDir.listSync();
-    for (FileSystemEntity entity in entities) {
+    for (final entity in entities) {
       final path = entity.path;
       final match = versionRegExp.firstMatch(path);
       if (match != null) {

--- a/tool/lib/commands/update_version.dart
+++ b/tool/lib/commands/update_version.dart
@@ -76,8 +76,8 @@ Future<void> resetReleaseNotes({
   if (semVerMatch == null) {
     throw 'Version format is unexpected';
   }
-  var major = int.parse(semVerMatch.namedGroup('major')!, radix: 10);
-  var minor = int.parse(semVerMatch.namedGroup('minor')!, radix: 10);
+  final major = int.parse(semVerMatch.namedGroup('major')!, radix: 10);
+  final minor = int.parse(semVerMatch.namedGroup('minor')!, radix: 10);
   final normalizedVersionNumber = '$major.$minor.0';
 
   final templateFile =

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -48,7 +48,7 @@ class DevToolsRepo {
     final result = <Package>[];
     final repoDir = Directory(repoPath);
 
-    for (FileSystemEntity entity in repoDir.listSync()) {
+    for (final entity in repoDir.listSync()) {
       final name = path.basename(entity.path);
       if (entity is Directory && !name.startsWith('.')) {
         _collectPackages(entity, result);
@@ -87,7 +87,7 @@ class DevToolsRepo {
       result.add(Package._(this, dir.path));
     }
 
-    for (FileSystemEntity entity in dir.listSync(followLinks: false)) {
+    for (final entity in dir.listSync(followLinks: false)) {
       final name = path.basename(entity.path);
       if (entity is Directory && !name.startsWith('.') && name != 'build') {
         _collectPackages(entity, result);
@@ -206,8 +206,7 @@ class FlutterSdk {
   static String get dartWrapperExecutableName =>
       Platform.isWindows ? 'dart.bat' : 'dart';
 
-  String get flutterExePath =>
-      path.join(sdkPath, 'bin', flutterExecutableName);
+  String get flutterExePath => path.join(sdkPath, 'bin', flutterExecutableName);
 
   String get dartExePath =>
       path.join(sdkPath, 'bin', dartWrapperExecutableName);
@@ -237,7 +236,7 @@ class Package {
   }
 
   void _collectDartFiles(Directory dir, List<String> result) {
-    for (FileSystemEntity entity in dir.listSync(followLinks: false)) {
+    for (final entity in dir.listSync(followLinks: false)) {
       final name = path.basename(entity.path);
       if (entity is Directory && !name.startsWith('.') && name != 'build') {
         _collectDartFiles(entity, result);


### PR DESCRIPTION
The repository already enables `prefer_final_locals` so for-loop declared iteration variables should match for consistency and to avoid accidental/potentially misunderstood assignments.

This matches `flutter/flutter` which [enables it as well](https://github.com/flutter/flutter/blob/master/analysis_options.yaml#L163).