### PR TITLE
Auto-refresh the widget tree on navigation events

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_shared/inspector_settings_dialog.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_shared/inspector_settings_dialog.dart
@@ -52,9 +52,9 @@ class FlutterInspectorSettingsDialog extends StatelessWidget {
                     notifier:
                         preferences.inspector.autoRefreshEnabled
                             as ValueNotifier<bool?>,
-                    title: 'Enable auto-refreshing of the widget tree',
+                    title: 'Enable widget tree auto-refreshing',
                     description:
-                        'The widget tree will automatically be refreshed after a hot-reload.',
+                        'The widget tree will automatically refresh after a hot-reload or navigation event.',
                     gaItem: gac.inspectorAutoRefreshEnabled,
                   ),
                 ] else ...[

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -445,16 +445,23 @@ class InspectorController extends DisposableController
   }
 
   bool _receivedIsolateReloadEvent = false;
+  bool _receivedFlutterNavigationEvent = false;
 
   Future<void> _maybeAutoRefreshInspector(Event event) async {
     if (!preferences.inspector.autoRefreshEnabled.value) return;
 
-    // It is not sufficent to wait for the isolate reload event, because Flutter
-    // might not have re-painted the app. Instead, we need to wait for the first
-    // frame AFTER the isolate reload event in order to request the new tree.
+    // It is not sufficent to wait for the navigation and isolate reload events
+    // only, because Flutter might not have re-painted the app. Instead, we need
+    // to wait for the first frame AFTER the isolate reload or navigation event
+    // in order to request the new tree.
     if (event.kind == EventKind.kExtension) {
-      if (!_receivedIsolateReloadEvent) return;
-      if (event.extensionKind == 'Flutter.Frame') {
+      final extensionEventKind = event.extensionKind;
+      if (extensionEventKind == 'Flutter.Navigation') {
+        _receivedFlutterNavigationEvent = true;
+      }
+      if ((_receivedFlutterNavigationEvent || _receivedIsolateReloadEvent) &&
+          extensionEventKind == 'Flutter.Frame') {
+        _receivedFlutterNavigationEvent = false;
         _receivedIsolateReloadEvent = false;
         await refreshInspector();
       }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/1423

We already added support to auto-refresh the widget tree after a hot-reload. This PR also auto-refreshes the tree after any Flutter navigation events. 

Hopefully with this change users will never have to manually refresh the widget tree!

Note: After this PR lands I'm going to follow up with a PR to turn on auto-refreshing on by default.
