### PR TITLE
make ancestorIds an iterable, avoids n^2 allocations for sets

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -923,11 +923,10 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
 
   final String? parentId;
 
-  /// The set of ids for all ancestors of this [CpuStackFrame].
+  /// The ids for all ancestors of this [CpuStackFrame].
   ///
-  /// This is late and final, so it will only be created once for performance
-  /// reasons. This method should only be called when the [CpuStackFrame] is
-  /// part of a processed CPU profile.
+  /// This method should only be called when the [CpuStackFrame] is part of a
+  /// processed CPU profile.
   // ignore: avoid-explicit-type-declaration, required due to cyclic definition.
   Iterable<String> get ancestorIds sync* {
     CpuStackFrame? next = this;

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -929,10 +929,13 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
   /// reasons. This method should only be called when the [CpuStackFrame] is
   /// part of a processed CPU profile.
   // ignore: avoid-explicit-type-declaration, required due to cyclic definition.
-  late final Set<String> ancestorIds = <String>{
-    if (parentId != null) parentId!,
-    ...parent?.ancestorIds ?? {},
-  };
+  Iterable<String> get ancestorIds sync* {
+    CpuStackFrame? next = this;
+    while (next != null) {
+      if (next.parentId case final parentId?) yield parentId;
+      next = next.parent;
+    }
+  }
 
   @override
   CpuProfileMetaData get profileMetaData => _profileMetaData;

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -927,7 +927,6 @@ class CpuStackFrame extends TreeNode<CpuStackFrame>
   ///
   /// This method should only be called when the [CpuStackFrame] is part of a
   /// processed CPU profile.
-  // ignore: avoid-explicit-type-declaration, required due to cyclic definition.
   Iterable<String> get ancestorIds sync* {
     CpuStackFrame? next = this;
     while (next != null) {


### PR DESCRIPTION
Part of https://github.com/flutter/devtools/issues/7917

Previously, calling this getter would cause n^2 allocations since it would recursively call the same getter, making  `_LinkedHashSetMixin._add` the largest contributor on CPU profiles (763ms, ~14%) when loading a large sample.

This is actually only ever used once, where it is iterated, so it doesn't need to be a set at all and can instead just be a lazy iterable. This should also come with some memory savings but I haven't evaluated that.