### PR TITLE
[Property Editor] Check for registered LSP service methods before calling them

### DIFF
--- a/packages/devtools_app/lib/src/shared/editor/api_classes.dart
+++ b/packages/devtools_app/lib/src/shared/editor/api_classes.dart
@@ -28,14 +28,14 @@ enum EditorMethod {
 ///
 /// [code link]: https://github.com/dart-lang/sdk/blob/ebfcd436da65802a2b20d415afe600b51e432305/pkg/analysis_server/lib/src/lsp/constants.dart#L136
 enum LspMethod {
-  editableArguments(
-    methodName: 'experimental/dart/textDocument/editableArguments',
-  ),
-  editArgument(methodName: 'experimental/dart/textDocument/editArgument');
+  editableArguments(methodName: 'dart/textDocument/editableArguments'),
+  editArgument(methodName: 'dart/textDocument/editArgument');
 
   const LspMethod({required this.methodName});
 
   final String methodName;
+
+  String get experimentalMethodName => 'experimental/$methodName';
 }
 
 /// Known kinds of events that may come from the editor.

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -63,8 +63,6 @@ class _PropertiesList extends StatelessWidget {
             ? const Center(
               child: Text(
                 'No widget properties at the current cursor location.',
-                textDirection: TextDirection.rtl,
-                textAlign: TextAlign.left,
               ),
             )
             : Column(

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 
 import '../../../shared/editor/api_classes.dart';
 import '../../../shared/primitives/utils.dart';
+import '../../../shared/ui/common_widgets.dart';
 import 'property_editor_controller.dart';
 
 class PropertyEditorView extends StatelessWidget {
@@ -18,12 +19,28 @@ class PropertyEditorView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        // TODO(elliette): Include widget name and documentation.
-        _PropertiesList(controller: controller),
+    return MultiValueListenableBuilder(
+      listenables: [
+        controller.editorClient.editArgumentMethodName,
+        controller.editorClient.editableArgumentsMethodName,
       ],
+      builder: (_, values, _) {
+        final editArgumentMethodName = values.first as String?;
+        final editableArgumentsMethodName = values.second as String?;
+
+        if (editArgumentMethodName == null ||
+            editableArgumentsMethodName == null) {
+          return const CenteredCircularProgressIndicator();
+        }
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            // TODO(elliette): Include widget name and documentation.
+            _PropertiesList(controller: controller),
+          ],
+        );
+      },
     );
   }
 }
@@ -46,6 +63,8 @@ class _PropertiesList extends StatelessWidget {
             ? const Center(
               child: Text(
                 'No widget properties at the current cursor location.',
+                textDirection: TextDirection.rtl,
+                textAlign: TextAlign.left,
               ),
             )
             : Column(

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
@@ -38,6 +38,12 @@ void main() {
 
     mockEditorClient = MockEditorClient();
     when(
+      mockEditorClient.editArgumentMethodName,
+    ).thenReturn(ValueNotifier(LspMethod.editArgument.methodName));
+    when(
+      mockEditorClient.editableArgumentsMethodName,
+    ).thenReturn(ValueNotifier(LspMethod.editableArguments.methodName));
+    when(
       mockEditorClient.activeLocationChangedStream,
     ).thenAnswer((_) => eventStream);
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8715
Work towards https://github.com/flutter/devtools/issues/1948

* Waits for the `editArgument` and `editableArguments` service methods to be registered on the LSP service before loading the property editor. 
* Uses either the experimental or non-experimental method depending on which one is registered.