### PR TITLE
[deep link] Add a ios AASA check tile

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -153,6 +153,10 @@ class DeepLinksController extends DisposableController
         selectedIosConfigurationIndex,
         _handleIosConfigurationChanged,
       );
+      addAutoDisposeListener(
+        selectedIosTargetIndex,
+        _handleIosConfigurationChanged,
+      );
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -153,10 +153,6 @@ class DeepLinksController extends DisposableController
         selectedIosConfigurationIndex,
         _handleIosConfigurationChanged,
       );
-      addAutoDisposeListener(
-        selectedIosTargetIndex,
-        _handleIosConfigurationChanged,
-      );
     }
   }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -153,6 +153,7 @@ class _DomainCheckTable extends StatelessWidget {
             const SizedBox(height: denseSpacing),
             const _CheckTableHeader(),
             _CheckExpansionTile(
+              os: PlatformOS.android,
               initiallyExpanded: !fingerprintExists,
               checkName: 'Digital assets link file',
               status: _CheckStatusText(
@@ -168,6 +169,16 @@ class _DomainCheckTable extends StatelessWidget {
                 ],
               ],
             ),
+            if (FeatureFlags.deepLinkIosCheck)
+              const _CheckExpansionTile(
+                os: PlatformOS.ios,
+                checkName: 'Apple-App-Site-Association file',
+                status: _CheckStatusText(
+                  //TODO (hangyu jin): add iOS domain errors when api is ready.
+                  hasError: false,
+                ),
+                children: <Widget>[],
+              ),
             const SizedBox(height: intermediateSpacing),
           ],
         );
@@ -645,6 +656,7 @@ class _ManifestFileCheck extends StatelessWidget {
         .toList();
 
     return _CheckExpansionTile(
+      os: PlatformOS.android,
       checkName: 'Manifest file',
       status: _CheckStatusText(hasError: errors.isNotEmpty),
       children: <Widget>[
@@ -683,6 +695,7 @@ class _PathFormatCheck extends StatelessWidget {
     final hasError = linkData.pathErrors.contains(PathError.pathFormat);
 
     return _CheckExpansionTile(
+      os: PlatformOS.android,
       checkName: 'URL format',
       status: _CheckStatusText(hasError: hasError),
       children: <Widget>[
@@ -723,12 +736,14 @@ class _CheckTableHeader extends StatelessWidget {
 
 class _CheckExpansionTile extends StatelessWidget {
   const _CheckExpansionTile({
+    required this.os,
     required this.checkName,
     required this.status,
     required this.children,
     this.initiallyExpanded = false,
   });
 
+  final PlatformOS os;
   final String checkName;
   final Widget status;
   final bool initiallyExpanded;
@@ -740,7 +755,7 @@ class _CheckExpansionTile extends StatelessWidget {
     final title = Row(
       children: [
         const SizedBox(width: defaultSpacing),
-        const Expanded(child: Text('Android')),
+        Expanded(child: Text(os == PlatformOS.ios ? 'iOS' : 'Android')),
         Expanded(child: Text(checkName)),
         Expanded(child: status),
       ],

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -601,12 +601,14 @@ class _CrossCheckTable extends StatelessWidget {
         const Divider(height: 1.0),
         if (missingAndroid)
           _CheckExpansionTile(
+            os: PlatformOS.android,
             checkName: 'Manifest file',
             status: domainMissing,
             children: const <Widget>[],
           ),
         if (missingIos)
           _CheckExpansionTile(
+            os: PlatformOS.ios,
             checkName: 'Settings',
             status: domainMissing,
             children: const <Widget>[],


### PR DESCRIPTION

This is just UI ,will fill in data to this check tile later
guarded by flag: FeatureFlags.deepLinkIosCheck

https://github.com/flutter/flutter/issues/149281
![image](https://github.com/flutter/devtools/assets/108393416/00555eb2-7aa6-4e97-acb6-29fbb7218182)


## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
