### PR TITLE
Don't load the JsonViewer with unparsable JSON

### DIFF
--- a/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_request_inspector_views.dart
@@ -345,9 +345,8 @@ class HttpTextResponseViewer extends StatelessWidget {
             _isJsonDecodable(responseBody)
                 ? JsonViewer(encodedJson: responseBody)
                 : TextViewer(
-                  // We could also include the decoding exception.
+                  // We could also include the decoding exception. Or push a notification.
                   text: responseBody,
-                  style: textStyle.copyWith(color: Colors.red),
                 ),
           NetworkResponseViewType.text => TextViewer(
             text: responseBody,


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8872

I also make HttpTextResponseViewer.contentType private in order to make it promotable, and reduce null-asserts by one.