### PR TITLE
[Inspector V2] Implementation details remain hidden on tree refresh

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -419,9 +419,11 @@ class InspectorController extends DisposableController
 
   Future<void> _recomputeTreeRoot(
     RemoteDiagnosticsNode? newSelection, {
-    bool hideImplementationWidgets = false,
+    bool? hideImplementationWidgets,
   }) async {
     assert(!_disposed);
+    hideImplementationWidgets =
+        hideImplementationWidgets ?? _implementationWidgetsHidden.value;
     final treeGroups = _treeGroups;
     if (_disposed || treeGroups == null) {
       return;

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -422,8 +422,7 @@ class InspectorController extends DisposableController
     bool? hideImplementationWidgets,
   }) async {
     assert(!_disposed);
-    hideImplementationWidgets =
-        hideImplementationWidgets ?? _implementationWidgetsHidden.value;
+    hideImplementationWidgets ??= _implementationWidgetsHidden.value;
     final treeGroups = _treeGroups;
     if (_disposed || treeGroups == null) {
       return;

--- a/packages/devtools_app/test/inspector_v2/inspector_integration_test.dart
+++ b/packages/devtools_app/test/inspector_v2/inspector_integration_test.dart
@@ -260,6 +260,18 @@ void main() {
           '../test_infra/goldens/integration_inspector_v2_implementation_widgets_hidden.png',
         ),
       );
+
+      // Refresh the tree.
+      final refreshTreeButton = find.descendant(
+        of: find.byType(ToolbarAction),
+        matching: find.byIcon(Icons.refresh),
+      );
+
+      await tester.tap(refreshTreeButton);
+      await tester.pumpAndSettle(inspectorChangeSettleTime);
+
+      // Confirm that the hidden widgets are still not visible.
+      expect(find.richTextContaining('more widgets...'), findsNothing);
     },
   );
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8467