### PR TITLE
Include query filter instructions for the standalone filter field

### DIFF
--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -172,10 +172,10 @@ class LoggingController extends DisposableController
 
   @override
   Map<String, QueryFilterArgument<LogData>> createQueryFilterArgs() =>
-      queryFilterArgs;
+      loggingQueryFilterArgs;
 
   @visibleForTesting
-  static final queryFilterArgs = <String, QueryFilterArgument<LogData>>{
+  static final loggingQueryFilterArgs = <String, QueryFilterArgument<LogData>>{
     kindFilterId: QueryFilterArgument<LogData>(
       keys: ['kind', 'k'],
       exampleUsages: ['k:stderr', '-k:stdout,gc'],

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -178,9 +178,11 @@ class LoggingController extends DisposableController
   static final queryFilterArgs = <String, QueryFilterArgument<LogData>>{
     kindFilterId: QueryFilterArgument<LogData>(
       keys: ['kind', 'k'],
+      exampleUsages: ['k:stderr', '-k:stdout'],
       dataValueProvider: (log) => log.kind,
       substringMatch: true,
     ),
+    // TODO(kenz): include zone and isolate as query filters.
   };
 
   @override

--- a/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controller.dart
@@ -178,7 +178,7 @@ class LoggingController extends DisposableController
   static final queryFilterArgs = <String, QueryFilterArgument<LogData>>{
     kindFilterId: QueryFilterArgument<LogData>(
       keys: ['kind', 'k'],
-      exampleUsages: ['k:stderr', '-k:stdout'],
+      exampleUsages: ['k:stderr', '-k:stdout,gc'],
       dataValueProvider: (log) => log.kind,
       substringMatch: true,
     ),

--- a/packages/devtools_app/lib/src/screens/logging/logging_controls.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controls.dart
@@ -61,6 +61,7 @@ Example queries:
         Expanded(
           child: StandaloneFilterField<LogData>(
             controller: controller,
+            filteredItem: 'log',
           ),
         ),
         const SizedBox(width: denseSpacing),

--- a/packages/devtools_app/lib/src/screens/logging/logging_controls.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_controls.dart
@@ -20,19 +20,6 @@ import 'shared/constants.dart';
 class LoggingControls extends StatelessWidget {
   const LoggingControls({super.key});
 
-  static const filterQueryInstructions = '''
-Type a filter query to show or hide specific logs.
-
-Any text that is not paired with an available filter key below will be queried against all categories (kind, message).
-
-Available filters:
-    'kind', 'k'       (e.g. 'k:flutter.frame', '-k:gc,stdout')
-
-Example queries:
-    'my log message k:stdout,stdin'
-    'flutter -k:gc'
-''';
-
   @override
   Widget build(BuildContext context) {
     final controller = Provider.of<LoggingController>(context);

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_model.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_model.dart
@@ -159,6 +159,7 @@ class LoggingTableModel extends DisposableController
   Map<String, QueryFilterArgument<LogDataV2>> createQueryFilterArgs() => {
         kindFilterId: QueryFilterArgument<LogDataV2>(
           keys: ['kind', 'k'],
+          exampleUsages: ['k:stderr', '-k:stdout'],
           dataValueProvider: (log) => log.kind,
           substringMatch: true,
         ),

--- a/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_table_v2.dart
+++ b/packages/devtools_app/lib/src/screens/logging/logging_screen_v2/logging_table_v2.dart
@@ -64,6 +64,7 @@ class _LoggingTableV2State extends State<LoggingTableV2>
             Expanded(
               child: StandaloneFilterField<LogDataV2>(
                 controller: widget.model,
+                filteredItem: 'log',
               ),
             ), // TODO for some reason the controller isn't hooking up correctly to the one over in the model. It is not getting notified of the changes?
             const SizedBox(width: defaultSpacing),

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -96,16 +96,19 @@ class NetworkController extends DisposableController
   Map<String, QueryFilterArgument<NetworkRequest>> createQueryFilterArgs() => {
         methodFilterId: QueryFilterArgument<NetworkRequest>(
           keys: ['method', 'm'],
+          exampleUsages: ['m:get', '-m:put,patch'],
           dataValueProvider: (request) => request.method,
           substringMatch: false,
         ),
         statusFilterId: QueryFilterArgument<NetworkRequest>(
           keys: ['status', 's'],
+          exampleUsages: ['s:200', '-s:404'],
           dataValueProvider: (request) => request.status,
           substringMatch: false,
         ),
         typeFilterId: QueryFilterArgument<NetworkRequest>(
           keys: ['type', 't'],
+          exampleUsages: ['t:json', '-t:text'],
           dataValueProvider: (request) => request.type,
           substringMatch: false,
         ),

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -88,23 +88,6 @@ class NetworkScreen extends Screen {
 class NetworkScreenBody extends StatefulWidget {
   const NetworkScreenBody({super.key});
 
-  static const filterQueryInstructions = '''
-Type a filter query to show or hide specific requests.
-
-Any text that is not paired with an available filter key below will be queried against all categories (method, uri, status, type).
-
-Available filters:
-    'method', 'm'       (e.g. 'm:get', '-m:put,patch')
-    'status', 's'           (e.g. 's:200', '-s:404')
-    'type', 't'               (e.g. 't:json', '-t:ws')
-
-Example queries:
-    'my-endpoint method:put,post -status:404 type:json'
-    'example.com -m:get s:200,201 t:htm,html,json'
-    'http s:404'
-    'POST'
-''';
-
   @override
   State<StatefulWidget> createState() => _NetworkScreenBodyState();
 }
@@ -266,7 +249,7 @@ class _NetworkProfilerControlsState extends State<_NetworkProfilerControls>
         context: context,
         builder: (context) => FilterDialog<NetworkRequest>(
           controller: widget.controller,
-          queryInstructions: NetworkScreenBody.filterQueryInstructions,
+          filteredItem: 'request',
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler.dart
@@ -14,6 +14,7 @@ import '../../shared/common_widgets.dart';
 import '../../shared/globals.dart';
 import '../../shared/primitives/utils.dart';
 import '../../shared/ui/colors.dart';
+import '../../shared/ui/filter.dart';
 import '../../shared/ui/search.dart';
 import '../../shared/ui/tab.dart';
 import 'common.dart';
@@ -287,8 +288,9 @@ class _CpuProfilerState extends State<CpuProfiler>
     unawaited(
       showDialog(
         context: context,
-        builder: (context) => CpuProfileFilterDialog(
+        builder: (context) => FilterDialog<CpuStackFrame>(
           controller: widget.controller,
+          filteredItem: 'stack frame',
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -172,6 +172,10 @@ class CpuProfilerController extends DisposableController
   Map<String, QueryFilterArgument> createQueryFilterArgs() => {
         uriFilterId: QueryFilterArgument<CpuStackFrame>(
           keys: ['uri', 'u'],
+          exampleUsages: [
+            'uri:my_dart_package/some_lib.dart',
+            '-u:some_lib_to_hide',
+          ],
           dataValueProvider: (stackFrame) => stackFrame.packageUri,
           substringMatch: true,
         ),

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profiler_controller.dart
@@ -169,7 +169,7 @@ class CpuProfilerController extends DisposableController
   static const uriFilterId = 'cpu-profiler-uri-filter';
 
   @override
-  Map<String, QueryFilterArgument> createQueryFilterArgs() => {
+  Map<String, QueryFilterArgument<CpuStackFrame>> createQueryFilterArgs() => {
         uriFilterId: QueryFilterArgument<CpuStackFrame>(
           keys: ['uri', 'u'],
           exampleUsages: [

--- a/packages/devtools_app/lib/src/screens/profiler/panes/controls/cpu_profiler_controls.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/controls/cpu_profiler_controls.dart
@@ -8,37 +8,8 @@ import 'package:devtools_app_shared/ui.dart';
 import 'package:flutter/material.dart';
 
 import '../../../../shared/globals.dart';
-import '../../../../shared/ui/filter.dart';
-import '../../cpu_profile_model.dart';
 import '../../cpu_profiler_controller.dart';
 import '../../profiler_screen_controller.dart';
-
-class CpuProfileFilterDialog extends StatelessWidget {
-  const CpuProfileFilterDialog({required this.controller, super.key});
-
-  static const filterQueryInstructions = '''
-Type a filter query to show or hide specific stack frames.
-
-Any text that is not paired with an available filter key below will be queried against all categories (method, uri).
-
-Available filters:
-    'uri', 'u'       (e.g. 'uri:my_dart_package/some_lib.dart', '-u:some_lib_to_hide')
-
-Example queries:
-    'someMethodName uri:my_dart_package,b_dart_package'
-    '.toString -uri:flutter'
-''';
-
-  final CpuProfilerController controller;
-
-  @override
-  Widget build(BuildContext context) {
-    return FilterDialog<CpuStackFrame>(
-      controller: controller,
-      queryInstructions: filterQueryInstructions,
-    );
-  }
-}
 
 /// DropdownButton that controls the value of
 /// [ProfilerScreenController.userTagFilter].

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -91,7 +91,8 @@ mixin FilterControllerMixin<T> on DisposableController
   /// query with arguments may look like 'foo category:bar type:baz'. In this
   /// example, 'category' and 'type' would need to be defined as query filter
   /// arguments.
-  QueryFilterArgs<T> createQueryFilterArgs() => <String, QueryFilterArgument<T>>{};
+  QueryFilterArgs<T> createQueryFilterArgs() =>
+      <String, QueryFilterArgument<T>>{};
 
   @visibleForTesting
   late final queryFilterArgs = createQueryFilterArgs();
@@ -100,7 +101,6 @@ mixin FilterControllerMixin<T> on DisposableController
     final filter = activeFilter.value;
     final queryFilterActive = !filter.queryFilter.isEmpty;
     final settingFilterActive =
-        filter.settingFilters.any((filter) => filter.enabled);
         filter.settingFilters.any((filter) => filter.enabled);
     return queryFilterActive || settingFilterActive;
   }
@@ -645,8 +645,6 @@ extension PatternListExtension on List<Pattern> {
   }
 }
 
-// TODO:: Change screens that use [DevtoolsFilterButton] to use a [StandaloneFilterField]
-// instead.
 /// A text field for controlling the filter query for a [FilterControllerMixin].
 ///
 /// This text field has a button to open a dialog for toggling any toggleable

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -819,6 +819,7 @@ Available filters:
               const SizedBox(width: extraLargeSpacing),
               Flexible(
                 child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   mainAxisSize: MainAxisSize.min,
                   children: [
                     for (final exampleUsage in filterExampleUsages)

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -15,7 +15,7 @@ import 'package:flutter/material.dart';
 import '../common_widgets.dart';
 import '../primitives/utils.dart';
 
-typedef QueryFilterArgs = Map<String, QueryFilterArgument>;
+typedef QueryFilterArgs<T> = Map<String, QueryFilterArgument<T>>;
 typedef SettingFilters<T> = List<SettingFilter<T, Object>>;
 
 // TODO(kenz): consider breaking this up for flat data filtering and tree data
@@ -91,7 +91,7 @@ mixin FilterControllerMixin<T> on DisposableController
   /// query with arguments may look like 'foo category:bar type:baz'. In this
   /// example, 'category' and 'type' would need to be defined as query filter
   /// arguments.
-  QueryFilterArgs createQueryFilterArgs() => <String, QueryFilterArgument>{};
+  QueryFilterArgs<T> createQueryFilterArgs() => <String, QueryFilterArgument<T>>{};
 
   late final _queryFilterArgs = createQueryFilterArgs();
 

--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -704,7 +704,6 @@ class _StandaloneFilterFieldState<T> extends State<StandaloneFilterField<T>>
                   child: ValueListenableBuilder<Filter>(
                     valueListenable: widget.controller.activeFilter,
                     builder: (context, _, _) {
-                      // TODO(https://github.com/flutter/devtools/issues/8426): support filtering by log level.
                       return DevToolsFilterButton(
                         message: 'More filters',
                         onPressed: () {

--- a/packages/devtools_app/test/shared/filter_test.dart
+++ b/packages/devtools_app/test/shared/filter_test.dart
@@ -450,7 +450,7 @@ class _TestController extends DisposableController
   static const categoryFilterId = 'category-filter';
 
   @override
-  Map<String, QueryFilterArgument> createQueryFilterArgs() => {
+  Map<String, QueryFilterArgument<_TestDataClass>> createQueryFilterArgs() => {
         categoryFilterId: QueryFilterArgument<_TestDataClass>(
           keys: ['cat', 'c'],
           exampleUsages: ['cat:foo', '-c:bar'],

--- a/packages/devtools_app/test/shared/filter_test.dart
+++ b/packages/devtools_app/test/shared/filter_test.dart
@@ -453,6 +453,7 @@ class _TestController extends DisposableController
   Map<String, QueryFilterArgument> createQueryFilterArgs() => {
         categoryFilterId: QueryFilterArgument<_TestDataClass>(
           keys: ['cat', 'c'],
+          exampleUsages: ['cat:foo', '-c:bar'],
           dataValueProvider: (data) => data.category,
           substringMatch: false,
         ),

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -2,6 +2,7 @@
 * Add `updateQueryParameter` utility method.
 * Add `jump` parameter to `ScrollController.autoScrollToBottom` extension method.
 * Add `DevToolsAreaPane` widget.
+* Add `InputDecorationSuffixButton.help` factory constructor.
 
 ## 0.2.3
 * Bump `web` dependency to `^1.0.0`

--- a/packages/devtools_app_shared/lib/src/ui/text_field.dart
+++ b/packages/devtools_app_shared/lib/src/ui/text_field.dart
@@ -124,6 +124,15 @@ final class InputDecorationSuffixButton extends StatelessWidget {
         tooltip: 'Close',
       );
 
+  factory InputDecorationSuffixButton.help({
+    required VoidCallback? onPressed,
+  }) =>
+      InputDecorationSuffixButton(
+        icon: Icons.question_mark,
+        onPressed: onPressed,
+        tooltip: 'Help',
+      );
+
   final IconData icon;
   final VoidCallback? onPressed;
   final String? tooltip;

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -190,10 +190,13 @@ MockLoggingController createMockLoggingControllerWithDefaults({
 
   // Set up mock filter state.
   when(mockLoggingController.createQueryFilterArgs())
-      .thenReturn(LoggingController.queryFilterArgs);
+      .thenReturn(LoggingController.loggingQueryFilterArgs);
+  when(mockLoggingController.queryFilterArgs)
+      .thenReturn(LoggingController.loggingQueryFilterArgs);
   final activeFilter = FixedValueListenable(
     Filter<LogData>(
-      queryFilter: QueryFilter.empty(args: LoggingController.queryFilterArgs),
+      queryFilter:
+          QueryFilter.empty(args: LoggingController.loggingQueryFilterArgs),
       settingFilters: LoggingController.settingFilters,
     ),
   );

--- a/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
+++ b/packages/devtools_test/lib/src/mocks/generated_mocks_factories.dart
@@ -189,6 +189,8 @@ MockLoggingController createMockLoggingControllerWithDefaults({
       .thenReturn(ValueNotifier<LogData?>(null));
 
   // Set up mock filter state.
+  when(mockLoggingController.createQueryFilterArgs())
+      .thenReturn(LoggingController.queryFilterArgs);
   final activeFilter = FixedValueListenable(
     Filter<LogData>(
       queryFilter: QueryFilter.empty(args: LoggingController.queryFilterArgs),


### PR DESCRIPTION
![Screenshot 2024-10-22 at 10 49 24 AM](https://github.com/user-attachments/assets/5931659b-617d-4d45-a530-471879ab2522)
![Screenshot 2024-10-22 at 12 40 32 PM](https://github.com/user-attachments/assets/dbd39508-58dc-4366-823a-e096c7fba826)

This PR also changes how the query filter instructions are defined so that they are generated from the pre-defined query filter arguments instead of raw text that can easily get out of date and that previously had to be duplicated for each filter.
