### PR TITLE
Upgrade the `package:mime` dependency to ^2.0.0

### DIFF
--- a/packages/devtools_app/lib/src/shared/http/http_request_data.dart
+++ b/packages/devtools_app/lib/src/shared/http/http_request_data.dart
@@ -144,8 +144,11 @@ class DartIOHttpRequestData extends NetworkRequest {
 
   @override
   String get type {
+    const defaultType = 'http';
     var mime = contentType;
-    if (mime == null) return 'http';
+    if (mime == null) {
+      return defaultType;
+    }
 
     // Extract the MIME from `contentType`.
     // Example: "[text/html; charset-UTF-8]" --> "text/html"
@@ -156,24 +159,24 @@ class DartIOHttpRequestData extends NetworkRequest {
     if (mime.endsWith(']')) {
       mime = mime.substring(0, mime.length - 1);
     }
-    return _extensionFromMime(mime);
+    return _extensionFromMime(mime) ?? defaultType;
   }
 
   /// Extracts the extension from [mime], with overrides for shortened
   /// extensions of common types (e.g., jpe -> jpeg).
-  String _extensionFromMime(String mime) {
-    final extension = extensionFromMime(mime);
-    if (extension == 'jpe') {
+  String? _extensionFromMime(String mime) {
+    final ext = extensionFromMime(mime);
+    if (ext == 'jpe') {
       return 'jpeg';
     }
-    if (extension == 'htm') {
+    if (ext == 'htm') {
       return 'html';
     }
     // text/plain -> conf
-    if (extension == 'conf') {
+    if (ext == 'conf') {
       return 'txt';
     }
-    return extension;
+    return ext;
   }
 
   @override

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   json_rpc_2: ^3.0.2
   logging: ^1.1.1
   meta: ^1.9.1
-  mime: ^1.0.0
+  mime: ^2.0.0
   path: ^1.8.0
   perfetto_ui_compiled:
     path: ../../third_party/packages/perfetto_ui_compiled


### PR DESCRIPTION
This will unblock https://dart-review.googlesource.com/c/sdk/+/387502 once this change is rolled into google3.

Depends on https://github.com/dart-lang/build/pull/3758 and a publish of `build_runner`