### PR TITLE
Refactor BottomUpTransformer to do less deep copying

### DIFF
--- a/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
+++ b/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
@@ -221,14 +221,10 @@ final _benchmarkThresholds = {
       p90: _frameTimeFor60FPSInMicros,
     ),
   },
-  // Note that some of these benchmarks exceed the 60fps frame budget,
-  // especially the p90 benchmarks.
-  //
-  // See https://github.com/flutter/devtools/pull/8892 which exposes this.
   DevToolsBenchmark.offlinePerformanceScreen: {
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameTotalTime,
-      avg: _frameTimeFor60FPSInMicros * 1.5,
+      avg: _frameTimeFor60FPSInMicros,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),

--- a/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
+++ b/packages/devtools_app/benchmark/devtools_benchmarks_test.dart
@@ -173,50 +173,62 @@ void _verifyScoresAgainstThresholds(
 const _frameTimeFor60FPSInMicros = 16666.6;
 
 final _benchmarkThresholds = {
+  // Note that some of these benchmarks exceed the 60fps frame budget,
+  // especially the p90 benchmarks.
+  //
+  // See https://github.com/flutter/devtools/pull/8892 which exposes this.
   DevToolsBenchmark.navigateThroughOfflineScreens: {
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameTotalTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
-      p90: _frameTimeFor60FPSInMicros,
+      p90: _frameTimeFor60FPSInMicros * 6,
     ),
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameBuildTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameRasterTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),
   },
+  // Note that some of these benchmarks exceed the 60fps frame budget,
+  // especially the p90 benchmarks.
+  //
+  // See https://github.com/flutter/devtools/pull/8892 which exposes this.
   DevToolsBenchmark.offlineCpuProfilerScreen: {
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameTotalTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
-      p90: _frameTimeFor60FPSInMicros,
+      p90: _frameTimeFor60FPSInMicros * 6,
     ),
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameBuildTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameRasterTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 2,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),
   },
+  // Note that some of these benchmarks exceed the 60fps frame budget,
+  // especially the p90 benchmarks.
+  //
+  // See https://github.com/flutter/devtools/pull/8892 which exposes this.
   DevToolsBenchmark.offlinePerformanceScreen: {
     ..._valuesForMetric(
       BenchmarkMetric.flutterFrameTotalTime,
-      avg: _frameTimeFor60FPSInMicros,
+      avg: _frameTimeFor60FPSInMicros * 1.5,
       p50: _frameTimeFor60FPSInMicros,
       p90: _frameTimeFor60FPSInMicros,
     ),

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -693,13 +693,17 @@ class CpuProfileData with Serializable {
   List<CpuStackFrame> get bottomUpRoots {
     if (!processed) return <CpuStackFrame>[];
 
-    _bottomUpRoots ??= BottomUpTransformer<CpuStackFrame>().bottomUpRootsFor(
-      topDownRoot: _cpuProfileRoot,
-      mergeSamples: mergeCpuProfileRoots,
-      rootedAtTags: rootedAtTags,
-    );
-
     return _bottomUpRoots!;
+  }
+
+  Future<void> computeBottomUpRoots() async {
+    assert(_bottomUpRoots == null);
+    _bottomUpRoots = await BottomUpTransformer<CpuStackFrame>()
+        .bottomUpRootsFor(
+          topDownRoot: _cpuProfileRoot,
+          mergeSamples: mergeCpuProfileRoots,
+          rootedAtTags: rootedAtTags,
+        );
   }
 
   List<CpuStackFrame>? _bottomUpRoots;

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -99,6 +99,8 @@ class CpuProfileTransformer {
       '(${cpuProfileData.cpuProfileRoot.inclusiveSampleCount})',
     );
 
+    // We always show the bottom up roots first, so it is fine to eagerly
+    // compute.
     await cpuProfileData.computeBottomUpRoots();
 
     // Reset the transformer after processing.

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -175,7 +175,7 @@ Future<void> mergeCpuProfileRoots(
 }) async {
   stopwatch ??= Stopwatch()..start();
   if (stopwatch.elapsedMilliseconds > frameBudgetMs * 0.5) {
-    await delayToReleaseUiThread(micros: 2000);
+    await delayToReleaseUiThread(micros: 5000);
     stopwatch.reset();
   }
   final mergedRoots = <CpuStackFrame>[];

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_transformer.dart
@@ -13,6 +13,9 @@ class CpuProfileTransformer {
   /// Number of stack frames we will process in each batch.
   static const _defaultBatchSize = 100;
 
+  /// Number of ms per frame alloted to maintain 60fps.
+  static const _frameBudget = 16;
+
   int _stackFramesProcessed = 0;
 
   String? _activeProcessId;
@@ -50,9 +53,11 @@ class CpuProfileTransformer {
       watch.stop();
       // Avoid divide by zero
       final elapsedMs = math.max(watch.elapsedMilliseconds, 1);
-      // 16ms is the budget for 60fps, adjust to use less than half that so there
-      // is some budget left for other things.
-      batchSize = math.max((batchSize * 8 / elapsedMs).ceil(), 1);
+      // Adjust to use half the frame budget.
+      batchSize = math.max(
+        (batchSize * _frameBudget * 0.5 / elapsedMs).ceil(),
+        1,
+      );
 
       // Await a small delay to give the UI thread a chance to update the
       // progress indicator. Use a longer delay than the default (0) so that the

--- a/packages/devtools_app/lib/src/shared/constants.dart
+++ b/packages/devtools_app/lib/src/shared/constants.dart
@@ -19,3 +19,6 @@ const hotReloadIcon = Icons.electric_bolt_outlined;
 
 /// The icon used for Hot Restart.
 const hotRestartIcon = Icons.settings_backup_restore_outlined;
+
+/// Number of ms per frame alloted to maintain 60fps.
+const frameBudgetMs = 16;

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_transformer_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_transformer_test.dart
@@ -89,7 +89,7 @@ void main() {
       expect(testStackFrame.profileAsString(), testStackFrameStringGolden);
       final bottomUpRoots = transformer.generateBottomUpRoots(
         node: testStackFrame,
-        currentBottomUpRoot: null,
+        parent: null,
         bottomUpRoots: [],
       );
 
@@ -122,7 +122,7 @@ void main() {
     test('processData step by step when skipping the root node', () {
       final bottomUpRoots = transformer.generateBottomUpRoots(
         node: testStackFrameWithRoot,
-        currentBottomUpRoot: null,
+        parent: null,
         bottomUpRoots: [],
         skipRoot: true,
       );

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_transformer_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_transformer_test.dart
@@ -85,9 +85,9 @@ void main() {
       );
     });
 
-    test('processData step by step', () {
+    test('processData step by step', () async {
       expect(testStackFrame.profileAsString(), testStackFrameStringGolden);
-      final bottomUpRoots = transformer.generateBottomUpRoots(
+      final bottomUpRoots = await transformer.generateBottomUpRoots(
         node: testStackFrame,
         parent: null,
         bottomUpRoots: [],
@@ -108,7 +108,7 @@ void main() {
       expect(buf.toString(), bottomUpPreMergeGolden);
 
       // Merge the bottom up roots.
-      mergeCpuProfileRoots(bottomUpRoots);
+      await mergeCpuProfileRoots(bottomUpRoots);
 
       expect(bottomUpRoots.length, 4);
 
@@ -119,8 +119,8 @@ void main() {
       expect(buf.toString(), bottomUpGolden);
     });
 
-    test('processData step by step when skipping the root node', () {
-      final bottomUpRoots = transformer.generateBottomUpRoots(
+    test('processData step by step when skipping the root node', () async {
+      final bottomUpRoots = await transformer.generateBottomUpRoots(
         node: testStackFrameWithRoot,
         parent: null,
         bottomUpRoots: [],
@@ -139,7 +139,7 @@ void main() {
       expect(buf.toString(), bottomUpPreMergeGolden);
 
       // Merge the bottom up roots.
-      mergeCpuProfileRoots(bottomUpRoots);
+      await mergeCpuProfileRoots(bottomUpRoots);
 
       expect(bottomUpRoots.length, 4);
 
@@ -150,12 +150,12 @@ void main() {
       expect(buf.toString(), bottomUpGolden);
     });
 
-    test('bottomUpRootsFor', () {
+    test('bottomUpRootsFor', () async {
       expect(
         testStackFrameWithRoot.profileAsString(),
         testStackFrameWithRootStringGolden,
       );
-      final bottomUpRoots = transformer.bottomUpRootsFor(
+      final bottomUpRoots = await transformer.bottomUpRootsFor(
         topDownRoot: testStackFrameWithRoot,
         mergeSamples: mergeCpuProfileRoots,
         rootedAtTags: false,
@@ -176,7 +176,7 @@ void main() {
       expect(buf.toString(), bottomUpGolden);
     });
 
-    test('bottomUpRootsFor rootedAtTags', () {
+    test('bottomUpRootsFor rootedAtTags', () async {
       expect(
         testTagRootedStackFrame.profileAsString(),
         testTagRootedStackFrameStringGolden,
@@ -184,7 +184,7 @@ void main() {
 
       // Note: this needs to be rooted at a root frame before transforming as
       // a tree rooted at a root frame is what is provided in cpu_profile_model.dart.
-      final bottomUpRoots = transformer.bottomUpRootsFor(
+      final bottomUpRoots = await transformer.bottomUpRootsFor(
         topDownRoot: CpuStackFrame.root(zeroProfileMetaData)
           ..addChild(testTagRootedStackFrame),
         mergeSamples: mergeCpuProfileRoots,


### PR DESCRIPTION
Follow up to https://github.com/flutter/devtools/pull/8885

We only actually need to deep copy nodes when they are bottom up roots - in the other cases we can just add the shallow copy as the child instead.

Reduces time to calculate bottom up roots on my 75MB example trace from 3.5s to <0.5 s. Merging them after is still slow, takes about 0.75s, so we spend close to 1.5s in total in the BottomUpTransformer still, all of which happens in one frame so it janks the UI for that long.

I might try and push an additional change here to make this happen  more eagerly,  but asynchronously in batches, similar to how the original processing happens.