### PR TITLE
Bump dev version and remove stale release notes

### DIFF
--- a/packages/devtools_app/lib/devtools.dart
+++ b/packages/devtools_app/lib/devtools.dart
@@ -9,4 +9,4 @@
 // the constant declaration `const version =`.
 // If you change the declaration you must also modify the regex in
 // tools/update_version.dart.
-const version = '2.41.0-dev.0';
+const version = '2.41.0-dev.1';

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -4,7 +4,7 @@ publish_to: none
 
 # Note: this version should only be updated by running tools/update_version.dart
 # that updates all versions of devtools packages (devtools_app, devtools_test).
-version: 2.41.0-dev.0
+version: 2.41.0-dev.1
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -10,11 +10,6 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-* Fixed a bug that was causing data filters to be cleared when clearing data
-on the Network and Logging screens. - [#8407](https://github.com/flutter/devtools/pull/8407)
-* Fixed a bug that was causing the navigator to lose state when opening the VM
-Flags dialog. - [#8413](https://github.com/flutter/devtools/pull/8413)
-
 ## Inspector updates
 
 TODO: Remove this section if there are not any general updates.


### PR DESCRIPTION
These release notes were part of the 2.40.1 cherry pick release. Included in https://github.com/flutter/website/pull/11255.