### PR TITLE
[Inspector V2] Refresh search matches when "Show implementation widgets" is toggled on or off

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -598,6 +598,9 @@ class InspectorController extends DisposableController
       );
       // Persist the selected node after refreshing the widget tree:
       refreshSelection(currentSelectedNode?.diagnostic);
+
+      // If the user is searching the tree, refresh the search matches.
+      inspectorTree.refreshSearchMatches();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8358
