### PR TITLE
License update - Batch 3

### DIFF
--- a/case_study/code_size/unoptimized/README.md
+++ b/case_study/code_size/unoptimized/README.md
@@ -1,2 +1,7 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 This directory holds unoptimized versions of the applications in
 `case_study/code_size/optimized/`.

--- a/case_study/code_size/unoptimized/code_size_images/README.md
+++ b/case_study/code_size/unoptimized/code_size_images/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # code_size_images
 
 A Flutter project demonstrating code size issues with images

--- a/case_study/code_size/unoptimized/code_size_images/android/app/build.gradle
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/build.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {

--- a/case_study/code_size/unoptimized/code_size_images/android/app/src/debug/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/src/debug/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_images">
     <!-- Flutter needs it to communicate with the running application

--- a/case_study/code_size/unoptimized/code_size_images/android/app/src/main/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/src/main/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_images">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that

--- a/case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/drawable/launch_background.xml
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/drawable/launch_background.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">

--- a/case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/values/styles.xml
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/values/styles.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting -->

--- a/case_study/code_size/unoptimized/code_size_images/android/app/src/profile/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_images/android/app/src/profile/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_images">
     <!-- Flutter needs it to communicate with the running application

--- a/case_study/code_size/unoptimized/code_size_images/android/build.gradle
+++ b/case_study/code_size/unoptimized/code_size_images/android/build.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {

--- a/case_study/code_size/unoptimized/code_size_images/android/settings.gradle
+++ b/case_study/code_size/unoptimized/code_size_images/android/settings.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 include ':app'
 
 def localPropertiesFile = new File(rootProject.projectDir, "local.properties")

--- a/case_study/code_size/unoptimized/code_size_images/ios/Runner/AppDelegate.swift
+++ b/case_study/code_size/unoptimized/code_size_images/ios/Runner/AppDelegate.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import UIKit
 import Flutter
 

--- a/case_study/code_size/unoptimized/code_size_images/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
+++ b/case_study/code_size/unoptimized/code_size_images/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # Launch Screen Assets
 
 You can customize the launch screen with your own desired assets by replacing the image files in this directory.

--- a/case_study/code_size/unoptimized/code_size_images/ios/Runner/Runner-Bridging-Header.h
+++ b/case_study/code_size/unoptimized/code_size_images/ios/Runner/Runner-Bridging-Header.h
@@ -1,1 +1,4 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 #import "GeneratedPluginRegistrant.h"

--- a/case_study/code_size/unoptimized/code_size_images/lib/animals.dart
+++ b/case_study/code_size/unoptimized/code_size_images/lib/animals.dart
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import 'package:flutter/material.dart';
 
 class Animals extends StatelessWidget {

--- a/case_study/code_size/unoptimized/code_size_images/lib/main.dart
+++ b/case_study/code_size/unoptimized/code_size_images/lib/main.dart
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import 'package:flutter/material.dart';
 
 import 'animals.dart';

--- a/case_study/code_size/unoptimized/code_size_images/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/case_study/code_size/unoptimized/code_size_images/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 //
 //  Generated file. Do not edit.
 //

--- a/case_study/code_size/unoptimized/code_size_images/macos/Runner/AppDelegate.swift
+++ b/case_study/code_size/unoptimized/code_size_images/macos/Runner/AppDelegate.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import Cocoa
 import FlutterMacOS
 

--- a/case_study/code_size/unoptimized/code_size_images/macos/Runner/MainFlutterWindow.swift
+++ b/case_study/code_size/unoptimized/code_size_images/macos/Runner/MainFlutterWindow.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import Cocoa
 import FlutterMacOS
 

--- a/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_images/pubspec.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: code_size_images
 description: A Flutter project demonstrating code size issues with images.
 publish_to: none

--- a/case_study/code_size/unoptimized/code_size_images/test/widget_test.dart
+++ b/case_study/code_size/unoptimized/code_size_images/test/widget_test.dart
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester

--- a/case_study/code_size/unoptimized/code_size_images/web/index.html
+++ b/case_study/code_size/unoptimized/code_size_images/web/index.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <!DOCTYPE html>
 <html>
 <head>

--- a/case_study/code_size/unoptimized/code_size_package/README.md
+++ b/case_study/code_size/unoptimized/code_size_package/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # code_size_package
 
 A Flutter project demonstrating code size issues with packages.

--- a/case_study/code_size/unoptimized/code_size_package/android/app/build.gradle
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/build.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 def localProperties = new Properties()
 def localPropertiesFile = rootProject.file('local.properties')
 if (localPropertiesFile.exists()) {

--- a/case_study/code_size/unoptimized/code_size_package/android/app/src/debug/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/src/debug/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_package">
     <!-- Flutter needs it to communicate with the running application

--- a/case_study/code_size/unoptimized/code_size_package/android/app/src/main/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/src/main/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_package">
     <!-- io.flutter.app.FlutterApplication is an android.app.Application that

--- a/case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/drawable/launch_background.xml
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/drawable/launch_background.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">

--- a/case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/values/styles.xml
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/values/styles.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- Theme applied to the Android Window while the process is starting -->

--- a/case_study/code_size/unoptimized/code_size_package/android/app/src/profile/AndroidManifest.xml
+++ b/case_study/code_size/unoptimized/code_size_package/android/app/src/profile/AndroidManifest.xml
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.code_size_package">
     <!-- Flutter needs it to communicate with the running application

--- a/case_study/code_size/unoptimized/code_size_package/android/build.gradle
+++ b/case_study/code_size/unoptimized/code_size_package/android/build.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 buildscript {
     ext.kotlin_version = '1.3.50'
     repositories {

--- a/case_study/code_size/unoptimized/code_size_package/android/settings.gradle
+++ b/case_study/code_size/unoptimized/code_size_package/android/settings.gradle
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 include ':app'
 
 def localPropertiesFile = new File(rootProject.projectDir, "local.properties")

--- a/case_study/code_size/unoptimized/code_size_package/ios/Runner/AppDelegate.swift
+++ b/case_study/code_size/unoptimized/code_size_package/ios/Runner/AppDelegate.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import UIKit
 import Flutter
 

--- a/case_study/code_size/unoptimized/code_size_package/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
+++ b/case_study/code_size/unoptimized/code_size_package/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # Launch Screen Assets
 
 You can customize the launch screen with your own desired assets by replacing the image files in this directory.

--- a/case_study/code_size/unoptimized/code_size_package/ios/Runner/Runner-Bridging-Header.h
+++ b/case_study/code_size/unoptimized/code_size_package/ios/Runner/Runner-Bridging-Header.h
@@ -1,1 +1,4 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 #import "GeneratedPluginRegistrant.h"

--- a/case_study/code_size/unoptimized/code_size_package/lib/main.dart
+++ b/case_study/code_size/unoptimized/code_size_package/lib/main.dart
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import 'package:encrypt/encrypt.dart' as encrypt;
 import 'package:flutter/material.dart';
 

--- a/case_study/code_size/unoptimized/code_size_package/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/case_study/code_size/unoptimized/code_size_package/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 //
 //  Generated file. Do not edit.
 //

--- a/case_study/code_size/unoptimized/code_size_package/macos/Runner/AppDelegate.swift
+++ b/case_study/code_size/unoptimized/code_size_package/macos/Runner/AppDelegate.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import Cocoa
 import FlutterMacOS
 

--- a/case_study/code_size/unoptimized/code_size_package/macos/Runner/MainFlutterWindow.swift
+++ b/case_study/code_size/unoptimized/code_size_package/macos/Runner/MainFlutterWindow.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import Cocoa
 import FlutterMacOS
 

--- a/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
+++ b/case_study/code_size/unoptimized/code_size_package/pubspec.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: code_size_package
 description: A Flutter project demonstrating code size issues with packages.
 publish_to: none

--- a/case_study/code_size/unoptimized/code_size_package/test/widget_test.dart
+++ b/case_study/code_size/unoptimized/code_size_package/test/widget_test.dart
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 // This is a basic Flutter widget test.
 //
 // To perform an interaction with a widget in your test, use the WidgetTester

--- a/case_study/code_size/unoptimized/code_size_package/web/index.html
+++ b/case_study/code_size/unoptimized/code_size_package/web/index.html
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 <!DOCTYPE html>
 <html>
 <head>


### PR DESCRIPTION
Updates the license headers for:

1. case_study/code_size/unoptimized/README.md
2. case_study/code_size/unoptimized/code_size_images/README.md
3. case_study/code_size/unoptimized/code_size_images/android/app/build.gradle
4. case_study/code_size/unoptimized/code_size_images/android/app/src/debug/AndroidManifest.xml
5. case_study/code_size/unoptimized/code_size_images/android/app/src/main/AndroidManifest.xml
6. case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/drawable/launch_background.xml
7. case_study/code_size/unoptimized/code_size_images/android/app/src/main/res/values/styles.xml
8. case_study/code_size/unoptimized/code_size_images/android/app/src/profile/AndroidManifest.xml
9. case_study/code_size/unoptimized/code_size_images/android/build.gradle
10. case_study/code_size/unoptimized/code_size_images/android/settings.gradle
11. case_study/code_size/unoptimized/code_size_images/ios/Runner/AppDelegate.swift
12. case_study/code_size/unoptimized/code_size_images/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
13. case_study/code_size/unoptimized/code_size_images/ios/Runner/Runner-Bridging-Header.h
14. case_study/code_size/unoptimized/code_size_images/lib/animals.dart
15. case_study/code_size/unoptimized/code_size_images/lib/main.dart
16. case_study/code_size/unoptimized/code_size_images/macos/Flutter/GeneratedPluginRegistrant.swift
17. case_study/code_size/unoptimized/code_size_images/macos/Runner/AppDelegate.swift
18. case_study/code_size/unoptimized/code_size_images/macos/Runner/MainFlutterWindow.swift
19. case_study/code_size/unoptimized/code_size_images/pubspec.yaml
20. case_study/code_size/unoptimized/code_size_images/test/widget_test.dart
21. case_study/code_size/unoptimized/code_size_images/web/index.html
22. case_study/code_size/unoptimized/code_size_package/README.md
23. case_study/code_size/unoptimized/code_size_package/android/app/build.gradle
24. case_study/code_size/unoptimized/code_size_package/android/app/src/debug/AndroidManifest.xml
25. case_study/code_size/unoptimized/code_size_package/android/app/src/main/AndroidManifest.xml
26. case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/drawable/launch_background.xml
27. case_study/code_size/unoptimized/code_size_package/android/app/src/main/res/values/styles.xml
28. case_study/code_size/unoptimized/code_size_package/android/app/src/profile/AndroidManifest.xml
29. case_study/code_size/unoptimized/code_size_package/android/build.gradle
30. case_study/code_size/unoptimized/code_size_package/android/settings.gradle
31. case_study/code_size/unoptimized/code_size_package/ios/Runner/AppDelegate.swift
32. case_study/code_size/unoptimized/code_size_package/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
33. case_study/code_size/unoptimized/code_size_package/ios/Runner/Runner-Bridging-Header.h
34. case_study/code_size/unoptimized/code_size_package/lib/main.dart
35. case_study/code_size/unoptimized/code_size_package/macos/Flutter/GeneratedPluginRegistrant.swift
36. case_study/code_size/unoptimized/code_size_package/macos/Runner/AppDelegate.swift
37. case_study/code_size/unoptimized/code_size_package/macos/Runner/MainFlutterWindow.swift
38. case_study/code_size/unoptimized/code_size_package/pubspec.yaml
39. case_study/code_size/unoptimized/code_size_package/test/widget_test.dart
40. case_study/code_size/unoptimized/code_size_package/web/index.html

https://github.com/flutter/devtools/issues/8216

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.

![build.yaml badge]

[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg