### PR TITLE
Add view licenses button to DevTools about dialog that shows license page

### DIFF
--- a/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
@@ -63,7 +63,10 @@ class DevToolsAboutDialog extends StatelessWidget {
           ),
         ],
       ),
-      actions: const [DialogCloseButton()],
+      actions: const [
+        DialogLicenseButton(),
+        DialogCloseButton()
+      ],
     );
   }
 }
@@ -143,4 +146,30 @@ class OpenAboutAction extends ScaffoldAction {
           );
         },
       );
+}
+
+/// Since [DevToolsAboutDialog] is not actually an [AboutDialog], there is no
+/// built-in way to add a 'View Licenses' button.
+/// So, adding a custom [DialogTextButton] to view licenses.
+/// Since this action is very specific to just the [DevToolsAboutDialog], 
+/// providing implementation in about_dialog.dart and not in
+/// dialogs.dart which contains the definition of [DevToolsDialog].
+/// TODO(mossmana): We may want to consider refactoring [DevToolsAboutDialog] to be an [AboutDialog].
+/// https://api.flutter.dev/flutter/material/AboutDialog-class.html
+final class DialogLicenseButton extends StatelessWidget {
+  const DialogLicenseButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DialogTextButton(
+      onPressed: () {
+        showLicensePage(
+          context: context,
+          applicationName: 'DevTools',
+          useRootNavigator: true,
+        );
+      },
+      child: const Text('View Licenses'),
+    );
+  }
 }

--- a/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
@@ -63,10 +63,7 @@ class DevToolsAboutDialog extends StatelessWidget {
           ),
         ],
       ),
-      actions: const [
-        DialogLicenseButton(),
-        DialogCloseButton()
-      ],
+      actions: const [DialogLicenseButton(), DialogCloseButton()],
     );
   }
 }
@@ -151,7 +148,7 @@ class OpenAboutAction extends ScaffoldAction {
 // Since [DevToolsAboutDialog] is not actually an [AboutDialog], there is no
 // built-in way to add a 'View Licenses' button.
 // So, adding a custom [DialogTextButton] to view licenses.
-// Since this action is very specific to just the [DevToolsAboutDialog], 
+// Since this action is very specific to just the [DevToolsAboutDialog],
 // providing implementation in about_dialog.dart and not in
 // dialogs.dart which contains the definition of [DevToolsDialog].
 // TODO(mossmana): We may want to consider refactoring [DevToolsAboutDialog] to

--- a/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
@@ -63,10 +63,7 @@ class DevToolsAboutDialog extends StatelessWidget {
           ),
         ],
       ),
-      actions: const [
-        DialogLicenseButton(),
-        DialogCloseButton()
-      ],
+      actions: const [DialogLicenseButton(), DialogCloseButton()],
     );
   }
 }
@@ -151,7 +148,7 @@ class OpenAboutAction extends ScaffoldAction {
 /// Since [DevToolsAboutDialog] is not actually an [AboutDialog], there is no
 /// built-in way to add a 'View Licenses' button.
 /// So, adding a custom [DialogTextButton] to view licenses.
-/// Since this action is very specific to just the [DevToolsAboutDialog], 
+/// Since this action is very specific to just the [DevToolsAboutDialog],
 /// providing implementation in about_dialog.dart and not in
 /// dialogs.dart which contains the definition of [DevToolsDialog].
 /// TODO(mossmana): We may want to consider refactoring [DevToolsAboutDialog] to be an [AboutDialog].
@@ -169,7 +166,7 @@ final class DialogLicenseButton extends StatelessWidget {
           useRootNavigator: true,
         );
       },
-      child: const Text('View Licenses'),
+      child: const Text('VIEW LICENSES'),
     );
   }
 }

--- a/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/about_dialog.dart
@@ -63,7 +63,10 @@ class DevToolsAboutDialog extends StatelessWidget {
           ),
         ],
       ),
-      actions: const [DialogLicenseButton(), DialogCloseButton()],
+      actions: const [
+        DialogLicenseButton(),
+        DialogCloseButton()
+      ],
     );
   }
 }
@@ -145,14 +148,15 @@ class OpenAboutAction extends ScaffoldAction {
       );
 }
 
-/// Since [DevToolsAboutDialog] is not actually an [AboutDialog], there is no
-/// built-in way to add a 'View Licenses' button.
-/// So, adding a custom [DialogTextButton] to view licenses.
-/// Since this action is very specific to just the [DevToolsAboutDialog],
-/// providing implementation in about_dialog.dart and not in
-/// dialogs.dart which contains the definition of [DevToolsDialog].
-/// TODO(mossmana): We may want to consider refactoring [DevToolsAboutDialog] to be an [AboutDialog].
-/// https://api.flutter.dev/flutter/material/AboutDialog-class.html
+// Since [DevToolsAboutDialog] is not actually an [AboutDialog], there is no
+// built-in way to add a 'View Licenses' button.
+// So, adding a custom [DialogTextButton] to view licenses.
+// Since this action is very specific to just the [DevToolsAboutDialog], 
+// providing implementation in about_dialog.dart and not in
+// dialogs.dart which contains the definition of [DevToolsDialog].
+// TODO(mossmana): We may want to consider refactoring [DevToolsAboutDialog] to
+// be an [AboutDialog].
+// https://api.flutter.dev/flutter/material/AboutDialog-class.html
 final class DialogLicenseButton extends StatelessWidget {
   const DialogLicenseButton({super.key});
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -14,6 +14,7 @@ To learn more about DevTools, check out the
 [#8456](https://github.com/flutter/devtools/pull/8456)
 [#8470](https://github.com/flutter/devtools/pull/8470)
 * Tables match IDE theme when embedded in an IDE. - [#8498](https://github.com/flutter/devtools/pull/8498)
+* View licenses added to about dialog. - [8610](https://github.com/flutter/devtools/pull/8610)
 
 ## Inspector updates
 

--- a/packages/devtools_app/test/framework/scaffold/about_dialog_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/about_dialog_test.dart
@@ -47,7 +47,7 @@ void main() {
     testWidgets('builds dialog', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(aboutDialog));
       expect(find.text('About DevTools'), findsOneWidget);
-      expect(find.text('View Licenses'), findsOneWidget);
+      expect(find.text('VIEW LICENSES'), findsOneWidget);
     });
 
     testWidgets('content renders correctly', (WidgetTester tester) async {

--- a/packages/devtools_app/test/framework/scaffold/about_dialog_test.dart
+++ b/packages/devtools_app/test/framework/scaffold/about_dialog_test.dart
@@ -47,6 +47,7 @@ void main() {
     testWidgets('builds dialog', (WidgetTester tester) async {
       await tester.pumpWidget(wrap(aboutDialog));
       expect(find.text('About DevTools'), findsOneWidget);
+      expect(find.text('View Licenses'), findsOneWidget);
     });
 
     testWidgets('content renders correctly', (WidgetTester tester) async {


### PR DESCRIPTION

<img width="486" alt="Screenshot 2024-12-06 at 1 00 16 PM" src="https://github.com/user-attachments/assets/dd220da1-1150-42c2-b6a0-1f765d9c7d71">
<img width="1206" alt="Screenshot 2024-12-06 at 1 00 28 PM" src="https://github.com/user-attachments/assets/82ecb9b1-ea44-4192-acfe-28085d60a0ea">

https://github.com/flutter/devtools/issues/8216

*Please add a note to `packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md` if your change requires release notes. Otherwise, add the 'release-notes-not-required' label to the PR.*

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]