### PR TITLE
Rename "track" settings to "trace" where timeline events are added.

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -607,9 +607,10 @@ class _CrossCheckTable extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: defaultSpacing),
                 child: Text(
-                    'This domain has an Asset link json file but it\'s missing in the android manifest file. '
-                    'If you want to set up deep linking for Android, you need to add this domain '
-                    'to your AndroidManifest.xml file.'),
+                  'This domain has an Asset link json file but it\'s missing in the android manifest file. '
+                  'If you want to set up deep linking for Android, you need to add this domain '
+                  'to your AndroidManifest.xml file.',
+                ),
               ),
             ],
           ),
@@ -622,9 +623,10 @@ class _CrossCheckTable extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.symmetric(horizontal: defaultSpacing),
                 child: Text(
-                    'This domain has an AASA file but it\'s missing in local settings. '
-                    'If you want to set up deep linking for iOS, you need to add this domain '
-                    'to your info.Plist file.'),
+                  'This domain has an AASA file but it\'s missing in local settings. '
+                  'If you want to set up deep linking for iOS, you need to add this domain '
+                  'to your info.Plist file.',
+                ),
               ),
             ],
           ),

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/more_debugging_options.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/more_debugging_options.dart
@@ -29,7 +29,7 @@ class MoreDebuggingOptionsButton extends StatelessWidget {
         extensions.disableClipLayers,
         extensions.disableOpacityLayers,
         extensions.disablePhysicalShapeLayers,
-        if (FeatureFlags.widgetRebuildStats) extensions.trackWidgetBuildCounts,
+        if (FeatureFlags.widgetRebuildStats) extensions.countWidgetBuilds,
       ],
       overlayDescription: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_analysis.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/frame_analysis/frame_analysis.dart
@@ -96,7 +96,7 @@ class FlutterFrameAnalysisView extends StatelessWidget {
                 valueListenable: serviceConnection
                     .serviceManager.serviceExtensionManager
                     .getServiceExtensionState(
-                  extensions.trackWidgetBuildCounts.extension,
+                  extensions.countWidgetBuilds.extension,
                 ),
                 builder: (context, extensionState, _) {
                   if (!extensionState.enabled) {
@@ -107,7 +107,7 @@ class FlutterFrameAnalysisView extends StatelessWidget {
                         ),
                         Flexible(
                           child: ServiceExtensionCheckbox(
-                            serviceExtension: extensions.trackWidgetBuildCounts,
+                            serviceExtension: extensions.countWidgetBuilds,
                             showDescription: false,
                           ),
                         ),

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -110,7 +110,7 @@ class _RebuildStatsViewState extends State<RebuildStatsView>
                     padding:
                         const EdgeInsets.symmetric(horizontal: denseSpacing),
                     child: ServiceExtensionCheckbox(
-                      serviceExtension: extensions.trackWidgetBuildCounts,
+                      serviceExtension: extensions.countWidgetBuilds,
                     ),
                   ),
                 ),
@@ -123,13 +123,13 @@ class _RebuildStatsViewState extends State<RebuildStatsView>
             valueListenable: serviceConnection
                 .serviceManager.serviceExtensionManager
                 .getServiceExtensionState(
-              extensions.trackWidgetBuildCounts.extension,
+              extensions.countWidgetBuilds.extension,
             ),
             builder: (context, state, _) {
               if (metrics.isEmpty && !state.enabled) {
                 return const Center(
                   child: Text(
-                    'Track widget build counts must be enabled to see data.',
+                    'Count widget builds must be enabled to see data.',
                   ),
                 );
               }

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -269,7 +269,7 @@ final performanceOverlay = ToggleableServiceExtensionDescription<bool>.from(
 
 final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>.from(
   extensions.profileWidgetBuilds,
-  title: 'Track widget builds',
+  title: 'Trace widget builds',
   iconAsset: 'icons/trackwidget-white.png',
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.trackRebuilds.name,
@@ -283,7 +283,7 @@ final profileWidgetBuilds = ToggleableServiceExtensionDescription<bool>.from(
 final profileUserWidgetBuilds =
     ToggleableServiceExtensionDescription<bool>.from(
   extensions.profileUserWidgetBuilds,
-  title: 'Track user-created widget builds',
+  title: 'Trace user-created widget builds',
   iconAsset: 'icons/trackwidget-white.png',
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.trackUserCreatedWidgetBuilds.name,
@@ -295,7 +295,7 @@ final profileUserWidgetBuilds =
 final profileRenderObjectPaints =
     ToggleableServiceExtensionDescription<bool>.from(
   extensions.profileRenderObjectPaints,
-  title: 'Track paints',
+  title: 'Trace paints',
   iconData: Icons.format_paint,
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.trackPaints.name,
@@ -309,7 +309,7 @@ final profileRenderObjectPaints =
 final profileRenderObjectLayouts =
     ToggleableServiceExtensionDescription<bool>.from(
   extensions.profileRenderObjectLayouts,
-  title: 'Track layouts',
+  title: 'Trace layouts',
   iconData: Icons.auto_awesome_mosaic,
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.trackLayouts.name,
@@ -475,12 +475,12 @@ final structuredErrors = ToggleableServiceExtensionDescription<bool>.from(
   tooltip: 'Toggle showing structured errors for Flutter framework issues',
 );
 
-final trackWidgetBuildCounts = ToggleableServiceExtensionDescription<bool>.from(
-  extensions.trackRebuildWidgets,
-  title: 'Track widget build counts',
+final countWidgetBuilds = ToggleableServiceExtensionDescription<bool>.from(
+  extensions.countWidgetBuilds,
+  title: 'Count widget builds',
   iconAsset: 'icons/inspector/diagram@2x.png',
   gaScreenName: gac.performance,
-  gaItem: gac.trackRebuildWidgets,
+  gaItem: gac.PerformanceEvents.countWidgetBuilds.nameOverride!,
   description: 'Tracks widget build counts for each Flutter frame.',
   tooltip: '''Enable this option to see the widgets that were built in each 
 Flutter frame using the Frame Analysis tool, or to see an aggregate
@@ -491,7 +491,7 @@ summary of these counts using the Rebuild Stats tool.''',
 final profilePlatformChannels =
     ToggleableServiceExtensionDescription<bool>.from(
   extensions.profilePlatformChannels,
-  title: 'Track platform channels',
+  title: 'Trace platform channels',
   iconAsset: 'icons/trackwidget-white.png',
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.profilePlatformChannels.name,

--- a/packages/devtools_app/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app/lib/src/service/service_extensions.dart
@@ -481,7 +481,7 @@ final countWidgetBuilds = ToggleableServiceExtensionDescription<bool>.from(
   iconAsset: 'icons/inspector/diagram@2x.png',
   gaScreenName: gac.performance,
   gaItem: gac.PerformanceEvents.countWidgetBuilds.nameOverride!,
-  description: 'Tracks widget build counts for each Flutter frame.',
+  description: 'Counts widget builds for each Flutter frame.',
   tooltip: '''Enable this option to see the widgets that were built in each 
 Flutter frame using the Frame Analysis tool, or to see an aggregate
 summary of these counts using the Rebuild Stats tool.''',

--- a/packages/devtools_app/lib/src/shared/analytics/constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants.dart
@@ -94,7 +94,6 @@ enum HomeScreenEvents {
 
 // Logging UX actions:
 const structuredErrors = 'structuredErrors';
-const trackRebuildWidgets = 'trackRebuildWidgets';
 
 // App Size Tools UX actions:
 const importFileSingle = 'importFileSingle';

--- a/packages/devtools_app/lib/src/shared/analytics/constants/_performance_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_performance_constants.dart
@@ -19,6 +19,7 @@ enum PerformanceEvents {
   disableClipLayers,
   disableOpacityLayers,
   disablePhysicalShapeLayers,
+  countWidgetBuilds('trackRebuildWidgets'),
   collectRasterStats,
   clearRasterStats,
   fullScreenLayerImage,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,7 +18,9 @@ TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any general updates.
+* Renamed the "Track" builds, paints, and layouts settings to "Trace"
+builds, paints, and layouts. - [#8084](https://github.com/flutter/devtools/pull/8084)
+* Renamed the "Track widget build counts" setting to "Count widget builds". - [#8084](https://github.com/flutter/devtools/pull/8084)
 
 ## CPU profiler updates
 

--- a/packages/devtools_app/test/performance/controls/enhance_tracing_test.dart
+++ b/packages/devtools_app/test/performance/controls/enhance_tracing_test.dart
@@ -27,7 +27,7 @@ void main() {
     setGlobal(IdeTheme, getIdeTheme());
   });
 
-  group('TrackWidgetBuildsSetting', () {
+  group('TraceWidgetBuildsSetting', () {
     setUp(() async {
       fakeExtensionManager = FakeServiceExtensionManager();
       await fakeExtensionManager.fakeFrame();
@@ -38,49 +38,49 @@ void main() {
     });
 
     testWidgets('builds successfully', (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+      await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
       await tester.pumpAndSettle();
-      expect(find.byType(TrackWidgetBuildsSetting), findsOneWidget);
-      expect(find.byType(TrackWidgetBuildsCheckbox), findsOneWidget);
+      expect(find.byType(TraceWidgetBuildsSetting), findsOneWidget);
+      expect(find.byType(TraceWidgetBuildsCheckbox), findsOneWidget);
       expect(find.byType(CheckboxSetting), findsOneWidget);
       expect(find.byType(MoreInfoLink), findsOneWidget);
-      expect(find.byType(TrackWidgetBuildsScopeSelector), findsOneWidget);
-      expect(find.byType(Radio<TrackWidgetBuildsScope>), findsNWidgets(2));
+      expect(find.byType(TraceWidgetBuildsScopeSelector), findsOneWidget);
+      expect(find.byType(Radio<TraceWidgetBuildsScope>), findsNWidgets(2));
       final userCreatedWidgetsRadio =
-          tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-              as Radio<TrackWidgetBuildsScope>;
+          tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+              as Radio<TraceWidgetBuildsScope>;
       expect(
         userCreatedWidgetsRadio.value,
-        equals(TrackWidgetBuildsScope.userCreated),
+        equals(TraceWidgetBuildsScope.userCreated),
       );
       final allWidgetsRadio =
-          tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-              as Radio<TrackWidgetBuildsScope>;
-      expect(allWidgetsRadio.value, equals(TrackWidgetBuildsScope.all));
+          tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+              as Radio<TraceWidgetBuildsScope>;
+      expect(allWidgetsRadio.value, equals(TraceWidgetBuildsScope.all));
     });
 
     testWidgets('builds with disabled state', (WidgetTester tester) async {
-      await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+      await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
       await tester.pumpAndSettle();
 
       verifyExtensionStates(
         mockServiceManager: mockServiceManager,
-        trackAllWidgets: false,
-        trackUserCreatedWidgets: false,
+        traceAllWidgets: false,
+        traceUserCreatedWidgets: false,
       );
 
-      final trackWidgetBuildsCheckbox =
+      final traceWidgetBuildsCheckbox =
           tester.widget(find.byType(Checkbox)) as Checkbox;
-      expect(trackWidgetBuildsCheckbox.value, isFalse);
+      expect(traceWidgetBuildsCheckbox.value, isFalse);
 
       final userCreatedWidgetsRadio =
-          tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-              as Radio<TrackWidgetBuildsScope>;
+          tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+              as Radio<TraceWidgetBuildsScope>;
       expect(userCreatedWidgetsRadio.groupValue, isNull);
 
       final allWidgetsRadio =
-          tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-              as Radio<TrackWidgetBuildsScope>;
+          tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+              as Radio<TraceWidgetBuildsScope>;
       expect(allWidgetsRadio.groupValue, isNull);
     });
 
@@ -93,33 +93,33 @@ void main() {
           enabled: true,
           value: true,
         );
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: true,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: true,
+          traceUserCreatedWidgets: false,
         );
 
-        final trackWidgetBuildsCheckbox =
+        final traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isTrue);
+        expect(traceWidgetBuildsCheckbox.value, isTrue);
 
         final userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           userCreatedWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.all),
+          equals(TraceWidgetBuildsScope.all),
         );
 
         final allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           allWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.all),
+          equals(TraceWidgetBuildsScope.all),
         );
       },
     );
@@ -133,33 +133,33 @@ void main() {
           enabled: true,
           value: true,
         );
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: true,
         );
 
-        final trackWidgetBuildsCheckbox =
+        final traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isTrue);
+        expect(traceWidgetBuildsCheckbox.value, isTrue);
 
         final userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           userCreatedWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.userCreated),
+          equals(TraceWidgetBuildsScope.userCreated),
         );
 
         final allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           allWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.userCreated),
+          equals(TraceWidgetBuildsScope.userCreated),
         );
       },
     );
@@ -182,74 +182,74 @@ void main() {
         );
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: true,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: true,
+          traceUserCreatedWidgets: true,
         );
 
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: true,
         );
 
-        final trackWidgetBuildsCheckbox =
+        final traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isTrue);
+        expect(traceWidgetBuildsCheckbox.value, isTrue);
 
         final userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           userCreatedWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.userCreated),
+          equals(TraceWidgetBuildsScope.userCreated),
         );
 
         final allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           allWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.userCreated),
+          equals(TraceWidgetBuildsScope.userCreated),
         );
       },
     );
 
     testWidgets(
-      'checking "Track Widget Builds" enables profileUserWidgetBuilds',
+      'checking "Trace Widget Builds" enables profileUserWidgetBuilds',
       (WidgetTester tester) async {
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: false,
         );
 
-        var trackWidgetBuildsCheckbox =
+        var traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isFalse);
+        expect(traceWidgetBuildsCheckbox.value, isFalse);
 
         await tester.tap(find.byType(Checkbox));
         await tester.pumpAndSettle();
 
-        trackWidgetBuildsCheckbox =
+        traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isTrue);
+        expect(traceWidgetBuildsCheckbox.value, isTrue);
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: true,
         );
       },
     );
 
     testWidgets(
-      'unchecking "Track Widget Builds" disables both service extensions',
+      'unchecking "Trace Widget Builds" disables both service extensions',
       (WidgetTester tester) async {
         await mockServiceManager.serviceExtensionManager
             .setServiceExtensionState(
@@ -257,36 +257,36 @@ void main() {
           enabled: true,
           value: true,
         );
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: true,
         );
 
-        var trackWidgetBuildsCheckbox =
+        var traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isTrue);
+        expect(traceWidgetBuildsCheckbox.value, isTrue);
 
         await tester.tap(find.byType(Checkbox));
         await tester.pumpAndSettle();
 
-        trackWidgetBuildsCheckbox =
+        traceWidgetBuildsCheckbox =
             tester.widget(find.byType(Checkbox)) as Checkbox;
-        expect(trackWidgetBuildsCheckbox.value, isFalse);
+        expect(traceWidgetBuildsCheckbox.value, isFalse);
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: false,
         );
       },
     );
 
     testWidgets(
-      'can toggle track widget builds scope',
+      'can toggle trace widget builds scope',
       (WidgetTester tester) async {
         await mockServiceManager.serviceExtensionManager
             .setServiceExtensionState(
@@ -294,38 +294,38 @@ void main() {
           enabled: true,
           value: true,
         );
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: true,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: true,
         );
 
         var userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           userCreatedWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.userCreated),
+          equals(TraceWidgetBuildsScope.userCreated),
         );
 
-        await tester.tap(find.byType(Radio<TrackWidgetBuildsScope>).at(1));
+        await tester.tap(find.byType(Radio<TraceWidgetBuildsScope>).at(1));
         await tester.pumpAndSettle();
 
         userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(
           userCreatedWidgetsRadio.groupValue,
-          equals(TrackWidgetBuildsScope.all),
+          equals(TraceWidgetBuildsScope.all),
         );
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: true,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: true,
+          traceUserCreatedWidgets: false,
         );
       },
     );
@@ -333,87 +333,87 @@ void main() {
     testWidgets(
       'cannot toggle scope when both service extensions are disabled',
       (WidgetTester tester) async {
-        await tester.pumpWidget(wrap(const TrackWidgetBuildsSetting()));
+        await tester.pumpWidget(wrap(const TraceWidgetBuildsSetting()));
         await tester.pumpAndSettle();
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: false,
         );
 
         var userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(userCreatedWidgetsRadio.groupValue, isNull);
         var allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(allWidgetsRadio.groupValue, isNull);
 
-        await tester.tap(find.byType(Radio<TrackWidgetBuildsScope>).first);
+        await tester.tap(find.byType(Radio<TraceWidgetBuildsScope>).first);
         await tester.pumpAndSettle();
 
         userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(userCreatedWidgetsRadio.groupValue, isNull);
         allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(allWidgetsRadio.groupValue, isNull);
 
-        await tester.tap(find.byType(Radio<TrackWidgetBuildsScope>).at(1));
+        await tester.tap(find.byType(Radio<TraceWidgetBuildsScope>).at(1));
         await tester.pumpAndSettle();
 
         userCreatedWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).first)
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).first)
+                as Radio<TraceWidgetBuildsScope>;
         expect(userCreatedWidgetsRadio.groupValue, isNull);
         allWidgetsRadio =
-            tester.widget(find.byType(Radio<TrackWidgetBuildsScope>).at(1))
-                as Radio<TrackWidgetBuildsScope>;
+            tester.widget(find.byType(Radio<TraceWidgetBuildsScope>).at(1))
+                as Radio<TraceWidgetBuildsScope>;
         expect(allWidgetsRadio.groupValue, isNull);
 
         verifyExtensionStates(
           mockServiceManager: mockServiceManager,
-          trackAllWidgets: false,
-          trackUserCreatedWidgets: false,
+          traceAllWidgets: false,
+          traceUserCreatedWidgets: false,
         );
       },
     );
   });
 
-  group('TrackWidgetBuildsScope enum', () {
+  group('TraceWidgetBuildsScope enum', () {
     test('radioDisplay', () {
       expect(
-        TrackWidgetBuildsScope.all.radioDisplay,
+        TraceWidgetBuildsScope.all.radioDisplay,
         equals('within all code'),
       );
       expect(
-        TrackWidgetBuildsScope.userCreated.radioDisplay,
+        TraceWidgetBuildsScope.userCreated.radioDisplay,
         equals('within your code'),
       );
     });
 
     test('opposite', () {
       expect(
-        TrackWidgetBuildsScope.all.opposite,
-        equals(TrackWidgetBuildsScope.userCreated),
+        TraceWidgetBuildsScope.all.opposite,
+        equals(TraceWidgetBuildsScope.userCreated),
       );
       expect(
-        TrackWidgetBuildsScope.userCreated.opposite,
-        equals(TrackWidgetBuildsScope.all),
+        TraceWidgetBuildsScope.userCreated.opposite,
+        equals(TraceWidgetBuildsScope.all),
       );
     });
 
     test('extensionForScope', () {
       expect(
-        TrackWidgetBuildsScope.all.extensionForScope,
+        TraceWidgetBuildsScope.all.extensionForScope,
         equals(profileWidgetBuilds),
       );
       expect(
-        TrackWidgetBuildsScope.userCreated.extensionForScope,
+        TraceWidgetBuildsScope.userCreated.extensionForScope,
         equals(profileUserWidgetBuilds),
       );
     });
@@ -422,21 +422,21 @@ void main() {
 
 void verifyExtensionStates({
   required MockServiceManager mockServiceManager,
-  required bool trackAllWidgets,
-  required bool trackUserCreatedWidgets,
+  required bool traceAllWidgets,
+  required bool traceUserCreatedWidgets,
 }) {
   expect(
     mockServiceManager.serviceExtensionManager
         .getServiceExtensionState(profileWidgetBuilds.extension)
         .value
         .enabled,
-    equals(trackAllWidgets),
+    equals(traceAllWidgets),
   );
   expect(
     mockServiceManager.serviceExtensionManager
         .getServiceExtensionState(profileUserWidgetBuilds.extension)
         .value
         .enabled,
-    equals(trackUserCreatedWidgets),
+    equals(traceUserCreatedWidgets),
   );
 }

--- a/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
+++ b/packages/devtools_app/test/performance/frame_analysis/frame_hints_test.dart
@@ -75,17 +75,17 @@ void main() {
       required MockFrameAnalysis frameAnalysis,
       required FlutterFrame frame,
       FramePhase? longestUiPhase,
-      bool buildsTracked = false,
-      bool layoutsTracked = false,
-      bool paintsTracked = false,
+      bool buildsTraced = false,
+      bool layoutsTraced = false,
+      bool paintsTraced = false,
       int saveLayerCount = 0,
       int intrinsicsCount = 0,
     }) {
       when(frameAnalysis.frame).thenReturn(frame);
       frame.enhanceTracingState = EnhanceTracingState(
-        builds: buildsTracked,
-        layouts: layoutsTracked,
-        paints: paintsTracked,
+        builds: buildsTraced,
+        layouts: layoutsTraced,
+        paints: paintsTraced,
       );
       when(frameAnalysis.longestUiPhase).thenReturn(
         longestUiPhase ?? mockBuildPhase,
@@ -140,13 +140,13 @@ void main() {
           createMockFrameAnalysis(
             frameAnalysis: mockFrameAnalysis,
             frame: jankyFrame,
-            buildsTracked: true,
+            buildsTraced: true,
           );
           await pumpHints(tester, mockFrameAnalysis);
 
           expect(
             find.richTextContaining(
-              'Build was the longest UI phase in this frame. Since "Track widget '
+              'Build was the longest UI phase in this frame. Since "Trace widget '
               'builds" was enabled while this frame was drawn, you should be able'
               ' to see timeline events for each widget built.',
             ),
@@ -168,7 +168,7 @@ void main() {
           expect(
             find.richTextContaining(
               'Build was the longest UI phase in this frame. Consider enabling '
-              '"Track widget builds" from the ',
+              '"Trace widget builds" from the ',
             ),
             findsOneWidget,
           );
@@ -190,13 +190,13 @@ void main() {
             frameAnalysis: mockFrameAnalysis,
             frame: jankyFrame,
             longestUiPhase: mockLayoutPhase,
-            layoutsTracked: true,
+            layoutsTraced: true,
           );
           await pumpHints(tester, mockFrameAnalysis);
 
           expect(
             find.richTextContaining(
-              'Layout was the longest UI phase in this frame. Since "Track '
+              'Layout was the longest UI phase in this frame. Since "Trace '
               'layouts" was enabled while this frame was drawn, you should be '
               'able to see timeline events for each render object laid out.',
             ),
@@ -219,7 +219,7 @@ void main() {
           expect(
             find.richTextContaining(
               'Layout was the longest UI phase in this frame. Consider enabling '
-              '"Track layouts" from the ',
+              '"Trace layouts" from the ',
             ),
             findsOneWidget,
           );
@@ -241,13 +241,13 @@ void main() {
             frameAnalysis: mockFrameAnalysis,
             frame: jankyFrame,
             longestUiPhase: mockPaintPhase,
-            paintsTracked: true,
+            paintsTraced: true,
           );
           await pumpHints(tester, mockFrameAnalysis);
 
           expect(
             find.richTextContaining(
-              'Paint was the longest UI phase in this frame. Since "Track '
+              'Paint was the longest UI phase in this frame. Since "Trace '
               'paints" was enabled while this frame was drawn, you should be '
               'able to see timeline events for each render object painted.',
             ),
@@ -270,7 +270,7 @@ void main() {
           expect(
             find.richTextContaining(
               'Paint was the longest UI phase in this frame. Consider enabling '
-              '"Track paints" from the ',
+              '"Trace paints" from the ',
             ),
             findsOneWidget,
           );

--- a/packages/devtools_app/test/performance/performance_screen_test.dart
+++ b/packages/devtools_app/test/performance/performance_screen_test.dart
@@ -329,13 +329,13 @@ void main() {
               findsOneWidget,
             );
             expect(
-              find.richTextContaining('Track widget builds'),
+              find.richTextContaining('Trace widget builds'),
               findsOneWidget,
             );
-            expect(find.richTextContaining('Track layouts'), findsOneWidget);
-            expect(find.richTextContaining('Track paints'), findsOneWidget);
+            expect(find.richTextContaining('Trace layouts'), findsOneWidget);
+            expect(find.richTextContaining('Trace paints'), findsOneWidget);
             expect(
-              find.richTextContaining('Track platform channels'),
+              find.richTextContaining('Trace platform channels'),
               findsOneWidget,
             );
             expect(find.byType(MoreInfoLink), findsNWidgets(4));

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -9,6 +9,7 @@ and `RoundedDropDownButton`.
 * Deprecate `ServiceManager.hasConnection` in favor of
 `ServiceManager.connectedState.value.connected`.
 * Correct the dartdoc for the `ListValueNotifier` class.
+* Deprecate `trackRebuildWidgets` in favor of `countWidgetBuilds`.
 
 ## 0.2.1
 * Add `navigateToCode` utility method for jumping to code in IDEs.

--- a/packages/devtools_app_shared/lib/src/service/service_extensions.dart
+++ b/packages/devtools_app_shared/lib/src/service/service_extensions.dart
@@ -209,7 +209,10 @@ final toggleSelectWidgetMode = ToggleableServiceExtension<bool>(
   disabledValue: false,
 );
 
-final trackRebuildWidgets = ToggleableServiceExtension<bool>(
+@Deprecated('Use countWidgetBuilds instead.')
+final trackRebuildWidgets = countWidgetBuilds;
+
+final countWidgetBuilds = ToggleableServiceExtension<bool>(
   extension:
       '$inspectorExtensionPrefix.${WidgetInspectorServiceExtensions.trackRebuildDirtyWidgets.name}',
   enabledValue: true,
@@ -254,7 +257,7 @@ final _extensionDescriptions = <ServiceExtension<Object>>[
   toggleOnDeviceWidgetInspector,
   togglePlatformMode,
   toggleSelectWidgetMode,
-  trackRebuildWidgets,
+  countWidgetBuilds,
   profilePlatformChannels,
 ];
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8082.

This also renames the "track widget build counts" to "count widget builds" to try to differentiate these two features.

![Screenshot 2024-07-19 at 12 15 18 PM](https://github.com/user-attachments/assets/acc6d31b-b292-4e5b-b652-7c0cdfe1595f)
![Screenshot 2024-07-19 at 12 16 20 PM](https://github.com/user-attachments/assets/c8002160-07f2-464e-aeb4-eb0ec3040648)
