### PR TITLE
Add a unique key to the notifications widget so they don't get reparented

### DIFF
--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -173,7 +173,7 @@ class _NotificationOverlay extends StatelessWidget {
 
 class _Notification extends StatefulWidget {
   _Notification({required this.message, required this.remove})
-    : super(key:  UniqueKey());
+    : super(key: UniqueKey());
 
   final NotificationMessage message;
   final void Function(_Notification) remove;

--- a/packages/devtools_app/lib/src/framework/notifications_view.dart
+++ b/packages/devtools_app/lib/src/framework/notifications_view.dart
@@ -172,7 +172,8 @@ class _NotificationOverlay extends StatelessWidget {
 }
 
 class _Notification extends StatefulWidget {
-  const _Notification({required this.message, required this.remove});
+  _Notification({required this.message, required this.remove})
+    : super(key:  UniqueKey());
 
   final NotificationMessage message;
   final void Function(_Notification) remove;


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8651

The state of a notification was getting attached to the next notification when its widget was removed, which would then cause that notification to be hidden instantly.