### PR TITLE
update actions-cache version to the 4.2 release hash

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -61,7 +61,7 @@ jobs:
         with:
           ref: "${{ github.event.pull_request.head.sha }}"
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -99,7 +99,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -121,7 +121,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -146,7 +146,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -173,7 +173,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -244,7 +244,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -278,7 +278,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -299,7 +299,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk
@@ -317,7 +317,7 @@ jobs:
       - name: git clone
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk

--- a/.github/workflows/daily-dev-bump.yaml
+++ b/.github/workflows/daily-dev-bump.yaml
@@ -42,7 +42,7 @@ jobs:
           ref: master
 
       - name: Load Cached Flutter SDK
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk

--- a/.github/workflows/flutter-prep.yaml
+++ b/.github/workflows/flutter-prep.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Load Cached Flutter SDK
         id: cache-flutter
-        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9
+        uses: actions/cache@faf639248d95d2a6c5884b8e6588e233eb3b10a0
         with:
           path: |
             ./tool/flutter-sdk


### PR DESCRIPTION
My recent CI job ([here](https://github.com/flutter/devtools/actions/runs/13269346371/job/37045466177?pr=8880)) failed, looks like we are on an old version of actions/cache which was just deprecated.