### PR TITLE
Remove unnecessary logging type prefix

### DIFF
--- a/packages/devtools_app/lib/src/framework/release_notes.dart
+++ b/packages/devtools_app/lib/src/framework/release_notes.dart
@@ -250,7 +250,7 @@ class ReleaseNotesController extends SidePanelController {
     markdown.value = null;
     toggleVisibility(false);
     if (message != null) {
-      _log.warning('Warning: $message');
+      _log.warning(message);
     }
   }
 


### PR DESCRIPTION
The logger implementation handles prepending the log type. This was the only case I found where we unnecessary add the log type as well.

Resolves https://github.com/flutter/devtools/issues/5518.
