### PR TITLE
Fix broken comment references in devtools_app

### DIFF
--- a/packages/devtools_app/lib/src/app.dart
+++ b/packages/devtools_app/lib/src/app.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport 'package:vm_service/vm_service.dart';
+library;
+
 import 'dart:async';
 
 import 'package:collection/collection.dart';
@@ -627,7 +630,7 @@ class ScreenUnavailable extends StatelessWidget {
 /// provided here.
 ///
 /// Conditional screens can be added to this list, and they will automatically
-/// be shown or hidden based on the [Screen.conditionalLibrary] provided.
+/// be shown or hidden based on the [Screen] conditionalLibrary provided.
 List<DevToolsScreen> defaultScreens({
   List<DevToolsJsonFile> sampleData = const [],
 }) {

--- a/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_controller_web.dart
@@ -23,11 +23,11 @@ import 'controller.dart';
 /// DevTools lifecycle.
 ///
 /// Each time [EmbeddedExtensionControllerImpl.init] is called, we create a new
-/// [html.IFrameElement] and register it to
+/// [HTMLIFrameElement] and register it to
 /// [EmbeddedExtensionControllerImpl.viewId] via
-/// [ui_web.platformViewRegistry.registerViewFactory]. Each new
-/// [html.IFrameElement] must have a unique id in the [PlatformViewRegistry],
-/// which [_viewIdIncrementer] is used to create.
+/// `ui_web.platformViewRegistry.registerViewFactory`. Each new
+/// [HTMLIFrameElement] must have a unique id in the
+/// [ui_web.PlatformViewRegistry], which [_viewIdIncrementer] is used to create.
 var _viewIdIncrementer = 0;
 
 class EmbeddedExtensionControllerImpl extends EmbeddedExtensionController

--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -92,7 +92,7 @@ class _ExtensionIFrameController extends DisposableController
 
   static const _pollUntilReadyTimeout = Duration(seconds: 10);
 
-  /// The listener that is added to DevTools' [html.window] to receive messages
+  /// The listener that is added to DevTools' [Window] to receive messages
   /// from the extension.
   ///
   /// We need to store this in a variable so that the listener is properly

--- a/packages/devtools_app/lib/src/extensions/extension_service.dart
+++ b/packages/devtools_app/lib/src/extensions/extension_service.dart
@@ -41,8 +41,8 @@ class ExtensionService extends DisposableController
   /// The fixed (unchanging) root file:// URI for the application this
   /// [ExtensionService] will manage DevTools extensions for.
   ///
-  /// When null, [_appRoot] will be calculated from the [serviceManager]'s
-  /// currently connected app. See [_initAppRoot].
+  /// When null, [_appRoot] will be calculated from the
+  /// `serviceConnection.serviceManager`'s currently connected app. See [_initAppRoot].
   final Uri? fixedAppRoot;
 
   /// Whether to ignore the VM service connection for the context of this

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport '../../devtools_app.dart';
+library;
+
 import 'dart:async';
 
 import 'package:devtools_app_shared/service.dart';

--- a/packages/devtools_app/lib/src/framework/framework_core.dart
+++ b/packages/devtools_app/lib/src/framework/framework_core.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-/// @docImport '../../devtools_app.dart';
+/// @docImport '../app.dart';
 library;
 
 import 'dart:async';

--- a/packages/devtools_app/lib/src/framework/initializer.dart
+++ b/packages/devtools_app/lib/src/framework/initializer.dart
@@ -24,7 +24,7 @@ import '../shared/ui/common_widgets.dart';
 /// See [_InitializerState.build] for the logic that determines whether the
 /// business logic is loaded.
 ///
-/// Use this widget to wrap pages that require [service.serviceManager] to be
+/// Use this widget to wrap pages that require `service.serviceManager` to be
 /// connected. As we require additional services to be available, add them
 /// here.
 class Initializer extends StatefulWidget {

--- a/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
+++ b/packages/devtools_app/lib/src/framework/scaffold/scaffold.dart
@@ -92,7 +92,7 @@ class DevToolsScaffold extends StatefulWidget {
 
   /// Actions that it's possible to perform in this Scaffold.
   ///
-  /// These will generally be [RegisteredServiceExtensionButton]s.
+  /// These will generally be `_RegisteredServiceExtensionButton`s.
   final List<Widget> actions;
 
   @override

--- a/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
+++ b/packages/devtools_app/lib/src/screens/app_size/app_size_controller.dart
@@ -632,9 +632,9 @@ class AppSizeController {
   ///
   /// The tree can be filtered with different [DiffTreeType] values:
   /// * [DiffTreeType.increaseOnly] - returns a tree with nodes with positive
-  ///   [byteSize].
+  ///   `byteSize`.
   /// * [DiffTreeType.decreaseOnly] - returns a tree with nodes with negative
-  ///   [byteSize].
+  ///   `byteSize`.
   /// * [DiffTreeType.combined] - returns a tree with all nodes.
   TreemapNode? generateDiffTree(
     Map<String, dynamic> treeJson,

--- a/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/span_parser.dart
@@ -608,7 +608,7 @@ class ScopeStack {
     pop(scope, end);
   }
 
-  /// Pushes a new scope onto the stack starting at [start].
+  /// Pushes a new scope onto the stack starting at [location].
   void push(String? scope, ScopeStackLocation location) {
     if (scope == null) return;
 

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_data_models.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport 'layout_explorer/ui/overflow_indicator_painter.dart';
+library;
+
 import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
@@ -32,25 +35,32 @@ const overflowEpsilon = 0.1;
 /// the sum of the render size to be equals to [maxSizeAvailable]
 ///
 /// Formula for computing render size:
-///   renderSize[i] = (size[i] - smallestSize)
-///               * (largestRenderSize - smallestRenderSize)
-///               / (largestSize - smallestSize) + smallestRenderSize
+/// ```
+/// renderSize[i] = (size[i] - smallestSize)
+///             * (largestRenderSize - smallestRenderSize)
+///             / (largestSize - smallestSize) + smallestRenderSize
+/// ```
 /// Explanation:
 /// - The computation formula for transforming size to renderSize is based on these two things:
 ///   - smallest element will be rendered to [smallestRenderSize]
 ///   - largest element will be rendered to [largestRenderSize]
 ///   - any other size will be scaled accordingly
 /// - The formula above is derived from:
-///    (renderSize[i] - smallestRenderSize) / (largestRenderSize - smallestRenderSize)
-///     = (size[i] - smallestSize) / (size[i] - smallestSize)
+///   ```
+///   (renderSize[i] - smallestRenderSize) / (largestRenderSize - smallestRenderSize)
+///    = (size[i] - smallestSize) / (size[i] - smallestSize)
+///   ```
 ///
 /// Formula for computing forced [largestRenderSize]:
-///   largestRenderSize = (maxSizeAvailable - sizes.length * smallestRenderSize)
-///     * (largestSize - smallestSize) / sum(s[i] - ss) + smallestRenderSize
+/// ```
+/// largestRenderSize = (maxSizeAvailable - sizes.length * smallestRenderSize)
+///   * (largestSize - smallestSize) / sum(s[i] - ss) + smallestRenderSize
+/// ```
 /// Explanation:
 /// - This formula is derived from the equation:
-///    sum(renderSize) = maxSizeAvailable
-///
+///   ```
+///   sum(renderSize) = maxSizeAvailable
+///   ```
 List<double> computeRenderSizes({
   required Iterable<double> sizes,
   required double smallestSize,

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -34,7 +34,7 @@ import 'inspector_controller.dart';
 
 final _log = Logger('inspector_tree_controller');
 
-/// Presents a [TreeNode].
+/// Presents a [InspectorTreeNode].
 class _InspectorTreeRowWidget extends StatefulWidget {
   /// Constructs a [_InspectorTreeRowWidget] that presents a line in the
   /// Inspector tree.

--- a/packages/devtools_app/lib/src/screens/inspector/layout_explorer/ui/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/layout_explorer/ui/utils.dart
@@ -103,12 +103,11 @@ class Truncateable extends StatelessWidget {
   }
 }
 
-/// Widget that draws bounding box with the title (usually widget name) in its top left
+/// Widget that draws bounding box with the title (usually widget name) in its
+/// top left.
 ///
-/// [hint] is an optional widget to be placed in the top right of the box
-/// [child] is an optional widget to be placed in the center of the box
-/// [borderColor] outer box border color and background color for the title
-/// [textColor] color for title text
+/// * [hint] is an optional widget to be placed in the top right of the box.
+/// * [child] is an optional widget to be placed in the center of the box.
 class WidgetVisualizer extends StatelessWidget {
   const WidgetVisualizer({
     super.key,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_data_models.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport '../inspector/layout_explorer/ui/overflow_indicator_painter.dart';
+library;
+
 import 'dart:math' as math;
 
 import 'package:flutter/rendering.dart';
@@ -32,24 +35,33 @@ const overflowEpsilon = 0.1;
 /// the sum of the render size to be equals to [maxSizeAvailable]
 ///
 /// Formula for computing render size:
-///   renderSize[i] = (size[i] - smallestSize)
-///               * (largestRenderSize - smallestRenderSize)
-///               / (largestSize - smallestSize) + smallestRenderSize
+/// ```
+/// renderSize[i] = (size[i] - smallestSize)
+///             * (largestRenderSize - smallestRenderSize)
+///             / (largestSize - smallestSize) + smallestRenderSize
+/// ```
+///
 /// Explanation:
 /// - The computation formula for transforming size to renderSize is based on these two things:
 ///   - smallest element will be rendered to [smallestRenderSize]
 ///   - largest element will be rendered to [largestRenderSize]
 ///   - any other size will be scaled accordingly
 /// - The formula above is derived from:
-///    (renderSize[i] - smallestRenderSize) / (largestRenderSize - smallestRenderSize)
-///     = (size[i] - smallestSize) / (size[i] - smallestSize)
+///   ```
+///   (renderSize[i] - smallestRenderSize) / (largestRenderSize - smallestRenderSize)
+///    = (size[i] - smallestSize) / (size[i] - smallestSize)
+///   ```
 ///
 /// Formula for computing forced [largestRenderSize]:
-///   largestRenderSize = (maxSizeAvailable - sizes.length * smallestRenderSize)
-///     * (largestSize - smallestSize) / sum(s[i] - ss) + smallestRenderSize
+/// ```
+/// largestRenderSize = (maxSizeAvailable - sizes.length * smallestRenderSize)
+///   * (largestSize - smallestSize) / sum(s[i] - ss) + smallestRenderSize
+/// ```
 /// Explanation:
 /// - This formula is derived from the equation:
-///    sum(renderSize) = maxSizeAvailable
+///   ```
+///   sum(renderSize) = maxSizeAvailable
+///   ```
 ///
 List<double> computeRenderSizes({
   required Iterable<double> sizes,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -33,7 +33,7 @@ import 'inspector_controller.dart';
 
 final _log = Logger('inspector_tree_controller');
 
-/// Presents a [TreeNode].
+/// Presents a [InspectorTreeNode].
 class _InspectorTreeRowWidget extends StatefulWidget {
   /// Constructs a [_InspectorTreeRowWidget] that presents a line in the
   /// Inspector tree.
@@ -394,7 +394,7 @@ class InspectorTreeController extends DisposableController
     );
   }
 
-  /// Given [shouldShow], toggles the visibility of a hideable group.
+  /// Given [showGroup], toggles the visibility of a hideable group.
   ///
   /// Returns a [bool] representing whether or not the group was toggled.
   bool _maybeToggleHideableGroup(

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/box/box.dart
@@ -341,7 +341,7 @@ const _widePaddingVisualizerPercent = 0.35;
 /// display based on the display's [availableSize] and the real widget's
 /// [WidgetSizes].
 ///
-/// Uses a constant [paddingFraction] for the display padding, regardless of
+/// Uses a constant `paddingFraction` for the display padding, regardless of
 /// the actual size.
 WidgetSizes _simpleFractionalLayout({
   required double availableSize,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/layout_explorer/ui/utils.dart
@@ -104,12 +104,11 @@ class Truncateable extends StatelessWidget {
   }
 }
 
-/// Widget that draws bounding box with the title (usually widget name) in its top left
+/// Widget that draws bounding box with the title (usually widget name) in its
+/// top left.
 ///
-/// [hint] is an optional widget to be placed in the top right of the box
-/// [child] is an optional widget to be placed in the center of the box
-/// [borderColor] outer box border color and background color for the title
-/// [textColor] color for title text
+/// * [hint] is an optional widget to be placed in the top right of the box.
+/// * [child] is an optional widget to be placed in the center of the box.
 class WidgetVisualizer extends StatelessWidget {
   const WidgetVisualizer({
     super.key,

--- a/packages/devtools_app/lib/src/screens/memory/framework/memory_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/memory_controller.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport 'memory_tabs.dart';
+library;
+
 import 'dart:async';
 
 import 'package:devtools_app_shared/utils.dart';

--- a/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/diff/controller/diff_pane_controller.dart
@@ -448,7 +448,7 @@ class DerivedData extends DisposableController with AutoDisposeControllerMixin {
   bool get updatingValues => _updatingValues;
   bool _updatingValues = false;
 
-  /// Updates fields in this instance based on the values in [core].
+  /// Updates fields in this instance based on the values in [_core].
   void _updateValues() {
     _startUpdatingValues();
     try {

--- a/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/tracing/tracing_data.dart
@@ -2,6 +2,9 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
+/// @docImport 'class_table.dart';
+library;
+
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_shared/devtools_shared.dart';
 import 'package:flutter/foundation.dart';
@@ -142,7 +145,7 @@ class TracingIsolateState with Serializable {
   late final Map<String, CpuProfileData> profiles;
   late final List<TracedClass> classes;
 
-  /// The current class selection in the [AllocationTracingTable]
+  /// The current class selection in the [AllocationTracingTable].
   final selectedClass = ValueNotifier<TracedClass?>(null);
 
   /// The list of classes for the currently selected isolate.


### PR DESCRIPTION
Some broken references were just typos. Some were pointing to properties of non-local types. Some were found on a class's doc comment, while refering to parameters in the constructor, which is not possible to do.