### PR TITLE
Fix bounds check error with dart2wasm -O4

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/filter.dart
+++ b/packages/devtools_app/lib/src/shared/ui/filter.dart
@@ -855,6 +855,7 @@ class FilterTag {
 
   static FilterTag? parse(String value) {
     final parts = value.split(filterTagSeparator);
+    if (parts.length < 2) return null;
     try {
       final useRegExp = parts.last == useRegExpTag;
       final query = parts[0].trim();


### PR DESCRIPTION
dart2wasm release mode omits bounds checks in standard library lists, similar to dart2js.

Update `FilterTag.parse` to avoid relying on bounds checks on `List`.

Fixes #8452.