### PR TITLE
force fetch tags from tools/build_release.sh

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -42,7 +42,7 @@ set -ex
 pushd "$FLUTTER_DIR"
   # The flutter tool relies on git tags to determine its version
   git fetch --tags https://github.com/flutter/flutter.git
-  git describe --tags
+  git describe --tags -f
   # Print out local tags for debugging
   git tag -l
 popd


### PR DESCRIPTION
Workaround for https://github.com/flutter/flutter/issues/142521

Follow up to https://github.com/flutter/devtools/pull/8257

Last build failed (I think) because fetching tags would have clobbered already existings ones:

` ! [rejected]              v0.0.11                 -> v0.0.11  (would clobber existing tag)`

This PR passes the force `-f` flag to `git fetch`, the same as the flutter tool does: https://github.com/flutter/flutter/blob/master/packages/flutter_tools/lib/src/version.dart#L968