### PR TITLE
Don't show an error when selecting an on-device implementation widget 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -638,7 +638,7 @@ class InspectorController extends DisposableController
     final pendingSelectionFuture = group.getSelection(
       selectedDiagnostic,
       treeType,
-      inLocalProjectOnly: isSummaryTree,
+      restrictToLocalProject: isSummaryTree,
     );
 
     final pendingDetailsFuture =

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -638,7 +638,7 @@ class InspectorController extends DisposableController
     final pendingSelectionFuture = group.getSelection(
       selectedDiagnostic,
       treeType,
-      inLocalProject: isSummaryTree,
+      inLocalProjectOnly: isSummaryTree,
     );
 
     final pendingDetailsFuture =

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_controller.dart
@@ -638,7 +638,7 @@ class InspectorController extends DisposableController
     final pendingSelectionFuture = group.getSelection(
       selectedDiagnostic,
       treeType,
-      isSummaryTree: isSummaryTree,
+      inLocalProject: isSummaryTree,
     );
 
     final pendingDetailsFuture =

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -734,7 +734,7 @@ class InspectorController extends DisposableController
       treeType,
       // If implementation widgets are hidden, the only widgets in the tree are
       // those that were created by the local project.
-      inLocalProject: implementationWidgetsHidden.value,
+      inLocalProjectOnly: implementationWidgetsHidden.value,
     );
 
     try {

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -727,7 +727,7 @@ class InspectorController extends DisposableController
       treeType,
       // If implementation widgets are hidden, the only widgets in the tree are
       // those that were created by the local project.
-      createdByLocalProjectOnly: implementationWidgetsHidden.value,
+      inLocalProject: implementationWidgetsHidden.value,
     );
 
     try {

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -724,6 +724,7 @@ class InspectorController extends DisposableController
     final pendingSelectionFuture = group.getSelection(
       selectedDiagnostic,
       treeType,
+      implementationWidgetsHidden: implementationWidgetsHidden.value,
     );
 
     try {
@@ -732,6 +733,8 @@ class InspectorController extends DisposableController
       // Show an error and don't update the selected node in the tree if the
       // user selected an implementation widget in the app while implementation
       // widgets are hidden in the tree.
+
+      // TODO: Update the following.
       if (implementationWidgetsHidden.value && newSelection != null) {
         final isInTree = valueToInspectorTreeNode.containsKey(
           newSelection.valueRef,
@@ -952,7 +955,7 @@ class InspectorController extends DisposableController
     }
   }
 
-  void selectionChanged() {
+  void selectionChanged({bool notifyFlutterInspector = false}) {
     if (!visibleToUser) {
       return;
     }
@@ -968,18 +971,24 @@ class InspectorController extends DisposableController
       setSelectedNode(node);
       unawaited(_addNodeToConsole(node));
 
-      syncSelectionHelper(selection: selectedDiagnostic);
+      syncSelectionHelper(
+        selection: selectedDiagnostic,
+        notifyFlutterInspector: notifyFlutterInspector,
+      );
     }
   }
 
-  void syncSelectionHelper({required RemoteDiagnosticsNode? selection}) {
+  void syncSelectionHelper({
+    required RemoteDiagnosticsNode? selection,
+    bool notifyFlutterInspector = false,
+  }) {
     if (selection != null) {
       if (selection.isCreatedByLocalProject) {
         _navigateTo(selection);
       }
     }
 
-    if (selection != null) {
+    if (notifyFlutterInspector && selection != null) {
       unawaited(selection.setSelectionInspector(true));
     }
   }

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -832,16 +832,23 @@ class InspectorController extends DisposableController
     if (_selectionIsOutOfDate(selectedNode)) return;
 
     final isImplementationWidget =
-        !(possibleImplementationWidget?.isCreatedByLocalProject ?? true);
+        possibleImplementationWidget != null &&
+        !possibleImplementationWidget.isCreatedByLocalProject;
     if (isImplementationWidget) {
       final selectedWidgetName = selectedNode.description ?? '';
+      final implementationWidgetName =
+          possibleImplementationWidget.description ?? '';
 
       // Return early if we have a new selected node.
       if (_selectionIsOutOfDate(selectedNode)) return;
 
+      final messageDetails =
+          selectedWidgetName.isEmpty
+              ? ''
+              : ' of $selectedWidgetName${implementationWidgetName.isEmpty ? '' : ': $implementationWidgetName'}';
       notificationService.pushNotification(
         NotificationMessage(
-          '$_implementationWidgetMessage${selectedWidgetName.isEmpty ? '' : ' of $selectedWidgetName'}.',
+          '$_implementationWidgetMessage$messageDetails.',
           duration: _notificationDuration,
         ),
         allowDuplicates: false,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -193,7 +193,10 @@ class InspectorTreeController extends DisposableController
     }
   }
 
-  bool setSelectedNode(InspectorTreeNode? node) {
+  bool setSelectedNode(
+    InspectorTreeNode? node, {
+    bool notifyFlutterInspector = false,
+  }) {
     if (node == _selection) return false;
 
     _selection?.selected = false;
@@ -201,7 +204,9 @@ class InspectorTreeController extends DisposableController
     _selection?.selected = true;
     final configLocal = config;
     if (configLocal.onSelectionChange != null) {
-      configLocal.onSelectionChange!();
+      configLocal.onSelectionChange!(
+        notifyFlutterInspector: notifyFlutterInspector,
+      );
     }
     return true;
   }
@@ -547,7 +552,7 @@ class InspectorTreeController extends DisposableController
   }
 
   void onSelectNode(InspectorTreeNode? node) {
-    setSelectedNode(node);
+    setSelectedNode(node, notifyFlutterInspector: true);
     ga.select(gac.inspector, gac.treeNodeSelection);
     final diagnostic = node?.diagnostic;
     if (diagnostic != null && diagnostic.groupIsHidden) {

--- a/packages/devtools_app/lib/src/shared/console/eval/inspector_tree_v2.dart
+++ b/packages/devtools_app/lib/src/shared/console/eval/inspector_tree_v2.dart
@@ -199,7 +199,7 @@ class InspectorTreeConfig {
   });
 
   final NodeAddedCallback? onNodeAdded;
-  final VoidCallback? onSelectionChange;
+  final void Function({bool notifyFlutterInspector})? onSelectionChange;
   final void Function(bool added)? onClientActiveChange;
   final TreeEventCallback? onExpand;
 }

--- a/packages/devtools_app/lib/src/shared/console/eval/inspector_tree_v2.dart
+++ b/packages/devtools_app/lib/src/shared/console/eval/inspector_tree_v2.dart
@@ -10,7 +10,6 @@
 library;
 
 import 'package:devtools_app_shared/ui.dart';
-import 'package:flutter/foundation.dart';
 
 import '../../diagnostics/diagnostics_node.dart';
 import '../../ui/search.dart';

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1025,7 +1025,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
     RemoteDiagnosticsNode? previousSelection,
     FlutterTreeType treeType, {
     bool isSummaryTree = false,
-    bool implementationWidgetsHidden = false,
+    bool createdByLocalProjectOnly = false,
   }) async {
     // There is no reason to allow calling this method on a disposed group.
     assert(!disposed);
@@ -1038,7 +1038,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
           isSummaryTree
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
-              : implementationWidgetsHidden
+              : createdByLocalProjectOnly
               ? WidgetInspectorServiceExtensions.getSelectedLocalWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1036,10 +1036,8 @@ class ObjectGroup extends InspectorObjectGroupBase {
     switch (treeType) {
       case FlutterTreeType.widget:
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
-          isSummaryTree
+          isSummaryTree || createdByLocalProjectOnly
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
-              : createdByLocalProjectOnly
-              ? WidgetInspectorServiceExtensions.getSelectedLocalWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,
         );

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1024,7 +1024,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
   Future<RemoteDiagnosticsNode?> getSelection(
     RemoteDiagnosticsNode? previousSelection,
     FlutterTreeType treeType, {
-    bool inLocalProject = false,
+    bool inLocalProjectOnly = false,
   }) async {
     // There is no reason to allow calling this method on a disposed group.
     assert(!disposed);
@@ -1035,7 +1035,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
     switch (treeType) {
       case FlutterTreeType.widget:
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
-          inLocalProject
+          inLocalProjectOnly
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1024,7 +1024,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
   Future<RemoteDiagnosticsNode?> getSelection(
     RemoteDiagnosticsNode? previousSelection,
     FlutterTreeType treeType, {
-    bool inLocalProjectOnly = false,
+    bool restrictToLocalProject = false,
   }) async {
     // There is no reason to allow calling this method on a disposed group.
     assert(!disposed);
@@ -1035,7 +1035,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
     switch (treeType) {
       case FlutterTreeType.widget:
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
-          inLocalProjectOnly
+          restrictToLocalProject
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1025,6 +1025,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
     RemoteDiagnosticsNode? previousSelection,
     FlutterTreeType treeType, {
     bool isSummaryTree = false,
+    bool implementationWidgetsHidden = false,
   }) async {
     // There is no reason to allow calling this method on a disposed group.
     assert(!disposed);
@@ -1037,6 +1038,8 @@ class ObjectGroup extends InspectorObjectGroupBase {
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
           isSummaryTree
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
+              : implementationWidgetsHidden
+              ? WidgetInspectorServiceExtensions.getSelectedLocalWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,
         );

--- a/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
+++ b/packages/devtools_app/lib/src/shared/diagnostics/inspector_service.dart
@@ -1024,8 +1024,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
   Future<RemoteDiagnosticsNode?> getSelection(
     RemoteDiagnosticsNode? previousSelection,
     FlutterTreeType treeType, {
-    bool isSummaryTree = false,
-    bool createdByLocalProjectOnly = false,
+    bool inLocalProject = false,
   }) async {
     // There is no reason to allow calling this method on a disposed group.
     assert(!disposed);
@@ -1036,7 +1035,7 @@ class ObjectGroup extends InspectorObjectGroupBase {
     switch (treeType) {
       case FlutterTreeType.widget:
         newSelection = await invokeServiceMethodReturningNodeInspectorRef(
-          isSummaryTree || createdByLocalProjectOnly
+          inLocalProject
               ? WidgetInspectorServiceExtensions.getSelectedSummaryWidget.name
               : WidgetInspectorServiceExtensions.getSelectedWidget.name,
           null,

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -22,7 +22,8 @@ To learn more about DevTools, check out the
   settings to allow auto-refreshing the widget tree after a hot-reload. - [#8483](https://github.com/flutter/devtools/pull/8483)
 - Fixed an [issue](https://github.com/flutter/devtools/issues/8487) where the [new Inspector](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) would not load after a hot-restart in the legacy Inspector. - [#8491](https://github.com/flutter/devtools/pull/8491)
 - Fixed an [issue](https://github.com/flutter/devtools/issues/8465) preventing scrolling to an implementation widget in the [new Inspector](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) after selecting it on the device. - [#8494](https://github.com/flutter/devtools/pull/8494)
-
+- Selecting an implementation widget on the device while implementation widget's are hidden in the [new Inspector's](https://docs.flutter.dev/tools/devtools/release-notes/release-notes-2.40.1#inspector-updates) does not show an error. - [8625](https://github.com/flutter/devtools/pull/8625)
+ 
 ## Performance updates
 
 TODO: Remove this section if there are not any general updates.

--- a/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
+++ b/packages/devtools_app/test/screens/inspector_v2/inspector_integration_test.dart
@@ -343,7 +343,7 @@ void main() {
 
     // Verify the notification about selecting an implementation widget is displayed.
     expect(
-      find.text('Selected an implementation widget of Text.'),
+      find.text('Selected an implementation widget of Text: RichText.'),
       findsOneWidget,
     );
   });


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8626

In https://github.com/flutter/devtools/pull/8494, we added an error notification when a user selects an implementation widget on their device, but implementation widgets are hidden. This is not the most friendly UI.

Instead, with this PR we select the implementation widget's ancestor in the tree, and show a notification (not an error) that an implementation widget has been selected.

![selecting_implementation_widget](https://github.com/user-attachments/assets/190c56e6-a4a6-4979-9cee-6256f14c1f1a)
