### PR TITLE
Serve command still works with `--machine` flag

### DIFF
--- a/tool/lib/commands/serve.dart
+++ b/tool/lib/commands/serve.dart
@@ -159,6 +159,16 @@ class ServeCommand extends Command {
     final serveWithDartSdk = results[_serveWithDartSdkFlag] as String?;
     final forMachine = results[_machineFlag] as bool;
 
+    // TODO(https://github.com/flutter/devtools/issues/8643): Support running in
+    // machine mode with a debuggable DevTools app.
+    if (runApp && forMachine) {
+      throw Exception(
+        'Machine mode is not supported with `flutter run` DevTools.\n'
+        'Please use either --machine or --run-app, not both.\n'
+        'See https://github.com/flutter/devtools/issues/8643 for details.',
+      );
+    }
+
     // Any flag that we aren't removing here is intended to be passed through.
     final remainingArguments =
         List.of(results.arguments)


### PR DESCRIPTION
Follow-up to https://github.com/flutter/devtools/pull/8621

I noticed that running DevTools locally in VS Code was timing out. This is because the output is JSON when running with `--machine`. 

If `--machine` is true, we simply run the serve process instead of starting it and handling the output ourselves.