### PR TITLE
[Property Editor] Fix text input state retention issues

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -120,7 +120,8 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return DropdownButtonFormField(
+    return DropdownButtonFormField(g
+      key: Key(widget.property.hashCode.toString()),
       value: widget.property.valueDisplay,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (text) => inputValidator(text, property: widget.property),
@@ -208,13 +209,11 @@ class _TextInputState<T> extends State<_TextInput<T>>
 
   String _currentValue = '';
 
-  late final TextEditingController _controller;
   late final FocusNode _focusNode;
 
   @override
   void initState() {
     super.initState();
-    _controller = TextEditingController(text: widget.property.valueDisplay);
     _focusNode = FocusNode(debugLabel: 'text-input-${widget.property.name}');
 
     addAutoDisposeListener(_focusNode, () async {
@@ -225,19 +224,12 @@ class _TextInputState<T> extends State<_TextInput<T>>
   }
 
   @override
-  void didUpdateWidget(_TextInput<T> oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    if (oldWidget.property != widget.property) {
-      _controller.text = widget.property.valueDisplay;
-    }
-  }
-
-  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return TextFormField(
+      key: Key(widget.property.hashCode.toString()),
       focusNode: _focusNode,
-      controller: _controller,
+      initialValue: widget.property.valueDisplay,
       enabled: widget.property.isEditable,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (text) => inputValidator(text, property: widget.property),

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -120,7 +120,7 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return DropdownButtonFormField(g
+    return DropdownButtonFormField(
       key: Key(widget.property.hashCode.toString()),
       value: widget.property.valueDisplay,
       autovalidateMode: AutovalidateMode.onUserInteraction,

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -204,14 +204,17 @@ class _TextInput<T> extends StatefulWidget {
 
 class _TextInputState<T> extends State<_TextInput<T>>
     with _PropertyInputMixin<_TextInput<T>, T>, AutoDisposeMixin {
-  String currentValue = '';
+  static const _paddingDiffComparedToDropdown = 1.0;
 
-  double paddingDiffComparedToDropdown = 1.0;
-  late FocusNode _focusNode;
+  String _currentValue = '';
+
+  late final TextEditingController _controller;
+  late final FocusNode _focusNode;
 
   @override
   void initState() {
     super.initState();
+    _controller = TextEditingController(text: widget.property.valueDisplay);
     _focusNode = FocusNode(debugLabel: 'text-input-${widget.property.name}');
 
     addAutoDisposeListener(_focusNode, () async {
@@ -222,11 +225,19 @@ class _TextInputState<T> extends State<_TextInput<T>>
   }
 
   @override
+  void didUpdateWidget(_TextInput<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.property != widget.property) {
+      _controller.text = widget.property.valueDisplay;
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return TextFormField(
       focusNode: _focusNode,
-      initialValue: widget.property.valueDisplay,
+      controller: _controller,
       enabled: widget.property.isEditable,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (text) => inputValidator(text, property: widget.property),
@@ -237,13 +248,13 @@ class _TextInputState<T> extends State<_TextInput<T>>
         // Note: The text input has an extra pixel compared to the dropdown
         // input. Therefore, to have their sizes match, subtract a half pixel
         // from the padding.
-        padding: defaultSpacing - (paddingDiffComparedToDropdown / 2),
+        padding: defaultSpacing - (_paddingDiffComparedToDropdown / 2),
       ),
       style: theme.fixedFontStyle,
       onChanged: (newValue) {
         clearServerError();
         setState(() {
-          currentValue = newValue;
+          _currentValue = newValue;
         });
       },
       onEditingComplete: _editProperty,
@@ -253,7 +264,7 @@ class _TextInputState<T> extends State<_TextInput<T>>
   Future<void> _editProperty() async {
     await editProperty(
       widget.property,
-      valueAsString: currentValue,
+      valueAsString: _currentValue,
       editPropertyCallback: widget.editProperty,
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
@@ -167,18 +167,6 @@ class EditableProperty extends EditableArgument {
   Object? convertFromInputString(String? _) {
     throw UnimplementedError();
   }
-
-  @override
-  bool operator ==(Object other) {
-    return other is EditableProperty &&
-        other.name == name &&
-        other.type == type &&
-        other.value == value &&
-        other.hasArgument == hasArgument;
-  }
-
-  @override
-  int get hashCode => Object.hash(name, type, value, hasArgument);
 }
 
 mixin NumericProperty on EditableProperty {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_types.dart
@@ -167,6 +167,18 @@ class EditableProperty extends EditableArgument {
   Object? convertFromInputString(String? _) {
     throw UnimplementedError();
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EditableProperty &&
+        other.name == name &&
+        other.type == type &&
+        other.value == value &&
+        other.hasArgument == hasArgument;
+  }
+
+  @override
+  int get hashCode => Object.hash(name, type, value, hasArgument);
 }
 
 mixin NumericProperty on EditableProperty {

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
@@ -675,8 +675,7 @@ String? _textFormFieldValue(
   required WidgetTester tester,
 }) {
   final textFormFieldWidget = tester.widget<TextFormField>(textFormFieldFinder);
-  final textEditingController = textFormFieldWidget.controller;
-  return textEditingController?.text;
+  return textFormFieldWidget.initialValue;
 }
 
 Finder _labelForInput(Finder inputFinder, {required String matching}) {

--- a/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
+++ b/packages/devtools_app/test/standalone_ui/ide_shared/property_editor/property_editor_test.dart
@@ -27,6 +27,8 @@ void main() {
   final LocationToArgsResult locationToArgsResult = {
     (document: textDocument1, position: activeCursorPosition1): result1,
     (document: textDocument2, position: activeCursorPosition2): result2,
+    (document: textDocument1, position: activeCursorPosition3): resultWithText,
+    (document: textDocument1, position: activeCursorPosition4): resultWithTitle,
   };
 
   late MockEditorClient mockEditorClient;
@@ -58,7 +60,9 @@ void main() {
     Future<List<EditableArgument>> waitForEditableArgs() {
       final argsCompleter = Completer<List<EditableArgument>>();
       listener = () {
-        argsCompleter.complete(controller.editableWidgetData.value!.args);
+        if (!argsCompleter.isCompleted) {
+          argsCompleter.complete(controller.editableWidgetData.value!.args);
+        }
       };
       controller.editableWidgetData.addListener(listener!);
       return argsCompleter.future;
@@ -129,6 +133,43 @@ void main() {
         // Wait for the expected editable args.
         final editableArgs = await editableArgsFuture;
         verifyEditableArgs(actual: editableArgs, expected: result2.args);
+      });
+    });
+
+    testWidgets('verify editable arguments update when widget changes', (
+      tester,
+    ) async {
+      await tester.runAsync(() async {
+        // Load the property editor.
+        await tester.pumpWidget(wrap(propertyEditor));
+
+        // Send an active location changed event.
+        final editableArgsFuture1 = waitForEditableArgs();
+        eventController.add(activeLocationChangedEvent3);
+
+        // Wait for the expected editable args.
+        await editableArgsFuture1;
+        await tester.pumpAndSettle();
+
+        // Verify the inputs.
+        final textInput = _findTextFormField('text');
+        expect(textInput, findsOneWidget);
+        final textValue = _textFormFieldValue(textInput, tester: tester);
+        expect(textValue, equals('This is some text.'));
+
+        // Send an active location changed event.
+        final editableArgsFuture2 = waitForEditableArgs();
+        eventController.add(activeLocationChangedEvent4);
+
+        // Wait for the expected editable args.
+        await editableArgsFuture2;
+        await tester.pumpAndSettle();
+
+        // Verify the inputs.
+        final titleInput = _findTextFormField('title*');
+        expect(titleInput, findsOneWidget);
+        final titleValue = _textFormFieldValue(titleInput, tester: tester);
+        expect(titleValue, equals('Hello world!'));
       });
     });
   });
@@ -629,6 +670,15 @@ Finder _findTextFormField(String inputName) => find.ancestor(
   matching: find.byType(TextFormField),
 );
 
+String? _textFormFieldValue(
+  Finder textFormFieldFinder, {
+  required WidgetTester tester,
+}) {
+  final textFormFieldWidget = tester.widget<TextFormField>(textFormFieldFinder);
+  final textEditingController = textFormFieldWidget.controller;
+  return textEditingController?.text;
+}
+
 Finder _labelForInput(Finder inputFinder, {required String matching}) {
   final rowFinder = find.ancestor(of: inputFinder, matching: find.byType(Row));
   final labelFinder = find.descendant(
@@ -802,6 +852,30 @@ final activeLocationChangedEvent2 = ActiveLocationChangedEvent(
   textDocument: textDocument2,
 );
 
+// Location position 3
+final activeCursorPosition3 = CursorPosition(character: 55, line: 2);
+final anchorCursorPosition3 = CursorPosition(character: 60, line: 4);
+final editorSelection3 = EditorSelection(
+  active: activeCursorPosition3,
+  anchor: anchorCursorPosition3,
+);
+final activeLocationChangedEvent3 = ActiveLocationChangedEvent(
+  selections: [editorSelection3],
+  textDocument: textDocument1,
+);
+
+// Location position 4
+final activeCursorPosition4 = CursorPosition(character: 10, line: 11);
+final anchorCursorPosition4 = CursorPosition(character: 12, line: 2);
+final editorSelection4 = EditorSelection(
+  active: activeCursorPosition4,
+  anchor: anchorCursorPosition4,
+);
+final activeLocationChangedEvent4 = ActiveLocationChangedEvent(
+  selections: [editorSelection4],
+  textDocument: textDocument1,
+);
+
 // Widget name and documentation
 const widgetName = 'MyFlutterWidget';
 
@@ -917,4 +991,23 @@ final resultWithWidgetNameAndDocsNoArgs = EditableArgumentsResult(
   name: widgetName,
   documentation: dartDocText,
   args: [],
+);
+
+// Example results for text input state change test cases.
+final textProperty = EditableArgument.fromJson({
+  'name': 'text',
+  'value': 'This is some text.',
+  'type': 'string',
+  'isEditable': true,
+  'isNullable': true,
+  'isRequired': false,
+  'hasArgument': true,
+});
+final resultWithText = EditableArgumentsResult(
+  name: 'WidgetWithText',
+  args: [textProperty],
+);
+final resultWithTitle = EditableArgumentsResult(
+  name: 'WidgetWithTitle',
+  args: [titleProperty],
 );


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8924, https://github.com/flutter/devtools/issues/8926, https://github.com/flutter/devtools/issues/8943

These three issues all had the same underlying cause: a text input's initial value is only set once during the initial build of the widget. Any subsequent builds will not change the initial value (see https://github.com/flutter/flutter/issues/120760). 

This meant that if a text input for a newly selected widget was in the same position as a text input for the previously selected widget, it would retain the value of the previously selected widget. It also meant that when the property value was updated directly from the code, the text input value would not be changed on rebuild. 

The solution here is to give the inputs a `key` so that a completely new input is inserted into the widget tree. 

Note: I also considered setting the initial value using a `TextEditingController`. Then checking if the property has changed in `didUpdateWidget`, and update the `TextEditingController`'s value if so. But I think it's better to completely rebuild the input widgets so that no state is maintained.