### PR TITLE
Remove the 'disconnected' memory controller creation mode

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_screen.dart
@@ -3,12 +3,15 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app_shared/shared.dart';
+import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import '../../../shared/analytics/analytics.dart' as ga;
 import '../../../shared/primitives/listenable.dart';
 import '../../../shared/screen.dart';
+import '../panes/diff/controller/diff_pane_controller.dart';
+import '../panes/diff/diff_pane.dart';
 import 'screen_body.dart';
 
 class MemoryScreen extends Screen {
@@ -24,11 +27,12 @@ class MemoryScreen extends Screen {
   String get docPageId => id;
 
   @override
-  Widget buildScreenBody(BuildContext context) => const MemoryBody();
+  Widget buildScreenBody(BuildContext context) => const MemoryScreenBody();
 
   @override
-  Widget? buildDisconnectedScreenBody(BuildContext context) =>
-      const MemoryBody();
+  Widget? buildDisconnectedScreenBody(BuildContext context) {
+    return const DisconnectedMemoryScreenBody();
+  }
 
   // TODO(polina-c): when embedded and VSCode console features are implemented,
   // should be in native console in VSCode
@@ -36,14 +40,14 @@ class MemoryScreen extends Screen {
   bool showConsole(EmbedMode embedMode) => true;
 }
 
-class MemoryBody extends StatefulWidget {
-  const MemoryBody({super.key});
+class MemoryScreenBody extends StatefulWidget {
+  const MemoryScreenBody({super.key});
 
   @override
-  MemoryBodyState createState() => MemoryBodyState();
+  MemoryScreenBodyState createState() => MemoryScreenBodyState();
 }
 
-class MemoryBodyState extends State<MemoryBody> {
+class MemoryScreenBodyState extends State<MemoryScreenBody> {
   @override
   void initState() {
     super.initState();
@@ -52,7 +56,52 @@ class MemoryBodyState extends State<MemoryBody> {
 
   @override
   Widget build(BuildContext context) {
-    // TODO(polina-c): load static body if not connected.
     return const ConnectedMemoryBody();
+  }
+}
+
+class DisconnectedMemoryScreenBody extends StatefulWidget {
+  const DisconnectedMemoryScreenBody({super.key});
+
+  @override
+  State<DisconnectedMemoryScreenBody> createState() =>
+      _DisconnectedMemoryScreenBodyState();
+}
+
+class _DisconnectedMemoryScreenBodyState
+    extends State<DisconnectedMemoryScreenBody> {
+  final diffController = DiffPaneController(loader: null, rootPackage: null);
+
+  @override
+  void initState() {
+    super.initState();
+    // TODO(kenz): we may want to differentiate this from connected memory
+    // screen usage for analytics.
+    ga.screen(MemoryScreen.id);
+  }
+
+  @override
+  void dispose() {
+    diffController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return RoundedOutlinedBorder(
+      clip: true,
+      child: Column(
+        children: [
+          const AreaPaneHeader(
+            title: Text('Diff Snapshots'),
+            roundedTopBorder: false,
+            includeTopBorder: false,
+          ),
+          Expanded(
+            child: DiffPane(diffController: diffController),
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_tabs.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_tabs.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 import '../../../shared/analytics/constants.dart' as gac;
 import '../../../shared/common_widgets.dart';
-import '../../../shared/primitives/simple_items.dart';
 import '../../../shared/ui/tab.dart';
 import '../panes/diff/diff_pane.dart';
 import '../panes/profile/profile_view.dart';
@@ -33,7 +32,7 @@ class MemoryTabView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return AnalyticsTabbedView(
-      tabs: _generateTabRecords(),
+      tabs: [_profile(), _diff(), _trace()],
       initialSelectedIndex: controller.selectedFeatureTabIndex,
       gaScreen: gac.memory,
       onTabChanged: (int index) {
@@ -78,15 +77,4 @@ class MemoryTabView extends StatelessWidget {
           child: TracingPane(controller: controller.trace!),
         ),
       );
-
-  List<TabAndView> _generateTabRecords() {
-    final hasData = controller.mode != ControllerCreationMode.disconnected;
-    return [
-      if (hasData) _profile(),
-      // Diff is enabled even in disconnected mode to allow users to load
-      // snapshots from file.
-      _diff(),
-      if (hasData) _trace(),
-    ];
-  }
 }

--- a/packages/devtools_app/lib/src/screens/memory/framework/screen_body.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/screen_body.dart
@@ -43,7 +43,7 @@ class _ConnectedMemoryBodyState extends State<ConnectedMemoryBody>
 
     if (!initController()) return;
 
-    if (controller.mode == ControllerCreationMode.connected) {
+    if (controller.mode == MemoryControllerCreationMode.connected) {
       maybePushDebugModeMemoryMessage(context, ScreenMetaData.memory.id);
       maybePushHttpLoggingMessage(context, ScreenMetaData.memory.id);
 
@@ -66,11 +66,10 @@ class _ConnectedMemoryBodyState extends State<ConnectedMemoryBody>
                 controller: controller.control,
               ),
               const SizedBox(height: intermediateSpacing),
-              if (controller.mode != ControllerCreationMode.disconnected)
-                MemoryChartPane(
-                  chart: controller.chart!,
-                  keyFocusNode: _focusNode,
-                ),
+              MemoryChartPane(
+                chart: controller.chart,
+                keyFocusNode: _focusNode,
+              ),
               Expanded(
                 child: MemoryTabView(controller),
               ),

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_data.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_data.dart
@@ -20,14 +20,14 @@ enum Json {
 /// Chart data, that should be saved when transferred to offline data mode.
 class ChartData with Serializable {
   ChartData({
-    required ControllerCreationMode mode,
+    required MemoryControllerCreationMode mode,
     this.isDeviceAndroid,
     MemoryTimeline? timeline,
     ChartInterval? interval,
     bool? isLegendVisible,
   })  : assert(
-          mode == ControllerCreationMode.connected ||
-              (mode == ControllerCreationMode.offlineData &&
+          mode == MemoryControllerCreationMode.connected ||
+              (mode == MemoryControllerCreationMode.offlineData &&
                   isDeviceAndroid != null &&
                   timeline != null &&
                   interval != null &&
@@ -41,7 +41,7 @@ class ChartData with Serializable {
 
   factory ChartData.fromJson(Map<String, dynamic> json) {
     final result = ChartData(
-      mode: ControllerCreationMode.offlineData,
+      mode: MemoryControllerCreationMode.offlineData,
       isDeviceAndroid: json[Json.isDeviceAndroid.name] as bool? ?? false,
       timeline: deserialize<MemoryTimeline>(
         json[Json.timeline.name],

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_pane_controller.dart
@@ -17,14 +17,14 @@ class MemoryChartPaneController extends DisposableController
     with AutoDisposeControllerMixin {
   MemoryChartPaneController(this.mode, {ChartData? data})
       : assert(
-          mode == ControllerCreationMode.connected ||
-              (mode == ControllerCreationMode.offlineData &&
+          mode == MemoryControllerCreationMode.connected ||
+              (mode == MemoryControllerCreationMode.offlineData &&
                   data != null &&
                   data.isDeviceAndroid != null),
           '$mode, $data, ${data?.isDeviceAndroid}',
         ) {
-    if (mode == ControllerCreationMode.connected) {
-      this.data = ChartData(mode: ControllerCreationMode.connected);
+    if (mode == MemoryControllerCreationMode.connected) {
+      this.data = ChartData(mode: MemoryControllerCreationMode.connected);
     } else {
       this.data = data!;
       // Setting paused to false, because `recomputeChartData` is noop when it is true.
@@ -44,7 +44,7 @@ class MemoryChartPaneController extends DisposableController
   }
 
   /// The mode at which the controller was created.
-  ControllerCreationMode mode;
+  MemoryControllerCreationMode mode;
 
   late final ChartData data;
 
@@ -94,7 +94,7 @@ class MemoryChartPaneController extends DisposableController
 
   void _maybeUpdateChart() {
     if (!isChartVisible.value) return;
-    if (mode == ControllerCreationMode.connected) {
+    if (mode == MemoryControllerCreationMode.connected) {
       if (_chartConnection == null) {
         _chartConnection ??= _chartConnection = ChartVmConnection(
           data.timeline,

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/widgets/chart_control_pane.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/widgets/chart_control_pane.dart
@@ -55,7 +55,7 @@ class _ChartControlPaneState extends State<ChartControlPane>
     return Column(
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        if (widget.chart.mode == ControllerCreationMode.connected) ...[
+        if (widget.chart.mode == MemoryControllerCreationMode.connected) ...[
           Row(
             children: [
               ValueListenableBuilder<bool>(

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/controller/control_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/controller/control_pane_controller.dart
@@ -13,12 +13,10 @@ class MemoryControlPaneController {
     this.memoryTimeline,
     this.mode, {
     required this.exportData,
-  }) : assert(
-          mode == ControllerCreationMode.disconnected || memoryTimeline != null,
-        );
+  });
 
-  final ControllerCreationMode mode;
-  final MemoryTimeline? memoryTimeline;
+  final MemoryControllerCreationMode mode;
+  final MemoryTimeline memoryTimeline;
   final VoidCallback exportData;
   final isChartVisible = preferences.memory.showChart;
 
@@ -26,8 +24,7 @@ class MemoryControlPaneController {
   bool _gcing = false;
 
   Future<void> gc() async {
-    assert(mode == ControllerCreationMode.connected);
-    assert(memoryTimeline != null);
+    assert(mode == MemoryControllerCreationMode.connected);
     _gcing = true;
     try {
       await serviceConnection.serviceManager.service!.getAllocationProfile(
@@ -35,7 +32,7 @@ class MemoryControlPaneController {
             .serviceManager.isolateManager.selectedIsolate.value?.id)!,
         gc: true,
       );
-      memoryTimeline!.addGCEvent();
+      memoryTimeline.addGCEvent();
       notificationService.push('Successfully garbage collected.');
     } finally {
       _gcing = false;

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/widgets/primary_controls.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/widgets/primary_controls.dart
@@ -6,7 +6,6 @@ import 'package:flutter/material.dart';
 
 import '../../../../../shared/analytics/constants.dart' as gac;
 import '../../../../../shared/common_widgets.dart';
-import '../../../../../shared/primitives/simple_items.dart';
 import '../../../shared/primitives/simple_elements.dart';
 import '../controller/control_pane_controller.dart';
 
@@ -23,9 +22,6 @@ class PrimaryControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    if (controller.mode == ControllerCreationMode.disconnected) {
-      return const SizedBox();
-    }
     return VisibilityButton(
       show: controller.isChartVisible,
       gaScreen: gac.memory,

--- a/packages/devtools_app/lib/src/screens/memory/panes/control/widgets/secondary_controls.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/control/widgets/secondary_controls.dart
@@ -25,7 +25,7 @@ class SecondaryControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final canGC = controller.mode == ControllerCreationMode.connected;
+    final canGC = controller.mode == MemoryControllerCreationMode.connected;
     return Row(
       mainAxisSize: MainAxisSize.min,
       children: [
@@ -48,13 +48,12 @@ class SecondaryControls extends StatelessWidget {
           ),
           const SizedBox(width: denseSpacing),
         ],
-        if (controller.mode != ControllerCreationMode.disconnected)
-          SettingsOutlinedButton(
-            gaScreen: gac.memory,
-            gaSelection: gac.MemoryEvents.settings.name,
-            onPressed: () => _openSettingsDialog(context),
-            tooltip: 'Open memory settings',
-          ),
+        SettingsOutlinedButton(
+          gaScreen: gac.memory,
+          gaSelection: gac.MemoryEvents.settings.name,
+          onPressed: () => _openSettingsDialog(context),
+          tooltip: 'Open memory settings',
+        ),
       ],
     );
   }

--- a/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_pane_controller.dart
@@ -28,8 +28,8 @@ class ProfilePaneController extends DisposableController
     required this.rootPackage,
     AdaptedProfile? profile,
   }) : assert(
-          (mode == ControllerCreationMode.connected && profile == null) ||
-              (mode == ControllerCreationMode.offlineData),
+          (mode == MemoryControllerCreationMode.connected && profile == null) ||
+              (mode == MemoryControllerCreationMode.offlineData),
         ) {
     if (profile != null) {
       _currentAllocationProfile.value = AdaptedProfile.withNewFilter(
@@ -42,7 +42,7 @@ class ProfilePaneController extends DisposableController
 
   factory ProfilePaneController.fromJson(Map<String, dynamic> json) {
     return ProfilePaneController(
-      mode: ControllerCreationMode.offlineData,
+      mode: MemoryControllerCreationMode.offlineData,
       profile: deserialize(json[Json.profile.name], AdaptedProfile.fromJson),
       rootPackage: json[Json.rootPackage.name],
     );
@@ -56,7 +56,7 @@ class ProfilePaneController extends DisposableController
     };
   }
 
-  final ControllerCreationMode mode;
+  final MemoryControllerCreationMode mode;
 
   bool _initialized = false;
 
@@ -64,7 +64,7 @@ class ProfilePaneController extends DisposableController
   void initialize() {
     if (_initialized) return;
 
-    if (mode == ControllerCreationMode.connected) {
+    if (mode == MemoryControllerCreationMode.connected) {
       autoDisposeStreamSubscription(
         serviceConnection.serviceManager.service!.onGCEvent.listen((event) {
           if (refreshOnGc.value) {

--- a/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/profile/profile_view.dart
@@ -620,7 +620,7 @@ class _AllocationProfileTableControls extends StatelessWidget {
         _ExportAllocationProfileButton(
           allocationProfileController: controller,
         ),
-        if (controller.mode == ControllerCreationMode.connected) ...[
+        if (controller.mode == MemoryControllerCreationMode.connected) ...[
           const SizedBox(width: denseSpacing),
           RefreshButton(
             gaScreen: gac.memory,

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
@@ -116,11 +116,14 @@ class TracingIsolateState with Serializable {
   }
 
   TracingIsolateState.empty()
-      : this(isolate: IsolateRef(), mode: ControllerCreationMode.connected);
+      : this(
+          isolate: IsolateRef(),
+          mode: MemoryControllerCreationMode.connected,
+        );
 
   factory TracingIsolateState.fromJson(Map<String, dynamic> json) {
     return TracingIsolateState(
-      mode: ControllerCreationMode.offlineData,
+      mode: MemoryControllerCreationMode.offlineData,
       isolate: IsolateRefEncodeDecode.instance
           .decode(json[TracingIsolateStateJson.isolate.name]),
       profiles: (json[TracingIsolateStateJson.profiles.name] as Map).map(
@@ -144,7 +147,7 @@ class TracingIsolateState with Serializable {
     };
   }
 
-  final ControllerCreationMode mode;
+  final MemoryControllerCreationMode mode;
 
   final IsolateRef isolate;
 
@@ -175,7 +178,7 @@ class TracingIsolateState with Serializable {
   int _lastClearTimeMicros = 0;
 
   Future<void> initialize() async {
-    if (mode == ControllerCreationMode.connected) {
+    if (mode == MemoryControllerCreationMode.connected) {
       final classList = await serviceConnection.serviceManager.service!
           .getClassList(isolate.id!);
       for (final clazz in classList.classes!) {

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_pane_controller.dart
@@ -43,7 +43,7 @@ class TracePaneController extends DisposableController
 
   factory TracePaneController.fromJson(Map<String, dynamic> json) {
     return TracePaneController(
-      ControllerCreationMode.offlineData,
+      MemoryControllerCreationMode.offlineData,
       stateForIsolate: (json[Json.stateForIsolate.name] as Map).map(
         (key, value) => MapEntry(
           key,
@@ -64,7 +64,7 @@ class TracePaneController extends DisposableController
     };
   }
 
-  final ControllerCreationMode mode;
+  final MemoryControllerCreationMode mode;
 
   /// Maps isolate IDs to their allocation tracing states.
   late final Map<String, TracingIsolateState> stateForIsolate;
@@ -121,7 +121,7 @@ class TracePaneController extends DisposableController
       _selection.value = state;
     }
 
-    if (mode == ControllerCreationMode.connected) {
+    if (mode == MemoryControllerCreationMode.connected) {
       addAutoDisposeListener(
         serviceConnection.serviceManager.isolateManager.selectedIsolate,
         updateState,

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_view.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_view.dart
@@ -98,7 +98,7 @@ class _TracingControls extends StatelessWidget {
       padding: const EdgeInsets.all(denseSpacing),
       child: Row(
         children: [
-          if (controller.mode == ControllerCreationMode.connected) ...[
+          if (controller.mode == MemoryControllerCreationMode.connected) ...[
             RefreshButton(
               tooltip: 'Request the set of updated allocation traces',
               gaScreen: gac.memory,

--- a/packages/devtools_app/lib/src/shared/primitives/simple_items.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/simple_items.dart
@@ -55,11 +55,8 @@ enum DocLinks {
   }
 }
 
-/// The DevTools mode in which a controller object was created.
-enum ControllerCreationMode {
-  /// Not interacting with app or data from a previous session.
-  disconnected,
-
+/// The mode in which a MemoryController object was created.
+enum MemoryControllerCreationMode {
   /// Interacting with a connected application.
   connected,
 

--- a/packages/devtools_app/lib/src/shared/utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils.dart
@@ -25,7 +25,6 @@ import '../../devtools.dart' as devtools;
 import 'common_widgets.dart';
 import 'connected_app.dart';
 import 'globals.dart';
-import 'primitives/simple_items.dart';
 import 'primitives/utils.dart';
 
 final _log = Logger('lib/src/shared/utils');
@@ -306,15 +305,6 @@ class DebounceTimer {
   void dispose() {
     cancel();
   }
-}
-
-/// Current mode of DevTools.
-ControllerCreationMode get devToolsMode {
-  return offlineDataController.showingOfflineData.value
-      ? ControllerCreationMode.offlineData
-      : serviceConnection.serviceManager.connectedState.value.connected
-          ? ControllerCreationMode.connected
-          : ControllerCreationMode.disconnected;
 }
 
 Future<void> launchUrlWithErrorHandling(String url) async {

--- a/packages/devtools_app/test/memory/chart/controller/chart_data_test.dart
+++ b/packages/devtools_app/test/memory/chart/controller/chart_data_test.dart
@@ -13,7 +13,7 @@ void main() {
     '$ChartData serializes and deserializes correctly, offline',
     () {
       final item = ChartData(
-        mode: ControllerCreationMode.offlineData,
+        mode: MemoryControllerCreationMode.offlineData,
         isDeviceAndroid: true,
         timeline: MemoryTimeline(),
         interval: ChartInterval.theDefault,
@@ -34,7 +34,7 @@ void main() {
   test(
     '$ChartData serializes and deserializes correctly, connected',
     () {
-      final item = ChartData(mode: ControllerCreationMode.connected);
+      final item = ChartData(mode: MemoryControllerCreationMode.connected);
       final fromJson = ChartData.fromJson(item.toJson());
 
       expect(fromJson.isDeviceAndroid, false);

--- a/packages/devtools_app/test/memory/framework/memory_screen_test.dart
+++ b/packages/devtools_app/test/memory/framework/memory_screen_test.dart
@@ -63,7 +63,7 @@ void main() {
   ) async {
     await tester.pumpWidget(
       wrapWithControllers(
-        const MemoryBody(),
+        const MemoryScreenBody(),
         memory: controller,
       ),
     );
@@ -71,7 +71,7 @@ void main() {
     // Delay to ensure the memory profiler has collected data.
     await tester
         .runAsync(() async => tester.pumpAndSettle(const Duration(seconds: 1)));
-    expect(find.byType(MemoryBody), findsOneWidget);
+    expect(find.byType(MemoryScreenBody), findsOneWidget);
   }
 
   // Set a wide enough screen width that we do not run into overflow.

--- a/packages/devtools_app/test/memory/framework/offline_data_test.dart
+++ b/packages/devtools_app/test/memory/framework/offline_data_test.dart
@@ -76,18 +76,18 @@ void main() {
         final item = OfflineMemoryData(
           DiffPaneController(loader: null, rootPackage: 'root'),
           ProfilePaneController(
-            mode: ControllerCreationMode.connected,
+            mode: MemoryControllerCreationMode.connected,
             rootPackage: 'root',
           ),
           ChartData(
-            mode: ControllerCreationMode.offlineData,
+            mode: MemoryControllerCreationMode.offlineData,
             isDeviceAndroid: true,
             timeline: MemoryTimeline(),
             interval: ChartInterval.theDefault,
             isLegendVisible: true,
           ),
           TracePaneController(
-            ControllerCreationMode.offlineData,
+            MemoryControllerCreationMode.offlineData,
             rootPackage: '',
           ),
           ClassFilter.empty(),

--- a/packages/devtools_app/test/memory/tracing/tracing_pane_controller_test.dart
+++ b/packages/devtools_app/test/memory/tracing/tracing_pane_controller_test.dart
@@ -11,25 +11,25 @@ import 'package:vm_service/vm_service.dart';
 // ignore: avoid_classes_with_only_static_members, ok for enum-like class
 class _Tests {
   static final emptyConnected = TracePaneController(
-    ControllerCreationMode.connected,
+    MemoryControllerCreationMode.connected,
     rootPackage: '',
   );
 
   static final emptyOffline = TracePaneController(
-    ControllerCreationMode.offlineData,
+    MemoryControllerCreationMode.offlineData,
     rootPackage: '',
   );
 
   static final selection = TracePaneController(
-    ControllerCreationMode.connected,
+    MemoryControllerCreationMode.connected,
     stateForIsolate: {
       'isolate1': TracingIsolateState(
         isolate: IsolateRef(id: 'isolate1'),
-        mode: ControllerCreationMode.connected,
+        mode: MemoryControllerCreationMode.connected,
       ),
       'isolate2': TracingIsolateState(
         isolate: IsolateRef(id: 'isolate2'),
-        mode: ControllerCreationMode.connected,
+        mode: MemoryControllerCreationMode.connected,
       ),
     },
     rootPackage: 'root',
@@ -37,15 +37,15 @@ class _Tests {
   );
 
   static final noSelection = TracePaneController(
-    ControllerCreationMode.connected,
+    MemoryControllerCreationMode.connected,
     stateForIsolate: {
       'isolate1': TracingIsolateState(
         isolate: IsolateRef(id: 'isolate1'),
-        mode: ControllerCreationMode.connected,
+        mode: MemoryControllerCreationMode.connected,
       ),
       'isolate2': TracingIsolateState(
         isolate: IsolateRef(id: 'isolate2'),
-        mode: ControllerCreationMode.connected,
+        mode: MemoryControllerCreationMode.connected,
       ),
     },
     rootPackage: 'root',
@@ -64,15 +64,15 @@ void main() {
     expect(
       () => TracePaneController(
         rootPackage: 'root',
-        ControllerCreationMode.connected,
+        MemoryControllerCreationMode.connected,
         stateForIsolate: {
           'isolate1': TracingIsolateState(
             isolate: IsolateRef(id: 'isolate1'),
-            mode: ControllerCreationMode.connected,
+            mode: MemoryControllerCreationMode.connected,
           ),
           'isolate2': TracingIsolateState(
             isolate: IsolateRef(id: 'isolate2'),
-            mode: ControllerCreationMode.connected,
+            mode: MemoryControllerCreationMode.connected,
           ),
         },
         selectedIsolateId: 'isolate3',
@@ -82,19 +82,19 @@ void main() {
   });
 
   test('$TracePaneController construction', () {
-    expect(_Tests.emptyConnected.mode, ControllerCreationMode.connected);
+    expect(_Tests.emptyConnected.mode, MemoryControllerCreationMode.connected);
     expect(_Tests.emptyConnected.selection.value.isolate.id, null);
     expect(_Tests.emptyConnected.stateForIsolate.length, 0);
 
-    expect(_Tests.emptyOffline.mode, ControllerCreationMode.offlineData);
+    expect(_Tests.emptyOffline.mode, MemoryControllerCreationMode.offlineData);
     expect(_Tests.emptyOffline.selection.value.isolate.id, null);
     expect(_Tests.emptyOffline.stateForIsolate.length, 0);
 
-    expect(_Tests.selection.mode, ControllerCreationMode.connected);
+    expect(_Tests.selection.mode, MemoryControllerCreationMode.connected);
     expect(_Tests.selection.selection.value.isolate.id, 'isolate1');
     expect(_Tests.selection.stateForIsolate.length, 2);
 
-    expect(_Tests.noSelection.mode, ControllerCreationMode.connected);
+    expect(_Tests.noSelection.mode, MemoryControllerCreationMode.connected);
     expect(_Tests.noSelection.selection.value.isolate.id, null);
     expect(_Tests.noSelection.stateForIsolate.length, 2);
   });
@@ -112,7 +112,7 @@ void main() {
         );
         final fromJson = TracePaneController.fromJson(json);
 
-        expect(fromJson.mode, ControllerCreationMode.offlineData);
+        expect(fromJson.mode, MemoryControllerCreationMode.offlineData);
         expect(
           fromJson.selection.value.isolate.id,
           trace.selection.value.isolate.id,

--- a/packages/devtools_app/test/test_infra/scenes/memory/default.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/default.dart
@@ -76,7 +76,7 @@ class MemoryDefaultScene extends Scene {
   @override
   Widget build(BuildContext context) {
     return wrapWithControllers(
-      const MemoryBody(),
+      const MemoryScreenBody(),
       memory: controller,
     );
   }
@@ -85,7 +85,7 @@ class MemoryDefaultScene extends Scene {
     await tester.pumpSceneAsync(this);
     // Delay to ensure the memory profiler has collected data.
     await tester.pumpAndSettle(const Duration(seconds: 1));
-    expect(find.byType(MemoryBody), findsOneWidget);
+    expect(find.byType(MemoryScreenBody), findsOneWidget);
   }
 
   @override
@@ -150,7 +150,7 @@ class MemoryDefaultScene extends Scene {
     )..derived.applyFilter(showAllFilter);
 
     final profileController = ProfilePaneController(
-      mode: ControllerCreationMode.connected,
+      mode: MemoryControllerCreationMode.connected,
       rootPackage: 'root',
     )..setFilter(showAllFilter);
 
@@ -161,7 +161,7 @@ class MemoryDefaultScene extends Scene {
 
     await controller.initialized;
 
-    controller.chart!.data.timeline.data
+    controller.chart.data.timeline.data
       ..clear()
       ..addAll(memoryJson.data);
   }

--- a/packages/devtools_app/test/test_infra/scenes/memory/offline.dart
+++ b/packages/devtools_app/test/test_infra/scenes/memory/offline.dart
@@ -32,7 +32,7 @@ class MemoryOfflineScene extends Scene {
           return const CircularProgressIndicator();
         }
         return wrapWithControllers(
-          const MemoryBody(),
+          const MemoryScreenBody(),
           memory: value,
         );
       },
@@ -43,7 +43,7 @@ class MemoryOfflineScene extends Scene {
     await tester.pumpSceneAsync(this);
     // Delay to ensure the memory profiler has collected data.
     await tester.pumpAndSettle(const Duration(seconds: 1));
-    expect(find.byType(MemoryBody), findsOneWidget);
+    expect(find.byType(MemoryScreenBody), findsOneWidget);
   }
 
   /// Sets up the scene.


### PR DESCRIPTION
This is a pre-requisite to fixing https://github.com/flutter/devtools/issues/8079. We can simplify the logic by removing this mode. The only reason this mode was needed was because we were showing the entire memory screen for the disconnected state instead of only the widget we needed (`DiffPane`). Now that we've removed the dependency on `MemoryController`, we no longer need this mode.

My hypothesis is that we will need to remove these "modes" entirely to fix the offline issue, but that will be a larger effort. This is a nice simplification for now.