### PR TITLE
Skip another eval_integration_test case that is flaking in the Flutter customer tests

### DIFF
--- a/packages/devtools_app/test/shared/eval_integration_test.dart
+++ b/packages/devtools_app/test/shared/eval_integration_test.dart
@@ -146,6 +146,9 @@ void main() {
           expect(error.valueAsString, 'foo');
         },
         timeout: const Timeout.factor(2),
+        // TODO(https://github.com/flutter/devtools/issues/6998): if this flake
+        // is addressed, we can unskip this for the Flutter customer tests.
+        tags: skipForCustomerTestsTag,
       );
     });
   });


### PR DESCRIPTION
Several recent runs of the devtools tests in the Flutter customer test suite have shown flakes in the FutureFailedException test in eval_integration_test.

Some other eval_integration_test cases have a tag that skips the test when running in the Flutter customer tests.  This PR applies that tag to FutureFailedException.

See https://github.com/flutter/devtools/issues/6998