### PR TITLE
Use `-O2` optimization for DevTools wasm build.

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -82,6 +82,7 @@ flutter pub get
 flutter build web \
   --source-maps \
   --wasm \
+  -O2 \
   --pwa-strategy=offline-first \
   --release \
   --no-tree-shake-icons

--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -83,6 +83,7 @@ flutter build web \
   --source-maps \
   --wasm \
   -O2 \
+  --dart2js-optimization=O4 \
   --pwa-strategy=offline-first \
   --release \
   --no-tree-shake-icons

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -108,9 +108,14 @@ class BuildCommand extends Command {
           ] else ...[
             // Do not minify stack traces in debug mode.
             if (buildMode == 'debug') '--dart2js-optimization=O1',
-            if (buildMode != 'debug') '--$buildMode',
+            if (buildMode != 'debug') ...[
+              '--$buildMode',
+              // Use -O2 optimization by default (sound dart) but override for
+              // dart2js with -O4 (it's too slow otherwise).
+              '-O2',
+              '--dart2js-optimization=O4',
+            ],
           ],
-          '-O2',
           '--pwa-strategy=offline-first',
           '--no-tree-shake-icons',
         ]),

--- a/tool/lib/commands/build.dart
+++ b/tool/lib/commands/build.dart
@@ -110,6 +110,7 @@ class BuildCommand extends Command {
             if (buildMode == 'debug') '--dart2js-optimization=O1',
             if (buildMode != 'debug') '--$buildMode',
           ],
+          '-O2',
           '--pwa-strategy=offline-first',
           '--no-tree-shake-icons',
         ]),


### PR DESCRIPTION
From @mkustermann: Deploying in `-O2` mode "will allow rooting out some issues much more easily as it will throw dart errors instead of crashing with wasm traps or illegal casts."