### PR TITLE
Discontinue the `ansi_up` package

### DIFF
--- a/third_party/packages/ansi_up/CHANGELOG.md
+++ b/third_party/packages/ansi_up/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.1.0
+* Discontinue the `ansi_up` package.
+
 ## 2.0.0
 * Fixed a regexp getting recompiled every time an `AnsiUp` is instantiated and
   `decodeAnsiColorEscapeCodes` is called for the first time.

--- a/third_party/packages/ansi_up/README.md
+++ b/third_party/packages/ansi_up/README.md
@@ -1,5 +1,7 @@
 # ansi_up.js
 
+**IMPORTANT: this package is discontinued.**
+
 __ansi_up__ is an easy to use library that transforms text containing
 [ANSI color escape codes](http://en.wikipedia.org/wiki/ANSI_escape_code#Colors) into HTML.
 

--- a/third_party/packages/ansi_up/pubspec.yaml
+++ b/third_party/packages/ansi_up/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ansi_up
 description: Minimal package containing 'ansi_up' third_party dependency used by package:devtools.
 homepage: https://github.com/flutter/devtools/tree/master/third_party/packages/ansi_up
-version: 2.0.0
+version: 2.1.0
 
 environment:
   sdk: ^3.2.0


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8603. I will follow up with a PR to delete the `ansi_up` code from `third_party` after one final publish of this package.