### PR TITLE
[Inspector V2] Prevent inspector tree scroll from bouncing 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -990,8 +990,12 @@ class _InspectorTreeState extends State<InspectorTree>
       safeViewportHeight,
     );
 
+    final centerLeftHalf = Offset(
+      (rect.centerLeft.dx + rect.center.dx) / 2,
+      rect.center.dy,
+    );
     final isRectInViewPort =
-        viewPortInScrollControllerSpace.contains(rect.centerLeft);
+        viewPortInScrollControllerSpace.contains(centerLeftHalf);
     if (isRectInViewPort) {
       // The rect is already in view, don't scroll
       return;

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -576,6 +576,7 @@ class InspectorTreeController extends DisposableController
   }
 
   void scrollToRect(Rect targetRect) {
+    print('scrolling to $targetRect');
     for (final client in _clients) {
       client.scrollToRect(targetRect);
     }
@@ -991,8 +992,7 @@ class _InspectorTreeState extends State<InspectorTree>
     );
 
     final isRectInViewPort =
-        viewPortInScrollControllerSpace.contains(rect.topLeft) &&
-            viewPortInScrollControllerSpace.contains(rect.bottomRight);
+        viewPortInScrollControllerSpace.contains(rect.centerLeft);
     if (isRectInViewPort) {
       // The rect is already in view, don't scroll
       return;
@@ -1013,6 +1013,7 @@ class _InspectorTreeState extends State<InspectorTree>
     }
 
     final targetX = _padTargetX(initialX: initialX);
+    print('target x is $targetX');
     if (_scrollControllerX.hasClients) {
       unawaited(
         _scrollControllerX.animateTo(

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -990,6 +990,8 @@ class _InspectorTreeState extends State<InspectorTree>
       safeViewportHeight,
     );
 
+    // Decide to scroll based on whether the middle of the center-left half of
+    // the row is visible. See https://github.com/flutter/devtools/pull/8367.
     final centerLeftHalf = Offset(
       (rect.centerLeft.dx + rect.center.dx) / 2,
       rect.center.dy,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -576,7 +576,6 @@ class InspectorTreeController extends DisposableController
   }
 
   void scrollToRect(Rect targetRect) {
-    print('scrolling to $targetRect');
     for (final client in _clients) {
       client.scrollToRect(targetRect);
     }
@@ -1013,7 +1012,6 @@ class _InspectorTreeState extends State<InspectorTree>
     }
 
     final targetX = _padTargetX(initialX: initialX);
-    print('target x is $targetX');
     if (_scrollControllerX.hasClients) {
       unawaited(
         _scrollControllerX.animateTo(


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8356

Previously we were determining whether or not to trigger a scroll based on whether the top-left and bottom-right of an item in the tree was visible. 

However, for items with long descriptions, we wouldn't actually horizontally scroll to their rightmost corner, which would cause the scroll controller to trigger a scroll that didn't actually do anything. 

Now we decide whether to scroll based on whether the "center left half" (red dot below) of the item is in view.

![image](https://github.com/user-attachments/assets/1f8c836d-e468-4159-8478-4b7547ded168)

![scrolling_fix](https://github.com/user-attachments/assets/2e116cb1-a89d-4ea3-a316-287455b9461f)
