### PR TITLE
[ Memory ] Remove `getIsolate` polling in memory chart update logic

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
@@ -70,6 +70,11 @@ class ChartVmConnection extends DisposableController
           .listen(_memoryTracker.onGCEvent),
     );
 
+    autoDisposeStreamSubscription(
+      serviceConnection.serviceManager.service!.onIsolateEvent
+          .listen(_memoryTracker.onIsolateEvent),
+    );
+
     _polling = DebounceTimer.periodic(
       chartUpdateDelay,
       () async {

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
@@ -90,7 +90,7 @@ class MemoryTracker {
   }
 
   void onIsolateEvent(Event data) {
-    if (data.kind != EventKind.kIsolateExit) {
+    if (data.kind == EventKind.kIsolateExit) {
       _isolateHeaps.remove(data.isolate!.id);
     }
   }

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
@@ -91,9 +91,8 @@ class MemoryTracker {
 
   void onIsolateEvent(Event data) {
     if (data.kind != EventKind.kIsolateExit) {
-      return;
+      _isolateHeaps.remove(data.isolate!.id);
     }
-    _isolateHeaps.remove(data.isolate!.id);
   }
 
   Future<void> pollMemory() async {

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/memory_tracker.dart
@@ -158,7 +158,7 @@ class MemoryTracker {
         (await serviceConnection.adbMemoryInfo).json!,
       );
 
-  void _recalculate({bool fromGC = false}) async {
+  void _recalculate({bool fromGC = false}) {
     int used = 0;
     int capacity = 0;
     int external = 0;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -33,6 +33,9 @@ crashes or hits an out-of-memory issue. - [#7843](https://github.com/flutter/dev
 [#8093](https://github.com/flutter/devtools/pull/8093),
 [#8096](https://github.com/flutter/devtools/pull/8096)
 
+* Fixed issue where the memory chart could cause the connected application to hit an
+out of memory exception while allocating large, short-lived objects repeatedly. - [#8209](https://github.com/flutter/devtools/pull/8209)
+
 ## Debugger updates
 
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
Repeatedly calling `getIsolate` results in variables currently in scope in the top frame of the isolate at the time of the request being assigned object IDs, inserting them into the VM service's object ID ring buffer. This keeps the objects alive until the buffer wraps around, which can cause OOM exceptions if the target application is repeatedly making large, temporary allocations that would otherwise be GC'd.

The logic has been updated to rely on SentinelExceptions and the Isolate event stream to determine when an isolate is no longer relevant and should be removed from the memory chart statistics.

Fixes https://github.com/flutter/devtools/issues/8180