### PR TITLE
Add a flag to `serve` and `build` commands to use wasm

### DIFF
--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -89,7 +89,8 @@ class BuildCommand extends Command {
     );
 
     logStatus(
-      'building DevTools in $buildMode mode${useWasm ? ' with dart2wasm' : ''}',
+      'building DevTools in $buildMode mode with '
+      '${useWasm ? 'dart2wasm' : 'dart2js'}',
     );
     await processManager.runAll(
       commands: [

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -43,7 +43,8 @@ class BuildCommand extends Command {
       ..addUpdateFlutterFlag()
       ..addUpdatePerfettoFlag()
       ..addPubGetFlag()
-      ..addBulidModeOption();
+      ..addBulidModeOption()
+      ..addWasmFlag();
   }
 
   @override
@@ -56,14 +57,14 @@ class BuildCommand extends Command {
   Future run() async {
     final repo = DevToolsRepo.getInstance();
     final processManager = ProcessManager();
-
+    final results = argResults!;
     final updateFlutter =
-        argResults![BuildCommandArgs.updateFlutter.flagName] as bool;
+        results[BuildCommandArgs.updateFlutter.flagName] as bool;
     final updatePerfetto =
-        argResults![BuildCommandArgs.updatePerfetto.flagName] as bool;
-    final runPubGet = argResults![BuildCommandArgs.pubGet.flagName] as bool;
-    final buildMode =
-        argResults![BuildCommandArgs.buildMode.flagName] as String;
+        results[BuildCommandArgs.updatePerfetto.flagName] as bool;
+    final runPubGet = results[BuildCommandArgs.pubGet.flagName] as bool;
+    final buildMode = results[BuildCommandArgs.buildMode.flagName] as String;
+    final useWasm = results[BuildCommandArgs.wasm.flagName] as bool;
 
     final webBuildDir =
         Directory(path.join(repo.devtoolsAppDirectoryPath, 'build', 'web'));
@@ -87,7 +88,9 @@ class BuildCommand extends Command {
       workingDirectory: repo.devtoolsAppDirectoryPath,
     );
 
-    logStatus('building DevTools in $buildMode mode');
+    logStatus(
+      'building DevTools in $buildMode mode${useWasm ? ' with dart2wasm' : ''}',
+    );
     await processManager.runAll(
       commands: [
         if (runPubGet) CliCommand.tool(['pub-get', '--only-main']),
@@ -95,12 +98,16 @@ class BuildCommand extends Command {
           [
             'build',
             'web',
-            '--web-renderer',
-            'canvaskit',
+            if (useWasm)
+              '--wasm'
+            else ...[
+              '--web-renderer',
+              'canvaskit',
+              // Do not minify stack traces in debug mode.
+              if (buildMode == 'debug') '--dart2js-optimization=O1',
+              if (buildMode != 'debug') '--$buildMode',
+            ],
             '--pwa-strategy=offline-first',
-            // Do not minify stack traces in debug mode.
-            if (buildMode == 'debug') '--dart2js-optimization=O1',
-            if (buildMode != 'debug') '--$buildMode',
             '--no-tree-shake-icons',
           ],
         ),

--- a/tool/lib/commands/release_helper.dart
+++ b/tool/lib/commands/release_helper.dart
@@ -17,8 +17,7 @@ class ReleaseHelperCommand extends Command {
     argParser.addFlag(
       _debugFlag,
       negatable: false,
-      help:
-          'Whether to run this script for development purposes. This allows '
+      help: 'Whether to run this script for development purposes. This allows '
           'local changes to be made to this script without throwing an '
           'exception, and will checkout the current branch after executing.',
     );

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -4,7 +4,6 @@
 
 import 'dart:io';
 
-import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:devtools_tool/model.dart';
 import 'package:devtools_tool/utils.dart';

--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -4,6 +4,7 @@
 
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:devtools_tool/model.dart';
 import 'package:devtools_tool/utils.dart';
@@ -79,6 +80,7 @@ class ServeCommand extends Command {
       ..addUpdatePerfettoFlag()
       ..addPubGetFlag()
       ..addBulidModeOption()
+      ..addWasmFlag()
       // Flags defined in the server in DDS.
       ..addFlag(
         _machineFlag,
@@ -120,22 +122,25 @@ class ServeCommand extends Command {
     final repo = DevToolsRepo.getInstance();
     final processManager = ProcessManager();
 
-    final buildApp = argResults![_buildAppFlag] as bool;
-    final debugServer = argResults![_debugServerFlag] as bool;
+    final results = argResults!;
+    final buildApp = results[_buildAppFlag] as bool;
+    final debugServer = results[_debugServerFlag] as bool;
     final updateFlutter =
-        argResults![BuildCommandArgs.updateFlutter.flagName] as bool;
+        results[BuildCommandArgs.updateFlutter.flagName] as bool;
     final updatePerfetto =
-        argResults![BuildCommandArgs.updatePerfetto.flagName] as bool;
-    final runPubGet = argResults![BuildCommandArgs.pubGet.flagName] as bool;
+        results[BuildCommandArgs.updatePerfetto.flagName] as bool;
+    final useWasm = results[BuildCommandArgs.wasm.flagName] as bool;
+    final runPubGet = results[BuildCommandArgs.pubGet.flagName] as bool;
     final devToolsAppBuildMode =
-        argResults![BuildCommandArgs.buildMode.flagName] as String;
-    final serveWithDartSdk = argResults![_serveWithDartSdkFlag] as String?;
+        results[BuildCommandArgs.buildMode.flagName] as String;
+    final serveWithDartSdk = results[_serveWithDartSdkFlag] as String?;
 
     // Any flag that we aren't removing here is intended to be passed through.
-    final remainingArguments = List.of(argResults!.arguments)
+    final remainingArguments = List.of(results.arguments)
       ..remove(BuildCommandArgs.updateFlutter.asArg())
       ..remove(BuildCommandArgs.updateFlutter.asArg(negated: true))
       ..remove(BuildCommandArgs.updatePerfetto.asArg())
+      ..remove(BuildCommandArgs.wasm.asArg())
       ..remove(valueAsArg(_buildAppFlag))
       ..remove(valueAsArg(_buildAppFlag, negated: true))
       ..remove(valueAsArg(_debugServerFlag))
@@ -174,6 +179,7 @@ class ServeCommand extends Command {
           'build',
           BuildCommandArgs.updateFlutter.asArg(negated: !updateFlutter),
           if (updatePerfetto) BuildCommandArgs.updatePerfetto.asArg(),
+          if (useWasm) BuildCommandArgs.wasm.asArg(),
           '${BuildCommandArgs.buildMode.asArg()}=$devToolsAppBuildMode',
           BuildCommandArgs.pubGet.asArg(negated: !runPubGet),
         ]),

--- a/tool/lib/commands/shared.dart
+++ b/tool/lib/commands/shared.dart
@@ -50,11 +50,20 @@ extension BuildCommandArgsExtension on ArgParser {
           '"tool/flutter-sdk" directory.',
     );
   }
+
+  void addWasmFlag() {
+    addFlag(
+      BuildCommandArgs.wasm.flagName,
+      defaultsTo: false,
+      help: 'Whether to build DevTools with dart2wasm instead of dart2js.',
+    );
+  }
 }
 
 enum BuildCommandArgs {
   buildMode('build-mode'),
   pubGet('pub-get'),
+  wasm('wasm'),
   updateFlutter('update-flutter'),
   updatePerfetto('update-perfetto');
 

--- a/tool/lib/model.dart
+++ b/tool/lib/model.dart
@@ -206,8 +206,7 @@ class FlutterSdk {
   static String get dartWrapperExecutableName =>
       Platform.isWindows ? 'dart.bat' : 'dart';
 
-  String get flutterExePath =>
-      path.join(sdkPath, 'bin', flutterExecutableName);
+  String get flutterExePath => path.join(sdkPath, 'bin', flutterExecutableName);
 
   String get dartExePath =>
       path.join(sdkPath, 'bin', dartWrapperExecutableName);


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/7856. Requires changes in https://dart-review.googlesource.com/c/sdk/+/369100 to serve properly from the DevTools server.