### PR TITLE
Fix customer test scripts

### DIFF
--- a/tool/flutter_customer_tests/analyze.sh
+++ b/tool/flutter_customer_tests/analyze.sh
@@ -1,7 +1,9 @@
+#!/bin/bash -e
+
 # Copyright 2025 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
-#!/bin/bash -e
+
 # Script to analyze the devtools repo for the flutter/tests registry
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter

--- a/tool/flutter_customer_tests/setup.sh
+++ b/tool/flutter_customer_tests/setup.sh
@@ -1,7 +1,9 @@
+#!/bin/bash -e
+
 # Copyright 2025 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
-#!/bin/bash -e
+
 # Script to generate mocks for Devtools from the flutter/tests registry
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter

--- a/tool/flutter_customer_tests/test.sh
+++ b/tool/flutter_customer_tests/test.sh
@@ -1,6 +1,7 @@
 # Copyright 2025 The Flutter Authors
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
 # Script to execute smoke tests for the flutter/tests registry
 # https://github.com/flutter/tests
 # This is executed as a pre-submit check for every PR in flutter/flutter


### PR DESCRIPTION
While addressing https://github.com/flutter/devtools/pull/8820, it was discovered that a few other bash scripts had incorrect license header placement as well.

## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or there is a reason for not adding tests.

![build.yaml badge]

[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg