### PR TITLE
Increase number of retries for eval test

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_utils.dart
@@ -40,6 +40,7 @@ class EvalTester {
     final responseFinder = await retryUntilFound(
       expectedResponse,
       tester: tester,
+      retries: 6,
     );
     expect(responseFinder, findsOneWidget);
   }


### PR DESCRIPTION
(Hopefully) fixes https://github.com/flutter/devtools/issues/8389

The initial fix was to add some retries. This test still seems to be occasionally flaking (although not nearly as often as it was before). This PR increases the number or retries. 
