### PR TITLE
[deep link] Distinguish IosDomainError and  AndroidDomainError.

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -21,15 +21,15 @@ import 'deep_links_services.dart';
 typedef _DomainAndPath = ({String? domain, String? path});
 
 const domainAssetLinksJsonFileErrors = {
-  DomainError.existence,
-  DomainError.appIdentifier,
-  DomainError.fingerprints,
+  AndroidDomainError.existence,
+  AndroidDomainError.appIdentifier,
+  AndroidDomainError.fingerprints,
 };
 const domainHostingErrors = {
-  DomainError.contentType,
-  DomainError.httpsAccessibility,
-  DomainError.nonRedirect,
-  DomainError.hostForm,
+  AndroidDomainError.contentType,
+  AndroidDomainError.httpsAccessibility,
+  AndroidDomainError.nonRedirect,
+  AndroidDomainError.hostForm,
 };
 
 /// The phase of the deep link page.

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -25,7 +25,7 @@ const domainAssetLinksJsonFileErrors = {
   AndroidDomainError.appIdentifier,
   AndroidDomainError.fingerprints,
 };
-const domainHostingErrors = {
+const domainAndroidHostingErrors = {
   AndroidDomainError.contentType,
   AndroidDomainError.httpsAccessibility,
   AndroidDomainError.nonRedirect,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -36,9 +36,11 @@ class CommonError {
   final String explanation;
   final String fixDetails;
 }
+
 class DomainError extends CommonError {
   const DomainError(super.title, super.explanation, super.fixDetails);
 }
+
 class AndroidDomainError extends DomainError {
   const AndroidDomainError(super.title, super.explanation, super.fixDetails);
 
@@ -123,7 +125,7 @@ class IosDomainError extends DomainError {
   const IosDomainError(super.title, super.explanation, super.fixDetails);
   // TODO: Add  domain errors for iOS.
 
-  /// Existence of an aasa file.
+  /// Existence of an Apple-App-Site-Association file.
   static const existence = DomainError(
     'Apple-App-Site-Association file does not exist',
     '',

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -36,9 +36,11 @@ class CommonError {
   final String explanation;
   final String fixDetails;
 }
-
 class DomainError extends CommonError {
   const DomainError(super.title, super.explanation, super.fixDetails);
+}
+class AndroidDomainError extends DomainError {
+  const AndroidDomainError(super.title, super.explanation, super.fixDetails);
 
   /// Existence of an asset link file.
   static const existence = DomainError(
@@ -115,6 +117,18 @@ class DomainError extends CommonError {
   /// Issues that are not covered by other checks. An example that may be in this
   /// category is Android validation API failures.
   static const other = DomainError('Check failed', '', '');
+}
+
+class IosDomainError extends DomainError {
+  const IosDomainError(super.title, super.explanation, super.fixDetails);
+  // TODO: Add  domain errors for iOS.
+
+  /// Existence of an aasa file.
+  static const existence = DomainError(
+    'Apple-App-Site-Association file does not exist',
+    '',
+    '',
+  );
 }
 
 /// There are currently two types of path errors, errors from intent filters and path format errors.

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -30,15 +30,15 @@ const String _failedChecksKey = 'failedChecks';
 const String _generatedContentKey = 'generatedContent';
 const int _domainBatchSize = 500;
 
-const Map<String, DomainError> checkNameToDomainError = {
-  'EXISTENCE': DomainError.existence,
-  'APP_IDENTIFIER': DomainError.appIdentifier,
-  'FINGERPRINT': DomainError.fingerprints,
-  'CONTENT_TYPE': DomainError.contentType,
-  'HTTPS_ACCESSIBILITY': DomainError.httpsAccessibility,
-  'NON_REDIRECT': DomainError.nonRedirect,
-  'HOST_FORMED_PROPERLY': DomainError.hostForm,
-  'OTHER_CHECKS': DomainError.other,
+const Map<String,DomainError> checkNameToDomainError = {
+  'EXISTENCE': AndroidDomainError.existence,
+  'APP_IDENTIFIER': AndroidDomainError.appIdentifier,
+  'FINGERPRINT': AndroidDomainError.fingerprints,
+  'CONTENT_TYPE': AndroidDomainError.contentType,
+  'HTTPS_ACCESSIBILITY': AndroidDomainError.httpsAccessibility,
+  'NON_REDIRECT': AndroidDomainError.nonRedirect,
+  'HOST_FORMED_PROPERLY': AndroidDomainError.hostForm,
+  'OTHER_CHECKS': AndroidDomainError.other,
 };
 
 class GenerateAssetLinksResult {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -30,7 +30,7 @@ const String _failedChecksKey = 'failedChecks';
 const String _generatedContentKey = 'generatedContent';
 const int _domainBatchSize = 500;
 
-const Map<String,DomainError> checkNameToDomainError = {
+const Map<String, DomainError> checkNameToDomainError = {
   'EXISTENCE': AndroidDomainError.existence,
   'APP_IDENTIFIER': AndroidDomainError.appIdentifier,
   'FINGERPRINT': AndroidDomainError.fingerprints,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -564,7 +564,7 @@ class _CrossCheckTable extends StatelessWidget {
     // TODO (hangyujin): Update this bool to actually check if aasa file exists.
     const hasIosAasaFile = true;
     final hasAndroidAssetLinksFile =
-        !linkData.domainErrors.contains(DomainError.existence);
+        !linkData.domainErrors.contains(AndroidDomainError.existence);
 
     final missingIos = hasIosAasaFile && !linkData.os.contains(PlatformOS.ios);
     final missingAndroid =

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -228,7 +228,7 @@ class _HostingIssues extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final errors = controller.selectedLink.value!.domainErrors
-        .where((error) => domainHostingErrors.contains(error))
+        .where((error) => domainAndroidHostingErrors.contains(error))
         .toList();
     return ExpansionTile(
       controlAffinity: ListTileControlAffinity.leading,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -155,8 +155,10 @@ class _DomainCheckTable extends StatelessWidget {
             _CheckExpansionTile(
               initiallyExpanded: !fingerprintExists,
               checkName: 'Digital assets link file',
-              status:
-                  _CheckStatusText(hasError: linkData.domainErrors.isNotEmpty),
+              status: _CheckStatusText(
+                hasError:
+                    linkData.domainErrors.any((e) => e is AndroidDomainError),
+              ),
               children: <Widget>[
                 _Fingerprint(controller: controller),
                 // The following checks are only displayed if a fingerprint exists.

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -48,7 +48,7 @@ final domainErrorlinkData = LinkData(
   domain: 'www.google.com',
   path: '/',
   os: {PlatformOS.android, PlatformOS.ios},
-  domainErrors: [ AndroidDomainError.existence],
+  domainErrors: [AndroidDomainError.existence],
 );
 
 final pathErrorlinkData = LinkData(
@@ -427,7 +427,7 @@ void main() {
             domain: 'www.domain1.com',
             path: '/',
             os: {PlatformOS.android},
-            domainErrors: [ AndroidDomainError.existence],
+            domainErrors: [AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',
@@ -499,7 +499,7 @@ void main() {
             domain: 'www.domain2.com',
             path: '/path',
             os: {PlatformOS.ios},
-            domainErrors: [ AndroidDomainError.existence],
+            domainErrors: [AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.google.com',
@@ -631,7 +631,7 @@ void main() {
             domain: 'www.domain1.com',
             path: '/path1',
             os: {PlatformOS.android},
-            domainErrors: [ AndroidDomainError.existence],
+            domainErrors: [AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -48,7 +48,7 @@ final domainErrorlinkData = LinkData(
   domain: 'www.google.com',
   path: '/',
   os: {PlatformOS.android, PlatformOS.ios},
-  domainErrors: [DomainError.existence],
+  domainErrors: [ AndroidDomainError.existence],
 );
 
 final pathErrorlinkData = LinkData(
@@ -427,7 +427,7 @@ void main() {
             domain: 'www.domain1.com',
             path: '/',
             os: {PlatformOS.android},
-            domainErrors: [DomainError.existence],
+            domainErrors: [ AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',
@@ -499,7 +499,7 @@ void main() {
             domain: 'www.domain2.com',
             path: '/path',
             os: {PlatformOS.ios},
-            domainErrors: [DomainError.existence],
+            domainErrors: [ AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.google.com',
@@ -631,7 +631,7 @@ void main() {
             domain: 'www.domain1.com',
             path: '/path1',
             os: {PlatformOS.android},
-            domainErrors: [DomainError.existence],
+            domainErrors: [ AndroidDomainError.existence],
           ),
           LinkData(
             domain: 'www.domain2.com',


### PR DESCRIPTION
Current domain errors are all Android, iOS domain errors are to be added.

issue: https://github.com/flutter/flutter/issues/149281

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/wiki/Chat
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
