### PR TITLE
fix release build: ensure FLUTTER_DIR is set, even if --no-update-flutter is passed

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -21,8 +21,9 @@ pushd $TOOL_DIR
 if [[ $1 = "--no-update-flutter" ]]
 then
   # Use the Flutter SDK that is already on the user's PATH.
-  FLUTTER_EXE=`which flutter`
+  FLUTTER_EXE="$(which flutter)"
   echo "Using the Flutter SDK that is already on PATH: $FLUTTER_EXE"
+  FLUTTER_DIR="$(dirname "$(dirname "$FLUTTER_EXE")")"
 else
   # Use the Flutter SDK from flutter-sdk/.
   FLUTTER_DIR="`pwd`/flutter-sdk"
@@ -35,7 +36,7 @@ fi
 popd
 
 # echo on
-set -ex
+set -eux
 
 # TODO(fujino): delete once https://github.com/flutter/flutter/issues/142521
 # is resolved.


### PR DESCRIPTION
In previous builds, the `$FLUTTER_DIR` var was unset because the recipe is passing the `--no-update-flutter` flag. Ensure we always set this variable.

In addition, adding the `-u` setting means the script will fail if we try to de-reference an unset variable, which is almost certainly an error (without this, bash defaults to an empty string).