### PR TITLE
Fix ansi_up repeatedly compiling a regexp

### DIFF
--- a/third_party/packages/ansi_up/CHANGELOG.md
+++ b/third_party/packages/ansi_up/CHANGELOG.md
@@ -1,5 +1,12 @@
+## 1.0.1-dev
+* Fixed a regexp getting recompiled every time an `AnsiUp` is instantiated and
+  `decodeAnsiColorEscapeCodes` is called for the first time.
+
+  The regexp is now compiled once during the lifetime of the program.
+
 ## 1.0.0
 * Migrate to null safety.
 
 ## 0.0.2
-* Implemented `decodeAnsiColorEscapeCodes` in dart - now no longer using JS interop
+* Implemented `decodeAnsiColorEscapeCodes` in Dart - now no longer using JS
+  interop.

--- a/third_party/packages/ansi_up/lib/ansi_up.dart
+++ b/third_party/packages/ansi_up/lib/ansi_up.dart
@@ -4,8 +4,7 @@
 
 // ignore_for_file: constant_identifier_names
 
-/// ansi_up is an library that parses text containing ANSI color escape
-/// codes.
+/// ansi_up is a library that parses text containing ANSI color escape codes.
 library;
 
 class AnsiUp {
@@ -43,7 +42,6 @@ class AnsiUp {
   List<AnsiUpColor> palette256;
   AnsiUpColor? fg;
   AnsiUpColor? bg;
-  RegExp? _csiRegex;
 
   void _setupPalettes() {
     ansiColors.forEach(palette256.addAll);
@@ -103,37 +101,7 @@ class AnsiUp {
         return pkt;
       }
       if (nextChar == '[') {
-        _csiRegex ??= _cleanAndConvertToRegex(
-          '\n                        '
-          '^                           # beginning of line'
-          '\n                                                    #'
-          '\n                                                    '
-          '# First attempt'
-          '\n                        '
-          '(?:                         # legal sequence'
-          '\n                          '
-          '\\x1b\\[                      # CSI'
-          '\n                          '
-          '([\\x3c-\\x3f]?)              # private-mode char'
-          '\n                          '
-          '([\\d;]*)                    # any digits or semicolons'
-          '\n                          '
-          '([\\x20-\\x2f]?               # an intermediate modifier'
-          '\n                          '
-          '[\\x40-\\x7e])                # the command'
-          '\n                        )\n                        '
-          '|                           # alternate (second attempt)'
-          '\n                        '
-          '(?:                         # illegal sequence'
-          '\n                          '
-          '\\x1b\\[                      # CSI'
-          '\n                          '
-          '[\\x20-\\x7e]*                # anything legal'
-          '\n                          '
-          '([\\x00-\\x1f:])              # anything illegal'
-          '\n                        )\n                    ',
-        );
-        final match = _csiRegex!.firstMatch(_text);
+        final match = _csiRegex.firstMatch(_text);
         if (match == null) {
           pkt.kind = PacketKind.Incomplete;
           return pkt;
@@ -316,6 +284,24 @@ class AnsiUp {
   }
 }
 
+final RegExp _csiRegex = RegExp('^' // beginning of line
+    // First attempt
+    '(?:' // legal sequence
+    '\\x1b\\[' // CSI
+    '([\\x3c-\\x3f]?)' // private-mode char
+    '([\\d;]*)' // any digits or semicolons
+    '([\\x20-\\x2f]?' // an intermediate modifier
+    '[\\x40-\\x7e])' // the command
+    ')'
+
+    // Second attempt
+    '|'
+    '(?:' // illegal sequence
+    '\\x1b\\[' // CSI
+    '[\\x20-\\x7e]*' // anything legal
+    '([\\x00-\\x1f:])' // anything illegal
+    ')');
+
 class _TextWithAttr {
   _TextWithAttr({
     this.fg,
@@ -356,14 +342,6 @@ class _TextPacket {
 }
 
 String _colorToCss(List/*<int>*/ rgb) => 'rgb(${rgb.join(',')})';
-
-// Removes comments and spaces/newlines from a regex string that were present
-// for readability.
-RegExp _cleanAndConvertToRegex(String regexText) {
-  final RegExp spacesAndComments =
-      RegExp(r'^\s+|\s+\n|\s*#[\s\S]*?\n|\n', multiLine: true);
-  return RegExp(regexText.replaceAll(spacesAndComments, ''));
-}
 
 /// Chunk of styled text stored in a Dart friendly format.
 class StyledText {

--- a/third_party/packages/ansi_up/pubspec.yaml
+++ b/third_party/packages/ansi_up/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ansi_up
 description: Minimal package containing 'ansi_up' third_party dependency used by package:devtools.
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/ansi_up
-version: 1.0.0
+version: 1.0.1-dev
 
 environment:
   sdk: ^3.2.0


### PR DESCRIPTION
Move the _csiRegexp to the top-level level to avoid re-compiling it every time `decodeAnsiColorEscapeCodes` is called for the first time in a new `AnsiUp` instance.

Also move the comments out of the regexp string to avoid processing it twice.

This library is not tested, but I've confirmed that the regexp string is the same before and after the change. The regexp string:

    ^(?:\x1b\[([\x3c-\x3f]?)([\d;]*)([\x20-\x2f]?[\x40-\x7e]))|(?:\x1b\[[\x20-\x7e]*([\x00-\x1f:]))