### PR TITLE
Fix `integration_test/test/live_connection/eval_and_inspect_test.dart` flake

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
@@ -55,20 +55,6 @@ class EvalTester {
     await tester.pump(longPumpDuration);
   }
 
-  Future<Finder> retryUntilFound(
-    Finder finder, {
-    required WidgetTester tester,
-    int retries = 3,
-  }) async {
-    if (retries == 0) return finder;
-
-    final found = tester.any(finder);
-    if (found) return finder;
-
-    await tester.pump(safePumpDuration);
-    return retryUntilFound(finder, tester: tester, retries: retries - 1);
-  }
-
   /// Prepares the UI of the inspector screen so that the eval-related
   /// elements are visible on the screen for testing.
   Future<void> prepareInspectorUI() async {

--- a/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
@@ -37,7 +37,11 @@ class EvalTester {
     await tester.pump(safePumpDuration);
     await _pressEnter();
 
-    expect(expectedResponse, findsOneWidget);
+    final responseFinder = await retryUntilFound(
+      expectedResponse,
+      tester: tester,
+    );
+    expect(responseFinder, findsOneWidget);
   }
 
   Future<void> _pressEnter() async {
@@ -49,6 +53,20 @@ class EvalTester {
     await simulateKeyDownEvent(LogicalKeyboardKey.enter);
     await simulateKeyUpEvent(LogicalKeyboardKey.enter);
     await tester.pump(longPumpDuration);
+  }
+
+  Future<Finder> retryUntilFound(
+    Finder finder, {
+    required WidgetTester tester,
+    int retries = 3,
+  }) async {
+    if (retries == 0) return finder;
+
+    final found = tester.any(finder);
+    if (found) return finder;
+
+    await tester.pump(safePumpDuration);
+    return retryUntilFound(finder, tester: tester, retries: retries - 1);
   }
 
   /// Prepares the UI of the inspector screen so that the eval-related

--- a/packages/devtools_test/lib/src/helpers/utils.dart
+++ b/packages/devtools_test/lib/src/helpers/utils.dart
@@ -210,8 +210,8 @@ void verifyIsSearchMatchForTreeData<T extends TreeDataSearchStateMixin<T>>(
   }
 }
 
-/// Given a [finder], repeatedly pumps until the found, or until there are no
-/// more retries.
+/// Given a [finder], repeatedly pumps until found, or until there are no more
+/// retries.
 Future<Finder> retryUntilFound(
   Finder finder, {
   required WidgetTester tester,

--- a/packages/devtools_test/lib/src/helpers/utils.dart
+++ b/packages/devtools_test/lib/src/helpers/utils.dart
@@ -210,6 +210,22 @@ void verifyIsSearchMatchForTreeData<T extends TreeDataSearchStateMixin<T>>(
   }
 }
 
+/// Given a [finder], repeatedly pumps until the found, or until there are no
+/// more retries.
+Future<Finder> retryUntilFound(
+  Finder finder, {
+  required WidgetTester tester,
+  int retries = 3,
+}) async {
+  if (retries == 0) return finder;
+
+  final found = tester.any(finder);
+  if (found) return finder;
+
+  await tester.pump(safePumpDuration);
+  return retryUntilFound(finder, tester: tester, retries: retries - 1);
+}
+
 void logStatus(String log) {
   // ignore: avoid_print, intentional print for test output
   print('TEST STATUS: $log');


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8013

Tries to fix one of our top integration test flakes:

* example run: https://github.com/flutter/devtools/actions/runs/9716615461/job/26820586270
```
Actual: _TextContainingWidgetFinder:<Found 0 widgets with text
containing Variable button is created : []>
   Which: means none were found but one was expected
```

Evaluation is async since it requires a response from the VM service. I think this test was flaking because we were looking for the eval response in the console too soon. This PR adds and uses a test utility function (`retryUntilFound`) that will retry looking for a `finder` with a `safePumpDuration` in between until the found or there are no more retries.



