### PR TITLE
Restore "devtools_tool" with deprecation warning for Windows users

### DIFF
--- a/tool/bin/devtools_tool.bat
+++ b/tool/bin/devtools_tool.bat
@@ -1,0 +1,4 @@
+@echo off
+
+echo Warning: devtools_tool has been replaced by dt. Please use dt instead.
+%~dp0/dt.bat %*


### PR DESCRIPTION
https://github.com/flutter/devtools/pull/8403 changed devtools_tool to dt, but only left a temporary compatibility wrapper for Mac/Linux. We need the same for Windows, otherwise:

1. Any users running `devtools_tool` may trigger the bash script and Windows will ask "What do you want to open this file with?"
2. Using the `dart.customDevTools` setting in VS Code assumes `devtools_tool` so it fails to start DevTools

As a temporary measure, we should put this wrapper script in similar to the Mac/Linux version. I'll update Dart-Code to not assume `devtools_tool` exists in a future version (when it's less likely contributors are on older branches without the `dt` file).
