### PR TITLE
Fix delta percentage calculation for benchmark script.

### DIFF
--- a/packages/devtools_app/benchmark/scripts/run_benchmarks.dart
+++ b/packages/devtools_app/benchmark/scripts/run_benchmarks.dart
@@ -50,7 +50,7 @@ Future<BenchmarkResults> runBenchmarks({
   required bool useBrowser,
 }) async {
   final benchmarkResults = <BenchmarkResults>[];
-  for (var i = 0; i < averageOf; i++) {
+  for (var i = 1; i <= averageOf; i++) {
     stdout.writeln('Starting web benchmark tests (run #$i) ...');
     benchmarkResults.add(
       await serveWebBenchmark(

--- a/packages/devtools_app/benchmark/scripts/utils.dart
+++ b/packages/devtools_app/benchmark/scripts/utils.dart
@@ -43,8 +43,9 @@ extension BenchmarkScoreExtension on BenchmarkScore {
     return [
       metric, // Metric name
       value.toString(), // Value
-      delta?.toString() ?? '--', // Delta value
-      delta != null ? (delta! / value).toString() : '--', // Delta % value
+      delta?.toString() ?? '', // Delta value
+      // value - delta represents the baseline score.
+      delta != null ? (delta! / (value - delta!)).toString() : '', // Delta % value
     ];
   }
 }

--- a/packages/devtools_app/benchmark/scripts/utils.dart
+++ b/packages/devtools_app/benchmark/scripts/utils.dart
@@ -45,7 +45,9 @@ extension BenchmarkScoreExtension on BenchmarkScore {
       value.toString(), // Value
       delta?.toString() ?? '', // Delta value
       // value - delta represents the baseline score.
-      delta != null ? (delta! / (value - delta!)).toString() : '', // Delta % value
+      delta != null
+          ? (delta! / (value - delta!)).toString()
+          : '', // Delta % value
     ];
   }
 }


### PR DESCRIPTION
The denominator for the delta percentage calculation was incorrect. The denominator should have been using the baseline score, not the test score.