### PR TITLE
Move logic to de-duplicate extensions into a helper file for shared use

### DIFF
--- a/packages/devtools_app/lib/devtools_app.dart
+++ b/packages/devtools_app/lib/devtools_app.dart
@@ -4,6 +4,7 @@
 
 export 'src/app.dart';
 export 'src/extensions/extension_service.dart';
+export 'src/extensions/extension_service_helpers.dart';
 export 'src/framework/app_bar.dart';
 export 'src/framework/home_screen.dart';
 export 'src/framework/notifications_view.dart';

--- a/packages/devtools_app/lib/src/extensions/extension_service_helpers.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service_helpers.dart
@@ -1,0 +1,87 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app_shared/utils.dart';
+import 'package:devtools_shared/devtools_extensions.dart';
+import 'package:devtools_shared/devtools_shared.dart';
+import 'package:flutter/foundation.dart';
+import 'package:logging/logging.dart';
+
+/// De-duplicates extensions by ignoring all that are not the latest version
+/// when there are duplicates.
+void deduplicateExtensionsAndTakeLatest(
+  List<DevToolsExtensionConfig> extensions, {
+  required void Function(DevToolsExtensionConfig ext, {required bool ignore})
+      onSetIgnored,
+  Logger? logger,
+  String extensionType = '',
+}) {
+  final deduped = <String>{};
+  for (final ext in extensions) {
+    if (deduped.contains(ext.name)) continue;
+    deduped.add(ext.name);
+
+    // This includes [ext] itself.
+    final matchingExtensions = extensions.where((e) => e.name == ext.name);
+    if (matchingExtensions.length > 1) {
+      logger?.fine(
+        'detected duplicate $extensionType extensions for ${ext.name}',
+      );
+
+      // Ignore all matching extensions and then mark the [latest] as
+      // unignored after the loop is finished.
+      var latest = ext;
+      for (final ext in matchingExtensions) {
+        onSetIgnored(ext, ignore: true);
+        latest = takeLatestExtension(latest, ext);
+      }
+      onSetIgnored(latest, ignore: false);
+
+      logger?.fine(
+        'ignored ${matchingExtensions.length - 1} duplicate $extensionType '
+        '${pluralize('extension', matchingExtensions.length - 1)} in favor of '
+        '${latest.identifier} at ${latest.devtoolsOptionsUri}',
+      );
+    } else {
+      logger?.fine(
+        'no duplicates found for $extensionType extension ${ext.name}',
+      );
+    }
+  }
+}
+
+/// Compares the versions of extension configurations [a] and [b] and returns
+/// the extension configuration with the latest version, following semantic
+/// versioning rules.
+@visibleForTesting
+DevToolsExtensionConfig takeLatestExtension(
+  DevToolsExtensionConfig a,
+  DevToolsExtensionConfig b,
+) {
+  bool exceptionParsingA = false;
+  bool exceptionParsingB = false;
+  SemanticVersion? versionA;
+  SemanticVersion? versionB;
+  try {
+    versionA = SemanticVersion.parse(a.version);
+  } catch (_) {
+    exceptionParsingA = true;
+  }
+
+  try {
+    versionB = SemanticVersion.parse(b.version);
+  } catch (_) {
+    exceptionParsingB = true;
+  }
+
+  if (exceptionParsingA || exceptionParsingB) {
+    if (exceptionParsingA) {
+      return b;
+    }
+    return a;
+  }
+
+  final versionCompare = versionA!.compareTo(versionB!);
+  return versionCompare >= 0 ? a : b;
+}

--- a/packages/devtools_app/test/extensions/extension_service_helpers_test.dart
+++ b/packages/devtools_app/test/extensions/extension_service_helpers_test.dart
@@ -1,0 +1,104 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_app/devtools_app.dart';
+import 'package:devtools_app/src/shared/development_helpers.dart';
+import 'package:devtools_shared/devtools_extensions.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('takeLatestExtension', () {
+    test('returns newer extension', () {
+      expect(
+        takeLatestExtension(
+          StubDevToolsExtensions.barExtension,
+          StubDevToolsExtensions.newerBarExtension,
+        ),
+        StubDevToolsExtensions.newerBarExtension,
+      );
+    });
+
+    test('handles parsing errors', () {
+      // Returns 'b' when 'a' has parsing errors.
+      var a = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey:
+            'file:///path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      var b = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: '2.1.0',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey:
+            'file:///path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      expect(takeLatestExtension(a, b), b);
+
+      // Returns 'a' when 'b' has parsing errors.
+      a = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: '2.1.0',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey:
+            'file:///path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      b = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey: '/path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      expect(takeLatestExtension(a, b), a);
+
+      // Returns 'a' when both 'a' and 'b' have parsing errors.
+      a = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey:
+            'file:///path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      b = DevToolsExtensionConfig.parse({
+        DevToolsExtensionConfig.nameKey: 'bar',
+        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
+        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
+        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
+        DevToolsExtensionConfig.requiresConnectionKey: 'false',
+        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
+        DevToolsExtensionConfig.devtoolsOptionsUriKey:
+            'file:///path/to/options/file',
+        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
+        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
+      });
+      expect(takeLatestExtension(a, b), a);
+    });
+  });
+}

--- a/packages/devtools_app/test/extensions/extension_service_test.dart
+++ b/packages/devtools_app/test/extensions/extension_service_test.dart
@@ -171,7 +171,10 @@ void main() {
         StubDevToolsExtensions.barExtension,
         StubDevToolsExtensions.bazExtension,
         StubDevToolsExtensions.someToolExtension,
-      ]..forEach(service.setExtensionIgnored);
+      ];
+      for (final e in extensionsToIgnore) {
+        service.setExtensionIgnored(e, ignore: true);
+      }
       for (final ext in StubDevToolsExtensions.extensions()) {
         expect(
           service.isExtensionIgnored(ext),
@@ -184,98 +187,6 @@ void main() {
       for (final ext in StubDevToolsExtensions.extensions()) {
         expect(service.isExtensionIgnored(ext), false);
       }
-    });
-
-    test('takeLatestExtension returns newer extension', () {
-      expect(
-        takeLatestExtension(
-          StubDevToolsExtensions.barExtension,
-          StubDevToolsExtensions.newerBarExtension,
-        ),
-        StubDevToolsExtensions.newerBarExtension,
-      );
-    });
-
-    test('takeLatestExtension handles parsing errors', () {
-      // Returns 'b' when 'a' has parsing errors.
-      var a = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey:
-            'file:///path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      var b = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: '2.1.0',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey:
-            'file:///path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      expect(takeLatestExtension(a, b), b);
-
-      // Returns 'a' when 'b' has parsing errors.
-      a = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: '2.1.0',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey:
-            'file:///path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      b = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey: '/path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      expect(takeLatestExtension(a, b), a);
-
-      // Returns 'a' when both 'a' and 'b' have parsing errors.
-      a = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey:
-            'file:///path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      b = DevToolsExtensionConfig.parse({
-        DevToolsExtensionConfig.nameKey: 'bar',
-        DevToolsExtensionConfig.issueTrackerKey: 'www.google.com',
-        DevToolsExtensionConfig.versionKey: 'this-will-not-parse',
-        DevToolsExtensionConfig.materialIconCodePointKey: 0xe638,
-        DevToolsExtensionConfig.requiresConnectionKey: 'false',
-        DevToolsExtensionConfig.extensionAssetsPathKey: '/absolute/path/to/bar',
-        DevToolsExtensionConfig.devtoolsOptionsUriKey:
-            'file:///path/to/options/file',
-        DevToolsExtensionConfig.isPubliclyHostedKey: 'false',
-        DevToolsExtensionConfig.detectedFromStaticContextKey: 'true',
-      });
-      expect(takeLatestExtension(a, b), a);
     });
   });
 }

--- a/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
+++ b/packages/devtools_app/test/shared/diagnostics/inspector_service_test.dart
@@ -268,7 +268,7 @@ void main() {
         test('isSummaryTree = true', () async {
           await env.setupEnvironment();
           final group = inspectorService!.createObjectGroup('test-group');
-          final RemoteDiagnosticsNode root = (await group.getRoot(
+          final root = (await group.getRoot(
             FlutterTreeType.widget,
             isSummaryTree: true,
           ))!;
@@ -299,7 +299,7 @@ void main() {
         test('isSummaryTree = false', () async {
           await env.setupEnvironment();
           final group = inspectorService!.createObjectGroup('test-group');
-          final RemoteDiagnosticsNode root = (await group.getRoot(
+          final root = (await group.getRoot(
             FlutterTreeType.widget,
             isSummaryTree: false,
           ))!;
@@ -331,7 +331,7 @@ void main() {
 
           // First get a node in the summary tree:
           final group = inspectorService!.createObjectGroup('test-group');
-          final RemoteDiagnosticsNode root = (await group.getRoot(
+          final root = (await group.getRoot(
             FlutterTreeType.widget,
             isSummaryTree: true,
           ))!;


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/7946. No functional changes in this PR - just a refactor. Second use of this helper will come in a follow up PR.