### PR TITLE
Debugger: soft wrap console input lines

### DIFF
--- a/packages/devtools_app/lib/src/shared/console/console.dart
+++ b/packages/devtools_app/lib/src/shared/console/console.dart
@@ -162,46 +162,55 @@ class _ConsoleOutputState extends State<_ConsoleOutput>
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: denseSpacing),
         child: SelectionArea(
-          child: ListView.separated(
-            padding: const EdgeInsets.all(denseSpacing),
-            itemCount: _currentLines.length + (widget.footer != null ? 1 : 0),
-            controller: _scroll,
-            // Scroll physics to try to keep content within view and avoid bouncing.
-            physics: const ClampingScrollPhysics(
-              parent: RangeMaintainingScrollPhysics(),
-            ),
-            separatorBuilder: (_, _) {
-              return const PaddedDivider.noPadding();
-            },
-            itemBuilder: (context, index) {
-              if (index == _currentLines.length && widget.footer != null) {
-                return widget.footer!;
-              }
-              final line = _currentLines[index];
-              if (line is TextConsoleLine) {
-                return Text.rich(
-                  TextSpan(
-                    // TODO(jacobr): consider caching the processed ansi terminal
-                    // codes.
-                    children: textSpansFromAnsi(
-                      line.text,
-                      theme.regularTextStyle,
-                    ),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Expanded(
+                child: ListView.separated(
+                  padding: const EdgeInsets.all(denseSpacing),
+                  itemCount: _currentLines.length,
+                  controller: _scroll,
+                  // Scroll physics to try to keep content within view and avoid bouncing.
+                  physics: const ClampingScrollPhysics(
+                    parent: RangeMaintainingScrollPhysics(),
                   ),
-                );
-              } else if (line is VariableConsoleLine) {
-                return ExpandableVariable(
-                  variable: line.variable,
-                  isSelectable: false,
-                );
-              } else {
-                assert(
-                  false,
-                  'ConsoleLine of unsupported type ${line.runtimeType} encountered',
-                );
-                return const SizedBox();
-              }
-            },
+                  separatorBuilder: (_, _) {
+                    return const PaddedDivider.noPadding();
+                  },
+                  itemBuilder: (context, index) {
+                    final line = _currentLines[index];
+                    if (line is TextConsoleLine) {
+                      return Text.rich(
+                        TextSpan(
+                          // TODO(jacobr): consider caching the processed ansi terminal
+                          // codes.
+                          children: textSpansFromAnsi(
+                            line.text,
+                            theme.regularTextStyle,
+                          ),
+                        ),
+                      );
+                    } else if (line is VariableConsoleLine) {
+                      return ExpandableVariable(
+                        variable: line.variable,
+                        isSelectable: false,
+                      );
+                    } else {
+                      assert(
+                        false,
+                        'ConsoleLine of unsupported type ${line.runtimeType} encountered',
+                      );
+                      return const SizedBox();
+                    }
+                  },
+                ),
+              ),
+              // consider constraining a max height.
+              Padding(
+                padding: const EdgeInsets.only(top: denseSpacing),
+                child: widget.footer!,
+              ),
+            ],
           ),
         ),
       ),

--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -35,8 +35,6 @@ class ExpressionEvalField extends StatefulWidget {
 
   final AutoCompleteResultsFunction getAutoCompleteResults;
 
-  static const _evalFieldHeight = 32.0;
-
   @override
   ExpressionEvalFieldState createState() => ExpressionEvalFieldState();
 }
@@ -218,46 +216,44 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
 
               return KeyEventResult.ignored;
             },
-            child: SizedBox(
-              height: ExpressionEvalField._evalFieldHeight,
-              child: AutoCompleteSearchField(
-                controller: _autoCompleteController,
-                searchFieldEnabled: true,
-                shouldRequestFocus: false,
-                clearFieldOnEscapeWhenOverlayHidden: true,
-                onSelection: _onSelection,
-                decoration: InputDecoration(
-                  contentPadding: const EdgeInsets.all(denseSpacing),
-                  border: const OutlineInputBorder(),
-                  focusedBorder: const OutlineInputBorder(
-                    borderSide: BorderSide.none,
-                  ),
-                  enabledBorder: const OutlineInputBorder(
-                    borderSide: BorderSide.none,
-                  ),
-                  labelText: 'Eval. Enter "?" for help.',
-                  labelStyle: Theme.of(context).subtleTextStyle,
+            child: AutoCompleteSearchField(
+              controller: _autoCompleteController,
+              searchFieldEnabled: true,
+              shouldRequestFocus: false,
+              clearFieldOnEscapeWhenOverlayHidden: true,
+              onSelection: _onSelection,
+              decoration: InputDecoration(
+                contentPadding: const EdgeInsets.all(denseSpacing),
+                border: const OutlineInputBorder(),
+                focusedBorder: const OutlineInputBorder(
+                  borderSide: BorderSide.none,
                 ),
-                overlayXPositionBuilder: (
-                  String inputValue,
-                  TextStyle? inputStyle,
-                ) {
-                  // X-coordinate is equivalent to the width of the input text
-                  // up to the last "." or the insertion point (cursor):
-                  final indexOfDot = inputValue.lastIndexOf('.');
-                  final textSegment =
-                      indexOfDot != -1
-                          ? inputValue.substring(0, indexOfDot + 1)
-                          : inputValue;
-                  return calculateTextSpanWidth(
-                    TextSpan(text: textSegment, style: inputStyle),
-                  );
-                },
-                // Disable ligatures, so the suggestions of the auto complete work correcly.
-                style: Theme.of(context).fixedFontStyle.copyWith(
-                  fontFeatures: [const FontFeature.disable('liga')],
+                enabledBorder: const OutlineInputBorder(
+                  borderSide: BorderSide.none,
                 ),
+                labelText: 'Eval. Enter "?" for help.',
+                labelStyle: Theme.of(context).subtleTextStyle,
               ),
+              overlayXPositionBuilder: (
+                String inputValue,
+                TextStyle? inputStyle,
+              ) {
+                // X-coordinate is equivalent to the width of the input text
+                // up to the last "." or the insertion point (cursor):
+                final indexOfDot = inputValue.lastIndexOf('.');
+                final textSegment =
+                    indexOfDot != -1
+                        ? inputValue.substring(0, indexOfDot + 1)
+                        : inputValue;
+                return calculateTextSpanWidth(
+                  TextSpan(text: textSegment, style: inputStyle),
+                );
+              },
+              // Disable ligatures, so the suggestions of the auto complete work correcly.
+              style: Theme.of(context).fixedFontStyle.copyWith(
+                fontFeatures: [const FontFeature.disable('liga')],
+              ),
+              shouldExpandHeight: true,
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
+++ b/packages/devtools_app/lib/src/shared/console/widgets/evaluate.dart
@@ -253,7 +253,7 @@ class ExpressionEvalFieldState extends State<ExpressionEvalField>
               style: Theme.of(context).fixedFontStyle.copyWith(
                 fontFeatures: [const FontFeature.disable('liga')],
               ),
-              shouldExpandHeight: true,
+              maxLines: null,
             ),
           ),
         ),

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -893,8 +893,10 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
     this.onClose,
     this.searchFieldWidth = defaultSearchFieldWidth,
     double? searchFieldHeight,
+    bool shouldExpandHeight = true,
     super.key,
-  }) : searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight;
+  }) : searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight,
+       _shouldExpandHeight = shouldExpandHeight;
 
   final T searchController;
 
@@ -917,6 +919,9 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
   /// triggered.
   final VoidCallback? onClose;
 
+  /// Whether the search field should soft wrap lines, expanding the height.
+  final bool _shouldExpandHeight;
+
   @override
   State<SearchField> createState() => _SearchFieldState();
 }
@@ -928,18 +933,23 @@ class _SearchFieldState extends State<SearchField>
 
   @override
   Widget build(BuildContext context) {
-    return SizedBox(
-      width: widget.searchFieldWidth,
-      height: widget.searchFieldHeight,
-      child: StatelessSearchField(
-        controller: searchController,
-        searchFieldEnabled: widget.searchFieldEnabled,
-        shouldRequestFocus: widget.shouldRequestFocus,
-        supportsNavigation: widget.supportsNavigation,
-        onClose: widget.onClose,
-        searchFieldHeight: widget.searchFieldHeight,
-      ),
+    final searchField = StatelessSearchField(
+      controller: searchController,
+      searchFieldEnabled: widget.searchFieldEnabled,
+      shouldRequestFocus: widget.shouldRequestFocus,
+      supportsNavigation: widget.supportsNavigation,
+      onClose: widget.onClose,
+      searchFieldHeight: widget.searchFieldHeight,
+      shouldExpandHeight: widget._shouldExpandHeight,
     );
+
+    return widget._shouldExpandHeight
+        ? searchField
+        : SizedBox(
+          width: widget.searchFieldWidth,
+          height: widget.searchFieldHeight,
+          child: searchField,
+        );
   }
 }
 
@@ -970,7 +980,8 @@ class StatelessSearchField<T extends SearchableDataMixin>
     this.suffix,
     this.style,
     this.searchFieldHeight,
-  });
+    bool shouldExpandHeight = false,
+  }) : _shouldExpandHeight = shouldExpandHeight;
 
   final SearchControllerMixin<T> controller;
 
@@ -1014,6 +1025,9 @@ class StatelessSearchField<T extends SearchableDataMixin>
 
   final double? searchFieldHeight;
 
+  /// Whether the search field should soft wrap lines, expanding the height.
+  final bool _shouldExpandHeight;
+
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
@@ -1032,6 +1046,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
       focusNode: controller.searchFieldFocusNode,
       controller: controller.searchTextFieldController,
       style: textStyle,
+      maxLines: _shouldExpandHeight ? null : 1,
       onChanged: onChanged,
       onEditingComplete: () {
         controller.searchFieldFocusNode?.requestFocus();
@@ -1116,7 +1131,8 @@ class AutoCompleteSearchField extends StatefulWidget {
     this.onFocusLost,
     this.style,
     this.keyEventsToIgnore = const {},
-  });
+    bool shouldExpandHeight = false,
+  }) : _shouldExpandHeight = shouldExpandHeight;
 
   final AutoCompleteSearchControllerMixin controller;
 
@@ -1163,6 +1179,9 @@ class AutoCompleteSearchField extends StatefulWidget {
   /// Handler called when either [controller.searchFieldFocusNode] or
   /// [controller.autocompleteFocusNode] has lost focus.
   final VoidCallback? onFocusLost;
+
+  /// Whether the search field should soft wrap lines, expanding the height.
+  final bool _shouldExpandHeight;
 
   @override
   State<AutoCompleteSearchField> createState() =>
@@ -1214,6 +1233,7 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
           },
           onClose: widget.onClose,
           style: widget.style,
+          shouldExpandHeight: widget._shouldExpandHeight,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -893,10 +893,10 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
     this.onClose,
     this.searchFieldWidth = defaultSearchFieldWidth,
     double? searchFieldHeight,
-    bool shouldExpandHeight = true,
+    int? maxLines = 1,
     super.key,
   }) : searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight,
-       _shouldExpandHeight = shouldExpandHeight;
+       _maxLines = maxLines;
 
   final T searchController;
 
@@ -919,8 +919,10 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
   /// triggered.
   final VoidCallback? onClose;
 
-  /// Whether the search field should soft wrap lines, expanding the height.
-  final bool _shouldExpandHeight;
+  /// The maximum number of lines, by default one.
+  ///
+  /// Can be set to null to remove the restriction; must not be zero.
+  final int? _maxLines;
 
   @override
   State<SearchField> createState() => _SearchFieldState();
@@ -940,10 +942,10 @@ class _SearchFieldState extends State<SearchField>
       supportsNavigation: widget.supportsNavigation,
       onClose: widget.onClose,
       searchFieldHeight: widget.searchFieldHeight,
-      shouldExpandHeight: widget._shouldExpandHeight,
+      maxLines: widget._maxLines,
     );
 
-    return widget._shouldExpandHeight
+    return widget._maxLines != 1
         ? searchField
         : SizedBox(
           width: widget.searchFieldWidth,
@@ -980,8 +982,8 @@ class StatelessSearchField<T extends SearchableDataMixin>
     this.suffix,
     this.style,
     this.searchFieldHeight,
-    bool shouldExpandHeight = false,
-  }) : _shouldExpandHeight = shouldExpandHeight;
+    int? maxLines = 1,
+  }) : _maxLines = maxLines;
 
   final SearchControllerMixin<T> controller;
 
@@ -1025,8 +1027,10 @@ class StatelessSearchField<T extends SearchableDataMixin>
 
   final double? searchFieldHeight;
 
-  /// Whether the search field should soft wrap lines, expanding the height.
-  final bool _shouldExpandHeight;
+  /// The maximum number of lines, by default one.
+  ///
+  /// Can be set to null to remove the restriction; must not be zero.
+  final int? _maxLines;
 
   @override
   Widget build(BuildContext context) {
@@ -1046,7 +1050,7 @@ class StatelessSearchField<T extends SearchableDataMixin>
       focusNode: controller.searchFieldFocusNode,
       controller: controller.searchTextFieldController,
       style: textStyle,
-      maxLines: _shouldExpandHeight ? null : 1,
+      maxLines: _maxLines,
       onChanged: onChanged,
       onEditingComplete: () {
         controller.searchFieldFocusNode?.requestFocus();
@@ -1131,8 +1135,8 @@ class AutoCompleteSearchField extends StatefulWidget {
     this.onFocusLost,
     this.style,
     this.keyEventsToIgnore = const {},
-    bool shouldExpandHeight = false,
-  }) : _shouldExpandHeight = shouldExpandHeight;
+    int? maxLines = 1,
+  }) : _maxLines = maxLines;
 
   final AutoCompleteSearchControllerMixin controller;
 
@@ -1180,8 +1184,10 @@ class AutoCompleteSearchField extends StatefulWidget {
   /// [controller.autocompleteFocusNode] has lost focus.
   final VoidCallback? onFocusLost;
 
-  /// Whether the search field should soft wrap lines, expanding the height.
-  final bool _shouldExpandHeight;
+  /// The maximum number of lines, by default one.
+  ///
+  /// Can be set to null to remove the restriction; must not be zero.
+  final int? _maxLines;
 
   @override
   State<AutoCompleteSearchField> createState() =>
@@ -1233,7 +1239,7 @@ class _AutoCompleteSearchFieldState extends State<AutoCompleteSearchField>
           },
           onClose: widget.onClose,
           style: widget.style,
-          shouldExpandHeight: widget._shouldExpandHeight,
+          maxLines: widget._maxLines,
         ),
       ),
     );

--- a/packages/devtools_app/lib/src/shared/ui/search.dart
+++ b/packages/devtools_app/lib/src/shared/ui/search.dart
@@ -895,7 +895,8 @@ class SearchField<T extends SearchControllerMixin> extends StatefulWidget {
     double? searchFieldHeight,
     int? maxLines = 1,
     super.key,
-  }) : searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight,
+  }) : assert(maxLines != 0, "'maxLines' must not be 0"),
+       searchFieldHeight = searchFieldHeight ?? defaultTextFieldHeight,
        _maxLines = maxLines;
 
   final T searchController;
@@ -983,7 +984,8 @@ class StatelessSearchField<T extends SearchableDataMixin>
     this.style,
     this.searchFieldHeight,
     int? maxLines = 1,
-  }) : _maxLines = maxLines;
+  }) : assert(maxLines != 0, "'maxLines' must not be 0"),
+       _maxLines = maxLines;
 
   final SearchControllerMixin<T> controller;
 
@@ -1136,7 +1138,8 @@ class AutoCompleteSearchField extends StatefulWidget {
     this.style,
     this.keyEventsToIgnore = const {},
     int? maxLines = 1,
-  }) : _maxLines = maxLines;
+  }) : assert(maxLines != 0, "'maxLines' must not be 0"),
+       _maxLines = maxLines;
 
   final AutoCompleteSearchControllerMixin controller;
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -35,7 +35,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
 
-TODO: Remove this section if there are not any general updates.
+* The console in the debugger now soft wraps lines.
+  [#8855](https://github.com/flutter/devtools/pull/8855).
 
 ## Network profiler updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -35,7 +35,7 @@ TODO: Remove this section if there are not any general updates.
 
 ## Debugger updates
 
-* The console in the debugger now soft wraps lines.
+* Added soft line wrapping in the debugger console.
   [#8855](https://github.com/flutter/devtools/pull/8855).
 
 ## Network profiler updates


### PR DESCRIPTION
See #5505 for original issue screenshot. Here is another:

<img width="769" alt="Screenshot 2025-02-05 at 2 21 39 PM" src="https://github.com/user-attachments/assets/6e501616-80de-4225-968d-5cdd36fc8eee" />

Afterwards, we get this nice expanding behavior:

<img width="774" alt="Screenshot 2025-02-05 at 2 20 25 PM" src="https://github.com/user-attachments/assets/b245ea67-7444-405c-9b17-8b27e9173f5e" />

<img width="768" alt="Screenshot 2025-02-05 at 2 20 46 PM" src="https://github.com/user-attachments/assets/a3d14eb9-735d-45ab-a3b8-bfb99f021c07" />

The console itself is still expandable:

<img width="770" alt="Screenshot 2025-02-05 at 2 20 55 PM" src="https://github.com/user-attachments/assets/817380fd-4385-4c2e-821b-a7dc190497c8" />


Fixes https://github.com/flutter/devtools/issues/5505
