### PR TITLE
Update dart_syntax grammar for latest fixes

### DIFF
--- a/packages/devtools_app/assets/dart_syntax.json
+++ b/packages/devtools_app/assets/dart_syntax.json
@@ -1,6 +1,6 @@
 {
 	"name": "Dart",
-	"version": "1.2.5",
+	"version": "1.4.1",
 	"fileTypes": [
 		"dart"
 	],
@@ -16,7 +16,7 @@
 		},
 		{
 			"name": "meta.declaration.dart",
-			"begin": "^\\w*\\b(library|import|part of|part|export)\\b",
+			"begin": "^\\w*\\b(augment\\s+library|library|import\\s+augment|import|part\\s+of|part|export)\\b",
 			"beginCaptures": {
 				"0": {
 					"name": "keyword.other.import.dart"
@@ -69,6 +69,16 @@
 	],
 
 	"repository": {
+		"dartdoc-codeblock-triple": {
+			"begin": "^\\s*///\\s*(?!\\s*```)",
+			"end": "\n",
+			"contentName": "variable.other.source.dart"
+		},
+		"dartdoc-codeblock-block": {
+			"begin": "^\\s*\\*\\s*(?!(\\s*```|\/))",
+			"end": "\n",
+			"contentName": "variable.other.source.dart"
+		},
 		"dartdoc": {
 			"patterns": [
 				{
@@ -80,30 +90,31 @@
 					}
 				},
 				{
-					"match": "^ {4,}(?![ \\*]).*",
-					"captures": {
-						"0": {
-							"name": "variable.name.source.dart"
+					"begin": "^\\s*///\\s*(```)",
+					"end": "^\\s*///\\s*(```)|^(?!\\s*///)",
+					"patterns": [
+						{
+							"include": "#dartdoc-codeblock-triple"
 						}
-					}
+					]
 				},
 				{
-					"contentName": "variable.other.source.dart",
-					"begin": "```.*?$",
-					"end": "```"
-				},
-				{
-					"match": "(`[^`]+?`)",
-					"captures": {
-						"0": {
-							"name": "variable.other.source.dart"
+					"begin": "^\\s*\\*\\s*(```)",
+					"end": "^\\s*\\*\\s*(```)|^(?=\\s*\\*\/)",
+					"patterns": [
+						{
+							"include": "#dartdoc-codeblock-block"
 						}
-					}
+					]
 				},
 				{
-					"match": "(\\* ((    ).*))$",
+					"match": "`[^`\n]+`",
+					"name": "variable.other.source.dart"
+				},
+				{
+					"match": "(?:\\*|\\/\\/)\\s{4,}(.*?)(?=($|\\*\\/))",
 					"captures": {
-						"2": {
+						"1": {
 							"name": "variable.other.source.dart"
 						}
 					}
@@ -157,7 +168,7 @@
 				{
 					"name": "comment.block.documentation.dart",
 					"begin": "///",
-					"while": "^\\s*///",
+					"end": "^(?!\\s*///)",
 					"patterns": [
 						{
 							"include": "#dartdoc"
@@ -211,11 +222,11 @@
 				},
 				{
 					"name": "variable.language.dart",
-					"match": "(?<!\\$)\\b(this|super)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(this|super|augmented)\\b(?!\\$)"
 				},
 				{
 					"name": "constant.numeric.dart",
-					"match": "(?<!\\$)\\b((0(x|X)[0-9a-fA-F]*)|(([0-9]+\\.?[0-9]*)|(\\.[0-9]+))((e|E)(\\+|-)?[0-9]+)?)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b((0(x|X)[0-9a-fA-F][0-9a-fA-F_]*)|(([0-9][0-9_]*\\.?[0-9_]*)|(\\.[0-9][0-9_]*))((e|E)(\\+|-)?[0-9][0-9_]*)?)\\b(?!\\$)"
 				},
 				{
 					"include": "#class-identifier"
@@ -312,7 +323,7 @@
 				},
 				{
 					"name": "keyword.control.dart",
-					"match": "(?<!\\$)\\b(break|case|continue|default|do|else|for|if|in|return|switch|while|when)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(break|case|continue|default|do|else|for|if|in|switch|while|when)\\b(?!\\$)"
 				},
 				{
 					"name": "keyword.control.dart",
@@ -327,12 +338,16 @@
 					"match": "(?<!\\$)\\b(new)\\b(?!\\$)"
 				},
 				{
+					"name": "keyword.control.return.dart",
+					"match": "(?<!\\$)\\b(return)\\b(?!\\$)"
+				},
+				{
 					"name": "keyword.declaration.dart",
-					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension type|extension|external|factory|implements|get(?!\\()|mixin|native|operator|set(?!\\()|typedef|with|covariant)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(abstract|sealed|base|interface|class|enum|extends|extension\\s+type|extension|external|factory|implements|get(?![(<])|mixin|native|operator|set(?![(<])|typedef|with|covariant)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.modifier.dart",
-					"match": "(?<!\\$)\\b(static|final|const|required|late)\\b(?!\\$)"
+					"match": "(?<!\\$)\\b(macro|augment|static|final|const|required|late)\\b(?!\\$)"
 				},
 				{
 					"name": "storage.type.primitive.dart",
@@ -388,10 +403,33 @@
 				}
 			]
 		},
+		"expression": {
+			"patterns": [
+				{
+					"include": "#constants-and-special-vars"
+				},
+				{
+					"include": "#strings"
+				},
+				{
+					"name": "variable.parameter.dart",
+					"match": "[a-zA-Z0-9_]+"
+				},
+				{
+					"begin": "\\{",
+					"end": "\\}",
+					"patterns": [
+						{
+							"include": "#expression"
+						}
+					]
+				}
+			]
+		},
 		"string-interp": {
 			"patterns": [
 				{
-					"name": "string.interpolated.expression.dart",
+					"name": "meta.embedded.expression.dart",
 					"match": "\\$([a-zA-Z0-9_]+)",
 					"captures": {
 						"1": {
@@ -400,19 +438,12 @@
 					}
 				},
 				{
-					"name": "string.interpolated.expression.dart",
+					"name": "meta.embedded.expression.dart",
 					"begin": "\\$\\{",
 					"end": "\\}",
 					"patterns": [
 						{
-							"include": "#constants-and-special-vars"
-						},
-						{
-							"include": "#strings"
-						},
-						{
-							"name": "variable.parameter.dart",
-							"match": "[a-zA-Z0-9_]+"
+							"include": "#expression"
 						}
 					]
 				},

--- a/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/syntax_highlighter.dart
@@ -245,6 +245,7 @@ class SyntaxHighlighter {
     const controlFlowScopes = <String>[
       'keyword.control.catch-exception.dart',
       'keyword.control.dart',
+      'keyword.control.return.dart',
       // While 'new' is not a control flow keyword, it uses the control flow
       // color scheme so we include it here.
       'keyword.control.new.dart',

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -36,7 +36,10 @@ TODO: Remove this section if there are not any general updates.
 ## Debugger updates
 
 * Added a tooltip to describe the exception mode drop-down. -
-[#8849](https://github.com/flutter/devtools/pull/8849)
+  [#8849](https://github.com/flutter/devtools/pull/8849)
+* Updated syntax highlighting with support for digit separators,
+  and improved comment and string interpolation handling. -
+  [#8861](https://github.com/flutter/devtools/pull/8861)
 
 ## Network profiler updates
 

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/comments.dart.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/comments.dart.golden
@@ -12,12 +12,10 @@
 >/// ```
 #^^^^^^^ comment.block.documentation.dart
 >/// doc
-#^^^ comment.block.documentation.dart
-#   ^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^ comment.block.documentation.dart
+#    ^^^ comment.block.documentation.dart variable.other.source.dart
 >/// ```
-#^^^ comment.block.documentation.dart
-#   ^ comment.block.documentation.dart variable.other.source.dart
-#    ^^^ comment.block.documentation.dart
+#^^^^^^^ comment.block.documentation.dart
 >///
 #^^^ comment.block.documentation.dart
 >/// ...

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/keywords.dart.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/keywords.dart.golden
@@ -74,7 +74,7 @@
 #           ^ punctuation.dot.dart
 #            ^^^^^^ entity.name.function.dart
 >    return _b;
-#    ^^^^^^ keyword.control.dart
+#    ^^^^^^ keyword.control.return.dart
 #             ^ punctuation.terminator.dart
 >  }
 >
@@ -97,7 +97,7 @@
 #                ^^ keyword.operator.comparison.dart
 #                   ^^^^^^ support.class.dart
 >    return false;
-#    ^^^^^^ keyword.control.dart
+#    ^^^^^^ keyword.control.return.dart
 #           ^^^^^ constant.language.dart
 #                ^ punctuation.terminator.dart
 >  }
@@ -193,7 +193,7 @@
 #^^^^ storage.type.primitive.dart
 #     ^^^^^^^ entity.name.function.dart
 >  return;
-#  ^^^^^^ keyword.control.dart
+#  ^^^^^^ keyword.control.return.dart
 #        ^ punctuation.terminator.dart
 >}
 >
@@ -322,7 +322,7 @@
 #           ^ punctuation.terminator.dart
 >    }
 >    return;
-#    ^^^^^^ keyword.control.dart
+#    ^^^^^^ keyword.control.return.dart
 #          ^ punctuation.terminator.dart
 >  }
 >
@@ -364,7 +364,7 @@
 #    ^^^^^^^ keyword.control.dart
 #           ^ keyword.operator.ternary.dart
 >      return;
-#      ^^^^^^ keyword.control.dart
+#      ^^^^^^ keyword.control.return.dart
 #            ^ punctuation.terminator.dart
 >  }
 >}

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/literals.dart.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/literals.dart.golden
@@ -28,8 +28,8 @@
 #               ^^ string.interpolated.single.dart
 #                 ^ punctuation.comma.dart
 #                   ^ string.interpolated.single.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                     ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                      ^ string.interpolated.single.dart
 #                        ^ punctuation.terminator.dart
 >const list4 = <String>['', '$a'];
@@ -41,8 +41,8 @@
 #                       ^^ string.interpolated.single.dart
 #                         ^ punctuation.comma.dart
 #                           ^ string.interpolated.single.dart
-#                            ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                             ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                            ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                             ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                              ^ string.interpolated.single.dart
 #                                ^ punctuation.terminator.dart
 >
@@ -63,8 +63,8 @@
 #              ^^ string.interpolated.single.dart
 #                ^ punctuation.comma.dart
 #                  ^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const set4 = <String>{'', '$a'};
@@ -76,8 +76,8 @@
 #                      ^^ string.interpolated.single.dart
 #                        ^ punctuation.comma.dart
 #                          ^ string.interpolated.single.dart
-#                           ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                            ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                           ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                            ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                             ^ string.interpolated.single.dart
 #                               ^ punctuation.terminator.dart
 >
@@ -96,8 +96,8 @@
 #              ^^ string.interpolated.single.dart
 #                ^ keyword.operator.ternary.dart
 #                  ^ string.interpolated.single.dart
-#                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                     ^ string.interpolated.single.dart
 #                       ^ punctuation.terminator.dart
 >const map3 = <String, String>{'': '$a'};
@@ -111,7 +111,23 @@
 #                              ^^ string.interpolated.single.dart
 #                                ^ keyword.operator.ternary.dart
 #                                  ^ string.interpolated.single.dart
-#                                   ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                    ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                                   ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                    ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                                     ^ string.interpolated.single.dart
 #                                       ^ punctuation.terminator.dart
+>
+>const num1 = 12345;
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^^^^^ constant.numeric.dart
+#                  ^ punctuation.terminator.dart
+>const num2 = 12345.678;
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^^^^^^^^^ constant.numeric.dart
+#                      ^ punctuation.terminator.dart
+>const num3 = 888_888_888;
+#^^^^^ storage.modifier.dart
+#           ^ keyword.operator.assignment.dart
+#             ^^^^^^^^^^^ constant.numeric.dart
+#                        ^ punctuation.terminator.dart

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/open_code_block.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/open_code_block.golden
@@ -5,8 +5,7 @@
 >///
 #^^^ comment.block.documentation.dart
 >/// This should not cause parsing to fail.
-#^^^ comment.block.documentation.dart
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
+#^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ comment.block.documentation.dart variable.other.source.dart
 >
 >void main() {
 #^^^^ storage.type.primitive.dart

--- a/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/string_interpolation.dart.golden
+++ b/packages/devtools_app/test/test_infra/goldens/syntax_highlighting/string_interpolation.dart.golden
@@ -24,8 +24,8 @@
 #        ^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                      ^^ string.interpolated.single.dart constant.character.escape.dart
 #                        ^^^^^ string.interpolated.single.dart
-#                             ^ string.interpolated.single.dart string.interpolated.expression.dart
-#                              ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
+#                             ^ string.interpolated.single.dart meta.embedded.expression.dart
+#                              ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
 #                               ^ string.interpolated.single.dart
 #                                 ^ punctuation.terminator.dart
 >  print('the value after \$i is ${i + 1}');
@@ -33,11 +33,11 @@
 #        ^^^^^^^^^^^^^^^^^ string.interpolated.single.dart
 #                         ^^ string.interpolated.single.dart constant.character.escape.dart
 #                           ^^^^^ string.interpolated.single.dart
-#                                ^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                  ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                   ^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                      ^ string.interpolated.single.dart string.interpolated.expression.dart constant.numeric.dart
-#                                       ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                ^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                  ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                   ^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                      ^ string.interpolated.single.dart meta.embedded.expression.dart constant.numeric.dart
+#                                       ^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                        ^ string.interpolated.single.dart
 #                                          ^ punctuation.terminator.dart
 >  print('the value of \$i + \$j is ${i + j}');
@@ -47,11 +47,11 @@
 #                        ^^^^ string.interpolated.single.dart
 #                            ^^ string.interpolated.single.dart constant.character.escape.dart
 #                              ^^^^^ string.interpolated.single.dart
-#                                   ^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                     ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                      ^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#                                         ^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#                                          ^ string.interpolated.single.dart string.interpolated.expression.dart
+#                                   ^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                     ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                      ^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#                                         ^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#                                          ^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                           ^ string.interpolated.single.dart
 #                                             ^ punctuation.terminator.dart
 >}
@@ -63,14 +63,14 @@
 #  ^^^^^ entity.name.function.dart
 >    '${() {
 #    ^ string.interpolated.single.dart
-#     ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#     ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >      return 'Hello';
-#^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#      ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#            ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#      ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#            ^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >    }}',
-#^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#     ^^ string.interpolated.single.dart
+#^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#      ^ string.interpolated.single.dart
 #       ^ punctuation.comma.dart
 >  );
 #   ^ punctuation.terminator.dart
@@ -78,27 +78,27 @@
 #  ^^^^^ entity.name.function.dart
 >    'print(${() {
 #    ^^^^^^^ string.interpolated.single.dart
-#           ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#           ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >      return 'Hello';
-#^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#      ^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart variable.parameter.dart
-#            ^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#      ^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart variable.parameter.dart
+#            ^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 >    }()})',
-#^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
-#     ^^^^^ string.interpolated.single.dart
+#^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
+#        ^^ string.interpolated.single.dart
 #          ^ punctuation.comma.dart
 >  );
 #   ^ punctuation.terminator.dart
 >  print('${() => 'Hello'}');
 #  ^^^^^ entity.name.function.dart
 #        ^ string.interpolated.single.dart
-#         ^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#         ^^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                         ^ string.interpolated.single.dart
 #                           ^ punctuation.terminator.dart
 >  print('print(${(() => 'Hello')()})');
 #  ^^^^^ entity.name.function.dart
 #        ^^^^^^^ string.interpolated.single.dart
-#               ^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart string.interpolated.expression.dart
+#               ^^^^^^^^^^^^^^^^^^^^ string.interpolated.single.dart meta.embedded.expression.dart
 #                                   ^^ string.interpolated.single.dart
 #                                      ^ punctuation.terminator.dart
 >}

--- a/packages/devtools_app/test/test_infra/test_data/syntax_highlighting/literals.dart
+++ b/packages/devtools_app/test/test_infra/test_data/syntax_highlighting/literals.dart
@@ -17,3 +17,7 @@ const set4 = <String>{'', '$a'};
 const map1 = <String, String>{};
 const map2 = {'': '$a'};
 const map3 = <String, String>{'': '$a'};
+
+const num1 = 12345;
+const num2 = 12345.678;
+const num3 = 888_888_888;


### PR DESCRIPTION
Updates from 1.2.5 to 1.4.1 ([Changelog](https://github.com/dart-lang/dart-syntax-highlight/blob/master/CHANGELOG.md)) with a few key improvements:

- Support for number separators
- Fixes for closing comments
- Improvements to string interpolation