### PR TITLE
Update string_scanner to 1.4

### DIFF
--- a/packages/devtools_app/pubspec.yaml
+++ b/packages/devtools_app/pubspec.yaml
@@ -50,7 +50,7 @@ dependencies:
   source_maps: ^0.10.12
   sse: ^4.1.2
   stack_trace: ^1.12.0
-  string_scanner: ^1.1.0
+  string_scanner: ^1.4.0
   unified_analytics: ^7.0.0
   vm_service: '>=15.0.0 <16.0.0'
   vm_service_protos: ^1.0.0

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -41,6 +41,9 @@ by default. - [#8899](https://github.com/flutter/devtools/pull/8899)
 * Updated syntax highlighting with support for digit separators,
   and improved comment and string interpolation handling. -
   [#8861](https://github.com/flutter/devtools/pull/8861)
+* Updated `string_scanner` dependency to avoid some syntax highlighting issues
+  when source contains `\r\n` in certain positions on Windows. -
+  [#8904](https://github.com/flutter/devtools/pull/8904)
 * Added soft line wrapping in the debugger console.
   [#8855](https://github.com/flutter/devtools/pull/8855).
 


### PR DESCRIPTION
string_scanner 1.4 includes a fix for some issues with handling \r\n's on Windows when using the latest version of the grammar ([which was updated in DevTools recently](https://github.com/flutter/devtools/pull/8861)). This just bumps the minimum version to ensure we always get that fix.

See:
- https://pub.dev/packages/string_scanner/changelog#140
- https://github.com/dart-lang/string_scanner/pull/81
- https://github.com/dart-lang/tools/issues/1797

