### PR TITLE
Pass args from legacy `devtools_tool` to `dt`

### DIFF
--- a/tool/bin/devtools_tool
+++ b/tool/bin/devtools_tool
@@ -5,4 +5,4 @@
 # TODO(kenz): remove this file in ~6 months (April 2025).
 
 echo Warning: devtools_tool has been replaced by dt. Please use dt instead.
-dt
+dt $@


### PR DESCRIPTION
Allows us to still use the `devtools_tool` command by passing the args it was run with to `dt`. 