### PR TITLE
Show extensions that require a connection even when there is not a connected app in embedded mode

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/devtools_extensions_test.dart
@@ -43,12 +43,14 @@ void main() {
     logStatus(
       'verify static extensions are available before connecting to an app',
     );
-    expect(extensionService.availableExtensions.length, 1);
-    expect(extensionService.visibleExtensions.length, 1);
+    expect(extensionService.availableExtensions.length, 3);
+    expect(extensionService.visibleExtensions.length, 3);
     await _verifyExtensionsSettingsMenu(
       tester,
       [
         ExtensionEnabledState.none, // bar
+        ExtensionEnabledState.none, // baz
+        ExtensionEnabledState.none, // foo
       ],
     );
 

--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -399,7 +399,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
     routerDelegate.refreshPages();
   }
 
-// TODO(kenz): consider showing all screens and displaying the reason why they
+  // TODO(kenz): consider showing all screens and displaying the reason why they
   // are not available instead of hiding screens.
   List<Screen> _visibleScreens() =>
       _screens.where((screen) => shouldShowScreen(screen).show).toList();

--- a/packages/devtools_app/lib/src/extensions/embedded/view.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/view.dart
@@ -2,10 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;
+import '../../shared/globals.dart';
+import '../../shared/utils.dart';
 import '_view_desktop.dart' if (dart.library.js_interop) '_view_web.dart';
 import 'controller.dart';
 
@@ -39,6 +42,41 @@ class _EmbeddedExtensionViewState extends State<EmbeddedExtensionView> {
 
   @override
   Widget build(BuildContext context) {
+    if (isEmbedded() &&
+        widget.controller.extensionConfig.requiresConnection &&
+        !serviceConnection.serviceManager.connectedState.value.connected) {
+      return ExtensionRequiresConnection(
+        extensionName: widget.controller.extensionConfig.displayName,
+      );
+    }
     return EmbeddedExtension(controller: widget.controller);
+  }
+}
+
+@visibleForTesting
+class ExtensionRequiresConnection extends StatelessWidget {
+  const ExtensionRequiresConnection({super.key, required this.extensionName});
+
+  final String extensionName;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            'The $extensionName extension requires a running applcation.',
+            style: theme.boldTextStyle,
+          ),
+          const SizedBox(height: denseSpacing),
+          Text(
+            'Start or connect to an active debug session to use this tool.',
+            style: theme.regularTextStyle,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/packages/devtools_app/lib/src/extensions/extension_screen.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_screen.dart
@@ -12,6 +12,7 @@ import '../shared/analytics/constants.dart' as gac;
 import '../shared/common_widgets.dart';
 import '../shared/globals.dart';
 import '../shared/screen.dart';
+import '../shared/utils.dart';
 import 'embedded/controller.dart';
 import 'embedded/view.dart';
 import 'extension_screen_controls.dart';
@@ -23,7 +24,15 @@ class ExtensionScreen extends Screen {
           id: extensionConfig.screenId,
           title: extensionConfig.name,
           icon: extensionConfig.icon,
-          requiresConnection: extensionConfig.requiresConnection,
+          requiresConnection:
+              // We set this to false all the time when embedded because the
+              // available extensions are displayed in a tool window (IntelliJ
+              // and Android Studio) with or without any active debug sessions.
+              // This prevents a "DevTools Extensions" tool window in IntelliJ
+              // and Android Studio that appears to be missing extensions. When
+              // a connection is still required to use the extension, messaging
+              // for this is provided by the [EmbeddedExtensionView] widget.
+              isEmbedded() ? false : extensionConfig.requiresConnection,
         );
 
   final DevToolsExtensionConfig extensionConfig;

--- a/packages/devtools_app/lib/src/extensions/extension_service.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service.dart
@@ -198,32 +198,18 @@ class ExtensionService extends DisposableController
         allExtensions.where((e) => !e.detectedFromStaticContext).toList();
     staticExtensions =
         allExtensions.where((e) => e.detectedFromStaticContext).toList();
-    _maybeIgnoreExtensions(connectedToApp: _appRoot != null);
+
+    // TODO(kenz): consider handling duplicates in a way that gives the user a
+    // choice of which version they want to use.
+    _deduplicateStaticExtensions();
+    _deduplicateStaticExtensionsWithRuntimeExtensions();
+
     final available = [
       ...runtimeExtensions,
       ...staticExtensions.where((ext) => !isExtensionIgnored(ext)),
     ]..sort();
     await _refreshExtensionEnabledStates(availableExtensions: available);
     _refreshInProgress.value = false;
-  }
-
-  void _maybeIgnoreExtensions({required bool connectedToApp}) {
-    // TODO(kenz): consider handling duplicates in a way that gives the user a
-    // choice of which version they want to use.
-    _deduplicateStaticExtensions();
-    _deduplicateStaticExtensionsWithRuntimeExtensions();
-
-    // Some extensions detected from a static context may actually require a
-    // running application.
-    for (final ext in staticExtensions) {
-      if (!connectedToApp && ext.requiresConnection) {
-        _log.fine(
-          'ignoring static extension ${ext.identifier} at '
-          '${ext.devtoolsOptionsUri} because it requires a connected app.',
-        );
-        setExtensionIgnored(ext, ignore: true);
-      }
-    }
   }
 
   /// De-duplicates static extensions from other static extensions by ignoring

--- a/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/import_export/_export_web.dart
@@ -32,10 +32,10 @@ class ExportControllerWeb extends ExportController {
       throw 'Unsupported content type: $T';
     }
 
-    element.setAttribute('href', URL.createObjectURL(blob as JSObject));
+    element.setAttribute('href', URL.createObjectURL(blob));
     element.setAttribute('download', fileName);
     element.style.display = 'none';
-    (document.body as HTMLBodyElement).append(element as JSAny);
+    (document.body as HTMLBodyElement).append(element);
     element.click();
     element.remove();
   }

--- a/packages/devtools_app/lib/src/shared/config_specific/notifications/_notifications_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/notifications/_notifications_web.dart
@@ -17,10 +17,7 @@ class Notification {
   late final web.Notification _impl;
 
   static Future<String> requestPermission() async =>
-      // TODO(srujzs): This was needed in 0.4.0 as generics were not available.
-      // This is no longer true 0.5.0 onwards.
-      // ignore: unnecessary_cast
-      ((await web.Notification.requestPermission().toDart) as JSString).toDart;
+      (await web.Notification.requestPermission().toDart).toDart;
 
   void close() {
     _impl.close();

--- a/packages/devtools_app/lib/src/shared/development_helpers.dart
+++ b/packages/devtools_app/lib/src/shared/development_helpers.dart
@@ -27,6 +27,9 @@ final _log = Logger('dev_helpers');
 /// server (devtools_tool serve) in order to pass a DTD URI to the DevTools
 /// server, which is not convenient for development.
 ///
+/// If you do need the DevTools server, then you should run
+/// `devtools_tool serve --dtd-uri=<uri>` instead of setting this debug flag.
+///
 /// You can use a real DTD URI from an IDE (VS Code or IntelliJ / Android
 /// Studio) using the "Copy DTD URI" action, or you can run a Dart or Flutter
 /// app from the command line with the `--print-dtd` flag.

--- a/packages/devtools_app/test/extensions/extension_screen_test.dart
+++ b/packages/devtools_app/test/extensions/extension_screen_test.dart
@@ -7,9 +7,11 @@ import 'package:devtools_app/src/extensions/embedded/view.dart';
 import 'package:devtools_app/src/extensions/extension_screen.dart';
 import 'package:devtools_app/src/extensions/extension_screen_controls.dart';
 import 'package:devtools_app/src/shared/development_helpers.dart';
+import 'package:devtools_app_shared/shared.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
+import 'package:devtools_test/devtools_test.dart';
 import 'package:devtools_test/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -137,6 +139,7 @@ void main() {
         await _verifyContextMenuContents(tester);
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
+        expect(find.byType(ExtensionRequiresConnection), findsNothing);
       },
     );
 
@@ -161,6 +164,39 @@ void main() {
         expect(_extensionContextMenuFinder, findsNothing);
         expect(find.byType(EnableExtensionPrompt), findsOneWidget);
         expect(find.byType(EmbeddedExtensionView), findsNothing);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'renders when embedded without a connected app',
+      windowSize,
+      (tester) async {
+        // The following state must be true for this test:
+        // * Embedded mode = true
+        // * Extension must require a connection (the fooExtension does)
+        // * The service manager must be in a disconnected state (this is true
+        //   after [setUp] runs above).
+
+        setGlobal(IdeTheme, IdeTheme(embedMode: EmbedMode.embedOne));
+
+        await extensionService.setExtensionEnabledState(
+          StubDevToolsExtensions.fooExtension,
+          enable: true,
+        );
+
+        await tester.pumpWidget(wrap(Builder(builder: fooScreen.build)));
+        expect(find.byType(ExtensionView), findsOneWidget);
+        expect(find.byType(EmbeddedExtensionHeader), findsOneWidget);
+        expect(
+          find.richTextContaining('package:foo extension'),
+          findsOneWidget,
+        );
+        expect(find.richTextContaining('(v1.0.0)'), findsOneWidget);
+        expect(find.richTextContaining('Report an issue'), findsOneWidget);
+        await _verifyContextMenuContents(tester);
+        expect(find.byType(EnableExtensionPrompt), findsNothing);
+        expect(find.byType(EmbeddedExtensionView), findsOneWidget);
+        expect(find.byType(ExtensionRequiresConnection), findsOneWidget);
       },
     );
 
@@ -196,6 +232,7 @@ void main() {
         );
         expect(find.byType(EnableExtensionPrompt), findsNothing);
         expect(find.byType(EmbeddedExtensionView), findsOneWidget);
+        expect(find.byType(ExtensionRequiresConnection), findsNothing);
         await _verifyContextMenuContents(
           tester,
           autoDismiss: false,

--- a/packages/devtools_app/test/extensions/extension_screen_test.dart
+++ b/packages/devtools_app/test/extensions/extension_screen_test.dart
@@ -11,7 +11,6 @@ import 'package:devtools_app_shared/shared.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_extensions.dart';
-import 'package:devtools_test/devtools_test.dart';
 import 'package:devtools_test/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_app/test/extensions/extension_service_test.dart
+++ b/packages/devtools_app/test/extensions/extension_service_test.dart
@@ -58,7 +58,7 @@ void main() {
       expect(ignoredRuntimeExtensions.length, 0);
     });
 
-    test('initialize when disconnected', () async {
+    test('initialize with ignoreServiceConnection', () async {
       when(mockServiceManager.connectedState)
           .thenReturn(ValueNotifier(const ConnectedState(false)));
 
@@ -70,15 +70,13 @@ void main() {
       await service.initialize();
       expect(service.staticExtensions.length, 4);
       expect(service.runtimeExtensions, isEmpty);
-      expect(service.availableExtensions.length, 1);
+      expect(service.availableExtensions.length, 3);
 
       final ignoredStaticExtensions =
           service.staticExtensions.where(service.isExtensionIgnored);
-      expect(ignoredStaticExtensions.length, 3);
+      expect(ignoredStaticExtensions.length, 1);
       expect(ignoredStaticExtensions.map((e) => e.identifier).toList(), [
         'bar_2.0.0', // Duplicate: older version of an existing extension.
-        'baz_1.0.0', // Requires a connected app.
-        'foo_1.0.0', // Requires a connected app.
       ]);
     });
 

--- a/packages/devtools_app/test/shared/screens_test.dart
+++ b/packages/devtools_app/test/shared/screens_test.dart
@@ -8,10 +8,16 @@ import 'package:devtools_app/src/framework/scaffold.dart';
 import 'package:devtools_app/src/shared/development_helpers.dart';
 import 'package:devtools_app/src/shared/query_parameters.dart';
 import 'package:devtools_app_shared/shared.dart';
+import 'package:devtools_app_shared/ui.dart';
+import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  setUp(() {
+    setGlobal(IdeTheme, IdeTheme());
+  });
+
   group('ScreenMetaData', () {
     test('values matches order of screens', () {
       final enumOrder = ScreenMetaData.values.map((s) => s.id).toList();

--- a/packages/devtools_app_shared/lib/src/utils/web_utils.dart
+++ b/packages/devtools_app_shared/lib/src/utils/web_utils.dart
@@ -7,10 +7,7 @@ import 'dart:js_interop';
 import 'package:web/web.dart';
 
 extension MessageExtension on Event {
-  bool get isMessageEvent =>
-      // TODO(srujzs): This is necessary in order to support package:web 0.4.0.
-      // This was not needed with 0.3.0, hence the lint.
-      (this as JSObject).instanceOfString('MessageEvent');
+  bool get isMessageEvent => instanceOfString('MessageEvent');
 }
 
 extension NodeListExtension on NodeList {


### PR DESCRIPTION
This is so that the available extensions will always show in the IntelliJ tool window for DevTools extensions. Without this change, we could end up in a state where we have a DevTools extensions tool window in IntelliJ that is empty, with no messaging as to why.

![Screenshot 2024-06-24 at 1 59 30 PM](https://github.com/flutter/devtools/assets/43759233/83f7c9f1-407a-448a-bac1-4cef07268261)

This PR addresses a similar problem that https://github.com/flutter/devtools/pull/7947 addresses for the VS code sidebar (showing all extensions with messaging when an extension is not available for the current state of the IDE).