### PR TITLE
[Property Editor] Launch from `devtools_app` instead or root 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -113,6 +113,12 @@
             ],
         },
         {
+            "name": "standalone_ui/property_editor_sidebar",
+            "request": "launch",
+            "type": "dart",
+            "program": "packages/devtools_app/test/test_infra/scenes/standalone_ui/property_editor_sidebar.stager_app.g.dart",
+        },
+        {
             "name": "devtools_extensions: foo + sim",
             "request": "launch",
             "type": "dart",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -113,13 +113,6 @@
             ],
         },
         {
-            "name": "standalone_ui/property_editor_sidebar",
-            "request": "launch",
-            "type": "dart",
-            "program": "packages/devtools_app/test/test_infra/scenes/standalone_ui/property_editor_sidebar.stager_app.g.dart",
-            "preLaunchTask": "Start DTD on Port 8500",
-        },
-        {
             "name": "devtools_extensions: foo + sim",
             "request": "launch",
             "type": "dart",

--- a/packages/devtools_app/.vscode/launch.json
+++ b/packages/devtools_app/.vscode/launch.json
@@ -60,5 +60,12 @@
             "type": "dart",
             "request": "attach",
         },
+        {
+            "name": "standalone_ui/property_editor_sidebar",
+            "request": "launch",
+            "type": "dart",
+            "program": "test/test_infra/scenes/standalone_ui/property_editor_sidebar.stager_app.g.dart",
+        },
+        
     ]
 }


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/8802

Implementation widgets were being included in the Widget Inspector debugging the property editor. I believe this is because we were launching the stager app from outside the `devtools_app` package, and the devtools root directory was included (including `tool/flutter-sdk`)