### PR TITLE
Fix `offline/perfetto_test` flake

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -11,6 +11,7 @@ import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_app_shared/web_utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
 import 'package:web/web.dart';
 
 import '../../../../../shared/analytics/analytics.dart' as ga;
@@ -21,6 +22,8 @@ import '../../../../../shared/utils.dart';
 import '../../../performance_utils.dart';
 import '_perfetto_controller_web.dart';
 import 'perfetto_controller.dart';
+
+final _log = Logger('PerfettoWeb');
 
 class Perfetto extends StatefulWidget {
   const Perfetto({
@@ -264,11 +267,15 @@ class _PerfettoViewController extends DisposableController
   void _postMessage(Object message) async {
     await _perfettoIFrameReady.future;
     if (_perfettoIFrameUnloaded) return;
-    assert(
-      perfettoController.perfettoIFrame.contentWindow != null,
-      'Something went wrong. The iFrame\'s contentWindow is null after the'
-      ' _perfettoIFrameReady future completed.',
-    );
+    final iframeWindow = perfettoController.perfettoIFrame.contentWindow;
+    if (iframeWindow == null) {
+      _log.warning(
+        'Something went wrong. The iFrame\'s contentWindow is null after the'
+        ' _perfettoIFrameReady future completed.',
+      );
+      return;
+    }
+
     perfettoController.perfettoIFrame.contentWindow!.postMessage(
       message.jsify(),
       perfettoController.perfettoUrl.toJS,

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -267,8 +267,8 @@ class _PerfettoViewController extends DisposableController
   void _postMessage(Object message) async {
     await _perfettoIFrameReady.future;
     if (_perfettoIFrameUnloaded) return;
-    final iframeWindow = perfettoController.perfettoIFrame.contentWindow;
-    if (iframeWindow == null) {
+    final iFrameWindow = perfettoController.perfettoIFrame.contentWindow;
+    if (iFrameWindow == null) {
       _log.warning(
         'Something went wrong. The iFrame\'s contentWindow is null after the'
         ' _perfettoIFrameReady future completed.',
@@ -276,7 +276,7 @@ class _PerfettoViewController extends DisposableController
       return;
     }
 
-    iframeWindow.postMessage(
+    iFrameWindow.postMessage(
       message.jsify(),
       perfettoController.perfettoUrl.toJS,
     );

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -276,7 +276,7 @@ class _PerfettoViewController extends DisposableController
       return;
     }
 
-    perfettoController.perfettoIFrame.contentWindow!.postMessage(
+    iframeWindow.postMessage(
       message.jsify(),
       perfettoController.perfettoUrl.toJS,
     );


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8013

This should prevent the flake in the `offline/perfetto_test.dart` by changing an `assert` to a `log` message. 

This is `assert` is being triggered after the test had already completed, which makes me think that the controller isn't being complete disposed during teardown. However, I haven't been able to reproduce the failure locally.

* https://github.com/flutter/devtools/actions/runs/10183727530/job/28169426456
* https://github.com/flutter/devtools/actions/runs/10219363545/job/28277509832?pr=8143
