### PR TITLE
Add API fields to allow passing requiresDebugSession to openDevTools

### DIFF
--- a/packages/devtools_app/lib/src/service/editor/editor_client.dart
+++ b/packages/devtools_app/lib/src/service/editor/editor_client.dart
@@ -45,6 +45,7 @@ abstract class EditorClient {
     String? debugSessionId, {
     String? page,
     bool? forceExternal,
+    bool? requiresDebugSession,
   });
 
   /// Requests the editor enables a new platform (for example by running

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/dart_tooling_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/dart_tooling_api.dart
@@ -211,11 +211,13 @@ class PostMessageEditorClient implements EditorClient {
     String? debugSessionId, {
     String? page,
     bool? forceExternal,
+    bool? requiresDebugSession,
   }) async {
     await _api.openDevToolsPage(
       debugSessionId,
       page: page,
       forceExternal: forceExternal,
+      requiresDebugSession: requiresDebugSession,
     );
   }
 

--- a/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/impl/vs_code_api.dart
@@ -94,6 +94,7 @@ final class VsCodeApiImpl implements VsCodeApi {
     String? debugSessionId, {
     String? page,
     bool? forceExternal,
+    bool? requiresDebugSession,
   }) {
     return sendRequest(
       VsCodeApi.jsonOpenDevToolsPageMethod,
@@ -101,6 +102,7 @@ final class VsCodeApiImpl implements VsCodeApi {
         VsCodeApi.jsonDebugSessionIdParameter: debugSessionId,
         VsCodeApi.jsonPageParameter: page,
         VsCodeApi.jsonForceExternalParameter: forceExternal,
+        VsCodeApi.jsonRequiresDebugSessionParameter: requiresDebugSession,
       },
     );
   }
@@ -211,6 +213,11 @@ class VsCodeCapabilitiesImpl implements VsCodeCapabilities {
   @override
   bool get openDevToolsExternally =>
       _raw?[VsCodeCapabilities.openDevToolsExternallyField] == true;
+
+  @override
+  bool get openDevToolsWithRequiresDebugSessionFlag =>
+      _raw?[VsCodeCapabilities.openDevToolsWithRequiresDebugSessionFlagField] ==
+      true;
 
   @override
   bool get hotReload => _raw?[VsCodeCapabilities.hotReloadField] == true;

--- a/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/api/vs_code_api.dart
@@ -55,10 +55,18 @@ abstract interface class VsCodeApi {
   ///
   /// Depending on user settings, this may open embedded (the default) or in an
   /// external browser window.
+  ///
+  /// If [debugSessionId] is `null` the [requiresDebugSession] flag will
+  /// determine whether the editor will select (or ask the user to select) a
+  /// debug session for the page. If [requiresDebugSession] is `null` (or if
+  /// the `openDevToolsWithRequiresDebugSessionFlag` capability is `false`) then
+  /// the editor will try to make this decision automatically (which may be
+  /// inaccurate for pages it does not know about, like extensions).
   Future<void> openDevToolsPage(
     String? debugSessionId, {
     String? page,
     bool? forceExternal,
+    bool? requiresDebugSession,
   });
 
   /// Sends a Hot Reload request to the debug session with ID [debugSessionId].
@@ -87,6 +95,7 @@ abstract interface class VsCodeApi {
   static const jsonForceExternalParameter = 'forceExternal';
   static const jsonDebugSessionIdParameter = 'debugSessionId';
   static const jsonPlatformTypeParameter = 'platformType';
+  static const jsonRequiresDebugSessionParameter = 'requiresDebugSession';
 }
 
 /// This class defines a device event sent by the Dart/Flutter extensions in VS
@@ -153,6 +162,11 @@ abstract interface class VsCodeCapabilities {
   /// regardless of user settings.
   bool get openDevToolsExternally;
 
+  /// Whether the `openDevToolsPage` method can be called with the
+  /// `requiresDebugSession` flag to indicate whether the editor should select/
+  /// prompt for a debug session if one was not provided.
+  bool get openDevToolsWithRequiresDebugSessionFlag;
+
   /// Whether the `hotReload` method is available call to hot reload a specific
   /// debug session.
   bool get hotReload;
@@ -164,6 +178,8 @@ abstract interface class VsCodeCapabilities {
   static const jsonSelectDeviceField = 'selectDevice';
   static const openDevToolsPageField = 'openDevToolsPage';
   static const openDevToolsExternallyField = 'openDevToolsExternally';
+  static const openDevToolsWithRequiresDebugSessionFlagField =
+      'openDevToolsWithRequiresDebugSessionFlag';
   static const hotReloadField = 'hotReload';
   static const hotRestartField = 'hotRestart';
 }

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/editor_service/editor_server.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/editor_service/editor_server.dart
@@ -38,6 +38,7 @@ abstract class EditorServer {
     String debugSessionId,
     String? page,
     bool forceExternal,
+    bool requiresDebugSession,
   ) {}
 
   /// Overridden by subclasses to provide an implementation of the

--- a/packages/devtools_app/test/test_infra/scenes/standalone_ui/editor_service/fake_editor.dart
+++ b/packages/devtools_app/test/test_infra/scenes/standalone_ui/editor_service/fake_editor.dart
@@ -115,6 +115,7 @@ mixin FakeEditor on EditorServer {
     String debugSessionId,
     String? page,
     bool forceExternal,
+    bool requiresDebugSession,
   ) {}
 }
 


### PR DESCRIPTION
This adds a new capability and parameter for openDevTools that allows DevTools to indicate to the editor that a call requires a debug session.

This allows calling openDevTools() without a debug session ID and letting the editor prompt so that things like Inspector could be top-level in the sidebar, but also supports having static tooling at the top level where this prompting is not desired.

If the `openDevToolsWithRequiresDebugSessionFlag` capability is `false`, this flag will not work and the behaviour (of whether an editor prompts or not) is not well defined, but for existing VS Code will prompt only for known DevTools pages that are not-static (that is, DevTools extensions will never prompt and always be assumed to be static if an explicit debug session is not passed).

This does not make any changes to the UI to use this functionality.

