### PR TITLE
[Property Editor] Handle `null` text document / text document version in `ActiveLocationChangedEvent`

### DIFF
--- a/packages/devtools_app/lib/src/shared/editor/api_classes.dart
+++ b/packages/devtools_app/lib/src/shared/editor/api_classes.dart
@@ -341,11 +341,11 @@ class TextDocument with Serializable {
   TextDocument.fromJson(Map<String, Object?> map)
     : this(
         uriAsString: map[Field.uri] as String,
-        version: map[Field.version] as int,
+        version: map[Field.version] as int?,
       );
 
   final String uriAsString;
-  final int version;
+  final int? version;
 
   @override
   Map<String, Object?> toJson() => {

--- a/packages/devtools_app/lib/src/shared/editor/api_classes.dart
+++ b/packages/devtools_app/lib/src/shared/editor/api_classes.dart
@@ -317,7 +317,7 @@ class ActiveLocationChangedEvent extends EditorEvent {
       );
 
   final List<EditorSelection> selections;
-  final TextDocument textDocument;
+  final TextDocument? textDocument;
 
   @override
   EditorEventKind get kind => EditorEventKind.activeLocationChanged;

--- a/packages/devtools_app/lib/src/shared/editor/editor_client.dart
+++ b/packages/devtools_app/lib/src/shared/editor/editor_client.dart
@@ -232,14 +232,14 @@ class EditorClient extends DisposableController
 
   /// Gets the editable arguments from the Analysis Server.
   Future<EditableArgumentsResult?> getEditableArguments({
-    required TextDocument textDocument,
+    required TextDocument? textDocument,
     required CursorPosition position,
   }) async {
     final response = await _callLspApi(
       LspMethod.editableArguments,
       params: {
         'type': 'Object', // This is required by DTD.
-        'textDocument': textDocument.toJson(),
+        'textDocument': textDocument?.toJson(),
         'position': position.toJson(),
       },
     );

--- a/packages/devtools_app/lib/src/shared/editor/editor_client.dart
+++ b/packages/devtools_app/lib/src/shared/editor/editor_client.dart
@@ -232,14 +232,14 @@ class EditorClient extends DisposableController
 
   /// Gets the editable arguments from the Analysis Server.
   Future<EditableArgumentsResult?> getEditableArguments({
-    required TextDocument? textDocument,
+    required TextDocument textDocument,
     required CursorPosition position,
   }) async {
     final response = await _callLspApi(
       LspMethod.editableArguments,
       params: {
         'type': 'Object', // This is required by DTD.
-        'textDocument': textDocument?.toJson(),
+        'textDocument': textDocument.toJson(),
         'position': position.toJson(),
       },
     );

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_controller.dart
@@ -27,6 +27,10 @@ class PropertyEditorController extends DisposableController
       editorClient.activeLocationChangedStream.listen((event) async {
         final textDocument = event.textDocument;
         final cursorPosition = event.selections.first.active;
+        // Don't do anything if the text document is null.
+        if (textDocument == null) {
+          return;
+        }
         // Don't do anything if the event corresponds to the current position.
         if (textDocument == _currentDocument &&
             cursorPosition == _currentCursorPosition) {


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8704, https://github.com/flutter/devtools/issues/8745
Work towards https://github.com/flutter/devtools/issues/1948

* In the `ActiveLocationChangedEvent`, the text document can be `null`
* In the text document, the `version` can also be `null`