### PR TITLE
Normalize analytics paths for Windows

### DIFF
--- a/packages/devtools_app/lib/src/shared/analytics/analytics_common.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/analytics_common.dart
@@ -130,11 +130,15 @@ Map<String, String?> createStackTraceForAnalytics(
   return stackTraceChunks;
 }
 
+/// A regex that matches a string that starts with a Windows drive letter (with
+/// colon).
+final _startsWithWindowsDriveLetterRegex = RegExp(r'^[a-zA-Z]:');
+
 /// Normalize a file path from either platform to the POSIX equivalent so that
 /// paths are the same for both Windows and non-Windows paths.
 String _normalizePath(String path) {
   // Windows path with drive letter.
-  if (!path.startsWith('/') && path.length > 2 && path[1] == ':') {
+  if (_startsWithWindowsDriveLetterRegex.hasMatch(path)) {
     // Strip drive letter and normalize slashes to match POSIX.
     // C:\foo\bar -> /foo/bar
     return path.substring(2).replaceAll(r'\', '/');

--- a/packages/devtools_app/lib/src/shared/analytics/analytics_common.dart
+++ b/packages/devtools_app/lib/src/shared/analytics/analytics_common.dart
@@ -59,7 +59,9 @@ Map<String, String?> createStackTraceForAnalytics(
 
   // Reduce whitespace characters to optimize available space.
   final trimmedStackFrames =
-      stackTrace.frames.map((f) => '${f.location} | ${f.member}\n').toList();
+      stackTrace.frames
+          .map((f) => '${_normalizePath(f.location)} | ${f.member}\n')
+          .toList();
   final stackTraceAsString = trimmedStackFrames.join();
 
   var stackTraceChunksForGa = chunkForGa(
@@ -126,6 +128,20 @@ Map<String, String?> createStackTraceForAnalytics(
   };
   assert(stackTraceChunks.length == stackTraceChunksLimit);
   return stackTraceChunks;
+}
+
+/// Normalize a file path from either platform to the POSIX equivalent so that
+/// paths are the same for both Windows and non-Windows paths.
+String _normalizePath(String path) {
+  // Windows path with drive letter.
+  if (!path.startsWith('/') && path.length > 2 && path[1] == ':') {
+    // Strip drive letter and normalize slashes to match POSIX.
+    // C:\foo\bar -> /foo/bar
+    return path.substring(2).replaceAll(r'\', '/');
+  }
+
+  // Otherwise, return as-is.
+  return path;
 }
 
 /// Returns the number of stack frames from [stackFrameStrings] that fit within

--- a/packages/devtools_app/test/shared/analytics/analytics_test.dart
+++ b/packages/devtools_app/test/shared/analytics/analytics_test.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'dart:io';
+
 import 'package:devtools_app/src/shared/analytics/analytics_common.dart';
 import 'package:devtools_test/helpers.dart';
 import 'package:stack_trace/stack_trace.dart' as stack_trace;
@@ -9,15 +11,17 @@ import 'package:test/test.dart';
 
 void main() {
   group('createStackTraceForAnalytics for stack trace', () {
+    final fileUriBase =
+        Platform.isWindows ? 'file:///c:/b/s/w' : 'file:///b/s/w';
     test(
       'with DevTools stack frames near the top',
       () {
         final stackTrace = stack_trace.Trace.parse(
-          '''file:///b/s/w/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/vm_service.dart 95:18          28240
-file:///b/s/w/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/dart_io_extensions.dart 63:12  28301
-file:///b/s/w/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/dart_io_extensions.dart 61:25  28300
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/screens/network/network_service.dart 104:34     28297
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app_shared/lib/src/service/service_utils.dart 82:25         9696
+          '''$fileUriBase/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/vm_service.dart 95:18          28240
+$fileUriBase/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/dart_io_extensions.dart 63:12  28301
+$fileUriBase/ir/x/w/rc/tmp6qd7qvz0/hosted/pub.dev/vm_service-14.3.0/lib/src/dart_io_extensions.dart 61:25  28300
+$fileUriBase/ir/x/w/devtools/packages/devtools_app/lib/src/screens/network/network_service.dart 104:34     28297
+$fileUriBase/ir/x/w/devtools/packages/devtools_app_shared/lib/src/service/service_utils.dart 82:25         9696
 org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart 103:30                                 2140''',
         );
         final stackTraceChunks = createStackTraceForAnalytics(stackTrace);
@@ -39,24 +43,24 @@ org-dartlang-sdk:///dart-sdk/lib/_internal/wasm/lib/async_patch.dart 103:30 |  2
       'with DevTools stack frames near the bottom',
       () {
         final stackTrace = stack_trace.Trace.parse(
-          '''file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/box.dart 2212:22         size
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 298:21    performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/shifted_box.dart 239:12  performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart 210:29  24070
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart 557:25                                       24080
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart 549:14                                       24079
-file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart 207:20  24074''',
+          '''$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/box.dart 2212:22         size
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 298:21    performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/shifted_box.dart 239:12  performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 117:21    performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7       layout
+$fileUriBase/ir/x/w/devtools/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart 210:29  24070
+$fileUriBase/ir/x/w/devtools/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart 557:25                                       24080
+$fileUriBase/ir/x/w/devtools/packages/devtools_app/lib/src/shared/analytics/_analytics_web.dart 549:14                                       24079
+$fileUriBase/ir/x/w/devtools/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/timeline_events_controller.dart 207:20  24074''',
         );
         final stackTraceChunks = createStackTraceForAnalytics(stackTrace);
         expect(
@@ -82,12 +86,12 @@ file:///b/s/w/ir/x/w/devtools/packages/devtools_app/lib/src/screens/performance/
       () {
         final stackTrace = stack_trace.Trace.parse(
           '''
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/box.dart 2212:22          size
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 298:21     performLayout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7        layout
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layout_helper.dart 61:11  layoutChild
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/stack.dart 601:43         _computeSize
-file:///b/s/w/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/stack.dart 628:12         performLayout''',
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/box.dart 2212:22          size
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/proxy_box.dart 298:21     performLayout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/object.dart 2627:7        layout
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/layout_helper.dart 61:11  layoutChild
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/stack.dart 601:43         _computeSize
+$fileUriBase/ir/x/w/rc/flutter/packages/flutter/lib/src/rendering/stack.dart 628:12         performLayout''',
         );
         final stackTraceChunks = createStackTraceForAnalytics(stackTrace);
         expect(


### PR DESCRIPTION
The analytics tests fail on Windows because it computes paths with backslashes but the test expects forward slashes.

While fixing, I figured it probably made sense to normalise both platforms paths to the same format so they could be grouped together more easily, so I made that change and updated the test to use the correct URI style depending on the current platform.

If this isn't right and we want to preserve the difference, we need to decide what the format of the stack traces should be when the URIs contain Windows paths.