### PR TITLE
Migrate devtools wiki & update old flutter wiki links

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,8 +21,8 @@ If you need help, consider asking for help on [Discord].
 
 <!-- Links -->
 [Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
-[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
-[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
+[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
+[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
 [CLA]: https://cla.developers.google.com/
-[Discord]: https://github.com/flutter/flutter/wiki/Chat
+[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
 [build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,10 +2,10 @@
 
 ![GitHub contributors](https://img.shields.io/github/contributors/flutter/devtools.svg)
 
-_tl;dr: join [Discord](https://github.com/flutter/flutter/wiki/Chat), be
+_tl;dr: join [Discord](https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md), be
 [courteous](https://github.com/flutter/flutter/blob/master/CODE_OF_CONDUCT.md), follow the steps below
 to set up a development environment; if you stick around and contribute, you can
-[join the team](https://github.com/flutter/flutter/wiki/Contributor-access) and get commit access._
+[join the team](https://github.com/flutter/flutter/blob/master/docs/contributing/Contributor-access.md) and get commit access._
 
 > If you are here because you just want to test the bleeding-edge (unreleased) DevTools functionality,
 follow our [beta testing guidance](https://github.com/flutter/devtools/blob/master/BETA_TESTING.md).
@@ -17,7 +17,7 @@ We gladly accept contributions via GitHub pull requests! We encourage you to rea
 framework's contributing guide, as all of that information applies to contributing to the `flutter/devtools`
 repo as well.
 
-We communicate primarily over GitHub and [Discord](https://github.com/flutter/flutter/wiki/Chat) on the
+We communicate primarily over GitHub and [Discord](https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md) on the
 [#hackers-devtools](https://discord.com/channels/608014603317936148/1106667330093723668) channel.
 
 Before contributing code:

--- a/STYLE.md
+++ b/STYLE.md
@@ -2,7 +2,7 @@
 
 We fully follow [Effective Dart](https://dart.dev/guides/language/effective-dart)
 and some items of
-[Style guide for Flutter repo](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo):
+[Style guide for Flutter repo](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md):
 
 ## Order of getters and setters
 
@@ -11,7 +11,7 @@ more complicated than just public field
 we declare the related class members always in the same order,
 without new lines separating the members,
 in compliance with
-[Flutter repo style guide]( https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#order-other-class-members-in-a-way-that-makes-sense):
+[Flutter repo style guide](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#order-other-class-members-in-a-way-that-makes-sense):
 
 1. Public getter
 2. Private field
@@ -19,11 +19,11 @@ in compliance with
 
 ## Naming for typedefs and function variables
 
-Follow [Flutter repo naming rules for typedefs and function variables](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#naming-rules-for-typedefs-and-function-variables).
+Follow [Flutter repo naming rules for typedefs and function variables](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#naming-rules-for-typedefs-and-function-variables).
 
 ## Overriding equality
 
-Use [boilerplate](https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#common-boilerplates-for-operator--and-hashcode).
+Use [boilerplate](https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#common-boilerplates-for-operator--and-hashcode).
 
 ## URIs and File Paths
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -20,7 +20,7 @@ For each new issue that comes in, perform all of these tasks that apply:
 
 ### Prioritize the issue. 
 
-Follow the prioritization rubric [here](https://github.com/flutter/flutter/wiki/Issue-hygiene#priorities). 
+Follow the prioritization rubric [here](https://github.com/flutter/flutter/blob/master/docs/contributing/issue_hygiene/README.md#priorities).
 
 Tag the area owner in a comment if the issue requires specific expertise. Assign to an owner if the issue is a work in process or if the issue needs immediate / almost-immediate attention (P0, P1).
 

--- a/TRIAGE.md
+++ b/TRIAGE.md
@@ -1,0 +1,32 @@
+# Triage
+
+## The Process
+
+If you are the devtools triage rotation on-call, you are expected to triage issues that appeared/updated during the week (it is ok to triage all of them at the end of the week).
+
+You are also expected to monitor the DevTools discord [channel](https://discord.com/channels/608014603317936148/958862085297672282) for user questions / concerns.
+
+## DevTools Issues
+
+Queue: https://github.com/flutter/devtools/issues?q=is%3Aopen+is%3Aissue+-label%3AP0%2CP1%2CP2%2CP3%2CP4%2CP5%2CP6 
+
+For each new issue that comes in, perform all of these tasks that apply:
+
+### Label/project the issue:
+* Add labels for its proper category or categories ( “Inspector page”, “debugger page”, “bug”, etc.)
+* Add label “waiting for customer response” if you requested more details from reporter
+* Add label “fix it friday” if the issue should be fixed and looks easy to fix
+* Add to project [go/dart-devtools-ux-issues](https://github.com/orgs/flutter/projects/54/settings) if the issue is cross-screen issue
+
+### Prioritize the issue. 
+
+Follow the prioritization rubric [here](https://github.com/flutter/flutter/wiki/Issue-hygiene#priorities). 
+
+Tag the area owner in a comment if the issue requires specific expertise. Assign to an owner if the issue is a work in process or if the issue needs immediate / almost-immediate attention (P0, P1).
+
+## Related Flutter Issues
+
+flutter/flutter issues relating to DevTools:
+https://github.com/flutter/flutter/issues?q=is%3Aopen+label%3A%22d%3A+devtools%22+++no%3Amilestone+ 
+
+Ping the [hackers-devtools](https://discord.com/channels/608014603317936148/1106667330093723668) discord channel about issues marked “severe: …” or “P0”. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+## Home
+
+This wiki is primarily aimed at engineers building or making contributions to DevTools.
+
+If you're looking to make a one-off contribution, please start with the [contributing guide](../CONTRIBUTING.md).

--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -100,7 +100,7 @@ linter:
     - prefer_const_literals_to_create_immutables
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains
-    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md#consider-using--for-short-functions-and-methods
     - prefer_final_fields
     - prefer_final_in_for_each
     - prefer_final_locals

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -114,7 +114,7 @@ class _ContributingLink extends StatelessWidget {
 class _DiscordLink extends StatelessWidget {
   const _DiscordLink();
 
-  static const _discordWikiUrl = 'https://github.com/flutter/flutter/wiki/Chat';
+  static const _discordWikiUrl = 'https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md';
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -114,7 +114,7 @@ class _ContributingLink extends StatelessWidget {
 class _DiscordLink extends StatelessWidget {
   const _DiscordLink();
 
-  static const _discordWikiUrl =
+  static const _discordDocsUrl =
       'https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md';
 
   @override
@@ -123,7 +123,7 @@ class _DiscordLink extends StatelessWidget {
       text: GaLinkTextSpan(
         link: const GaLink(
           display: 'Discord',
-          url: _discordWikiUrl,
+          url: _discordDocsUrl,
           gaScreenName: gac.devToolsMain,
           gaSelectedItemDescription: gac.discordLink,
         ),

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -114,7 +114,8 @@ class _ContributingLink extends StatelessWidget {
 class _DiscordLink extends StatelessWidget {
   const _DiscordLink();
 
-  static const _discordWikiUrl = 'https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md';
+  static const _discordWikiUrl =
+      'https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md';
 
   @override
   Widget build(BuildContext context) {

--- a/packages/devtools_app/test/legacy_integration_tests/integration.dart
+++ b/packages/devtools_app/test/legacy_integration_tests/integration.dart
@@ -423,7 +423,7 @@ class WebBuildFixture {
     // directly to prevent Windows-based test runs getting killed but leaving
     // the pub process behind. Something similar might be needed here.
     // See here for more information:
-    // https://github.com/flutter/flutter/wiki/The-flutter-tool#debugging-the-flutter-command-line-tool
+    // https://github.com/flutter/flutter/blob/master/docs/tool/README.md#debugging-the-flutter-command-line-tool
     final executable = Platform.isWindows ? 'flutter.bat' : 'flutter';
 
     if (verbose) {

--- a/packages/devtools_extensions/README.md
+++ b/packages/devtools_extensions/README.md
@@ -392,7 +392,7 @@ popd
 
 ## Resources and support
 
-Please join the [Flutter Discord server](https://github.com/flutter/flutter/wiki/Chat) and then check out
+Please join the [Flutter Discord server](https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md) and then check out
 the [#devtools-extension-authors](https://discord.com/channels/608014603317936148/1159561514072690739)
 channel to connect with other DevTools extension authors and the DevTools team.
 

--- a/packages/devtools_shared/lib/src/test/chrome_driver.dart
+++ b/packages/devtools_shared/lib/src/test/chrome_driver.dart
@@ -13,7 +13,7 @@ class ChromeDriver with IOMixin {
 
   // TODO(kenz): add error messaging if the chromedriver executable is not
   // found. We can also consider using web installers directly in this script:
-  // https://github.com/flutter/flutter/wiki/Running-Flutter-Driver-tests-with-Web#web-installers-repo.
+  // https://github.com/flutter/flutter/blob/master/docs/contributing/testing/Running-Flutter-Driver-tests-with-Web.md#web-installers-repo.
   Future<void> start({bool debugLogging = false}) async {
     try {
       if (debugLogging) {

--- a/tool/RELEASE_INSTRUCTIONS.md
+++ b/tool/RELEASE_INSTRUCTIONS.md
@@ -370,7 +370,7 @@ onto the `flutter/devtools` protected branch (`master`).
 
 ### Additional resources
 - `dart-lang/sdk` cherry-pick [Wiki](https://github.com/dart-lang/sdk/wiki/Cherry-picks-to-a-release-channel)
-- Flutter cherry-pick [Wiki](https://github.com/flutter/flutter/blob/master/docs/releases/Flutter-Cherrypick-Process.md)
+- Flutter cherry-pick [docs](https://github.com/flutter/flutter/blob/master/docs/releases/Flutter-Cherrypick-Process.md)
 - Example cherry-pick cl: https://dart-review.googlesource.com/c/sdk/+/336827
 - Example cherry-pick issue: https://github.com/dart-lang/sdk/issues/54085
 - Example merge commit on `flutter/devtools`: https://github.com/flutter/devtools/pull/6812

--- a/tool/RELEASE_INSTRUCTIONS.md
+++ b/tool/RELEASE_INSTRUCTIONS.md
@@ -370,7 +370,7 @@ onto the `flutter/devtools` protected branch (`master`).
 
 ### Additional resources
 - `dart-lang/sdk` cherry-pick [Wiki](https://github.com/dart-lang/sdk/wiki/Cherry-picks-to-a-release-channel)
-- Flutter cherry-pick [Wiki](https://github.com/flutter/flutter/wiki/Flutter-Cherrypick-Process)
+- Flutter cherry-pick [Wiki](https://github.com/flutter/flutter/blob/master/docs/releases/Flutter-Cherrypick-Process.md)
 - Example cherry-pick cl: https://dart-review.googlesource.com/c/sdk/+/336827
 - Example cherry-pick issue: https://github.com/dart-lang/sdk/issues/54085
 - Example merge commit on `flutter/devtools`: https://github.com/flutter/devtools/pull/6812


### PR DESCRIPTION
Part of https://github.com/flutter/flutter/issues/145009

This migrates the home and triage page of the devtools wiki into checked in files, and updates all old references to flutter/flutter/wiki

I'll update the original wiki pages to point to these new places after this lands

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
