### PR TITLE
Add `avoid-importing-entrypoint-exports` DCM lint.

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -157,6 +157,8 @@ dart_code_metrics:
   rules:
 #    - arguments-ordering Too strict
 #    - avoid-banned-imports # TODO(polina-c): add configuration
+    - avoid-importing-entrypoint-exports:
+        only-in-src: true
     - avoid-cascade-after-if-null
     - avoid-collection-methods-with-unrelated-types
     - avoid-duplicate-exports

--- a/packages/devtools_app/lib/src/framework/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/about_dialog.dart
@@ -8,10 +8,10 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-import '../../devtools.dart' as devtools;
 import '../shared/analytics/constants.dart' as gac;
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
+import '../shared/utils.dart';
 import 'release_notes/release_notes.dart';
 
 class DevToolsAboutDialog extends StatelessWidget {
@@ -30,7 +30,7 @@ class DevToolsAboutDialog extends StatelessWidget {
         children: [
           Wrap(
             children: [
-              const SelectableText('DevTools version ${devtools.version}'),
+              SelectableText('DevTools version $devToolsVersion'),
               const Text(' - '),
               InkWell(
                 child: Text(

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -12,7 +12,6 @@ import 'package:devtools_shared/service.dart';
 import 'package:logging/logging.dart';
 import 'package:vm_service/vm_service.dart';
 
-import '../../devtools.dart' as devtools show version;
 import '../extensions/extension_service.dart';
 import '../screens/debugger/breakpoint_manager.dart';
 import '../service/service_manager.dart';
@@ -29,6 +28,7 @@ import '../shared/primitives/message_bus.dart';
 import '../shared/scripts/script_manager.dart';
 import '../shared/server/server.dart' as server;
 import '../shared/survey.dart';
+import '../shared/utils.dart';
 import 'app_error_handling.dart';
 
 typedef ErrorReporter = void Function(String title, Object error);
@@ -47,7 +47,7 @@ abstract class FrameworkCore {
     await initializePlatform();
 
     // Print the version number at startup.
-    _log.info('DevTools version ${devtools.version}.');
+    _log.info('DevTools version $devToolsVersion.');
 
     await _initDTDConnection();
 

--- a/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
@@ -11,7 +11,6 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 import 'package:logging/logging.dart';
 
-import '../../../devtools.dart' as devtools;
 import '../../shared/primitives/url_utils.dart';
 import '../../shared/server/server.dart' as server;
 import '../../shared/side_panel.dart';
@@ -80,6 +79,7 @@ class ReleaseNotesController extends SidePanelController {
     if (server.isDevToolsServerAvailable) {
       final lastReleaseNotesShownVersion =
           await server.getLastShownReleaseNotesVersion();
+          'after calling last shown: $lastReleaseNotesShownVersion which is a ${lastReleaseNotesShownVersion.runtimeType}');
       if (lastReleaseNotesShownVersion.isNotEmpty) {
         previousVersion = SemanticVersion.parse(lastReleaseNotesShownVersion);
       }
@@ -117,7 +117,7 @@ class ReleaseNotesController extends SidePanelController {
     // strip off any build metadata (any characters following a '+' character).
     // Release notes will be hosted on the Flutter website with a version number
     // that does not contain any build metadata.
-    final parsedVersion = SemanticVersion.parse(devtools.version);
+    final parsedVersion = SemanticVersion.parse(devToolsVersion);
     final notesVersion = latestVersionToCheckForReleaseNotes(parsedVersion);
 
     if (notesVersion <= versionFloor) {

--- a/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes/release_notes.dart
@@ -79,7 +79,6 @@ class ReleaseNotesController extends SidePanelController {
     if (server.isDevToolsServerAvailable) {
       final lastReleaseNotesShownVersion =
           await server.getLastShownReleaseNotesVersion();
-          'after calling last shown: $lastReleaseNotesShownVersion which is a ${lastReleaseNotesShownVersion.runtimeType}');
       if (lastReleaseNotesShownVersion.isNotEmpty) {
         previousVersion = SemanticVersion.parse(lastReleaseNotesShownVersion);
       }

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -15,7 +15,6 @@ import 'package:logging/logging.dart';
 import 'package:unified_analytics/unified_analytics.dart' as ua;
 import 'package:web/web.dart';
 
-import '../../../devtools.dart' as devtools show version;
 import '../dtd_manager_extensions.dart';
 import '../globals.dart';
 import '../server/server.dart' as server;
@@ -638,7 +637,7 @@ String _devtoolsPlatformType =
     ''; // dimension4 MacIntel/Linux/Windows/Android_n
 String _devtoolsChrome = ''; // dimension5 Chrome/n.n.n  or Crios/n.n.n
 
-const String devtoolsVersion = devtools.version; //dimension6 n.n.n
+final devtoolsVersion = devToolsVersion; //dimension6 n.n.n
 
 String _ideLaunched = ''; // dimension7 IDE launched DevTools (VSCode, CLI, ...)
 

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/import_export.dart
@@ -6,11 +6,12 @@ import 'dart:convert';
 
 import 'package:devtools_app_shared/service.dart';
 import 'package:intl/intl.dart';
-import '../../../../devtools.dart';
+
 import '../../globals.dart';
 import '../../primitives/encoding.dart';
 import '../../primitives/utils.dart';
 import '../../screen.dart';
+import '../../utils.dart';
 import '_export_desktop.dart' if (dart.library.js_interop) '_export_web.dart';
 
 const nonDevToolsFileMessage = 'The imported file is not a Dart DevTools file.'
@@ -162,7 +163,7 @@ abstract class ExportController {
   }) {
     final contents = {
       DevToolsExportKeys.devToolsSnapshot.name: true,
-      DevToolsExportKeys.devToolsVersion.name: version,
+      DevToolsExportKeys.devToolsVersion.name: devToolsVersion,
       DevToolsExportKeys.connectedApp.name: connectedApp?.toJson() ??
           serviceConnection.serviceManager.connectedApp!.toJson(),
       ...offlineScreenData,

--- a/packages/devtools_app/lib/src/shared/diagnostics/references.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/references.dart
@@ -7,9 +7,10 @@ import 'dart:math';
 
 import 'package:vm_service/vm_service.dart';
 
-import '../../../devtools_app.dart';
+import '../globals.dart';
 import '../memory/class_name.dart';
 import '../memory/heap_object.dart';
+import '../primitives/utils.dart';
 import 'dart_object_node.dart';
 import 'generic_instance_reference.dart';
 import 'helpers.dart';

--- a/packages/devtools_app/lib/src/shared/survey.dart
+++ b/packages/devtools_app/lib/src/shared/survey.dart
@@ -10,7 +10,6 @@ import 'package:flutter/widgets.dart';
 import 'package:http/http.dart';
 import 'package:logging/logging.dart';
 
-import '../../../devtools.dart' as devtools show version;
 import '../shared/notifications.dart';
 import 'analytics/analytics.dart' as ga;
 import 'development_helpers.dart';
@@ -235,7 +234,7 @@ extension ShowSurveyExtension on DevToolsSurvey {
 
   bool get meetsMinVersionRequirement =>
       minDevToolsVersion == null ||
-      SemanticVersion.parse(devtools.version)
+      SemanticVersion.parse(devToolsVersion)
           .isSupported(minSupportedVersion: minDevToolsVersion!);
 
   bool get meetsEnvironmentRequirement =>

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -18,6 +18,7 @@ import 'package:logging/logging.dart';
 import 'package:provider/provider.dart';
 import 'package:vm_service/vm_service.dart';
 
+// ignore: avoid-importing-entrypoint-exports, special case for getting version.
 import '../../devtools.dart' as devtools;
 import 'common_widgets.dart';
 import 'connected_app.dart';
@@ -116,7 +117,7 @@ List<String> issueLinkDetails() {
   final issueDescriptionItems = [
     '<-- Please describe your problem here. Be sure to include repro steps. -->',
     '___', // This will create a separator in the rendered markdown.
-    '**DevTools version**: ${devtools.version}',
+    '**DevTools version**: $devToolsVersion',
     if (ide != null) '**IDE**: $ide',
   ];
   final vm = serviceConnection.serviceManager.vm;
@@ -297,3 +298,5 @@ Future<void> launchUrlWithErrorHandling(String url) async {
     onError: () => notificationService.push('Unable to open $url.'),
   );
 }
+
+String get devToolsVersion => devtools.version;

--- a/packages/devtools_extensions/lib/src/utils.dart
+++ b/packages/devtools_extensions/lib/src/utils.dart
@@ -7,7 +7,7 @@ import 'dart:js_interop';
 import 'package:devtools_app_shared/web_utils.dart';
 import 'package:web/web.dart';
 
-import '../api.dart';
+import 'api/model.dart';
 
 DevToolsExtensionEvent? tryParseExtensionEvent(Event e) {
   if (e.isMessageEvent) {


### PR DESCRIPTION
This lint will provide a warning whenever entrypoint exports are imported directly (like the `devtools_app.dart` file).