### PR TITLE
Determine the logging split view axis by the aspect ratio

### DIFF
--- a/packages/devtools_app/test/logging/logging_screen_test.dart
+++ b/packages/devtools_app/test/logging/logging_screen_test.dart
@@ -11,6 +11,7 @@ import 'package:devtools_app/src/screens/logging/_logs_table.dart';
 import 'package:devtools_app/src/screens/logging/_message_column.dart';
 import 'package:devtools_app/src/screens/logging/logging_controls.dart';
 import 'package:devtools_app/src/service/service_extension_widgets.dart';
+import 'package:devtools_app/src/shared/ui/utils.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -113,6 +114,39 @@ void main() {
         expect(find.byType(StandaloneFilterField<LogData>), findsOneWidget);
         expect(find.byType(DevToolsFilterButton), findsOneWidget);
         expect(find.byType(SettingsOutlinedButton), findsOneWidget);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'builds with horizontal axis for small screens',
+      Size(600.0, MediaSize.s.heightThreshold), // 1.0 aspect ratio
+      (WidgetTester tester) async {
+        await pumpLoggingScreen(tester);
+        final splitPaneFinder = find.byType(SplitPane);
+        final splitPane = tester.widget(splitPaneFinder) as SplitPane;
+        expect(splitPane.axis, Axis.horizontal);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'builds with horizontal axis for aspect ratio',
+      Size(722.0, MediaSize.s.heightThreshold + 1), // 1.20 aspect ratio
+      (WidgetTester tester) async {
+        await pumpLoggingScreen(tester);
+        final splitPaneFinder = find.byType(SplitPane);
+        final splitPane = tester.widget(splitPaneFinder) as SplitPane;
+        expect(splitPane.axis, Axis.horizontal);
+      },
+    );
+
+    testWidgetsWithWindowSize(
+      'builds with vertical axis for aspect ratio',
+      Size(721.0, MediaSize.s.heightThreshold + 1), // 1.19 aspect ratio
+      (WidgetTester tester) async {
+        await pumpLoggingScreen(tester);
+        final splitPaneFinder = find.byType(SplitPane);
+        final splitPane = tester.widget(splitPaneFinder) as SplitPane;
+        expect(splitPane.axis, Axis.vertical);
       },
     );
 


### PR DESCRIPTION
This allows for a better viewing experience when the view is small vertically:
![Screenshot 2024-10-14 at 4 17 57 PM](https://github.com/user-attachments/assets/aa2745e5-0f23-4bc5-86f5-d7f7a786849c)
