### PR TITLE
Do not update patch versions for `dependabot/github-actions`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,8 @@ updates:
     labels:
       - "autosubmit"
       - "release-notes-not-required"
+    # Updating patch versions for "github-actions" is too chatty.
+    # See https://github.com/flutter/flutter/issues/158350.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]


### PR DESCRIPTION
Towards https://github.com/flutter/flutter/issues/158350.