### PR TITLE
Fix licence tool include/excludes for Windows

### DIFF
--- a/tool/lib/license_utils.dart
+++ b/tool/lib/license_utils.dart
@@ -138,14 +138,16 @@ class LicenseConfig {
   bool shouldExclude(File file) {
     var included = false;
     for (final includePath in includePaths) {
-      if (file.path.startsWith(includePath)) {
+      if (p.equals(includePath, file.path) ||
+          p.isWithin(includePath, file.path)) {
         included = true;
         break;
       }
     }
     var excluded = false;
     for (final excludePath in excludePaths) {
-      if (file.path.startsWith(excludePath)) {
+      if (p.equals(excludePath, file.path) ||
+          p.isWithin(excludePath, file.path)) {
         excluded = true;
         break;
       }


### PR DESCRIPTION
If the YAML file contains an exclusion using a forward slash then this condition would fail to match when running on Windows. This change uses `path.isWithin()` which handles the mismatched slashes automatically.

This fixes some test failures when running the licence tests on Windows.

CC @mossmana 