### PR TITLE
Speed up analysis for Flutter customer tests

### DIFF
--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -16,6 +16,6 @@ flutter pub get
 
 # Skip unimportant directories to speed up analysis.
 # Unimportant directories are defined in tool/lib/commands/analyze.dart.
-dart bin/dt.dart analyze --no-fatal-infos --skip-unimportant
+dt analyze --no-fatal-infos --skip-unimportant
 
 cd ..

--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -8,7 +8,6 @@
 # https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test.
 
 cd tool
-flutter pub get
 
 # We do not need to run `dt pub-get` here because the Flutter customer
 # test retgistry script already runs `flutter packages get` on the

--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -9,6 +9,13 @@
 
 cd tool
 flutter pub get
-dart bin/dt.dart pub-get
-dart bin/dt.dart analyze --no-fatal-infos
+
+# We do not need to run `dart bin/dt.dart pub-get` here because
+# the Flutter customer test retgistry script already runs 
+# `flutter packages get` on the DevTools packages.
+
+# Skip unimportant directories to speed up analysis.
+# Unimportant directories are defined in tool/lib/commands/analyze.dart.
+dart bin/dt.dart analyze --no-fatal-infos --skip-unimportant
+
 cd ..

--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -7,6 +7,13 @@
 # setup.sh, which is called from the setup steps in
 # https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test.
 
+# Ensure the `dt` executable is on PATH.
+root_dir=$(pwd)
+tool_dir="$root_dir/tool/bin"
+export PATH=$PATH:$tool_dir
+# Force `dt` to use the current Flutter (which is available on PATH).
+export DEVTOOLS_TOOL_FLUTTER_FROM_PATH=true
+
 cd tool
 
 # We do not need to run `dt pub-get` here because the Flutter customer

--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -3,16 +3,16 @@
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter
 
-# At this point we can expect that mocks have already been generated
-# from the setup steps in
-# https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test
+# At this point we can expect that mocks have already been generated from
+# setup.sh, which is called from the setup steps in
+# https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test.
 
 cd tool
 flutter pub get
 
-# We do not need to run `dart bin/dt.dart pub-get` here because
-# the Flutter customer test retgistry script already runs 
-# `flutter packages get` on the DevTools packages.
+# We do not need to run `dt pub-get` here because the Flutter customer
+# test retgistry script already runs `flutter packages get` on the
+# DevTools packages.
 
 # Skip unimportant directories to speed up analysis.
 # Unimportant directories are defined in tool/lib/commands/analyze.dart.

--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -11,8 +11,12 @@ export PATH=$PATH:$tool_dir
 
 # Force `dt` to use the current Flutter (which is available on PATH).
 export DEVTOOLS_TOOL_FLUTTER_FROM_PATH=true
+
 cd tool
 flutter pub get
-dt pub-get
+
+# We do not need to run `dt pub-get` explicitly here because
+# `dt generate-code --upgrade` will run `dt pub-get --only-main --upgrade`.
 dt generate-code --upgrade
+
 cd ..

--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -13,8 +13,7 @@ export DEVTOOLS_TOOL_FLUTTER_FROM_PATH=true
 cd tool
 flutter pub get
 
-# We do not need to run `dt pub-get` explicitly here because
-# `dt generate-code --upgrade` will run `dt pub-get --only-main --upgrade`.
-dt generate-code --upgrade
+dt pub-get --upgrade
+dt generate-code --no-pub-get
 
 cd ..

--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -3,12 +3,10 @@
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter
 
+# Ensure the `dt` executable is on PATH.
 root_dir=$(pwd)
 tool_dir="$root_dir/tool/bin"
-
-# Ensure the `dt` executable is on PATH.
 export PATH=$PATH:$tool_dir
-
 # Force `dt` to use the current Flutter (which is available on PATH).
 export DEVTOOLS_TOOL_FLUTTER_FROM_PATH=true
 

--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -5,8 +5,11 @@
 
 root_dir=$(pwd)
 tool_dir="$root_dir/tool/bin"
+
+# Ensure the `dt` executable is on PATH.
 export PATH=$PATH:$tool_dir
-# Force dt to use the current Flutter (which is available on PATH).
+
+# Force `dt` to use the current Flutter (which is available on PATH).
 export DEVTOOLS_TOOL_FLUTTER_FROM_PATH=true
 cd tool
 flutter pub get

--- a/tool/flutter_customer_tests/test.sh
+++ b/tool/flutter_customer_tests/test.sh
@@ -2,9 +2,9 @@
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter
 
-# At this point we can expect that mocks have already been generated
-# from the setup steps in
-# https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test
+# At this point we can expect that mocks have already been generated from
+# setup.sh, which is called from the setup steps in
+# https://github.com/flutter/tests/blob/main/registry/flutter_devtools.test.
 
 # Test all tests in devtools_app_shared
 cd packages/devtools_app_shared

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -12,15 +12,27 @@ import '../model.dart';
 import '../utils.dart';
 
 const _fatalInfosArg = 'fatal-infos';
+const _skipUnimportantArg = 'skip-unimportant';
+
+const _unimportantDirectories = ['case_study', 'fixtures'];
 
 class AnalyzeCommand extends Command {
   AnalyzeCommand() {
-    argParser.addFlag(
-      'fatal-infos',
-      help: 'Sets the "fatal-infos" flag for the dart analyze command',
-      defaultsTo: true,
-      negatable: true,
-    );
+    argParser
+      ..addFlag(
+        _fatalInfosArg,
+        help: 'Sets the "fatal-infos" flag for the dart analyze command',
+        defaultsTo: true,
+        negatable: true,
+      )
+      ..addFlag(
+        _skipUnimportantArg,
+        help:
+            'Skips analysis for unimportant directories '
+            '${_unimportantDirectories.toString()}',
+        defaultsTo: false,
+        negatable: false,
+      );
   }
 
   @override
@@ -34,7 +46,10 @@ class AnalyzeCommand extends Command {
     final log = Logger.standard();
     final repo = DevToolsRepo.getInstance();
     final processManager = ProcessManager();
-    final packages = repo.getPackages();
+    final skipUnimportant = argResults![_skipUnimportantArg] as bool;
+    final packages = repo.getPackages(
+      skip: skipUnimportant ? _unimportantDirectories : [],
+    );
     final fatalInfos = argResults![_fatalInfosArg] as bool;
 
     log.stdout('Running flutter analyze...');

--- a/tool/lib/commands/analyze.dart
+++ b/tool/lib/commands/analyze.dart
@@ -49,6 +49,9 @@ class AnalyzeCommand extends Command {
     final skipUnimportant = argResults![_skipUnimportantArg] as bool;
     final packages = repo.getPackages(
       skip: skipUnimportant ? _unimportantDirectories : [],
+      // Analyzing packages that are subdirectories of another package is
+      // redundant.
+      includeSubdirectories: false,
     );
     final fatalInfos = argResults![_fatalInfosArg] as bool;
 

--- a/tool/lib/commands/generate_code.dart
+++ b/tool/lib/commands/generate_code.dart
@@ -9,16 +9,25 @@ import 'package:path/path.dart' as path;
 
 import '../utils.dart';
 
+const _pubGetFlag = 'pub-get';
 const _upgradeFlag = 'upgrade';
 
 class GenerateCodeCommand extends Command {
   GenerateCodeCommand() {
-    argParser.addFlag(
-      _upgradeFlag,
-      negatable: false,
-      help:
-          'Run pub upgrade on the DevTools packages before performing the code generation.',
-    );
+    argParser
+      ..addFlag(
+        _pubGetFlag,
+        defaultsTo: true,
+        negatable: true,
+        help:
+            'Run pub get on the DevTools packages before performing the code generation.',
+      )
+      ..addFlag(
+        _upgradeFlag,
+        negatable: false,
+        help:
+            'Run pub upgrade on the DevTools packages before performing the code generation.',
+      );
   }
 
   @override
@@ -54,10 +63,13 @@ class GenerateCodeCommand extends Command {
       commandDescription: 'git clean',
     );
 
+    final pubGet = argResults![_pubGetFlag] as bool;
     final upgrade = argResults![_upgradeFlag] as bool;
-    await processManager.runProcess(
-      CliCommand.tool(['pub-get', '--only-main', if (upgrade) '--upgrade']),
-    );
+    if (pubGet) {
+      await processManager.runProcess(
+        CliCommand.tool(['pub-get', '--only-main', if (upgrade) '--upgrade']),
+      );
+    }
 
     await runOverPackages(
       CliCommand.flutter([

--- a/tool/pubspec.yaml
+++ b/tool/pubspec.yaml
@@ -11,6 +11,7 @@ executables:
 dependencies:
   args: ^2.4.2
   cli_util: ^0.4.1
+  collection: ^1.19.1
   io: ^1.0.4
   path: ^1.9.0
   yaml: ^3.1.2


### PR DESCRIPTION
This PR
- adds functionality to the `dt analyze` command to optionally skip analysis for "unimportant" directories such as "case_study" and "fixtures". This is used by the `analyze.sh` script that is run on the Flutter customer test registry tests for DevTools.
- adds functionality to the `dt analyze` command to skip analysis for subdirectories. It is redundant to analyze subdirectories of a package that has already been analyzed.
- adds functionality to the `dt generate-code` command to optionally skip running `pub get`. This will reduce redundant work on the flutter customer test registry run.
- fixes a bug in the `dt analyze` command that assumes the repository name 'devtools' is on the path for the logic to skip the top level 'packages' directory. This is not true on the flutter customer test registry CI.
- reduces unnecessary calls to `flutter pub get` that are costing time on the test registry run.