### PR TITLE
Clean up survey prompt styling

### DIFF
--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -245,7 +245,7 @@ class _NotificationState extends State<_Notification>
         );
       },
       child: Card(
-        color: theme.snackBarTheme.backgroundColor,
+        color: theme.colorScheme.secondaryContainer,
         margin: const EdgeInsets.only(bottom: densePadding),
         child: DefaultTextStyle(
           style: theme.snackBarTheme.contentTextStyle ??
@@ -276,7 +276,7 @@ class _NotificationState extends State<_Notification>
                         widget: widget,
                       ),
                 const SizedBox(height: defaultSpacing),
-                _NotificationActions(widget: widget),
+                _NotificationActions(actions: widget.message.actions),
               ],
             ),
           ),
@@ -317,7 +317,8 @@ class _NotificationMessage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final textStyle = theme.regularTextStyle;
+    final textStyle =
+        theme.regularTextStyleWithColor(theme.colorScheme.onSecondaryContainer);
     return Padding(
       padding: const EdgeInsets.only(
         left: denseSpacing,
@@ -337,15 +338,12 @@ class _NotificationMessage extends StatelessWidget {
 }
 
 class _NotificationActions extends StatelessWidget {
-  const _NotificationActions({
-    required this.widget,
-  });
+  const _NotificationActions({required this.actions});
 
-  final _Notification widget;
+  final List<Widget> actions;
 
   @override
   Widget build(BuildContext context) {
-    final actions = widget.message.actions;
     if (actions.isEmpty) return const SizedBox();
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,

--- a/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/codeview_controller.dart
@@ -382,8 +382,9 @@ class CodeViewController extends DisposableController
     final enableSourceMapsLink = devToolsExtensionPoints.enableSourceMapsLink();
     if (isWebApp && enableSourceMapsLink != null) {
       final enableSourceMapsAction = NotificationAction(
-        'Enable sourcemaps',
-        () => unawaited(launchUrlWithErrorHandling(enableSourceMapsLink.url)),
+        label: 'Enable sourcemaps',
+        onPressed: () =>
+            unawaited(launchUrlWithErrorHandling(enableSourceMapsLink.url)),
       );
       notificationService.pushNotification(
         NotificationMessage(

--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -139,7 +139,9 @@ class _DebuggingControlsState extends State<DebuggingControls>
           label: 'File Explorer',
           onPressed: controller.codeViewController.toggleLibrariesVisible,
           gaScreen: gac.debugger,
-          gaSelection: visible ? gac.hideFileExplorer : gac.showFileExplorer,
+          gaSelection: visible
+              ? gac.DebuggerEvents.hideFileExplorer.name
+              : gac.DebuggerEvents.showFileExplorer.name,
           minScreenWidthForTextBeforeScaling:
               DebuggingControls.minWidthBeforeScaling,
         );
@@ -195,7 +197,7 @@ class CodeStatisticsControls extends StatelessWidget {
               iconOnly: true,
               tooltip: 'Refresh statistics',
               gaScreen: gac.debugger,
-              gaSelection: gac.refreshStatistics,
+              gaSelection: gac.DebuggerEvents.refreshStatistics.name,
               onPressed: showCodeCoverage || showProfileInformation
                   ? () => unawaited(
                         controller.codeViewController.refreshCodeStatistics(),

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_controller.dart
@@ -411,7 +411,7 @@ class DebuggerController extends DisposableController
           ],
           truncated: true,
         );
-        ga.select(gac.debugger, gac.pausedWithNoFrames);
+        ga.select(gac.debugger, gac.DebuggerEvents.pausedWithNoFrames.name);
         return;
       }
       await _populateFrameInfo(

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -8,6 +8,7 @@ import '../preferences/preferences.dart';
 import '../screen.dart';
 
 part 'constants/_cpu_profiler_constants.dart';
+part 'constants/_debugger_constants.dart';
 part 'constants/_deep_links_constants.dart';
 part 'constants/_extension_constants.dart';
 part 'constants/_memory_constants.dart';
@@ -89,12 +90,6 @@ enum HomeScreenEvents {
   connectToNewApp,
   viewVmFlags,
 }
-
-// Debugger UX actions:
-const refreshStatistics = 'refreshStatistics';
-const showFileExplorer = 'showFileExplorer';
-const hideFileExplorer = 'hideFileExplorer';
-const pausedWithNoFrames = 'pausedWithNoFrames';
 
 // Logging UX actions:
 const structuredErrors = 'structuredErrors';

--- a/packages/devtools_app/lib/src/shared/analytics/constants/_debugger_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_debugger_constants.dart
@@ -1,0 +1,12 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of '../constants.dart';
+
+enum DebuggerEvents {
+  refreshStatistics,
+  showFileExplorer,
+  hideFileExplorer,
+  pausedWithNoFrames,
+}

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:collection';
 
+import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import 'globals.dart';
@@ -73,8 +74,8 @@ class NotificationService {
     bool isReportable = true,
   }) {
     final reportErrorAction = NotificationAction(
-      'Report error',
-      () {
+      label: 'Report error',
+      onPressed: () {
         final additionalInfoParts = [
           if (reportExplanation != null) 'Explanation:\n$reportExplanation',
           if (stackTrace != null) 'Stack trace:\n$stackTrace',
@@ -152,30 +153,28 @@ class NotificationService {
 }
 
 class NotificationAction extends StatelessWidget {
-  const NotificationAction(
-    this.label,
-    this.onAction, {
+  const NotificationAction({
     super.key,
+    required this.label,
+    required this.onPressed,
     this.isPrimary = false,
   });
 
   final String label;
-
-  final VoidCallback onAction;
-
+  final VoidCallback onPressed;
   final bool isPrimary;
 
   @override
   Widget build(BuildContext context) {
-    final labelText = Text(label);
-    return isPrimary
-        ? ElevatedButton(
-            onPressed: onAction,
-            child: labelText,
-          )
-        : OutlinedButton(
-            onPressed: onAction,
-            child: labelText,
-          );
+    final theme = Theme.of(context);
+    return DevToolsButton(
+      label: label,
+      color: isPrimary
+          ? theme.colorScheme.onPrimary
+          : theme.colorScheme.onSecondaryContainer,
+      elevated: isPrimary,
+      outlined: !isPrimary,
+      onPressed: onPressed,
+    );
   }
 }

--- a/packages/devtools_app/lib/src/shared/survey.dart
+++ b/packages/devtools_app/lib/src/shared/survey.dart
@@ -21,9 +21,9 @@ import 'utils.dart';
 final _log = Logger('survey');
 
 class SurveyService {
-  static const _noThanksLabel = 'NO THANKS';
+  static const _noThanksLabel = 'No thanks';
 
-  static const _takeSurveyLabel = 'TAKE SURVEY';
+  static const _takeSurveyLabel = 'Take survey';
 
   static const _maxShowSurveyCount = 5;
 
@@ -43,7 +43,7 @@ class SurveyService {
 
   Future<DevToolsSurvey?> get activeSurvey async {
     // If the server is unavailable we don't need to do anything survey related.
-    if (!server.isDevToolsServerAvailable) return null;
+    if (!server.isDevToolsServerAvailable && !debugSurvey) return null;
 
     _cachedSurvey ??= await fetchSurveyContent();
     if (_cachedSurvey?.id != null) {
@@ -62,14 +62,14 @@ class SurveyService {
       final message = survey.title!;
       final actions = [
         NotificationAction(
-          _noThanksLabel,
-          () => _noThanksPressed(
+          label: _noThanksLabel,
+          onPressed: () => _noThanksPressed(
             message: message,
           ),
         ),
         NotificationAction(
-          _takeSurveyLabel,
-          () => _takeSurveyPressed(
+          label: _takeSurveyLabel,
+          onPressed: () => _takeSurveyPressed(
             surveyUrl: _generateSurveyUrl(survey.url!),
             message: message,
           ),

--- a/packages/devtools_app_shared/lib/src/ui/common.dart
+++ b/packages/devtools_app_shared/lib/src/ui/common.dart
@@ -389,9 +389,7 @@ class DevToolsButton extends StatelessWidget {
               : IconButton(
                   onPressed: onPressed,
                   iconSize: defaultIconSize,
-                  icon: Icon(
-                    icon,
-                  ),
+                  icon: Icon(icon),
                 ),
         ),
       );


### PR DESCRIPTION
Before:
![Screenshot 2024-06-11 at 2 33 39 PM](https://github.com/flutter/devtools/assets/43759233/a6e1ef04-1549-4c5c-896c-a764eba305ba)

After:
![Screenshot 2024-06-11 at 2 55 56 PM](https://github.com/flutter/devtools/assets/43759233/f9379b23-19a1-4813-8256-a8e2972fdcf3)

This PR also moves some GA consts as part of a yak shave