### PR TITLE
[Property Editor] Label should always be at the top of the input

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -204,6 +204,7 @@ mixin _PropertyInputMixin<T> {
       isDense: true,
       label: inputLabel(property, theme: theme),
       border: const OutlineInputBorder(),
+      floatingLabelBehavior: FloatingLabelBehavior.always,
     );
   }
 


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/1948

Previously, if a text input was empty (e.g. an empty string) the label text would display in the input box itself. This meant that most of the labels would be at the top of the input boxes, while others would show up in the input box:

<img width="373" alt="Screenshot 2025-01-28 at 4 49 55 PM" src="https://github.com/user-attachments/assets/4ef1ff4d-73f1-4ffd-a3d7-69f6849502b8" />

This change makes sure the labels always stay at the top of the input box:

<img width="372" alt="Screenshot 2025-01-28 at 4 49 24 PM" src="https://github.com/user-attachments/assets/bd9123ac-f2d8-449d-a6ef-ae624043c56f" />


*Note: I'm still trying to decide how/if we want to try to show the surrounding quotes for string inputs. For example above, that would mean showing  `''` in the input box instead of nothing.*
