### PR TITLE
Fix a bug with detecting the base path for DevTools assets

### DIFF
--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1114,10 +1114,13 @@ Map<K, R> subtractMaps<K, F, S, R>({
 ///     ==> 'http://127.0.0.1:61962/mb9Sw4gCYvU=/devtools'
 /// * 'http://127.0.0.1:61962/performance' ==> 'http://127.0.0.1:61962'
 String devtoolsAssetsBasePath({required String origin, required String path}) {
+  // Ensure that we are truly only using the origin of the URI String passed as
+  // the [origin] parameter.
+  final trimmedOrigin = Uri.parse(origin).origin;
   const separator = '/';
   final pathParts = path.split(separator);
   // The last path part is the DevTools page (e.g. 'performance' or 'snapshot'),
   // which is not part of the hosted asset path.
   pathParts.removeLast();
-  return '$origin${pathParts.join(separator)}';
+  return '$trimmedOrigin${pathParts.join(separator)}';
 }

--- a/packages/devtools_app/test/shared/primitives/utils_test.dart
+++ b/packages/devtools_app/test/shared/primitives/utils_test.dart
@@ -1336,6 +1336,22 @@ void main() {
       ),
       equals('http://127.0.0.1:61962'),
     );
+    // This is how a DevTools url will be structured when DevTools is ran
+    // locally using `dt run`.
+    expect(
+      devtoolsAssetsBasePath(origin: 'http://127.0.0.1:9100/', path: '/home'),
+      equals('http://127.0.0.1:9100'),
+    );
+    // This is how a DevTools url will be structured when it has query
+    // parameters (e.g. when it is connected to an app).
+    expect(
+      devtoolsAssetsBasePath(
+        origin:
+            'http://127.0.0.1:9100/home?uri=ws://127.0.0.1:50416/Hnr3zwp99d0=/ws',
+        path: '/home',
+      ),
+      equals('http://127.0.0.1:9100'),
+    );
   });
 }
 


### PR DESCRIPTION
This behavior was broken in https://github.com/flutter/devtools/commit/2da31a2c50ebd32bc6590da40c17eedc246aabc4#diff-7fcb9b313dc9c9fcf66daa6d7a33c107ac6d7570c92688a7322411c1993fd179 and was causing errors loading DevTools extensions:
![image](https://github.com/user-attachments/assets/97ffa821-771e-48b1-a1c3-e4af3573f289)

This will need to be cherry picked to the beta branch that will soon go to stable.

Fixes https://github.com/flutter/devtools/issues/8705
