### PR TITLE
Fix bug with timeline overlay and improve logging

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -165,8 +165,11 @@ class _ExtensionIFrameController extends DisposableController
     final message = event.toJson();
     assert(
       embeddedExtensionController.extensionIFrame.contentWindow != null,
-      'Something went wrong. The iFrame\'s contentWindow is null after the'
-      ' _iFrameReady future completed.',
+      'Something went wrong. The '
+      '${embeddedExtensionController.extensionConfig.name} extension\'s iFrame '
+      'contentWindow is null after the _iFrameReady future completed. The '
+      'message that was being posted when the error occurred was:\n'
+      '${message.toString()}',
     );
     embeddedExtensionController.extensionIFrame.contentWindow!.postMessage(
       message.jsify(),

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -270,8 +270,9 @@ class _PerfettoViewController extends DisposableController
     final iFrameWindow = perfettoController.perfettoIFrame.contentWindow;
     if (iFrameWindow == null) {
       _log.warning(
-        'Something went wrong. The iFrame\'s contentWindow is null after the'
-        ' _perfettoIFrameReady future completed.',
+        'Something went wrong. The Perfetto iFrame\'s contentWindow is null '
+        'after the _perfettoIFrameReady future completed. The message that '
+        'was being posted when the error occurred was:\n${message.toString()}',
       );
       return;
     }

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -49,7 +49,8 @@ class _TimelineEventsTabViewState extends State<TimelineEventsTabView>
     super.initState();
     addAutoDisposeListener(widget.controller.status, () {
       final status = widget.controller.status.value;
-      if (status == EventsControllerStatus.refreshing) {
+      if (status == EventsControllerStatus.refreshing &&
+          widget.controller.isActiveFeature) {
         _insertOverlay();
       } else {
         _removeOverlay();

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -19,7 +19,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Performance updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed an issue with the "Refreshing timeline" overlay that was getting shown
+when it should not have been. - [#8318](https://github.com/flutter/devtools/pull/8318)
 
 ## CPU profiler updates
 


### PR DESCRIPTION
The "refreshing timeline" overlay was showing on the Performance page even when the Timeline Events tab was not selected. This PR addresses the issue by only showing the overlay when the Timeline is the active feature on the Performance page. This PR also adds some additional information to warnings about iFrames.