### PR TITLE
[Property Editor] Indicate default option in dropdown input

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -124,27 +124,62 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
         padding: denseSpacing,
       ),
       isExpanded: true,
+      selectedItemBuilder: (context) {
+        return widget.property.propertyOptions.map((option) {
+          return DropdownMenuItem(
+            value: option.text,
+            child: _DropdownContent(option: option, showDefaultLabel: false),
+          );
+        }).toList();
+      },
       items:
           widget.property.propertyOptions.map((option) {
             return DropdownMenuItem(
-              value: option,
-              child: Row(
-                children: [
-                  Text(option, style: theme.fixedFontStyle),
-                  if (widget.property.hasDefault &&
-                      widget.property.defaultValue.toString() == option)
-                    const RoundedLabel(labelText: 'default'),
-                ],
-              ),
+              value: option.text,
+              child: _DropdownContent(option: option, showDefaultLabel: true),
             );
           }).toList(),
       onChanged: (newValue) async {
-        await editProperty(
-          widget.property,
-          valueAsString: newValue,
-          controller: widget.controller,
-        );
+        if (newValue != widget.property.valueDisplay) {
+          await editProperty(
+            widget.property,
+            valueAsString: newValue,
+            controller: widget.controller,
+          );
+        }
       },
+    );
+  }
+}
+
+class _DropdownContent extends StatelessWidget {
+  const _DropdownContent({
+    required this.option,
+    required this.showDefaultLabel,
+  });
+
+  final PropertyOption option;
+  final bool showDefaultLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Text(
+            option.text,
+            style: Theme.of(context).fixedFontStyle,
+            overflow: TextOverflow.ellipsis,
+          ),
+        ),
+        if (showDefaultLabel && option.isDefault) ...[
+          const Spacer(),
+          const RoundedLabel(
+            labelText: 'D',
+            tooltipText: 'Matches the default value.',
+          ),
+        ],
+      ],
     );
   }
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -124,21 +124,9 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
         padding: denseSpacing,
       ),
       isExpanded: true,
-      selectedItemBuilder: (context) {
-        return widget.property.propertyOptions.map((option) {
-          return DropdownMenuItem(
-            value: option.text,
-            child: _DropdownContent(option: option, showDefaultLabel: false),
-          );
-        }).toList();
-      },
-      items:
-          widget.property.propertyOptions.map((option) {
-            return DropdownMenuItem(
-              value: option.text,
-              child: _DropdownContent(option: option, showDefaultLabel: true),
-            );
-          }).toList(),
+      selectedItemBuilder:
+          (context) => _dropdownItems(withDefaultLabels: false),
+      items: _dropdownItems(withDefaultLabels: true),
       onChanged: (newValue) async {
         if (newValue != widget.property.valueDisplay) {
           await editProperty(
@@ -150,6 +138,17 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
       },
     );
   }
+
+  List<DropdownMenuItem> _dropdownItems({required bool withDefaultLabels}) =>
+      widget.property.propertyOptions.map((option) {
+        return DropdownMenuItem(
+          value: option.text,
+          child: _DropdownContent(
+            option: option,
+            showDefaultLabel: withDefaultLabels,
+          ),
+        );
+      }).toList();
 }
 
 class _DropdownContent extends StatelessWidget {
@@ -164,6 +163,7 @@ class _DropdownContent extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
       children: [
         Expanded(
           child: Text(
@@ -172,13 +172,11 @@ class _DropdownContent extends StatelessWidget {
             overflow: TextOverflow.ellipsis,
           ),
         ),
-        if (showDefaultLabel && option.isDefault) ...[
-          const Spacer(),
+        if (showDefaultLabel && option.isDefault)
           const RoundedLabel(
             labelText: 'D',
             tooltipText: 'Matches the default value.',
           ),
-        ],
       ],
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -128,7 +128,14 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
           widget.property.propertyOptions.map((option) {
             return DropdownMenuItem(
               value: option,
-              child: Text(option, style: theme.fixedFontStyle),
+              child: Row(
+                children: [
+                  Text(option, style: theme.fixedFontStyle),
+                  if (widget.property.hasDefault &&
+                      widget.property.defaultValue.toString() == option)
+                    const RoundedLabel(labelText: 'default'),
+                ],
+              ),
             );
           }).toList(),
       onChanged: (newValue) async {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -146,7 +146,7 @@ class _PropertyLabels extends StatelessWidget {
               ),
             if (isDefault)
               Padding(
-                padding: _labelPadding(isTopLabel: false),
+                padding: _labelPadding(isTopLabel: !isSet),
                 child: RoundedLabel(
                   labelText: _maybeTruncateLabel('default', width: width),
                   tooltipText: 'Property argument matches the default value.',

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -124,30 +124,29 @@ class _PropertyLabels extends StatelessWidget {
     final isSet = property.hasArgument;
     final isDefault = property.isDefault;
 
-
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            if (isSet)
-              Padding(
-                padding: const EdgeInsets.all(_PropertiesList.itemPadding),
-                child: RoundedLabel(
-                  labelText: 'S',
-                  backgroundColor: colorScheme.primary,
-                  textColor: colorScheme.onPrimary,
-                  tooltipText: 'Property argument is set.',
-                ),
-              ),
-            if (isDefault)
-              const Padding(
-                padding: EdgeInsets.all(_PropertiesList.itemPadding),
-                child: RoundedLabel(
-                  labelText: 'D',
-                  tooltipText: 'Property argument matches the default value.',
-                ),
-              ),
-          ],
-        );
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (isSet)
+          Padding(
+            padding: const EdgeInsets.all(_PropertiesList.itemPadding),
+            child: RoundedLabel(
+              labelText: 'S',
+              backgroundColor: colorScheme.primary,
+              textColor: colorScheme.onPrimary,
+              tooltipText: 'Property argument is set.',
+            ),
+          ),
+        if (isDefault)
+          const Padding(
+            padding: EdgeInsets.all(_PropertiesList.itemPadding),
+            child: RoundedLabel(
+              labelText: 'D',
+              tooltipText: 'Property argument matches the default value.',
+            ),
+          ),
+      ],
+    );
   }
 }
 

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -50,7 +50,8 @@ class _PropertiesList extends StatelessWidget {
 
   final PropertyEditorController controller;
 
-  static const itemPadding = borderPadding;
+  static const defaultItemPadding = borderPadding;
+  static const denseItemPadding = defaultItemPadding / 2;
 
   @override
   Widget build(BuildContext context) {
@@ -100,7 +101,7 @@ class _EditablePropertyItem extends StatelessWidget {
         Flexible(
           flex: 3,
           child: Padding(
-            padding: const EdgeInsets.all(_PropertiesList.itemPadding),
+            padding: const EdgeInsets.all(_PropertiesList.defaultItemPadding),
             child: _PropertyInput(property: property, controller: controller),
           ),
         ),
@@ -118,36 +119,59 @@ class _PropertyLabels extends StatelessWidget {
 
   final EditableProperty property;
 
+  static const _widthForFullLabels = 60;
+
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final isSet = property.hasArgument;
     final isDefault = property.isDefault;
 
-    return Column(
-      crossAxisAlignment: CrossAxisAlignment.start,
-      children: [
-        if (isSet)
-          Padding(
-            padding: const EdgeInsets.all(_PropertiesList.itemPadding),
-            child: RoundedLabel(
-              labelText: 'S',
-              backgroundColor: colorScheme.primary,
-              textColor: colorScheme.onPrimary,
-              tooltipText: 'Property argument is set.',
-            ),
-          ),
-        if (isDefault)
-          const Padding(
-            padding: EdgeInsets.all(_PropertiesList.itemPadding),
-            child: RoundedLabel(
-              labelText: 'D',
-              tooltipText: 'Property argument matches the default value.',
-            ),
-          ),
-      ],
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final width = constraints.maxWidth;
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            if (isSet)
+              Padding(
+                padding: _labelPadding(isTopLabel: true),
+                child: RoundedLabel(
+                  labelText: _maybeTruncateLabel('set', width: width),
+                  tooltipText: 'Property argument is set.',
+                  fontSize: smallFontSize,
+                  backgroundColor: colorScheme.primary,
+                  textColor: colorScheme.onPrimary,
+                ),
+              ),
+            if (isDefault)
+              Padding(
+                padding: _labelPadding(isTopLabel: false),
+                child: RoundedLabel(
+                  labelText: _maybeTruncateLabel('default', width: width),
+                  tooltipText: 'Property argument matches the default value.',
+                  fontSize: smallFontSize,
+                ),
+              ),
+          ],
+        );
+      },
     );
   }
+
+  EdgeInsets _labelPadding({required bool isTopLabel}) => EdgeInsets.fromLTRB(
+    _PropertiesList.defaultItemPadding,
+    isTopLabel
+        ? _PropertiesList.defaultItemPadding
+        : _PropertiesList.denseItemPadding,
+    _PropertiesList.defaultItemPadding,
+    isTopLabel
+        ? _PropertiesList.denseItemPadding
+        : _PropertiesList.defaultItemPadding,
+  );
+
+  String _maybeTruncateLabel(String labelText, {required double width}) =>
+      width >= _widthForFullLabels ? labelText : labelText[0].toUpperCase();
 }
 
 class _PropertyInput extends StatelessWidget {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -118,17 +118,13 @@ class _PropertyLabels extends StatelessWidget {
 
   final EditableProperty property;
 
-  static const _widthForFullLabels = 60;
-
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
     final isSet = property.hasArgument;
     final isDefault = property.isDefault;
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        final width = constraints.maxWidth;
+
         return Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -136,28 +132,23 @@ class _PropertyLabels extends StatelessWidget {
               Padding(
                 padding: const EdgeInsets.all(_PropertiesList.itemPadding),
                 child: RoundedLabel(
-                  labelText: _maybeTruncateLabel('set', width: width),
+                  labelText: 'S',
                   backgroundColor: colorScheme.primary,
                   textColor: colorScheme.onPrimary,
                   tooltipText: 'Property argument is set.',
                 ),
               ),
             if (isDefault)
-              Padding(
-                padding: const EdgeInsets.all(_PropertiesList.itemPadding),
+              const Padding(
+                padding: EdgeInsets.all(_PropertiesList.itemPadding),
                 child: RoundedLabel(
-                  labelText: _maybeTruncateLabel('default', width: width),
+                  labelText: 'D',
                   tooltipText: 'Property argument matches the default value.',
                 ),
               ),
           ],
         );
-      },
-    );
   }
-
-  String _maybeTruncateLabel(String labelText, {required double width}) =>
-      width >= _widthForFullLabels ? labelText : labelText[0].toUpperCase();
 }
 
 class _PropertyInput extends StatelessWidget {

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
@@ -212,6 +212,7 @@ void main() {
         softWrapInput,
         menuOptions: ['true', 'false'],
         selectedOption: 'true',
+        defaultOption: 'true',
         tester: tester,
       );
     });
@@ -240,6 +241,7 @@ void main() {
           '.topRight',
         ],
         selectedOption: '.center',
+        defaultOption: '.bottomLeft',
         tester: tester,
       );
     });
@@ -584,6 +586,7 @@ Future<void> _verifyDropdownMenuItems(
   required List<String> menuOptions,
   required String selectedOption,
   required WidgetTester tester,
+  String? defaultOption,
 }) async {
   // Click button to open the options.
   await tester.tap(dropdownButton);
@@ -595,6 +598,17 @@ Future<void> _verifyDropdownMenuItems(
       of: find.text(menuOptionValue),
       matching: find.byType(DropdownMenuItem<String>),
     );
+    // Verify the default value has a label.
+    if (menuOptionValue == defaultOption) {
+      final defaultLabelFinder = find.descendant(
+        of: menuOptionFinder,
+        matching: find.descendant(
+          of: find.byType(RoundedLabel),
+          matching: find.text('D'),
+        ),
+      );
+      expect(defaultLabelFinder, findsOneWidget);
+    }
     if (menuOptionValue == selectedOption) {
       // Flutter renders two menu options for the selected option.
       expect(menuOptionFinder, findsNWidgets(2));

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor_test.dart
@@ -578,7 +578,7 @@ Finder _helperTextForInput(Finder inputFinder, {required String matching}) {
 
 Finder _findDropdownButtonFormField(String inputName) => find.ancestor(
   of: find.richTextContaining(inputName),
-  matching: find.byType(DropdownButtonFormField<String>),
+  matching: find.byType(DropdownButtonFormField),
 );
 
 Future<void> _verifyDropdownMenuItems(

--- a/packages/devtools_app_shared/lib/src/ui/common.dart
+++ b/packages/devtools_app_shared/lib/src/ui/common.dart
@@ -619,6 +619,7 @@ class RoundedLabel extends StatelessWidget {
     super.key,
     required this.labelText,
     this.backgroundColor,
+    this.fontSize,
     this.textColor,
     this.tooltipText,
   });
@@ -642,10 +643,10 @@ class RoundedLabel extends StatelessWidget {
         labelText,
         overflow: TextOverflow.clip,
         softWrap: false,
-        style: theme.regularTextStyleWithColor(
-          textColor ?? colorScheme.onSecondary,
-          backgroundColor: backgroundColor ?? colorScheme.secondary,
-        ),
+        style: theme.regularTextStyle.copyWith(
+            color: textColor ?? colorScheme.onSecondary,
+            backgroundColor: backgroundColor ?? colorScheme.secondary
+            fontSize: fontSize ?? defaultFontSize),
       ),
     );
     return tooltipText != null

--- a/packages/devtools_app_shared/lib/src/ui/common.dart
+++ b/packages/devtools_app_shared/lib/src/ui/common.dart
@@ -619,14 +619,15 @@ class RoundedLabel extends StatelessWidget {
     super.key,
     required this.labelText,
     this.backgroundColor,
-    this.fontSize,
     this.textColor,
+    this.fontSize,
     this.tooltipText,
   });
 
   final String labelText;
   final Color? backgroundColor;
   final Color? textColor;
+  final double? fontSize;
   final String? tooltipText;
 
   @override
@@ -645,7 +646,7 @@ class RoundedLabel extends StatelessWidget {
         softWrap: false,
         style: theme.regularTextStyle.copyWith(
             color: textColor ?? colorScheme.onSecondary,
-            backgroundColor: backgroundColor ?? colorScheme.secondary
+            backgroundColor: backgroundColor ?? colorScheme.secondary,
             fontSize: fontSize ?? defaultFontSize),
       ),
     );


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8713
Work towards https://github.com/flutter/devtools/issues/1948

Demo:
![default value](https://github.com/user-attachments/assets/8bfa63f3-d7fa-48a8-9901-476e2c24eb83)


Also updated formatting of labels to the side of the input so they match height of input:

<img width="275" alt="Screenshot 2025-02-18 at 9 53 01 AM" src="https://github.com/user-attachments/assets/0beb32e4-b1bc-4f35-9a4c-630729fa481d" />

<img width="158" alt="Screenshot 2025-02-18 at 9 53 10 AM" src="https://github.com/user-attachments/assets/23998bac-4d38-404d-8cb7-3608f6757b44" />
