### PR TITLE
[CQ] migrate to using `fileNameFromUri`

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/breakpoints.dart
@@ -110,7 +110,7 @@ class _BreakpointsState extends State<Breakpoints>
 
   String _descriptionFor(BreakpointAndSourcePosition breakpoint) {
     final scriptUri = breakpoint.scriptUri;
-    final fileName = scriptUri == null ? 'file' : scriptUri.split('/').last;
+    final fileName = scriptUri == null ? 'file' : fileNameFromUri(scriptUri);
     // Consider showing columns in the future if we allow multiple breakpoints
     // per line.
     return '$fileName:${breakpoint.line}';

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_model.dart
@@ -6,6 +6,7 @@ import 'package:vm_service/vm_service.dart';
 
 import '../../shared/diagnostics/primitives/source_location.dart';
 import '../../shared/primitives/simple_items.dart';
+import '../../shared/primitives/utils.dart';
 import '../../shared/ui/search.dart';
 
 /// Whether to include properties surfaced through Diagnosticable objects as
@@ -230,7 +231,7 @@ class StackFrameAndSourcePosition {
     if (uri == null) {
       return uri;
     }
-    final file = uri.split('/').last;
+    final file = fileNameFromUri(uri);
     return line == null ? file : '$file:$line';
   }
 }
@@ -238,5 +239,5 @@ class StackFrameAndSourcePosition {
 // ignore: avoid_classes_with_only_static_members, fine for utility method.
 abstract class ScriptRefUtils {
   static String fileName(ScriptRef scriptRef) =>
-      Uri.parse(scriptRef.uri!).path.split('/').last;
+      fileNameFromUri(Uri.parse(scriptRef.uri!).path)!;
 }

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -499,7 +499,7 @@ class _DebuggerStatusState extends State<DebuggerStatus> with AutoDisposeMixin {
       return 'paused$reason';
     }
 
-    final fileName = ' at ${scriptUri.split('/').last}';
+    final fileName = ' at ${fileNameFromUri(scriptUri)}';
     final tokenPos = location?.tokenPos;
     final scriptRef = location?.script;
     if (tokenPos == null || scriptRef == null) {

--- a/packages/devtools_app/lib/src/screens/debugger/file_search.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/file_search.dart
@@ -292,7 +292,7 @@ class FileQuery {
   }
 
   String _fileName(String fullPath) {
-    return _fileNamesCache[fullPath] ??= fullPath.split('/').last;
+    return _fileNamesCache[fullPath] ??= fileNameFromUri(fullPath)!;
   }
 }
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/rebuild_stats/rebuild_stats.dart
@@ -248,7 +248,7 @@ class _LocationColumn extends ColumnData<RebuildLocationStats> {
       return '<resolving location>';
     }
 
-    return '${fileUriString.split('/').last}:${dataObject.location.line}';
+    return '${fileNameFromUri(fileUriString)}:${dataObject.location.line}';
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/console/widgets/description.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/description.dart
@@ -460,7 +460,7 @@ class DiagnosticsNodeDescription extends StatelessWidget {
         overflow: TextOverflow.ellipsis,
         text: TextSpan(
           text:
-              '${location.getFile()!.split('/').last}:${location.getLine()}:${location.getColumn()}            ',
+              '${fileNameFromUri(location.getFile())}:${location.getLine()}:${location.getColumn()}            ',
           style: DiagnosticsTextStyles.regular(Theme.of(context).colorScheme),
         ),
       ),

--- a/packages/devtools_app/lib/src/shared/primitives/utils.dart
+++ b/packages/devtools_app/lib/src/shared/primitives/utils.dart
@@ -1074,9 +1074,6 @@ const connectToNewAppText = 'Connect to a new app';
 /// favor of a new request.
 class ProcessCancelledException implements Exception {}
 
-// TODO(mtaylee): Prefer to use this helper method whenever a call to
-// .split('/').last is made on a String (usually on URIs).
-// See https://github.com/flutter/devtools/issues/4360.
 /// Returns the file name from a URI or path string, by splitting the [uri] at
 /// the directory separators '/', and returning the last element.
 String? fileNameFromUri(String? uri) => uri?.split('/').lastOrNull;


### PR DESCRIPTION
Fixes: https://github.com/flutter/devtools/issues/4360

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
