### PR TITLE
[Property Editor] Fix text input state retention issues follow-up

### DIFF
--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_inputs.dart
@@ -121,7 +121,6 @@ class _DropdownInputState<T> extends State<_DropdownInput<T>>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return DropdownButtonFormField(
-      key: Key(widget.property.hashCode.toString()),
       value: widget.property.valueDisplay,
       autovalidateMode: AutovalidateMode.onUserInteraction,
       validator: (text) => inputValidator(text, property: widget.property),
@@ -207,9 +206,9 @@ class _TextInputState<T> extends State<_TextInput<T>>
     with _PropertyInputMixin<_TextInput<T>, T>, AutoDisposeMixin {
   static const _paddingDiffComparedToDropdown = 1.0;
 
-  String _currentValue = '';
-
   late final FocusNode _focusNode;
+
+  late String _currentValue;
 
   @override
   void initState() {
@@ -228,7 +227,6 @@ class _TextInputState<T> extends State<_TextInput<T>>
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     return TextFormField(
-      key: Key(widget.property.hashCode.toString()),
       focusNode: _focusNode,
       initialValue: widget.property.valueDisplay,
       enabled: widget.property.isEditable,

--- a/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
+++ b/packages/devtools_app/lib/src/standalone_ui/ide_shared/property_editor/property_editor_view.dart
@@ -193,29 +193,38 @@ class _PropertyInput extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final argType = property.type;
+    final propertyKey = Key(property.hashCode.toString());
     switch (argType) {
       case boolType:
         return BooleanInput(
+          key: propertyKey,
           property: property as FiniteValuesProperty,
           editProperty: editProperty,
         );
       case doubleType:
         return DoubleInput(
+          key: propertyKey,
           property: property as NumericProperty,
           editProperty: editProperty,
         );
       case enumType:
         return EnumInput(
+          key: propertyKey,
           property: property as FiniteValuesProperty,
           editProperty: editProperty,
         );
       case intType:
         return IntegerInput(
+          key: propertyKey,
           property: property as NumericProperty,
           editProperty: editProperty,
         );
       case stringType:
-        return StringInput(property: property, editProperty: editProperty);
+        return StringInput(
+          key: propertyKey,
+          property: property,
+          editProperty: editProperty,
+        );
       default:
         return Text(property.valueDisplay);
     }


### PR DESCRIPTION
Follow-up to https://github.com/flutter/devtools/pull/8945

I realized the `key` should be set on the DevTools `[Type]Input` widgets themselves, instead of on the Flutter `TextFormField` or `DropdownButtonFormField` buttons. 

This way, when DevTools receives a property update from the Analysis Server, `initState` is called (which is where we set the `_currentValue` to the property value).
