### PR TITLE
[Inspector V2] Fixes an issue where the V2 Inspector wouldn't load after hot-restarting from legacy inspector 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_shared/inspector_screen.dart
@@ -3,12 +3,14 @@
 // found in the LICENSE file.
 
 import 'package:devtools_app_shared/shared.dart';
+import 'package:devtools_app_shared/utils.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import '../../shared/feature_flags.dart';
 import '../../shared/globals.dart';
 import '../../shared/screen.dart';
+import '../../shared/utils.dart';
 import '../inspector/inspector_screen_body.dart' as legacy;
 import '../inspector_v2/inspector_screen_body.dart' as v2;
 import 'inspector_screen_controller.dart';
@@ -33,8 +35,35 @@ class InspectorScreen extends Screen {
       const InspectorScreenSwitcher();
 }
 
-class InspectorScreenSwitcher extends StatelessWidget {
+class InspectorScreenSwitcher extends StatefulWidget {
   const InspectorScreenSwitcher({super.key});
+
+  @override
+  State<InspectorScreenSwitcher> createState() =>
+      _InspectorScreenSwitcherState();
+}
+
+class _InspectorScreenSwitcherState extends State<InspectorScreenSwitcher>
+    with
+        AutoDisposeMixin,
+        ProvidedControllerMixin<InspectorScreenController,
+            InspectorScreenSwitcher> {
+  bool get shouldShowInspectorV2 =>
+      FeatureFlags.inspectorV2 &&
+      preferences.inspector.inspectorV2Enabled.value;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!initController()) return;
+
+    addAutoDisposeListener(preferences.inspector.inspectorV2Enabled, () async {
+      controller.legacyInspectorController
+          .setVisibleToUser(!shouldShowInspectorV2);
+      await controller.v2InspectorController
+          .setVisibleToUser(shouldShowInspectorV2);
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,7 +72,7 @@ class InspectorScreenSwitcher extends StatelessWidget {
     return ValueListenableBuilder(
       valueListenable: preferences.inspector.inspectorV2Enabled,
       builder: (context, v2Enabled, _) {
-        if (FeatureFlags.inspectorV2 && v2Enabled) {
+        if (shouldShowInspectorV2) {
           return v2.InspectorScreenBody(
             controller: controller.v2InspectorController,
           );

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -169,7 +169,7 @@ class InspectorController extends DisposableController
       serviceConnection.serviceManager.serviceExtensionManager
           .hasServiceExtension(extensions.toggleSelectWidgetMode.extension);
 
-  void _onClientChange(bool added) {
+  Future<void> _onClientChange(bool added) async {
     if (!added && _clientCount == 0) {
       // Don't try to remove clients if there are none
       return;
@@ -178,10 +178,10 @@ class InspectorController extends DisposableController
     _clientCount += added ? 1 : -1;
     assert(_clientCount >= 0);
     if (_clientCount == 1) {
-      setVisibleToUser(true);
+      await setVisibleToUser(true);
       setActivate(true);
     } else if (_clientCount == 0) {
-      setVisibleToUser(false);
+      await setVisibleToUser(false);
     }
   }
 
@@ -276,13 +276,14 @@ class InspectorController extends DisposableController
     return treeType;
   }
 
-  void setVisibleToUser(bool visible) {
+  Future<void> setVisibleToUser(bool visible) async {
     if (visibleToUser == visible) {
       return;
     }
     visibleToUser = visible;
 
     if (visibleToUser) {
+      await refreshInspector();
     } else {
       shutdownTree(false);
     }

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,6 +18,7 @@ To learn more about DevTools, check out the
 
 - Added an option to the [new Inspector's](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates)
   settings to allow auto-refreshing the widget tree after a hot-reload. - [#8483](https://github.com/flutter/devtools/pull/8483)
+- Fixed an [issue](https://github.com/flutter/devtools/issues/8487) where the [new Inspector](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) would not load after a hot-restart in the legacy Inspector. - [#8491](https://github.com/flutter/devtools/pull/8491)
 
 ## Performance updates
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8487

Added a test case, but skipped until I can figure out how to solve https://github.com/flutter/devtools/issues/8490 (I want to get this and a few other fixes in before the release cut-off, after they're in I will work on https://github.com/flutter/devtools/issues/8490)