### PR TITLE
Remove whitespace from build script

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -77,7 +77,7 @@ rm -rf build/web
 flutter pub get
 
 flutter build web \
-  --source-maps \ 
+  --source-maps \
   --wasm \
   --pwa-strategy=offline-first \
   --release \


### PR DESCRIPTION
Pretty sure this is why our LUCI build is failing with:

```
+ flutter build web --source-maps ' '
Target file " " not found.
```