### PR TITLE
[deep link] Add default scheme to ios universal links

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -19,6 +19,7 @@ import 'deep_links_model.dart';
 import 'deep_links_services.dart';
 
 typedef _DomainAndPath = ({String? domain, String? path});
+const defaultSchemes = {'http', 'https'};
 
 const domainAssetLinksJsonFileErrors = {
   AndroidDomainError.existence,
@@ -379,6 +380,7 @@ class DeepLinksController extends DisposableController
           (domain) => LinkData(
             domain: domain,
             path: null,
+            scheme: defaultSchemes,
             os: {PlatformOS.ios},
           ),
         )

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -19,7 +19,7 @@ import 'deep_links_model.dart';
 import 'deep_links_services.dart';
 
 typedef _DomainAndPath = ({String? domain, String? path});
-const defaultSchemes = {'http', 'https'};
+const _defaultSchemes = {'http', 'https'};
 
 const domainAssetLinksJsonFileErrors = {
   AndroidDomainError.existence,
@@ -380,7 +380,7 @@ class DeepLinksController extends DisposableController
           (domain) => LinkData(
             domain: domain,
             path: null,
-            scheme: defaultSchemes,
+            scheme: _defaultSchemes,
             os: {PlatformOS.ios},
           ),
         )


### PR DESCRIPTION
For android deep links, schemes are set in manifest file(http/https or custom schemes)

For iOS links, default scheme is also http/https 

Also, the deep link validator tool doesn't support validating links with custom URL schemes yet

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
