### PR TITLE
Fix build failure

### DIFF
--- a/tool/build_release.sh
+++ b/tool/build_release.sh
@@ -1,14 +1,11 @@
-# Copyright 2025 The Flutter Authors
-# Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 #!/bin/bash
 
 # TODO(kenz): delete this script once we can confirm it is not used in the
 # Dart SDK or in infra tooling.
 
-# Copyright 2019 The Chromium Authors. All rights reserved.
+# Copyright 2025 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
-# found in the LICENSE file.
+# found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 # Contains a path to this script, relative to the directory it was called from.
 RELATIVE_PATH_TO_SCRIPT="${BASH_SOURCE[0]}"


### PR DESCRIPTION
As a result of an automated search/replace of license headers for ongoing work for https://github.com/flutter/devtools/issues/8216, devtools/tools/release_build.sh had been corrupted. This caused a failure at build time.

https://ci.chromium.org/ui/p/dart-internal/builders/flutter/devtools/1199/overview

This PR is an attempt to fix the build failure.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.

![build.yaml badge]

[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg