### PR TITLE
Move the DevTools debug mode banner to the bottom right

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -584,7 +584,7 @@ class _AlternateCheckedModeBanner extends StatelessWidget {
     return Banner(
       message: 'DEBUG',
       textDirection: TextDirection.ltr,
-      location: BannerLocation.topStart,
+      location: BannerLocation.bottomEnd,
       child: Builder(
         builder: builder,
       ),


### PR DESCRIPTION
In the upper left, the debug banner frequently gets in the way when taking screenshots of new features for release notes. This PR moves the banner to the bottom right, where it is less in the way of primary DevTools features like page controls and the tab bar.
![Screenshot 2024-10-15 at 11 26 21 AM](https://github.com/user-attachments/assets/97d56384-0842-4954-8c6b-44a9967d037b)
