### PR TITLE
Fix an issue with the DevTools app bar in embedded mode

### DIFF
--- a/packages/devtools_app/lib/src/framework/app_bar.dart
+++ b/packages/devtools_app/lib/src/framework/app_bar.dart
@@ -55,11 +55,15 @@ class DevToolsAppBar extends StatelessWidget {
 
     // Add a leading [VerticalLineSpacer] to the actions to separate them from
     // the tabs.
-    final actionsWithSpacer = List<Widget>.from(actions ?? [])
-      ..insert(0, VerticalLineSpacer(height: defaultToolbarHeight));
+    final actionsWithSpacer = List<Widget>.from(actions ?? []);
+    if (screens.isNotEmpty && actionsWithSpacer.isNotEmpty) {
+      actionsWithSpacer.insert(
+        0,
+        VerticalLineSpacer(height: defaultToolbarHeight),
+      );
+    }
 
-    final hasMultipleTabs = screens.length > 1;
-    if (hasMultipleTabs) {
+    if (screens.isNotEmpty) {
       tabBar = TabBar(
         controller: tabController,
         isScrollable: true,

--- a/packages/devtools_app/test/shared/scaffold_test.dart
+++ b/packages/devtools_app/test/shared/scaffold_test.dart
@@ -163,7 +163,7 @@ void main() {
   );
 
   testWidgets(
-    'displays no tabs when only one is given',
+    'displays tabs with only one screen',
     (WidgetTester tester) async {
       await tester.pumpWidget(
         wrapScaffold(
@@ -172,7 +172,7 @@ void main() {
       );
       expect(find.byType(DevToolsAppBar), findsOneWidget);
       expect(find.byKey(_k1), findsOneWidget);
-      expect(find.byKey(_t1), findsNothing);
+      expect(find.byKey(_t1), findsOneWidget);
     },
   );
 


### PR DESCRIPTION
Now when we are in `embedMode=many`, the tab bar is still shown even when there is only one screen.

Fixes https://github.com/flutter/devtools/issues/8217.