### PR TITLE
Ensure TextPainters are disposed when possible.

### DIFF
--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -901,6 +901,7 @@ class ChartAxisPainter extends CustomPainter {
             baselineAdjust,
       ),
     );
+    textPainter.dispose();
   }
 
   @override
@@ -953,19 +954,20 @@ class FPSLinePainter extends CustomPainter {
       Paint()..color = themeData.colorScheme.chartAccentColor,
     );
 
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: '${displayRefreshRate.toStringAsFixed(0)} FPS',
-        style: themeData.subtleChartTextStyle,
-      ),
-      textAlign: TextAlign.right,
-      textDirection: TextDirection.ltr,
-    )..layout();
-
-    textPainter.paint(
-      canvas,
-      Offset(chartArea.right - fpsTextSpace, targetLineY + borderPadding),
-    );
+    TextPainter(
+        text: TextSpan(
+          text: '${displayRefreshRate.toStringAsFixed(0)} FPS',
+          style: themeData.subtleChartTextStyle,
+        ),
+        textAlign: TextAlign.right,
+        textDirection: TextDirection.ltr,
+      )
+      ..layout()
+      ..paint(
+        canvas,
+        Offset(chartArea.right - fpsTextSpace, targetLineY + borderPadding),
+      )
+      ..dispose();
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/charts/chart.dart
+++ b/packages/devtools_app/lib/src/shared/charts/chart.dart
@@ -360,7 +360,7 @@ class ChartPainter extends CustomPainter {
         // Draw the X-axis labels.
         for (final timestamp in chartController.labelTimestamps) {
           final xCoord = chartController.timestampToXCanvasCoord(timestamp);
-          drawXTick(canvas, timestamp, xCoord, axis, displayTime: true);
+          _drawXTick(canvas, timestamp, xCoord, axis);
         }
       });
 
@@ -380,7 +380,7 @@ class ChartPainter extends CustomPainter {
       });
     }
 
-    drawTitle(canvas, size, chartController.title);
+    _drawTitle(canvas, size, chartController.title);
 
     final elapsedTime = DateTime.now().difference(startTime).inMilliseconds;
     if (debugTrackPaintTime && elapsedTime > 500) {
@@ -410,9 +410,10 @@ class ChartPainter extends CustomPainter {
   }
 
   // TODO(terry): Use drawText?
-  void drawTitle(Canvas canvas, Size size, String title) {
-    final tp = createText(title, 1.5);
+  void _drawTitle(Canvas canvas, Size size, String title) {
+    final tp = _createText(title, 1.5);
     tp.paint(canvas, Offset(size.width / 2 - tp.width / 2, 0));
+    tp.dispose();
   }
 
   void drawAxes(
@@ -470,7 +471,7 @@ class ChartPainter extends CustomPainter {
       );
 
       // Label starts at left edge.
-      drawText(labelName, canvas, -chartController.xCanvasChart / 2, yCoord);
+      _drawText(labelName, canvas, -chartController.xCanvasChart / 2, yCoord);
 
       // Draw horizontal tick 6 pixels from Y-axis line.
       canvas.drawLine(Offset(0, yCoord), Offset(-6, yCoord), axis);
@@ -524,36 +525,22 @@ class ChartPainter extends CustomPainter {
     return label == 0 ? '0' : '$label$unit';
   }
 
-  void drawXTick(
-    Canvas canvas,
-    int timestamp,
-    double xTickCoord,
-    Paint axis, {
-    bool shortTick = true,
-    bool displayTime = false,
-  }) {
-    if (displayTime) {
-      // Draw vertical tick (short or long).
-      canvas.drawLine(
-        Offset(xTickCoord, 0),
-        Offset(xTickCoord, shortTick ? 2 : 6),
-        axis,
-      );
+  void _drawXTick(Canvas canvas, int timestamp, double xTickCoord, Paint axis) {
+    // Draw vertical tick (short or long).
+    canvas.drawLine(Offset(xTickCoord, 0), Offset(xTickCoord, 2), axis);
 
-      final tp = createText(prettyTimestamp(timestamp), 1);
-      tp.paint(
-        canvas,
-        Offset(xTickCoord - tp.width ~/ 2, 15.0 - tp.height ~/ 2),
-      );
-    }
+    final tp = _createText(prettyTimestamp(timestamp), 1);
+    tp.paint(canvas, Offset(xTickCoord - tp.width ~/ 2, 15.0 - tp.height ~/ 2));
+    tp.dispose();
   }
 
-  void drawText(String textValue, Canvas canvas, double x, double y) {
-    final tp = createText(textValue, 1);
+  void _drawText(String textValue, Canvas canvas, double x, double y) {
+    final tp = _createText(textValue, 1);
     tp.paint(canvas, Offset(x + -tp.width / 2, y - tp.height / 2));
+    tp.dispose();
   }
 
-  TextPainter createText(String textValue, double scale) {
+  TextPainter _createText(String textValue, double scale) {
     final span = TextSpan(
       // TODO(terry): All text in a chart is grey. A chart like a Trace
       //              should have PaintCharacteristics.

--- a/packages/devtools_app/lib/src/shared/charts/flame_chart.dart
+++ b/packages/devtools_app/lib/src/shared/charts/flame_chart.dart
@@ -1389,6 +1389,7 @@ class TimelineGridPainter extends FlameChartPainter {
     if (xOffset > 0) {
       textPainter.paint(canvas, Offset(xOffset, rowPadding));
     }
+    textPainter.dispose();
   }
 
   void _paintGridLine(Canvas canvas, double lineX) {

--- a/packages/devtools_app/lib/src/shared/charts/treemap.dart
+++ b/packages/devtools_app/lib/src/shared/charts/treemap.dart
@@ -893,6 +893,7 @@ class MultiCellPainter extends CustomPainter {
       final centerY =
           positionedCell.top! + bounds.height / 2 - textPainter.height / 2;
       textPainter.paint(canvas, Offset(centerX, centerY));
+      textPainter.dispose();
     }
   }
 

--- a/packages/devtools_app/lib/src/shared/framework/screen.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen.dart
@@ -16,6 +16,7 @@ import '../feature_flags.dart';
 import '../globals.dart';
 import '../primitives/listenable.dart';
 import '../ui/icons.dart';
+import '../ui/utils.dart';
 
 final _log = Logger('screen.dart');
 
@@ -355,12 +356,9 @@ abstract class Screen {
     bool includeTabBarSpacing = true,
   }) {
     final title = _userFacingTitle;
-    final painter = TextPainter(
-      text: TextSpan(text: title),
-      textDirection: TextDirection.ltr,
-    )..layout();
+    final textWidth = calculateTextSpanWidth(TextSpan(text: title));
     const measurementBuffer = 1.0;
-    return painter.width +
+    return textWidth +
         denseSpacing +
         defaultIconSize +
         (includeTabBarSpacing ? tabBarSpacing * 2 : 0.0) +
@@ -408,15 +406,10 @@ abstract class Screen {
 
         if (count > 0) {
           // Calculate the width of the title text so that we can provide an accurate
-          // size for the [BadgePainter]
-          final painter = TextPainter(
-            text: TextSpan(
-              text: title,
-              style: Theme.of(context).regularTextStyle,
-            ),
-            textDirection: TextDirection.ltr,
-          )..layout();
-          final titleWidth = painter.width;
+          // size for the [BadgePainter].
+          final titleWidth = calculateTextSpanWidth(
+            TextSpan(text: title, style: Theme.of(context).regularTextStyle),
+          );
 
           return LayoutBuilder(
             builder: (context, constraints) {
@@ -604,6 +597,7 @@ class BadgePainter extends CustomPainter {
       canvas,
       Offset(size.width + (badgeWidth - countPainter.width) / 2, 0),
     );
+    countPainter.dispose();
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/ui/hover.dart
+++ b/packages/devtools_app/lib/src/shared/ui/hover.dart
@@ -28,7 +28,7 @@ TextStyle get _hoverTitleTextStyle => fixBlurryText(
 final _identifier = RegExp(r'^[a-zA-Z0-9]|_|\$');
 
 /// Returns the word in the [line] for the provided hover [dx] offset given
-/// the [line]'s [textStyle].
+/// the [line]'s `textStyle`.
 String wordForHover(double dx, TextSpan line) {
   String word = '';
   final hoverIndex = _hoverIndexFor(dx, line);
@@ -85,17 +85,14 @@ bool isPrimitiveValueOrNull(String valueAsString) {
   return isNull || isBool || isInt || isDouble || isString;
 }
 
-/// Returns the index in the Textspan's plainText for which the hover offset is
-/// located.
+/// Returns the index in the [TextSpan]'s `plainText` for which the hover offset
+/// is located.
 int _hoverIndexFor(double dx, TextSpan line) {
   int hoverIndex = -1;
   final length = line.toPlainText().length;
   for (var i = 0; i < length; i++) {
-    final painter = TextPainter(
-      text: truncateTextSpan(line, i + 1),
-      textDirection: TextDirection.ltr,
-    )..layout();
-    if (dx <= painter.width) {
+    final textWidth = calculateTextSpanWidth(truncateTextSpan(line, i + 1));
+    if (dx <= textWidth) {
       hoverIndex = i;
       break;
     }

--- a/packages/devtools_app/lib/src/shared/ui/utils.dart
+++ b/packages/devtools_app/lib/src/shared/ui/utils.dart
@@ -48,14 +48,16 @@ TextSpan truncateTextSpan(TextSpan span, int length) {
 }
 
 /// Returns the width in pixels of the [span].
-double calculateTextSpanWidth(TextSpan? span) {
+double calculateTextSpanWidth(TextSpan span) {
   final textPainter = TextPainter(
     text: span,
     textAlign: TextAlign.left,
     textDirection: TextDirection.ltr,
   )..layout();
+  final width = textPainter.width;
+  textPainter.dispose();
 
-  return textPainter.width;
+  return width;
 }
 
 /// Returns the height in pixels of the [span].
@@ -78,9 +80,10 @@ double calculateTextSpanHeight(TextSpan span, {double? maxWidth}) {
   return calculateTextSpanSize(span, maxWidth: maxWidth).height;
 }
 
-TextSpan? findLongestTextSpan(List<TextSpan> spans) {
-  int longestLength = 0;
-  TextSpan? longestSpan;
+TextSpan findLongestTextSpan(List<TextSpan> spans) {
+  assert(spans.isNotEmpty, 'Cannot find longest text span of 0 spans.');
+  var longestSpan = spans.removeAt(0);
+  var longestLength = longestSpan.toPlainText().length;
   for (final span in spans) {
     final currentLength = span.toPlainText().length;
     if (currentLength > longestLength) {


### PR DESCRIPTION
There are a few ways in which TextPainters are used:

* To get the width of what would be rendered; in this case, we delegate all implementations to calculateTextSpanWidth. We then `dispose` the TextPainter in that function.
* To instantiate, layout, and paint exactly once; in this case, we `dispose` immediately after painting, as the documentation says we should.
* To be passed to a CustomPainter. in these cases, I think it is not safe to immediately dispose. I'm not sure what the expected workflow is.

Work towards https://github.com/flutter/devtools/issues/5888

