### PR TITLE
tools/build_release.sh force fetch and delete earlier flutter tool version file

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -40,9 +40,11 @@ set -ex
 # TODO(fujino): delete once https://github.com/flutter/flutter/issues/142521
 # is resolved.
 pushd "$FLUTTER_DIR"
+  # If we've already written the wrong version number to disk, delete it
+  rm -f bin/cache/flutter.version.json
   # The flutter tool relies on git tags to determine its version
-  git fetch --tags https://github.com/flutter/flutter.git
-  git describe --tags -f
+  git fetch https://github.com/flutter/flutter.git --tags -f
+  git describe --tags
   # Print out local tags for debugging
   git tag -l
 popd


### PR DESCRIPTION
Workaround for https://github.com/flutter/flutter/issues/142521

A follow-up to https://github.com/flutter/devtools/pull/8258

Last time I added the `-f` flag to `git describe`, and not `git fetch`. Also, attempt to delete an older cached flutter version file in case it contains `v0.0.0`.