### PR TITLE
Fix type-cast error when deserializing a widget's `size`

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
@@ -96,7 +96,7 @@ List<double> computeRenderSizes({
 class LayoutProperties {
   LayoutProperties(this.node, {int copyLevel = 1})
       : description = node.description,
-        size = node.size,
+        size = node.size!,
         constraints = node.constraints,
         isFlex = node.isFlex,
         flexFactor = node.flexFactor,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -152,8 +152,6 @@ class LayoutProperties {
     }
   }
 
-  static bool hasLayout(RemoteDiagnosticsNode node) => node.size != null;
-
   LayoutProperties? parent;
   final RemoteDiagnosticsNode node;
   final List<LayoutProperties> children;

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -119,7 +119,7 @@ enum SizeType {
 class LayoutProperties {
   LayoutProperties(this.node, {int copyLevel = 1})
       : description = node.description,
-        size = node.size,
+        size = node.size!,
         constraints = node.constraints,
         isFlex = node.isFlex,
         flexFactor = node.flexFactor,
@@ -127,6 +127,7 @@ class LayoutProperties {
         children = copyLevel == 0
             ? []
             : node.childrenNow
+                .where((child) => child.size != null)
                 .map(
                   (child) => LayoutProperties(child, copyLevel: copyLevel - 1),
                 )
@@ -150,6 +151,8 @@ class LayoutProperties {
       child.parent = this;
     }
   }
+
+  static bool hasLayout(RemoteDiagnosticsNode node) => node.size != null;
 
   LayoutProperties? parent;
   final RemoteDiagnosticsNode node;

--- a/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
@@ -75,10 +75,13 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
       );
   }
 
-  static Size deserializeSize(Map<String, Object> json) {
+  static Size? deserializeSize(Map<String, Object> json) {
+    final width = json['width'] as String?;
+    final height = json['height'] as String?;
+    if (width == null || height == null) return null;
     return Size(
-      double.parse(json['width'] as String),
-      double.parse(json['height'] as String),
+      double.parse(width),
+      double.parse(height),
     );
   }
 
@@ -153,7 +156,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   // [deserializeSize] expects a parameter of type Map<String, Object> (note the
   // non-nullable Object), so we need to first type check as a Map and then we
   // can cast to the expected type.
-  Size get size => deserializeSize(
+  Size? get size => deserializeSize(
         (json['size'] as Map?)?.cast<String, Object>() ?? <String, Object>{},
       );
 
@@ -454,8 +457,9 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     return json[memberName] as bool;
   }
 
-  LayoutProperties computeLayoutProperties({required bool forFlexLayout}) {
+  LayoutProperties? computeLayoutProperties({required bool forFlexLayout}) {
     assert(!forFlexLayout || (forFlexLayout && isFlexLayout));
+    if (size == null) return null;
     return forFlexLayout
         ? FlexLayoutProperties.fromDiagnostics(this)
         : LayoutProperties(this);
@@ -472,9 +476,7 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
     return this;
   }
 
-  // TODO(https://github.com/flutter/devtools/issues/8238): Actually determine
-  // whether this node has a box layout.
-  bool get isBoxLayout => true;
+  bool get isBoxLayout => size != null;
 
   bool get isFlexLayout => isFlex || (parent?.isFlex ?? false);
 

--- a/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/diagnostics_node.dart
@@ -156,9 +156,12 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   // [deserializeSize] expects a parameter of type Map<String, Object> (note the
   // non-nullable Object), so we need to first type check as a Map and then we
   // can cast to the expected type.
-  Size? get size => deserializeSize(
-        (json['size'] as Map?)?.cast<String, Object>() ?? <String, Object>{},
-      );
+  Size? get size {
+    final sizeMap = json['size'] as Map?;
+    return sizeMap == null
+        ? null
+        : deserializeSize(sizeMap.cast<String, Object>());
+  }
 
   bool get isLocalClass {
     final objectGroup = objectGroupApi;
@@ -458,7 +461,9 @@ class RemoteDiagnosticsNode extends DiagnosticableTree {
   }
 
   LayoutProperties? computeLayoutProperties({required bool forFlexLayout}) {
-    assert(!forFlexLayout || (forFlexLayout && isFlexLayout));
+    if ((!forFlexLayout && !isBoxLayout) || (forFlexLayout && !isFlexLayout)) {
+      return null;
+    }
     if (size == null) return null;
     return forFlexLayout
         ? FlexLayoutProperties.fromDiagnostics(this)


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8238

Fixes bug where type-cast error would be displayed instead of widget properties.

### Before
<img width="785" alt="Screenshot 2024-09-24 at 10 47 12 AM" src="https://github.com/user-attachments/assets/c356c87b-13c8-44a8-93e0-4a9bfb616eef">

### After
<img width="796" alt="Screenshot 2024-09-24 at 11 05 28 AM" src="https://github.com/user-attachments/assets/086fa822-6361-49c5-aecf-9c54c56c206a">

