### PR TITLE
Account for the optional parameters that will be added in package:vm_service 14.3.0

### DIFF
--- a/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
+++ b/packages/devtools_app/lib/src/service/vm_service_wrapper.dart
@@ -153,6 +153,7 @@ class VmServiceWrapper extends VmService {
     String objectId, {
     int? offset,
     int? count,
+    String? idZoneId,
   }) {
     final cachedObj = fakeServiceCache.getObject(
       objectId: objectId,

--- a/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
+++ b/packages/devtools_test/lib/src/mocks/fake_vm_service_wrapper.dart
@@ -272,6 +272,7 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
     String objectId, {
     int? offset,
     int? count,
+    String? idZoneId,
   }) {
     return Future.value(MockObj());
   }
@@ -298,7 +299,11 @@ class FakeVmServiceWrapper extends Fake implements VmServiceWrapper {
   }
 
   @override
-  Future<Stack> getStack(String isolateId, {int? limit}) {
+  Future<Stack> getStack(
+    String isolateId, {
+    int? limit,
+    String? idZoneId,
+  }) {
     return Future.value(Stack(frames: [], messages: [], truncated: false));
   }
 


### PR DESCRIPTION
This is needed to land the SDK CL that checks in package:vm_service 14.3.0, because this is needed to make the g3-cbuild-try job pass.