### PR TITLE
use a fused json decoder for decoding json files 

### DIFF
--- a/packages/devtools_app/lib/src/shared/ui/file_import.dart
+++ b/packages/devtools_app/lib/src/shared/ui/file_import.dart
@@ -288,7 +288,7 @@ Future<List<XFile>> importRawFilesFromPicker({
 
 @visibleForTesting
 Future<DevToolsJsonFile> toDevToolsFile(XFile file) async {
-  final data = jsonDecode(await file.readAsString());
+  final data = json.fuse(utf8).decode(await file.readAsBytes())!;
   final lastModifiedTime = await file.lastModified();
   // TODO(kenz): this will need to be modified if we need to support other file
   // extensions than .json. We will need to return a more generic file type.


### PR DESCRIPTION
When loading a 75MB cpu profile, this reduces the time from 6.9s to 5.2s.

Part of https://github.com/flutter/devtools/issues/7917.