### PR TITLE
Prepare for re-publish of retracted packages

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Add `FlutterEvent` and `DeveloperServiceEvent` constants.
 * Add `connectedAppPackageRoot`, `rootPackageDirectoryForMainIsolate`, and
 `mainIsolateRootLibraryUriAsString` methods to the `ServiceManager` class.
+* Bump minimum Dart SDK version to Dart stable `3.4.3` and minimum Flutter SDK
+version to Flutter stable `3.22.2`.
 
 ## 0.2.0-dev.0
 * Add `tooltipWaitExtraLong` to `utils.dart`.

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -1,11 +1,11 @@
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.2.0
+version: 0.2.1
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:
-  sdk: ">=3.4.0-282.1.beta <4.0.0"
-  flutter: ">=3.22.0-0.1.pre"
+  sdk: ">=3.4.3 <4.0.0"
+  flutter: ">=3.22.2"
 
 dependencies:
   collection: ^1.15.0

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,6 +1,8 @@
-## 0.2.0
+## 0.2.1
 * Add testimonies from extension authors to the `README.md`.
 * Add an integration test to the example app, `app_that_uses_foo`.
+* Bump minimum Dart SDK version to Dart stable `3.4.3` and minimum Flutter SDK
+version to Flutter stable `3.22.2`.
 
 ## 0.2.0-dev.0
 * Deprecate the `DevToolsExtension.requiresRunningApplication` field.

--- a/packages/devtools_extensions/README.md
+++ b/packages/devtools_extensions/README.md
@@ -46,7 +46,7 @@ for reference.
       - [Step 2: Configure your extension](#step-2-configure-your-extension)
       - [Step 3: Build your extension](#step-3-build-your-extension)
       - [Step 4: Debug your extension](#step-4-debug-your-extension)
-3. [Publish your package with a DevTools extension](#publish-your-package-with-a-DevTools-extension)
+3. [Publish your package with a DevTools extension](#publish-your-package-with-a-devTools-extension)
 4. [Resources and support](#resources-and-support)
 5. [Testimonies from extension authors](#testimonies-from-extension-authors)
 

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,12 +1,12 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.2.0
+version: 0.2.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:
-  sdk: ">=3.4.0-282.1.beta <4.0.0"
-  flutter: ">=3.22.0-0.1.pre"
+  sdk: ">=3.4.3 <4.0.0"
+  flutter: ">=3.22.2"
 
 executables:
   devtools_extensions: devtools_extensions

--- a/packages/devtools_shared/CHANGELOG.md
+++ b/packages/devtools_shared/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 10.0.0
+# 10.0.1
 * Added helper `deserialize` and `deserializeNullable`
 * Extended serialization for `HeapSample` and `ExtensionEvents`
 * Added mixin `Serializable`
 * Fix a regression with accessing the Flutter store file.
+* Bump minimum Dart SDK version to Dart stable `3.4.3`.
 
 # 10.0.0-dev.2
 * Support detecting package roots for nested Dart projects in the

--- a/packages/devtools_shared/pubspec.yaml
+++ b/packages/devtools_shared/pubspec.yaml
@@ -1,12 +1,12 @@
 name: devtools_shared
 description: Package of shared Dart structures between devtools_app, dds, and other tools.
 
-version: 10.0.0
+version: 10.0.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_shared
 
 environment:
-  sdk: ">=3.4.0-282.1.beta <4.0.0"
+  sdk: ">=3.4.3 <4.0.0"
 
 dependencies:
   args: ^2.4.2


### PR DESCRIPTION
These packages will need to be published from Flutter stable due to a pub regression (https://github.com/dart-lang/pub/issues/4305) that broke the previous publish.

Fixes https://github.com/flutter/devtools/issues/7925.