### PR TITLE
Fix debugger panel integration test flake

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/debugger_panel_test.dart
@@ -153,6 +153,12 @@ void main() {
 
     logStatus('looking for the other_classes.dart file');
 
+    final otherClassesFinder = await retryUntilFound(
+      find.text('package:flutter_app/src/other_classes.dart'),
+      tester: tester,
+    );
+    expect(otherClassesFinder, findsOneWidget);
+
     expect(
       find.text('package:flutter_app/src/other_classes.dart'),
       findsOneWidget,


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8013

Example run: https://github.com/flutter/devtools/actions/runs/9717510192/job/26823396168

Opening a file from the stackframe is async, so uses the `retryUntilFound` test utility (added in https://github.com/flutter/devtools/pull/8123) to retry looking for the file until it is found.