### PR TITLE
remove the dep on package:ansicolor

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -16,7 +16,6 @@ resolution: workspace
 
 dependencies:
   ansi_up: ^1.0.0
-  ansicolor: ^2.0.0
   async: ^2.0.0 # okay
   clock: ^1.1.1 # Okay
   collection: ^1.15.0

--- a/packages/devtools_app/test/screens/debugger/debugger_console_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_console_test.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/console/widgets/console_pane.dart';
 import 'package:devtools_app_shared/ui.dart';
@@ -14,6 +13,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
+import '../../test_infra/utils/ansi.dart';
 import '../../test_infra/utils/test_utils.dart';
 
 void main() {
@@ -129,7 +129,7 @@ void main() {
 String _ansiCodesOutput() {
   final sb = StringBuffer();
   sb.write('Ansi color codes processed for ');
-  final pen = AnsiPen()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
-  sb.write(pen('console'));
+  final ansi = AnsiWriter()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
+  sb.write(ansi.write('console'));
   return sb.toString();
 }

--- a/packages/devtools_app/test/screens/logging/logging_screen_data_test.dart
+++ b/packages/devtools_app/test/screens/logging/logging_screen_data_test.dart
@@ -5,7 +5,6 @@
 @TestOn('vm')
 library;
 
-import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/screens/logging/_log_details.dart';
 import 'package:devtools_app/src/screens/logging/_logs_table.dart';
@@ -16,6 +15,8 @@ import 'package:devtools_test/helpers.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+
+import '../../test_infra/utils/ansi.dart';
 
 void main() {
   late MockLoggingController mockLoggingController;
@@ -310,7 +311,7 @@ const jsonOutput = '{\n"Details": "of log event 9",\n"logEvent": "9"\n}\n';
 String _ansiCodesOutput() {
   final sb = StringBuffer();
   sb.write('Ansi color codes processed for ');
-  final pen = AnsiPen()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
-  sb.write(pen('log 5'));
+  final ansi = AnsiWriter()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
+  sb.write(ansi.write('log 5'));
   return sb.toString();
 }

--- a/packages/devtools_app/test/shared/ansi_up_test.dart
+++ b/packages/devtools_app/test/shared/ansi_up_test.dart
@@ -6,7 +6,6 @@
 library;
 
 import 'package:ansi_up/ansi_up.dart';
-import 'package:ansicolor/ansicolor.dart';
 import 'package:devtools_app/devtools_app.dart';
 import 'package:devtools_app/src/shared/console/widgets/console_pane.dart';
 import 'package:devtools_app_shared/utils.dart';
@@ -16,22 +15,24 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 
+import '../test_infra/utils/ansi.dart';
+
 void main() {
   group('ansi_up', () {
     test('test standard colors', () {
-      final pen = AnsiPen();
+      final ansi = AnsiWriter();
       final sb = StringBuffer();
       // Test the 16 color defaults.
       for (int c = 0; c < 16; c++) {
-        pen
+        ansi
           ..reset()
           ..white(bold: true)
           ..xterm(c, bg: true);
-        sb.write(pen('$c '));
-        pen
+        sb.write(ansi.write('$c '));
+        ansi
           ..reset()
           ..xterm(c);
-        sb.write(pen(' $c '));
+        sb.write(ansi.write(' $c '));
         if (c == 7 || c == 15) {
           sb.writeln();
         }
@@ -43,15 +44,15 @@ void main() {
         for (int g = 0; g < 6; g += 3) {
           for (int b = 0; b < 6; b += 3) {
             final c = r * 36 + g * 6 + b + 16;
-            pen
+            ansi
               ..reset()
               ..rgb(r: r / 5, g: g / 5, b: b / 5, bg: true)
               ..white(bold: true);
-            sb.write(pen(' $c '));
-            pen
+            sb.write(ansi.write(' $c '));
+            ansi
               ..reset()
               ..rgb(r: r / 5, g: g / 5, b: b / 5);
-            sb.write(pen(' $c '));
+            sb.write(ansi.write(' $c '));
           }
           sb.writeln();
         }
@@ -61,15 +62,15 @@ void main() {
         if (0 == c % 8) {
           sb.writeln();
         }
-        pen
+        ansi
           ..reset()
           ..gray(level: c / 23, bg: true)
           ..white(bold: true);
-        sb.write(pen(' ${c + 232} '));
-        pen
+        sb.write(ansi.write(' ${c + 232} '));
+        ansi
           ..reset()
           ..gray(level: c / 23);
-        sb.write(pen(' ${c + 232} '));
+        sb.write(ansi.write(' ${c + 232} '));
       }
 
       final output = StringBuffer();
@@ -114,8 +115,8 @@ void main() {
     String ansiCodesOutput() {
       final sb = StringBuffer();
       sb.write('Ansi color codes processed for ');
-      final pen = AnsiPen()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
-      sb.write(pen('log 5'));
+      final ansi = AnsiWriter()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
+      sb.write(ansi.write('log 5'));
       return sb.toString();
     }
 
@@ -266,8 +267,8 @@ void main() {
     String ansiCodesOutput() {
       final sb = StringBuffer();
       sb.write('Ansi color codes processed for ');
-      final pen = AnsiPen()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
-      sb.write(pen('console'));
+      final ansi = AnsiWriter()..rgb(r: 0.8, g: 0.3, b: 0.4, bg: true);
+      sb.write(ansi.write('console'));
       return sb.toString();
     }
 

--- a/packages/devtools_app/test/test_infra/fixtures/color_console_output_app.dart
+++ b/packages/devtools_app/test/test_infra/fixtures/color_console_output_app.dart
@@ -7,7 +7,7 @@
 import 'dart:async';
 import 'dart:developer' as developer;
 
-import 'package:ansicolor/ansicolor.dart';
+import '../utils/ansi.dart';
 
 void main() {
   // Start paused to avoid race conditions getting the initial output from the
@@ -17,19 +17,19 @@ void main() {
 
   // Print out text exercising a wide range of ansi color styles.
   final sb = StringBuffer();
-  final pen = AnsiPen();
+  final ansi = AnsiWriter();
 
   // Test the 16 color defaults.
   for (int c = 0; c < 16; c++) {
-    pen
+    ansi
       ..reset()
       ..white(bold: true)
       ..xterm(c, bg: true);
-    sb.write(pen('$c '));
-    pen
+    sb.write(ansi.write('$c '));
+    ansi
       ..reset()
       ..xterm(c);
-    sb.write(pen(' $c '));
+    sb.write(ansi.write(' $c '));
     if (c == 7 || c == 15) {
       sb.writeln();
     }
@@ -41,15 +41,15 @@ void main() {
     for (int g = 0; g < 6; g += 3) {
       for (int b = 0; b < 6; b += 3) {
         final c = r * 36 + g * 6 + b + 16;
-        pen
+        ansi
           ..reset()
           ..rgb(r: r / 5, g: g / 5, b: b / 5, bg: true)
           ..white(bold: true);
-        sb.write(pen(' $c '));
-        pen
+        sb.write(ansi.write(' $c '));
+        ansi
           ..reset()
           ..rgb(r: r / 5, g: g / 5, b: b / 5);
-        sb.write(pen(' $c '));
+        sb.write(ansi.write(' $c '));
       }
       sb.writeln();
     }
@@ -59,15 +59,15 @@ void main() {
     if (0 == c % 8) {
       sb.writeln();
     }
-    pen
+    ansi
       ..reset()
       ..gray(level: c / 23, bg: true)
       ..white(bold: true);
-    sb.write(pen(' ${c + 232} '));
-    pen
+    sb.write(ansi.write(' ${c + 232} '));
+    ansi
       ..reset()
       ..gray(level: c / 23);
-    sb.write(pen(' ${c + 232} '));
+    sb.write(ansi.write(' ${c + 232} '));
   }
   print(sb.toString());
 

--- a/packages/devtools_app/test/test_infra/utils/ansi.dart
+++ b/packages/devtools_app/test/test_infra/utils/ansi.dart
@@ -1,0 +1,71 @@
+// Copyright 2024 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+class AnsiWriter {
+  static const _escape = '\x1B[';
+
+  int? _foreground;
+  int? _background;
+
+  /// Sets the pen color to the rgb value between 0.0..1.0.
+  void rgb({num r = 1.0, num g = 1.0, num b = 1.0, bool bg = false}) {
+    xterm(
+      (r.clamp(0.0, 1.0) * 5).toInt() * 36 +
+          (g.clamp(0.0, 1.0) * 5).toInt() * 6 +
+          (b.clamp(0.0, 1.0) * 5).toInt() +
+          16,
+      bg: bg,
+    );
+  }
+
+  /// Sets the pen color to a grey scale value between 0.0 and 1.0.
+  void gray({num level = 1.0, bool bg = false}) {
+    xterm(232 + (level.clamp(0.0, 1.0) * 23).round(), bg: bg);
+  }
+
+  void white({bool bg = false, bool bold = false}) {
+    _standardColor(7, bold, bg);
+  }
+
+  void _standardColor(int color, bool bold, bool bg) {
+    xterm(color + (bold ? 8 : 0), bg: bg);
+  }
+
+  /// Directly index the xterm 256 color palette.
+  void xterm(int color, {bool bg = false}) {
+    final c =
+        color < 0
+            ? 0
+            : color > 255
+            ? 255
+            : color;
+
+    if (bg) {
+      _background = c;
+    } else {
+      _foreground = c;
+    }
+  }
+
+  /// Write the [message] with the pen's current settings.
+  String write(Object message) {
+    final pen = StringBuffer();
+    if (_foreground != null) {
+      pen.write('${_escape}38;5;${_foreground}m');
+    }
+    if (_background != null) {
+      pen.write('${_escape}48;5;${_background}m');
+    }
+
+    const normal = '${_escape}0m';
+
+    return '$pen$message$normal';
+  }
+
+  /// Resets the pen's attributes.
+  void reset() {
+    _background = null;
+    _foreground = null;
+  }
+}


### PR DESCRIPTION
- remove the dependency on `package:ansicolor`

This is work towards generally reducing the number of deps that devtools has. Note that the `package:ansicolor` had been a regular dep of devtools_app, but it looks like it was only ever referenced from tests.

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
