### PR TITLE
Persist logging filter to storage

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -177,8 +177,7 @@ class LoggingController extends DisposableController
   };
 
   @override
-  ValueNotifier<String>? get filterTagNotifier =>
-      preferences.logging.filterTag;
+  ValueNotifier<String>? get filterTagNotifier => preferences.logging.filterTag;
 
   final _logStatusController = StreamController<String>.broadcast();
 

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -113,16 +113,17 @@ class LoggingController extends DisposableController
       _handleConnectionStart(serviceConnection.serviceManager.service!);
     }
     _handleBusEvents();
-    subscribeToFilterChanges();
+    initFilterController();
   }
 
-  /// The toggle filters available for the Logging screen.
+  /// The setting filters available for the Logging screen.
   @override
-  List<SettingFilter<LogData, Object>> createSettingFilters() => settingFilters;
+  SettingFilters<LogData> createSettingFilters() => settingFilters;
 
   @visibleForTesting
   static final settingFilters = <SettingFilter<LogData, Object>>[
     SettingFilter<LogData, Level>(
+      id: 'min-log-level',
       name: 'Hide logs below the minimum log level',
       includeCallback: (LogData element, Level currentFilterValue) =>
           element.level >= currentFilterValue.value,
@@ -136,6 +137,7 @@ class LoggingController extends DisposableController
     if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
         true) ...[
       ToggleFilter<LogData>(
+        id: 'verbose-flutter-framework',
         name: 'Hide verbose Flutter framework logs (initialization, frame '
             'times, image sizes)',
         includeCallback: (log) => !_verboseFlutterFrameworkLogKinds
@@ -143,6 +145,7 @@ class LoggingController extends DisposableController
         defaultValue: true,
       ),
       ToggleFilter<LogData>(
+        id: 'verbose-flutter-service',
         name: 'Hide verbose Flutter service logs (service extension state '
             'changes)',
         includeCallback: (log) => !_verboseFlutterServiceLogKinds
@@ -151,6 +154,7 @@ class LoggingController extends DisposableController
       ),
     ],
     ToggleFilter<LogData>(
+      id: 'gc',
       name: 'Hide garbage collection logs',
       includeCallback: (log) => !log.kind.caseInsensitiveEquals(_gcLogKind),
       defaultValue: true,
@@ -171,6 +175,10 @@ class LoggingController extends DisposableController
       substringMatch: true,
     ),
   };
+
+  @override
+  ValueNotifier<String>? get filterTagNotifier =>
+      preferences.logging.filterTag;
 
   final _logStatusController = StreamController<String>.broadcast();
 

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -116,6 +116,11 @@ class LoggingController extends DisposableController
     initFilterController();
   }
 
+  static const _minLogLevelFilterId = 'min-log-level';
+  static const _verboseFlutterFrameworkFilterId = 'verbose-flutter-framework';
+  static const _verboseFlutterServiceFilterId = 'verbose-flutter-service';
+  static const _gcFilterId = 'gc';
+
   /// The setting filters available for the Logging screen.
   @override
   SettingFilters<LogData> createSettingFilters() => settingFilters;
@@ -123,7 +128,7 @@ class LoggingController extends DisposableController
   @visibleForTesting
   static final settingFilters = <SettingFilter<LogData, Object>>[
     SettingFilter<LogData, Level>(
-      id: 'min-log-level',
+      id: _minLogLevelFilterId,
       name: 'Hide logs below the minimum log level',
       includeCallback: (LogData element, Level currentFilterValue) =>
           element.level >= currentFilterValue.value,
@@ -137,7 +142,7 @@ class LoggingController extends DisposableController
     if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
         true) ...[
       ToggleFilter<LogData>(
-        id: 'verbose-flutter-framework',
+        id: _verboseFlutterFrameworkFilterId,
         name: 'Hide verbose Flutter framework logs (initialization, frame '
             'times, image sizes)',
         includeCallback: (log) => !_verboseFlutterFrameworkLogKinds
@@ -145,7 +150,7 @@ class LoggingController extends DisposableController
         defaultValue: true,
       ),
       ToggleFilter<LogData>(
-        id: 'verbose-flutter-service',
+        id: _verboseFlutterServiceFilterId,
         name: 'Hide verbose Flutter service logs (service extension state '
             'changes)',
         includeCallback: (log) => !_verboseFlutterServiceLogKinds
@@ -154,7 +159,7 @@ class LoggingController extends DisposableController
       ),
     ],
     ToggleFilter<LogData>(
-      id: 'gc',
+      id: _gcFilterId,
       name: 'Hide garbage collection logs',
       includeCallback: (log) => !log.kind.caseInsensitiveEquals(_gcLogKind),
       defaultValue: true,

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_model.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_model.dart
@@ -97,7 +97,7 @@ class LoggingTableModel extends DisposableController
       _onRetentionLimitUpdate,
     );
 
-    subscribeToFilterChanges();
+    initFilterController();
 
     _retentionLimit = preferences.logging.retentionLimit.value;
     addAutoDisposeListener(serviceConnection.serviceManager.connectedState, () {
@@ -125,10 +125,11 @@ class LoggingTableModel extends DisposableController
 
   /// The toggle filters available for the Logging screen.
   @override
-  List<SettingFilter<LogDataV2, bool>> createSettingFilters() => [
+  SettingFilters<LogDataV2> createSettingFilters() => [
         if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
             true) ...[
           ToggleFilter<LogDataV2>(
+            id: 'verbose-flutter-framework-logs',
             name: 'Hide verbose Flutter framework logs (initialization, frame '
                 'times, image sizes)',
             includeCallback: (log) => !_verboseFlutterFrameworkLogKinds
@@ -136,6 +137,7 @@ class LoggingTableModel extends DisposableController
             defaultValue: true,
           ),
           ToggleFilter<LogDataV2>(
+            id: 'verbose-flutter-service-logs',
             name: 'Hide verbose Flutter service logs (service extension state '
                 'changes)',
             includeCallback: (log) => !_verboseFlutterServiceLogKinds
@@ -144,6 +146,7 @@ class LoggingTableModel extends DisposableController
           ),
         ],
         ToggleFilter<LogDataV2>(
+          id: 'gc-logs',
           name: 'Hide garbage collection logs',
           includeCallback: (log) => !log.kind.caseInsensitiveEquals(_gcLogKind),
           defaultValue: true,

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -58,7 +58,7 @@ class NetworkController extends DisposableController
       _filterAndRefreshSearchMatches,
     );
     // TODO(https://github.com/flutter/devtools/issues/7727): add support for
-    // persisting network filter. 
+    // persisting network filter.
     initFilterController();
   }
   List<DartIOHttpRequestData>? _httpRequests;

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -57,7 +57,9 @@ class NetworkController extends DisposableController
       _currentNetworkRequests,
       _filterAndRefreshSearchMatches,
     );
-    subscribeToFilterChanges();
+    // TODO(https://github.com/flutter/devtools/issues/7727): add support for
+    // persisting network filter. 
+    initFilterController();
   }
   List<DartIOHttpRequestData>? _httpRequests;
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -51,7 +51,9 @@ class CpuProfilerController extends DisposableController
         FilterControllerMixin<CpuStackFrame>,
         AutoDisposeControllerMixin {
   CpuProfilerController() {
-    subscribeToFilterChanges();
+    // TODO(https://github.com/flutter/devtools/issues/7727): add support for
+    // persisting network filter.
+    initFilterController();
   }
 
   /// Tag to represent when no user tag filters are applied.
@@ -137,13 +139,15 @@ class CpuProfilerController extends DisposableController
 
   /// The toggle filters available for the CPU profiler.
   @override
-  List<SettingFilter<CpuStackFrame, bool>> createSettingFilters() => [
+  SettingFilters<CpuStackFrame> createSettingFilters() => [
         ToggleFilter<CpuStackFrame>(
+          id: 'native',
           name: 'Hide Native code',
           includeCallback: (stackFrame) => !stackFrame.isNative,
           defaultValue: true,
         ),
         ToggleFilter<CpuStackFrame>(
+          id: 'core-dart',
           name: 'Hide core Dart libraries',
           includeCallback: (stackFrame) => !stackFrame.isDartCore,
           defaultValue: false,
@@ -151,6 +155,7 @@ class CpuProfilerController extends DisposableController
         if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
             true)
           ToggleFilter<CpuStackFrame>(
+            id: 'core-flutter',
             name: 'Hide core Flutter libraries',
             includeCallback: (stackFrame) => !stackFrame.isFlutterCore,
             defaultValue: false,

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -137,17 +137,21 @@ class CpuProfilerController extends DisposableController
   final _viewType =
       ValueNotifier<CpuProfilerViewType>(CpuProfilerViewType.function);
 
+  static const _nativeFilterId = 'native';
+  static const _coreDartFilterId = 'core-dart';
+  static const _coreFlutterFilterId = 'core-flutter';
+
   /// The toggle filters available for the CPU profiler.
   @override
   SettingFilters<CpuStackFrame> createSettingFilters() => [
         ToggleFilter<CpuStackFrame>(
-          id: 'native',
+          id: _nativeFilterId,
           name: 'Hide Native code',
           includeCallback: (stackFrame) => !stackFrame.isNative,
           defaultValue: true,
         ),
         ToggleFilter<CpuStackFrame>(
-          id: 'core-dart',
+          id: _coreDartFilterId,
           name: 'Hide core Dart libraries',
           includeCallback: (stackFrame) => !stackFrame.isDartCore,
           defaultValue: false,
@@ -155,7 +159,7 @@ class CpuProfilerController extends DisposableController
         if (serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
             true)
           ToggleFilter<CpuStackFrame>(
-            id: 'core-flutter',
+            id: _coreFlutterFilterId,
             name: 'Hide core Flutter libraries',
             includeCallback: (stackFrame) => !stackFrame.isFlutterCore,
             defaultValue: false,

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -52,7 +52,7 @@ class CpuProfilerController extends DisposableController
         AutoDisposeControllerMixin {
   CpuProfilerController() {
     // TODO(https://github.com/flutter/devtools/issues/7727): add support for
-    // persisting network filter.
+    // persisting cpu profiler filter.
     initFilterController();
   }
 

--- a/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
@@ -19,17 +19,22 @@ class LoggingPreferencesController extends DisposableController
   final detailsFormat =
       ValueNotifier<LoggingDetailsFormat>(_defaultDetailsFormat);
 
+  /// The active filter tag for the logging screen.
+  ///
+  /// This value caches the most recent filter settings.
+  final filterTag = ValueNotifier<String>('');
+
   static const _defaultRetentionLimit = 3000;
   static const _defaultDetailsFormat = LoggingDetailsFormat.text;
 
   static const _retentionLimitStorageId = 'logging.retentionLimit';
   static const _detailsFormatStorageId = 'logging.detailsFormat';
+  static const _filterStorageId = 'logging.filter';
 
   Future<void> init() async {
     retentionLimit.value =
         int.tryParse(await storage.getValue(_retentionLimitStorageId) ?? '') ??
             _defaultRetentionLimit;
-
     addAutoDisposeListener(
       retentionLimit,
       () {
@@ -51,7 +56,6 @@ class LoggingPreferencesController extends DisposableController
           (value) => detailsFormatValueFromStorage == value.name,
         ) ??
         _defaultDetailsFormat;
-
     addAutoDisposeListener(
       detailsFormat,
       () {
@@ -62,6 +66,12 @@ class LoggingPreferencesController extends DisposableController
           value: detailsFormat.value.index,
         );
       },
+    );
+
+    filterTag.value = await storage.getValue(_filterStorageId) ?? '';
+    addAutoDisposeListener(
+      filterTag,
+      () => storage.setValue(_filterStorageId, filterTag.value),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -38,7 +38,7 @@ mixin FilterControllerMixin<T> on DisposableController
   final useRegExp = ValueNotifier<bool>(false);
 
   /// The notifier that stores the current filter tag in DevTools preferences.
-  /// 
+  ///
   /// This should be overriden as a getter by subclasses to support persisting
   /// the most recent filter to DevTools preferences.
   ValueNotifier<String>? filterTagNotifier;

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -10,7 +10,7 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-TODO: Remove this section if there are not any general updates.
+* Persist filter settings across sessions. - [#8447](https://github.com/flutter/devtools/pull/8447)
 
 ## Inspector updates
 

--- a/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
+++ b/packages/devtools_app/test/cpu_profiler/cpu_profiler_test.dart
@@ -140,35 +140,35 @@ void main() {
       },
     );
 
+    Future<void> loadData(ProfilerScreenController controller) async {
+      for (final filter in controller
+          .cpuProfilerController.activeFilter.value.settingFilters) {
+        filter.setting.value = false;
+      }
+      final data = CpuProfilePair(
+        functionProfile: cpuProfileData,
+        // Function and code profiles have the same structure, so just use
+        // the function profile in place of a dedicated code profile for
+        // testing since we don't care about the contents as much as we
+        // care about testing the ability to switch between function and
+        // code profile views.
+        codeProfile: cpuProfileData,
+      );
+      await controller.cpuProfilerController.processAndSetData(
+        data,
+        processId: 'test-load-data',
+        storeAsUserTagNone: true,
+        shouldApplyFilters: true,
+        shouldRefreshSearchMatches: false,
+      );
+    }
+
     group('profile views', () {
       late ProfilerScreenController controller;
 
-      Future<void> loadData() async {
-        for (final filter in controller
-            .cpuProfilerController.activeFilter.value.settingFilters) {
-          filter.setting.value = false;
-        }
-        final data = CpuProfilePair(
-          functionProfile: cpuProfileData,
-          // Function and code profiles have the same structure, so just use
-          // the function profile in place of a dedicated code profile for
-          // testing since we don't care about the contents as much as we
-          // care about testing the ability to switch between function and
-          // code profile views.
-          codeProfile: cpuProfileData,
-        );
-        await data.process(
-          transformer: controller.cpuProfilerController.transformer,
-          processId: 'test',
-        );
-        // Call this to force the value of `_dataByTag[userTagNone]` to be set.
-        controller.cpuProfilerController.loadProcessedData(
-          data,
-          storeAsUserTagNone: true,
-        );
-      }
-
       setUp(() async {
+        preferences.toggleVmDeveloperMode(false);
+
         controller = ProfilerScreenController();
 
         // Await a small delay to allow the ProfilerScreenController to complete
@@ -206,7 +206,7 @@ void main() {
 
             // Verify the profile view dropdown appears when toggling VM developer
             // mode and data is present.
-            await loadData();
+            await loadData(controller);
             await tester.pumpAndSettle();
             expect(find.byType(ModeDropdown), findsOneWidget);
 
@@ -248,7 +248,7 @@ void main() {
             preferences.toggleVmDeveloperMode(true);
             await tester.pumpAndSettle();
             expect(find.byType(CpuProfiler), findsNothing);
-            await loadData();
+            await loadData(controller);
             await tester.pumpAndSettle();
 
             // Verify the function profile view is still selected.
@@ -585,7 +585,7 @@ void main() {
       );
     });
 
-    group('Group by ', () {
+    group('Group by', () {
       late ProfilerScreenController controller;
 
       setUp(() async {
@@ -598,28 +598,7 @@ void main() {
         preferences.toggleVmDeveloperMode(true);
         cpuProfileData =
             CpuProfileData.fromJson(cpuProfileDataWithUserTagsJson);
-        for (final filter in controller
-            .cpuProfilerController.activeFilter.value.settingFilters) {
-          filter.setting.value = false;
-        }
-        final data = CpuProfilePair(
-          functionProfile: cpuProfileData,
-          // Function and code profiles have the same structure, so just use
-          // the function profile in place of a dedicated code profile for
-          // testing since we don't care about the contents as much as we
-          // care about testing the ability to switch between function and
-          // code profile views.
-          codeProfile: cpuProfileData,
-        );
-        await data.process(
-          transformer: controller.cpuProfilerController.transformer,
-          processId: 'test',
-        );
-        // Call this to force the value of `_dataByTag[userTagNone]` to be set.
-        controller.cpuProfilerController.loadProcessedData(
-          data,
-          storeAsUserTagNone: true,
-        );
+        await loadData(controller);
       });
 
       testWidgetsWithWindowSize('user tags', windowSize, (tester) async {

--- a/packages/devtools_app/test/logging/logging_controller_test.dart
+++ b/packages/devtools_app/test/logging/logging_controller_test.dart
@@ -7,8 +7,7 @@ library;
 
 import 'dart:convert';
 
-import 'package:devtools_app/src/screens/logging/logging_controller.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/primitives/message_bus.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -19,7 +18,6 @@ import 'package:logging/logging.dart';
 void main() {
   group('LoggingController', () {
     late LoggingController controller;
-    setGlobal(MessageBus, MessageBus());
 
     void addStdoutData(String message) {
       controller.log(
@@ -62,6 +60,8 @@ void main() {
         ServiceConnectionManager,
         FakeServiceConnectionManager(),
       );
+      setGlobal(MessageBus, MessageBus());
+      setGlobal(PreferencesController, PreferencesController());
 
       controller = LoggingController();
     });


### PR DESCRIPTION
This PR adds functionality to the `FilterControllerMixin` to support saving and loading a filter from storage, saved as a "tag".

Work towards https://github.com/flutter/devtools/issues/7703
Work towards https://github.com/flutter/devtools/issues/7727