### PR TITLE
Remove uses of deprecated `--web-renderer` option

### DIFF
--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.0
 * Bump minimum Dart SDK version to `3.6.0`.
-* Bump minimum Flutter SDK version to `3.24.0`.
+* Bump minimum Flutter SDK version to `3.27.1`.
 * Bump `devtools_shared` dependency to `^11.1.0`.
 * Add `DevToolsIcon` and `AssetImageIcon` widgets.
 * Add `iconAsset` and `iconSize` fields to the `ButtonGroupItemData` class.

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/flutter/devtools/tree/master/packages/devtools_ap
 
 environment:
   sdk: ">=3.6.0 <4.0.0"
-  flutter: ">=3.24.0"
+  flutter: ">=3.27.1"
 
 resolution: workspace
 

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 0.3.0-dev.1
+## 0.3.0
+* Fix `build_and_copy` command by removing deprecated `--web-renderer` option.
+* Bump minimum Dart SDK version to `3.6.0` and minimum Flutter SDK version
+to `3.27.1`.
 * Bump `devtools_app_shared` dependency to `0.3.0`.
 * Bump `devtools_shared` dependency to `11.1.0`.
 * Clarify VS Code configuration in `README.md`.

--- a/packages/devtools_extensions/bin/_build_and_copy.dart
+++ b/packages/devtools_extensions/bin/_build_and_copy.dart
@@ -60,8 +60,6 @@ class BuildExtensionCommand extends Command {
       [
         'build',
         'web',
-        '--web-renderer',
-        'canvaskit',
         '--pwa-strategy=offline-first',
         '--release',
         '--no-tree-shake-icons',

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -1,12 +1,12 @@
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.3.0-dev.1
+version: 0.3.0
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
 environment:
-  sdk: ">=3.6.0-149.3.beta <4.0.0"
-  flutter: ">=3.25.0-0.1.pre"
+  sdk: ">=3.6.0 <4.0.0"
+  flutter: ">=3.27.1"
 
 resolution: workspace
 

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -106,8 +106,6 @@ class BuildCommand extends Command {
             SharedCommandArgs.wasm.asArg(),
             if (noStripWasm) SharedCommandArgs.noStripWasm.asArg(),
           ] else ...[
-            '--web-renderer',
-            'canvaskit',
             // Do not minify stack traces in debug mode.
             if (buildMode == 'debug') '--dart2js-optimization=O1',
             if (buildMode != 'debug') '--$buildMode',


### PR DESCRIPTION
Follow up PR to https://github.com/flutter/devtools/pull/8636. Removes `--web-renderer` flag, which was removed in https://github.com/flutter/flutter/pull/159314

This PR also prepares `package:devtools_extensions` for a new release 