### PR TITLE
Include referrers in memory snapshots

### DIFF
--- a/packages/devtools_app/lib/src/screens/memory/shared/primitives/memory_utils.dart
+++ b/packages/devtools_app/lib/src/screens/memory/shared/primitives/memory_utils.dart
@@ -12,7 +12,6 @@ Future<HeapSnapshotGraph?> snapshotMemoryInSelectedIsolate() async {
   if (isolate == null) return null;
   return await serviceConnection.serviceManager.service?.getHeapSnapshotGraph(
     isolate,
-    calculateReferrers: false,
     decodeExternalProperties: false,
     decodeObjectData: false,
   );

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -31,7 +31,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## Memory updates
 
-TODO: Remove this section if there are not any general updates.
+* Changed memory heap snapshot tool so that references are included in snapshots
+by default. - [#8899](https://github.com/flutter/devtools/pull/8899)
 
 ## Debugger updates
 


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8895 so that we can see references in memory heap snapshots. Without this information, it is almost impossible to track down a memory leak.