### PR TITLE
Delete unreachable `default` clauses.

### DIFF
--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -37,7 +37,6 @@ enum DiffTreeType {
       case DiffTreeType.decreaseOnly:
         return 'Decrease Only';
       case DiffTreeType.combined:
-      default:
         return 'Combined';
     }
   }
@@ -55,7 +54,6 @@ enum AppUnit {
       case AppUnit.mainOnly:
         return _mainNodeName;
       case AppUnit.entireApp:
-      default:
         return _entireAppNodeName;
     }
   }
@@ -185,7 +183,6 @@ class AppSizeController {
       case AppUnit.deferredOnly:
         return _deferredDiffTreeMap;
       case AppUnit.entireApp:
-      default:
         return _diffTreeMap;
     }
   }
@@ -205,8 +202,6 @@ class AppSizeController {
         return diffMap.decreaseOnly;
       case DiffTreeType.combined:
         return diffMap.combined;
-      default:
-        return diffMap.combined;
     }
   }
 
@@ -221,7 +216,6 @@ class AppSizeController {
       case AppUnit.mainOnly:
         return _mainOnly;
       case AppUnit.entireApp:
-      default:
         return _entireApp;
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector/layout_explorer/flex/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/layout_explorer/flex/utils.dart
@@ -197,7 +197,6 @@ extension AxisExtension on Axis {
       case Axis.horizontal:
         return 'Row';
       case Axis.vertical:
-      default:
         return 'Column';
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/flex/utils.dart
@@ -197,7 +197,6 @@ extension AxisExtension on Axis {
       case Axis.horizontal:
         return 'Row';
       case Axis.vertical:
-      default:
         return 'Column';
     }
   }

--- a/packages/devtools_app/lib/src/shared/charts/chart.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart.dart
@@ -698,10 +698,6 @@ class ChartPainter extends CustomPainter {
         );
         canvas.drawPath(path, paintFirst);
         break;
-      default:
-        final message = 'Unknown symbol ${characteristics.symbol}';
-        assert(false, message);
-        _log.shout(message);
     }
   }
 

--- a/packages/devtools_app/lib/src/shared/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/shared/charts/treemap.dart
@@ -123,8 +123,6 @@ class _TreemapState extends State<Treemap> {
           }
         }
         return pivotIndex;
-      default:
-        return -1;
     }
   }
 

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -518,7 +518,6 @@ class TimeRange {
       case TimeUnit.microseconds:
         return '[${_start?.inMicroseconds} μs - ${end?.inMicroseconds} μs]';
       case TimeUnit.milliseconds:
-      default:
         return '[${_start?.inMilliseconds} ms - ${end?.inMilliseconds} ms]';
     }
   }

--- a/packages/devtools_app/lib/src/shared/table/_table_row.dart
+++ b/packages/devtools_app/lib/src/shared/table/_table_row.dart
@@ -365,7 +365,6 @@ class _TableRowState<T> extends State<TableRow<T>>
       case ColumnAlignment.right:
         return Alignment.centerRight;
       case ColumnAlignment.left:
-      default:
         return Alignment.centerLeft;
     }
   }

--- a/packages/devtools_app/lib/src/shared/table/table_data.dart
+++ b/packages/devtools_app/lib/src/shared/table/table_data.dart
@@ -175,7 +175,6 @@ extension ColumnDataExtension<T> on ColumnData<T> {
       case ColumnAlignment.right:
         return MainAxisAlignment.end;
       case ColumnAlignment.left:
-      default:
         return MainAxisAlignment.start;
     }
   }
@@ -187,7 +186,6 @@ extension ColumnDataExtension<T> on ColumnData<T> {
       case ColumnAlignment.right:
         return TextAlign.right;
       case ColumnAlignment.left:
-      default:
         return TextAlign.left;
     }
   }


### PR DESCRIPTION
The Dart analyzer will soon be changed so that if the `default` clause of a `switch` statement is determined to be unreachable by the exhaustiveness checker, a new warning of type
`unreachable_switch_default` will be issued. This parallels the behavior of the existing `unreachable_switch_case` warning, which is issued whenever a `case` clause of a `switch` statement is determined to be unreachable. For details see
https://github.com/dart-lang/sdk/issues/54575.

This PR deletes unreachable `default` clauses from `devtools` now, to avoid a spurious warning when the analyzer change lands.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
