### PR TITLE
[Deep link] Generate AASA template when it doesn't exist

### DIFF
--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -180,13 +180,13 @@ class _DomainCheckTable extends StatelessWidget {
                 children: <Widget>[
                   for (final error
                       in linkData.domainErrors.whereType<IosDomainError>())
-                    error == IosDomainError.existence
-                        ? _IssuesBorderWrap(
-                            children: [
+                    _IssuesBorderWrap(
+                      children: error == IosDomainError.existence
+                          ? [
                               _FailureDetails(
                                 errors: [error],
                                 oneFixGuideForAll:
-                                    'To fix this issues, add an Apple-App-Site-Association file at the following location: '
+                                    'To fix this issue, add an Apple-App-Site-Association file at the following location: '
                                     'https://${controller.selectedLink.value!.domain}/.well-known/assetlinks.json.',
                               ),
                               const SizedBox(height: denseSpacing),
@@ -205,13 +205,11 @@ class _DomainCheckTable extends StatelessWidget {
     ]
   }''',
                               ),
-                            ],
-                          )
-                        : _IssuesBorderWrap(
-                            children: [
+                            ]
+                          : [
                               _FailureDetails(errors: [error]),
                             ],
-                          ),
+                    ),
                 ],
               ),
             const SizedBox(height: intermediateSpacing),

--- a/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
+++ b/packages/devtools_app/lib/src/screens/deep_link_validation/validation_details_view.dart
@@ -180,11 +180,38 @@ class _DomainCheckTable extends StatelessWidget {
                 children: <Widget>[
                   for (final error
                       in linkData.domainErrors.whereType<IosDomainError>())
-                    _IssuesBorderWrap(
-                      children: [
-                        _FailureDetails(errors: [error]),
-                      ],
-                    ),
+                    error == IosDomainError.existence
+                        ? _IssuesBorderWrap(
+                            children: [
+                              _FailureDetails(
+                                errors: [error],
+                                oneFixGuideForAll:
+                                    'To fix this issues, add an Apple-App-Site-Association file at the following location: '
+                                    'https://${controller.selectedLink.value!.domain}/.well-known/assetlinks.json.',
+                              ),
+                              const SizedBox(height: denseSpacing),
+                              _CodeCard(
+                                content: '''{
+  "applinks": {
+    "details": [
+      {
+        "appIDs": [ "${controller.teamId}.${controller.bundleId}" ],
+        "components": [
+          {
+            "/": "*"
+          }
+        ]
+      }
+    ]
+  }''',
+                              ),
+                            ],
+                          )
+                        : _IssuesBorderWrap(
+                            children: [
+                              _FailureDetails(errors: [error]),
+                            ],
+                          ),
                 ],
               ),
             const SizedBox(height: intermediateSpacing),


### PR DESCRIPTION
We currently don't have an API for AASA generation. However, for users that don't have an AASA file, we can provide a template that's easy to copy-paste.

Pre-condition - Developer has an associated domain in "entitlements", but EXISTENCE check failed at ERROR severity level.

Assumption - The developer has appID as TEAMID.bundle.id and a associated domain like www.example.com

Generated template ([Apple documentation](http://go/appledoc/xcode/supporting-associated-domains#Add-the-associated-domain-file-to-your-website)):

## Pre-launch Checklist

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [ ] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
