### PR TITLE
Prepare ansi_up for 2.0.0 publish

### DIFF
--- a/third_party/packages/ansi_up/CHANGELOG.md
+++ b/third_party/packages/ansi_up/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-dev
+## 2.0.0
 * Fixed a regexp getting recompiled every time an `AnsiUp` is instantiated and
   `decodeAnsiColorEscapeCodes` is called for the first time.
 

--- a/third_party/packages/ansi_up/pubspec.yaml
+++ b/third_party/packages/ansi_up/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ansi_up
 description: Minimal package containing 'ansi_up' third_party dependency used by package:devtools.
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/ansi_up
-version: 2.0.0-dev
+version: 2.0.0
 
 environment:
   sdk: ^3.2.0


### PR DESCRIPTION
I will follow this with a 2.1.0 publish to discontinue the package. It is no longer needed as of https://github.com/flutter/devtools/pull/8601.

Work towards https://github.com/flutter/devtools/issues/8603.