### PR TITLE
[deep link]  added a http client to deep link service, connect tests with  deep link controller .validateLinks()

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -148,13 +148,12 @@ class DisplayOptions {
 class DeepLinksController extends DisposableController
     with AutoDisposeControllerMixin {
   DeepLinksController() {
-    client = Client();
-    deepLinksServices = DeepLinksServices(client);
+    deepLinksServices = DeepLinksServices();
   }
 
   @override
   void dispose() {
-    client.close();
+    deepLinksServices.dispose();
     super.dispose();
   }
 
@@ -470,7 +469,6 @@ class DeepLinksController extends DisposableController
   /// The [TextEditingController] for the search text field.
   final textEditingController = TextEditingController();
   late DeepLinksServices deepLinksServices;
-  late Client client;
 
   bool addLocalFingerprint(String fingerprint) {
     // A valid fingerprint consists of 32 pairs of hexadecimal digits separated by colons.

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -147,7 +147,6 @@ class DisplayOptions {
 
 class DeepLinksController extends DisposableController
     with AutoDisposeControllerMixin {
-
   @override
   void dispose() {
     deepLinksService.dispose();

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -9,7 +9,6 @@ import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_deeplink.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:http/http.dart';
 
 import '../../shared/analytics/analytics.dart' as ga;
 import '../../shared/analytics/constants.dart' as gac;

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -147,13 +147,10 @@ class DisplayOptions {
 
 class DeepLinksController extends DisposableController
     with AutoDisposeControllerMixin {
-  DeepLinksController() {
-    deepLinksServices = DeepLinksServices();
-  }
 
   @override
   void dispose() {
-    deepLinksServices.dispose();
+    deepLinksService.dispose();
     super.dispose();
   }
 
@@ -468,7 +465,7 @@ class DeepLinksController extends DisposableController
 
   /// The [TextEditingController] for the search text field.
   final textEditingController = TextEditingController();
-  late DeepLinksServices deepLinksServices;
+  final deepLinksService = DeepLinksService();
 
   bool addLocalFingerprint(String fingerprint) {
     // A valid fingerprint consists of 32 pairs of hexadecimal digits separated by colons.
@@ -494,7 +491,7 @@ class DeepLinksController extends DisposableController
     final domain = selectedLink.value!.domain;
     if (domain != null) {
       generatedAssetLinksForSelectedLink.value =
-          await deepLinksServices.generateAssetLinks(
+          await deepLinksService.generateAssetLinks(
         domain: domain,
         applicationId: applicationId,
         localFingerprint: localFingerprint.value,
@@ -517,7 +514,7 @@ class DeepLinksController extends DisposableController
     Map<String, List<DomainError>> iosDomainErrors =
         <String, List<DomainError>>{};
     try {
-      final androidResult = await deepLinksServices.validateAndroidDomain(
+      final androidResult = await deepLinksService.validateAndroidDomain(
         domains: domains,
         applicationId: applicationId,
         localFingerprint: localFingerprint.value,
@@ -526,7 +523,7 @@ class DeepLinksController extends DisposableController
       googlePlayFingerprintsAvailability.value =
           androidResult.googlePlayFingerprintsAvailability;
       if (FeatureFlags.deepLinkIosCheck) {
-        final iosResult = await deepLinksServices.validateIosDomain(
+        final iosResult = await deepLinksService.validateIosDomain(
           bundleId: bundleId,
           teamId: teamId,
           domains: domains,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -89,8 +89,8 @@ class ValidateAndroidDomainResult {
   Map<String, List<DomainError>> domainErrors;
 }
 
-class DeepLinksServices {
-  DeepLinksServices() {
+class DeepLinksService {
+  DeepLinksService() {
     client = Client();
   }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -5,16 +5,21 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:http/http.dart' as http;
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart';
 
 import 'deep_links_model.dart';
 
 const _apiKey = 'AIzaSyCf_2E9N2AUZR-YSnZTQ72YbCNhKIskIsw';
-const _assetLinksGenerationURL =
+
+@visibleForTesting
+const assetLinksGenerationURL =
     'https://deeplinkassistant-pa.googleapis.com/android/generation/v1/assetlinks:generate?key=$_apiKey';
-const _androidDomainValidationURL =
+@visibleForTesting
+const androidDomainValidationURL =
     'https://deeplinkassistant-pa.googleapis.com/android/validation/v1/domains:batchValidate?key=$_apiKey';
-const _iosDomainValidationURL =
+@visibleForTesting
+const iosDomainValidationURL =
     'https://deeplinkassistant-pa.googleapis.com/ios/validation/v1/domains:batchValidate?key=$_apiKey';
 const postHeader = {'Content-Type': 'application/json'};
 
@@ -85,6 +90,9 @@ class ValidateAndroidDomainResult {
 }
 
 class DeepLinksServices {
+  DeepLinksServices(this.client);
+  final Client client;
+
   Future<ValidateAndroidDomainResult> validateAndroidDomain({
     required List<String> domains,
     required String applicationId,
@@ -98,8 +106,8 @@ class DeepLinksServices {
     late bool googlePlayFingerprintsAvailable;
 
     for (final domainList in domainsByBatch) {
-      final response = await http.post(
-        Uri.parse(_androidDomainValidationURL),
+      final response = await client.post(
+        Uri.parse(androidDomainValidationURL),
         headers: postHeader,
         body: jsonEncode({
           _packageNameKey: applicationId,
@@ -151,8 +159,8 @@ class DeepLinksServices {
     final domainsByBatch = _splitDomains(domains);
 
     for (final domainList in domainsByBatch) {
-      final response = await http.post(
-        Uri.parse(_iosDomainValidationURL),
+      final response = await client.post(
+        Uri.parse(iosDomainValidationURL),
         headers: postHeader,
         body: jsonEncode({
           _appIdKey: {
@@ -209,8 +217,8 @@ class DeepLinksServices {
     required String domain,
     required String? localFingerprint,
   }) async {
-    final response = await http.post(
-      Uri.parse(_assetLinksGenerationURL),
+    final response = await client.post(
+      Uri.parse(assetLinksGenerationURL),
       headers: postHeader,
       body: jsonEncode(
         {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -90,11 +90,7 @@ class ValidateAndroidDomainResult {
 }
 
 class DeepLinksService {
-  DeepLinksService() {
-    client = Client();
-  }
-
-  late Client client;
+  final client = Client();
 
   void dispose() {
     client.close();

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -90,8 +90,15 @@ class ValidateAndroidDomainResult {
 }
 
 class DeepLinksServices {
-  DeepLinksServices(this.client);
-  final Client client;
+  DeepLinksServices() {
+    client = Client();
+  }
+
+  late Client client;
+
+  void dispose() {
+    client.close();
+  }
 
   Future<ValidateAndroidDomainResult> validateAndroidDomain({
     required List<String> domains,

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -50,7 +50,7 @@ void main() {
   });
 
   late DeepLinksScreen screen;
-  late DeepLinksTestController deepLinksController;
+  late TestDeepLinksController deepLinksController;
 
   const windowSize = Size(2560.0, 1338.0);
 
@@ -71,7 +71,7 @@ void main() {
   group('DeepLinkScreen', () {
     setUp(() {
       screen = DeepLinksScreen();
-      deepLinksController = DeepLinksTestController();
+      deepLinksController = TestDeepLinksController();
     });
 
     testWidgets('builds its tab', (WidgetTester tester) async {
@@ -126,7 +126,7 @@ void main() {
       'builds deeplink list page with links',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -152,7 +152,7 @@ void main() {
       'builds deeplink list page with default ios and android configurations',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -180,7 +180,7 @@ void main() {
       'builds deeplink list page with split screen',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -214,7 +214,7 @@ void main() {
       'shows notification cards when there are domain errors',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController(
+        final deepLinksController = TestDeepLinksController(
           hasAndroidDomainErrors: true,
           hasIosDomainErrors: true,
         );
@@ -242,7 +242,7 @@ void main() {
       'shows notification cards when there are path errors',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -269,7 +269,7 @@ void main() {
       'taps the action button in notification cards to go to the split screen',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController(
+        final deepLinksController = TestDeepLinksController(
           hasAndroidDomainErrors: true,
           hasIosDomainErrors: true,
         );
@@ -304,7 +304,7 @@ void main() {
       'search links',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -342,7 +342,7 @@ void main() {
       'filter links with os',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
         deepLinksController
           ..selectedProject.value = FlutterProject(
             path: '/abc',
@@ -397,7 +397,7 @@ void main() {
       windowSize,
       (WidgetTester tester) async {
         final deepLinksController =
-            DeepLinksTestController(hasIosDomainErrors: true);
+            TestDeepLinksController(hasIosDomainErrors: true);
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -451,7 +451,7 @@ void main() {
       'sort links',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -516,7 +516,7 @@ void main() {
       'show scheme or missing scheme',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -546,7 +546,7 @@ void main() {
       'path view',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = TestDeepLinksController();
 
         deepLinksController
           ..selectedProject.value = FlutterProject(

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -191,14 +191,12 @@ void main() {
           ..fakeAndroidDeepLinks = [defaultAndroidDeeplink]
           ..fakeIosDomains = [defaultDomain];
 
-
-
         await pumpDeepLinkScreen(
           tester,
           controller: deepLinksController,
         );
 
-        deepLinksController.autoSelectLink( TableViewType.domainView);
+        deepLinksController.autoSelectLink(TableViewType.domainView);
         deepLinksController.displayOptionsNotifier.value =
             DisplayOptions(showSplitScreen: true);
 
@@ -409,8 +407,7 @@ void main() {
             androidDeepLinkJson('www.domain1.com'),
             androidDeepLinkJson('www.google.com'),
           ]
-          ..fakeIosDomains = [defaultDomain]
-          ;
+          ..fakeIosDomains = [defaultDomain];
 
         await pumpDeepLinkScreen(
           tester,

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -26,45 +26,6 @@ import '../test_infra/utils/deep_links_utils.dart';
 final xcodeBuildOptions = XcodeBuildOptions.fromJson(
   '''{"configurations":["debug", "release"],"targets":["runner","runnerTests"]}''',
 );
-final linkDatas = [
-  LinkData(
-    domain: 'www.domain1.com',
-    path: '/',
-    os: {PlatformOS.android},
-  ),
-  LinkData(
-    domain: 'www.domain2.com',
-    path: '/',
-    os: {PlatformOS.ios},
-  ),
-  LinkData(
-    domain: 'www.google.com',
-    path: '/',
-    os: {PlatformOS.android, PlatformOS.ios},
-  ),
-  LinkData(
-    domain: 'www.google.com',
-    path: '/home',
-    os: {PlatformOS.android, PlatformOS.ios},
-  ),
-];
-
-final domainErrorlinkData = LinkData(
-  domain: 'www.google.com',
-  path: '/',
-  os: {PlatformOS.android, PlatformOS.ios},
-  domainErrors: [AndroidDomainError.existence, IosDomainError.existence],
-);
-
-final pathErrorlinkData = LinkData(
-  domain: 'www.google.com',
-  path: '/abcd',
-  os: {PlatformOS.android, PlatformOS.ios},
-  pathErrors: {
-    PathError.intentFilterActionView,
-    PathError.intentFilterDefault,
-  },
-);
 
 void main() {
   // ignore: avoid-redundant-async, false positive.
@@ -230,14 +191,18 @@ void main() {
           ..fakeAndroidDeepLinks = [defaultAndroidDeeplink]
           ..fakeIosDomains = [defaultDomain];
 
-        deepLinksController.displayOptionsNotifier.value =
-            DisplayOptions(showSplitScreen: true);
-        deepLinksController.selectedLink.value = linkDatas.first;
+
 
         await pumpDeepLinkScreen(
           tester,
           controller: deepLinksController,
         );
+
+        deepLinksController.autoSelectLink( TableViewType.domainView);
+        deepLinksController.displayOptionsNotifier.value =
+            DisplayOptions(showSplitScreen: true);
+
+        await tester.pumpAndSettle();
 
         expect(find.byType(DeepLinkPage), findsOneWidget);
         expect(find.byType(DeepLinkListView), findsOneWidget);

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -20,6 +20,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
+import '../test_infra/test_data/deep_link/fake_responses.dart';
 import '../test_infra/utils/deep_links_utils.dart';
 
 final xcodeBuildOptions = XcodeBuildOptions.fromJson(
@@ -248,7 +249,10 @@ void main() {
       'shows notification cards when there are domain errors',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = DeepLinksTestController(
+          hasAndroidDomainErrors: true,
+          hasIosDomainErrors: true,
+        );
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -257,9 +261,7 @@ void main() {
             iosBuildOptions: xcodeBuildOptions,
           )
           ..fakeAndroidDeepLinks = [defaultAndroidDeeplink]
-          ..fakeIosDomains = [defaultDomain]
-          ..hasAndroidDomainErrors = true
-          ..hasIosDomainErrors = true;
+          ..fakeIosDomains = [defaultDomain];
 
         await pumpDeepLinkScreen(
           tester,
@@ -286,9 +288,7 @@ void main() {
           ..fakeAndroidDeepLinks = [
             androidDeepLinkJson(defaultDomain, hasPathError: true),
           ]
-          ..fakeIosDomains = [defaultDomain]
-          ..hasAndroidDomainErrors = false
-          ..hasIosDomainErrors = false;
+          ..fakeIosDomains = [defaultDomain];
         await pumpDeepLinkScreen(
           tester,
           controller: deepLinksController,
@@ -304,7 +304,10 @@ void main() {
       'taps the action button in notification cards to go to the split screen',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController = DeepLinksTestController(
+          hasAndroidDomainErrors: true,
+          hasIosDomainErrors: true,
+        );
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -313,9 +316,7 @@ void main() {
             iosBuildOptions: xcodeBuildOptions,
           )
           ..fakeAndroidDeepLinks = [defaultAndroidDeeplink]
-          ..fakeIosDomains = [defaultDomain]
-          ..hasAndroidDomainErrors = true
-          ..hasIosDomainErrors = true;
+          ..fakeIosDomains = [defaultDomain];
 
         await pumpDeepLinkScreen(
           tester,
@@ -430,7 +431,8 @@ void main() {
       'filter links with validation result',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = DeepLinksTestController();
+        final deepLinksController =
+            DeepLinksTestController(hasIosDomainErrors: true);
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -443,7 +445,7 @@ void main() {
             androidDeepLinkJson('www.google.com'),
           ]
           ..fakeIosDomains = [defaultDomain]
-          ..hasIosDomainErrors = true;
+          ;
 
         await pumpDeepLinkScreen(
           tester,
@@ -589,8 +591,11 @@ void main() {
           )
           ..fakeAndroidDeepLinks = [
             androidDeepLinkJson('www.domain1.com', path: '/path1'),
-            androidDeepLinkJson('www.domain2.com',
-                path: '/path2', hasPathError: true),
+            androidDeepLinkJson(
+              'www.domain2.com',
+              path: '/path2',
+              hasPathError: true,
+            ),
             androidDeepLinkJson('www.domain3.com', path: '/path3'),
           ];
 

--- a/packages/devtools_app/test/deep_link_vlidation/select_project_view_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/select_project_view_test.dart
@@ -56,7 +56,7 @@ void main() {
 
   group('$SelectProjectView', () {
     setUp(() {
-      deepLinksController = DeepLinksTestController();
+      deepLinksController = TestDeepLinksController();
     });
 
     testWidgetsWithWindowSize(

--- a/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
+++ b/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
@@ -1,0 +1,244 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:devtools_shared/devtools_deeplink.dart';
+
+// Fake responses for the deep link validation API.
+const androidValidationResponseWithNoError = '''
+{
+  "validationResult": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HOST_FORMED_PROPERLY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "CONTENT_TYPE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FINGERPRINT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "CHECKED"
+    }
+  ],
+  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
+}
+''';
+
+const androidValidationResponseWithError = '''
+{
+  "validationResult": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HOST_FORMED_PROPERLY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "failedChecks": [
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "CONTENT_TYPE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FINGERPRINT",
+          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "CHECKED"
+    }
+  ],
+  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
+}
+''';
+
+const iosValidationResponseWithNoError = '''
+{
+  "validationResults": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FILE_FORMAT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "VALIDATION_COMPLETE"
+    }
+  ]
+}
+''';
+
+const iosValidationResponseWithError = '''
+{
+  "validationResults": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "failedChecks": [
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "FAILED_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FILE_FORMAT",
+          "resultType": "FAILED_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "VALIDATION_COMPLETE"
+    }
+  ]
+}
+''';
+
+const androidDeepLinkWithPathErrors = '''{
+      "host": "example.com",
+      "path": "/path",
+      "intentFilterCheck": {
+        "hasBrowsableCategory": false,
+        "hasActionView": true,
+        "hasDefaultCategory": true,
+        "hasAutoVerify": true
+      }
+    }
+''';
+
+const defaultDomain = 'example.com';
+
+String androidDeepLinkJson(
+  String domain, {
+  String? scheme = 'http',
+  String? path = '/path',
+  bool hasPathError = false,
+}) {
+  return '''{
+${(scheme != null) ? '"scheme": "$scheme",' : ''}
+      "host": "$domain",
+      "path": "$path",
+      "intentFilterCheck": {
+        "hasBrowsableCategory": ${!hasPathError},
+        "hasActionView": true,
+        "hasDefaultCategory": true,
+        "hasAutoVerify": true
+      }
+    }
+''';
+}
+
+AppLinkSettings fakeAppLinkSettings(List<String> androidDeepLink) {
+  return AppLinkSettings.fromJson('''{
+  "deeplinks": [
+    ${androidDeepLink.join(',')}
+  ],
+  "deeplinkingFlagEnabled": true,
+  "applicationId": "app.id"
+}
+''');
+}
+
+
+UniversalLinkSettings fakeUniversalLinkSettings(List<String> domains) {
+  return UniversalLinkSettings.fromJson('''
+{
+  "bundleIdentifier": "app.id",
+  "teamIdentifier": "AAAABBBB",
+  "associatedDomains": [
+    ${domains.map(
+            (d) => '"$d"',
+          ).join(',')}
+  ]
+}
+''');
+}

--- a/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
+++ b/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
@@ -228,7 +228,6 @@ AppLinkSettings fakeAppLinkSettings(List<String> androidDeepLink) {
 ''');
 }
 
-
 UniversalLinkSettings fakeUniversalLinkSettings(List<String> domains) {
   return UniversalLinkSettings.fromJson('''
 {

--- a/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
@@ -5,9 +5,286 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/deep_link_validation/deep_links_model.dart';
 import 'package:devtools_app/src/screens/deep_link_validation/deep_links_services.dart';
+import 'package:devtools_shared/devtools_deeplink.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart';
+import 'package:http/testing.dart';
+
+// Fake responses for the deep link validation API.
+const androidValidationResponseWithNoError = '''
+{
+  "validationResult": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HOST_FORMED_PROPERLY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "CONTENT_TYPE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FINGERPRINT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "CHECKED"
+    }
+  ],
+  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
+}
+''';
+
+const androidValidationResponseWithError = '''
+{
+  "validationResult": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HOST_FORMED_PROPERLY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "failedChecks": [
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "CONTENT_TYPE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FINGERPRINT",
+          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "CHECKED"
+    }
+  ],
+  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
+}
+''';
+
+const iosValidationResponseWithNoError = '''
+{
+  "validationResults": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FILE_FORMAT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "VALIDATION_COMPLETE"
+    }
+  ]
+}
+''';
+
+const iosValidationResponseWithError = '''
+{
+  "validationResults": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "failedChecks": [
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "FAILED_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FILE_FORMAT",
+          "resultType": "FAILED_PREREQUISITE_FAILURE",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "status": "VALIDATION_COMPLETE"
+    }
+  ]
+}
+''';
+
+final defaultAndroidDeeplink = androidDeepLinkJson(defaultDomain);
+
+const androidDeepLinkWithPathErrors = '''{
+      "host": "example.com",
+      "path": "/path",
+      "intentFilterCheck": {
+        "hasBrowsableCategory": false,
+        "hasActionView": true,
+        "hasDefaultCategory": true,
+        "hasAutoVerify": true
+      }
+    }
+''';
+
+String androidDeepLinkJson(
+  String domain, {
+  String? scheme = 'http',
+  String? path = '/path',
+  bool hasPathError = false,
+}) {
+  return '''{
+${(scheme != null) ? '"scheme": "$scheme",' : ''}
+      "host": "$domain",
+      "path": "$path",
+      "intentFilterCheck": {
+        "hasBrowsableCategory": ${!hasPathError},
+        "hasActionView": true,
+        "hasDefaultCategory": true,
+        "hasAutoVerify": true
+      }
+    }
+''';
+}
+
+AppLinkSettings fakeAppLinkSettings(List<String> androidDeepLink) {
+  return AppLinkSettings.fromJson('''{
+  "deeplinks": [
+    ${androidDeepLink.join(',')}
+  ],
+  "deeplinkingFlagEnabled": true,
+  "applicationId": "app.id"
+}
+''');
+}
+
+const defaultDomain = 'example.com';
+UniversalLinkSettings fakeUniversalLinkSettings(List<String> domains) {
+  return UniversalLinkSettings.fromJson('''
+{
+  "bundleIdentifier": "app.id",
+  "teamIdentifier": "AAAABBBB",
+  "associatedDomains": [
+    ${domains.map(
+            (d) => '"$d"',
+          ).join(',')}
+  ]
+}
+''');
+}
 
 class DeepLinksTestController extends DeepLinksController {
+  DeepLinksTestController() {
+    // Create a mock client to return fake responses.
+    final client = MockClient((request) async {
+      if (request.url == Uri.parse(androidDomainValidationURL)) {
+        if (hasAndroidDomainErrors) {
+          return Response(androidValidationResponseWithError, 200);
+        } else {
+          return Response(androidValidationResponseWithNoError, 200);
+        }
+      }
+      if (request.url == Uri.parse(iosDomainValidationURL)) {
+        print('request.url == Uri.parse(iosDomainValidationURL');
+        if (hasIosDomainErrors) {
+          return Response(iosValidationResponseWithError, 200);
+        } else {
+          return Response(iosValidationResponseWithNoError, 200);
+        }
+      }
+      return Response('this is a body', 404);
+    });
+    deepLinksServices = DeepLinksServices(client);
+  }
+
+  @override
+  void dispose() {
+    client.close();
+    super.dispose();
+  }
+
+  List<String> fakeAndroidDeepLinks = [];
+  bool hasAndroidDomainErrors = false;
+  bool hasAndroidPathErrors = false;
+  bool hasIosDomainErrors = false;
+  List<String> fakeIosDomains = [];
+
   @override
   Future<String?> packageDirectoryForMainIsolate() async {
     return null;
@@ -15,19 +292,12 @@ class DeepLinksTestController extends DeepLinksController {
 
   @override
   Future<void> validateLinks() async {
-    if (validatedLinkDatas.all.isEmpty) {
-      return;
-    }
-    displayOptionsNotifier.value = displayOptionsNotifier.value.copyWith(
-      domainErrorCount: validatedLinkDatas.byDomain
-          .where((element) => element.domainErrors.isNotEmpty)
-          .length,
-      pathErrorCount: validatedLinkDatas.byPath
-          .where((element) => element.pathErrors.isNotEmpty)
-          .length,
-    );
-    applyFilters();
-    pagePhase.value = PagePhase.linksValidated;
+    androidAppLinks[selectedAndroidVariantIndex.value] =
+        fakeAppLinkSettings(fakeAndroidDeepLinks);
+    iosLinks[selectedIosConfigurationIndex.value] =
+        fakeUniversalLinkSettings(fakeIosDomains);
+
+    await super.validateLinks();
   }
 
   @override

--- a/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
@@ -13,8 +13,8 @@ import '../test_data/deep_link/fake_responses.dart';
 
 final defaultAndroidDeeplink = androidDeepLinkJson(defaultDomain);
 
-class DeepLinksTestServices extends DeepLinksServices {
-  DeepLinksTestServices({
+class TestDeepLinksService extends DeepLinksService {
+  TestDeepLinksService({
     this.hasAndroidDomainErrors = false,
     this.hasIosDomainErrors = false,
   }) {
@@ -42,12 +42,12 @@ class DeepLinksTestServices extends DeepLinksServices {
   final bool hasIosDomainErrors;
 }
 
-class DeepLinksTestController extends DeepLinksController {
-  DeepLinksTestController({
+class TestDeepLinksController extends DeepLinksController {
+  TestDeepLinksController({
     this.hasAndroidDomainErrors = false,
     this.hasIosDomainErrors = false,
   }) {
-    deepLinksServices = DeepLinksTestServices(
+    _deepLinksService = TestDeepLinksService(
       hasAndroidDomainErrors: hasAndroidDomainErrors,
       hasIosDomainErrors: hasIosDomainErrors,
     );
@@ -58,6 +58,11 @@ class DeepLinksTestController extends DeepLinksController {
   bool hasAndroidPathErrors = false;
   bool hasIosDomainErrors = false;
   List<String> fakeIosDomains = [];
+
+  late DeepLinksService _deepLinksService;
+
+  @override
+  DeepLinksService get deepLinksService => _deepLinksService;
 
   @override
   Future<String?> packageDirectoryForMainIsolate() async {

--- a/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
@@ -19,7 +19,7 @@ class TestDeepLinksService extends DeepLinksService {
     this.hasIosDomainErrors = false,
   }) {
     // Create a mock client to return fake responses.
-    client = MockClient((request) async {
+    _client = MockClient((request) async {
       if (request.url == Uri.parse(androidDomainValidationURL)) {
         if (hasAndroidDomainErrors) {
           return Response(androidValidationResponseWithError, 200);
@@ -37,6 +37,11 @@ class TestDeepLinksService extends DeepLinksService {
       return Response('this is a body', 404);
     });
   }
+
+  late Client _client;
+
+  @override
+  Client get client => _client;
 
   final bool hasAndroidDomainErrors;
   final bool hasIosDomainErrors;

--- a/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
@@ -5,254 +5,21 @@
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/deep_link_validation/deep_links_model.dart';
 import 'package:devtools_app/src/screens/deep_link_validation/deep_links_services.dart';
-import 'package:devtools_shared/devtools_deeplink.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart';
 import 'package:http/testing.dart';
 
-// Fake responses for the deep link validation API.
-const androidValidationResponseWithNoError = '''
-{
-  "validationResult": [
-    {
-      "domainName": "example.com",
-      "passedChecks": [
-        {
-          "checkName": "HOST_FORMED_PROPERLY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "EXISTENCE",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "NON_REDIRECT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "HTTPS_ACCESSIBILITY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "CONTENT_TYPE",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "APP_IDENTIFIER",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "FINGERPRINT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "status": "CHECKED"
-    }
-  ],
-  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
-}
-''';
-
-const androidValidationResponseWithError = '''
-{
-  "validationResult": [
-    {
-      "domainName": "example.com",
-      "passedChecks": [
-        {
-          "checkName": "HOST_FORMED_PROPERLY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "NON_REDIRECT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "HTTPS_ACCESSIBILITY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "failedChecks": [
-        {
-          "checkName": "EXISTENCE",
-          "resultType": "FAILED_INDEPENDENTLY",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "CONTENT_TYPE",
-          "resultType": "FAILED_INDEPENDENTLY",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "APP_IDENTIFIER",
-          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "FINGERPRINT",
-          "resultType": "FAILED_DUE_TO_PREREQUISITE_FAILURE",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "status": "CHECKED"
-    }
-  ],
-  "googlePlayFingerprintsAvailability": "FINGERPRINTS_AVAILABLE"
-}
-''';
-
-const iosValidationResponseWithNoError = '''
-{
-  "validationResults": [
-    {
-      "domainName": "example.com",
-      "passedChecks": [
-        {
-          "checkName": "HTTPS_ACCESSIBILITY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "NON_REDIRECT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "EXISTENCE",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "APP_IDENTIFIER",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "FILE_FORMAT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "status": "VALIDATION_COMPLETE"
-    }
-  ]
-}
-''';
-
-const iosValidationResponseWithError = '''
-{
-  "validationResults": [
-    {
-      "domainName": "example.com",
-      "passedChecks": [
-        {
-          "checkName": "HTTPS_ACCESSIBILITY",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "NON_REDIRECT",
-          "resultType": "PASSED",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "failedChecks": [
-        {
-          "checkName": "EXISTENCE",
-          "resultType": "FAILED_INDEPENDENTLY",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "APP_IDENTIFIER",
-          "resultType": "FAILED_PREREQUISITE_FAILURE",
-          "severityLevel": "ERROR"
-        },
-        {
-          "checkName": "FILE_FORMAT",
-          "resultType": "FAILED_PREREQUISITE_FAILURE",
-          "severityLevel": "ERROR"
-        }
-      ],
-      "status": "VALIDATION_COMPLETE"
-    }
-  ]
-}
-''';
+import '../test_data/deep_link/fake_responses.dart';
 
 final defaultAndroidDeeplink = androidDeepLinkJson(defaultDomain);
 
-const androidDeepLinkWithPathErrors = '''{
-      "host": "example.com",
-      "path": "/path",
-      "intentFilterCheck": {
-        "hasBrowsableCategory": false,
-        "hasActionView": true,
-        "hasDefaultCategory": true,
-        "hasAutoVerify": true
-      }
-    }
-''';
-
-String androidDeepLinkJson(
-  String domain, {
-  String? scheme = 'http',
-  String? path = '/path',
-  bool hasPathError = false,
-}) {
-  return '''{
-${(scheme != null) ? '"scheme": "$scheme",' : ''}
-      "host": "$domain",
-      "path": "$path",
-      "intentFilterCheck": {
-        "hasBrowsableCategory": ${!hasPathError},
-        "hasActionView": true,
-        "hasDefaultCategory": true,
-        "hasAutoVerify": true
-      }
-    }
-''';
-}
-
-AppLinkSettings fakeAppLinkSettings(List<String> androidDeepLink) {
-  return AppLinkSettings.fromJson('''{
-  "deeplinks": [
-    ${androidDeepLink.join(',')}
-  ],
-  "deeplinkingFlagEnabled": true,
-  "applicationId": "app.id"
-}
-''');
-}
-
-const defaultDomain = 'example.com';
-UniversalLinkSettings fakeUniversalLinkSettings(List<String> domains) {
-  return UniversalLinkSettings.fromJson('''
-{
-  "bundleIdentifier": "app.id",
-  "teamIdentifier": "AAAABBBB",
-  "associatedDomains": [
-    ${domains.map(
-            (d) => '"$d"',
-          ).join(',')}
-  ]
-}
-''');
-}
-
-class DeepLinksTestController extends DeepLinksController {
-  DeepLinksTestController() {
+class DeepLinksTestServices extends DeepLinksServices {
+  DeepLinksTestServices({
+    this.hasAndroidDomainErrors = false,
+    this.hasIosDomainErrors = false,
+  }) {
     // Create a mock client to return fake responses.
-    final client = MockClient((request) async {
+    client = MockClient((request) async {
       if (request.url == Uri.parse(androidDomainValidationURL)) {
         if (hasAndroidDomainErrors) {
           return Response(androidValidationResponseWithError, 200);
@@ -261,7 +28,6 @@ class DeepLinksTestController extends DeepLinksController {
         }
       }
       if (request.url == Uri.parse(iosDomainValidationURL)) {
-        print('request.url == Uri.parse(iosDomainValidationURL');
         if (hasIosDomainErrors) {
           return Response(iosValidationResponseWithError, 200);
         } else {
@@ -270,13 +36,21 @@ class DeepLinksTestController extends DeepLinksController {
       }
       return Response('this is a body', 404);
     });
-    deepLinksServices = DeepLinksServices(client);
   }
 
-  @override
-  void dispose() {
-    client.close();
-    super.dispose();
+  final bool hasAndroidDomainErrors;
+  final bool hasIosDomainErrors;
+}
+
+class DeepLinksTestController extends DeepLinksController {
+  DeepLinksTestController({
+    this.hasAndroidDomainErrors = false,
+    this.hasIosDomainErrors = false,
+  }) {
+    deepLinksServices = DeepLinksTestServices(
+      hasAndroidDomainErrors: hasAndroidDomainErrors,
+      hasIosDomainErrors: hasIosDomainErrors,
+    );
   }
 
   List<String> fakeAndroidDeepLinks = [];


### PR DESCRIPTION
This is also a follow up for https://github.com/flutter/devtools/pull/8193.

This PR added a http client to deep link service and mocked it in DeepLinksTestController. The tests tested if the the mock client is called and the response is reflected in UI changes.

Using a single Client for multiple requests to the same server is also encouraged: 
https://github.com/dart-lang/http/blob/7f21111aa90eee8d6adfe5dc20d92d1c6ec21764/pkgs/http/lib/http.dart#L44-L45


Before this PR, DeepLinksTestController overrides the validation functionality in  DeepLinksController,  the tests were only testing UI, the validation functionality was not tested.




## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
