### PR TITLE
Fix a bug with the review history on disconnect experience

### DIFF
--- a/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
+++ b/packages/devtools_app/lib/src/shared/framework/screen_controllers.dart
@@ -82,6 +82,25 @@ class ScreenControllers {
     }
     offlineControllers.clear();
   }
+
+  /// Calls the [callback] function on each initialized screen controller.
+  /// 
+  /// Optionally, calls the [callback] on the offline screen controllers when
+  /// [includeOfflineControllers] is true.
+  void forEachInitialized(
+    void Function(DevToolsScreenController screenController) callback, {
+    bool includeOfflineControllers = false,
+  }) {
+    final controllers =
+        includeOfflineControllers
+            ? [...this.controllers.values, ...offlineControllers.values]
+            : this.controllers.values;
+    for (final lazyController in controllers) {
+      if (lazyController.initialized) {
+        callback(lazyController.controller);
+      }
+    }
+  }
 }
 
 /// Helper class that performs lazy initialization for
@@ -95,6 +114,9 @@ class _LazyController<T extends DevToolsScreenController> {
   /// Lazily create and initialize the controller on the first use.
   T get controller => _controller ??= creator()..init();
   T? _controller;
+
+  /// Whether the controller has been initialized.
+  bool get initialized => _controller != null;
 
   void dispose() {
     _controller?.dispose();

--- a/packages/devtools_app/lib/src/shared/offline/offline_data.dart
+++ b/packages/devtools_app/lib/src/shared/offline/offline_data.dart
@@ -192,37 +192,24 @@ mixin OfflineScreenControllerMixin<T>
     _exportController.downloadFile(encodedData);
   }
 
-  /// Adds a listener that will prepare the screen's current data for offline
-  /// viewing after an app disconnect.
+  /// Prepare the screen's current data for offline viewing after an app
+  /// disconnect.
   ///
   /// This is in preparation for the user clicking the 'Review History' button
   /// from the disconnect screen.
-  ///
-  /// For screens that support the disconnect experience, which is a screen that
-  /// allows you to view historical data from before the app was disconnected
-  /// even after we lose connection to the device, this should be called in the
-  /// controller's initialization.
-  void initReviewHistoryOnDisconnectListener() {
-    addAutoDisposeListener(serviceConnection.serviceManager.connectedState, () {
-      final connectionState =
-          serviceConnection.serviceManager.connectedState.value;
-      if (!connectionState.connected &&
-          !connectionState.userInitiatedConnectionState) {
-        final currentScreenData = prepareOfflineScreenData();
-        // Only store data for the current page. We can change this in the
-        // future if we support offline imports for more than once screen at a
-        // time.
-        if (DevToolsRouterDelegate.currentPage == currentScreenData.screenId) {
-          final previouslyConnectedApp =
-              offlineDataController.previousConnectedApp;
-          final offlineData = _exportController.generateDataForExport(
-            offlineScreenData: currentScreenData.toJson(),
-            connectedApp: previouslyConnectedApp,
-          );
-          offlineDataController.offlineDataJson = offlineData;
-        }
-      }
-    });
+  void maybePrepareDataForReviewingHistory() {
+    final currentScreenData = prepareOfflineScreenData();
+    // Only store data for the current page. We can change this in the
+    // future if we support offline imports for more than once screen at a
+    // time.
+    if (DevToolsRouterDelegate.currentPage == currentScreenData.screenId) {
+      final previouslyConnectedApp = offlineDataController.previousConnectedApp;
+      final offlineData = _exportController.generateDataForExport(
+        offlineScreenData: currentScreenData.toJson(),
+        connectedApp: previouslyConnectedApp,
+      );
+      offlineDataController.offlineDataJson = offlineData;
+    }
   }
 }
 


### PR DESCRIPTION
This was broken by the new screenControllers lifecycle logic added in https://github.com/flutter/devtools/pull/8908 and https://github.com/flutter/devtools/pull/8916. After the lifecycle changes, the review history on disconnect logic was getting disposed before it got a change to execute. Now we handle this logic in `app.dart` where the rest of the screen controller lifecycle is managed.