### PR TITLE
Fix overflow error in widget tree

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/widgets/description.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/description.dart
@@ -582,17 +582,21 @@ class DescriptionDisplay extends StatelessWidget {
     if (actionLabel != null) {
       return Row(
         children: [
-          RichText(
-            overflow: TextOverflow.ellipsis,
-            text: text,
-          ),
-          TextButton(
-            style: TextButton.styleFrom(
-              textStyle: Theme.of(context).regularTextStyle,
+          Flexible(
+            child: RichText(
+              overflow: TextOverflow.ellipsis,
+              text: text,
             ),
-            onPressed: actionCallback,
-            child: Text(
-              actionLabel!,
+          ),
+          Flexible(
+            child: TextButton(
+              style: TextButton.styleFrom(
+                textStyle: Theme.of(context).regularTextStyle,
+              ),
+              onPressed: actionCallback,
+              child: Text(
+                actionLabel!,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8102

Widget tree can now be resized without causing overflow error:


![overflow error](https://github.com/user-attachments/assets/585aaf1a-d8df-4303-962b-4a607805517c)
