### PR TITLE
 Add `DisposableController.init` method and `DisposableController.disposed` getter.

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -100,6 +100,7 @@ class _ExtensionIFrameController extends DisposableController
   /// leaking listeners when an extension is disabled and re-enabled.
   EventListener? _handleMessageListener;
 
+  @override
   void init() {
     _iFrameReady = Completer<void>();
     _extensionHandlerReady = Completer<void>();

--- a/packages/devtools_app/lib/src/extensions/embedded/controller.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/controller.dart
@@ -20,8 +20,6 @@ abstract class EmbeddedExtensionController extends DisposableController {
 
   final DevToolsExtensionConfig extensionConfig;
 
-  void init() {}
-
   void postMessage(
     DevToolsExtensionEventType type, {
     Map<String, String> data = const <String, String>{},

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
@@ -44,6 +44,7 @@ class ChartVmConnection extends DisposableController
   ///
   /// This method should be called without async gap after validation that
   /// the application is still connected.
+  @override
   void init() {
     if (initialized) return;
 

--- a/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/controls/enhance_tracing/enhance_tracing_controller.dart
@@ -68,6 +68,7 @@ class EnhanceTracingController extends DisposableController
         });
   }
 
+  @override
   void init() {
     for (int i = 0; i < enhanceTracingExtensions.length; i++) {
       final extension = enhanceTracingExtensions[i];

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/_perfetto_web.dart
@@ -135,6 +135,7 @@ class _PerfettoViewController extends DisposableController
   /// removed in [dispose].
   EventListener? _handleMessageListener;
 
+  @override
   void init() {
     _perfettoIFrameReady = Completer<void>();
     _perfettoHandlerReady = Completer<void>();

--- a/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/timeline_events/perfetto/perfetto_controller.dart
@@ -39,8 +39,6 @@ abstract class PerfettoController extends DisposableController {
   /// For non-flutter apps, this processor will not be used.
   late final FlutterTimelineEventProcessor processor;
 
-  void init() {}
-
   void onBecomingActive() {}
 
   Future<void> loadTrace(Uint8List traceBinary) async {}

--- a/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_controller.dart
@@ -280,8 +280,6 @@ abstract class PerformanceFeatureController extends DisposableController {
 
   void onBecomingActive();
 
-  Future<void> init();
-
   Future<void> setOfflineData(OfflinePerformanceData offlineData);
 
   FutureOr<void> clearData();

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/object_inspector_view_controller.dart
@@ -49,6 +49,7 @@ class ObjectInspectorViewController extends DisposableController
 
   bool _initialized = false;
 
+  @override
   Future<void> init() async {
     if (!_initialized) {
       await programExplorerController.initialize();

--- a/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
@@ -104,5 +104,6 @@ class _LazyController<T extends DevToolsScreenController> {
 
 /// Base class for all DevTools screen controllers.
 abstract class DevToolsScreenController extends DisposableController {
-  void init() {}
+  @override
+  void init();
 }

--- a/packages/devtools_app/lib/src/shared/preferences/_cpu_profiler_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_cpu_profiler_preferences.dart
@@ -14,6 +14,7 @@ class CpuProfilerPreferencesController extends DisposableController
   @visibleForTesting
   static const filterStorageId = 'cpuProfiler.filter';
 
+  @override
   Future<void> init() async {
     filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(

--- a/packages/devtools_app/lib/src/shared/preferences/_extension_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_extension_preferences.dart
@@ -12,6 +12,7 @@ class ExtensionsPreferencesController extends DisposableController
       '${gac.DevToolsExtensionEvents.extensionScreenId}.'
       '${gac.DevToolsExtensionEvents.showOnlyEnabledExtensionsSetting.name}';
 
+  @override
   Future<void> init() async {
     addAutoDisposeListener(showOnlyEnabledExtensions, () {
       storage.setValue(

--- a/packages/devtools_app/lib/src/shared/preferences/_inspector_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_inspector_preferences.dart
@@ -80,6 +80,7 @@ class InspectorPreferencesController extends DisposableController
     _mainScriptDir = rootLibDirectory.path;
   }
 
+  @override
   Future<void> init() async {
     await _initHoverEvalMode();
     await _initLegacyInspectorEnabled();

--- a/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_logging_preferences.dart
@@ -33,6 +33,7 @@ class LoggingPreferencesController extends DisposableController
   @visibleForTesting
   static const filterStorageId = 'logging.filter';
 
+  @override
   Future<void> init() async {
     retentionLimit.value =
         int.tryParse(await storage.getValue(_retentionLimitStorageId) ?? '') ??

--- a/packages/devtools_app/lib/src/shared/preferences/_memory_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_memory_preferences.dart
@@ -23,6 +23,7 @@ class MemoryPreferencesController extends DisposableController
   static const _defaultRefLimit = 100000;
   static const _refLimitStorageId = 'memory.refLimit';
 
+  @override
   Future<void> init() async {
     addAutoDisposeListener(androidCollectionEnabled, () {
       storage.setValue(

--- a/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_network_preferences.dart
@@ -14,6 +14,7 @@ class NetworkPreferencesController extends DisposableController
   @visibleForTesting
   static const filterStorageId = 'network.filter';
 
+  @override
   Future<void> init() async {
     filterTag.value = await storage.getValue(filterStorageId) ?? '';
     addAutoDisposeListener(

--- a/packages/devtools_app/lib/src/shared/preferences/_performance_preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/_performance_preferences.dart
@@ -19,6 +19,7 @@ class PerformancePreferencesController extends DisposableController
   static final _includeCpuSamplesInTimelineId =
       '${gac.performance}.${gac.PerformanceEvents.includeCpuSamplesInTimeline.name}';
 
+  @override
   Future<void> init() async {
     addAutoDisposeListener(showFlutterFramesChart, () {
       storage.setValue(

--- a/packages/devtools_app/lib/src/shared/preferences/preferences.dart
+++ b/packages/devtools_app/lib/src/shared/preferences/preferences.dart
@@ -104,6 +104,7 @@ class PreferencesController extends DisposableController
   PerformancePreferencesController get performance => _performance;
   final _performance = PerformancePreferencesController();
 
+  @override
   Future<void> init() async {
     // Get the current values and listen for and write back changes.
     await _initDarkMode();

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/extensions_view.dart
@@ -54,7 +54,7 @@ class _SidebarDevToolsExtensionsState extends State<SidebarDevToolsExtensions>
   @override
   void initState() {
     super.initState();
-    unawaited(sidebarExtensionsController.init(widget.debugSessions));
+    unawaited(sidebarExtensionsController.initialize(widget.debugSessions));
     addAutoDisposeListener(sidebarExtensionsController.uniqueExtensions);
   }
 

--- a/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/sidebar_extensions_controller.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/vs_code/devtools/sidebar_extensions_controller.dart
@@ -92,7 +92,9 @@ class SidebarDevToolsExtensionsController extends DisposableController
 
   final _initialized = Completer<bool>();
 
-  Future<void> init(Map<String, EditorDebugSession> debugSessions) async {
+  // This method does not override [DisposableController.init] because it has
+  // an additional parameter.
+  Future<void> initialize(Map<String, EditorDebugSession> debugSessions) async {
     _debugSessions = debugSessions;
     await _initExtensionsForWorkspace();
     await _initExtensionsForDebugSessions();

--- a/packages/devtools_app_shared/CHANGELOG.md
+++ b/packages/devtools_app_shared/CHANGELOG.md
@@ -3,6 +3,10 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.3.2 (not released)
+* Add `DisposableController.init` method and `DisposableController.disposed`
+getter.
+
 ## 0.3.1
 * Bump `vm_service` dependency to `>=13.0.0 <16.0.0`.
 

--- a/packages/devtools_app_shared/example/utils/auto_dispose_example.dart
+++ b/packages/devtools_app_shared/example/utils/auto_dispose_example.dart
@@ -83,9 +83,19 @@ class MyController extends DisposableController
 
   final ValueNotifier<String> notifier;
 
+  final otherNotifierICreated = ValueNotifier<bool>(false);
+
+  @override
   void init() {
     addAutoDisposeListener(notifier, () {
-      // Do something.
+      otherNotifierICreated.value = notifier.value == 'expected value';
     });
+  }
+
+  @override
+  void dispose() {
+    // dispose anything that [MyController] created that needs to be cleaned up.
+    otherNotifierICreated.dispose();
+    super.dispose();
   }
 }

--- a/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
+++ b/packages/devtools_app_shared/lib/src/service/eval_on_dart_library.dart
@@ -85,14 +85,10 @@ class EvalOnDartLibrary extends DisposableController
     }
   }
 
-  bool get disposed => _disposed;
-  bool _disposed = false;
-
   @override
   void dispose() {
     _dartDeveloperEvalCache?.dispose();
     _widgetInspectorEvalCache?.dispose();
-    _disposed = true;
     super.dispose();
   }
 
@@ -207,7 +203,7 @@ class EvalOnDartLibrary extends DisposableController
     required Map<String, String>? scope,
     bool shouldLogError = true,
   }) async {
-    if (_disposed) return null;
+    if (disposed) return null;
 
     try {
       final libraryRef = await _waitForLibraryRef();
@@ -239,7 +235,7 @@ class EvalOnDartLibrary extends DisposableController
     List<String> argRefs, {
     bool shouldLogError = true,
   }) async {
-    if (_disposed) return null;
+    if (disposed) return null;
 
     try {
       final result = await service.invoke(
@@ -265,7 +261,7 @@ class EvalOnDartLibrary extends DisposableController
   }
 
   void _handleError(Object e, StackTrace stack) {
-    if (_disposed || !logExceptions) return;
+    if (disposed || !logExceptions) return;
 
     if (e is RPCError) {
       _log.shout('RPCError: $e', e, stack);
@@ -571,19 +567,19 @@ class EvalOnDartLibrary extends DisposableController
     final response = Completer<T?>();
     // This is an optimization to avoid sending stale requests across the wire.
     void wrappedRequest() async {
-      if (isAlive != null && isAlive.disposed || _disposed) {
+      if (isAlive != null && isAlive.disposed || disposed) {
         response.complete(null);
         return;
       }
       try {
         final value = await request();
-        if (!_disposed && value is! Sentinel) {
+        if (!disposed && value is! Sentinel) {
           response.complete(value);
         } else {
           response.complete(null);
         }
       } catch (e) {
-        if (_disposed || isAlive?.disposed == true) {
+        if (disposed || isAlive?.disposed == true) {
           response.complete(null);
         } else {
           response.completeError(e);
@@ -595,7 +591,7 @@ class EvalOnDartLibrary extends DisposableController
       allPendingRequestsDone = response;
       wrappedRequest();
     } else {
-      if (isAlive != null && isAlive.disposed || _disposed) {
+      if (isAlive != null && isAlive.disposed || disposed) {
         response.complete(null);
         return response.future;
       }
@@ -606,7 +602,7 @@ class EvalOnDartLibrary extends DisposableController
       try {
         await previousDone;
       } catch (e, st) {
-        if (!_disposed) {
+        if (!disposed) {
           _log.shout(e, e, st);
         }
       }

--- a/packages/devtools_app_shared/lib/src/utils/auto_dispose.dart
+++ b/packages/devtools_app_shared/lib/src/utils/auto_dispose.dart
@@ -243,8 +243,16 @@ mixin DisposerMixin {
 
 /// Base class for controllers that need to manage their lifecycle.
 abstract class DisposableController {
+  void init() {}
+
+  bool get disposed => _disposed;
+
+  bool _disposed = false;
+
   @mustCallSuper
-  void dispose() {}
+  void dispose() {
+    _disposed = true;
+  }
 }
 
 /// Mixin to simplifying managing the lifetime of listeners used by a

--- a/packages/devtools_app_shared/pubspec.yaml
+++ b/packages/devtools_app_shared/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_app_shared
 description: Package of Dart & Flutter structures shared between devtools_app and devtools extensions.
-version: 0.3.1
+version: 0.3.2
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_app_shared
 
 environment:

--- a/packages/devtools_extensions/CHANGELOG.md
+++ b/packages/devtools_extensions/CHANGELOG.md
@@ -3,6 +3,9 @@ Copyright 2025 The Flutter Authors
 Use of this source code is governed by a BSD-style license that can be
 found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 -->
+## 0.3.2 (not released)
+* Bump `devtools_app_shared` dependency to `0.3.2`.
+
 ## 0.3.1
 * Bump `vm_service` dependency to `>=13.0.0 <16.0.0`.
 

--- a/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_controller.dart
+++ b/packages/devtools_extensions/lib/src/template/_simulated_devtools_environment/_simulated_devtools_controller.dart
@@ -19,6 +19,7 @@ class SimulatedDevToolsController extends DisposableController
   /// removed in [dispose].
   EventListener? _handleMessageListener;
 
+  @override
   void init() {
     window.addEventListener(
       'message',

--- a/packages/devtools_extensions/pubspec.yaml
+++ b/packages/devtools_extensions/pubspec.yaml
@@ -3,7 +3,7 @@
 # found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 name: devtools_extensions
 description: A package for building and supporting extensions for Dart DevTools.
-version: 0.3.1
+version: 0.3.2
 
 repository: https://github.com/flutter/devtools/tree/master/packages/devtools_extensions
 
@@ -19,7 +19,7 @@ executables:
 dependencies:
   args: ^2.4.2
   devtools_shared: ^11.1.0
-  devtools_app_shared: ^0.3.0
+  devtools_app_shared: ^0.3.2
   flutter:
     sdk: flutter
   io: ^1.0.4


### PR DESCRIPTION
Prerequisite work for fixing memory leaks across DevTools