### PR TITLE
Register the Property Editor as a standalone screen 

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 
 import '../shared/globals.dart';
 import '../shared/ui/common_widgets.dart';
+import 'ide_shared/property_editor/property_editor_panel.dart';
 import 'vs_code/flutter_panel.dart';
 
 /// "Screens" that are intended for standalone use only, likely for embedding
@@ -18,6 +19,7 @@ enum StandaloneScreenType {
   // TODO(elliette): Add property editor as a standalone screen, see:
   // https://github.com/flutter/devtools/issues/8546
   editorSidebar,
+  propertyEditor,
   vsCodeFlutterPanel; // Legacy postMessage version, shows an upgrade message.
 
   Widget get screen {
@@ -39,6 +41,14 @@ enum StandaloneScreenType {
           return data == null
               ? const CenteredCircularProgressIndicator()
               : EditorSidebarPanel(data);
+        },
+      ),
+      StandaloneScreenType.propertyEditor => ValueListenableBuilder(
+        valueListenable: dtdManager.connection,
+        builder: (context, data, _) {
+          return data == null
+              ? const CenteredCircularProgressIndicator()
+              : PropertyEditorPanel(data);
         },
       ),
     };

--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -6,8 +6,8 @@ import 'package:flutter/material.dart';
 
 import '../shared/globals.dart';
 import '../shared/ui/common_widgets.dart';
-import 'ide_shared/property_editor/property_editor_panel.dart';
 import 'vs_code/flutter_panel.dart';
+import 'vs_code/property_editor_panel.dart';
 
 /// "Screens" that are intended for standalone use only, likely for embedding
 /// directly in an IDE.
@@ -48,7 +48,7 @@ enum StandaloneScreenType {
         builder: (context, data, _) {
           return data == null
               ? const CenteredCircularProgressIndicator()
-              : PropertyEditorPanel(data);
+              : PropertyEditorSidebarPanel(data);
         },
       ),
     };

--- a/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/standalone_screen.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:dtd/dtd.dart';
 import 'package:flutter/material.dart';
 
 import '../shared/globals.dart';
@@ -38,19 +39,37 @@ enum StandaloneScreenType {
         //  useful message.
         valueListenable: dtdManager.connection,
         builder: (context, data, _) {
-          return data == null
-              ? const CenteredCircularProgressIndicator()
-              : EditorSidebarPanel(data);
+          return _DtdConnectedScreen(
+            dtd: data,
+            screenProvider: (dtd) => EditorSidebarPanel(dtd),
+          );
         },
       ),
       StandaloneScreenType.propertyEditor => ValueListenableBuilder(
         valueListenable: dtdManager.connection,
         builder: (context, data, _) {
-          return data == null
-              ? const CenteredCircularProgressIndicator()
-              : PropertyEditorSidebarPanel(data);
+          return _DtdConnectedScreen(
+            dtd: data,
+            screenProvider: (dtd) => PropertyEditorSidebarPanel(dtd),
+          );
         },
       ),
     };
+  }
+}
+
+/// Widget that returns a [CenteredCircularProgressIndicator] while it waits for
+/// a [DartToolingDaemon] connection.
+class _DtdConnectedScreen extends StatelessWidget {
+  const _DtdConnectedScreen({required this.dtd, required this.screenProvider});
+
+  final DartToolingDaemon? dtd;
+  final Widget Function(DartToolingDaemon) screenProvider;
+
+  @override
+  Widget build(BuildContext context) {
+    return dtd == null
+        ? const CenteredCircularProgressIndicator()
+        : screenProvider(dtd!);
   }
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8546

With the changes @DanTup has made in the VS Code extension, this allows us to now test the Property Editor in VS Code 🎉 

![propery_editor_in_ide](https://github.com/user-attachments/assets/8585ff69-0bf7-427d-9d6c-6796f964f6f4)
