### PR TITLE
[Inspector V2] Inspector tree loads when switching to the inspector panel

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -307,6 +307,9 @@ class InspectorController extends DisposableController
     inspectorTree.root = inspectorTree.createNode();
     programmaticSelectionChangeInProgress = false;
     valueToInspectorTreeNode.clear();
+    // Mark tree as inactive so that it will be re-loaded the next time it is
+    // opened:
+    isActive = false;
   }
 
   void onIsolateStopped() {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8100

When a user switched away from the inspector panel, the inspector tree is disposed. However, because the tree was not being marked as inactive, when a user switched to the inspector panel again, we were incorrectly returning early thinking the tree had already been activated:

https://github.com/flutter/devtools/blob/9400141b23c6c42bfe283a6a44fa129099261d50/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart#L347-L350

This PR makes sure that we load the tree again when a user switches back to the inspector panel.

