### PR TITLE
[PE] tooltip to describe current exception mode

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -256,23 +256,27 @@ class BreakOnExceptionsControl extends StatelessWidget {
     return ValueListenableBuilder<String?>(
       valueListenable: controller.exceptionPauseMode,
       builder: (BuildContext context, modeId, _) {
-        return RoundedDropDownButton<ExceptionMode>(
-          value: ExceptionMode.from(modeId),
-          // Cannot set exception pause mode for system isolates.
-          onChanged:
-              controller.isSystemIsolate
-                  ? null
-                  : (ExceptionMode? mode) {
-                    unawaited(controller.setIsolatePauseMode(mode!.id));
-                  },
-          isDense: true,
-          items: [
-            for (final mode in ExceptionMode.modes)
-              DropdownMenuItem<ExceptionMode>(
-                value: mode,
-                child: Text(isInSmallMode ? mode.name : mode.description),
-              ),
-          ],
+        final exceptionMode = ExceptionMode.from(modeId);
+        return DevToolsTooltip(
+          message: exceptionMode.description,
+          child: RoundedDropDownButton<ExceptionMode>(
+            value: exceptionMode,
+            // Cannot set exception pause mode for system isolates.
+            onChanged:
+                controller.isSystemIsolate
+                    ? null
+                    : (ExceptionMode? mode) {
+                      unawaited(controller.setIsolatePauseMode(mode!.id));
+                    },
+            isDense: true,
+            items: [
+              for (final mode in ExceptionMode.modes)
+                DropdownMenuItem<ExceptionMode>(
+                  value: mode,
+                  child: Text(isInSmallMode ? mode.name : mode.description),
+                ),
+            ],
+          ),
         );
       },
     );

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -36,7 +36,7 @@ TODO: Remove this section if there are not any general updates.
 ## Debugger updates
 
 * Added a tooltip to describe the exception mode drop-down. -
-[#4876](https://github.com/flutter/devtools/issues/4876)
+[#8849](https://github.com/flutter/devtools/pull/8849)
 
 ## Network profiler updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -35,7 +35,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
 
-TODO: Remove this section if there are not any general updates.
+* Added a tooltip to describe the exception mode drop-down. -
+[#4876](https://github.com/flutter/devtools/issues/4876)
 
 ## Network profiler updates
 

--- a/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
@@ -255,6 +255,7 @@ void main() {
 
 extension on CommonFinders {
   /// Finds [DevToolsTooltip] widgets with the given message.
+  /// (Based on [CommonFinders.byTooltip].)
   Finder byDevToolsTooltip(Pattern message, {bool skipOffstage = true}) {
     return byWidgetPredicate((Widget widget) {
       return widget is DevToolsTooltip &&

--- a/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
@@ -183,10 +183,7 @@ void main() {
         ),
       );
       expect(
-        _findDevToolsTooltip(
-          'Stop on uncaught exceptions',
-          skipOffstage: false,
-        ),
+        find.byTooltip('Stop on uncaught exceptions', skipOffstage: false),
         findsOneWidget,
       );
     },
@@ -251,18 +248,4 @@ void main() {
     expect(state!.script, libScriptRef);
     expect(state.line, testClassRef.location!.line);
   });
-}
-
-/// Finds [DevToolsTooltip] widgets with the given message.
-/// (Based on [CommonFinders.byTooltip].)
-Finder _findDevToolsTooltip(Pattern message, {bool skipOffstage = true}) {
-  return find.byWidgetPredicate((Widget widget) {
-    return widget is DevToolsTooltip &&
-        (message is RegExp
-            ? ((widget.message != null && message.hasMatch(widget.message!)) ||
-                (widget.richMessage != null &&
-                    message.hasMatch(widget.richMessage!.toPlainText())))
-            : ((widget.message ?? widget.richMessage?.toPlainText()) ==
-                message));
-  }, skipOffstage: skipOffstage);
 }

--- a/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
@@ -172,6 +172,26 @@ void main() {
     },
   );
 
+  testWidgetsWithWindowSize(
+    'debugger exception mode tooltip',
+    smallWindowSize,
+    (WidgetTester tester) async {
+      await tester.pumpWidget(
+        wrapWithControllers(
+          Builder(builder: screen.build),
+          debugger: debuggerController,
+        ),
+      );
+      expect(
+        find.byDevToolsTooltip(
+          'Stop on uncaught exceptions',
+          skipOffstage: false,
+        ),
+        findsOneWidget,
+      );
+    },
+  );
+
   testWidgetsWithWindowSize('node selection state', windowSize, (
     WidgetTester tester,
   ) async {
@@ -231,4 +251,20 @@ void main() {
     expect(state!.script, libScriptRef);
     expect(state.line, testClassRef.location!.line);
   });
+}
+
+extension on CommonFinders {
+  /// Finds [DevToolsTooltip] widgets with the given message.
+  Finder byDevToolsTooltip(Pattern message, {bool skipOffstage = true}) {
+    return byWidgetPredicate((Widget widget) {
+      return widget is DevToolsTooltip &&
+          (message is RegExp
+              ? ((widget.message != null &&
+                      message.hasMatch(widget.message!)) ||
+                  (widget.richMessage != null &&
+                      message.hasMatch(widget.richMessage!.toPlainText())))
+              : ((widget.message ?? widget.richMessage?.toPlainText()) ==
+                  message));
+    }, skipOffstage: skipOffstage);
+  }
 }

--- a/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
+++ b/packages/devtools_app/test/screens/debugger/debugger_screen_test.dart
@@ -183,7 +183,7 @@ void main() {
         ),
       );
       expect(
-        find.byDevToolsTooltip(
+        _findDevToolsTooltip(
           'Stop on uncaught exceptions',
           skipOffstage: false,
         ),
@@ -253,19 +253,16 @@ void main() {
   });
 }
 
-extension on CommonFinders {
-  /// Finds [DevToolsTooltip] widgets with the given message.
-  /// (Based on [CommonFinders.byTooltip].)
-  Finder byDevToolsTooltip(Pattern message, {bool skipOffstage = true}) {
-    return byWidgetPredicate((Widget widget) {
-      return widget is DevToolsTooltip &&
-          (message is RegExp
-              ? ((widget.message != null &&
-                      message.hasMatch(widget.message!)) ||
-                  (widget.richMessage != null &&
-                      message.hasMatch(widget.richMessage!.toPlainText())))
-              : ((widget.message ?? widget.richMessage?.toPlainText()) ==
-                  message));
-    }, skipOffstage: skipOffstage);
-  }
+/// Finds [DevToolsTooltip] widgets with the given message.
+/// (Based on [CommonFinders.byTooltip].)
+Finder _findDevToolsTooltip(Pattern message, {bool skipOffstage = true}) {
+  return find.byWidgetPredicate((Widget widget) {
+    return widget is DevToolsTooltip &&
+        (message is RegExp
+            ? ((widget.message != null && message.hasMatch(widget.message!)) ||
+                (widget.richMessage != null &&
+                    message.hasMatch(widget.richMessage!.toPlainText())))
+            : ((widget.message ?? widget.richMessage?.toPlainText()) ==
+                message));
+  }, skipOffstage: skipOffstage);
 }


### PR DESCRIPTION
Adds a tooltip to the exception combo.

![image](https://github.com/user-attachments/assets/9afa142b-1c2d-4e3f-9779-d1274bcd1055)

Fixes: https://github.com/flutter/devtools/issues/4876

See [byTooltip](https://api.flutter.dev/flutter/flutter_test/CommonFinders/byTooltip.html) for the finder inspiration.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or there is a reason for not adding tests.


![build.yaml badge]

If you need help, consider asking for help on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/devtools/blob/master/CONTRIBUTING.md
[Tree Hygiene]: https://github.com/flutter/flutter/blob/master/docs/contributing/Tree-hygiene.md
[Flutter Style Guide]: https://github.com/flutter/flutter/blob/master/docs/contributing/Style-guide-for-Flutter-repo.md
[CLA]: https://cla.developers.google.com/
[Discord]: https://github.com/flutter/flutter/blob/master/docs/contributing/Chat.md
[build.yaml badge]: https://github.com/flutter/devtools/actions/workflows/build.yaml/badge.svg
