### PR TITLE
Fix CPU profiler tab time estimates

### DIFF
--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -379,9 +379,7 @@ class CpuProfileData with Serializable {
             .toList();
     assert(samplesWithTag.isNotEmpty);
 
-    final originalTime = originalData.profileMetaData.time!.duration;
-    final microsPerSample =
-        originalTime.inMicroseconds / originalData.profileMetaData.sampleCount;
+    final microsPerSample = originalData.profileMetaData.samplePeriod;
     final newSampleCount = samplesWithTag.length;
     final metaData = originalData.profileMetaData.copyWith(
       sampleCount: newSampleCount,
@@ -486,7 +484,7 @@ class CpuProfileData with Serializable {
       return null;
     }
 
-    final originalTime = originalData.profileMetaData.time!.duration;
+    final originalTime = originalData.profileMetaData.measuredDuration;
     final microsPerSample =
         originalTime.inMicroseconds / originalData.profileMetaData.sampleCount;
     final updatedMetaData = originalData.profileMetaData.copyWith(
@@ -791,12 +789,10 @@ extension type _CpuProfileDataJson(Map<String, Object?> json) {
 class CpuProfileMetaData extends ProfileMetaData {
   CpuProfileMetaData({
     required super.sampleCount,
-    required this.samplePeriod,
+    required super.samplePeriod,
     required this.stackDepth,
     required super.time,
   });
-
-  final int samplePeriod;
 
   final int stackDepth;
 

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -172,7 +172,7 @@ class CpuProfileData with Serializable {
     final json = _CpuProfileDataJson(json_);
 
     // All CPU samples.
-    final samples = json.traceEvents ?? [];
+    final samples = json.traceEvents ?? <CpuSampleEvent>[];
 
     // Sort the samples so we can compute the observed time difference between
     // each sample.
@@ -1414,8 +1414,8 @@ extension on vm_service.CpuSamples {
   }
 }
 
-// Computes the median of 5 numbers without allocating a list
-// or actually sorting all the numbers.
+/// Computes the median of 5 numbers without allocating a list
+/// or actually sorting all the numbers.
 int _median5(int a, int b, int c, int d, int e) {
   while (true) {
     if (c < a) {

--- a/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/cpu_profile_model.dart
@@ -170,9 +170,43 @@ class CpuProfileData with Serializable {
 
   factory CpuProfileData.fromJson(Map<String, Object?> json_) {
     final json = _CpuProfileDataJson(json_);
+
+    // All CPU samples.
+    final samples = json.traceEvents ?? [];
+
+    // Sort the samples so we can compute the observed time difference between
+    // each sample.
+    samples.sort((a, b) => a.timestampMicros!.compareTo(b.timestampMicros!));
+
+    // To compute the median efficiently, we compute the median of groups of 5
+    // elements, and then grab the median of those medians by sorting, which
+    // brings us a linear time complexity.
+    final mediansOfGroupsOf5 = <int>[];
+    for (var i = 1; i + 5 < samples.length; i += 5) {
+      // The time diff between the sample at index and the previous sample.
+      int diff(int index) {
+        return samples[index].timestampMicros! -
+            samples[index - 1].timestampMicros!;
+      }
+
+      mediansOfGroupsOf5.add(
+        _median5(diff(i), diff(i + 1), diff(i + 2), diff(i + 3), diff(i + 4)),
+      );
+    }
+    mediansOfGroupsOf5.sort();
+
+    // Sort the remaining diffs and grab the median, or trust the given period
+    // if we don't have any data.
+    //
+    // See https://github.com/flutter/devtools/pull/8941 for more information.
+    final samplePeriod =
+        mediansOfGroupsOf5.isNotEmpty
+            ? mediansOfGroupsOf5[(mediansOfGroupsOf5.length / 2).floor()]
+            : json.samplePeriod ?? 0;
+
     final profileMetaData = CpuProfileMetaData(
       sampleCount: json.sampleCount ?? 0,
-      samplePeriod: json.samplePeriod ?? 0,
+      samplePeriod: samplePeriod,
       stackDepth: json.stackDepth ?? 0,
       time:
           (json.timeOriginMicros != null && json.timeExtentMicros != null)
@@ -210,9 +244,6 @@ class CpuProfileData with Serializable {
       );
       stackFrames[stackFrame.id] = stackFrame;
     }
-
-    // Initialize all CPU samples.
-    final samples = json.traceEvents ?? [];
 
     return CpuProfileData._(
       stackFrames: stackFrames,
@@ -1380,5 +1411,23 @@ extension on vm_service.CpuSamples {
     );
     processStackFrame(current: root, parent: null);
     return traceObject;
+  }
+}
+
+// Computes the median of 5 numbers without allocating a list
+// or actually sorting all the numbers.
+int _median5(int a, int b, int c, int d, int e) {
+  while (true) {
+    if (c < a) {
+      (a, c) = (c, a);
+    } else if (c < b) {
+      (b, c) = (c, b);
+    } else if (c > d) {
+      (c, d) = (d, c);
+    } else if (c > e) {
+      (c, e) = (e, c);
+    } else {
+      return c;
+    }
   }
 }

--- a/packages/devtools_app/lib/src/screens/profiler/panes/method_table/method_table_model.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/panes/method_table/method_table_model.dart
@@ -68,7 +68,8 @@ class MethodTableGraphNode extends GraphNode with SearchableDataMixin {
 
   Duration get selfTime => Duration(
     microseconds:
-        (selfTimeRatio * profileMetaData.time!.duration.inMicroseconds).round(),
+        (selfTimeRatio * profileMetaData.measuredDuration.inMicroseconds)
+            .round(),
   );
 
   double get totalTimeRatio =>
@@ -76,7 +77,7 @@ class MethodTableGraphNode extends GraphNode with SearchableDataMixin {
 
   Duration get totalTime => Duration(
     microseconds:
-        (totalTimeRatio * profileMetaData.time!.duration.inMicroseconds)
+        (totalTimeRatio * profileMetaData.measuredDuration.inMicroseconds)
             .round(),
   );
 

--- a/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
+++ b/packages/devtools_app/lib/src/shared/config_specific/framework_initialize/_framework_initialize_web.dart
@@ -98,11 +98,11 @@ void _sendKeyPressToParent(KeyboardEvent event) {
 class BrowserStorage implements Storage {
   @override
   Future<String?> getValue(String key) async {
-    return window.localStorage[key];
+    return window.localStorage.getItem(key);
   }
 
   @override
   Future<void> setValue(String key, String value) async {
-    window.localStorage[key] = value;
+    window.localStorage.setItem(key, value);
   }
 }

--- a/packages/devtools_app/lib/src/shared/utils/profiler_utils.dart
+++ b/packages/devtools_app/lib/src/shared/utils/profiler_utils.dart
@@ -42,7 +42,7 @@ mixin ProfilableDataMixin<T extends TreeNode<T>> on TreeNode<T> {
 
   late Duration totalTime = Duration(
     microseconds:
-        (totalTimeRatio * profileMetaData.time!.duration.inMicroseconds)
+        (totalTimeRatio * profileMetaData.measuredDuration.inMicroseconds)
             .round(),
   );
 
@@ -53,7 +53,8 @@ mixin ProfilableDataMixin<T extends TreeNode<T>> on TreeNode<T> {
 
   late Duration selfTime = Duration(
     microseconds:
-        (selfTimeRatio * profileMetaData.time!.duration.inMicroseconds).round(),
+        (selfTimeRatio * profileMetaData.measuredDuration.inMicroseconds)
+            .round(),
   );
 
   double get inclusiveSampleRatio =>
@@ -97,11 +98,31 @@ mixin ProfilableDataMixin<T extends TreeNode<T>> on TreeNode<T> {
 }
 
 class ProfileMetaData {
-  const ProfileMetaData({required this.sampleCount, required this.time});
+  const ProfileMetaData({
+    required this.sampleCount,
+    required this.samplePeriod,
+    required this.time,
+  });
 
+  /// The total number of samples in this profile.
   final int sampleCount;
 
+  /// The sample period for this profile in microseconds.
+  final int samplePeriod;
+
+  /// The time range of the entire profile.
+  ///
+  /// Note that there may be periods of time with no samples, so the duration
+  /// of this time should not be used in any calculations for how long a given
+  /// sample took, instead use [measuredDuration].
   final TimeRange? time;
+
+  /// The amount of time measured by all the samples taken in this profile.
+  ///
+  /// This is different from [time] which is just the start to end time of the
+  /// entire profile which includes time where no samples were taken.
+  Duration get measuredDuration =>
+      Duration(microseconds: sampleCount * samplePeriod);
 }
 
 /// Process for converting a [ProfilableDataMixin] into a bottom-up

--- a/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
+++ b/packages/devtools_app/release_notes/NEXT_RELEASE_NOTES.md
@@ -35,7 +35,8 @@ TODO: Remove this section if there are not any general updates.
 
 ## CPU profiler updates
 
-TODO: Remove this section if there are not any general updates.
+* Fixed incorrect duration calculations when there is time during which no
+  samples were taken - [#8941](https://github.com/flutter/devtools/pull/8941).
 
 ## Memory updates
 

--- a/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_model_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/cpu_profile_model_test.dart
@@ -4,6 +4,7 @@
 
 import 'package:devtools_app/src/screens/profiler/cpu_profile_model.dart';
 import 'package:devtools_app/src/service/service_manager.dart';
+import 'package:devtools_app/src/shared/primitives/trace_event.dart';
 import 'package:devtools_app/src/shared/primitives/utils.dart';
 import 'package:devtools_app_shared/utils.dart';
 import 'package:devtools_test/devtools_test.dart';
@@ -437,5 +438,54 @@ void main() {
     expect(stackFrameC.matches(stackFrameC2), isTrue);
     expect(stackFrameC.matches(stackFrameG), isFalse);
     expect(stackFrameC.matches(stackFrameC4), isFalse);
+  });
+
+  group('observedSamplePeriod', () {
+    CpuSampleEvent sampleEventWithTimestamp(int timestampMicros) {
+      return CpuSampleEvent.fromJson({
+        CpuProfileData.stackFrameIdKey: '0',
+        ChromeTraceEvent.timestampKey: timestampMicros,
+      });
+    }
+
+    test('returns null if less than 100 samples', () {
+      expect(observedSamplePeriod([]), isNull);
+      expect(
+        observedSamplePeriod(List.filled(99, sampleEventWithTimestamp(1))),
+        isNull,
+      );
+      expect(
+        observedSamplePeriod(
+          List.generate(100, (i) => sampleEventWithTimestamp(i)),
+        ),
+        1,
+      );
+    });
+
+    test('asserts that samples are sorted', () {
+      expect(
+        () => observedSamplePeriod([
+          sampleEventWithTimestamp(10),
+          sampleEventWithTimestamp(5),
+          // Need at least 100 elements for anything to happen.
+          ...List.filled(100, sampleEventWithTimestamp(1)),
+        ]),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('computes an approximate time difference median', () {
+      final samples = List.generate(
+        100,
+        (i) => sampleEventWithTimestamp(i * i),
+      );
+      // Better to hard code this than rely on computing the median correctly.
+      const actualMedianSamplePeriod = 50 * 50 - 49 * 49;
+      expect(
+        observedSamplePeriod(samples),
+        // Ensure we are within 5%, this is not a perfect median.
+        closeTo(actualMedianSamplePeriod, actualMedianSamplePeriod * 0.05),
+      );
+    });
   });
 }

--- a/packages/devtools_app/test/screens/cpu_profiler/method_table/method_table_model_test.dart
+++ b/packages/devtools_app/test/screens/cpu_profiler/method_table/method_table_model_test.dart
@@ -17,6 +17,7 @@ void main() {
       selfCount: 1,
       profileMetaData: ProfileMetaData(
         sampleCount: 10,
+        samplePeriod: 250,
         time:
             TimeRange()
               ..start = Duration.zero
@@ -32,6 +33,7 @@ void main() {
       selfCount: 4,
       profileMetaData: ProfileMetaData(
         sampleCount: 10,
+        samplePeriod: 250,
         time:
             TimeRange()
               ..start = Duration.zero
@@ -47,6 +49,7 @@ void main() {
       selfCount: 2,
       profileMetaData: ProfileMetaData(
         sampleCount: 10,
+        samplePeriod: 250,
         time:
             TimeRange()
               ..start = Duration.zero
@@ -62,6 +65,7 @@ void main() {
       selfCount: 3,
       profileMetaData: ProfileMetaData(
         sampleCount: 10,
+        samplePeriod: 250,
         time:
             TimeRange()
               ..start = Duration.zero

--- a/packages/devtools_app/test/test_infra/test_data/cpu_profiler/cpu_profile.dart
+++ b/packages/devtools_app/test/test_infra/test_data/cpu_profiler/cpu_profile.dart
@@ -1211,7 +1211,9 @@ final profileMetaData = CpuProfileMetaData(
   time:
       TimeRange()
         ..start = const Duration()
-        ..end = const Duration(microseconds: 10000),
+        // Note this intentionally adds 10000 microseconds more than what
+        // was measured, regression test for Issue #8870.
+        ..end = const Duration(microseconds: 20000),
 );
 
 final tagFrameA = CpuStackFrame(


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8870.

This fixes all views on the cpu profiler tab to take into account time where no code was executing (no samples taken).

The approach taken is to use the sampleCount * samplePeriod to get the total duration, which is then used in all the other calculations, instead of the total duration of the profile. This isn't necessarily perfect but should be much better than what we had before, and I don't know that we can do any better.

For the reproduction case in the issue you now get this:

<img width="1273" alt="Screenshot 2025-02-24 at 11 35 22 AM" src="https://github.com/user-attachments/assets/565e2502-7d23-4e66-b0c5-1e2c57c42595" />

Instead of this:

<img width="1273" alt="Screenshot 2025-02-24 at 11 36 12 AM" src="https://github.com/user-attachments/assets/b106296c-07c4-4542-b85d-02a8105dba72" />
