### PR TITLE
Add dep override to ansi_up

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -164,6 +164,8 @@ flutter:
         - asset: packages/codicon/font/codicon.ttf
 
 dependency_overrides:
+  ansi_up:
+    path: ../../third_party/packages/ansi_up
   devtools_shared:
     path: ../devtools_shared
   devtools_app_shared:


### PR DESCRIPTION
Use the version in the tree instead of from pub.dev to be able to use the latest changes always, without having to publish a new version.