### PR TITLE
[Property Editor] Increase label font size

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -208,6 +208,8 @@ mixin _PropertyInputMixin<T> {
   }
 
   Widget inputLabel(EditableProperty property, {required ThemeData theme}) {
+    // Flutter scales down the label font size by 75%, therefore we need to
+    // increase the size to make it glegible.
     final fixedFontStyle = theme.fixedFontStyle.copyWith(
       fontSize: defaultFontSize + 1,
     );

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -208,22 +208,25 @@ mixin _PropertyInputMixin<T> {
   }
 
   Widget inputLabel(EditableProperty property, {required ThemeData theme}) {
+    final fixedFontStyle = theme.fixedFontStyle.copyWith(
+      fontSize: defaultFontSize + 1,
+    );
     return RichText(
       overflow: TextOverflow.ellipsis,
       text: TextSpan(
         text: '${property.displayType} ',
-        style: theme.fixedFontStyle,
+        style: fixedFontStyle,
         children: [
           TextSpan(
             text: property.name,
-            style: theme.fixedFontStyle.copyWith(
+            style: fixedFontStyle.copyWith(
               fontWeight: FontWeight.bold,
               color: theme.colorScheme.primary,
             ),
             children: [
               TextSpan(
                 text: property.isRequired ? '*' : '',
-                style: theme.fixedFontStyle,
+                style: fixedFontStyle,
               ),
             ],
           ),


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/1948

Flutter scales down the label to inputs by 75%, so the default `fixedFontStyle` from the DevTools theme (which already is smaller than the default font) is too small to read clearly.

This PR increases the font size so they are legible. 

After:
![Screenshot 2025-01-30 at 1 47 58 PM](https://github.com/user-attachments/assets/bcb61d45-f3d6-4fcd-baf6-92dd4b27183f)

Before:

![Screenshot 2025-01-30 at 1 48 22 PM](https://github.com/user-attachments/assets/0362b98e-057b-4c57-a8a0-12e4381ede90)
