### PR TITLE
[Inspector V2] Change selected node heuristic after navigation event triggering a tree refresh

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -462,6 +462,7 @@ class InspectorController extends DisposableController
       }
       if ((_receivedFlutterNavigationEvent || _receivedIsolateReloadEvent) &&
           extensionEventKind == 'Flutter.Frame') {
+        _refreshingAfterNavigationEvent = _receivedFlutterNavigationEvent;
         _receivedFlutterNavigationEvent = false;
         _receivedIsolateReloadEvent = false;
         await refreshInspector();
@@ -519,6 +520,8 @@ class InspectorController extends DisposableController
     }
   }
 
+  var _refreshingAfterNavigationEvent = false;
+
   RemoteDiagnosticsNode? _determineNewSelection(
     RemoteDiagnosticsNode? previousSelection,
   ) {
@@ -535,6 +538,11 @@ class InspectorController extends DisposableController
       distanceToAncestor,
     ) = _findClosestUnchangedAncestor(previousSelection);
     if (closestUnchangedAncestor == null) return inspectorTree.root?.diagnostic;
+
+    if (_refreshingAfterNavigationEvent) {
+      _refreshingAfterNavigationEvent = false;
+      return closestUnchangedAncestor;
+    }
 
     const distanceOffset = 3;
     final matchingDescendant = _findMatchingDescendant(

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -539,6 +539,12 @@ class InspectorController extends DisposableController
     ) = _findClosestUnchangedAncestor(previousSelection);
     if (closestUnchangedAncestor == null) return inspectorTree.root?.diagnostic;
 
+    // TODO(elliette): This might cause a race event that will set this to false
+    // for a subsequent navigate event. Consider passing the value of
+    // _refreshingAfterNavigationEvent through the method chain from where the
+    // navigation event is detected. This would require updating the interface
+    // of InspectorServiceClient.onForceRefresh, or refactoring to avoid doing
+    // so.
     if (_refreshingAfterNavigationEvent) {
       _refreshingAfterNavigationEvent = false;
       return closestUnchangedAncestor;


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/1423

Currently, when live reloading of the widget tree is enabled, the widget tree is reloaded when:
1. We detect a hot-reload
2. We detect a Flutter navigation event

For both, we try to determine the node to select in the reloaded tree by walking up from the selected node to its nearest unchanged ancestor, then walking down to find a node matching its name. This makes sense for hot-reloads, but for navigation events entire branches of the tree have changed.

This PR changes the heuristic after navigation events to simply select the closest unchanged ancestor.


