### PR TITLE
Enable all bots on Windows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,6 +13,12 @@ on:
 # Declare default permissions as read only.
 permissions: read-all
 
+defaults:
+  run:
+    # Use Bash on all platforms including Windows to avoid
+    # two copies of bot scripts.
+    shell: bash
+
 env:
   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 jobs:
@@ -20,11 +26,14 @@ jobs:
     uses: ./.github/workflows/flutter-prep.yaml
 
   main:
-    name: main
+    name: ${{ matrix.os }} main
     needs: flutter-prep
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -75,9 +84,9 @@ jobs:
           dcm analyze packages/devtools_app packages/devtools_app_shared packages/devtools_extensions packages/devtools_shared packages/devtools_test
 
   test-packages:
-    name: ${{ matrix.package }} test
+    name: ${{ matrix.os }} ${{ matrix.package }} test
     needs: flutter-prep
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -85,6 +94,7 @@ jobs:
           - devtools_app_shared
           - devtools_extensions
           - devtools_shared
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -100,11 +110,13 @@ jobs:
         run: ./tool/ci/package_tests.sh
 
   test-tool:
-    name: Tool test
+    name: ${{ matrix.os }} Tool test
     needs: flutter-prep
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -118,9 +130,9 @@ jobs:
         run: ./tool/ci/tool_tests.sh
 
   test:
-    name: ${{ matrix.bot }}
+    name: ${{ matrix.os }} ${{ matrix.bot }}
     needs: flutter-prep
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
@@ -129,6 +141,7 @@ jobs:
           - build_dart2js
           - test_ddc
           - test_dart2js
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
@@ -186,12 +199,13 @@ jobs:
           echo "::notice title=To Quickly Fix Goldens:: Run \`dt fix-goldens --run-id=$WORKFLOW_ID\` on your local branch."
 
   devtools-app-integration-test:
-    name: devtools_app integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}
+    name: ${{ matrix.os }} devtools_app integration-test ${{ matrix.bot }} - ${{ matrix.device }} - shard ${{ matrix.shard }}
     needs: flutter-prep
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest, windows-latest]
         # Consider running integration tests in ddc mode, too.
         bot: [integration_dart2js]
         device: [flutter, flutter-web, dart-cli]
@@ -251,14 +265,15 @@ jobs:
           path: packages/devtools_app/integration_test/**/failures/*.png
 
   devtools-extensions-integration-test:
-    name: devtools_extensions integration-test ${{ matrix.bot }}
+    name: ${{ matrix.os }} devtools_extensions integration-test ${{ matrix.bot }}
     needs: flutter-prep
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         # Consider running integration tests in ddc mode, too.
         bot: [integration_dart2js]
+        os: [ubuntu-latest, windows-latest]
     steps:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -4,11 +4,17 @@
 
 name: Flutter SDK prep
 
+defaults:
+  run:
+    # Use Bash on all platforms including Windows to avoid
+    # two copies of bot scripts.
+    shell: bash
+
 on:
   workflow_call:
     inputs:
       os-name:
-        description: 'The OS to run against, either "macos" or "ubuntu". If neither is provided, will run against both.'
+        description: 'The OS to run against, either "macos", "ubuntu" or "windows". If none is provided, will run against all.'
         type: string
 
     outputs:
@@ -23,7 +29,7 @@ jobs:
       latest_flutter_candidate: ${{ steps.flutter-candidate.outputs.FLUTTER_CANDIDATE }}
     strategy:
       matrix:
-        os: ${{ (inputs.os-name == 'macos' && fromJSON('[ "macos-latest"]')) || (inputs.os-name == 'ubuntu' && fromJSON('[ "ubuntu-latest"]')) || fromJSON('["ubuntu-latest", "macos-latest"]') }}
+        os: ${{ (inputs.os-name == 'macos' && fromJSON('[ "macos-latest"]')) || (inputs.os-name == 'ubuntu' && fromJSON('[ "ubuntu-latest"]')) || (inputs.os-name == 'windows' && fromJSON('[ "windows-latest"]')) || fromJSON('["ubuntu-latest", "macos-latest", "windows-latest"]') }}
     runs-on: ${{ matrix.os }}
     steps:
       # TODO(https://github.com/flutter/devtools/issues/5729) Consider caching DevTools so that we

--- a/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
+++ b/packages/devtools_app/integration_test/test_infra/run/_test_app_driver.dart
@@ -21,14 +21,18 @@ class TestFlutterApp extends IntegrationTestApp {
 
   @override
   Future<void> startProcess() async {
-    runProcess = await Process.start('flutter', [
-      'run',
-      '--machine',
-      '-d',
-      testAppDevice.argName,
-      // Do not serve DevTools from Flutter Tools.
-      '--no-devtools',
-    ], workingDirectory: testAppPath);
+    runProcess = await Process.start(
+      Platform.isWindows ? 'flutter.bat' : 'flutter',
+      [
+        'run',
+        '--machine',
+        '-d',
+        testAppDevice.argName,
+        // Do not serve DevTools from Flutter Tools.
+        '--no-devtools',
+      ],
+      workingDirectory: testAppPath,
+    );
   }
 
   @override

--- a/packages/devtools_app/test/screens/memory/diff/controller/memory_footprint_test.dart
+++ b/packages/devtools_app/test/screens/memory/diff/controller/memory_footprint_test.dart
@@ -40,5 +40,12 @@ void main() {
       expect(delta, greaterThan(lowerThreshold));
       expect(delta, lessThan(upperThreshold));
     },
+    // TODO(dantup): Understand why this fails on Windows. The delta is smaller
+    //  than expected.
+    //
+    //    Expected: a value greater than <322122547.2>
+    //    Actual: <320659456>
+    //     Which: is not a value greater than <322122547.2>
+    skip: Platform.isWindows,
   );
 }

--- a/packages/devtools_shared/lib/src/test/integration_test_runner.dart
+++ b/packages/devtools_shared/lib/src/test/integration_test_runner.dart
@@ -62,7 +62,8 @@ class IntegrationTestRunner with IOMixin {
       ];
 
       debugLog('> flutter ${flutterDriveArgs.join(' ')}');
-      final process = await Process.start('flutter', flutterDriveArgs);
+      final process = await Process.start(
+          Platform.isWindows ? 'flutter.bat' : 'flutter', flutterDriveArgs);
 
       bool stdOutWriteInProgress = false;
       bool stdErrWriteInProgress = false;

--- a/tool/ci/package_tests.sh
+++ b/tool/ci/package_tests.sh
@@ -22,7 +22,7 @@ elif [ "$PACKAGE" = "devtools_extensions" ]; then
     echo `pwd`
     flutter test test/*_test.dart
     # Skip this on Windows because `flutter test --platform chrome`
-    # appears to hand there.
+    # appears to hang there.
     # https://github.com/flutter/flutter/issues/162798
     if [[ $RUNNER_OS != "Windows" ]]; then
         flutter test test/web --platform chrome

--- a/tool/ci/package_tests.sh
+++ b/tool/ci/package_tests.sh
@@ -16,15 +16,20 @@ if [ "$PACKAGE" = "devtools_app_shared" ]; then
     flutter test test/
     popd
 
-elif [ "$PACKAGE" = "devtools_extensions" ]; then 
+elif [ "$PACKAGE" = "devtools_extensions" ]; then
 
     pushd $DEVTOOLS_DIR/packages/devtools_extensions
     echo `pwd`
     flutter test test/*_test.dart
-    flutter test test/web --platform chrome
+    # Skip this on Windows because `flutter test --platform chrome`
+    # appears to hand there.
+    # https://github.com/flutter/flutter/issues/162798
+    if [[ $RUNNER_OS != "Windows" ]]; then
+        flutter test test/web --platform chrome
+    fi
     popd
 
-elif [ "$PACKAGE" = "devtools_shared" ]; then 
+elif [ "$PACKAGE" = "devtools_shared" ]; then
 
     pushd $DEVTOOLS_DIR/packages/devtools_shared
     echo `pwd`

--- a/tool/ci/setup.sh
+++ b/tool/ci/setup.sh
@@ -13,7 +13,6 @@ export DEVTOOLS_DIR=$SCRIPT_DIR/../..
 # In GitBash on Windows, we have to call flutter.bat so we alias them in this
 # script to call the correct one based on the OS.
 function flutter {
-    # TODO: Also support windows on github actions.
     if [[ $RUNNER_OS == "Windows" ]]; then
         command flutter.bat "$@"
     else
@@ -22,7 +21,6 @@ function flutter {
 }
 export -f flutter
 
-# TODO: Also support windows on github actions.
 if [[ $RUNNER_OS == "Windows" ]]; then
     echo Installing Google Chrome Stable...
     # Install Chrome via Chocolatey while `addons: chrome` doesn't seem to work on Windows yet

--- a/tool/ci/setup.sh
+++ b/tool/ci/setup.sh
@@ -21,13 +21,6 @@ function flutter {
 }
 export -f flutter
 
-if [[ $RUNNER_OS == "Windows" ]]; then
-    echo Installing Google Chrome Stable...
-    # Install Chrome via Chocolatey while `addons: chrome` doesn't seem to work on Windows yet
-    # https://travis-ci.community/t/installing-google-chrome-stable-but-i-cant-find-it-anywhere/2118
-    choco install googlechrome --acceptlicense --yes --no-progress --ignore-checksums
-fi
-
 # Make sure Flutter sdk has been provided
 if [ ! -d "./tool/flutter-sdk" ]; then
     echo "Expected ./tool/flutter-sdk to exist"


### PR DESCRIPTION
This enables Windows bots on GitHub Actions by:

- Adding `matrix` to each bot that includes `windows-latest` (note: the existing bots seem to mostly run on Linux including `devtools-extensions-integration-test` but `devtools-app-integration-test` runs on macOS and I'm not sure why the distinction... I added Windows both both anyway)
- Setting `shell: bash` as a default so that the same scripts work on Windows bots (the GitHub runners do have a Bash version on Windows, but it's not the default shell)
- Using `flutter.bat` when spawning Flutter on Windows (it would be nice to centralise this, but the tests are spread across different packages so I just left it inline for now)
- Skipping a memory_footprint test because it always fails on Windows (see comment against code for the failure)
- Skipping `flutter test --platform chrome` for devtools_extensions test because it seems broken (I've filed https://github.com/flutter/flutter/issues/162798)

This will slow down the bots on all PRs. We could reduce which ones run on Windows and/or only run them on a schedule, though these obviously remove some of the benefits of catching potential Windows issues earlier.

~~Note: There will still be some failures on this PR until https://github.com/flutter/devtools/pull/8846 is merged. I didn't include that in this PR to avoid confusing the review, but I will merge/rebase once that lands.~~ (Rebased)