### PR TITLE
[deep link]  Check severityLevel and stop showing warnings (treat them as passing)

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/deep_links_services.dart
@@ -26,6 +26,8 @@ const postHeader = {'Content-Type': 'application/json'};
 // The keys used in both android and ios domain validation API.
 const _domainNameKey = 'domainName';
 const _checkNameKey = 'checkName';
+const _severityLevelKey = 'severityLevel';
+const _severityLevelError = 'ERROR';
 const _failedChecksKey = 'failedChecks';
 const _domainBatchSize = 500;
 
@@ -194,7 +196,8 @@ class DeepLinksService {
             for (final failedCheck in failedChecks) {
               final checkName = failedCheck[_checkNameKey] as String;
               final domainError = iosCheckNameToDomainError[checkName];
-              if (domainError != null) {
+              final severityLevel = failedCheck[_severityLevelKey] as String;
+              if (domainError != null && severityLevel == _severityLevelError) {
                 domainErrors
                     .putIfAbsent(domainName, () => <DomainError>[])
                     .add(domainError);

--- a/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
+++ b/packages/devtools_app/test/deep_link_vlidation/deep_links_screen_test.dart
@@ -214,9 +214,8 @@ void main() {
       (WidgetTester tester) async {
         final deepLinksController = TestDeepLinksController(
           hasAndroidDomainErrors: true,
-          hasIosDomainErrors: true,
+          iosValidationResponse: iosValidationResponseWithError,
         );
-
         deepLinksController
           ..selectedProject.value = FlutterProject(
             path: '/abc',
@@ -269,7 +268,7 @@ void main() {
       (WidgetTester tester) async {
         final deepLinksController = TestDeepLinksController(
           hasAndroidDomainErrors: true,
-          hasIosDomainErrors: true,
+          iosValidationResponse: iosValidationResponseWithError,
         );
 
         deepLinksController
@@ -295,6 +294,44 @@ void main() {
         expect(find.byType(ValidationDetailView), findsOneWidget);
         expect(find.text('Digital assets link file'), findsOneWidget);
         expect(find.text('Apple-App-Site-Association file'), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'Don\'t show domain errors when they are just warnings',
+      windowSize,
+      (WidgetTester tester) async {
+        final deepLinksController = TestDeepLinksController(
+          iosValidationResponse: iosValidationResponseWithWarning,
+        );
+
+        deepLinksController
+          ..selectedProject.value = FlutterProject(
+            path: '/abc',
+            androidVariants: ['debug', 'release'],
+            iosBuildOptions: xcodeBuildOptions,
+          )
+          ..fakeAndroidDeepLinks = [
+            androidDeepLinkJson('www.domain1.com'),
+            androidDeepLinkJson('www.google.com'),
+          ]
+          ..fakeIosDomains = [defaultDomain];
+
+        await pumpDeepLinkScreen(
+          tester,
+          controller: deepLinksController,
+        );
+
+        expect(find.text('www.domain1.com'), findsOneWidget);
+        expect(find.text('example.com'), findsOneWidget);
+        expect(find.text('www.google.com'), findsOneWidget);
+
+        await tester.tap(find.text('example.com'));
+        await tester.pumpAndSettle(const Duration(milliseconds: 500));
+
+        final domainErrors =
+            deepLinksController.selectedLink.value!.domainErrors;
+        expect(domainErrors.length, 0);
       },
     );
 
@@ -394,8 +431,9 @@ void main() {
       'filter links with validation result',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController =
-            TestDeepLinksController(hasIosDomainErrors: true);
+        final deepLinksController = TestDeepLinksController(
+          iosValidationResponse: iosValidationResponseWithError,
+        );
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -448,7 +486,9 @@ void main() {
       'sort links',
       windowSize,
       (WidgetTester tester) async {
-        final deepLinksController = TestDeepLinksController();
+        final deepLinksController = TestDeepLinksController(
+          iosValidationResponse: iosValidationResponseWithError,
+        );
 
         deepLinksController
           ..selectedProject.value = FlutterProject(
@@ -456,8 +496,7 @@ void main() {
             androidVariants: ['debug', 'release'],
             iosBuildOptions: xcodeBuildOptions,
           )
-          ..fakeIosDomains = [defaultDomain, 'domain1.com', 'domain2.com']
-          ..hasIosDomainErrors = true;
+          ..fakeIosDomains = [defaultDomain, 'domain1.com', 'domain2.com'];
 
         await pumpDeepLinkScreen(
           tester,

--- a/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
+++ b/packages/devtools_app/test/test_infra/test_data/deep_link/fake_responses.dart
@@ -176,6 +176,84 @@ const iosValidationResponseWithNoError = '''
 }
 ''';
 
+const iosValidationResponseWithWarning = '''
+{
+  "validationResults": [
+    {
+      "domainName": "example.com",
+      "passedChecks": [
+        {
+          "checkName": "HTTPS_ACCESSIBILITY",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "NON_REDIRECT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "EXISTENCE",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "APP_IDENTIFIER",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        },
+        {
+          "checkName": "FILE_FORMAT",
+          "resultType": "PASSED",
+          "severityLevel": "ERROR"
+        }
+      ],
+      "failedChecks": [
+        {
+          "checkName": "DEFAULTS_FORMAT",
+          "resultType": "FAILED_INDEPENDENTLY",
+          "severityLevel": "WARNING"
+        }
+      ],
+      "status": "VALIDATION_COMPLETE",
+      "aasaAppPaths": [
+        {
+          "aasaAppId": {
+            "bundleId": "bundle.id",
+            "teamId": "AAABBB"
+          },
+          "aasaPaths": [
+            {
+              "path": "/ios-path1",
+              "queryParams": [
+                {
+                  "key": "dplnk",
+                  "value": "?*"
+                }
+              ],
+              "isCaseSensitive": true,
+              "isPercentEncoded": true
+            },
+            {
+              "path": "/ios-path2",
+              "isExcluded": true,
+              "queryParams": [
+                {
+                  "key": "dplnk",
+                  "value": "?*"
+                }
+              ],
+              "isCaseSensitive": true,
+              "isPercentEncoded": true
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}
+''';
+
 const iosValidationResponseWithError = '''
 {
   "validationResults": [

--- a/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
+++ b/packages/devtools_app/test/test_infra/utils/deep_links_utils.dart
@@ -16,7 +16,7 @@ final defaultAndroidDeeplink = androidDeepLinkJson(defaultDomain);
 class TestDeepLinksService extends DeepLinksService {
   TestDeepLinksService({
     this.hasAndroidDomainErrors = false,
-    this.hasIosDomainErrors = false,
+    this.iosValidationResponse = '',
   }) {
     // Create a mock client to return fake responses.
     _client = MockClient((request) async {
@@ -28,11 +28,7 @@ class TestDeepLinksService extends DeepLinksService {
         }
       }
       if (request.url == Uri.parse(iosDomainValidationURL)) {
-        if (hasIosDomainErrors) {
-          return Response(iosValidationResponseWithError, 200);
-        } else {
-          return Response(iosValidationResponseWithNoError, 200);
-        }
+        return Response(iosValidationResponse, 200);
       }
       return Response('this is a body', 404);
     });
@@ -44,24 +40,24 @@ class TestDeepLinksService extends DeepLinksService {
   Client get client => _client;
 
   final bool hasAndroidDomainErrors;
-  final bool hasIosDomainErrors;
+  final String iosValidationResponse;
 }
 
 class TestDeepLinksController extends DeepLinksController {
   TestDeepLinksController({
     this.hasAndroidDomainErrors = false,
-    this.hasIosDomainErrors = false,
+    this.iosValidationResponse = iosValidationResponseWithNoError,
   }) {
     _deepLinksService = TestDeepLinksService(
       hasAndroidDomainErrors: hasAndroidDomainErrors,
-      hasIosDomainErrors: hasIosDomainErrors,
+      iosValidationResponse: iosValidationResponse,
     );
   }
 
   List<String> fakeAndroidDeepLinks = [];
   bool hasAndroidDomainErrors = false;
   bool hasAndroidPathErrors = false;
-  bool hasIosDomainErrors = false;
+  String iosValidationResponse = '';
   List<String> fakeIosDomains = [];
 
   late DeepLinksService _deepLinksService;


### PR DESCRIPTION
Eventual solution should be showing different scheme for errors and warnings(warnings are just recommendations),   For now (this PR) we choose to omit warnings to reduce noise.



## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
