### PR TITLE
Add back golden test to `inspector_service_test`

### DIFF
--- a/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
+++ b/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
@@ -306,11 +306,12 @@ MaterialApp
         );
         RemoteDiagnosticsNode nodeInDetailsTree =
             (await group.getDetailsSubtree(nodeInSummaryTree))!;
-
-        // TODO(gspencergoog): revert the PR
-        // https://github.com/flutter/devtools/pull/7740 once Flutter PR
-        // https://github.com/flutter/flutter/pull/143259 lands, with an updated
-        // golden file for the test.
+        // When flutter rolls, this string may sometimes change due to
+        // implementation details.
+        expect(
+          treeToDebugStringTruncated(nodeInDetailsTree, 30),
+          equalsGoldenIgnoringHashCodes('inspector_service_details_tree.txt'),
+        );
 
         nodeInSummaryTree = findNodeMatching(root, 'Text')!;
         expect(nodeInSummaryTree, isNotNull);

--- a/packages/devtools_app/test/test_infra/goldens/inspector_service_details_tree.txt
+++ b/packages/devtools_app/test/test_infra/goldens/inspector_service_details_tree.txt
@@ -6,6 +6,7 @@ MaterialApp
    │
    └─HeroControllerScope
      └─Focus
+       │ dependencies: [_FocusInheritedScope]
        │ state: _FocusState#00000
        │
        └─_FocusInheritedScope
@@ -27,5 +28,4 @@ MaterialApp
                    │
                    └─UnmanagedRestorationScope
                      └─SharedAppData
-                       │ state: _SharedAppDataState#00000
 ...

--- a/packages/devtools_app/test/test_infra/goldens/inspector_service_details_tree.txt
+++ b/packages/devtools_app/test/test_infra/goldens/inspector_service_details_tree.txt
@@ -1,0 +1,31 @@
+MaterialApp
+ │ state: _MaterialAppState#00000
+ │
+ └─ScrollConfiguration
+   │ behavior: MaterialScrollBehavior
+   │
+   └─HeroControllerScope
+     └─Focus
+       │ state: _FocusState#00000
+       │
+       └─_FocusInheritedScope
+         └─Semantics
+           │ container: false
+           │ properties: SemanticsProperties
+           │ renderObject: RenderSemanticsAnnotations#00000
+           │
+           └─WidgetsApp-[GlobalObjectKey _MaterialAppState#00000]
+             │ state: _WidgetsAppState#00000
+             │
+             └─RootRestorationScope
+               │ state: _RootRestorationScopeState#00000
+               │
+               └─UnmanagedRestorationScope
+                 └─RestorationScope
+                   │ dependencies: [UnmanagedRestorationScope]
+                   │ state: _RestorationScopeState#00000
+                   │
+                   └─UnmanagedRestorationScope
+                     └─SharedAppData
+                       │ state: _SharedAppDataState#00000
+...

--- a/packages/devtools_app/test/test_infra/matchers/matchers.dart
+++ b/packages/devtools_app/test/test_infra/matchers/matchers.dart
@@ -33,6 +33,14 @@ String treeToDebugString(RemoteDiagnosticsNode node) {
   return node.toDiagnosticsNode().toStringDeep();
 }
 
+String treeToDebugStringTruncated(RemoteDiagnosticsNode node, int maxLines) {
+  List<String> lines = node.toDiagnosticsNode().toStringDeep().split('\n');
+  if (lines.length > maxLines) {
+    lines = lines.take(maxLines).toList()..add('...');
+  }
+  return lines.join('\n');
+}
+
 /// Asserts that a [path] matches a golden file after normalizing likely hash
 /// codes.
 ///


### PR DESCRIPTION
Resolves a TODO in the `inspector_service_test` which was added in https://github.com/flutter/devtools/pull/7740

https://github.com/flutter/flutter/pull/143259 has landed, so it is safe to add this test case back in. 

This TODO was noticed when updating the tests for https://github.com/flutter/devtools/pull/7912