### PR TITLE
[Inspector V2] Fix bug preventing us from capturing initial load time for the V2 inspector 

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -1006,6 +1006,7 @@ class _InspectorTreeState extends State<InspectorTree>
     if (!controller.firstInspectorTreeLoadCompleted && widget.isSummaryTree) {
       final screenId = widget.screenId;
       if (screenId != null) {
+        print('LEGACY ROW COUNT: ${treeControllerLocal.numRows}');
         ga.timeEnd(
           screenId,
           gac.pageReady,

--- a/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector/inspector_tree_controller.dart
@@ -1006,7 +1006,6 @@ class _InspectorTreeState extends State<InspectorTree>
     if (!controller.firstInspectorTreeLoadCompleted && widget.isSummaryTree) {
       final screenId = widget.screenId;
       if (screenId != null) {
-        print('LEGACY ROW COUNT: ${treeControllerLocal.numRows}');
         ga.timeEnd(
           screenId,
           gac.pageReady,

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -393,6 +393,11 @@ class InspectorController extends DisposableController
       // We do not want to complete this timing operation because the manual
       // refresh will skew the results.
       ga.cancelTimingOperation(InspectorScreen.id, gac.pageReady);
+      ga.select(
+        gac.inspector,
+        gac.refreshEmptyTree,
+        screenMetricsProvider: () => InspectorScreenMetrics.v2(),
+      );
       firstInspectorTreeLoadCompleted = true;
     }
     await onForceRefresh();

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_controller.dart
@@ -385,19 +385,14 @@ class InspectorController extends DisposableController
     return _waitForPendingUpdateDone();
   }
 
-  Future<void> refreshInspector() async {
-    // If the user is force refreshing the inspector before the first load has
-    // completed, this could indicate a slow load time or that the inspector
+  Future<void> refreshInspector({bool isManualRefresh = false}) async {
+    // If the user is manually refreshing the inspector before the first load
+    // has completed, this could indicate a slow load time or that the inspector
     // failed to load the tree once available.
-    if (!firstInspectorTreeLoadCompleted) {
-      // We do not want to complete this timing operation because the force
+    if (isManualRefresh && !firstInspectorTreeLoadCompleted) {
+      // We do not want to complete this timing operation because the manual
       // refresh will skew the results.
       ga.cancelTimingOperation(InspectorScreen.id, gac.pageReady);
-      ga.select(
-        gac.inspector,
-        gac.refreshEmptyTree,
-        screenMetricsProvider: () => InspectorScreenMetrics.v2(),
-      );
       firstInspectorTreeLoadCompleted = true;
     }
     await onForceRefresh();

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_body.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_body.dart
@@ -107,7 +107,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     addAutoDisposeListener(preferences.inspector.pubRootDirectories, () {
       if (serviceConnection.serviceManager.connectedState.value.connected &&
           controller.firstInspectorTreeLoadCompleted) {
-        _refreshInspector();
+        controller.refreshInspector();
       }
     });
 
@@ -152,7 +152,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
               InspectorTreeControls(
                 isSearchVisible: searchVisible,
                 constraints: constraints,
-                onRefreshInspectorPressed: _refreshInspector,
+                onRefreshInspectorPressed: _manualInspectorRefresh,
                 onSearchVisibleToggle: _onSearchVisibleToggle,
                 searchFieldBuilder:
                     () => StatelessSearchField<InspectorTreeRow>(
@@ -219,7 +219,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     _inspectorTreeController.resetSearch();
   }
 
-  void _refreshInspector() {
+  void _manualInspectorRefresh() {
     ga.select(
       gac.inspector,
       gac.refresh,
@@ -227,7 +227,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     );
     unawaited(
       blockWhileInProgress(() async {
-        await controller.refreshInspector();
+        await controller.refreshInspector(isManualRefresh: true);
       }),
     );
   }


### PR DESCRIPTION
I noticed in our analytics we didn't have any analytics for the load time of the new inspector. That's because the timing operation was being canceled in the call to `refreshInspector`.
