### PR TITLE
Refactor BannerMessages to use widgets instead of data classes

### DIFF
--- a/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
+++ b/packages/devtools_app/lib/src/extensions/embedded/_view_web.dart
@@ -314,12 +314,13 @@ class _ExtensionIFrameController extends DisposableController
         '${showBannerMessageEvent.messageId}',
       ),
       screenId: '${showBannerMessageEvent.extensionName}_ext',
-      textSpans: [
-        TextSpan(
-          text: showBannerMessageEvent.message,
-          style: TextStyle(fontSize: defaultFontSize),
-        ),
-      ],
+      buildTextSpans:
+          (_) => [
+            TextSpan(
+              text: showBannerMessageEvent.message,
+              style: TextStyle(fontSize: defaultFontSize),
+            ),
+          ],
     );
     bannerMessages.addMessage(
       bannerMessage,

--- a/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
+++ b/packages/devtools_app/lib/src/screens/debugger/debugger_screen.dart
@@ -125,7 +125,7 @@ class _DebuggerScreenBodyWrapperState extends State<_DebuggerScreenBodyWrapper>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    pushDebuggerIdeRecommendationMessage(context, DebuggerScreen.id);
+    pushDebuggerIdeRecommendationMessage(DebuggerScreen.id);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_body.dart
+++ b/packages/devtools_app/lib/src/screens/inspector_v2/inspector_screen_body.dart
@@ -228,7 +228,7 @@ class InspectorScreenBodyState extends State<InspectorScreenBody>
     // Mark the welcome message as shown.
     await storage.setValue(_welcomeShownStorageId, 'true');
     if (context.mounted) {
-      pushWelcomeToNewInspectorMessage(context, InspectorScreen.id);
+      pushWelcomeToNewInspectorMessage(InspectorScreen.id);
     }
   }
 }

--- a/packages/devtools_app/lib/src/screens/memory/framework/screen_body.dart
+++ b/packages/devtools_app/lib/src/screens/memory/framework/screen_body.dart
@@ -37,11 +37,11 @@ class _ConnectedMemoryBodyState extends State<ConnectedMemoryBody>
   void didChangeDependencies() {
     super.didChangeDependencies();
     if (!offlineDataController.showingOfflineData.value) {
-      maybePushDebugModeMemoryMessage(context, ScreenMetaData.memory.id);
-      maybePushHttpLoggingMessage(context, ScreenMetaData.memory.id);
+      maybePushDebugModeMemoryMessage(ScreenMetaData.memory.id);
+      maybePushHttpLoggingMessage(ScreenMetaData.memory.id);
 
       addAutoDisposeListener(http_service.httpLoggingState, () {
-        maybePushHttpLoggingMessage(context, ScreenMetaData.memory.id);
+        maybePushHttpLoggingMessage(ScreenMetaData.memory.id);
       });
     }
   }

--- a/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
+++ b/packages/devtools_app/lib/src/screens/performance/panes/flutter_frames/flutter_frames_chart.dart
@@ -123,12 +123,13 @@ class _FlutterFramesChartState extends State<_FlutterFramesChart> {
       );
       bannerMessages.addMessage(
         ShaderJankMessage(
-          offlineDataController.showingOfflineData.value
-              ? ScreenMetaData.simple.id
-              : ScreenMetaData.performance.id,
+          screenId:
+              offlineDataController.showingOfflineData.value
+                  ? ScreenMetaData.simple.id
+                  : ScreenMetaData.performance.id,
           jankyFramesCount: shaderJankFrames.length,
           jankDuration: shaderJankDuration,
-        ).build(context),
+        ),
       );
     }
   }

--- a/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
+++ b/packages/devtools_app/lib/src/screens/performance/performance_screen.dart
@@ -73,7 +73,7 @@ class PerformanceScreenBodyState extends State<PerformanceScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    maybePushDebugModePerformanceMessage(context, PerformanceScreen.id);
+    maybePushDebugModePerformanceMessage(PerformanceScreen.id);
   }
 
   @override

--- a/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
+++ b/packages/devtools_app/lib/src/screens/profiler/profiler_screen.dart
@@ -96,7 +96,7 @@ class _ProfilerScreenBodyState extends State<ProfilerScreenBody>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    maybePushDebugModePerformanceMessage(context, ProfilerScreen.id);
+    maybePushDebugModePerformanceMessage(ProfilerScreen.id);
   }
 
   @override

--- a/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
@@ -219,7 +219,7 @@ class BannerMessage extends StatelessWidget {
             if (buildActions != null) ...[
               const SizedBox(height: defaultSpacing),
               Row(
-                crossAxisAlignment: CrossAxisAlignment.end,
+                mainAxisAlignment: MainAxisAlignment.end,
                 children: buildActions!(context),
               ),
             ],
@@ -522,10 +522,7 @@ class WelcomeToNewInspectorMessage extends BannerInfo {
       );
 }
 
-void maybePushDebugModePerformanceMessage(
-  BuildContext context,
-  String screenId,
-) {
+void maybePushDebugModePerformanceMessage(String screenId) {
   if (offlineDataController.showingOfflineData.value) return;
   if (serviceConnection.serviceManager.connectedApp?.isDebugFlutterAppNow ??
       false) {
@@ -533,7 +530,7 @@ void maybePushDebugModePerformanceMessage(
   }
 }
 
-void maybePushDebugModeMemoryMessage(BuildContext context, String screenId) {
+void maybePushDebugModeMemoryMessage(String screenId) {
   if (offlineDataController.showingOfflineData.value) return;
   if (serviceConnection.serviceManager.connectedApp?.isDebugFlutterAppNow ??
       false) {
@@ -541,22 +538,19 @@ void maybePushDebugModeMemoryMessage(BuildContext context, String screenId) {
   }
 }
 
-void maybePushHttpLoggingMessage(BuildContext context, String screenId) {
+void maybePushHttpLoggingMessage(String screenId) {
   if (http_service.httpLoggingEnabled) {
     bannerMessages.addMessage(HttpLoggingEnabledMessage(screenId: screenId));
   }
 }
 
-void pushDebuggerIdeRecommendationMessage(
-  BuildContext context,
-  String screenId,
-) {
+void pushDebuggerIdeRecommendationMessage(String screenId) {
   bannerMessages.addMessage(
     DebuggerIdeRecommendationMessage(screenId: screenId),
   );
 }
 
-void pushWelcomeToNewInspectorMessage(BuildContext context, String screenId) {
+void pushWelcomeToNewInspectorMessage(String screenId) {
   bannerMessages.addMessage(WelcomeToNewInspectorMessage(screenId: screenId));
 }
 

--- a/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
+++ b/packages/devtools_app/lib/src/shared/managers/banner_messages.dart
@@ -134,7 +134,6 @@ class BannerMessages extends StatelessWidget {
   }
 }
 
-// TODO(kenz): add an 'info' type.
 enum BannerMessageType {
   warning,
   error,
@@ -148,16 +147,17 @@ enum BannerMessageType {
   }
 }
 
-@visibleForTesting
 class BannerMessage extends StatelessWidget {
   const BannerMessage({
     required super.key,
-    required this.textSpans,
+    required this.buildTextSpans,
     required this.screenId,
     required this.messageType,
+    this.buildActions,
   });
 
-  final List<InlineSpan> textSpans;
+  final List<InlineSpan> Function(BuildContext) buildTextSpans;
+  final List<Widget> Function(BuildContext)? buildActions;
   final String screenId;
   final BannerMessageType messageType;
 
@@ -200,7 +200,7 @@ class BannerMessage extends StatelessWidget {
                       style: theme.regularTextStyle.copyWith(
                         color: foregroundColor,
                       ),
-                      children: textSpans,
+                      children: buildTextSpans(context),
                     ),
                   ),
                 ),
@@ -216,6 +216,13 @@ class BannerMessage extends StatelessWidget {
                 ),
               ],
             ),
+            if (buildActions != null) ...[
+              const SizedBox(height: defaultSpacing),
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.end,
+                children: buildActions!(context),
+              ),
+            ],
           ],
         ),
       ),
@@ -245,8 +252,8 @@ class BannerMessage extends StatelessWidget {
 
 class _BannerError extends BannerMessage {
   const _BannerError({
-    required Key super.key,
-    required List<TextSpan> super.textSpans,
+    required super.key,
+    required super.buildTextSpans,
     required super.screenId,
   }) : super(messageType: BannerMessageType.error);
 }
@@ -255,307 +262,264 @@ class _BannerError extends BannerMessage {
 class BannerWarning extends BannerMessage {
   const BannerWarning({
     required super.key,
-    required super.textSpans,
+    required super.buildTextSpans,
     required super.screenId,
+    super.buildActions,
   }) : super(messageType: BannerMessageType.warning);
 }
 
 class BannerInfo extends BannerMessage {
   const BannerInfo({
     required super.key,
-    required super.textSpans,
+    required super.buildTextSpans,
     required super.screenId,
+    super.buildActions,
   }) : super(messageType: BannerMessageType.info);
 }
 
-class DebugModePerformanceMessage {
-  const DebugModePerformanceMessage(this.screenId);
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    final theme = Theme.of(context);
-    return BannerWarning(
-      key: Key('DebugModePerformanceMessage - $screenId'),
-      textSpans: [
-        const TextSpan(
-          text:
-              'You are running your app in debug mode. Debug mode performance '
-              'is not indicative of release performance, but you may use debug '
-              'mode to gain visibility into the work the system performs (e.g. '
-              'building widgets, calculating layouts, rasterizing scenes,'
-              ' etc.). For precise measurement of performance, relaunch your '
-              'application in ',
-        ),
-        _runInProfileModeTextSpan(
-          context,
-          screenId: screenId,
-          style: theme.warningMessageLinkStyle,
-        ),
-        const TextSpan(text: '.'),
-      ],
-      screenId: screenId,
-    );
-  }
+class DebugModePerformanceMessage extends BannerWarning {
+  DebugModePerformanceMessage({required super.screenId})
+    : super(
+        key: Key('DebugModePerformanceMessage - $screenId'),
+        buildTextSpans:
+            (context) => [
+              const TextSpan(
+                text:
+                    'You are running your app in debug mode. Debug mode performance '
+                    'is not indicative of release performance, but you may use debug '
+                    'mode to gain visibility into the work the system performs (e.g. '
+                    'building widgets, calculating layouts, rasterizing scenes,'
+                    ' etc.). For precise measurement of performance, relaunch your '
+                    'application in ',
+              ),
+              _runInProfileModeTextSpan(
+                context,
+                screenId: screenId,
+                style: Theme.of(context).warningMessageLinkStyle,
+              ),
+              const TextSpan(text: '.'),
+            ],
+      );
 }
 
-// TODO(jacobr): cleanup this class that looks like a Widget but can't quite be
-// a widget due to some questionable design choices involving BannerMessage.
-class ProviderUnknownErrorBanner {
-  const ProviderUnknownErrorBanner({required this.screenId});
-
-  final String screenId;
-
-  BannerMessage build() {
-    return _BannerError(
-      key: Key('ProviderUnknownErrorBanner - $screenId'),
-      screenId: screenId,
-      textSpans: [
-        TextSpan(
-          text: '''
+class ProviderUnknownErrorBanner extends _BannerError {
+  ProviderUnknownErrorBanner({required super.screenId})
+    : super(
+        key: Key('ProviderUnknownErrorBanner - $screenId'),
+        buildTextSpans:
+            (_) => [
+              TextSpan(
+                text: '''
 DevTools failed to connect with package:provider.
 
 This could be caused by an older version of package:provider; please make sure that you are using version >=5.0.0.''',
-          style: TextStyle(fontSize: defaultFontSize),
-        ),
-      ],
-    );
-  }
+                style: TextStyle(fontSize: defaultFontSize),
+              ),
+            ],
+      );
 }
 
-class ShaderJankMessage {
-  const ShaderJankMessage(
-    this.screenId, {
-    required this.jankyFramesCount,
-    required this.jankDuration,
-  });
-
-  final String screenId;
-
-  final int jankyFramesCount;
-
-  final Duration jankDuration;
-
-  BannerMessage build(BuildContext context) {
-    final theme = Theme.of(context);
-    final jankDurationText = durationText(
-      jankDuration,
-      unit: DurationDisplayUnit.milliseconds,
-    );
-    return _BannerError(
-      key: Key('ShaderJankMessage - $screenId'),
-      textSpans: [
-        TextSpan(
-          text:
-              'Shader compilation jank detected. $jankyFramesCount '
-              '${pluralize('frame', jankyFramesCount)} janked with a total of '
-              '$jankDurationText spent in shader compilation. To pre-compile '
-              'shaders, see the instructions at ',
-        ),
-        GaLinkTextSpan(
-          link: GaLink(
-            display: preCompileShadersDocsUrl,
-            url: preCompileShadersDocsUrl,
-            gaScreenName: screenId,
-            gaSelectedItemDescription:
-                gac.PerformanceDocs.shaderCompilationDocs.name,
-          ),
-          context: context,
-          style: theme.errorMessageLinkStyle,
-        ),
-        const TextSpan(text: '.'),
-        if (serviceConnection.serviceManager.connectedApp!.isIosApp) ...[
-          const TextSpan(
-            text:
-                '\n\nNote: this is a legacy solution with many pitfalls. '
-                'Try ',
-          ),
-          GaLinkTextSpan(
-            link: GaLink(
-              display: 'Impeller',
-              url: impellerDocsUrl,
-              gaScreenName: screenId,
-              gaSelectedItemDescription:
-                  gac.PerformanceDocs.impellerDocsLink.name,
-            ),
-            context: context,
-            style: theme.errorMessageLinkStyle,
-          ),
-          const TextSpan(text: ' instead!'),
-        ],
-      ],
-      screenId: screenId,
-    );
-  }
+class ShaderJankMessage extends _BannerError {
+  ShaderJankMessage({
+    required super.screenId,
+    required int jankyFramesCount,
+    required Duration jankDuration,
+  }) : super(
+         key: Key('ShaderJankMessage - $screenId'),
+         buildTextSpans: (context) {
+           final theme = Theme.of(context);
+           final jankDurationText = durationText(
+             jankDuration,
+             unit: DurationDisplayUnit.milliseconds,
+           );
+           return [
+             TextSpan(
+               text:
+                   'Shader compilation jank detected. $jankyFramesCount '
+                   '${pluralize('frame', jankyFramesCount)} janked with a total of '
+                   '$jankDurationText spent in shader compilation. To pre-compile '
+                   'shaders, see the instructions at ',
+             ),
+             GaLinkTextSpan(
+               link: GaLink(
+                 display: preCompileShadersDocsUrl,
+                 url: preCompileShadersDocsUrl,
+                 gaScreenName: screenId,
+                 gaSelectedItemDescription:
+                     gac.PerformanceDocs.shaderCompilationDocs.name,
+               ),
+               context: context,
+               style: theme.errorMessageLinkStyle,
+             ),
+             const TextSpan(text: '.'),
+             if (serviceConnection.serviceManager.connectedApp!.isIosApp) ...[
+               const TextSpan(
+                 text:
+                     '\n\nNote: this is a legacy solution with many pitfalls. '
+                     'Try ',
+               ),
+               GaLinkTextSpan(
+                 link: GaLink(
+                   display: 'Impeller',
+                   url: impellerDocsUrl,
+                   gaScreenName: screenId,
+                   gaSelectedItemDescription:
+                       gac.PerformanceDocs.impellerDocsLink.name,
+                 ),
+                 context: context,
+                 style: theme.errorMessageLinkStyle,
+               ),
+               const TextSpan(text: ' instead!'),
+             ],
+           ];
+         },
+       );
 }
 
-class HighCpuSamplingRateMessage {
-  HighCpuSamplingRateMessage(this.screenId)
-    : key = Key('HighCpuSamplingRateMessage - $screenId');
-
-  final Key key;
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    final theme = Theme.of(context);
-    return BannerWarning(
-      key: key,
-      textSpans: [
-        const TextSpan(
-          text: '''
+class HighCpuSamplingRateMessage extends BannerWarning {
+  HighCpuSamplingRateMessage({required super.screenId})
+    : super(
+        key: generateKey(screenId),
+        buildTextSpans:
+            (context) => [
+              const TextSpan(
+                text: '''
 You are opting in to a high CPU sampling rate. This may affect the performance of your application. Please read our ''',
-        ),
-        GaLinkTextSpan(
-          link: GaLink(
-            display: 'documentation',
-            url: _cpuSamplingRateDocsUrl,
-            gaScreenName: screenId,
-            gaSelectedItemDescription:
-                gac.CpuProfilerDocs.profileGranularityDocs.name,
-          ),
-          context: context,
-          style: theme.warningMessageLinkStyle,
-        ),
-        const TextSpan(
-          text: ' to understand the trade-offs associated with this setting.',
-        ),
-      ],
-      screenId: screenId,
-    );
-  }
+              ),
+              GaLinkTextSpan(
+                link: GaLink(
+                  display: 'documentation',
+                  url: _cpuSamplingRateDocsUrl,
+                  gaScreenName: screenId,
+                  gaSelectedItemDescription:
+                      gac.CpuProfilerDocs.profileGranularityDocs.name,
+                ),
+                context: context,
+                style: Theme.of(context).warningMessageLinkStyle,
+              ),
+              const TextSpan(
+                text:
+                    ' to understand the trade-offs associated with this setting.',
+              ),
+            ],
+      );
+
+  static Key generateKey(String screenId) =>
+      Key('HighCpuSamplingRateMessage - $screenId');
 }
 
-class HttpLoggingEnabledMessage {
-  HttpLoggingEnabledMessage(this.screenId)
-    : key = Key('HttpLoggingEnabledMessage - $screenId');
-
-  final Key key;
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    final theme = Theme.of(context);
-    late final BannerWarning message;
-    message = BannerWarning(
-      key: key,
-      textSpans: [
-        const TextSpan(
-          text: '''
+class HttpLoggingEnabledMessage extends BannerWarning {
+  HttpLoggingEnabledMessage({required super.screenId})
+    : super(
+        key: _generateKey(screenId),
+        buildTextSpans:
+            (context) => [
+              const TextSpan(
+                text: '''
 HTTP traffic is being logged for debugging purposes. This may result in increased memory usage for your app. If this is not intentional, consider ''',
-        ),
-        TextSpan(
-          text: 'disabling http logging',
-          style: theme.warningMessageLinkStyle,
-          recognizer:
-              TapGestureRecognizer()
-                ..onTap = () async {
-                  await http_service.toggleHttpRequestLogging(false).then((_) {
-                    if (!http_service.httpLoggingEnabled) {
-                      notificationService.push('Http logging disabled.');
-                      bannerMessages.removeMessage(message);
-                    }
-                  });
-                },
-        ),
-        const TextSpan(
-          text: ' before profiling the memory of your application.',
-        ),
-      ],
-      screenId: screenId,
-    );
-    return message;
-  }
+              ),
+              TextSpan(
+                text: 'disabling http logging',
+                style: Theme.of(context).warningMessageLinkStyle,
+                recognizer:
+                    TapGestureRecognizer()
+                      ..onTap = () async {
+                        await http_service.toggleHttpRequestLogging(false).then(
+                          (_) {
+                            if (!http_service.httpLoggingEnabled) {
+                              notificationService.push(
+                                'Http logging disabled.',
+                              );
+                              bannerMessages.removeMessageByKey(
+                                _generateKey(screenId),
+                                screenId,
+                              );
+                            }
+                          },
+                        );
+                      },
+              ),
+              const TextSpan(
+                text: ' before profiling the memory of your application.',
+              ),
+            ],
+      );
+
+  static Key _generateKey(String screenId) =>
+      Key('HttpLoggingEnabledMessage - $screenId');
 }
 
-class DebugModeMemoryMessage {
-  const DebugModeMemoryMessage(this.screenId);
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    return BannerWarning(
-      key: Key('DebugModeMemoryMessage - $screenId'),
-      textSpans: [
-        const TextSpan(
-          text: '''
+class DebugModeMemoryMessage extends BannerWarning {
+  DebugModeMemoryMessage({required super.screenId})
+    : super(
+        key: Key('DebugModeMemoryMessage - $screenId'),
+        buildTextSpans:
+            (context) => [
+              const TextSpan(
+                text: '''
 You are running your app in debug mode. Absolute memory usage may be higher in a debug build than in a release build.
 For the most accurate absolute memory stats, relaunch your application in ''',
-        ),
-        _runInProfileModeTextSpan(
-          context,
-          screenId: screenId,
-          style: Theme.of(context).warningMessageLinkStyle,
-        ),
-        const TextSpan(text: '.'),
-      ],
-      screenId: screenId,
-    );
-  }
+              ),
+              _runInProfileModeTextSpan(
+                context,
+                screenId: screenId,
+                style: Theme.of(context).warningMessageLinkStyle,
+              ),
+              const TextSpan(text: '.'),
+            ],
+      );
 }
 
-class DebuggerIdeRecommendationMessage {
-  const DebuggerIdeRecommendationMessage(this.screenId);
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    final isFlutterApp =
-        serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ?? false;
-    final codeType = isFlutterApp ? 'Flutter' : 'Dart';
-    final recommendedDebuggers = devToolsEnvironmentParameters
-        .recommendedDebuggers(context, isFlutterApp: isFlutterApp);
-
-    return BannerWarning(
-      key: Key('DebuggerIdeRecommendationMessage - $screenId'),
-      textSpans: [
-        TextSpan(
-          text: '''
+class DebuggerIdeRecommendationMessage extends BannerWarning {
+  DebuggerIdeRecommendationMessage({required super.screenId})
+    : super(
+        key: Key('DebuggerIdeRecommendationMessage - $screenId'),
+        buildTextSpans: (context) {
+          final isFlutterApp =
+              serviceConnection.serviceManager.connectedApp?.isFlutterAppNow ??
+              false;
+          final codeType = isFlutterApp ? 'Flutter' : 'Dart';
+          final recommendedDebuggers = devToolsEnvironmentParameters
+              .recommendedDebuggers(context, isFlutterApp: isFlutterApp);
+          return [
+            TextSpan(
+              text: '''
 The $codeType DevTools debugger is in maintenance mode. For the best debugging experience, we recommend debugging your $codeType code in a supported IDE''',
-        ),
-        if (recommendedDebuggers != null) ...[
-          const TextSpan(text: ', such as '),
-          ...recommendedDebuggers,
-        ],
-        const TextSpan(text: '.'),
-      ],
-      screenId: screenId,
-    );
-  }
+            ),
+            if (recommendedDebuggers != null) ...[
+              const TextSpan(text: ', such as '),
+              ...recommendedDebuggers,
+            ],
+            const TextSpan(text: '.'),
+          ];
+        },
+      );
 }
 
-class WelcomeToNewInspectorMessage {
-  WelcomeToNewInspectorMessage(this.screenId)
-    : key = Key('WelcomeToNewInspectorMessage - $screenId');
+class WelcomeToNewInspectorMessage extends BannerInfo {
+  WelcomeToNewInspectorMessage({required super.screenId})
+    : super(
+        key: Key('WelcomeToNewInspectorMessage - $screenId'),
 
-  final Key key;
-
-  final String screenId;
-
-  BannerMessage build(BuildContext context) {
-    const docsUrl = 'https://docs.flutter.dev/tools/devtools/inspector#new';
-    return BannerInfo(
-      key: key,
-      textSpans: [
-        const TextSpan(
-          text: '''
+        buildTextSpans:
+            (context) => [
+              const TextSpan(
+                text: '''
 👋 Welcome to the new Flutter inspector! To get started, check out the ''',
-        ),
-        GaLinkTextSpan(
-          link: GaLink(
-            display: 'documentation',
-            url: docsUrl,
-            gaScreenName: screenId,
-            gaSelectedItemDescription: gac.inspectorV2Docs,
-          ),
-          context: context,
-          style: Theme.of(context).linkTextStyle,
-        ),
-        const TextSpan(text: '.'),
-      ],
-      screenId: screenId,
-    );
-  }
+              ),
+              GaLinkTextSpan(
+                link: GaLink(
+                  display: 'documentation',
+                  url: 'https://docs.flutter.dev/tools/devtools/inspector#new',
+                  gaScreenName: screenId,
+                  gaSelectedItemDescription: gac.inspectorV2Docs,
+                ),
+                context: context,
+                style: Theme.of(context).linkTextStyle,
+              ),
+              const TextSpan(text: '.'),
+            ],
+      );
 }
 
 void maybePushDebugModePerformanceMessage(
@@ -565,9 +529,7 @@ void maybePushDebugModePerformanceMessage(
   if (offlineDataController.showingOfflineData.value) return;
   if (serviceConnection.serviceManager.connectedApp?.isDebugFlutterAppNow ??
       false) {
-    bannerMessages.addMessage(
-      DebugModePerformanceMessage(screenId).build(context),
-    );
+    bannerMessages.addMessage(DebugModePerformanceMessage(screenId: screenId));
   }
 }
 
@@ -575,15 +537,13 @@ void maybePushDebugModeMemoryMessage(BuildContext context, String screenId) {
   if (offlineDataController.showingOfflineData.value) return;
   if (serviceConnection.serviceManager.connectedApp?.isDebugFlutterAppNow ??
       false) {
-    bannerMessages.addMessage(DebugModeMemoryMessage(screenId).build(context));
+    bannerMessages.addMessage(DebugModeMemoryMessage(screenId: screenId));
   }
 }
 
 void maybePushHttpLoggingMessage(BuildContext context, String screenId) {
   if (http_service.httpLoggingEnabled) {
-    bannerMessages.addMessage(
-      HttpLoggingEnabledMessage(screenId).build(context),
-    );
+    bannerMessages.addMessage(HttpLoggingEnabledMessage(screenId: screenId));
   }
 }
 
@@ -592,14 +552,12 @@ void pushDebuggerIdeRecommendationMessage(
   String screenId,
 ) {
   bannerMessages.addMessage(
-    DebuggerIdeRecommendationMessage(screenId).build(context),
+    DebuggerIdeRecommendationMessage(screenId: screenId),
   );
 }
 
 void pushWelcomeToNewInspectorMessage(BuildContext context, String screenId) {
-  bannerMessages.addMessage(
-    WelcomeToNewInspectorMessage(screenId).build(context),
-  );
+  bannerMessages.addMessage(WelcomeToNewInspectorMessage(screenId: screenId));
 }
 
 extension BannerMessageThemeExtension on ThemeData {

--- a/packages/devtools_app/lib/src/shared/ui/vm_flag_widgets.dart
+++ b/packages/devtools_app/lib/src/shared/ui/vm_flag_widgets.dart
@@ -57,11 +57,11 @@ class CpuSamplingRateDropdown extends StatelessWidget {
 
         if (safeValue == highProfilePeriod) {
           bannerMessages.addMessage(
-            HighCpuSamplingRateMessage(screenId).build(context),
+            HighCpuSamplingRateMessage(screenId: screenId),
           );
         } else {
           bannerMessages.removeMessageByKey(
-            HighCpuSamplingRateMessage(screenId).key,
+            HighCpuSamplingRateMessage.generateKey(screenId),
             screenId,
           );
         }

--- a/packages/devtools_app/test/shared/managers/banner_messages_test.dart
+++ b/packages/devtools_app/test/shared/managers/banner_messages_test.dart
@@ -168,13 +168,13 @@ const k1 = Key('test message 1');
 const k2 = Key('test message 2');
 final testMessage1 = BannerMessage(
   key: k1,
-  textSpans: const [TextSpan(text: 'Test Message 1')],
+  buildTextSpans: (_) => const [TextSpan(text: 'Test Message 1')],
   screenId: testMessage1ScreenId,
   messageType: BannerMessageType.warning,
 );
 final testMessage2 = BannerMessage(
   key: k2,
-  textSpans: const [TextSpan(text: 'Test Message 2')],
+  buildTextSpans: (_) => const [TextSpan(text: 'Test Message 2')],
   screenId: testMessage2ScreenId,
   messageType: BannerMessageType.warning,
 );


### PR DESCRIPTION
This will allow pushing BannerMessages from business logic. Before this change, access to BuildContext was required.

Tip: review with hide whitespace enabled.