### PR TITLE
called getFullRequestData() before export

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -388,8 +388,7 @@ class NetworkController extends DisposableController
     }
   }
 
-  Future<void> _fetchFullDataBeforeExport() =>
-      Future.wait(
+  Future<void> _fetchFullDataBeforeExport() => Future.wait(
         filteredData.value
             .whereType<DartIOHttpRequestData>()
             .map((item) => item.getFullRequestData()),

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -61,7 +61,8 @@ class NetworkController extends DisposableController
   }
   List<DartIOHttpRequestData>? _httpRequests;
 
-  String? exportAsHarFile() {
+  Future<String?> exportAsHarFile() async {
+    await _fetchFullDataBeforeExport();
     _httpRequests =
         filteredData.value.whereType<DartIOHttpRequestData>().toList();
 
@@ -384,6 +385,15 @@ class NetworkController extends DisposableController
   void _checkForError(NetworkRequest r) {
     if (r.didFail) {
       serviceConnection.errorBadgeManager.incrementBadgeCount(NetworkScreen.id);
+    }
+  }
+
+  Future<void> _fetchFullDataBeforeExport() async {
+    for (final NetworkRequest item in filteredData.value) {
+      // Check if the request is of type DartIOHttpRequestData and fetch full data
+      if (item is DartIOHttpRequestData) {
+        await item.getFullRequestData();
+      }
     }
   }
 }

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -388,14 +388,12 @@ class NetworkController extends DisposableController
     }
   }
 
-  Future<void> _fetchFullDataBeforeExport() async {
-    for (final NetworkRequest item in filteredData.value) {
-      // Check if the request is of type DartIOHttpRequestData and fetch full data
-      if (item is DartIOHttpRequestData) {
-        await item.getFullRequestData();
-      }
-    }
-  }
+  Future<void> _fetchFullDataBeforeExport() =>
+      Future.wait(
+        filteredData.value
+            .whereType<DartIOHttpRequestData>()
+            .map((item) => item.getFullRequestData()),
+      );
 }
 
 /// Class for managing the set of all current sockets, and

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -41,7 +41,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## Network profiler updates
 
-TODO: Remove this section if there are not any general updates.
+* Resolved an issue in .har export where response content was sometimes missing in the data. - [#8333](https://github.com/flutter/devtools/pull/8333)
 
 ## Logging updates
 


### PR DESCRIPTION
Fixes bug -
Not able to see response content in exported har for few requests.

*List which issues are fixed by this PR.*
https://github.com/flutter/devtools/issues/8253

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
