### PR TITLE
Set `requiresDebugSession` and `prefersDebugSession` values for DevTools extension screen open events

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
@@ -113,7 +113,14 @@ class _SidebarDevToolsExtensionsState extends State<SidebarDevToolsExtensions>
               ),
             );
             unawaited(
-              widget.editor.openDevToolsPage(null, page: ext.screenId),
+              widget.editor.openDevToolsPage(
+                null,
+                page: ext.screenId,
+                requiresDebugSession: ext.requiresConnection,
+                // TODO(https://github.com/flutter/devtools/issues/7955): set
+                // this value based on support matrix declared by the extension.
+                prefersDebugSession: true,
+              ),
             );
           },
         ),

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
@@ -118,8 +118,8 @@ class _SidebarDevToolsExtensionsState extends State<SidebarDevToolsExtensions>
                 page: ext.screenId,
                 requiresDebugSession: ext.requiresConnection,
                 // TODO(https://github.com/flutter/devtools/issues/7955): set
-                // this value based on support matrix declared by the extension.
-                prefersDebugSession: true,
+                // the 'prefersDebugSession' value based on the support matrix
+                // declared by the extension.
               ),
             );
           },


### PR DESCRIPTION
@DanTup the only other place we call `openDevToolsPage` is to open externally in the browser. Just wanted to double check - these values are fine to leave null for that case? https://github.com/flutter/devtools/blob/master/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/devtools_view.dart/#L96