### PR TITLE
Dispose all disposables in the Network screen

### DIFF
--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_tree_controller.dart
@@ -1295,7 +1295,7 @@ class _RowPainter extends CustomPainter {
       final width =
           showExpandCollapse
               ? inspectorColumnIndent * 0.45
-              : inspectorColumnIndent * .6;
+              : inspectorColumnIndent * 0.6;
       canvas.drawLine(
         Offset(parentExpandCollapseX, 0.0),
         Offset(parentExpandCollapseX, inspectorRowHeight * 0.5),

--- a/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
+++ b/packages/devtools_app/lib/src/screens/memory/panes/chart/controller/chart_connection.dart
@@ -79,7 +79,9 @@ class ChartVmConnection extends DisposableController
       ),
     );
 
-    _polling = DebounceTimer.periodic(chartUpdateDelay, () async {
+    _polling = DebounceTimer.periodic(chartUpdateDelay, ({
+      DebounceCancelledCallback? cancelledCallback,
+    }) async {
       if (!_isConnected) {
         _polling?.cancel();
         return;

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -45,24 +45,22 @@ enum NetworkResponseViewType {
 
 enum _NetworkTrafficType { http, socket }
 
+/// Screen controller for the Network screen.
+///
+/// This controller can be accessed from anywhere in DevTools, as long as it was
+/// first registered, by
+/// calling `screenControllers.lookup<NetworkController>()`.
+///
+/// The controller lifecycle is managed by the [ScreenControllers] class. The
+/// `init` method is called lazily upon the first controller access from
+/// `screenControllers`. The `dispose` method is called by `screenControllers`
+/// when DevTools is destroying a set of DevTools screen controllers.
 class NetworkController extends DevToolsScreenController
     with
         SearchControllerMixin<NetworkRequest>,
         FilterControllerMixin<NetworkRequest>,
         OfflineScreenControllerMixin,
         AutoDisposeControllerMixin {
-  NetworkController() {
-    _networkService = NetworkService(this);
-    _currentNetworkRequests = CurrentNetworkRequests();
-    _initHelper();
-    addAutoDisposeListener(
-      _currentNetworkRequests,
-      _filterAndRefreshSearchMatches,
-    );
-    // TODO(https://github.com/flutter/devtools/issues/7727): add support for
-    // persisting network filter.
-    initFilterController();
-  }
   List<DartIOHttpRequestData>? _httpRequests;
 
   Future<String?> exportAsHarFile() async {
@@ -146,9 +144,7 @@ class NetworkController extends DevToolsScreenController
   ValueListenable<bool> get recordingNotifier => _recordingNotifier;
   final _recordingNotifier = ValueNotifier<bool>(false);
 
-  @visibleForTesting
-  NetworkService get networkService => _networkService;
-  late NetworkService _networkService;
+  final networkService = NetworkService();
 
   /// The timeline timestamps are relative to when the VM started.
   ///
@@ -167,6 +163,29 @@ class NetworkController extends DevToolsScreenController
 
   @visibleForTesting
   bool get isPolling => _pollingTimer != null;
+
+  @override
+  void init() {
+    super.init();
+    _currentNetworkRequests = CurrentNetworkRequests();
+    _initHelper();
+    addAutoDisposeListener(
+      _currentNetworkRequests,
+      _filterAndRefreshSearchMatches,
+    );
+  }
+
+  @override
+  void dispose() {
+    // Cancel and dispose the polling timer before disposing anything else.
+    _pollingTimer?.dispose();
+    _pollingTimer = null;
+    _currentResponseViewType.dispose();
+    selectedRequest.dispose();
+    _recordingNotifier.dispose();
+    _currentNetworkRequests.dispose();
+    super.dispose();
+  }
 
   void _initHelper() async {
     if (offlineDataController.showingOfflineData.value) {
@@ -255,7 +274,7 @@ class NetworkController extends DevToolsScreenController
         // TODO(kenz): look into improving performance by caching more data.
         // Polling less frequently helps performance.
         const Duration(milliseconds: 2000),
-        _networkService.refreshNetworkData,
+        networkService.refreshNetworkData,
       );
     } else {
       _pollingTimer?.cancel();
@@ -286,10 +305,10 @@ class NetworkController extends DevToolsScreenController
     // Cancel existing polling timer before starting recording.
     _updatePollingState(false);
 
-    _networkService.updateLastHttpDataRefreshTime(
+    networkService.updateLastHttpDataRefreshTime(
       alreadyRecordingHttp: alreadyRecordingHttp,
     );
-    final timestamp = await _networkService.updateLastSocketDataRefreshTime(
+    final timestamp = await networkService.updateLastSocketDataRefreshTime(
       alreadyRecordingSocketData: alreadyRecordingSocketData,
     );
 
@@ -319,7 +338,9 @@ class NetworkController extends DevToolsScreenController
   }
 
   Future<void> stopRecording() async {
-    await togglePolling(false);
+    if (!disposed) {
+      await togglePolling(false);
+    }
   }
 
   Future<void> togglePolling(bool state) async {
@@ -339,8 +360,8 @@ class NetworkController extends DevToolsScreenController
   /// This will ensure that future fetches for http and socket requests will at
   /// most fetch requests since [updateLastRefreshTime] was called.
   Future<void> updateLastRefreshTime() async {
-    _networkService.updateLastHttpDataRefreshTime();
-    await _networkService.updateLastSocketDataRefreshTime();
+    networkService.updateLastHttpDataRefreshTime();
+    await networkService.updateLastSocketDataRefreshTime();
   }
 
   Future<bool> _recordingNetworkTraffic({
@@ -370,7 +391,7 @@ class NetworkController extends DevToolsScreenController
   /// Clears the HTTP profile and socket profile from the vm, and resets the
   /// last refresh timestamp to the current time.
   Future<void> clear() async {
-    await _networkService.clearData();
+    await networkService.clearData();
     _currentNetworkRequests.clear();
     _filterAndRefreshSearchMatches();
     _updateSelection();

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -175,6 +175,7 @@ class NetworkController extends DevToolsScreenController
       _currentNetworkRequests,
       _filterAndRefreshSearchMatches,
     );
+    initFilterController();
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/network/network_controller.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_controller.dart
@@ -164,6 +164,8 @@ class NetworkController extends DevToolsScreenController
   @visibleForTesting
   bool get isPolling => _pollingTimer != null;
 
+  static const _pollingDuration = Duration(milliseconds: 2000);
+
   @override
   void init() {
     super.init();
@@ -273,7 +275,7 @@ class NetworkController extends DevToolsScreenController
       _pollingTimer ??= DebounceTimer.periodic(
         // TODO(kenz): look into improving performance by caching more data.
         // Polling less frequently helps performance.
-        const Duration(milliseconds: 2000),
+        _pollingDuration,
         networkService.refreshNetworkData,
       );
     } else {
@@ -395,6 +397,15 @@ class NetworkController extends DevToolsScreenController
     _currentNetworkRequests.clear();
     _filterAndRefreshSearchMatches();
     _updateSelection();
+  }
+
+  @override
+  void setActiveFilter({
+    String? query,
+    SettingFilters<NetworkRequest>? settingFilters,
+  }) {
+    super.setActiveFilter(query: query, settingFilters: settingFilters);
+    _filterAndRefreshSearchMatches();
   }
 
   void _filterAndRefreshSearchMatches() {

--- a/packages/devtools_app/lib/src/screens/network/network_screen.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_screen.dart
@@ -143,10 +143,10 @@ class _NetworkScreenBodyState extends State<NetworkScreenBody>
 
   @override
   void dispose() {
+    unawaited(controller.stopRecording());
     // TODO(kenz): this won't work well if we eventually have multiple clients
     // that want to listen to network data.
     super.dispose();
-    unawaited(controller.stopRecording());
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -9,9 +9,8 @@ import '../../shared/primitives/utils.dart';
 import 'network_controller.dart';
 
 class NetworkService {
-  NetworkService(this.networkController);
-
-  final NetworkController networkController;
+  NetworkController get networkController =>
+      screenControllers.lookup<NetworkController>();
 
   /// Tracks the time (microseconds since epoch) that the HTTP profile was last
   /// retrieved for a given isolate ID.

--- a/packages/devtools_app/lib/src/screens/network/network_service.dart
+++ b/packages/devtools_app/lib/src/screens/network/network_service.dart
@@ -61,8 +61,8 @@ class NetworkService {
 
   /// Force refreshes the HTTP requests logged to the timeline as well as any
   /// recorded Socket traffic.
-  /// 
-  /// This methoc calls `cancelledCallback` after each async gap to ensure that
+  ///
+  /// This method calls `cancelledCallback` after each async gap to ensure that
   /// this operation has not been cancelled during the async gap.
   Future<void> refreshNetworkData({
     DebounceCancelledCallback? cancelledCallback,

--- a/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_ic_data_display.dart
+++ b/packages/devtools_app/lib/src/screens/vm_developer/object_inspector/vm_ic_data_display.dart
@@ -34,7 +34,7 @@ class _VmICDataDisplayState extends State<VmICDataDisplay> {
   final entries = <ObjRef?>[];
 
   Future<void> get _initialized => _initializingCompleter.future;
-  final Completer<void> _initializingCompleter = Completer<void>();
+  final _initializingCompleter = Completer<void>();
 
   @override
   void initState() {

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -18,8 +18,13 @@ To learn more about DevTools, check out the
 * Fixed various memory leaks and lifecycle issues. - 
 [#8901](https://github.com/flutter/devtools/pull/8901),
 [#8902](https://github.com/flutter/devtools/pull/8902),
-[#8907](https://github.com/flutter/devtools/pull/8907)
-[#8917](https://github.com/flutter/devtools/pull/8917)
+[#8907](https://github.com/flutter/devtools/pull/8907),
+[#8917](https://github.com/flutter/devtools/pull/8917),
+[#8932](https://github.com/flutter/devtools/pull/8932),
+[#8933](https://github.com/flutter/devtools/pull/8933),
+[#8934](https://github.com/flutter/devtools/pull/8934),
+[#8935](https://github.com/flutter/devtools/pull/8935),
+[#8936](https://github.com/flutter/devtools/pull/8936)
 
 ## Inspector updates
 

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -24,7 +24,7 @@ To learn more about DevTools, check out the
 [#8933](https://github.com/flutter/devtools/pull/8933),
 [#8934](https://github.com/flutter/devtools/pull/8934),
 [#8935](https://github.com/flutter/devtools/pull/8935),
-[#8936](https://github.com/flutter/devtools/pull/8936)
+[#8937](https://github.com/flutter/devtools/pull/8937)
 
 ## Inspector updates
 

--- a/packages/devtools_app/test/screens/network/network_controller_test.dart
+++ b/packages/devtools_app/test/screens/network/network_controller_test.dart
@@ -57,7 +57,7 @@ void main() {
       expect(controller.isPolling, false);
       await addListenerScope(
         listenable: controller.recordingNotifier,
-        listener: () async {
+        listener: () {
           expect(controller.recordingNotifier.value, true);
           expect(controller.isPolling, true);
         },

--- a/packages/devtools_app/test/screens/network/network_model_test.dart
+++ b/packages/devtools_app/test/screens/network/network_model_test.dart
@@ -87,8 +87,15 @@ void main() {
       setGlobal(ServiceConnectionManager, fakeServiceConnection);
       setGlobal(PreferencesController, PreferencesController());
       setGlobal(OfflineDataController, OfflineDataController());
-      controller = NetworkController();
+      setGlobal(ScreenControllers, ScreenControllers());
+      screenControllers.register<NetworkController>(() => NetworkController());
+      // Lookup the controller immediately to force initialization.
+      controller = screenControllers.lookup<NetworkController>();
       await controller.startRecording();
+    });
+
+    tearDown(() {
+      screenControllers.disposeConnectedControllers();
     });
 
     test('method returns correct value', () {

--- a/packages/devtools_app/test/screens/network/network_request_inspector_test.dart
+++ b/packages/devtools_app/test/screens/network/network_request_inspector_test.dart
@@ -20,7 +20,6 @@ import '../../test_infra/utils/test_utils.dart';
 
 void main() {
   group('NetworkRequestInspector', () {
-    late NetworkController controller;
     late FakeServiceConnectionManager fakeServiceConnection;
     final httpRequest = HttpProfileRequest.parse(httpPostJson);
     String clipboardContents = '';
@@ -44,7 +43,6 @@ void main() {
       setGlobal(ServiceConnectionManager, fakeServiceConnection);
       setGlobal(NotificationService, NotificationService());
       setGlobal(OfflineDataController, OfflineDataController());
-      controller = NetworkController();
       setupClipboardCopyListener(
         clipboardContentsCallback: (contents) {
           clipboardContents = contents ?? '';
@@ -52,25 +50,27 @@ void main() {
       );
     });
 
+    tearDown(() {
+      screenControllers.disposeConnectedControllers();
+    });
+
     testWidgets('copy request body', (tester) async {
-      final requestsNotifier = controller.requests;
-
-      await controller.startRecording();
-
       await tester.pumpWidget(
         wrapWithControllers(
           const NetworkRequestInspector(),
-          network: controller,
+          network: NetworkController(),
           debugger: createMockDebuggerControllerWithDefaults(),
         ),
       );
+      final controller = screenControllers.lookup<NetworkController>();
+      await controller.startRecording();
 
       // Load the network request.
       await controller.networkService.refreshNetworkData();
-      expect(requestsNotifier.value.length, equals(1));
+      expect(controller.requests.value.length, 1);
 
       // Select the request in the network request list.
-      final networkRequest = requestsNotifier.value.first;
+      final networkRequest = controller.requests.value.first;
       controller.selectedRequest.value = networkRequest;
       await tester.pumpAndSettle();
       await tester.tap(find.text('Request'));
@@ -94,24 +94,22 @@ void main() {
     });
 
     testWidgets('copy response body', (tester) async {
-      final requestsNotifier = controller.requests;
-
-      await controller.startRecording();
-
       await tester.pumpWidget(
         wrapWithControllers(
           const NetworkRequestInspector(),
-          network: controller,
+          network: NetworkController(),
           debugger: createMockDebuggerControllerWithDefaults(),
         ),
       );
+      final controller = screenControllers.lookup<NetworkController>();
+      await controller.startRecording();
 
       // Load the network request.
       await controller.networkService.refreshNetworkData();
-      expect(requestsNotifier.value.length, equals(1));
+      expect(controller.requests.value.length, 1);
 
       // Select the request in the network request list.
-      final networkRequest = requestsNotifier.value.first;
+      final networkRequest = controller.requests.value.first;
       controller.selectedRequest.value = networkRequest;
       await tester.pumpAndSettle();
       await tester.tap(find.text('Response'));
@@ -169,7 +167,7 @@ void main() {
                   currentResponseViewType.value = value;
                 },
               ),
-              network: controller,
+              network: NetworkController(),
               debugger: createMockDebuggerControllerWithDefaults(),
             ),
           );
@@ -209,7 +207,7 @@ void main() {
                   initial = afterOnChanged;
                 },
               ),
-              network: controller,
+              network: NetworkController(),
               debugger: createMockDebuggerControllerWithDefaults(),
             ),
           );
@@ -261,7 +259,7 @@ void main() {
                 ),
               ],
             ),
-            network: controller,
+            network: NetworkController(),
             debugger: createMockDebuggerControllerWithDefaults(),
           ),
         );


### PR DESCRIPTION
Work towards https://github.com/flutter/devtools/issues/4742

Fixing up the network controller lifecycle exposed an issue with calling async callbacks in a `DebounceTimer` callback, so this PR also adds functionality to cancel the callback running from a `DebounceTimer`. Previously, you could only cancel the timer but you could not cancel the callback itself if the timer was cancelled in the middle of a callback run (e.g. during an async gap of the callback).