### PR TITLE
[Inspector V2] Up the opacity of the inspector tree on search

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -1387,7 +1387,7 @@ class InspectorRowContent extends StatelessWidget {
         valueListenable: controller.searchNotifier,
         builder: (context, searchValue, _) {
           return Opacity(
-            opacity: searchValue.isEmpty || row.isSearchMatch ? 1 : 0.2,
+            opacity: searchValue.isEmpty || row.isSearchMatch ? 1 : 0.6,
             child: Row(
               mainAxisSize: MainAxisSize.min,
               children: [


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8051

Previously the opacity of the inspector tree was so low that the rows were nearly invisible. This increases the opacity so that the tree is more visible on search.

Before:
![opacity_old](https://github.com/user-attachments/assets/8a2919d6-41d4-4484-abaf-3b282dca72a1)

After:
![new_opacity](https://github.com/user-attachments/assets/d153a428-9889-47b0-acca-26800a7d9e8e)

After for light mode:
<img width="321" alt="Screenshot 2024-09-25 at 2 34 56 PM" src="https://github.com/user-attachments/assets/aaeedc3a-f322-4a94-95ea-422d5c975762">
