### PR TITLE
[deep link] Make path a class to add isExclude and queryParam

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -207,7 +207,7 @@ class DeepLinksController extends DisposableController
         },
         associatedPath: [
           ...previousRecord?.associatedPath ?? [],
-          if (!(linkData.path?.isExcluded ?? true)) linkData.path!.path,
+          if (linkData.path != null && !linkData.path!.isExcluded) linkData.path!.path,
         ],
         domainErrors: linkData.domainErrors,
         hasAndroidAssetLinksFile: linkData.hasAndroidAssetLinksFile,
@@ -552,7 +552,7 @@ class DeepLinksController extends DisposableController
           false);
 
       if (linkdata.os.contains(PlatformOS.ios)) {
-        final iosPaths = iosDomainPaths[linkdata.domain] ?? <String>[];
+        final iosPaths = iosDomainPaths[linkdata.domain] ?? <Path>[];
 
         // If no path is provided, we will still show the domain just with domain errors.
         if (iosPaths.isEmpty) {

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -207,8 +207,7 @@ class DeepLinksController extends DisposableController
         },
         associatedPath: [
           ...previousRecord?.associatedPath ?? [],
-          if (linkData.path != null && !linkData.path!.isExcluded)
-            linkData.path!.path,
+          if (!(linkData.path?.isExcluded ?? true)) linkData.path!.path,
         ],
         domainErrors: linkData.domainErrors,
         hasAndroidAssetLinksFile: linkData.hasAndroidAssetLinksFile,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -168,9 +168,9 @@ class DeepLinksController extends DisposableController
       if (path == null) {
         continue;
       }
-      final previousRecord = linkDatasByPath[path];
+      final previousRecord = linkDatasByPath[path.path];
 
-      linkDatasByPath[path] = LinkData(
+      linkDatasByPath[path.path] = LinkData(
         domain: linkData.domain,
         path: linkData.path,
         scheme: linkData.scheme.union(previousRecord?.scheme ?? {}),
@@ -207,7 +207,8 @@ class DeepLinksController extends DisposableController
         },
         associatedPath: [
           ...previousRecord?.associatedPath ?? [],
-          if (linkData.path != null) linkData.path!,
+          if (linkData.path != null && !linkData.path!.isExcluded)
+            linkData.path!.path,
         ],
         domainErrors: linkData.domainErrors,
         hasAndroidAssetLinksFile: linkData.hasAndroidAssetLinksFile,
@@ -401,7 +402,7 @@ class DeepLinksController extends DisposableController
       if (domainPathToLinkData[domainAndPath] == null) {
         domainPathToLinkData[domainAndPath] = LinkData(
           domain: appLink.host,
-          path: appLink.path,
+          path: Path(path: appLink.path),
           pathErrors:
               _getPathErrorsFromIntentFilterChecks(appLink.intentFilterChecks),
           os: {PlatformOS.android},
@@ -510,7 +511,7 @@ class DeepLinksController extends DisposableController
     Map<String, List<DomainError>> iosDomainErrors =
         <String, List<DomainError>>{};
 
-    late final Map<String, List<String>> iosDomainPaths;
+    late final Map<String, List<Path>> iosDomainPaths;
     try {
       final androidResult = await deepLinksService.validateAndroidDomain(
         domains: domains,
@@ -593,7 +594,7 @@ class DeepLinksController extends DisposableController
 
   Future<List<LinkData>> _validatePath(List<LinkData> linkdatas) async {
     for (final linkData in linkdatas) {
-      final path = linkData.path;
+      final path = linkData.path?.path;
       if (path == null) {
         continue;
       }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_controller.dart
@@ -207,7 +207,8 @@ class DeepLinksController extends DisposableController
         },
         associatedPath: [
           ...previousRecord?.associatedPath ?? [],
-          if (linkData.path != null && !linkData.path!.isExcluded) linkData.path!.path,
+          if (linkData.path != null && !linkData.path!.isExcluded)
+            linkData.path!.path,
         ],
         domainErrors: linkData.domainErrors,
         hasAndroidAssetLinksFile: linkData.hasAndroidAssetLinksFile,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -258,7 +258,7 @@ class Path {
   final Map<String, String> queryParams;
 
   /// A Boolean value that indicates whether to stop pattern matching and prevent the universal
-  /// link from opening if the URL matches the associated pattern. 
+  /// link from opening if the URL matches the associated pattern.
   ///
   /// The default is false.
   final bool isExcluded;

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -244,6 +244,19 @@ class ValidatedLinkDatas {
   final List<LinkData> byPath;
 }
 
+class Path {
+  Path({
+    required this.path,
+    this.queryParams = const {},
+    this.isExcluded = false,
+  });
+  final String path;
+
+  // TODO(hangyujin): display queryParams in path table.
+  final Map<String, String> queryParams;
+  final bool isExcluded;
+}
+
 /// Contains all data relevant to a deep link.
 class LinkData with SearchableDataMixin {
   LinkData({
@@ -259,7 +272,7 @@ class LinkData with SearchableDataMixin {
     this.hasIosAasaFile = true,
   });
 
-  final String? path;
+  final Path? path;
   final String? domain;
   final Set<PlatformOS> os;
   final Set<String> scheme;
@@ -274,17 +287,17 @@ class LinkData with SearchableDataMixin {
   @override
   bool matchesSearchToken(RegExp regExpSearch) {
     return (domain?.caseInsensitiveContains(regExpSearch) ?? false) ||
-        (path?.caseInsensitiveContains(regExpSearch) ?? false);
+        (path?.path.caseInsensitiveContains(regExpSearch) ?? false);
   }
 
   @override
   String toString() => 'LinkData($domain $path $os)';
 
-  String get safePath => path ?? '';
+  String get safePath => path?.path ?? '';
   String get safeDomain => domain ?? '';
 
   LinkData copyWith({
-    String? path,
+    Path? path,
     List<DomainError>? domainErrors,
     bool? hasAndroidAssetLinksFile,
     bool? hasIosAasaFile,
@@ -501,7 +514,8 @@ class PathColumn extends ColumnData<LinkData>
     return _ErrorAwareText(
       isError: dataObject.pathErrors.isNotEmpty,
       controller: controller,
-      text: dataObject.safePath,
+      text:
+          '${(dataObject.path?.isExcluded ?? false) ? 'NOT ' : ''}${getValue(dataObject)}',
       link: dataObject,
     );
   }

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -257,8 +257,10 @@ class Path {
   // TODO(hangyujin): display queryParams in path table.
   final Map<String, String> queryParams;
 
-  // A Boolean value that indicates whether to stop pattern matching and prevent the universal
-  // link from opening if the URL matches the associated pattern. The default is false.
+  /// A Boolean value that indicates whether to stop pattern matching and prevent the universal
+  /// link from opening if the URL matches the associated pattern. 
+  ///
+  /// The default is false.
   final bool isExcluded;
 }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_model.dart
@@ -244,16 +244,21 @@ class ValidatedLinkDatas {
   final List<LinkData> byPath;
 }
 
+/// Represents a path in a deep link.
 class Path {
   Path({
     required this.path,
     this.queryParams = const {},
     this.isExcluded = false,
   });
+
   final String path;
 
   // TODO(hangyujin): display queryParams in path table.
   final Map<String, String> queryParams;
+
+  // A Boolean value that indicates whether to stop pattern matching and prevent the universal
+  // link from opening if the URL matches the associated pattern. The default is false.
   final bool isExcluded;
 }
 

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -201,7 +201,6 @@ class DeepLinksService {
               }
             }
           }
-          paths[domainName] ??= <Path>[];
           final aasaAppPaths = (domainResult[_aasaAppPathsKey] as List?)
               ?.cast<Map<String, Object?>>();
           if (aasaAppPaths != null) {
@@ -212,12 +211,10 @@ class DeepLinksService {
                 for (final aasaPath in aasaPaths) {
                   final rawQueryParams = (aasaPath[_queryParamsKey] as List?)
                       ?.cast<Map<String, Object?>>();
-                  final Map<String, String> queryParams = rawQueryParams != null
-                      ? {
-                          for (final item in rawQueryParams)
-                            item[_keyKey] as String: item[_valueKey] as String,
-                        }
-                      : {};
+                  final  queryParams = <String, String>{
+                    for (final item in rawQueryParams ?? <Map>[])
+                      item[_keyKey] as String: item[_valueKey] as String,
+                  };
                   paths.putIfAbsent(domainName, () => <Path>[]).add(
                         Path(
                           path: aasaPath[_pathKey] as String,

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -211,7 +211,7 @@ class DeepLinksService {
                 for (final aasaPath in aasaPaths) {
                   final rawQueryParams = (aasaPath[_queryParamsKey] as List?)
                       ?.cast<Map<String, Object?>>();
-                  final  queryParams = <String, String>{
+                  final queryParams = <String, String>{
                     for (final item in rawQueryParams ?? <Map>[])
                       item[_keyKey] as String: item[_valueKey] as String,
                   };

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -62,6 +62,10 @@ const _iosValidationResultsKey = 'validationResults';
 const _aasaAppPathsKey = 'aasaAppPaths';
 const _aasaPathsKey = 'aasaPaths';
 const _pathKey = 'path';
+const _isExcludedKey = 'isExcluded';
+const _queryParamsKey = 'queryParams';
+const _keyKey = 'key';
+const _valueKey = 'value';
 
 const iosCheckNameToDomainError = <String, DomainError>{
   'EXISTENCE': IosDomainError.existence,
@@ -75,7 +79,7 @@ class ValidateIosDomainResult {
   ValidateIosDomainResult(this.errorCode, this.domainErrors, this.paths);
   final String errorCode;
   final Map<String, List<DomainError>> domainErrors;
-  final Map<String, List<String>> paths;
+  final Map<String, List<Path>> paths;
 }
 
 class GenerateAssetLinksResult {
@@ -158,7 +162,7 @@ class DeepLinksService {
     required List<String> domains,
   }) async {
     final domainErrors = <String, List<DomainError>>{};
-    final paths = <String, List<String>>{};
+    final paths = <String, List<Path>>{};
     // TODO(hangyujin): Add error code to the result.
     const errorCode = '';
 
@@ -197,6 +201,7 @@ class DeepLinksService {
               }
             }
           }
+          paths[domainName] ??= <Path>[];
           final aasaAppPaths = (domainResult[_aasaAppPathsKey] as List?)
               ?.cast<Map<String, Object?>>();
           if (aasaAppPaths != null) {
@@ -205,9 +210,22 @@ class DeepLinksService {
                   ?.cast<Map<String, Object?>>();
               if (aasaPaths != null) {
                 for (final aasaPath in aasaPaths) {
-                  paths
-                      .putIfAbsent(domainName, () => <String>[])
-                      .add(aasaPath[_pathKey] as String);
+                  final rawQueryParams = (aasaPath[_queryParamsKey] as List?)
+                      ?.cast<Map<String, Object?>>();
+                  final Map<String, String> queryParams = rawQueryParams != null
+                      ? {
+                          for (final item in rawQueryParams)
+                            item[_keyKey] as String: item[_valueKey] as String,
+                        }
+                      : {};
+                  paths.putIfAbsent(domainName, () => <Path>[]).add(
+                        Path(
+                          path: aasaPath[_pathKey] as String,
+                          queryParams: queryParams,
+                          isExcluded:
+                              aasaPath[_isExcludedKey] as bool? ?? false,
+                        ),
+                      );
                 }
                 continue;
               }

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -574,7 +574,7 @@ void main() {
         expect(find.text('/path2'), findsOneWidget);
         expect(find.text('/path3'), findsOneWidget);
         expect(find.text('/ios-path1'), findsOneWidget);
-        expect(find.text('/ios-path2'), findsOneWidget);
+        expect(find.text('NOT /ios-path2'), findsOneWidget);
 
         // Only show links with path error.
         deepLinksController.updateDisplayOptions(
@@ -587,7 +587,7 @@ void main() {
         expect(find.text('/path2'), findsOneWidget);
         expect(find.text('/path3'), findsNothing);
         expect(find.text('/ios-path1'), findsNothing);
-        expect(find.text('/ios-path2'), findsNothing);
+        expect(find.text('NOT /ios-path2'), findsNothing);
 
         // Only show links with no issue.
         deepLinksController.updateDisplayOptions(
@@ -603,7 +603,7 @@ void main() {
         expect(find.text('/path2'), findsNothing);
         expect(find.text('/path3'), findsOneWidget);
         expect(find.text('/ios-path1'), findsOneWidget);
-        expect(find.text('/ios-path2'), findsOneWidget);
+        expect(find.text('NOT /ios-path2'), findsOneWidget);
       },
     );
   });

--- a/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
+++ b/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
@@ -158,6 +158,7 @@ const iosValidationResponseWithNoError = '''
             },
             {
               "path": "/ios-path2",
+              "isExcluded": true,
               "queryParams": [
                 {
                   "key": "dplnk",
@@ -230,6 +231,7 @@ const iosValidationResponseWithError = '''
             },
             {
               "path": "/ios-path2",
+              "isExcluded": true,
               "queryParams": [
                 {
                   "key": "dplnk",


### PR DESCRIPTION
Context: 
A deeplink path in AASA file is more than just a string, it can have other attributions like `exclude` , 

exclude : A Boolean value that indicates whether to stop pattern matching and prevent the universal link from opening if the URL matches the associated pattern. The default is false. 

For a excluded path, we just display them as  `NOT /path` in the path table.

For other attributions, will add them in the UI later. 






## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
