### PR TITLE
Skip flaky test

### DIFF
--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
@@ -45,10 +45,22 @@ void main() {
 
     logStatus('testing variable assignment');
     await testAssignment(evalTester);
-
-    logStatus('testing eval on widget tree node');
-    await _testEvalOnWidgetTreeNode(evalTester);
   });
+
+  testWidgets(
+    'eval with scope on widget tree node',
+    (tester) async {
+      await pumpAndConnectDevTools(tester, testApp);
+
+      final evalTester = EvalTester(tester);
+      await evalTester.prepareInspectorUI();
+
+      logStatus('testing eval on widget tree node');
+      await _testEvalOnWidgetTreeNode(evalTester);
+    },
+    // https://github.com/flutter/devtools/pull/8123
+    skip: true,
+  );
 }
 
 Future<void> _testEvalOnWidgetTreeNode(EvalTester tester) async {

--- a/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
+++ b/packages/devtools_app/integration_test/test/live_connection/eval_and_inspect_test.dart
@@ -58,7 +58,7 @@ void main() {
       logStatus('testing eval on widget tree node');
       await _testEvalOnWidgetTreeNode(evalTester);
     },
-    // https://github.com/flutter/devtools/pull/8123
+    // https://github.com/flutter/devtools/issues/8389
     skip: true,
   );
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8389

Previous attempts to fix this involved adding retry logic and then increasing the number or retries:
* https://github.com/flutter/devtools/pull/8123
* https://github.com/flutter/devtools/pull/8391

However, we're still seeing flakes here so I think I need to figure out a better way to determine whether the eval has completed successfully before looking for the eval message in the console. Skipping the failing test case for now.
