### PR TITLE
Include screen information with `unified_analytics` events and bump `unified_analytics` to 7.0.0

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -111,8 +111,11 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
     int? root_set_count, // metric10
     int? row_count, // metric11
     int? inspector_tree_controller_id, // metric12
+    // Deep Link screen metrics. See [DeepLinkScreenMetrics].
     String? android_app_id, //metric13
     String? ios_bundle_id, //metric14
+    // Inspector screen metrics. See [InspectorScreenMetrics].
+    bool? is_v2_inspector, // metric15
   });
 
   factory GtagEventDevTools._create({
@@ -192,6 +195,9 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
       ios_bundle_id: screenMetrics is DeepLinkScreenMetrics
           ? screenMetrics.iosBundleId
           : null,
+      // [InspectorScreenMetrics]
+      is_v2_inspector:
+          screenMetrics is InspectorScreenMetrics ? screenMetrics.isV2 : null,
     );
   }
 
@@ -227,6 +233,7 @@ extension type GtagEventDevTools._(JSObject _) implements GtagEvent {
   external int? get inspector_tree_controller_id;
   external String? get android_app_id;
   external String? get ios_bundle_id;
+  external bool? get is_v2_inspector;
 }
 
 extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
@@ -280,8 +287,11 @@ extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
     int? root_set_count, // metric10
     int? row_count, // metric11
     int? inspector_tree_controller_id, // metric12
+    // Deep Link screen metrics. See [DeepLinkScreenMetrics].
     String? android_app_id, //metric13
     String? ios_bundle_id, //metric14
+    // Inspector screen metrics. See [InspectorScreenMetrics].
+    bool? is_v2_inspector, // metric15
   });
 
   factory GtagExceptionDevTools._create(
@@ -353,6 +363,9 @@ extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
       ios_bundle_id: screenMetrics is DeepLinkScreenMetrics
           ? screenMetrics.iosBundleId
           : null,
+      // [InspectorScreenMetrics]
+      is_v2_inspector:
+          screenMetrics is InspectorScreenMetrics ? screenMetrics.isV2 : null,
     );
   }
 
@@ -386,6 +399,7 @@ extension type GtagExceptionDevTools._(JSObject _) implements GtagException {
   external int? get inspector_tree_controller_id;
   external String? get android_app_id;
   external String? get ios_bundle_id;
+  external bool? get is_v2_inspector;
 }
 
 /// Whether google analytics are enabled.
@@ -920,23 +934,24 @@ ua.Event _uaEventFromGtagEvent(GtagEventDevTools gtagEvent) {
     // all of the below metrics will be non-null at the same time, it is okay to
     // include all the metrics here. The [ua.Event.devtoolsEvent] constructor
     // will remove any entries with a null value from the sent event parameters.
-    additionalMetrics: {
-      'uiDurationMicros': gtagEvent.ui_duration_micros,
-      'rasterDurationMicros': gtagEvent.raster_duration_micros,
-      'shaderCompilationDurationMicros':
+    additionalMetrics: _DevToolsEventMetrics(
+      uiDurationMicros: gtagEvent.ui_duration_micros,
+      rasterDurationMicros: gtagEvent.raster_duration_micros,
+      shaderCompilationDurationMicros:
           gtagEvent.shader_compilation_duration_micros,
-      'traceEventCount': gtagEvent.trace_event_count,
-      'cpuSampleCount': gtagEvent.cpu_sample_count,
-      'cpuStackDepth': gtagEvent.cpu_stack_depth,
-      'heapDiffObjectsBefore': gtagEvent.heap_diff_objects_before,
-      'heapDiffObjectsAfter': gtagEvent.heap_diff_objects_after,
-      'heapObjectsTotal': gtagEvent.heap_objects_total,
-      'rootSetCount': gtagEvent.root_set_count,
-      'rowCount': gtagEvent.row_count,
-      'inspectorTreeControllerId': gtagEvent.inspector_tree_controller_id,
-      'androidAppId': gtagEvent.android_app_id,
-      'iosBundleId': gtagEvent.ios_bundle_id,
-    },
+      traceEventCount: gtagEvent.trace_event_count,
+      cpuSampleCount: gtagEvent.cpu_sample_count,
+      cpuStackDepth: gtagEvent.cpu_stack_depth,
+      heapDiffObjectsBefore: gtagEvent.heap_diff_objects_before,
+      heapDiffObjectsAfter: gtagEvent.heap_diff_objects_after,
+      heapObjectsTotal: gtagEvent.heap_objects_total,
+      rootSetCount: gtagEvent.root_set_count,
+      rowCount: gtagEvent.row_count,
+      inspectorTreeControllerId: gtagEvent.inspector_tree_controller_id,
+      isV2Inspector: gtagEvent.is_v2_inspector,
+      androidAppId: gtagEvent.android_app_id,
+      iosBundleId: gtagEvent.ios_bundle_id,
+    ),
   );
 }
 
@@ -978,4 +993,68 @@ ua.Event _uaEventFromGtagException(
       // trace chunks.
     },
   );
+}
+
+final class _DevToolsEventMetrics extends ua.CustomMetrics {
+  _DevToolsEventMetrics({
+    required this.rasterDurationMicros,
+    required this.shaderCompilationDurationMicros,
+    required this.traceEventCount,
+    required this.cpuSampleCount,
+    required this.cpuStackDepth,
+    required this.heapDiffObjectsBefore,
+    required this.heapDiffObjectsAfter,
+    required this.heapObjectsTotal,
+    required this.rootSetCount,
+    required this.rowCount,
+    required this.inspectorTreeControllerId,
+    required this.isV2Inspector,
+    required this.androidAppId,
+    required this.iosBundleId,
+    required this.uiDurationMicros,
+  });
+
+  // [PerformanceScreenMetrics]
+  final int? uiDurationMicros;
+  final int? rasterDurationMicros;
+  final int? shaderCompilationDurationMicros;
+  final int? traceEventCount;
+
+  // [ProfilerScreenMetrics]
+  final int? cpuSampleCount;
+  final int? cpuStackDepth;
+
+  // [MemoryScreenMetrics]
+  final int? heapDiffObjectsBefore;
+  final int? heapDiffObjectsAfter;
+  final int? heapObjectsTotal;
+
+  // [InspectorScreenMetrics]
+  final int? rootSetCount;
+  final int? rowCount;
+  final int? inspectorTreeControllerId;
+  final bool? isV2Inspector;
+
+  // [DeepLinkScreenMetrics]
+  final String? androidAppId;
+  final String? iosBundleId;
+
+  @override
+  Map<String, Object> toMap() => (<String, Object?>{
+        'uiDurationMicros': uiDurationMicros,
+        'rasterDurationMicros': rasterDurationMicros,
+        'shaderCompilationDurationMicros': shaderCompilationDurationMicros,
+        'traceEventCount': traceEventCount,
+        'cpuSampleCount': cpuSampleCount,
+        'cpuStackDepth': cpuStackDepth,
+        'heapDiffObjectsBefore': heapDiffObjectsBefore,
+        'heapDiffObjectsAfter': heapDiffObjectsAfter,
+        'heapObjectsTotal': heapObjectsTotal,
+        'rootSetCount': rootSetCount,
+        'rowCount': rowCount,
+        'inspectorTreeControllerId': inspectorTreeControllerId,
+        'isV2Inspector': isV2Inspector,
+        'androidAppId': androidAppId,
+        'iosBundleId': iosBundleId,
+      }..removeWhere((key, value) => value == null)) as Map<String, Object>;
 }

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -434,7 +434,7 @@ void screen(String screenName, [int value = 0]) {
     value: value,
     send_to: gaDevToolsPropertyId(),
   );
-  _sendEventForScreen(gtagEvent);
+  _sendEvent(gtagEvent);
 }
 
 String _operationKey(String screenName, String timedOperation) {
@@ -581,7 +581,7 @@ void _timing(
     send_to: gaDevToolsPropertyId(),
     screenMetrics: screenMetrics,
   );
-  _sendEventForScreen(gtagEvent);
+  _sendEvent(gtagEvent);
 }
 
 /// Sends an analytics event to signal that something in DevTools was selected.
@@ -609,7 +609,7 @@ void select(
     screenMetrics:
         screenMetricsProvider != null ? screenMetricsProvider() : null,
   );
-  _sendEventForScreen(gtagEvent);
+  _sendEvent(gtagEvent);
 }
 
 /// Sends an analytics event to signal that something in DevTools was viewed.
@@ -634,7 +634,7 @@ void impression(
     screenMetrics:
         screenMetricsProvider != null ? screenMetricsProvider() : null,
   );
-  _sendEventForScreen(gtagEvent);
+  _sendEvent(gtagEvent);
 }
 
 String? _lastGaError;
@@ -886,7 +886,7 @@ void legacyOnSetupAnalytics() {
   jsHookupListenerForGA();
 }
 
-void _sendEventForScreen(GtagEventDevTools gtagEvent) {
+void _sendEvent(GtagEventDevTools gtagEvent) {
   GTag.event(
     gtagEvent.screen!,
     gaEventProvider: () => gtagEvent,

--- a/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart
@@ -1056,5 +1056,6 @@ final class _DevToolsEventMetrics extends ua.CustomMetrics {
         'isV2Inspector': isV2Inspector,
         'androidAppId': androidAppId,
         'iosBundleId': iosBundleId,
-      }..removeWhere((key, value) => value == null)) as Map<String, Object>;
+      }..removeWhere((key, value) => value == null))
+          .cast<String, Object>();
 }

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
   devtools_app_shared: ^0.2.2
   devtools_extensions: ^0.3.0-wip
   devtools_shared: ^10.0.1
-  dtd: ^2.3.0
+  dtd: ^2.4.0
   file: ^7.0.0
   file_selector: ^1.0.0
   fixnum: ^1.1.0

--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -53,7 +53,7 @@ dependencies:
   stack_trace: ^1.12.0
   stream_channel: ^2.1.1
   string_scanner: ^1.1.0
-  unified_analytics: ^6.1.5
+  unified_analytics: ^7.0.0
   vm_service: ^14.2.5
   vm_service_protos: ^1.0.0
   vm_snapshot_analysis: ^0.7.6

--- a/packages/devtools_app/web/devtools_analytics.js
+++ b/packages/devtools_app/web/devtools_analytics.js
@@ -44,6 +44,9 @@ function initializeGA() {
       'metric10': 'root_set_count',
       'metric11': 'row_count',
       'metric12': 'inspector_tree_controller_id',
+      'metric13': 'android_app_id',
+      'metric14': 'ios_bundle_id',
+      'metric15': 'is_v2_inspector',
     },
     cookie_flags: 'SameSite=None;Secure',
   });


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8513

Depends on https://github.com/dart-lang/tools/pull/1193 landing an a unified_analytics 7.0.0. being published.

This PR also incorporates the inspector metrics addition from https://github.com/flutter/devtools/pull/8512, since that was where the original suggestion to use `additionalMetrics` stemmed from. This PR fixes https://github.com/flutter/devtools/issues/8511 too.