### PR TITLE
Fix dropdown overflow for enums

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -175,6 +175,7 @@ class _PropertyInputState extends State<_PropertyInput> {
                   child: Text(option),
                 );
               }).toList(),
+          isExpanded: true,
           onChanged: (newValue) async {
             await _editArgument(newValue);
           },


### PR DESCRIPTION
Pulled this small change out of https://github.com/flutter/devtools/pull/8637

This prevents the contents of the enum dropdowns from overflowing. Note: I would like to get this into the DevTools release so that we can start dog-fooding the Property Editor in VS Code without this annoying UI bug. 

