### PR TITLE
Fix VS Code sidebar mock app + generated mocks + remove unused method

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -41,17 +41,6 @@ final class VsCodeApiImpl extends ToolApiImpl implements VsCodeApi {
   late final VsCodeCapabilities capabilities;
 
   @override
-  Future<Object?> executeCommand(String command, [List<Object?>? arguments]) {
-    return sendRequest(
-      VsCodeApi.jsonExecuteCommandMethod,
-      {
-        VsCodeApi.jsonCommandParameter: command,
-        VsCodeApi.jsonArgumentsParameter: arguments,
-      },
-    );
-  }
-
-  @override
   Future<bool> selectDevice(String id) {
     return sendRequest(
       VsCodeApi.jsonSelectDeviceMethod,
@@ -285,10 +274,6 @@ class VsCodeCapabilitiesImpl implements VsCodeCapabilities {
   VsCodeCapabilitiesImpl(this._raw);
 
   final Map<String, Object?>? _raw;
-
-  @override
-  bool get executeCommand =>
-      _raw?[VsCodeCapabilities.jsonExecuteCommandField] == true;
 
   @override
   bool get selectDevice =>

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -32,15 +32,6 @@ abstract interface class VsCodeApi {
   /// An event with initial sessions is sent after [initialize] is called.
   Stream<VsCodeDebugSessionsEvent> get debugSessionsChanged;
 
-  /// Executes a VS Code command.
-  ///
-  /// Commands can be native VS Code commands or commands registered by the
-  /// Dart/Flutter extensions.
-  ///
-  /// Which commands are available is not part of the API contract so callers
-  /// should take care when calling APIs that might evolve over time.
-  Future<Object?> executeCommand(String command, [List<Object?>? arguments]);
-
   /// Changes the current Flutter device.
   ///
   /// The selected device is the same one shown in the status bar in VS Code.
@@ -77,7 +68,6 @@ abstract interface class VsCodeApi {
   static const jsonApiName = 'vsCode';
 
   static const jsonInitializeMethod = 'initialize';
-  static const jsonExecuteCommandMethod = 'executeCommand';
 
   static const jsonSelectDeviceMethod = 'selectDevice';
   static const jsonOpenDevToolsPageMethod = 'openDevToolsPage';
@@ -226,10 +216,6 @@ abstract interface class VsCodeDebugSessionsEvent {
 /// [VsCodeCapabilities] to advertise which capabilities are available and
 /// handle any changes in behaviour.
 abstract interface class VsCodeCapabilities {
-  /// Whether the `executeCommand` method is available to call to execute VS
-  /// Code commands.
-  bool get executeCommand;
-
   /// Whether the `selectDevice` method is available to call to change the
   /// selected Flutter device.
   bool get selectDevice;
@@ -251,7 +237,6 @@ abstract interface class VsCodeCapabilities {
   /// debug session.
   bool get hotRestart;
 
-  static const jsonExecuteCommandField = 'executeCommand';
   static const jsonSelectDeviceField = 'selectDevice';
   static const openDevToolsPageField = 'openDevToolsPage';
   static const openDevToolsExternallyField = 'openDevToolsExternally';

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/vs_code.dart
@@ -4,9 +4,11 @@
 
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/standalone_ui/vs_code/flutter_panel.dart';
+import 'package:devtools_app_shared/service.dart';
 import 'package:devtools_app_shared/shared.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter/material.dart';
 import 'package:stager/stager.dart';
 
@@ -59,6 +61,11 @@ class VsCodeScene extends Scene {
   @override
   Future<void> setUp() async {
     setStagerMode();
+    setGlobal(
+      DevToolsEnvironmentParameters,
+      ExternalDevToolsEnvironmentParameters(),
+    );
+    setGlobal(DTDManager, MockDTDManager());
     setGlobal(IdeTheme, IdeTheme());
     setGlobal(PreferencesController, PreferencesController());
   }

--- a/packages/devtools_test/pubspec.yaml
+++ b/packages/devtools_test/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   async: ^2.0.0
   collection: ^1.15.0
+  dap: ^1.1.0
   devtools_app:
     path: ../devtools_app
   devtools_app_shared:


### PR DESCRIPTION
1. Fixes an error in the mock VS Code sidebar stager app because `DevToolsEnvironmentParameters` and `DTDManager` where not set
2. Removes the `executeCommand` method from the VS Code API (we never used this and we'll be moving to a DTD-based API so this will make the postMessage and DTD implementations during the transition more similar).
3. Add a dependency on `dap` to `devtools_test` since it's used in the VM Service wrapper that has a mock generated and otherwise products `dynamic` in the generated code which is an error.

