### PR TITLE
Uncomment assert and remove todo

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -80,15 +80,13 @@ class CpuProfileTransformer {
     _setExclusiveSampleCountsAndTags(cpuProfileData);
     cpuProfileData.processed = true;
 
-    // TODO(kenz): investigate why this assert is firing again.
-    // https://github.com/flutter/devtools/issues/1529.
-//    assert(
-//      cpuProfileData.profileMetaData.sampleCount ==
-//          cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
-//      'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
-//      ' != sample count from root '
-//      '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
-//    );
+   assert(
+     cpuProfileData.profileMetaData.sampleCount ==
+         cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
+     'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
+     ' != sample count from root '
+     '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
+   );
 
     // Reset the transformer after processing.
     reset();

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -80,13 +80,13 @@ class CpuProfileTransformer {
     _setExclusiveSampleCountsAndTags(cpuProfileData);
     cpuProfileData.processed = true;
 
-   assert(
-     cpuProfileData.profileMetaData.sampleCount ==
-         cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
-     'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
-     ' != sample count from root '
-     '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
-   );
+    assert(
+      cpuProfileData.profileMetaData.sampleCount ==
+          cpuProfileData.cpuProfileRoot.inclusiveSampleCount,
+      'SampleCount from response (${cpuProfileData.profileMetaData.sampleCount})'
+      ' != sample count from root '
+      '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
+    );
 
     // Reset the transformer after processing.
     reset();


### PR DESCRIPTION
This removes an assert that was commented out due to https://github.com/flutter/devtools/issues/1529. This is no longer reproducible, so this PR adds the assert back.