### PR TITLE
add health checks for breaking changes, changelogs, pubspecs, etc

### DIFF
--- a/.github/workflows/health.yaml
+++ b/.github/workflows/health.yaml
@@ -1,0 +1,13 @@
+name: Health
+on:
+  pull_request:
+    branches: [ main, master ]
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+jobs:
+  health:
+    uses: dart-lang/ecosystem/.github/workflows/health.yaml@main
+    with:
+      use-flutter: true
+      checks: "version,changelog,license,breaking,do-not-submit,leaking"
+    permissions:
+      pull-requests: write

--- a/.github/workflows/post_summaries.yaml
+++ b/.github/workflows/post_summaries.yaml
@@ -1,0 +1,16 @@
+name: Comment on the pull request
+
+on:
+  # Trigger this workflow after the Health workflow completes. This workflow will have permissions to
+  # do things like create comments on the PR, even if the original workflow couldn't.
+  workflow_run:
+    workflows:
+      - Health
+    types:
+      - completed
+
+jobs:
+  upload:
+    uses: dart-lang/ecosystem/.github/workflows/post_summaries.yaml@main
+    permissions:
+      pull-requests: write


### PR DESCRIPTION
Add a health check job that checks various things, such as changelog entries and proper semver.

Would avoid issues such as the one in https://github.com/flutter/devtools/pull/8291 where breaking changes are accidentally released in non-breaking versions.

I am not actually sure this works with repos that are a mixture of flutter and dart packages, we might need some extra functionality from the health check tool if this fails on the non-flutter packages.

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.