### PR TITLE
Update package:web_benchmarks dep.

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -76,7 +76,7 @@ dev_dependencies:
   mockito: ^5.4.1
   stager: ^1.0.1
   test: ^1.21.0
-  web_benchmarks: ^3.1.0
+  web_benchmarks: ^4.0.0
   webkit_inspection_protocol: ">=0.5.0 <2.0.0"
 
 flutter:


### PR DESCRIPTION
This change is in preparation of the removal of `--web-renderer=html`.

* Related: https://github.com/flutter/packages/pull/8103 (tooling change to remove the parameter from the benchmark runner)
* Related: https://github.com/flutter/flutter/issues/145954 (general thread)

## Tests

In this case, CI should continue normally. The change is just adopting a new major version of `package:web_benchmarks` that removed some public API (that wasn't used in devtools).

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
