### PR TITLE
Store the logging details format in user preferences

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/constants/_logging_constants.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/constants/_logging_constants.dart
@@ -7,4 +7,5 @@ part of '../constants.dart';
 /// Logging event constants specific for logging screen.
 enum LoggingEvents {
   changeRetentionLimit,
+  changeDetailsFormat,
 }

--- a/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
@@ -8,12 +8,22 @@ class LoggingPreferencesController extends DisposableController
     with AutoDisposeControllerMixin {
   final retentionLimitTitle = 'Limit for the number of logs retained.';
 
+  // TODO(kenz): remove the retention limit setting if we cannot apply this
+  // functionality to the existing logging page, since the logging V2 code may
+  // be removed.
   /// The number of logs to retain on the logging table.
   final retentionLimit = ValueNotifier<int>(_defaultRetentionLimit);
 
+  /// The [LoggingDetailsFormat] to use when displaying a log in the log details
+  /// view.
+  final detailsFormat =
+      ValueNotifier<LoggingDetailsFormat>(_defaultDetailsFormat);
+
   static const _defaultRetentionLimit = 3000;
+  static const _defaultDetailsFormat = LoggingDetailsFormat.text;
 
   static const _retentionLimitStorageId = 'logging.retentionLimit';
+  static const _detailsFormatStorageId = 'logging.detailsFormat';
 
   Future<void> init() async {
     retentionLimit.value =
@@ -27,7 +37,6 @@ class LoggingPreferencesController extends DisposableController
           _retentionLimitStorageId,
           retentionLimit.value.toString(),
         );
-
         ga.select(
           gac.logging,
           gac.LoggingEvents.changeRetentionLimit.name,
@@ -35,5 +44,38 @@ class LoggingPreferencesController extends DisposableController
         );
       },
     );
+
+    final detailsFormatValueFromStorage =
+        await storage.getValue(_detailsFormatStorageId);
+    detailsFormat.value = LoggingDetailsFormat.values.firstWhereOrNull(
+          (value) => detailsFormatValueFromStorage == value.name,
+        ) ??
+        _defaultDetailsFormat;
+
+    addAutoDisposeListener(
+      detailsFormat,
+      () {
+        storage.setValue(_detailsFormatStorageId, detailsFormat.value.name);
+        ga.select(
+          gac.logging,
+          gac.LoggingEvents.changeDetailsFormat.name,
+          value: detailsFormat.value.index,
+        );
+      },
+    );
+  }
+}
+
+enum LoggingDetailsFormat {
+  json,
+  text;
+
+  LoggingDetailsFormat opposite() {
+    switch (this) {
+      case LoggingDetailsFormat.json:
+        return LoggingDetailsFormat.text;
+      case LoggingDetailsFormat.text:
+        return LoggingDetailsFormat.json;
+    }
   }
 }

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -5,6 +5,7 @@
 import 'dart:async';
 import 'dart:convert';
 
+import 'package:collection/collection.dart';
 import 'package:devtools_app_shared/ui.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/foundation.dart';

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -400,6 +400,57 @@ void main() {
     });
   });
 
+  group('$LoggingPreferencesController', () {
+    late LoggingPreferencesController controller;
+    late FlutterTestStorage storage;
+
+    setUp(() async {
+      setGlobal(Storage, storage = FlutterTestStorage());
+      controller = LoggingPreferencesController();
+      await controller.init();
+    });
+
+    test('has expected default values', () {
+      expect(controller.detailsFormat.value, LoggingDetailsFormat.text);
+    });
+
+    test('stores values and reads them on init', () async {
+      storage.values.clear();
+
+      // Remember original values.
+      final detailsFormat = controller.detailsFormat.value;
+
+      // Flip the values in controller.
+      controller.detailsFormat.value = detailsFormat.opposite();
+
+      // Check the values are stored.
+      expect(storage.values, hasLength(1));
+
+      // Reload the values from storage.
+      await controller.init();
+
+      // Check they did not change back to default.
+      expect(
+        controller.detailsFormat.value,
+        detailsFormat.opposite(),
+      );
+
+      // Flip the values in storage.
+      for (final key in storage.values.keys) {
+        storage.values[key] = detailsFormat.name;
+      }
+
+      // Reload the values from storage.
+      await controller.init();
+
+      // Check they flipped values are loaded.
+      expect(
+        controller.detailsFormat.value,
+        detailsFormat,
+      );
+    });
+  });
+
   group('$PerformancePreferencesController', () {
     late PerformancePreferencesController controller;
     late FlutterTestStorage storage;


### PR DESCRIPTION
This is a follow up change to https://github.com/flutter/devtools/pull/8445 which stores the log details format selection in user preferences.

Work towards https://github.com/flutter/devtools/issues/7703
