### PR TITLE
Fix property editor tests

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -22,6 +22,11 @@ class PropertyEditorController extends DisposableController
   ValueListenable<List<EditableArgument>> get editableArgs => _editableArgs;
   final _editableArgs = ValueNotifier<List<EditableArgument>>([]);
 
+  @visibleForTesting
+  void updateEditableArgs(List<EditableArgument> args) {
+    _editableArgs.value = args;
+  }
+
   void _init() {
     autoDisposeStreamSubscription(
       editorClient.activeLocationChangedStream.listen((event) async {
@@ -40,7 +45,7 @@ class PropertyEditorController extends DisposableController
           position: cursorPosition,
         );
         final args = result?.args ?? <EditableArgument>[];
-        _editableArgs.value = args;
+        updateEditableArgs(args);
       }),
     );
   }


### PR DESCRIPTION
I realized in writing the tests for editing arguments in the property editor that our existing tests weren't actually testing anything (they were passing without calling `expect`). 

This PR refactors them so that they are actually call `expect`. It also refactors the test cases to be more modular.
