### PR TITLE
Re-enable disconnect experience for memory screen

### DIFF
--- a/packages/.vscode/launch.json
+++ b/packages/.vscode/launch.json
@@ -23,7 +23,7 @@
             "program": "devtools_app/lib/main.dart",
             "args": [
                 "--dart-define",
-                "memory_offline_experiment=true",
+                "memory_disconnect_experience=true",
                 "--dart-define",
                 "enable_experiments=true",
             ],

--- a/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
+++ b/packages/devtools_app/integration_test/test/offline/memory_offline_data_test.dart
@@ -1,0 +1,40 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_test/helpers.dart';
+import 'package:devtools_test/integration_test.dart';
+import 'package:devtools_test/test_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+// To run:
+// dart run integration_test/run_tests.dart --target=integration_test/test/offline/memory_offline_data_test.dart
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'Memory screen can load offline data',
+    (tester) async {
+      await pumpDevTools(tester);
+      logStatus('1 - pumped devtools');
+      await loadSampleData(tester, memoryFileName);
+      logStatus('2 - loaded sample data');
+      await tester.pumpAndSettle(longPumpDuration);
+      logStatus('3 - pumped and settled');
+
+      const diffTab = 'Diff Snapshots';
+      const profileTab = 'Profile Memory';
+      const traceTab = 'Trace Instances';
+
+      expect(find.text('_MyClass'), findsOneWidget);
+      logStatus('5 - found _MyClass');
+
+      for (final tab in [diffTab, profileTab, traceTab]) {
+        expect(find.text(tab), findsOneWidget);
+        logStatus('6.$tab - found');
+      }
+    },
+  );
+}

--- a/packages/devtools_app/lib/src/shared/feature_flags.dart
+++ b/packages/devtools_app/lib/src/shared/feature_flags.dart
@@ -35,8 +35,8 @@ void setEnableExperiments() {
 @visibleForTesting
 bool get enableBeta => enableExperiments || !isExternalBuild;
 
-const _kMemoryOfflineExperiment =
-    bool.fromEnvironment('memory_offline_experiment');
+const _kMemoryDisconnectExperience =
+    bool.fromEnvironment('memory_disconnect_experience', defaultValue: true);
 
 // It is ok to have enum-like static only classes.
 // ignore: avoid_classes_with_only_static_members
@@ -56,12 +56,13 @@ abstract class FeatureFlags {
   /// https://github.com/flutter/devtools/issues/4564.
   static bool widgetRebuildStats = true;
 
-  /// Flag to enable offline data on memory screen.
+  /// Flag to enable viewing offline data on the memory screen when an app
+  /// disconnects.
   ///
   /// https://github.com/flutter/devtools/issues/5606
-  static const memoryOffline = _kMemoryOfflineExperiment;
+  static const memoryDisconnectExperience = _kMemoryDisconnectExperience;
 
-  /// Flag to enable save/load.
+  /// Flag to enable save/load for the Memory screen.
   ///
   /// https://github.com/flutter/devtools/issues/8019
   static bool memorySaveLoad = enableExperiments;
@@ -104,7 +105,7 @@ abstract class FeatureFlags {
   /// well.
   static final _allFlags = <String, bool>{
     'widgetRebuildStats': widgetRebuildStats,
-    'memoryOffline': memoryOffline,
+    'memoryOffline': memoryDisconnectExperience,
     'dapDebugging': dapDebugging,
     'loggingV2': loggingV2,
     'deepLinkIosCheck': deepLinkIosCheck,

--- a/packages/devtools_app/lib/src/shared/screen.dart
+++ b/packages/devtools_app/lib/src/shared/screen.dart
@@ -58,10 +58,10 @@ enum ScreenMetaData {
     iconAsset: 'icons/app_bar/memory.png',
     requiresDartVm: true,
     // ignore: avoid_redundant_argument_values, false positive
-    requiresConnection: !FeatureFlags.memoryOffline,
+    requiresConnection: !FeatureFlags.memoryDisconnectExperience,
     tutorialVideoTimestamp: '?t=420',
     // ignore: avoid_redundant_argument_values, false positive
-    worksWithOfflineData: FeatureFlags.memoryOffline,
+    worksWithOfflineData: FeatureFlags.memoryDisconnectExperience,
   ),
   debugger(
     'debugger',

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,9 +27,9 @@ TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
 
-* Added support for viewing memory data when an app disconnects. For example,
-this may happen when an app unexpectedly crashes or hits an out-of-memory
-issue. - [#7843](https://github.com/flutter/devtools/pull/7843),
+* Enabled offline analysis of memory snapshots, as well as support for viewing memory
+data when an app disconnects. For example, this may happen when an app unexpectedly
+crashes or hits an out-of-memory issue. - [#7843](https://github.com/flutter/devtools/pull/7843),
 [#8093](https://github.com/flutter/devtools/pull/8093),
 [#8096](https://github.com/flutter/devtools/pull/8096)
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -27,7 +27,11 @@ TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
 
-TODO: Remove this section if there are not any general updates.
+* Added support for viewing memory data when an app disconnects. For example,
+this may happen when an app unexpectedly crashes or hits an out-of-memory
+issue. - [#7843](https://github.com/flutter/devtools/pull/7843),
+[#8093](https://github.com/flutter/devtools/pull/8093),
+[#8096](https://github.com/flutter/devtools/pull/8096)
 
 ## Debugger updates
 

--- a/packages/devtools_app/test/shared/visible_screens_test.dart
+++ b/packages/devtools_app/test/shared/visible_screens_test.dart
@@ -232,7 +232,7 @@ void main() {
           // InspectorScreen,
           PerformanceScreen, // Works offline, so appears regardless of web flag
           ProfilerScreen, // Works offline, so appears regardless of web flag
-          // MemoryScreen,
+          MemoryScreen, // Works offline, so appears regardless of web flag
           // DebuggerScreen,
           // NetworkScreen,
           // LoggingScreen,


### PR DESCRIPTION
Reverts https://github.com/flutter/devtools/pull/8128 and re-enables the disconnect experience for the memory screen.