### PR TITLE
Skip flaky eval integration tests for test registry

### DIFF
--- a/packages/devtools_app/test/shared/eval_integration_test.dart
+++ b/packages/devtools_app/test/shared/eval_integration_test.dart
@@ -63,6 +63,9 @@ void main() {
           expect(instance2.classRef!.name, '_Future');
         },
         timeout: const Timeout.factor(2),
+        // TODO(https://github.com/flutter/devtools/issues/6998): if this flake
+        // is addressed, we can unskip this for the Flutter customer tests.
+        tags: skipForCustomerTestsTag,
       );
 
       test(


### PR DESCRIPTION
This unblocks https://github.com/flutter/tests/pull/432. Skips another flake tracked at https://github.com/flutter/devtools/issues/6998.