### PR TITLE
Check in devtools_options.yaml at the repo level

### DIFF
--- a/devtools_options.yaml
+++ b/devtools_options.yaml
@@ -1,0 +1,4 @@
+description: This file stores settings for Dart & Flutter DevTools.
+documentation: https://docs.flutter.dev/tools/devtools/extensions#configure-extension-enablement-states
+extensions:
+  - provider: true

--- a/packages/devtools_app/devtools_options.yaml
+++ b/packages/devtools_app/devtools_options.yaml
@@ -1,2 +1,0 @@
-extensions:
-  - provider: true


### PR DESCRIPTION
After the switch to pub workspaces, the devtools_options.yaml file should be stored at the root

Fixes https://github.com/flutter/devtools/issues/8589