### PR TITLE
Persist filters for the network screen

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -114,6 +114,9 @@ class NetworkController extends DisposableController
         ),
       };
 
+  @override
+  ValueNotifier<String>? get filterTagNotifier => preferences.network.filterTag;
+
   /// Notifies that new Network requests have been processed.
   ValueListenable<List<NetworkRequest>> get requests => _currentNetworkRequests;
 

--- a/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
@@ -28,8 +28,12 @@ class LoggingPreferencesController extends DisposableController
   static const _defaultDetailsFormat = LoggingDetailsFormat.text;
 
   static const _retentionLimitStorageId = 'logging.retentionLimit';
-  static const _detailsFormatStorageId = 'logging.detailsFormat';
-  static const _filterStorageId = 'logging.filter';
+
+  @visibleForTesting
+  static const detailsFormatStorageId = 'logging.detailsFormat';
+
+  @visibleForTesting
+  static const filterStorageId = 'logging.filter';
 
   Future<void> init() async {
     retentionLimit.value =
@@ -51,7 +55,7 @@ class LoggingPreferencesController extends DisposableController
     );
 
     final detailsFormatValueFromStorage =
-        await storage.getValue(_detailsFormatStorageId);
+        await storage.getValue(detailsFormatStorageId);
     detailsFormat.value = LoggingDetailsFormat.values.firstWhereOrNull(
           (value) => detailsFormatValueFromStorage == value.name,
         ) ??
@@ -59,7 +63,7 @@ class LoggingPreferencesController extends DisposableController
     addAutoDisposeListener(
       detailsFormat,
       () {
-        storage.setValue(_detailsFormatStorageId, detailsFormat.value.name);
+        storage.setValue(detailsFormatStorageId, detailsFormat.value.name);
         ga.select(
           gac.logging,
           gac.LoggingEvents.changeDetailsFormat.name,
@@ -68,10 +72,10 @@ class LoggingPreferencesController extends DisposableController
       },
     );
 
-    filterTag.value = await storage.getValue(_filterStorageId) ?? '';
+    filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(
       filterTag,
-      () => storage.setValue(_filterStorageId, filterTag.value),
+      () => storage.setValue(filterStorageId, filterTag.value),
     );
   }
 }

--- a/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
@@ -1,0 +1,24 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of 'preferences.dart';
+
+class NetworkPreferencesController extends DisposableController
+    with AutoDisposeControllerMixin {
+  /// The active filter tag for the network screen.
+  ///
+  /// This value caches the most recent filter settings.
+  final filterTag = ValueNotifier<String>('');
+
+  @visibleForTesting
+  static const filterStorageId = 'network.filter';
+
+  Future<void> init() async {
+    filterTag.value = await storage.getValue(filterStorageId) ?? '';
+    addAutoDisposeListener(
+      filterTag,
+      () => storage.setValue(filterStorageId, filterTag.value),
+    );
+  }
+}

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -26,6 +26,7 @@ part '_extension_preferences.dart';
 part '_inspector_preferences.dart';
 part '_memory_preferences.dart';
 part '_logging_preferences.dart';
+part '_network_preferences.dart';
 part '_performance_preferences.dart';
 
 final _log = Logger('PreferencesController');
@@ -80,22 +81,25 @@ class PreferencesController extends DisposableController
   final verboseLoggingEnabled =
       ValueNotifier<bool>(Logger.root.level == verboseLoggingLevel);
 
+  ExtensionsPreferencesController get devToolsExtensions => _extensions;
+  final _extensions = ExtensionsPreferencesController();
+
   // TODO(https://github.com/flutter/devtools/issues/7860): Clean-up after
   // Inspector V2 has been released.
   InspectorPreferencesController get inspector => _inspector;
   final _inspector = InspectorPreferencesController();
 
-  MemoryPreferencesController get memory => _memory;
-  final _memory = MemoryPreferencesController();
-
   LoggingPreferencesController get logging => _logging;
   final _logging = LoggingPreferencesController();
 
+  MemoryPreferencesController get memory => _memory;
+  final _memory = MemoryPreferencesController();
+
+  NetworkPreferencesController get network => _network;
+  final _network = NetworkPreferencesController();
+
   PerformancePreferencesController get performance => _performance;
   final _performance = PerformancePreferencesController();
-
-  ExtensionsPreferencesController get devToolsExtensions => _extensions;
-  final _extensions = ExtensionsPreferencesController();
 
   Future<void> init() async {
     // Get the current values and listen for and write back changes.
@@ -106,11 +110,12 @@ class PreferencesController extends DisposableController
     }
     await _initVerboseLogging();
 
-    await inspector.init();
-    await memory.init();
-    await logging.init();
-    await performance.init();
     await devToolsExtensions.init();
+    await inspector.init();
+    await logging.init();
+    await memory.init();
+    await network.init();
+    await performance.init();
 
     setGlobal(PreferencesController, this);
   }
@@ -225,11 +230,12 @@ class PreferencesController extends DisposableController
 
   @override
   void dispose() {
-    inspector.dispose();
-    memory.dispose();
-    logging.dispose();
-    performance.dispose();
     devToolsExtensions.dispose();
+    inspector.dispose();
+    logging.dispose();
+    memory.dispose();
+    network.dispose();
+    performance.dispose();
     super.dispose();
   }
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -10,7 +10,8 @@ To learn more about DevTools, check out the
 
 ## General updates
 
-* Persist filter settings across sessions. - [#8447](https://github.com/flutter/devtools/pull/8447)
+* Persist filter settings across sessions. - [#8447](https://github.com/flutter/devtools/pull/8447),
+[#8470](https://github.com/flutter/devtools/pull/8470)
 
 ## Inspector updates
 

--- a/packages/devtools_app/test/network/network_controller_test.dart
+++ b/packages/devtools_app/test/network/network_controller_test.dart
@@ -5,10 +5,7 @@
 @TestOn('vm')
 library;
 
-import 'package:devtools_app/src/screens/network/network_controller.dart';
-import 'package:devtools_app/src/screens/network/network_model.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/http/http_request_data.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:devtools_test/helpers.dart';
@@ -34,6 +31,7 @@ void main() {
         ),
       );
       setGlobal(ServiceConnectionManager, fakeServiceConnection);
+      setGlobal(PreferencesController, PreferencesController());
       controller = NetworkController();
     });
 

--- a/packages/devtools_app/test/network/network_model_test.dart
+++ b/packages/devtools_app/test/network/network_model_test.dart
@@ -4,9 +4,7 @@
 
 import 'dart:convert';
 
-import 'package:devtools_app/src/screens/network/network_controller.dart';
-import 'package:devtools_app/src/service/service_manager.dart';
-import 'package:devtools_app/src/shared/primitives/utils.dart';
+import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -87,6 +85,7 @@ void main() {
         ),
       );
       setGlobal(ServiceConnectionManager, fakeServiceConnection);
+      setGlobal(PreferencesController, PreferencesController());
       controller = NetworkController();
       await controller.startRecording();
     });

--- a/packages/devtools_app/test/network/network_table_test.dart
+++ b/packages/devtools_app/test/network/network_table_test.dart
@@ -35,6 +35,7 @@ void main() {
         ),
       );
       setGlobal(ServiceConnectionManager, fakeServiceConnection);
+      setGlobal(PreferencesController, PreferencesController());
       setGlobal(IdeTheme, IdeTheme());
 
       // Bypass controller recording so timelineMicroOffset is not time dependant

--- a/packages/devtools_app/test/shared/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences_controller_test.dart
@@ -403,7 +403,6 @@ void main() {
   group('$LoggingPreferencesController', () {
     late LoggingPreferencesController controller;
     late FlutterTestStorage storage;
-
     setUp(() async {
       setGlobal(Storage, storage = FlutterTestStorage());
       controller = LoggingPreferencesController();
@@ -412,16 +411,70 @@ void main() {
 
     test('has expected default values', () {
       expect(controller.detailsFormat.value, LoggingDetailsFormat.text);
+      expect(controller.filterTag.value, '');
     });
 
     test('stores values and reads them on init', () async {
       storage.values.clear();
 
       // Remember original values.
-      final detailsFormat = controller.detailsFormat.value;
+      final originalDetailsFormat = controller.detailsFormat.value;
+      final originalFilterTag = controller.filterTag.value;
 
-      // Flip the values in controller.
-      controller.detailsFormat.value = detailsFormat.opposite();
+      // Change the values in controller.
+      final detailsFormat = originalDetailsFormat.opposite();
+      const filterTag = 'foo|[{"level":2}]|regexp';
+      controller.detailsFormat.value = detailsFormat;
+      controller.filterTag.value = filterTag;
+
+      // Check the values are stored.
+      expect(storage.values, hasLength(2));
+
+      // Reload the values from storage.
+      await controller.init();
+
+      // Check they did not change back to the original values.
+      expect(controller.detailsFormat.value, detailsFormat);
+      expect(controller.filterTag.value, filterTag);
+
+      // Change the values from storage.
+      storage.values[LoggingPreferencesController.detailsFormatStorageId] =
+          originalDetailsFormat.name;
+      storage.values[LoggingPreferencesController.filterStorageId] =
+          originalFilterTag;
+
+      // Reload the values from storage.
+      await controller.init();
+
+      // Check they flipped values are loaded.
+      expect(controller.detailsFormat.value, originalDetailsFormat);
+      expect(controller.filterTag.value, originalFilterTag);
+    });
+  });
+
+  group('$NetworkPreferencesController', () {
+    late NetworkPreferencesController controller;
+    late FlutterTestStorage storage;
+
+    setUp(() async {
+      setGlobal(Storage, storage = FlutterTestStorage());
+      controller = NetworkPreferencesController();
+      await controller.init();
+    });
+
+    test('has expected default values', () {
+      expect(controller.filterTag.value, '');
+    });
+
+    test('stores values and reads them on init', () async {
+      storage.values.clear();
+
+      // Remember original values.
+      final originalFilterTag = controller.filterTag.value;
+
+      // Change the values in controller.
+      const filterTag = 'foo|[{"level":2}]|regexp';
+      controller.filterTag.value = filterTag;
 
       // Check the values are stored.
       expect(storage.values, hasLength(1));
@@ -429,25 +482,18 @@ void main() {
       // Reload the values from storage.
       await controller.init();
 
-      // Check they did not change back to default.
-      expect(
-        controller.detailsFormat.value,
-        detailsFormat.opposite(),
-      );
+      // Check they did not change back to the original values.
+      expect(controller.filterTag.value, filterTag);
 
-      // Flip the values in storage.
-      for (final key in storage.values.keys) {
-        storage.values[key] = detailsFormat.name;
-      }
+      // Change the values from storage.
+      storage.values[NetworkPreferencesController.filterStorageId] =
+          originalFilterTag;
 
       // Reload the values from storage.
       await controller.init();
 
       // Check they flipped values are loaded.
-      expect(
-        controller.detailsFormat.value,
-        detailsFormat,
-      );
+      expect(controller.filterTag.value, originalFilterTag);
     });
   });
 


### PR DESCRIPTION
This breaks out the Network screen changes from https://github.com/flutter/devtools/pull/8456 so that these can land. The changes to persist filters for the CPU profiler page are blocked on a [WASM bug](https://github.com/flutter/devtools/issues/8452) that breaks the DevTools benchmarks with the changes from https://github.com/flutter/devtools/pull/8456