### PR TITLE
Fix incorrect type in release notes server api.

### DIFF
--- a/packages/devtools_app/test/shared/disconnect_observer_test.dart
+++ b/packages/devtools_app/test/shared/disconnect_observer_test.dart
@@ -74,7 +74,7 @@ void main() {
     }
 
     testWidgets(
-      'initiailized in a disconnected state',
+      'initialized in a disconnected state',
       (WidgetTester tester) async {
         fakeServiceConnectionManager.serviceManager.setConnectedState(false);
         await pumpDisconnectObserver(tester);
@@ -83,7 +83,7 @@ void main() {
     );
 
     testWidgets(
-      'initiailized in a connected state',
+      'initialized in a connected state',
       (WidgetTester tester) async {
         await pumpDisconnectObserver(tester);
         verifyObserverState(tester, connected: true, showingOverlay: false);

--- a/packages/devtools_shared/lib/src/server/server_api.dart
+++ b/packages/devtools_shared/lib/src/server/server_api.dart
@@ -189,11 +189,9 @@ class ServerApi {
         if (queryParams.containsKey(lastReleaseNotesVersionPropertyName)) {
           _devToolsStore.lastReleaseNotesVersion =
               queryParams[lastReleaseNotesVersionPropertyName]!;
+          return _encodeResponse(true, api: api);
         }
-        return _encodeResponse(
-          _devToolsStore.lastReleaseNotesVersion,
-          api: api,
-        );
+        return _encodeResponse(false, api: api);
 
       // ----- App size api. -----
 


### PR DESCRIPTION
Fixes the failures seen when building DevTools with the DevTools server:

```
main.dart.js:52160 [zoneGuarded]: TypeError: "2.36.0": type 'String' is not a subtype of type 'bool'
main.dart.js:3555 Uncaught 
    at Object.i (http://127.0.0.1:9100/main.dart.js:3555:19)
    at Object.dW (http://127.0.0.1:9100/main.dart.js:4375:9)
    at http://127.0.0.1:9100/main.dart.js:21703:27
    at bS4.a (http://127.0.0.1:9100/main.dart.js:5004:63)
    at bS4.$2 (http://127.0.0.1:9100/main.dart.js:62979:14)
    at bPM.$1 (http://127.0.0.1:9100/main.dart.js:62973:21)
    at Object.bRI (http://127.0.0.1:9100/main.dart.js:5300:19)
    at apm.<anonymous> (http://127.0.0.1:9100/main.dart.js:183085:10)
    at a31.uq (http://127.0.0.1:9100/main.dart.js:64214:12)
    at bBs.$0 (http://127.0.0.1:9100/main.dart.js:63540:11)
```
