### PR TITLE
Fix log ordering bug

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/_when_column.dart
+++ b/packages/devtools_app/lib/src/screens/logging/_when_column.dart
@@ -18,8 +18,20 @@ class WhenColumn extends ColumnData<LogData> {
   bool get supportsSorting => false;
 
   @override
-  String getValue(LogData dataObject) => dataObject.timestamp == null
+  bool get numeric => true;
+
+  @override
+  int getValue(LogData dataObject) => dataObject.timestamp ?? -1;
+
+  @override
+  String getDisplayValue(LogData dataObject) => dataObject.timestamp == null
       ? ''
       : timeFormat
+          .format(DateTime.fromMillisecondsSinceEpoch(dataObject.timestamp!));
+
+  @override
+  String getTooltip(LogData dataObject) => dataObject.timestamp == null
+      ? ''
+      : dateTimeFormat
           .format(DateTime.fromMillisecondsSinceEpoch(dataObject.timestamp!));
 }

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -34,6 +34,7 @@ final _log = Logger('logging_controller');
 const kMaxLogItemsLowerBound = 5000;
 const kMaxLogItemsUpperBound = 5500;
 final timeFormat = DateFormat('HH:mm:ss.SSS');
+final dateTimeFormat = DateFormat('HH:mm:ss.SSS (MM/dd/yy)');
 
 bool _verboseDebugging = false;
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -41,7 +41,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Logging updates
 
-TODO: Remove this section if there are not any general updates.
+* Fix a bug where logs would get out of order after midnight. - 
+[#8420](https://github.com/flutter/devtools/pull/8420)
 
 ## App size tool updates
 


### PR DESCRIPTION
Logs would get out of order after midnight because we were sorting by the string representation of the timestamp and not the milliseconds since epoch value.

Fixes https://github.com/flutter/devtools/issues/2188