### PR TITLE
Bring "Include CPU samples" option out of settings menu

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_view.dart
@@ -131,18 +131,28 @@ class TimelineEventsTabControls extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final showingOfflineData = offlineDataController.showingOfflineData.value;
     return Row(
       mainAxisAlignment: MainAxisAlignment.end,
       children: [
-        Padding(
-          padding: const EdgeInsets.only(right: densePadding),
-          child: PerfettoHelpButton(
-            perfettoController: controller.perfettoController,
+        if (!showingOfflineData)
+          Row(
+            children: [
+              const Text('Include CPU samples'),
+              const SizedBox(width: densePadding),
+              DevToolsTooltip(
+                message:
+                    'Include CPU samples in the timeline\n'
+                    '(this may negatively impact performance)',
+                child: NotifierSwitch(
+                  notifier: preferences.performance.includeCpuSamplesInTimeline,
+                ),
+              ),
+            ],
           ),
-        ),
-        if (!offlineDataController.showingOfflineData.value) ...[
-          // TODO(kenz): add a switch to enable the CPU profiler once the
-          // tracing format supports it (when we switch to protozero).
+        const SizedBox(width: densePadding),
+        PerfettoHelpButton(perfettoController: controller.perfettoController),
+        if (!showingOfflineData) ...[
           const SizedBox(width: densePadding),
           const TimelineSettingsButton(),
           const SizedBox(width: densePadding),
@@ -258,13 +268,6 @@ class _TimelineSettingsDialogState extends State<TimelineSettingsDialog>
 
   List<Widget> _defaultRecordedStreams(ThemeData theme) {
     return [
-      ...dialogSubHeader(theme, 'General'),
-      CheckboxSetting(
-        notifier: preferences.performance.includeCpuSamplesInTimeline,
-        title: 'Include CPU samples in the timeline',
-        description: 'This may negatively affect performance.',
-      ),
-      const SizedBox(height: defaultSpacing),
       ...dialogSubHeader(theme, 'Trace categories'),
       RichText(text: TextSpan(text: 'Default', style: theme.subtleTextStyle)),
       ..._timelineStreams(advanced: false),

--- a/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/devtools_app/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -1,6 +1,3 @@
-// Copyright 2025 The Flutter Authors
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 //
 //  Generated file. Do not edit.
 //

--- a/packages/devtools_app/test/screens/performance/tabbed_performance_view_test.dart
+++ b/packages/devtools_app/test/screens/performance/tabbed_performance_view_test.dart
@@ -198,6 +198,7 @@ void main() {
           await tester.tap(find.text('Timeline Events'));
           await tester.pumpAndSettle();
 
+          expect(find.byType(NotifierSwitch), findsOneWidget);
           expect(find.byType(TimelineSettingsButton), findsOneWidget);
           expect(find.byType(RefreshTimelineEventsButton), findsOneWidget);
           expect(find.byType(TimelineEventsTabView), findsOneWidget);
@@ -227,6 +228,7 @@ void main() {
           expect(find.byType(DevToolsTab), findsOneWidget);
           expect(find.text('Timeline Events'), findsOneWidget);
           expect(find.text('Frame Analysis'), findsNothing);
+          expect(find.text('Rebuild Stats'), findsNothing);
         });
       },
     );


### PR DESCRIPTION
Addresses a TODO to show the "Include CPU samples" option as a switch. This will help with discoverability of this feature that was previously difficult to discover in the settings menu.

![Screenshot 2025-01-17 at 10 13 27 AM](https://github.com/user-attachments/assets/9dc89a77-e42f-4b7b-bd49-fccba6bd4508)
