### PR TITLE
Inspector infers correct pub root directory for widget previews

### DIFF
--- a/packages/devtools_app/test/shared/preferences/preferences_controller_test.dart
+++ b/packages/devtools_app/test/shared/preferences/preferences_controller_test.dart
@@ -162,6 +162,10 @@ void main() {
           'my_user/google3/dart_apps/test_app/lib/main.dart': '/dart_apps/',
           'my_user/google3/third_party/dart/dart_apps/test_app/lib/main.dart':
               '/third_party/dart/',
+          'my_user/fake_app/.dart_tool/widget_preview_scaffold':
+              'my_user/fake_app/',
+          'my_user/fake_app/lib/.dart_tool/widget_preview_scaffold':
+              'my_user/fake_app/',
         };
 
         for (final MapEntry(key: rootLib, value: expectedPubRoot)


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8807

I'm assuming we never want to set a directory in `.dart_tool` as a pub root directory, but in case we do we can change the logic to specifically only exclude the `widget_previews_scaffold` directory. 
