### PR TITLE
Prepare for release 2.39.0

### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -9,4 +9,4 @@
 // the constant declaration `const version =`.
 // If you change the declaration you must also modify the regex in
 // tools/update_version.dart.
-const version = '2.39.0-dev.18';
+const version = '2.39.0';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.39.0-dev.18
+version: 2.39.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 


### PR DESCRIPTION
Uses Flutter version `3e4f1cdf494e09304587f648456f2560d3628fe9`
See https://github.com/flutter/devtools/pull/8255