### PR TITLE
[Property Editor] Add workaround for embedded `TextField` focus issues

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -14,7 +14,6 @@ import '../../../shared/analytics/constants.dart' as gac;
 import '../../../shared/editor/api_classes.dart';
 import 'property_editor_controller.dart';
 import 'property_editor_types.dart';
-import 'utils/utils.dart';
 
 class BooleanInput extends StatelessWidget {
   const BooleanInput({

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -223,14 +223,6 @@ class _TextInputState<T> extends State<_TextInput<T>>
       // Edit property when clicking or tabbing away from input.
       await _editProperty();
     });
-
-    setUpTextFieldFocusFixHandler();
-  }
-
-  @override
-  void dispose() {
-    super.dispose();
-    removeTextFieldFocusFixHandler();
   }
 
   @override

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -14,6 +14,7 @@ import '../../../shared/analytics/constants.dart' as gac;
 import '../../../shared/editor/api_classes.dart';
 import 'property_editor_controller.dart';
 import 'property_editor_types.dart';
+import 'utils/utils.dart';
 
 class BooleanInput extends StatelessWidget {
   const BooleanInput({
@@ -222,6 +223,14 @@ class _TextInputState<T> extends State<_TextInput<T>>
       // Edit property when clicking or tabbing away from input.
       await _editProperty();
     });
+
+    setUpTextFieldFocusFixHandler();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    removeTextFieldFocusFixHandler();
   }
 
   @override

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -64,7 +64,7 @@ class PropertyEditorView extends StatelessWidget {
   }
 }
 
-class _PropertiesList extends StatelessWidget {
+class _PropertiesList extends StatefulWidget {
   const _PropertiesList({
     required this.editableProperties,
     required this.editProperty,
@@ -77,13 +77,32 @@ class _PropertiesList extends StatelessWidget {
   static const denseItemPadding = defaultItemPadding / 2;
 
   @override
+  State<_PropertiesList> createState() => _PropertiesListState();
+}
+
+class _PropertiesListState extends State<_PropertiesList> {
+  @override
+  void initState() {
+    super.initState();
+    // Workaround for https://github.com/flutter/devtools/issues/8929.
+    setUpTextFieldFocusFixHandler();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    // Workaround for https://github.com/flutter/devtools/issues/8929.
+    removeTextFieldFocusFixHandler();
+  }
+
+  @override
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
-        ...editableProperties.map(
+        ...widget.editableProperties.map(
           (property) => _EditablePropertyItem(
             property: property,
-            editProperty: editProperty,
+            editProperty: widget.editProperty,
           ),
         ),
       ].joinWith(const PaddedDivider.noPadding()),

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -99,12 +99,11 @@ class _PropertiesListState extends State<_PropertiesList> {
   Widget build(BuildContext context) {
     return Column(
       children: <Widget>[
-        ...widget.editableProperties.map(
-          (property) => _EditablePropertyItem(
+        for (final property in widget.editableProperties)
+          _EditablePropertyItem(
             property: property,
             editProperty: widget.editProperty,
           ),
-        ),
       ].joinWith(const PaddedDivider.noPadding()),
     );
   }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_desktop.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_desktop.dart
@@ -1,0 +1,7 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+void addBlurListener() {}
+
+void removeBlurListener() {}

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_desktop.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_desktop.dart
@@ -2,6 +2,10 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
-void addBlurListener() {}
+void addBlurListener() {
+  // No-op for desktop platforms.
+}
 
-void removeBlurListener() {}
+void removeBlurListener() {
+  // No-op for desktop platforms.
+}

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
@@ -1,0 +1,19 @@
+// Copyright 2025 The Flutter Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
+
+import 'dart:js_interop';
+
+import 'package:web/web.dart';
+
+void addBlurListener() {
+  window.addEventListener('blur', _onBlur.toJS);
+}
+
+void removeBlurListener() {
+  window.removeEventListener('blur', _onBlur.toJS);
+}
+
+void _onBlur(Event _) {
+  (document.activeElement as HTMLElement?)?.blur();
+}

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/_utils_web.dart
@@ -15,5 +15,6 @@ void removeBlurListener() {
 }
 
 void _onBlur(Event _) {
-  (document.activeElement as HTMLElement?)?.blur();
+  final inputElement = document.activeElement as HTMLElement?;
+  inputElement?.blur();
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
@@ -85,6 +85,9 @@ void setUpTextFieldFocusFixHandler() {
   addBlurListener();
 }
 
+/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
+///
+/// See https://github.com/flutter/devtools/issues/8929 for details.
 void removeTextFieldFocusFixHandler() {
   removeBlurListener();
 }

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
@@ -78,7 +78,7 @@ RichText convertDartDocToRichText(
   return RichText(text: TextSpan(children: children));
 }
 
-/// Workaround to prevent TextField from holding onto focus when IFRAME-ed.
+/// Workaround to prevent TextFields from holding onto focus when IFRAME-ed.
 ///
 /// See https://github.com/flutter/devtools/issues/8929 for details.
 void setUpTextFieldFocusFixHandler() {

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/utils/utils.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file or at https://developers.google.com/open-source/licenses/bsd.
 
 import 'package:flutter/widgets.dart';
+import '_utils_desktop.dart' if (dart.library.js_interop) '_utils_web.dart';
 
 /// Converts a [dartDocText] String into a [RichText] widget.
 ///
@@ -75,4 +76,15 @@ RichText convertDartDocToRichText(
   }
 
   return RichText(text: TextSpan(children: children));
+}
+
+/// Workaround to prevent TextField from holding onto focus when IFRAME-ed.
+///
+/// See https://github.com/flutter/devtools/issues/8929 for details.
+void setUpTextFieldFocusFixHandler() {
+  addBlurListener();
+}
+
+void removeTextFieldFocusFixHandler() {
+  removeBlurListener();
 }


### PR DESCRIPTION
Fixes https://github.com/flutter/devtools/issues/8929

Adds workaround described in https://github.com/flutter/flutter/issues/155265#issuecomment-2503506627 to prevent `TextField` from holding onto focus when embedded in an IFRAME. 

#### Demo (fixed!) 🎉 


![fixed_textfield](https://github.com/user-attachments/assets/40df0aae-efb7-4a7c-8373-25ea502a9d90)
