### PR TITLE
Remove unnecessary cascade from fix_goldens.dart

### DIFF
--- a/tool/lib/commands/fix_goldens.dart
+++ b/tool/lib/commands/fix_goldens.dart
@@ -65,7 +65,7 @@ class FixGoldensCommand extends Command {
       final allLocalGoldenPngs =
           Directory(pathFromRepoRoot("packages/devtools_app/test/"))
               .listSync(recursive: true)
-            ..where((e) => e.path.endsWith('.png'));
+              .where((e) => e.path.endsWith('.png'));
 
       for (final downloadedGolden in downloadedGoldens) {
         final downloadedGoldenBaseName = path.basename(downloadedGolden.path);


### PR DESCRIPTION
This was resulting in `allLocalGoldenPngs` being the set of all files in `packages/devtools_app/test/` instead of just the golden images.