### PR TITLE
License update - Batch 55

### DIFF
--- a/packages/devtools_extensions/example/README.md
+++ b/packages/devtools_extensions/example/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # DevTools extension examples
 This directory contains end-to-end examples of DevTools extensions. Each
 end-to-end example is made up of three components:

--- a/packages/devtools_extensions/example/app_that_uses_foo/README.md
+++ b/packages/devtools_extensions/example/app_that_uses_foo/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # app_that_uses_foo
 
 This is an example application that uses a package, `package:foo`, that includes a

--- a/packages/devtools_extensions/example/app_that_uses_foo/bin/script.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/bin/script.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:dart_foo/dart_foo.dart';
 

--- a/packages/devtools_extensions/example/app_that_uses_foo/devtools_options.yaml
+++ b/packages/devtools_extensions/example/app_that_uses_foo/devtools_options.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 extensions:
   - foo: true
   - standalone_extension: true

--- a/packages/devtools_extensions/example/app_that_uses_foo/integration_test/example_integration_test.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/integration_test/example_integration_test.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:app_that_uses_foo/main.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/AppDelegate.swift
+++ b/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/AppDelegate.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import UIKit
 import Flutter
 

--- a/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
+++ b/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2025 The Flutter Authors
+Use of this source code is governed by a BSD-style license that can be
+found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+-->
 # Launch Screen Assets
 
 You can customize the launch screen with your own desired assets by replacing the image files in this directory.

--- a/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Runner-Bridging-Header.h
+++ b/packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Runner-Bridging-Header.h
@@ -1,1 +1,4 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 #import "GeneratedPluginRegistrant.h"

--- a/packages/devtools_extensions/example/app_that_uses_foo/ios/RunnerTests/RunnerTests.swift
+++ b/packages/devtools_extensions/example/app_that_uses_foo/ios/RunnerTests/RunnerTests.swift
@@ -1,3 +1,6 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 import Flutter
 import UIKit
 import XCTest

--- a/packages/devtools_extensions/example/app_that_uses_foo/lib/main.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/lib/main.dart
@@ -1,6 +1,6 @@
-// Copyright 2023 The Chromium Authors. All rights reserved.
+// Copyright 2023 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:dart_foo/dart_foo.dart';
 import 'package:flutter/material.dart';

--- a/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
+++ b/packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
@@ -1,3 +1,6 @@
+# Copyright 2025 The Flutter Authors
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: app_that_uses_foo
 description: A Flutter app that uses package:foo (which contains a DevTools extension)
 publish_to: 'none'

--- a/packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_1.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_1.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:app_that_uses_foo/main.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_2.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_2.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:app_that_uses_foo/main.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_1.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_1.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:dart_foo/dart_foo.dart';
 import 'package:test/test.dart';

--- a/packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_2.dart
+++ b/packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_2.dart
@@ -1,6 +1,6 @@
-// Copyright 2024 The Chromium Authors. All rights reserved.
+// Copyright 2024 The Flutter Authors
 // Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:dart_foo/dart_foo.dart';
 import 'package:test/test.dart';


### PR DESCRIPTION
Updates the license headers for:

1. packages/devtools_extensions/example/README.md
2. packages/devtools_extensions/example/app_that_uses_foo/README.md
3. packages/devtools_extensions/example/app_that_uses_foo/bin/script.dart
4. packages/devtools_extensions/example/app_that_uses_foo/devtools_options.yaml
5. packages/devtools_extensions/example/app_that_uses_foo/integration_test/example_integration_test.dart
6. packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/AppDelegate.swift
7. packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Assets.xcassets/LaunchImage.imageset/README.md
8. packages/devtools_extensions/example/app_that_uses_foo/ios/Runner/Runner-Bridging-Header.h
9. packages/devtools_extensions/example/app_that_uses_foo/ios/RunnerTests/RunnerTests.swift
10. packages/devtools_extensions/example/app_that_uses_foo/lib/main.dart
11. packages/devtools_extensions/example/app_that_uses_foo/pubspec.yaml
12. packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_1.dart
13. packages/devtools_extensions/example/app_that_uses_foo/test/flutter_test_2.dart
14. packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_1.dart
15. packages/devtools_extensions/example/app_that_uses_foo/test/nested/dart_test_2.dart

https://github.com/flutter/devtools/issues/8216

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg