### PR TITLE
Prepare DevTools packages for publish

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -26,7 +26,7 @@ dependencies:
   dds_service_extensions: ^2.0.0
   devtools_app_shared: ^0.2.0-dev.1
   devtools_extensions: ^0.2.0-dev.0
-  devtools_shared: ^10.0.0-dev.2
+  devtools_shared: ^10.0.0
   dtd: ^2.2.0
   file: ">=6.0.0 <8.0.0"
   file_selector: ^1.0.0

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-dev.1 (wip)
+## 0.2.0
 * Add `navigateToCode` utility method for jumping to code in IDEs.
 * Add `FlutterEvent` and `DeveloperServiceEvent` constants.
 

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.2.0-dev.1
+version: 0.2.0
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
@@ -10,7 +10,7 @@ environment:
 dependencies:
   collection: ^1.15.0
   dds_service_extensions: ^2.0.0
-  devtools_shared: ^10.0.0-dev.2
+  devtools_shared: ^10.0.0
   dtd: ^2.1.0
   flutter:
     sdk: flutter

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.2.0-dev.1
+## 0.2.0
 * Add testimonies from extension authors to the `README.md`.
 * Add an integration test to the example app, `app_that_uses_foo`.
 

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.2.0-dev.1
+version: 0.2.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
@@ -13,8 +13,8 @@ executables:
 
 dependencies:
   args: ^2.4.2
-  devtools_shared: ^10.0.0-dev.2
-  devtools_app_shared: ^0.2.0-dev.0
+  devtools_shared: ^10.0.0
+  devtools_app_shared: ^0.2.0
   flutter:
     sdk: flutter
   io: ^1.0.4

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 10.0.0-dev.3
+# 10.0.0
 * Added helper `deserialize` and `deserializeNullable`
 * Extended serialization for `HeapSample` and `ExtensionEvents`
 * Added mixin `Serializable`

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,7 +1,7 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 10.0.0-dev.3
+version: 10.0.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 


### PR DESCRIPTION
Now that the minimum Dart and Flutter SDK versions are stable, these packages can also be published as stable.