### PR TITLE
Cleanup: replace usage of `containsWhere` in favor of `any`

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -287,7 +287,7 @@ class DevToolsAppState extends State<DevToolsApp> with AutoDisposeMixin {
               _screens.firstWhereOrNull((s) => s.screenId == page);
           final screenInOriginalScreens = originalScreen != null;
           final screenInScaffoldScreens =
-              screensInScaffold.containsWhere((s) => s.screenId == page);
+              screensInScaffold.any((s) => s.screenId == page);
           if (page != null &&
               screenInOriginalScreens &&
               !screenInScaffoldScreens) {

--- a/packages/devtools_app/lib/src/extensions/extension_service.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service.dart
@@ -8,7 +8,6 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 
 import '../shared/globals.dart';
-import '../shared/primitives/utils.dart';
 import '../shared/server/server.dart' as server;
 import 'extension_service_helpers.dart';
 
@@ -234,7 +233,7 @@ class ExtensionService extends DisposableController
       // not always be true for extensions that are not published on pub or
       // extensions that do not follow best practices for naming.
       final isRuntimeDuplicate = runtimeExtensions
-          .containsWhere((ext) => ext.name == staticExtension.name);
+          .any((ext) => ext.name == staticExtension.name);
       if (isRuntimeDuplicate) {
         _log.fine(
           'ignoring duplicate static extension ${staticExtension.identifier} '

--- a/packages/devtools_app/lib/src/extensions/extension_service.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service.dart
@@ -232,8 +232,8 @@ class ExtensionService extends DisposableController
       // _should_ be unique since they match a pub package name, but this may
       // not always be true for extensions that are not published on pub or
       // extensions that do not follow best practices for naming.
-      final isRuntimeDuplicate = runtimeExtensions
-          .any((ext) => ext.name == staticExtension.name);
+      final isRuntimeDuplicate =
+          runtimeExtensions.any((ext) => ext.name == staticExtension.name);
       if (isRuntimeDuplicate) {
         _log.fine(
           'ignoring duplicate static extension ${staticExtension.identifier} '

--- a/packages/devtools_app/lib/src/shared/notifications.dart
+++ b/packages/devtools_app/lib/src/shared/notifications.dart
@@ -9,7 +9,6 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import 'globals.dart';
-import 'primitives/utils.dart';
 import 'utils.dart';
 
 class NotificationMessage {
@@ -118,8 +117,7 @@ class NotificationService {
     NotificationMessage message, {
     bool allowDuplicates = true,
   }) {
-    if (!allowDuplicates &&
-        activeMessages.containsWhere((m) => m.text == message.text)) {
+    if (!allowDuplicates && activeMessages.any((m) => m.text == message.text)) {
       return false;
     }
     activeMessages.add(message);
@@ -138,7 +136,7 @@ class NotificationService {
     }
 
     // Add task to dismiss for those that were picked up by UI.
-    if (activeMessages.containsWhere((element) => element.text == message)) {
+    if (activeMessages.any((element) => element.text == message)) {
       toDismiss.addLast(NotificationMessage(message));
       newTasks.value++;
     }

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1007,15 +1007,6 @@ extension ListExtension<T> on List<T> {
     ];
   }
 
-  bool containsWhere(bool Function(T element) test) {
-    for (final e in this) {
-      if (test(e)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   T get second => this[1];
 
   T get third => this[2];
@@ -1039,15 +1030,6 @@ extension NullableListExtension<T> on List<T>? {
 }
 
 extension SetExtension<T> on Set<T> {
-  bool containsWhere(bool Function(T element) test) {
-    for (final e in this) {
-      if (test(e)) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   bool containsAny(Iterable<T> any) {
     for (final e in any) {
       if (contains(e)) {

--- a/packages/devtools_app/test/shared/primitives/utils_test.dart
+++ b/packages/devtools_app/test/shared/primitives/utils_test.dart
@@ -1067,27 +1067,6 @@ void main() {
         expect(['a', 'b'].joinWith('z'), equals(['a', 'z', 'b']));
       });
 
-      test('containsWhere', () {
-        final list = [1, 2, 1, 2, 3, 4];
-        expect(list.containsWhere((element) => element == 1), isTrue);
-        expect(list.containsWhere((element) => element == 5), isFalse);
-        expect(list.containsWhere((element) => element + 2 == 3), isTrue);
-
-        final otherList = ['hi', 'hey', 'foo', 'bar'];
-        expect(
-          otherList.containsWhere((element) => element.contains('h')),
-          isTrue,
-        );
-        expect(
-          otherList.containsWhere((element) => element.startsWith('ba')),
-          isTrue,
-        );
-        expect(
-          otherList.containsWhere((element) => element.endsWith('ba')),
-          isFalse,
-        );
-      });
-
       test('allIndicesWhere', () {
         final list = [1, 2, 1, 2, 3, 4];
         expect(list.allIndicesWhere((element) => element.isEven), [1, 3, 5]);
@@ -1108,25 +1087,13 @@ void main() {
     });
 
     group('SetExtension', () {
-      test('containsWhere', () {
-        final set = {1, 2, 3, 4};
-        expect(set.containsWhere((element) => element == 1), isTrue);
-        expect(set.containsWhere((element) => element == 5), isFalse);
-        expect(set.containsWhere((element) => element + 2 == 3), isTrue);
-
-        final otherSet = {'hi', 'hey', 'foo', 'bar'};
-        expect(
-          otherSet.containsWhere((element) => element.contains('h')),
-          isTrue,
-        );
-        expect(
-          otherSet.containsWhere((element) => element.startsWith('ba')),
-          isTrue,
-        );
-        expect(
-          otherSet.containsWhere((element) => element.endsWith('ba')),
-          isFalse,
-        );
+      test('containsAny', () {
+        final test = {1, 2, 3, 4};
+        final subSet = {1, 2};
+        final disjointSet = {5, 6, 7};
+        expect(test.containsAny(test), true);
+        expect(test.containsAny(subSet), true);
+        expect(test.containsAny(disjointSet), false);
       });
     });
 


### PR DESCRIPTION
We do not need the `containsWhere` extension methods when these do the same thing as the `Iterable.any` method.