### PR TITLE
Combine resume / pause buttons in the debugger controls

### DIFF
--- a/packages/devtools_app/lib/src/screens/debugger/controls.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/controls.dart
@@ -93,27 +93,26 @@ class _DebuggingControlsState extends State<DebuggingControls>
     final isSystemIsolate = controller.isSystemIsolate;
     return RoundedButtonGroup(
       items: [
-        ButtonGroupItemData(
-          tooltip: 'Pause',
-          icon: Icons.pause,
-          autofocus: true,
-          // Disable when paused or selected isolate is a system isolate.
-          onPressed:
-              (isPaused || isSystemIsolate)
-                  ? null
-                  : () => unawaited(controller.pause()),
-        ),
-        ButtonGroupItemData(
-          tooltip: 'Resume',
-          iconAsset: 'icons/material_symbols/resume.png',
-          iconSize: DebuggingControls.materialIconSize,
-          // Enable while paused + not resuming and selected isolate is not
-          // a system isolate.
-          onPressed:
-              ((isPaused && !resuming) && !isSystemIsolate)
-                  ? () => unawaited(controller.resume())
-                  : null,
-        ),
+        if (!isPaused)
+          ButtonGroupItemData(
+            tooltip: 'Pause',
+            icon: Icons.pause,
+            autofocus: true,
+            // Disable when paused or selected isolate is a system isolate.
+            onPressed:
+                isSystemIsolate ? null : () => unawaited(controller.pause()),
+          ),
+        if (isPaused)
+          ButtonGroupItemData(
+            tooltip: 'Resume',
+            iconAsset: 'icons/material_symbols/resume.png',
+            iconSize: DebuggingControls.materialIconSize,
+            // Enable while paused + not resuming and selected isolate is not
+            // a system isolate.
+            onPressed:
+                (!resuming && !isSystemIsolate)
+                    ? () => unawaited(controller.resume())
+                  
       ],
     );
   }


### PR DESCRIPTION
This fixes https://github.com/flutter/devtools/issues/4924 by showing only one button at any given time.