### PR TITLE
Fix doc formatting and remove `dynamic` usages in shared memory classes

### DIFF
--- a/packages/devtools_shared/lib/src/memory/adb_memory_info.dart
+++ b/packages/devtools_shared/lib/src/memory/adb_memory_info.dart
@@ -18,10 +18,10 @@ class AdbMemoryInfo with Serializable {
     this.total,
   );
 
-  /// All data inside of AdbMemoryInfo is in total bytes. When receiving ADB data
-  /// from the service extension (directly from ADB) then the data is in kilobytes.
-  /// See the factory constructor fromJsonInKB.
-  factory AdbMemoryInfo.fromJson(Map<String, dynamic> json) => AdbMemoryInfo(
+  /// All data inside of [AdbMemoryInfo] is in total bytes.
+  /// When receiving ADB data from the service extension (directly from ADB)
+  /// then the data is in kilobytes. See the factory constructor [fromJsonInKB].
+  factory AdbMemoryInfo.fromJson(Map<String, Object?> json) => AdbMemoryInfo(
         json[realTimeKey] as int,
         json[javaHeapKey] as int,
         json[nativeHeapKey] as int,
@@ -33,21 +33,19 @@ class AdbMemoryInfo with Serializable {
         json[totalKey] as int,
       );
 
-  /// Use when converting data received from the service extension, directly from
-  /// ADB. All data received from ADB dumpsys meminfo is in kilobytes must adjust to
-  /// total bytes for AdbMemoryInfo data.
-  factory AdbMemoryInfo.fromJsonInKB(
-    Map<String, dynamic> json,
-  ) {
-    final int realTime = json[realTimeKey];
-    int javaHeap = json[javaHeapKey];
-    int nativeHeap = json[nativeHeapKey];
-    int code = json[codeKey];
-    int stack = json[stackKey];
-    int graphics = json[graphicsKey];
-    int other = json[otherKey];
-    int system = json[systemKey];
-    int total = json[totalKey];
+  /// Use when converting data received from the service extension,
+  /// directly from ADB. All data received from ADB dumpsys meminfo is
+  /// in kilobytes must adjust to total bytes for [AdbMemoryInfo] data.
+  factory AdbMemoryInfo.fromJsonInKB(Map<String, Object?> json) {
+    final realTime = json[realTimeKey] as int;
+    var javaHeap = json[javaHeapKey] as int;
+    var nativeHeap = json[nativeHeapKey] as int;
+    var code = json[codeKey] as int;
+    var stack = json[stackKey] as int;
+    var graphics = json[graphicsKey] as int;
+    var other = json[otherKey] as int;
+    var system = json[systemKey] as int;
+    var total = json[totalKey] as int;
 
     // Convert to total bytes.
     javaHeap *= 1024;
@@ -72,7 +70,8 @@ class AdbMemoryInfo with Serializable {
     );
   }
 
-  /// JSON keys of data retrieved from ADB tool.
+  // JSON keys of data retrieved from ADB tool.
+
   static const String realTimeKey = 'Realtime';
   static const String javaHeapKey = 'Java Heap';
   static const String nativeHeapKey = 'Native Heap';
@@ -84,7 +83,7 @@ class AdbMemoryInfo with Serializable {
   static const String totalKey = 'Total';
 
   @override
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() => <String, Object?>{
         realTimeKey: realtime,
         javaHeapKey: javaHeap,
         nativeHeapKey: nativeHeap,
@@ -96,7 +95,7 @@ class AdbMemoryInfo with Serializable {
         totalKey: total,
       };
 
-  /// Create an empty AdbMemoryInfo (all values are)
+  /// Create an empty [AdbMemoryInfo], where all values are 0.
   static AdbMemoryInfo empty() => AdbMemoryInfo(0, 0, 0, 0, 0, 0, 0, 0, 0);
 
   /// Milliseconds since the device was booted (value zero) including deep sleep.
@@ -106,8 +105,8 @@ class AdbMemoryInfo with Serializable {
   /// This DateTime, from USA PST, would be Dec 31, 1960 16:00:00 (UTC - 8 hours).
   final int realtime;
 
-  /// All remaining values are received from ADB in kilobytes but converted to total
-  /// bytes using the AdbMemoryInfo.fromJsonInKilobytes factory.
+  /// All remaining values are received from ADB in kilobytes but converted to
+  /// total bytes using the [fromJsonInKB] factory.
   final int javaHeap;
 
   final int nativeHeap;

--- a/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
+++ b/packages/devtools_shared/lib/src/memory/class_heap_detail_stats.dart
@@ -4,7 +4,7 @@
 
 import 'package:vm_service/vm_service.dart';
 
-/// Entries for each class statistics
+/// Entries for each class's statistics.
 class ClassHeapDetailStats {
   ClassHeapDetailStats(
     this.classRef, {
@@ -19,7 +19,7 @@ class ClassHeapDetailStats {
         instancesDelta = deltaInstances,
         isStacktraced = traceAllocations;
 
-  factory ClassHeapDetailStats.fromJson(Map<String, dynamic> json) {
+  factory ClassHeapDetailStats.fromJson(Map<String, Object?> json) {
     final {'id': classId, 'name': className} = json['class'] as Map;
 
     return ClassHeapDetailStats(
@@ -33,7 +33,10 @@ class ClassHeapDetailStats {
   }
 
   Map<String, dynamic> toJson() => {
-        'class': {'id': classRef.id, 'name': classRef.name},
+        'class': {
+          'id': classRef.id,
+          'name': classRef.name,
+        },
         'bytesCurrent': bytesCurrent,
         'bytesDelta': bytesDelta,
         'instancesCurrent': instancesCurrent,
@@ -41,7 +44,7 @@ class ClassHeapDetailStats {
         'isStackedTraced': isStacktraced,
       };
 
-  /// Version of ClassHeapDetailsStats payload.
+  /// Version of [ClassHeapDetailStats] payload.
   static const version = 1;
 
   final ClassRef classRef;

--- a/packages/devtools_shared/lib/src/memory/event_sample.dart
+++ b/packages/devtools_shared/lib/src/memory/event_sample.dart
@@ -6,14 +6,15 @@ import 'dart:convert';
 
 import '../utils/serialization.dart';
 
-/// Monitor heap object allocations (in the VM).  The allocation monitor will
-/// cause 'start' event exist in the HeapSample. Immediately afterwards a
-/// 'continues' event is added on each subsequent timestamp tick (HeapSample)
-/// until another monitor start event.  A 'reset' event stops the 'continues'
-/// event for one timestamp tick with a 'reset' event. Immediately after the
-/// reset event a 'continues' event will again appear in the HeapSample's
-/// MemoryEventInfo - until a new monitor is started. One monitor exists per
-/// VM connection.
+/// Monitor heap object allocations (in the VM).
+///
+/// The allocation monitor will cause 'start' event exist in the `HeapSample`.
+/// Immediately afterwards a 'continues' event is added on each
+/// subsequent timestamp tick (`HeapSample`) until another monitor start event.
+/// A 'reset' event stops the 'continues' event for one timestamp tick
+/// with a 'reset' event. Immediately after the reset event a 'continues' event
+/// will again appear in the HeapSample's `MemoryEventInfo` - until
+/// a new monitor is started. One monitor exists per VM connection.
 class AllocationAccumulator {
   AllocationAccumulator(this._start, this._continues, this._reset);
 
@@ -30,14 +31,14 @@ class AllocationAccumulator {
         _continues = false,
         _reset = true;
 
-  factory AllocationAccumulator.fromJson(Map<String, dynamic> json) =>
+  factory AllocationAccumulator.fromJson(Map<String, Object?> json) =>
       AllocationAccumulator(
         json['start'] as bool,
         json['continues'] as bool,
         json['reset'] as bool,
       );
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() => <String, Object?>{
         'start': _start,
         'continues': _continues,
         'reset': _reset,
@@ -78,7 +79,7 @@ class ExtensionEvent {
     this.data,
   );
 
-  factory ExtensionEvent.fromJson(Map<String, dynamic> json) =>
+  factory ExtensionEvent.fromJson(Map<String, Object?> json) =>
       ExtensionEvent.custom(
         json['timestamp'] as int?,
         json['eventKind'] as String?,
@@ -86,7 +87,7 @@ class ExtensionEvent {
         (json['data'] as Map?)?.cast<String, Object>(),
       );
 
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() => <String, Object?>{
         'timestamp': timestamp,
         'eventKind': eventKind,
         'data': data,
@@ -124,7 +125,7 @@ class ExtensionEvents {
     final List<ExtensionEvent> events = [];
 
     json.forEach((key, value) {
-      final event = ExtensionEvent.fromJson(value as Map<String, dynamic>);
+      final event = ExtensionEvent.fromJson(value as Map<String, Object?>);
       events.add(event);
     });
 
@@ -132,7 +133,7 @@ class ExtensionEvents {
   }
 
   Map<String, dynamic> toJson() {
-    final eventsAsJson = <String, dynamic>{};
+    final eventsAsJson = <String, Object?>{};
     var index = 0;
     for (final event in events) {
       eventsAsJson['$index'] = event.toJson();
@@ -215,7 +216,7 @@ class EventSample with Serializable {
         isEventSnapshotAuto = false,
         allocationAccumulator = null;
 
-  factory EventSample.fromJson(Map<String, dynamic> json) {
+  factory EventSample.fromJson(Map<String, Object?> json) {
     final extensionEvents =
         (json['extensionEvents'] as Map?)?.cast<String, Object>();
 
@@ -225,7 +226,9 @@ class EventSample with Serializable {
       (json['snapshotEvent'] as bool?) ?? false,
       (json['snapshotAutoEvent'] as bool?) ?? false,
       json['allocationAccumulatorEvent'] != null
-          ? AllocationAccumulator.fromJson(json['allocationAccumulatorEvent'])
+          ? AllocationAccumulator.fromJson(
+              json['allocationAccumulatorEvent'] as Map<String, Object?>,
+            )
           : null,
       extensionEvents != null
           ? ExtensionEvents.fromJson(extensionEvents)
@@ -234,7 +237,7 @@ class EventSample with Serializable {
   }
 
   @override
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() => <String, Object?>{
         'timestamp': timestamp,
         'gcEvent': isEventGC,
         'snapshotEvent': isEventSnapshot,
@@ -253,7 +256,7 @@ class EventSample with Serializable {
         extensionEvents,
       );
 
-  /// Create an empty event (all values are nothing)
+  /// Create an empty event (all values are nothing).
   static EventSample empty() => EventSample(
         -1,
         false,
@@ -265,7 +268,7 @@ class EventSample with Serializable {
 
   bool get isEmpty => timestamp == -1;
 
-  /// Version of EventSample JSON payload.
+  /// The version of the [EventSample] JSON payload.
   static const version = 1;
 
   final int timestamp;
@@ -293,16 +296,16 @@ class EventSample with Serializable {
 class RasterCache with Serializable {
   RasterCache._({required this.layerBytes, required this.pictureBytes});
 
-  factory RasterCache.fromJson(Map<String, dynamic> json) {
+  factory RasterCache.fromJson(Map<String, Object?> json) {
     return RasterCache._(
-      layerBytes: json['layerBytes'],
-      pictureBytes: json['pictureBytes'],
+      layerBytes: json['layerBytes'] as int,
+      pictureBytes: json['pictureBytes'] as int,
     );
   }
 
   static RasterCache empty() => RasterCache._(layerBytes: 0, pictureBytes: 0);
 
-  static RasterCache? parse(Map<String, dynamic>? json) =>
+  static RasterCache? parse(Map<String, Object?>? json) =>
       json == null ? null : RasterCache.fromJson(json);
 
   int layerBytes;
@@ -310,7 +313,7 @@ class RasterCache with Serializable {
   int pictureBytes;
 
   @override
-  Map<String, dynamic> toJson() => {
+  Map<String, dynamic> toJson() => <String, Object?>{
         'layerBytes': layerBytes,
         'pictureBytes': pictureBytes,
       };

--- a/packages/devtools_shared/lib/src/memory/heap_sample.dart
+++ b/packages/devtools_shared/lib/src/memory/heap_sample.dart
@@ -45,7 +45,7 @@ class HeapSample with Serializable {
         memoryEventInfo = memoryEventInfo ?? EventSample.empty(),
         rasterCache = rasterCache ?? RasterCache.empty();
 
-  factory HeapSample.fromJson(Map<String, dynamic> json) {
+  factory HeapSample.fromJson(Map<String, Object?> json) {
     return HeapSample(
       json[Json.timestamp.key] as int,
       json[Json.rss.key] as int,
@@ -71,7 +71,7 @@ class HeapSample with Serializable {
   }
 
   @override
-  Map<String, dynamic> toJson() => <String, dynamic>{
+  Map<String, dynamic> toJson() => <String, Object?>{
         Json.timestamp.key: timestamp,
         Json.rss.key: rss,
         Json.capacity.key: capacity,

--- a/packages/devtools_shared/lib/src/memory/heap_space.dart
+++ b/packages/devtools_shared/lib/src/memory/heap_space.dart
@@ -5,18 +5,19 @@
 /// HeapSpace of Dart VM collected heap data.
 class HeapSpace {
   HeapSpace._fromJson(this.json)
-      : avgCollectionPeriodMillis = json['avgCollectionPeriodMillis'],
-        capacity = json['capacity'],
-        collections = json['collections'],
-        external = json['external'],
-        name = json['name'],
-        time = json['time'],
-        used = json['used'];
+      : avgCollectionPeriodMillis =
+            json['avgCollectionPeriodMillis'] as double?,
+        capacity = json['capacity'] as int?,
+        collections = json['collections'] as int?,
+        external = json['external'] as int?,
+        name = json['name'] as String?,
+        time = json['time'] as double?,
+        used = json['used'] as int?;
 
-  static HeapSpace? parse(Map<String, dynamic>? json) =>
+  static HeapSpace? parse(Map<String, Object?>? json) =>
       json == null ? null : HeapSpace._fromJson(json);
 
-  final Map<String, dynamic> json;
+  final Map<String, Object?> json;
 
   final double? avgCollectionPeriodMillis;
 
@@ -32,20 +33,16 @@ class HeapSpace {
 
   final int? used;
 
-  Map<String, dynamic> toJson() {
-    final json = <String, dynamic>{};
-    json['type'] = 'HeapSpace';
-    json.addAll({
-      'avgCollectionPeriodMillis': avgCollectionPeriodMillis,
-      'capacity': capacity,
-      'collections': collections,
-      'external': external,
-      'name': name,
-      'time': time,
-      'used': used,
-    });
-    return json;
-  }
+  Map<String, dynamic> toJson() => <String, Object?>{
+        'type': 'HeapSpace',
+        'avgCollectionPeriodMillis': avgCollectionPeriodMillis,
+        'capacity': capacity,
+        'collections': collections,
+        'external': external,
+        'name': name,
+        'time': time,
+        'used': used,
+      };
 
   @override
   String toString() => '[HeapSpace]';

--- a/packages/devtools_shared/lib/src/memory/memory_json.dart
+++ b/packages/devtools_shared/lib/src/memory/memory_json.dart
@@ -16,24 +16,24 @@ abstract class DecodeEncode<T> {
   /// More than one Encoded entry, add a comma and the Encoded entry.
   String encodeAnother(T sample);
 
-  T fromJson(Map<String, dynamic> json);
+  T fromJson(Map<String, Object?> json);
 }
 
 abstract class MemoryJson<T> implements DecodeEncode<T> {
   MemoryJson();
 
-  /// Given a JSON string representing an array of HeapSample, decode to a
+  /// Given a JSON string representing an array of [HeapSample], decode to a
   /// List of HeapSample.
   MemoryJson.decode(
     String payloadName, {
     required String argJsonString,
-    Map<String, dynamic>? argDecodedMap,
+    Map<String, Object?>? argDecodedMap,
   }) {
-    final Map<String, dynamic> decodedMap =
-        argDecodedMap ?? jsonDecode(argJsonString);
-    Map<String, dynamic> payload = decodedMap[payloadName];
+    final decodedMap =
+        argDecodedMap ?? (jsonDecode(argJsonString) as Map<String, Object?>);
+    var payload = decodedMap[payloadName] as Map<String, Object?>;
 
-    int payloadVersion = payload[jsonVersionField];
+    var payloadVersion = payload[jsonVersionField] as int;
     final payloadDevToolsScreen = payload[jsonDevToolsScreenField];
 
     if (payloadVersion != version) {
@@ -47,15 +47,15 @@ abstract class MemoryJson<T> implements DecodeEncode<T> {
     // Any problem return (data is empty).
     if (!isMatchedVersion || !isMemoryPayload) return;
 
-    final List dynamicList = payload[jsonDataField];
+    final dynamicList = payload[jsonDataField] as List<Object?>;
     for (var index = 0; index < dynamicList.length; index++) {
-      final sample = fromJson(dynamicList[index] as Map<String, dynamic>);
+      final sample = fromJson(dynamicList[index] as Map<String, Object?>);
       data.add(sample);
     }
   }
 
   Map<String, dynamic> upgradeToVersion(
-    Map<String, dynamic> payload,
+    Map<String, Object?> payload,
     int oldVersion,
   );
 
@@ -91,10 +91,10 @@ class SamplesMemoryJson extends MemoryJson<HeapSample> {
   SamplesMemoryJson();
 
   /// Given a JSON string representing an array of HeapSample, decode to a
-  /// List of HeapSample.
+  /// list of [HeapSample].
   SamplesMemoryJson.decode({
     required String argJsonString,
-    Map<String, dynamic>? argDecodedMap,
+    Map<String, Object?>? argDecodedMap,
   }) : super.decode(
           _jsonMemoryPayloadField,
           argJsonString: argJsonString,
@@ -104,71 +104,80 @@ class SamplesMemoryJson extends MemoryJson<HeapSample> {
   /// Exported JSON payload of collected memory statistics.
   static const String _jsonMemoryPayloadField = 'samples';
 
-  /// Structure of the memory JSON file:
+  /// ## Structure of the memory JSON file
   ///
+  /// ```json
   /// {
   ///   "samples": {
   ///     "version": 1,
   ///     "dartDevToolsScreen": "memory"
   ///     "data": [
-  ///       Encoded Heap Sample see section below.
+  ///       # Encoded Heap Sample see section below.
   ///     ]
   ///   }
   /// }
-
-  /// Header portion (memoryJsonHeader) e.g.,
-  /// =======================================
+  /// ```
+  ///
+  /// ## Header portion (`memoryJsonHeader`)
+  ///
+  /// ```json
   /// {
   ///   "samples": {
   ///     "version": 1,
   ///     "dartDevToolsScreen": "memory"
   ///     "data": [
+  /// ```
   ///
-  /// Encoded Allocations entry (SamplesMemoryJson),
-  /// ==============================================================================
-  ///     {
-  ///       "timestamp":1581540967479,
-  ///       "rss":211419136,
-  ///       "capacity":50956576,
-  ///       "used":41384952,
-  ///       "external":166176,
-  ///       "gc":false,
-  ///       "adb_memoryInfo":{
-  ///         "Realtime":450147758,
-  ///         "Java Heap":7416,
-  ///         "Native Heap":41712,
-  ///         "Code":12644,
-  ///         "Stack":52,
-  ///         "Graphics":0,
-  ///         "Private Other":94420,
-  ///         "System":6178,
-  ///         "Total":162422
-  ///       }
-  ///     },
+  /// ## Encoded Allocations entry (`SamplesMemoryJson`),
   ///
-  /// Trailer portion (memoryJsonTrailer) e.g.,
-  /// =========================================
+  /// ```json
+  /// {
+  ///   "timestamp":1581540967479,
+  ///   "rss":211419136,
+  ///   "capacity":50956576,
+  ///   "used":41384952,
+  ///   "external":166176,
+  ///   "gc":false,
+  ///   "adb_memoryInfo":{
+  ///     "Realtime":450147758,
+  ///     "Java Heap":7416,
+  ///     "Native Heap":41712,
+  ///     "Code":12644,
+  ///     "Stack":52,
+  ///     "Graphics":0,
+  ///     "Private Other":94420,
+  ///     "System":6178,
+  ///     "Total":162422
+  ///   }
+  /// },
+  /// ```
+  ///
+  /// ## Trailer portion (`memoryJsonTrailer`)
+  ///
+  /// ```json
   ///     ]
   ///   }
   /// }
+  /// ```
 
   @override
   int get version => HeapSample.version;
 
-  /// Encoded Heap Sample
+  /// Encode the specified [sample].
   @override
   String encode(HeapSample sample) => jsonEncode(sample);
 
-  /// More than one Encoded Heap Sample, add a comma and the Encoded Heap Sample.
+  /// More than one encoded [HeapSample],
+  /// add a comma and the encoded [sample].
   @override
   String encodeAnother(HeapSample sample) => ',\n${jsonEncode(sample)}';
 
   @override
-  HeapSample fromJson(Map<String, dynamic> json) => HeapSample.fromJson(json);
+  HeapSample fromJson(Map<String, Object?> json) => HeapSample.fromJson(json);
 
   @override
   Map<String, dynamic> upgradeToVersion(
-    Map<String, dynamic> payload,
+    Map<String, Object?> payload,
     int oldVersion,
   ) =>
       throw UnimplementedError(
@@ -197,62 +206,70 @@ class SamplesMemoryJson extends MemoryJson<HeapSample> {
       '"${MemoryJson.jsonDataField}": [\n';
 }
 
-/// Structure of the memory JSON file:
+/// ## Structure of the memory JSON file
 ///
+/// ```json
 /// {
 ///   "allocations": {
 ///     "version": 2,
 ///     "dartDevToolsScreen": "memory"
 ///     "data": [
-///       Encoded ClassHeapStats see section below.
+///       # Encoded ClassHeapStats see section below.
 ///     ]
 ///   }
 /// }
-
-/// Header portion (memoryJsonHeader) e.g.,
-/// =======================================
+/// ```
+///
+/// ## Header portion (`memoryJsonHeader`)
+///
+/// ```json
 /// {
 ///   "allocations": {
 ///     "version": 2,
 ///     "dartDevToolsScreen": "memory"
 ///     "data": [
+/// ```
 ///
-/// Encoded Allocations entry (AllocationMemoryJson),
-/// ==============================================================================
-///     {
-///       "class" : {
-///          id: "classes/1"
-///          name: "AClassName"
-///        },
-///       "instancesCurrent": 100,
-///       "instancesAccumulated": 0,
-///       "bytesCurrent": 55,
-///       "accumulatedSize": 5,
-///       "_new": [
-///         100,
-///         50,
-///         5
-///       ],
-///       "_old": [
-///         0,
-///         0,
-///         0
-///       ]
-///     },
+/// ## Encoded Allocations entry (`AllocationMemoryJson`)
 ///
-/// Trailer portion (memoryJsonTrailer) e.g.,
-/// =========================================
+/// ```json
+/// {
+///   "class" : {
+///      id: "classes/1"
+///      name: "AClassName"
+///    },
+///   "instancesCurrent": 100,
+///   "instancesAccumulated": 0,
+///   "bytesCurrent": 55,
+///   "accumulatedSize": 5,
+///   "_new": [
+///     100,
+///     50,
+///     5
+///   ],
+///   "_old": [
+///     0,
+///     0,
+///     0
+///   ]
+/// },
+/// ```
+///
+/// ## Trailer portion (`memoryJsonTrailer`)
+///
+/// ```json
 ///     ]
 ///   }
 /// }
+/// ```
 class AllocationMemoryJson extends MemoryJson<ClassHeapStats> {
   AllocationMemoryJson();
 
   /// Given a JSON string representing an array of HeapSample, decode to a
-  /// List of HeapSample.
+  /// list of [HeapSample].
   AllocationMemoryJson.decode({
     required String argJsonString,
-    Map<String, dynamic>? argDecodedMap,
+    Map<String, Object?>? argDecodedMap,
   }) : super.decode(
           _jsonAllocationPayloadField,
           argJsonString: argJsonString,
@@ -262,34 +279,35 @@ class AllocationMemoryJson extends MemoryJson<ClassHeapStats> {
   /// Exported JSON payload of collected memory statistics.
   static const String _jsonAllocationPayloadField = 'allocations';
 
-  /// Encoded ClassHeapDetailStats
+  /// JSON encoded version of the [sample].
   @override
   String encode(ClassHeapStats sample) => jsonEncode(sample.json);
 
-  /// More than one Encoded ClassHeapDetailStats, add a comma and the Encoded ClassHeapDetailStats entry.
+  /// More than one encoded [ClassHeapStats],
+  /// add a comma and the encoded [sample].
   @override
   String encodeAnother(ClassHeapStats sample) =>
       ',\n${jsonEncode(sample.json)}';
 
   @override
-  ClassHeapStats fromJson(Map<String, dynamic> json) =>
+  ClassHeapStats fromJson(Map<String, Object?> json) =>
       ClassHeapStats.parse(json)!;
 
   @override
   Map<String, dynamic> upgradeToVersion(
-    Map<String, dynamic> payload,
+    Map<String, Object?> payload,
     int oldVersion,
   ) {
     assert(oldVersion < version);
     assert(oldVersion == 1);
-    final updatedPayload = Map<String, dynamic>.of(payload);
+    final updatedPayload = Map<String, Object?>.of(payload);
     updatedPayload['version'] = version;
     final oldData = (payload['data'] as List).map((e) => _OldData(e));
     updatedPayload['data'] = [
       for (final data in oldData)
         {
           'type': 'ClassHeapStats',
-          'class': <String, dynamic>{
+          'class': <String, Object?>{
             'type': '@Class',
             ...data.class_,
           },
@@ -342,14 +360,14 @@ class AllocationMemoryJson extends MemoryJson<ClassHeapStats> {
       '"${MemoryJson.jsonDataField}": [\n';
 }
 
-extension type _OldData(Map<String, dynamic> data) {
-  Map<String, dynamic> get class_ => data['class'];
+extension type _OldData(Map<String, Object?> data) {
+  Map<String, Object?> get class_ => data['class'] as Map<String, Object?>;
 
-  int get bytesCurrent => data['bytesCurrent'];
+  int get bytesCurrent => data['bytesCurrent'] as int;
 
-  int get bytesDelta => data['bytesDelta'];
+  int get bytesDelta => data['bytesDelta'] as int;
 
-  int get instancesCurrent => data['instancesCurrent'];
+  int get instancesCurrent => data['instancesCurrent'] as int;
 
-  int get instancesDelta => data['instancesDelta'];
+  int get instancesDelta => data['instancesDelta'] as int;
 }


### PR DESCRIPTION
- Clean up doc comments.
  - Fit within 80 characters.
  - Match Effective Dart suggestions more often.
  - Fix rendering of JSON samples snippets
- Remove implicit casts from `dynamic`
- Add missing generic types to avoid raw type arguments being inferred as `dynamic`

Fixes https://github.com/flutter/devtools/issues/3011
