### PR TITLE
Disable two lint rules which are being removed.

### DIFF
--- a/packages/analysis_options.yaml
+++ b/packages/analysis_options.yaml
@@ -43,7 +43,6 @@ linter:
     - avoid_function_literals_in_foreach_calls
     - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime
-    - avoid_null_checks_in_equality_operators
     # - avoid_positional_boolean_parameters # not yet tested
     - avoid_print
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
@@ -138,7 +137,6 @@ linter:
     - unnecessary_statements
     - unnecessary_this
     - unrelated_type_equality_checks
-    - unsafe_html
     - use_rethrow_when_possible
     # - use_setters_to_change_properties # not yet tested
     # - use_string_buffers # https://github.com/dart-lang/linter/pull/664

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -87,7 +87,6 @@ class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController
     _extensionIFrame = HTMLIFrameElement()
       // This url is safe because we built it ourselves and it does not include
       // any user input.
-      // ignore: unsafe_html
       ..src = extensionUrl
       ..allow = 'usb';
     _extensionIFrame.style

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_controller_web.dart
@@ -167,7 +167,6 @@ class PerfettoControllerImpl extends PerfettoController {
     _perfettoIFrame = HTMLIFrameElement()
       // This url is safe because we built it ourselves and it does not include
       // any user input.
-      // ignore: unsafe_html
       ..src = perfettoUrl
       ..allow = 'usb';
     _perfettoIFrame.style


### PR DESCRIPTION
Each of these are going to be removed soon.

* avoid_null_checks_in_equality_operators
* unsafe_html

Work towards https://github.com/dart-lang/linter/issues/5063 and https://github.com/dart-lang/linter/issues/5001


## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [ ] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
