### PR TITLE
Fix some extensions + file util tests on Windows

### DIFF
--- a/packages/devtools_shared/test/helpers/extension_test_manager.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager.dart
@@ -394,6 +394,10 @@ class TestPackageWithExtension {
   final bool requiresConnection;
   final bool isPubliclyHosted;
   final String? packageVersion;
+
+  /// The relative path from the extensions.
+  ///
+  /// Uses the paths separator for the current platform.
   final String relativePathFromExtensions;
 
   String get configYamlContent => '''
@@ -439,8 +443,9 @@ ${_dependenciesAsString()}
       } else {
         sb
           ..writeln() // Add a new line for the path dependency.
+          // Always write paths in pubspec.yaml with forward slashes.
           ..writeln(
-            '    path: $pathToExtensions/${dep.relativePathFromExtensions}',
+            '    path: $pathToExtensions/${dep.relativePathFromExtensions.replaceAll(r'\', '/')}',
           );
       }
     }

--- a/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
+++ b/packages/devtools_shared/test/helpers/extension_test_manager_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+import 'package:path/path.dart' as p;
 import 'package:test/test.dart';
 
 import 'extension_test_manager.dart';
@@ -115,7 +116,7 @@ requiresConnection: false
       expect(newerStaticExtension1Package.packageVersion, null);
       expect(
         newerStaticExtension1Package.relativePathFromExtensions,
-        'newer/static_extension_1',
+        p.join('newer', 'static_extension_1'),
       );
       expect(
         newerStaticExtension1Package.pubspecContent,

--- a/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
+++ b/packages/devtools_shared/test/server/devtools_extensions_api_test.dart
@@ -146,14 +146,14 @@ void main() {
 
   group(ExtensionsApi.apiExtensionEnabledState, () {
     late File optionsFile;
-    late final optionsFileUriString = p.join(
+    late final optionsFileUriString = p.posix.join(
       extensionTestManager.runtimeAppRoot,
       devtoolsOptionsFileName,
     );
 
     setUp(() async {
       await initializeTestDirectory();
-      optionsFile = File.fromUri(Uri.file(optionsFileUriString));
+      optionsFile = File.fromUri(Uri.parse(optionsFileUriString));
     });
 
     Future<Response> sendEnabledStateRequest({
@@ -374,7 +374,7 @@ void _verifyExtension(
       ext.extensionAssetsPath,
       endsWith(
         p.join(
-          '.pub-cache',
+          Platform.isWindows ? r'Pub\Cache' : '.pub-cache',
           'hosted',
           'pub.dev',
           '${extensionPackage.name}-${extensionPackage.packageVersion}',
@@ -401,7 +401,7 @@ void _verifyExtension(
   expect(
     ext.devtoolsOptionsUri,
     endsWith(
-      p.join('packages', detectedFromPath, devtoolsOptionsFileName),
+      p.posix.join('packages', detectedFromPath, devtoolsOptionsFileName),
     ),
   );
   expect(ext.detectedFromStaticContext, fromStaticContext);

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -14,7 +14,7 @@ import '../helpers/helpers.dart';
 const projectRootParts = ['absolute_path_to', 'my_app_root'];
 
 /// The project root as a URI string.
-late String projectRoot;
+late String projectRootUriString;
 
 late Directory testDirectory;
 late File libFile;
@@ -48,7 +48,7 @@ void main() {
 
       await testDtdConnection!.setIDEWorkspaceRoots(
         dtd!.info!.secret!,
-        [Uri.parse(projectRoot)],
+        [Uri.parse(projectRootUriString)],
       );
     });
 
@@ -74,7 +74,7 @@ void main() {
         dtd: useDtd ? testDtdConnection! : null,
         throwOnDtdSearchFailed: useDtd,
       );
-      expect(result, equals(expected ?? projectRoot));
+      expect(result, equals(expected ?? projectRootUriString));
     }
 
     test('packageRootFromFileUriString throw exception for invalid input', () {
@@ -132,24 +132,26 @@ void main() {
           // Dart file in a nested project.
           await verifyPackageRoot(
             nestedProjectLibFile.uri.toString(),
-            expected: p.posix.join(projectRoot, 'example', 'nested_project'),
+            expected:
+                p.posix.join(projectRootUriString, 'example', 'nested_project'),
             useDtd: useDtd,
           );
           await verifyPackageRoot(
             nestedProjectTestFile.uri.toString(),
-            expected: p.posix.join(projectRoot, 'example', 'nested_project'),
+            expected:
+                p.posix.join(projectRootUriString, 'example', 'nested_project'),
             useDtd: useDtd,
           );
 
           // Dart file under an unknown directory.
           await verifyPackageRoot(
             anyFile.uri.toString(),
-            expected: useDtd ? projectRoot : anyFile.uri.toString(),
+            expected: useDtd ? projectRootUriString : anyFile.uri.toString(),
             useDtd: useDtd,
           );
           await verifyPackageRoot(
             anySubFile.uri.toString(),
-            expected: useDtd ? projectRoot : anySubFile.uri.toString(),
+            expected: useDtd ? projectRootUriString : anySubFile.uri.toString(),
             useDtd: useDtd,
           );
         },
@@ -202,11 +204,12 @@ void _setupTestDirectoryStructure() {
   final projectRootDirectory =
       Directory(p.joinAll([testDirectory.path, ...projectRootParts]))
         ..createSync(recursive: true);
-  final directoryPath =
+  final projectRootDirectoryUriString =
       Uri.file(projectRootDirectory.uri.toFilePath()).toString();
 
   // Remove the trailing slash and set the value of [projectRoot].
-  projectRoot = directoryPath.substring(0, directoryPath.length - 1);
+  projectRootUriString = projectRootDirectoryUriString.substring(
+      0, projectRootDirectoryUriString.length - 1);
 
   // Set up the project root contents.
   Directory(p.join(projectRootDirectory.path, '.dart_tool'))

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -12,6 +12,8 @@ import 'package:test/test.dart';
 import '../helpers/helpers.dart';
 
 const projectRootParts = ['absolute_path_to', 'my_app_root'];
+
+/// The project root as a URI string.
 late String projectRoot;
 
 late Directory testDirectory;
@@ -130,12 +132,12 @@ void main() {
           // Dart file in a nested project.
           await verifyPackageRoot(
             nestedProjectLibFile.uri.toString(),
-            expected: p.join(projectRoot, 'example', 'nested_project'),
+            expected: p.posix.join(projectRoot, 'example', 'nested_project'),
             useDtd: useDtd,
           );
           await verifyPackageRoot(
             nestedProjectTestFile.uri.toString(),
-            expected: p.join(projectRoot, 'example', 'nested_project'),
+            expected: p.posix.join(projectRoot, 'example', 'nested_project'),
             useDtd: useDtd,
           );
 
@@ -207,23 +209,27 @@ void _setupTestDirectoryStructure() {
   projectRoot = directoryPath.substring(0, directoryPath.length - 1);
 
   // Set up the project root contents.
-  Directory(p.join(projectRootDirectory.path, '.dart_tool'))
+  Directory(p.posix.join(projectRootDirectory.path, '.dart_tool'))
       .createSync(recursive: true);
-  libFile = File(p.join(projectRootDirectory.path, 'lib', 'foo.dart'))
+  libFile = File(p.posix.join(projectRootDirectory.path, 'lib', 'foo.dart'))
     ..createSync(recursive: true);
-  libSubFile = File(p.join(projectRootDirectory.path, 'lib', 'sub', 'foo.dart'))
+  libSubFile =
+      File(p.posix.join(projectRootDirectory.path, 'lib', 'sub', 'foo.dart'))
+        ..createSync(recursive: true);
+  binFile = File(p.posix.join(projectRootDirectory.path, 'bin', 'foo.dart'))
     ..createSync(recursive: true);
-  binFile = File(p.join(projectRootDirectory.path, 'bin', 'foo.dart'))
-    ..createSync(recursive: true);
-  binSubFile = File(p.join(projectRootDirectory.path, 'bin', 'sub', 'foo.dart'))
-    ..createSync(recursive: true);
-  testFile = File(p.join(projectRootDirectory.path, 'test', 'foo_test.dart'))
-    ..createSync(recursive: true);
+  binSubFile =
+      File(p.posix.join(projectRootDirectory.path, 'bin', 'sub', 'foo.dart'))
+        ..createSync(recursive: true);
+  testFile =
+      File(p.posix.join(projectRootDirectory.path, 'test', 'foo_test.dart'))
+        ..createSync(recursive: true);
   testSubFile = File(
-    p.join(projectRootDirectory.path, 'test', 'sub', 'foo_test.dart'),
+    p.posix.join(projectRootDirectory.path, 'test', 'sub', 'foo_test.dart'),
   )..createSync(recursive: true);
   integrationTestFile = File(
-    p.join(projectRootDirectory.path, 'integration_test', 'foo_test.dart'),
+    p.posix
+        .join(projectRootDirectory.path, 'integration_test', 'foo_test.dart'),
   )..createSync(recursive: true);
   integrationTestSubFile = File(
     p.join(
@@ -234,16 +240,17 @@ void _setupTestDirectoryStructure() {
     ),
   )..createSync(recursive: true);
   benchmarkFile =
-      File(p.join(projectRootDirectory.path, 'benchmark', 'foo.dart'))
+      File(p.posix.join(projectRootDirectory.path, 'benchmark', 'foo.dart'))
         ..createSync(recursive: true);
   benchmarkSubFile = File(
-    p.join(projectRootDirectory.path, 'benchmark', 'sub', 'foo.dart'),
+    p.posix.join(projectRootDirectory.path, 'benchmark', 'sub', 'foo.dart'),
   )..createSync(recursive: true);
-  exampleFile = File(p.join(projectRootDirectory.path, 'example', 'foo.dart'))
-    ..createSync(recursive: true);
-  exampleSubFile =
-      File(p.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
+  exampleFile =
+      File(p.posix.join(projectRootDirectory.path, 'example', 'foo.dart'))
         ..createSync(recursive: true);
+  exampleSubFile = File(
+      p.posix.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
+    ..createSync(recursive: true);
   // Setup a nested Dart project under the 'example' directory.
   Directory(
     p.join(
@@ -271,9 +278,10 @@ void _setupTestDirectoryStructure() {
       'foo_test.dart',
     ),
   )..createSync(recursive: true);
-  anyFile = File(p.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
-    ..createSync(recursive: true);
-  anySubFile =
-      File(p.join(projectRootDirectory.path, 'any_name', 'sub', 'foo.dart'))
+  anyFile =
+      File(p.posix.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
         ..createSync(recursive: true);
+  anySubFile = File(
+      p.posix.join(projectRootDirectory.path, 'any_name', 'sub', 'foo.dart'))
+    ..createSync(recursive: true);
 }

--- a/packages/devtools_shared/test/utils/file_utils_test.dart
+++ b/packages/devtools_shared/test/utils/file_utils_test.dart
@@ -209,27 +209,23 @@ void _setupTestDirectoryStructure() {
   projectRoot = directoryPath.substring(0, directoryPath.length - 1);
 
   // Set up the project root contents.
-  Directory(p.posix.join(projectRootDirectory.path, '.dart_tool'))
+  Directory(p.join(projectRootDirectory.path, '.dart_tool'))
       .createSync(recursive: true);
-  libFile = File(p.posix.join(projectRootDirectory.path, 'lib', 'foo.dart'))
+  libFile = File(p.join(projectRootDirectory.path, 'lib', 'foo.dart'))
     ..createSync(recursive: true);
-  libSubFile =
-      File(p.posix.join(projectRootDirectory.path, 'lib', 'sub', 'foo.dart'))
-        ..createSync(recursive: true);
-  binFile = File(p.posix.join(projectRootDirectory.path, 'bin', 'foo.dart'))
+  libSubFile = File(p.join(projectRootDirectory.path, 'lib', 'sub', 'foo.dart'))
     ..createSync(recursive: true);
-  binSubFile =
-      File(p.posix.join(projectRootDirectory.path, 'bin', 'sub', 'foo.dart'))
-        ..createSync(recursive: true);
-  testFile =
-      File(p.posix.join(projectRootDirectory.path, 'test', 'foo_test.dart'))
-        ..createSync(recursive: true);
+  binFile = File(p.join(projectRootDirectory.path, 'bin', 'foo.dart'))
+    ..createSync(recursive: true);
+  binSubFile = File(p.join(projectRootDirectory.path, 'bin', 'sub', 'foo.dart'))
+    ..createSync(recursive: true);
+  testFile = File(p.join(projectRootDirectory.path, 'test', 'foo_test.dart'))
+    ..createSync(recursive: true);
   testSubFile = File(
-    p.posix.join(projectRootDirectory.path, 'test', 'sub', 'foo_test.dart'),
+    p.join(projectRootDirectory.path, 'test', 'sub', 'foo_test.dart'),
   )..createSync(recursive: true);
   integrationTestFile = File(
-    p.posix
-        .join(projectRootDirectory.path, 'integration_test', 'foo_test.dart'),
+    p.join(projectRootDirectory.path, 'integration_test', 'foo_test.dart'),
   )..createSync(recursive: true);
   integrationTestSubFile = File(
     p.join(
@@ -240,17 +236,16 @@ void _setupTestDirectoryStructure() {
     ),
   )..createSync(recursive: true);
   benchmarkFile =
-      File(p.posix.join(projectRootDirectory.path, 'benchmark', 'foo.dart'))
+      File(p.join(projectRootDirectory.path, 'benchmark', 'foo.dart'))
         ..createSync(recursive: true);
   benchmarkSubFile = File(
-    p.posix.join(projectRootDirectory.path, 'benchmark', 'sub', 'foo.dart'),
+    p.join(projectRootDirectory.path, 'benchmark', 'sub', 'foo.dart'),
   )..createSync(recursive: true);
-  exampleFile =
-      File(p.posix.join(projectRootDirectory.path, 'example', 'foo.dart'))
-        ..createSync(recursive: true);
-  exampleSubFile = File(
-      p.posix.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
+  exampleFile = File(p.join(projectRootDirectory.path, 'example', 'foo.dart'))
     ..createSync(recursive: true);
+  exampleSubFile =
+      File(p.join(projectRootDirectory.path, 'example', 'sub', 'foo.dart'))
+        ..createSync(recursive: true);
   // Setup a nested Dart project under the 'example' directory.
   Directory(
     p.join(
@@ -278,10 +273,9 @@ void _setupTestDirectoryStructure() {
       'foo_test.dart',
     ),
   )..createSync(recursive: true);
-  anyFile =
-      File(p.posix.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
-        ..createSync(recursive: true);
-  anySubFile = File(
-      p.posix.join(projectRootDirectory.path, 'any_name', 'sub', 'foo.dart'))
+  anyFile = File(p.join(projectRootDirectory.path, 'any_name', 'foo.dart'))
     ..createSync(recursive: true);
+  anySubFile =
+      File(p.join(projectRootDirectory.path, 'any_name', 'sub', 'foo.dart'))
+        ..createSync(recursive: true);
 }


### PR DESCRIPTION
This fixes up some tests that were failing on Windows, largely because of path separators (see inline comments for specifics).