### PR TITLE
[deep link][ios] load links for ios and change path to nullable

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -272,6 +272,7 @@ class DeepLinksController extends DisposableController
     final iosBuildOptions = selectedProject.value!.iosBuildOptions;
     final configuration =
         iosBuildOptions.configurations[selectedIosConfigurationIndex.value];
+    final target = iosBuildOptions.targets[selectedIosTargetIndex.value];
     await ga.timeAsync(
       gac.deeplink,
       gac.AnalyzeFlutterProject.loadIosLinks.name,
@@ -281,7 +282,7 @@ class DeepLinksController extends DisposableController
           result = await server.requestIosUniversalLinkSettings(
             selectedProject.value!.path,
             configuration: configuration,
-            target: iosBuildOptions.targets[selectedIosTargetIndex.value],
+            target: target,
           );
           _iosLinks[selectedAndroidVariantIndex.value] = result;
         } catch (_) {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -281,7 +281,7 @@ class DeepLinksController extends DisposableController
           result = await server.requestIosUniversalLinkSettings(
             selectedProject.value!.path,
             configuration: configuration,
-            target: iosBuildOptions.targets[0],
+            target: iosBuildOptions.targets[selectedIosTargetIndex.value],
           );
           _iosLinks[selectedAndroidVariantIndex.value] = result;
         } catch (_) {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -10,6 +10,7 @@ import 'package:flutter/material.dart';
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
+import '../../shared/feature_flags.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/server/server.dart' as server;
@@ -17,7 +18,7 @@ import 'deep_link_list_view.dart';
 import 'deep_links_model.dart';
 import 'deep_links_services.dart';
 
-typedef _DomainAndPath = ({String? domain, String path});
+typedef _DomainAndPath = ({String? domain, String? path});
 
 const domainAssetLinksJsonFileErrors = {
   DomainError.existence,
@@ -145,9 +146,14 @@ class DeepLinksController extends DisposableController
   DeepLinksController() {
     addAutoDisposeListener(
       selectedAndroidVariantIndex,
-      _handleSelectedAndroidVariantIndexChanged,
+      _handleAndroidConfigurationChanged,
     );
-    // TODO(Hangyujin): Add listerner for selectedIosConfigurationIndex.
+    if (FeatureFlags.deepLinkIosCheck) {
+      addAutoDisposeListener(
+        selectedIosConfigurationIndex,
+        _handleIosConfigurationChanged,
+      );
+    }
   }
 
   DisplayOptions get displayOptions => displayOptionsNotifier.value;
@@ -158,19 +164,20 @@ class DeepLinksController extends DisposableController
   List<LinkData> linkDatasByPath(List<LinkData> linkdatas) {
     final linkDatasByPath = <String, LinkData>{};
     for (final linkData in linkdatas) {
-      final previousRecord = linkDatasByPath[linkData.path];
-      linkDatasByPath[linkData.path] = LinkData(
+      final path = linkData.path;
+      if (path == null) {
+        continue;
+      }
+      final previousRecord = linkDatasByPath[path];
+
+      linkDatasByPath[path] = LinkData(
         domain: linkData.domain,
         path: linkData.path,
         scheme: linkData.scheme.union(previousRecord?.scheme ?? {}),
-        os: [
-          if (previousRecord?.os.contains(PlatformOS.android) ??
-              false || linkData.os.contains(PlatformOS.android))
-            PlatformOS.android,
-          if (previousRecord?.os.contains(PlatformOS.ios) ??
-              false || linkData.os.contains(PlatformOS.ios))
-            PlatformOS.ios,
-        ],
+        os: {
+          if (previousRecord != null) ...previousRecord.os,
+          ...linkData.os,
+        },
         associatedDomains: [
           ...previousRecord?.associatedDomains ?? [],
           if (linkData.domain != null) linkData.domain!,
@@ -194,10 +201,13 @@ class DeepLinksController extends DisposableController
         domain: linkData.domain,
         path: linkData.path,
         scheme: linkData.scheme.union(previousRecord?.scheme ?? {}),
-        os: linkData.os,
+        os: {
+          if (previousRecord != null) ...previousRecord.os,
+          ...linkData.os,
+        },
         associatedPath: [
           ...previousRecord?.associatedPath ?? [],
-          linkData.path,
+          if (linkData.path != null) linkData.path!,
         ],
         domainErrors: linkData.domainErrors,
       );
@@ -208,19 +218,32 @@ class DeepLinksController extends DisposableController
   AppLinkSettings? get currentAppLinkSettings =>
       _androidAppLinks[selectedAndroidVariantIndex.value];
 
-  final Map<int, AppLinkSettings> _androidAppLinks = <int, AppLinkSettings>{};
+  final _androidAppLinks = <int, AppLinkSettings>{};
+  final _iosLinks = <int, UniversalLinkSettings>{};
 
   late final selectedAndroidVariantIndex = ValueNotifier<int>(0);
   late final selectedIosConfigurationIndex = ValueNotifier<int>(0);
   late final selectedIosTargetIndex = ValueNotifier<int>(0);
 
-  void _handleSelectedAndroidVariantIndexChanged() {
-    unawaited(loadAndroidAppLinksAndValidate());
+  void _handleAndroidConfigurationChanged() async {
+    pagePhase.value = PagePhase.linksLoading;
+    await loadAndroidAppLinks();
+    if (pagePhase.value == PagePhase.validationErrorPage) {
+      return;
+    }
+    await validateLinks();
   }
 
-  Future<void> loadAndroidAppLinksAndValidate() async {
+  void _handleIosConfigurationChanged() async {
     pagePhase.value = PagePhase.linksLoading;
+    await loadIosLinks();
+    if (pagePhase.value == PagePhase.validationErrorPage) {
+      return;
+    }
+    await validateLinks();
+  }
 
+  Future<void> loadAndroidAppLinks() async {
     final variant = selectedProject
         .value!.androidVariants[selectedAndroidVariantIndex.value];
     await ga.timeAsync(
@@ -243,9 +266,42 @@ class DeepLinksController extends DisposableController
         }
       },
     );
+  }
 
+  Future<void> loadIosLinks() async {
+    final iosBuildOptions = selectedProject.value!.iosBuildOptions;
+    final configuration =
+        iosBuildOptions.configurations[selectedIosConfigurationIndex.value];
+    await ga.timeAsync(
+      gac.deeplink,
+      gac.AnalyzeFlutterProject.loadIosLinks.name,
+      asyncOperation: () async {
+        final UniversalLinkSettings result;
+        try {
+          result = await server.requestIosUniversalLinkSettings(
+            selectedProject.value!.path,
+            configuration: configuration,
+            target: iosBuildOptions.targets[0],
+          );
+          _iosLinks[selectedAndroidVariantIndex.value] = result;
+        } catch (_) {
+          pagePhase.value = PagePhase.validationErrorPage;
+        }
+      },
+    );
+  }
+
+  Future<void> loadLinksAndValidate() async {
+    pagePhase.value = PagePhase.linksLoading;
+    await loadAndroidAppLinks();
     if (pagePhase.value == PagePhase.validationErrorPage) {
       return;
+    }
+    if (FeatureFlags.deepLinkIosCheck) {
+      await loadIosLinks();
+      if (pagePhase.value == PagePhase.validationErrorPage) {
+        return;
+      }
     }
     await validateLinks();
   }
@@ -273,7 +329,12 @@ class DeepLinksController extends DisposableController
   }
 
   /// Get all unverified link data.
-  List<LinkData> _allRawLinkDatas(AppLinkSettings appLinksSettings) {
+  List<LinkData> get _rawAndroidLinkDatas {
+    final appLinksSettings =
+        _androidAppLinks[selectedAndroidVariantIndex.value];
+    if (appLinksSettings == null) {
+      return const <LinkData>[];
+    }
     final appLinks = appLinksSettings.deeplinks;
 
     final domainPathToLinkData = <_DomainAndPath, LinkData>{};
@@ -287,7 +348,7 @@ class DeepLinksController extends DisposableController
           path: appLink.path,
           pathErrors:
               _getPathErrorsFromIntentFilterChecks(appLink.intentFilterChecks),
-          os: [PlatformOS.android],
+          os: {PlatformOS.android},
           scheme: {if (scheme != null) scheme},
         );
       } else {
@@ -307,6 +368,20 @@ class DeepLinksController extends DisposableController
     }
 
     return domainPathToLinkData.values.toList();
+  }
+
+  List<LinkData> get _rawIosLinkDatas {
+    final iosDomains =
+        _iosLinks[selectedIosConfigurationIndex.value]?.associatedDomains ?? [];
+    return iosDomains
+        .map(
+          (domain) => LinkData(
+            domain: domain,
+            path: null,
+            os: {PlatformOS.ios},
+          ),
+        )
+        .toList();
   }
 
   final selectedProject = ValueNotifier<FlutterProject?>(null);
@@ -415,7 +490,11 @@ class DeepLinksController extends DisposableController
 
   Future<List<LinkData>> _validatePath(List<LinkData> linkdatas) async {
     for (final linkData in linkdatas) {
-      if (!(linkData.path.startsWith('/') || linkData.path == '.*')) {
+      final path = linkData.path;
+      if (path == null) {
+        continue;
+      }
+      if (!(path.startsWith('/') || path == '.*')) {
         linkData.pathErrors.add(PathError.pathFormat);
       }
     }
@@ -437,7 +516,10 @@ class DeepLinksController extends DisposableController
       return;
     }
     pagePhase.value = PagePhase.linksValidating;
-    var linkdata = _allRawLinkDatas(appLinkSettings);
+    List<LinkData> linkdata = [
+      ..._rawAndroidLinkDatas,
+      if (FeatureFlags.deepLinkIosCheck) ..._rawIosLinkDatas,
+    ];
     if (linkdata.isEmpty) {
       ga.select(
         gac.deeplink,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -201,9 +201,9 @@ class LinkData with SearchableDataMixin {
     this.associatedDomains = const <String>[],
   });
 
-  final String path;
+  final String? path;
   final String? domain;
-  final List<PlatformOS> os;
+  final Set<PlatformOS> os;
   final Set<String> scheme;
   final List<DomainError> domainErrors;
   Set<PathError> pathErrors;
@@ -214,11 +214,14 @@ class LinkData with SearchableDataMixin {
   @override
   bool matchesSearchToken(RegExp regExpSearch) {
     return (domain?.caseInsensitiveContains(regExpSearch) ?? false) ||
-        path.caseInsensitiveContains(regExpSearch);
+        (path?.caseInsensitiveContains(regExpSearch) ?? false);
   }
 
   @override
   String toString() => 'LinkData($domain $path)';
+
+  String get safePath => path ?? '';
+  String get safeDomain => domain ?? '';
 }
 
 class _ErrorAwareText extends StatelessWidget {
@@ -392,7 +395,7 @@ class PathColumn extends ColumnData<LinkData>
   }
 
   @override
-  String getValue(LinkData dataObject) => dataObject.path;
+  String getValue(LinkData dataObject) => dataObject.safePath;
 
   @override
   Widget build(
@@ -405,7 +408,7 @@ class PathColumn extends ColumnData<LinkData>
     return _ErrorAwareText(
       isError: dataObject.pathErrors.isNotEmpty,
       controller: controller,
-      text: dataObject.path,
+      text: dataObject.safePath,
       link: dataObject,
     );
   }
@@ -730,12 +733,12 @@ int _compareLinkData(
       }
       return 0;
     case SortingOption.aToZ:
-      if (compareDomain) return (a.domain ?? '').compareTo(b.domain ?? '');
+      if (compareDomain) return (a.safeDomain).compareTo(b.safeDomain);
 
-      return a.path.compareTo(b.path);
+      return a.safePath.compareTo(b.safePath);
     case SortingOption.zToA:
-      if (compareDomain) return (b.domain ?? '').compareTo(a.domain ?? '');
+      if (compareDomain) return (b.safeDomain).compareTo(a.safeDomain);
 
-      return b.path.compareTo(a.path);
+      return b.safePath.compareTo(a.safePath);
   }
 }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -733,11 +733,11 @@ int _compareLinkData(
       }
       return 0;
     case SortingOption.aToZ:
-      if (compareDomain) return (a.safeDomain).compareTo(b.safeDomain);
+      if (compareDomain) return a.safeDomain.compareTo(b.safeDomain);
 
       return a.safePath.compareTo(b.safePath);
     case SortingOption.zToA:
-      if (compareDomain) return (b.safeDomain).compareTo(a.safeDomain);
+      if (compareDomain) return b.safeDomain.compareTo(a.safeDomain);
 
       return b.safePath.compareTo(a.safePath);
   }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -66,7 +66,7 @@ class ValidationDetailView extends StatelessWidget {
                   alignment: Alignment.bottomRight,
                   child: FilledButton(
                     onPressed: () async {
-                      await controller.loadAndroidAppLinksAndValidate();
+                      await controller.loadLinksAndValidate();
                       controller.autoSelectLink(viewType);
                     },
                     child: const Text('Recheck all'),

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -25,36 +25,36 @@ final linkDatas = [
   LinkData(
     domain: 'www.domain1.com',
     path: '/',
-    os: [PlatformOS.android],
+    os: {PlatformOS.android},
   ),
   LinkData(
     domain: 'www.domain2.com',
     path: '/',
-    os: [PlatformOS.ios],
+    os: {PlatformOS.ios},
   ),
   LinkData(
     domain: 'www.google.com',
     path: '/',
-    os: [PlatformOS.android, PlatformOS.ios],
+    os: {PlatformOS.android, PlatformOS.ios},
   ),
   LinkData(
     domain: 'www.google.com',
     path: '/home',
-    os: [PlatformOS.android, PlatformOS.ios],
+    os: {PlatformOS.android, PlatformOS.ios},
   ),
 ];
 
 final domainErrorlinkData = LinkData(
   domain: 'www.google.com',
   path: '/',
-  os: [PlatformOS.android, PlatformOS.ios],
+  os: {PlatformOS.android, PlatformOS.ios},
   domainErrors: [DomainError.existence],
 );
 
 final pathErrorlinkData = LinkData(
   domain: 'www.google.com',
   path: '/abcd',
-  os: [PlatformOS.android, PlatformOS.ios],
+  os: {PlatformOS.android, PlatformOS.ios},
   pathErrors: {
     PathError.intentFilterActionView,
     PathError.intentFilterDefault,
@@ -356,17 +356,17 @@ void main() {
           LinkData(
             domain: 'www.domain1.com',
             path: '/',
-            os: [PlatformOS.android],
+            os: {PlatformOS.android},
           ),
           LinkData(
             domain: 'www.domain2.com',
             path: '/',
-            os: [PlatformOS.ios],
+            os: {PlatformOS.ios},
           ),
           LinkData(
             domain: 'www.google.com',
             path: '/',
-            os: [PlatformOS.android, PlatformOS.ios],
+            os: {PlatformOS.android, PlatformOS.ios},
           ),
         ];
 
@@ -426,19 +426,19 @@ void main() {
           LinkData(
             domain: 'www.domain1.com',
             path: '/',
-            os: [PlatformOS.android],
+            os: {PlatformOS.android},
             domainErrors: [DomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',
             path: '/path',
-            os: [PlatformOS.ios],
+            os: {PlatformOS.ios},
             pathErrors: {PathError.intentFilterActionView},
           ),
           LinkData(
             domain: 'www.google.com',
             path: '/',
-            os: [PlatformOS.android, PlatformOS.ios],
+            os: {PlatformOS.android, PlatformOS.ios},
           ),
         ];
 
@@ -493,18 +493,18 @@ void main() {
           LinkData(
             domain: 'www.domain1.com',
             path: '/',
-            os: [PlatformOS.android],
+            os: {PlatformOS.android},
           ),
           LinkData(
             domain: 'www.domain2.com',
             path: '/path',
-            os: [PlatformOS.ios],
+            os: {PlatformOS.ios},
             domainErrors: [DomainError.existence],
           ),
           LinkData(
             domain: 'www.google.com',
             path: '/',
-            os: [PlatformOS.android, PlatformOS.ios],
+            os: {PlatformOS.android, PlatformOS.ios},
           ),
         ];
 
@@ -585,12 +585,12 @@ void main() {
           LinkData(
             domain: 'www.domain1.com',
             path: '/',
-            os: [PlatformOS.android],
+            os: {PlatformOS.android},
           ),
           LinkData(
             domain: 'www.domain2.com',
             path: '/',
-            os: [PlatformOS.ios],
+            os: {PlatformOS.ios},
             scheme: {'http'},
           ),
         ];
@@ -630,19 +630,19 @@ void main() {
           LinkData(
             domain: 'www.domain1.com',
             path: '/path1',
-            os: [PlatformOS.android],
+            os: {PlatformOS.android},
             domainErrors: [DomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',
             path: '/path2',
-            os: [PlatformOS.ios],
+            os: {PlatformOS.ios},
             pathErrors: {PathError.intentFilterActionView},
           ),
           LinkData(
             domain: 'www.google.com',
             path: '/path3',
-            os: [PlatformOS.android, PlatformOS.ios],
+            os: {PlatformOS.android, PlatformOS.ios},
           ),
         ];
 

--- a/packages/devtools_shared/lib/src/deeplink/universal_link_settings.dart
+++ b/packages/devtools_shared/lib/src/deeplink/universal_link_settings.dart
@@ -28,5 +28,5 @@ extension type const UniversalLinkSettings._(Map<String, Object?> _json) {
 
   /// The associated domains of the iOS build of this Flutter project.
   List<String> get associatedDomains =>
-      _json[_kAssociatedDomainsKey] as List<String>;
+      (_json[_kAssociatedDomainsKey] as List).cast<String>().toList();
 }


### PR DESCRIPTION
1. load ios links, 
2. change path to nullable because ios can only get domains from the app side, the paths are on the web side.

issue: https://github.com/flutter/devtools/issues/7799 



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
